### PR TITLE
Slack direct message

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,17 @@ hockey({
 ```
 More information about the available options can be found in the [HockeyApp Docs](http://support.hockeyapp.net/kb/api/api-versions#upload-version).
 
+#### [Slack](http://slack.com)
+Send a message to **#channel** (by default) or a direct message to **@username** with success (green) or failure (red) status.
+
+```ruby
+  slack({
+    message: "HELLO WORLD!",
+    channel: "#channel",
+    success: true,
+  })
+```
+
 #### [Testmunk](http://testmunk.com)
 Run your functional tests on real iOS devices over the cloud (for free on an iPod). With this simple [testcase](https://github.com/testmunk/TMSample/blob/master/testcases/smoke/smoke_features.zip) you can ensure your app launches and there is no crash at launch. Tests can be extended with [Testmunk's library](http://docs.testmunk.com/en/latest/steps.html) or custom steps. More details about this action can be found in [`testmunk.rb`](https://github.com/KrauseFx/fastlane/blob/master/lib/fastlane/actions/testmunk.rb).
 ```ruby

--- a/lib/assets/FastfileTemplate
+++ b/lib/assets/FastfileTemplate
@@ -1,4 +1,4 @@
-# Customise this file, documentation can be found here: 
+# Customise this file, documentation can be found here:
 # https://github.com/krausefx/fastlane#customise-the-fastfile
 
 # Change the syntax highlighting to Ruby
@@ -11,13 +11,13 @@ before_all do
   # sh "./customShellScript.sh"
 
   # increment_build_number
-  
+
   cocoapods
 
   xctool
 end
 
-lane :test do 
+lane :test do
   snapshot
 end
 

--- a/lib/fastlane/actions/slack.rb
+++ b/lib/fastlane/actions/slack.rb
@@ -1,16 +1,16 @@
 module Fastlane
   module Actions
     module SharedValues
-      
+
     end
 
     class SlackAction
       def self.run(params)
-        options = { message: '', 
-                    success: true, 
+        options = { message: '',
+                    success: true,
                     channel: nil
                   }.merge(params.first || {})
-        
+
         require 'slack-notifier'
 
         color = (options[:success] ? 'good' : 'danger')
@@ -45,7 +45,7 @@ module Fastlane
           ]
         }
 
-        notifier.ping "", 
+        notifier.ping "",
                       icon_url: 'https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png',
                       attachments: [test_result]
 

--- a/lib/fastlane/actions/slack.rb
+++ b/lib/fastlane/actions/slack.rb
@@ -25,7 +25,8 @@ module Fastlane
         notifier = Slack::Notifier.new url
 
         notifier.username = 'fastlane'
-        notifier.channel = "##{options[:channel]}" if options[:channel].to_s.length > 0
+        notifier.channel = "#{options[:channel]}" if options[:channel].to_s.length > 0
+        notifier.channel = "##{notifier.channel}" unless ["#", "@"].include? notifier.channel[0] #send msg to channel by default
 
         test_result = {
           fallback: options[:message],


### PR DESCRIPTION
Allow to send private messages with slack (using @nickname).
By default it will write a '#' before the name, unless it start by # (message to channel) or a @ (private).
