### PR TITLE
S3 action

### DIFF
--- a/bin/fastlane
+++ b/bin/fastlane
@@ -29,7 +29,7 @@ class FastlaneApplication
 
       c.action do |args, _options|
         if Fastlane::FastlaneFolder.path
-          Fastlane::LaneManager.cruise_lanes(args, options.env)
+          Fastlane::LaneManager.cruise_lanes(args, _options.env)
         else
           create = agree('Could not find fastlane in current directory. Would you like to set it up? (y/n)'.yellow, true)
           Fastlane::Setup.new.run if create

--- a/lib/assets/s3_html_template.erb
+++ b/lib/assets/s3_html_template.erb
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title><%= title %></title>
+
+  </head>
+
+  <body>
+
+    <div class="site-wrapper">
+
+      <div class="site-wrapper-inner">
+
+        <div class="cover-container">
+
+         <div class="masthead clearfix">
+            <div class="inner">
+              <h3 class="masthead-brand"><%= title %></h3>
+            </div>
+          </div>
+
+          <div class="inner cover">
+            <h1 class="cover-heading"></h1>
+            <p class="lead"></p>
+            <p class="lead">
+              <a href="itms-services://?action=download-manifest&url=itms-services://?action=download-manifest&url=<%= url %>" id="text" class="btn btn-lg btn-default">Install <%= title %> <%= bundle_version %></a>
+            </p>
+          </div>
+
+          <div class="mastfoot">
+            <div class="inner">
+              <p></p>
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+    </div>
+    
+  </body>
+</html>

--- a/lib/assets/s3_html_template.erb
+++ b/lib/assets/s3_html_template.erb
@@ -11,37 +11,11 @@
 
   <body>
 
-    <div class="site-wrapper">
-
-      <div class="site-wrapper-inner">
-
-        <div class="cover-container">
-
-         <div class="masthead clearfix">
-            <div class="inner">
-              <h3 class="masthead-brand"><%= title %></h3>
-            </div>
-          </div>
-
-          <div class="inner cover">
-            <h1 class="cover-heading"></h1>
-            <p class="lead"></p>
-            <p class="lead">
-              <a href="itms-services://?action=download-manifest&url=itms-services://?action=download-manifest&url=<%= url %>" id="text" class="btn btn-lg btn-default">Install <%= title %> <%= bundle_version %></a>
-            </p>
-          </div>
-
-          <div class="mastfoot">
-            <div class="inner">
-              <p></p>
-            </div>
-          </div>
-
-        </div>
-
-      </div>
-
-    </div>
+    <h1 class="masthead-brand"><%= title %></h3>
+ 
+    <p>
+      <a href="itms-services://?action=download-manifest&url=itms-services://?action=download-manifest&url=<%= url %>" id="text" class="btn btn-lg btn-default">Install <%= title %> <%= bundle_version %></a>
+    </p>
     
   </body>
 </html>

--- a/lib/assets/s3_plist_template.erb
+++ b/lib/assets/s3_plist_template.erb
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>items</key>
+  <array>
+    <dict>
+      <key>assets</key>
+      <array>
+        <dict>
+          <key>kind</key>
+          <string>software-package</string>
+          <key>url</key>
+          <string><%= url %></string>
+        </dict>
+      </array>
+      <key>metadata</key>
+      <dict>
+        <key>bundle-identifier</key>
+        <string><%= bundle_id %></string>
+        <key>bundle-version</key>
+        <string><%= bundle_version %></string>
+        <key>kind</key>
+        <string>software</string>
+        <key>title</key>
+        <string><%= title %></string>
+      </dict>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/lib/fastlane/actions/s3.rb
+++ b/lib/fastlane/actions/s3.rb
@@ -1,0 +1,187 @@
+require 'erb'
+require 'ostruct'
+require 'shenzhen'
+
+module Fastlane
+  module Actions
+
+    module SharedValues
+      IPA_OUTPUT_PATH = :IPA_OUTPUT_PATH
+      DSYM_OUTPUT_PATH = :DSYM_OUTPUT_PATH
+    end
+
+    # -f, --file FILE      .ipa file for the build 
+    # -d, --dsym FILE      zipped .dsym package for the build 
+    # -a, --access-key-id ACCESS_KEY_ID AWS Access Key ID 
+    # -s, --secret-access-key SECRET_ACCESS_KEY AWS Secret Access Key 
+    # -b, --bucket BUCKET  S3 bucket 
+    # --[no-]create        Create bucket if it doesn't already exist 
+    # -r, --region REGION  Optional AWS region (for bucket creation) 
+    # --acl ACL            Uploaded object permissions e.g public_read (default), private, public_read_write, authenticated_read 
+    # --source-dir SOURCE  Optional source directory e.g. ./build 
+    # -P, --path PATH      S3 'path'. Values from Info.plist will be substituded for keys wrapped in {}  
+    #              eg. "/path/to/folder/{CFBundleVersion}/" could be evaluated as "/path/to/folder/1.0.0/" 
+
+    ARGS_MAP = {
+      file: '-f',
+      dsym: '-d',
+      access_key: '-a',
+      secret_access_key: '-s',
+      bucket: '--b',
+      acl: '--acl',
+      source: '--source-dir',
+      path: '-P',
+    }
+
+    class S3Action
+      def self.run(params)
+        
+        unless params.first.is_a? Hash
+          return
+        end
+
+        # Other things that we need
+        params = params.first
+        s3_access_key = params[:access_key]
+        s3_secret_access_key = params[:secret_access_key]
+        s3_bucket = params[:bucket]
+        ipa_file = params[:file]
+        s3_path = params[:path]
+
+        plist_template_path = params[:plist_template_path]
+        html_template_path = params[:html_template_path]
+
+        # Maps nice developer build parameters to Shenzhen args
+        build_args = params_to_build_args(params)
+
+        # If no dest directory given, default to current directory
+        absolute_dest_directory ||= Dir.pwd
+
+        if Helper.is_test?
+          # Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] = File.join(absolute_dest_directory, "test.ipa")
+          # Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH] = File.join(absolute_dest_directory, "test.app.dSYM.zip")
+          return build_args 
+        end
+
+        # Joins args into space delimited string
+        build_args = build_args.join(' ')
+
+        command = "ipa distribute:s3 #{build_args}"
+        Helper.log.debug command
+        Actions.sh command
+
+        #####################################
+        #
+        # Does plist stuff
+        #
+        #####################################
+
+        # Gets values for plist
+        url_part = expand_path_with_substitutions_from_ipa_plist( ipa_file, s3_path )
+        url = "https://s3.amazonaws.com/#{s3_bucket}/#{url_part}#{ipa_file}"
+
+        bundle_id, bundle_version, title = nil
+        Dir.mktmpdir do |dir|
+
+          system "unzip -q #{ipa_file} -d #{dir} 2> /dev/null"
+          plist = Dir["#{dir}/**/*.app/Info.plist"].last
+
+          bundle_id = Shenzhen::PlistBuddy.print(plist, 'CFBundleIdentifier')
+          bundle_version = Shenzhen::PlistBuddy.print(plist, 'CFBundleShortVersionString')
+          title = Shenzhen::PlistBuddy.print(plist, 'CFBundleName')
+
+        end
+
+        plist_template_path ||= "#{Helper.gem_path}/lib/assets/s3_plist_template.erb"
+        plist_template = File.read(plist_template_path)
+
+        et = ErbalT.new({
+          url: url,
+          bundle_id: bundle_id,
+          bundle_version: bundle_version,
+          title: title
+          })
+        plist_render = et.render(plist_template)
+
+        
+        #####################################
+        #
+        # Does html stuff
+        #
+        #####################################
+
+        html_template_path ||= "#{Helper.gem_path}/lib/assets/s3_html_template.erb"
+        html_template = File.read(html_template_path)
+
+        et = ErbalT.new({
+          url: url,
+          bundle_id: bundle_id,
+          bundle_version: bundle_version,
+          title: title
+          })
+        html_render = et.render(html_template)
+
+        #####################################
+        #
+        # Does upload to s3 stuff
+        #
+        #####################################
+
+        s3_client = AWS::S3.new(
+            access_key_id: s3_access_key,
+            secret_access_key: s3_secret_access_key
+        )
+        bucket = s3_client.buckets[s3_bucket]
+        plist_file_name = "#{url_part}#{title}.plist"
+        bucket.objects.create(plist_file_name, plist_render.to_s, :acl => :public_read)
+
+        bucket.objects.create("index.html", html_render.to_s, :acl => :public_read)
+
+        return true
+
+      end
+
+      def self.params_to_build_args(params)
+        # Remove nil value params unless :clean or :archive
+        params = params.delete_if { |k, v| (k != :clean && k != :archive ) && v.nil? }
+
+        # Maps nice developer param names to Shenzhen's `ipa build` arguments
+        params.collect do |k,v|
+          v ||= ''
+          if args = ARGS_MAP[k]
+            value = (v.to_s.length > 0 ? "\"#{v}\"" : "")
+            "#{ARGS_MAP[k]} #{value}".strip
+          end
+        end.compact
+      end
+
+      def self.expand_path_with_substitutions_from_ipa_plist(ipa, path)
+        substitutions = path.scan(/\{CFBundle[^}]+\}/)
+        return path if substitutions.empty?
+
+        Dir.mktmpdir do |dir|
+          system "unzip -q #{ipa} -d #{dir} 2> /dev/null"
+
+          plist = Dir["#{dir}/**/*.app/Info.plist"].last
+
+          substitutions.uniq.each do |substitution|
+            key = substitution[1...-1]
+            value = Shenzhen::PlistBuddy.print(plist, key)
+
+            path.gsub!(Regexp.new(substitution), value) if value
+          end
+        end
+
+        return path
+      end
+
+    end
+
+  end
+end
+
+class ErbalT < OpenStruct
+  def render(template)
+    ERB.new(template).result(binding)
+  end
+end

--- a/lib/fastlane/actions/s3.rb
+++ b/lib/fastlane/actions/s3.rb
@@ -73,8 +73,6 @@ module Fastlane
         html_file_name = params[:html_file_name]
 
         if Helper.is_test?
-          # Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] = File.join(absolute_dest_directory, "test.ipa")
-          # Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH] = File.join(absolute_dest_directory, "test.app.dSYM.zip")
           return build_args 
         end
 

--- a/lib/fastlane/actions/s3.rb
+++ b/lib/fastlane/actions/s3.rb
@@ -92,7 +92,7 @@ module Fastlane
         html_url = "https://s3.amazonaws.com/#{s3_bucket}/#{html_file_name}"
 
         # Creates plist from template
-        plist_template_path ||= "#{Helper.gem_path}/lib/assets/s3_plist_template.erb"
+        plist_template_path ||= "#{Helper.gem_path('fastlane')}/lib/assets/s3_plist_template.erb"
         plist_template = File.read(plist_template_path)
 
         et = ErbalT.new({
@@ -104,7 +104,7 @@ module Fastlane
         plist_render = et.render(plist_template)
 
         # Creates html from template
-        html_template_path ||= "#{Helper.gem_path}/lib/assets/s3_html_template.erb"
+        html_template_path ||= "#{Helper.gem_path('fastlane')}/lib/assets/s3_html_template.erb"
         html_template = File.read(html_template_path)
 
         et = ErbalT.new({

--- a/lib/fastlane/actions/s3.rb
+++ b/lib/fastlane/actions/s3.rb
@@ -74,7 +74,7 @@ module Fastlane
 
         #####################################
         #
-        # Does plist stuff
+        # html and plist building
         #
         #####################################
 
@@ -117,7 +117,7 @@ module Fastlane
 
         #####################################
         #
-        # Does upload to s3 stuff
+        # html and plist uploading
         #
         #####################################
 

--- a/spec/actions_specs/s3_spec.rb
+++ b/spec/actions_specs/s3_spec.rb
@@ -1,0 +1,133 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "S3 Integration" do
+
+# raise "No S3 access key given, pass using `access_key: 'key'`".red unless s3_access_key.to_s.length > 0
+# raise "No S3 secret access key given, pass using `secret_access_key: 'secret key'`".red unless s3_secret_access_key.to_s.length > 0
+# raise "No S3 bucket given, pass using `bucket: 'bucket'`".red unless s3_bucket.to_s.length > 0
+# raise "No IPA file path given, pass using `ipa: 'ipa path'`".red unless ipa_file.to_s.length > 0
+
+      it "raise an error if no S3 access key was given" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do 
+            s3({})
+          end").runner.execute(:test)
+        }.to raise_error("No S3 access key given, pass using `access_key: 'key'`".red)
+      end
+
+      it "raise an error if no S3 secret access key was given" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do 
+            s3({
+              access_key: 'access_key'
+              })
+          end").runner.execute(:test)
+        }.to raise_error("No S3 secret access key given, pass using `secret_access_key: 'secret key'`".red)
+      end
+
+      it "raise an error if no S3 bucket was given" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do 
+            s3({
+              access_key: 'access_key',
+              secret_access_key: 'secret_access_key'
+              })
+          end").runner.execute(:test)
+        }.to raise_error("No S3 bucket given, pass using `bucket: 'bucket'`".red)
+      end
+
+      it "raise an error if no IPA was given" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do 
+            s3({
+              access_key: 'access_key',
+              secret_access_key: 'secret_access_key',
+              bucket: 'bucket'
+              })
+          end").runner.execute(:test)
+        }.to raise_error("No IPA file path given, pass using `ipa: 'ipa path'`".red)
+      end
+
+      it "raise an error if no IPA was given" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do 
+            s3({
+              access_key: 'access_key',
+              secret_access_key: 'secret_access_key',
+              bucket: 'bucket'
+              })
+          end").runner.execute(:test)
+        }.to raise_error("No IPA file path given, pass using `ipa: 'ipa path'`".red)
+      end
+
+      it "works with required arguments" do
+
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          s3({
+              access_key: 'access_key',
+              secret_access_key: 'secret_access_key',
+              bucket: 'bucket',
+              ipa: 'ipa'
+              })
+        end").runner.execute(:test)
+
+        expect(result.size).to eq(5) # 5 because path is defaulted
+        expect(result).to include('-a "access_key"')
+        expect(result).to include('-s "secret_access_key"')
+        expect(result).to include('-b "bucket"')
+        expect(result).to include('-f "ipa"')
+        expect(result).to include('-P "v{CFBundleShortVersionString}_b{CFBundleVersion}/"')
+
+      end
+
+      it "works with required arguments and dsym and path" do
+
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          s3({
+              access_key: 'access_key',
+              secret_access_key: 'secret_access_key',
+              bucket: 'bucket',
+              ipa: 'ipa',
+              dsym: 'dsym',
+              path: './'
+              })
+        end").runner.execute(:test)
+
+        expect(result.size).to eq(6) # 6 because path is defaulted
+        expect(result).to include('-a "access_key"')
+        expect(result).to include('-s "secret_access_key"')
+        expect(result).to include('-b "bucket"')
+        expect(result).to include('-f "ipa"')
+        expect(result).to include('-d "dsym"')
+        expect(result).to include('-P "./"')
+
+      end
+
+      it "works with no arguments (magic variables)" do
+
+        # Environment variables
+        ENV['S3_ACCESS_KEY'] = 'access_key'
+        ENV['S3_SECRET_ACCESS_KEY'] = 'secret_access_key'
+        ENV['S3_BUCKET'] = 'bucket'
+
+        # IPA Action
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::IPA_OUTPUT_PATH] = 'ipa'
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DSYM_OUTPUT_PATH] = 'dsym'
+
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          s3({})
+        end").runner.execute(:test)
+
+        expect(result.size).to eq(6) # 6 because path is defaulted
+        expect(result).to include('-a "access_key"')
+        expect(result).to include('-s "secret_access_key"')
+        expect(result).to include('-b "bucket"')
+        expect(result).to include('-f "ipa"')
+        expect(result).to include('-d "dsym"')
+        expect(result).to include('-P "v{CFBundleShortVersionString}_b{CFBundleVersion}/"')
+
+      end
+
+    end
+  end
+end

--- a/spec/actions_specs/s3_spec.rb
+++ b/spec/actions_specs/s3_spec.rb
@@ -2,10 +2,13 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "S3 Integration" do
 
-# raise "No S3 access key given, pass using `access_key: 'key'`".red unless s3_access_key.to_s.length > 0
-# raise "No S3 secret access key given, pass using `secret_access_key: 'secret key'`".red unless s3_secret_access_key.to_s.length > 0
-# raise "No S3 bucket given, pass using `bucket: 'bucket'`".red unless s3_bucket.to_s.length > 0
-# raise "No IPA file path given, pass using `ipa: 'ipa path'`".red unless ipa_file.to_s.length > 0
+      before(:each) do
+        ENV['S3_ACCESS_KEY'] = nil
+        ENV['S3_SECRET_ACCESS_KEY'] = nil
+        ENV['S3_BUCKET'] = nil
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::IPA_OUTPUT_PATH] = nil
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DSYM_OUTPUT_PATH] = nil
+      end
 
       it "raise an error if no S3 access key was given" do
         expect {


### PR DESCRIPTION
And we now have S3 action :boom: :boom: :boom: :boom: 
## Things to improve upon yet (in another PR probably)
- Styles on the HTML template (its SUPER generic looking)
  - Could use some `fastlane` branding possibly
- Really waiting on this `shenzhen` PR to go through so I can remove some duplicate code - https://github.com/nomad/shenzhen/pull/215
## Default S3 Directory Structurer (determined by `:path`)
- fastlane-test-bucket
  - index.html
  - v0.9.0_b20
    - AppName.app.dSYM.zip
    - AppName.ipa
    - AppName.plist
## Examples

``` ruby
lane :do_s3_could_be_this_easy do
  # When paired with IpaAction and ENV settings
  ipa({})
  s3({})
end

lane :do_s3_should_be_this_easy do
  # When paired with IpaAction
  ipa({})
  s3({
    access_key: ENV['S3_ACCESS_KEY']
    secret_access_key: ENV['S3_SECRET_ACCESS_KEY']
    bucket: ENV['S3_BUCKET']
  })
end

lane :do_s3_all_the_things do
  s3({
    # All of these are used to make Shenzhen's `ipa distribute:s3` command
    access_key: ENV['S3_ACCESS_KEY'], # Required from user
    secret_access_key: ENV['S3_SECRET_ACCESS_KEY'], # Required from user
    bucket: ENV['S3_BUCKET'], # Required from user
    file: 'AppName.ipa', # This would come from IpaAction
    dsym: 'AppName.app.dSYM.zip', # This would come from IpaAction
    path: 'v{CFBundleShortVersionString}_b{CFBundleVersion}/', # This is actually the default

    # These are optional used to the plist and html file uploaded to S3
    # Templates default to packaged ones in the gem
    # HTML file name defaults to 'index.html'
    plist_template_path: ".fastlane/my_app_s3_plist_template.erb",
    html_template_path: "./fastlane/my_app_s3_html_template.erb",
    html_file_name: "download_this.html"
    })
end
```
