### PR TITLE
houndci - Prefer single quoted strings

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -2,3 +2,6 @@
 
 ruby:
   config_file: .rubocop.yml
+
+StringLiterals:
+  EnforcedStyle: single_quotes


### PR DESCRIPTION
For some reason **houndci** prefers double quoted strings by default:

> Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping

Let's align that rule with Rubocop style guide and prefer single quotes instead.
