### PR TITLE
Custom config file for houndci

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+# Custom config file for houndci (https://houndci.com/)
+
+ruby:
+  config_file: .rubocop.yml


### PR DESCRIPTION
Tell houndci to use our custom config for Rubocop analysis. See https://houndci.com/configuration
