### PR TITLE
Added hipchat messaging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 pkg
+.idea

--- a/README.md
+++ b/README.md
@@ -238,6 +238,17 @@ Send a message to **#channel** (by default) or a direct message to **@username**
   })
 ```
 
+#### [HipChat](http://www.hipchat.com/)
+Send a message to **room** (by default) or a direct message to **@username** with success (green) or failure (red) status.
+
+```ruby
+  hipchat({
+    message: "App successfully released!",
+    channel: "Room or @username",
+    success: true
+  })
+```
+
 #### [Testmunk](http://testmunk.com)
 Run your functional tests on real iOS devices over the cloud (for free on an iPod). With this simple [testcase](https://github.com/testmunk/TMSample/blob/master/testcases/smoke/smoke_features.zip) you can ensure your app launches and there is no crash at launch. Tests can be extended with [Testmunk's library](http://docs.testmunk.com/en/latest/steps.html) or custom steps. More details about this action can be found in [`testmunk.rb`](https://github.com/KrauseFx/fastlane/blob/master/lib/fastlane/actions/testmunk.rb).
 ```ruby

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri', '~> 1.6.5' # generating JUnit reports for Jenkins
   spec.add_dependency 'shenzhen', '~> 0.11.0' # to upload to Hockey and Crashlytics
   spec.add_dependency 'slack-notifier', '~> 1.0' # Slack notifications
+  spec.add_dependency 'hipchat', '~> 1.0' # Hipchat notifications
 
   spec.add_dependency 'credentials_manager'
   spec.add_dependency 'deliver', '>= 0.5.0'

--- a/lib/fastlane/actions/hipchat.rb
+++ b/lib/fastlane/actions/hipchat.rb
@@ -1,0 +1,30 @@
+module Fastlane
+  module Actions
+    module SharedValues
+
+    end
+
+    class HipchatAction
+      def self.run(params)
+        options = { message: '',
+                    success: true,
+                    room: nil
+                  }.merge(params.first || {})
+
+        require 'hipchat'
+
+        api_token = ENV["HIPCHAT_API_TOKEN"]
+
+        unless api_token
+          Helper.log.fatal "Please add 'ENV[\"HIPCHAT_API_TOKEN\"] = \"your token\"' to your Fastfile's `before_all` section.".red
+          raise "No HIPCHAT_API_TOKEN given.".red
+        end
+
+        client = HipChat::Client.new(api_token, :api_version => 'v2')
+        color = (options[:success] ? 'green' : 'red')
+        client[options[:room]].send('fastlane',options[:message], :message_format => 'text', :color => color)
+
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/hipchat.rb
+++ b/lib/fastlane/actions/hipchat.rb
@@ -8,7 +8,7 @@ module Fastlane
       def self.run(params)
         options = { message: '',
                     success: true,
-                    room: nil
+                    channel: nil
                   }.merge(params.first || {})
 
         require 'hipchat'
@@ -21,8 +21,19 @@ module Fastlane
         end
 
         client = HipChat::Client.new(api_token, :api_version => 'v2')
+        channel = options[:channel]
         color = (options[:success] ? 'green' : 'red')
-        client[options[:room]].send('fastlane',options[:message], :message_format => 'text', :color => color)
+
+        if channel.to_s.start_with?('@')
+          #private message
+          #currently hipchat-rb release wrapper doesn´t allow to send private html message we have to send the raw message
+          channel.slice!(0)
+          client.user(channel).send(options[:message])
+        else
+          #room message
+          message = "<table><tr><td><img src=\"https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png\" style=\"width:50px;height:auto\"></td><td>" + options[:message] + "</td></tr></table>"
+          client[channel].send('fastlane',message, :message_format => 'html', :color => color)
+        end
 
       end
     end


### PR DESCRIPTION
Like the slack integration you can send a message to a hipchat room e.g.:

```
ENV["HIPCHAT_API_TOKEN"] = "hipchat_api_token"

hipchat({
     message: "Successfully deployed new App Update for [App](http://link.com).",
     success: true,
     channel: 'room or @username'
  })
```
