### PR TITLE
Correct function name for HipChat APIv1 response check.

### DIFF
--- a/lib/fastlane/actions/hipchat.rb
+++ b/lib/fastlane/actions/hipchat.rb
@@ -42,7 +42,7 @@ module Fastlane
                                                   'room_id' => channel,
                                                   'message' => message })
 
-            checkResponseCodeForRoom(response, channel)
+            check_response_code(response, channel)
           end
         else
           ########## running on V2 ##########


### PR DESCRIPTION
checkResponseCodeForRoom -> check_response_code

Using HipChat API v1 would cause any fastlane execution to throw an error when attempting to send a HipChat message due to checkResponseCodeForRoom being undefined. Updated function call to the defined function name.
