### PR TITLE
Upload dSYM file with build

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ hockey({
   notes: "Changelog"
 })
 ```
+
+Symbols will also be uploaded automatically if a `app.dSYM.zip` file is found next to `app.ipa`. In case it is located in a different place you can specify the path explicitly in `:dsym` parameter.
+
 More information about the available options can be found in the [HockeyApp Docs](http://support.hockeyapp.net/kb/api/api-versions#upload-version).
 
 #### [Testmunk](http://testmunk.com)

--- a/lib/fastlane/actions/hockey.rb
+++ b/lib/fastlane/actions/hockey.rb
@@ -25,6 +25,19 @@ module Fastlane
         raise "No IPA file given or found, pass using `ipa: 'path.ipa'`".red unless options[:ipa]
         raise "IPA file on path '#{File.expand_path(options[:ipa])}' not found".red unless File.exists?(options[:ipa])
 
+        if options[:dsym]
+          options[:dsym_filename] = options[:dsym]
+        else  
+          dsym_path = options[:ipa].gsub("ipa", "app.dSYM.zip")
+          if File.exists?(dsym_path)
+            options[:dsym_filename] = dsym_path
+          else
+            Helper.log.info "Symbols not found on path #{File.expand_path(dsym_path)}. Crashes won't be symbolicated properly".yellow
+          end
+        end
+
+        raise "Symbols on path '#{File.expand_path(options[:dsym_filename])}' not found".red if (options[:dsym_filename] && !File.exists?(options[:dsym_filename])) 
+
         Helper.log.info "Starting with ipa upload to HockeyApp... this could take some time.".green
         
         client = Shenzhen::Plugins::HockeyApp::Client.new(options[:api_token])

--- a/spec/actions_specs/hockey_spec.rb
+++ b/spec/actions_specs/hockey_spec.rb
@@ -22,6 +22,18 @@ describe Fastlane do
         }.to raise_error("IPA file on path '#{File.expand_path('../notHere.ipa')}' not found".red)
       end
 
+      it "raises an error if supplied dsym file was not found" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do 
+            hockey({
+              api_token: 'xxx',
+              ipa: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+              dsym: './notHere.dSYM.zip'
+            })
+          end").runner.execute(:test)
+        }.to raise_error("Symbols on path '#{File.expand_path('../notHere.dSYM.zip')}' not found".red)
+      end
+
       it "works with valid parameters" do
         Fastlane::FastFile.new.parse("lane :test do 
           hockey({


### PR DESCRIPTION
At the moment crashes cannot be symbolicated properly because symbols are not uploaded together with the `.ipa`.

This fix adds support for uploading dSYM.zip if it is found in the current directory (this is provided if Shenzen is used to create `.ipa`) or you can optionally supply a parameter with dSYM path.
