### PR TITLE
Made crashlytics_path docs less ambiguous.

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ More information about the available options can be found in the [HockeyApp Docs
 #### [Crashlytics Beta](http://try.crashlytics.com/beta/)
 ```ruby
 crashlytics({
-  crashlytics_path: './path', # path to your 'Crashlytics.framework'
+  crashlytics_path: './Crashlytics.framework', # path to your 'Crashlytics.framework'
   api_token: '...',
   build_secret: '...',
   ipa_path: './app.ipa'


### PR DESCRIPTION
I encountered an error when I tried to use Crashlytics Beta because I took `crashlytics_path: './path', # path to your 'Crashlytics.framework'` to mean the path to the folder where the framework exists, NOT the path to the framework itself. I worry that others may encounter the same confusion, so I think this small change might be less ambiguous.
