### PR TITLE
Fixed unit test deprecation warnings

### DIFF
--- a/spec/update_checker_spec.rb
+++ b/spec/update_checker_spec.rb
@@ -40,13 +40,13 @@ describe Fastlane do
 
       it "current: Pre-Release - new official version" do
         mock_ruby_gems_response('0.9.1')
-        Fastlane::UpdateChecker.stub(:current_version) { '0.9.1.pre' }
+        allow(Fastlane::UpdateChecker).to receive(:current_version) { '0.9.1.pre' }
         expect(Fastlane::UpdateChecker.update_available?).to eq(true)
       end
 
       it "a new pre-release when pre-release is installed" do
         mock_ruby_gems_response('0.9.1.pre2')
-        Fastlane::UpdateChecker.stub(:current_version) { '0.9.1.pre1' }
+        allow(Fastlane::UpdateChecker).to receive(:current_version) { '0.9.1.pre1' }
         expect(Fastlane::UpdateChecker.update_available?).to eq(true)
       end
     end


### PR DESCRIPTION
This PR fixes unit test deprecation warnings in `update_checker_spec.rb`.

> Deprecation Warnings:
> 
> Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/janijegoroff/projects/fastlane/spec/update_checker_spec.rb:43:in `block (4 levels) in <top (required)>'.
> 
> If you need more of the backtrace for any of these deprecations to
> identify where to make the necessary changes, you can configure
> `config.raise_errors_for_deprecations!`, and it will turn the
> deprecation warnings into errors, giving you the full backtrace.
> 
> 1 deprecation warning total
> 
> Finished in 2.06 seconds (files took 0.69875 seconds to load)
> 58 examples, 0 failures
