### PR TITLE
Replace style section of img tag in HipChat messages.

### DIFF
--- a/lib/fastlane/actions/hipchat.rb
+++ b/lib/fastlane/actions/hipchat.rb
@@ -27,7 +27,7 @@ module Fastlane
 
         channel = options[:channel]
         color = (options[:success] ? 'green' : 'red')
-        message = "<table><tr><td><img src=\"https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png\" style=\"width:50px;height:auto\"></td><td>" + options[:message] + '</td></tr></table>'
+        message = "<table><tr><td><img src=\"https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png\" width=\"50\" height=\"50\"></td><td>" + options[:message] + '</td></tr></table>'
 
         if api_version.to_i == 1
           ########## running on V1 ##########


### PR DESCRIPTION
Style tags seem to be currently unsupported by Atlassian in HipChat messages. 

> See: https://twitter.com/hipchat/status/309704328229298177

Replaced style section of img in HipChat message with standard width/height definitions to support properly resizing the fastlane icon.
