### PR TITLE
IPA Action (using Shenzhen)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 pkg
 .idea
+
+# RVM stuff
+.ruby-gemset

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.6)
+    addressable (2.3.7)
     aws-sdk (1.61.0)
       aws-sdk-v1 (= 1.61.0)
     aws-sdk-v1 (1.61.0)
@@ -45,7 +45,7 @@ GEM
       colored
       highline (~> 1.6.21)
       security (~> 0.1.3)
-    deliver (0.7.5)
+    deliver (0.7.7)
       capybara (~> 2.4.3)
       colored
       commander (~> 4.2.0)
@@ -55,6 +55,7 @@ GEM
       json
       multi_json
       nokogiri (~> 1.6.5)
+      phantomjs (~> 1.9.8)
       plist (~> 3.1.0)
       poltergeist (~> 1.5.1)
       prawn
@@ -92,14 +93,16 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     pdf-core (0.4.0)
-    pem (0.3.1)
+    pem (0.3.2)
       capybara (~> 2.4.3)
       colored
       commander (~> 4.2.0)
       credentials_manager
       highline (~> 1.6.21)
       json
+      phantomjs (~> 1.9.8)
       poltergeist (~> 1.5.1)
+    phantomjs (1.9.8.0)
     plist (3.1.0)
     poltergeist (1.5.1)
       capybara (~> 2.1)
@@ -109,13 +112,14 @@ GEM
     prawn (1.3.0)
       pdf-core (~> 0.4.0)
       ttfunk (~> 1.4.0)
-    produce (0.1.1)
+    produce (0.1.3)
       capybara (~> 2.4.3)
       colored
       commander (~> 4.2.0)
       credentials_manager
       highline (~> 1.6.21)
       json
+      phantomjs (~> 1.9.8)
       poltergeist (~> 1.5.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -137,7 +141,7 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    rubyzip (1.1.6)
+    rubyzip (1.1.7)
     safe_yaml (1.0.4)
     security (0.1.3)
     shenzhen (0.11.0)
@@ -152,13 +156,14 @@ GEM
       rubyzip (~> 1.1)
       security (~> 0.1.3)
       terminal-table (~> 1.4.5)
-    sigh (0.2.1)
+    sigh (0.2.4)
       capybara (~> 2.4.3)
       colored
       commander (~> 4.2.0)
       credentials_manager
       highline (~> 1.6.21)
       json
+      phantomjs (~> 1.9.8)
       poltergeist (~> 1.5.1)
     simplecov (0.9.1)
       docile (~> 1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       deliver (>= 0.5.0)
       frameit (>= 0.2.0)
       highline (~> 1.6.21)
-      hipchat (~> 1.4)
       json
       nokogiri (~> 1.6.5)
       pem (>= 0.3.0)
@@ -46,7 +45,7 @@ GEM
       colored
       highline (~> 1.6.21)
       security (~> 0.1.3)
-    deliver (0.7.6)
+    deliver (0.7.5)
       capybara (~> 2.4.3)
       colored
       commander (~> 4.2.0)
@@ -56,7 +55,6 @@ GEM
       json
       multi_json
       nokogiri (~> 1.6.5)
-      phantomjs (~> 1.9.8)
       plist (~> 3.1.0)
       poltergeist (~> 1.5.1)
       prawn
@@ -81,18 +79,12 @@ GEM
       json
       mini_magick (~> 4.0.2)
     highline (1.6.21)
-    hipchat (1.4.0)
-      httparty
-    httparty (0.13.3)
-      json (~> 1.8)
-      multi_xml (>= 0.5.2)
     json (1.8.2)
     method_source (0.8.2)
     mime-types (2.4.3)
     mini_magick (4.0.3)
     mini_portile (0.6.2)
     multi_json (1.10.1)
-    multi_xml (0.5.5)
     multipart-post (1.2.0)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
@@ -100,16 +92,14 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     pdf-core (0.4.0)
-    pem (0.3.2)
+    pem (0.3.1)
       capybara (~> 2.4.3)
       colored
       commander (~> 4.2.0)
       credentials_manager
       highline (~> 1.6.21)
       json
-      phantomjs (~> 1.9.8)
       poltergeist (~> 1.5.1)
-    phantomjs (1.9.8.0)
     plist (3.1.0)
     poltergeist (1.5.1)
       capybara (~> 2.1)
@@ -119,14 +109,13 @@ GEM
     prawn (1.3.0)
       pdf-core (~> 0.4.0)
       ttfunk (~> 1.4.0)
-    produce (0.1.2)
+    produce (0.1.1)
       capybara (~> 2.4.3)
       colored
       commander (~> 4.2.0)
       credentials_manager
       highline (~> 1.6.21)
       json
-      phantomjs (~> 1.9.8)
       poltergeist (~> 1.5.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -148,7 +137,7 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    rubyzip (1.1.7)
+    rubyzip (1.1.6)
     safe_yaml (1.0.4)
     security (0.1.3)
     shenzhen (0.11.0)
@@ -163,14 +152,13 @@ GEM
       rubyzip (~> 1.1)
       security (~> 0.1.3)
       terminal-table (~> 1.4.5)
-    sigh (0.2.2)
+    sigh (0.2.1)
       capybara (~> 2.4.3)
       colored
       commander (~> 4.2.0)
       credentials_manager
       highline (~> 1.6.21)
       json
-      phantomjs (~> 1.9.8)
       poltergeist (~> 1.5.1)
     simplecov (0.9.1)
       docile (~> 1.1.0)

--- a/lib/fastlane/actions/ipa.rb
+++ b/lib/fastlane/actions/ipa.rb
@@ -58,18 +58,29 @@ module Fastlane
           build_args = params
         end
 
+        # If no dest directory given, default to current directory
+        absolute_dest_directory ||= Dir.pwd
+
+        if Helper.is_test?
+          Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] = File.join(absolute_dest_directory, "test.ipa")
+          Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH] = File.join(absolute_dest_directory, "test.app.dSTM.zip")
+          return build_args 
+        end
+
         # Joins args into space delimited string
         build_args = build_args.join(' ')
+
         Actions.sh "ipa build #{build_args}"
         
         # Finds absolute path of IPA and dSYM
-        absolute_dest_directory ||= Dir.pwd
         absolute_ipa_path = find_ipa_file(absolute_dest_directory)
         absolute_dsym_path = find_dsym_file(absolute_dest_directory)
 
         # Sets shared values to use after this action is performed
         Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] = absolute_ipa_path
         Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH] = absolute_dsym_path
+
+
       end
 
       def self.params_to_build_args(params)

--- a/lib/fastlane/actions/ipa.rb
+++ b/lib/fastlane/actions/ipa.rb
@@ -1,0 +1,90 @@
+module Fastlane
+  module Actions
+
+    module SharedValues
+      IPA_OUTPUT_PATH = :IPA_OUTPUT_PATH
+      DSYM_OUTPUT_PATH = :DSYM_OUTPUT_PATH
+    end
+
+    # -w, --workspace WORKSPACE Workspace (.xcworkspace) file to use to build app (automatically detected in current directory) 
+    # -p, --project PROJECT Project (.xcodeproj) file to use to build app (automatically detected in current directory, overridden by --workspace option, if passed) 
+    # -c, --configuration CONFIGURATION Configuration used to build 
+    # -s, --scheme SCHEME  Scheme used to build app 
+    # --xcconfig XCCONFIG  use an extra XCCONFIG file to build the app 
+    # --xcargs XCARGS      pass additional arguments to xcodebuild when building the app. Be sure to quote multiple args. 
+    # --[no-]clean         Clean project before building 
+    # --[no-]archive       Archive project after building 
+    # -d, --destination DESTINATION Destination. Defaults to current directory 
+    # -m, --embed PROVISION Sign .ipa file with .mobileprovision 
+    # -i, --identity IDENTITY Identity to be used along with --embed 
+    # --sdk SDK            use SDK as the name or path of the base SDK when building the project 
+    # --ipa IPA            specify the name of the .ipa file to generate (including file extension) 
+
+    ARGS_MAP = {
+      workspace: '-w',
+      project: '-p',
+      configuration: '-c',
+      scheme: '-s',
+      clean: '--clean',
+      archive: '--archive',
+      destination: '-d',
+      embed: '-m',
+      identity: '-i',
+      sdk: '--sdk',
+      ipa: '--ipa'
+    }
+
+    class IpaAction
+      def self.run(params)
+        
+        # The args we will build with
+        build_args = nil
+
+        # The output path of the IPA
+        absolute_ipa_path = nil
+
+        # Allows for a whole variety of configurations
+        if params.first.is_a? Hash
+          destination = params.first[:destination]
+          build_args = params_to_build_args(params.first)
+        else
+          build_args = params
+        end
+
+        build_args = build_args.join(' ')
+
+        Actions.sh "ipa build #{build_args}"
+        
+        absolute_ipa_path ||= find_ipa_file
+        absolute_ipa_path = File.join(Dir.pwd, absolute_ipa_path)
+        absolute_dsym_path = File.join(Dir.pwd, find_dsym_file)
+
+        Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] = absolute_ipa_path
+        Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH] = absolute_dsym_path
+      end
+
+      def self.params_to_build_args(params)
+        # Remove nil value params unless :clean or :archive
+        params = params.delete_if { |k, v| (k != :clean && k != :archive ) && v.nil? }
+
+        # Maps nice developer param names to Shenzhen's `ipa build` arguments
+        params.collect do |k,v|
+          v ||= ''
+          if args = ARGS_MAP[k]
+           "#{ARGS_MAP[k]} #{v}".strip
+          end
+        end.compact
+      end
+
+      def self.find_ipa_file
+        Dir["*"].sort { |a,b| File.mtime(a) <=> File.mtime(b) }.find { |f| f.end_with? ".ipa"}
+      end
+
+      def self.find_dsym_file
+        Dir["*"].sort { |a,b| File.mtime(a) <=> File.mtime(b) }.find { |f| f.end_with? ".dSYM.zip"}
+      end
+
+    end
+
+  end
+end

--- a/lib/fastlane/actions/ipa.rb
+++ b/lib/fastlane/actions/ipa.rb
@@ -40,13 +40,13 @@ module Fastlane
         # The args we will build with
         build_args = nil
 
-        # The output directory of the IPA and DSYM
+        # The output directory of the IPA and dSYM
         absolute_dest_directory = nil
 
         # Allows for a whole variety of configurations
         if params.first.is_a? Hash
 
-          # Used to get the final path of the IPA and DSYM
+          # Used to get the final path of the IPA and dSYM
           if dest = params.first[:destination]
             absolute_dest_directory = Dir.glob(dest).map(&File.method(:realpath)).first
           end
@@ -58,14 +58,16 @@ module Fastlane
           build_args = params
         end
 
+        # Joins args into space delimited string
         build_args = build_args.join(' ')
-
         Actions.sh "ipa build #{build_args}"
         
+        # Finds absolute path of IPA and dSYM
         absolute_dest_directory ||= Dir.pwd
         absolute_ipa_path = find_ipa_file(absolute_dest_directory)
         absolute_dsym_path = find_dsym_file(absolute_dest_directory)
 
+        # Sets shared values to use after this action is performed
         Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] = absolute_ipa_path
         Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH] = absolute_dsym_path
       end

--- a/spec/actions_specs/ipa_spec.rb
+++ b/spec/actions_specs/ipa_spec.rb
@@ -1,0 +1,116 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "IPA Integration" do
+
+      it "works with default setting" do
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          ipa
+        end").runner.execute(:test)
+
+        expect(result).to eq([])
+      end
+
+      it "works with array of arguments" do
+
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          ipa '-s TestScheme', '-w Test.xcworkspace'
+        end").runner.execute(:test)
+
+        expect(result).to eq(['-s TestScheme', '-w Test.xcworkspace'])
+      end
+
+      it "works with object argument without clean and archive" do
+
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          ipa ({
+            workspace: 'Test.xcworkspace',
+            project: nil,
+            configuration: 'Release',
+            scheme: 'TestScheme',
+            destination: nil,
+            embed: nil,
+            identity: nil,
+            ipa: 'JoshIsAwesome.ipa'
+          })
+        end").runner.execute(:test)
+
+        expect(result.size).to eq(4)
+      end
+
+      it "works with object argument with clean and archive" do
+
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          ipa ({
+            workspace: 'Test.xcworkspace',
+            project: nil,
+            configuration: 'Release',
+            scheme: 'TestScheme',
+            clean: nil,
+            archive: nil,
+            destination: nil,
+            embed: nil,
+            identity: nil,
+            ipa: 'JoshIsAwesome.ipa'
+          })
+        end").runner.execute(:test)
+
+        expect(result.size).to eq(6)
+      end
+
+      it "works with object argument with all" do
+
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          ipa ({
+            workspace: 'Test.xcworkspace',
+            project: 'Test.xcproject',
+            configuration: 'Release',
+            scheme: 'TestScheme',
+            clean: nil,
+            archive: nil,
+            destination: 'Nowhere',
+            embed: 'Sure',
+            identity: 'bourne',
+            sdk: '10.0',
+            ipa: 'JoshIsAwesome.ipa'
+          })
+        end").runner.execute(:test)
+
+        expect(result.size).to eq(11)
+        expect(result).to include('-w Test.xcworkspace')
+        expect(result).to include('-p Test.xcproject')
+        expect(result).to include('-c Release')
+        expect(result).to include('-s TestScheme')
+        expect(result).to include('--clean')
+        expect(result).to include('--archive')
+        expect(result).to include('-d Nowhere')
+        expect(result).to include('-m Sure')
+        expect(result).to include('-i bourne')
+        expect(result).to include('--sdk 10.0')
+        expect(result).to include('--ipa JoshIsAwesome.ipa')
+      end
+
+      it "works with object argument with all and extras" do
+
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          ipa ({
+            workspace: 'Test.xcworkspace',
+            project: 'Test.xcproject',
+            configuration: 'Release',
+            scheme: 'TestScheme',
+            clean: nil,
+            archive: nil,
+            destination: 'Nowhere',
+            embed: 'Sure',
+            identity: 'bourne',
+            sdk: '10.0',
+            ipa: 'JoshIsAwesome.ipa',
+            hehehe: 'hahah'
+          })
+        end").runner.execute(:test)
+
+        expect(result.size).to eq(11)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
**Because** making an IPA is awesome

And added tests!! :whale: :dolphin: :pig: :dog: :cat: :mouse: 
### With an array (uses `ipa build` arguments)

``` ruby
  ipa "-w JoshIsAwesome.xcworkspace", "-s AlwaysBeScheming", "-d ../final_destination"

  ipa_path = Actions.lane_context[ Actions::SharedValues::IPA_OUTPUT_PATH ]
  dsym_path = Actions.lane_context[ Actions::SharedValues::DSYM_OUTPUT_PATH ]
```
### With an object (uses nice keys that we convert to `ipa build` arguments)
- Anything that is nil won't get converted to arguments
  - Except for `clean` and `archive` because they don't take arguments. They **will** get converted if the keys exist in the object. - Does that make sense? Otherwise i can make it use `clean` and `archive` when true, and not use it when false :question: :question: :question:  

``` ruby
ipa({
    workspace: ENV['WORKSPACE'],
    project: nil,
    configuration: nil,
    scheme: ENV['SCHEME'],
    clean: nil,
    archive: nil,
    destination: nil,
    embed: nil,
    identity: nil,
    sdk: nil,
    ipa: 'JoshIsAwesome.ipa'p
  })

  ipa_path = Actions.lane_context[ Actions::SharedValues::IPA_OUTPUT_PATH ]
  dsym_path = Actions.lane_context[ Actions::SharedValues::DSYM_OUTPUT_PATH ]
```
