### PR TITLE
Add verbose parameter to ipa action

### DIFF
--- a/lib/fastlane/actions/ipa.rb
+++ b/lib/fastlane/actions/ipa.rb
@@ -30,7 +30,8 @@ module Fastlane
       embed: '-m',
       identity: '-i',
       sdk: '--sdk',
-      ipa: '--ipa'
+      ipa: '--ipa',
+      verbose: '--verbose'
     }
 
     class IpaAction
@@ -84,8 +85,8 @@ module Fastlane
       end
 
       def self.params_to_build_args(params)
-        # Remove nil value params unless :clean or :archive
-        params = params.delete_if { |k, v| (k != :clean && k != :archive) && v.nil? }
+        # Remove nil value params unless :clean or :archive or :verbose
+        params = params.delete_if { |k, v| (k != :clean && k != :archive && k != :verbose) && v.nil? }
 
         # Maps nice developer param names to Shenzhen's `ipa build` arguments
         params.collect do |k, v|

--- a/spec/actions_specs/ipa_spec.rb
+++ b/spec/actions_specs/ipa_spec.rb
@@ -19,7 +19,7 @@ describe Fastlane do
         expect(result).to eq(['-s TestScheme', '-w Test.xcworkspace'])
       end
 
-      it "works with object argument without clean and archive" do
+      it "works with object argument without clean and archive and verbose" do
 
         result = Fastlane::FastFile.new.parse("lane :test do 
           ipa ({
@@ -37,7 +37,7 @@ describe Fastlane do
         expect(result.size).to eq(4)
       end
 
-      it "works with object argument with clean and archive" do
+      it "works with object argument with clean and archive and verbose" do
 
         result = Fastlane::FastFile.new.parse("lane :test do 
           ipa ({
@@ -50,11 +50,12 @@ describe Fastlane do
             destination: nil,
             embed: nil,
             identity: nil,
-            ipa: 'JoshIsAwesome.ipa'
+            ipa: 'JoshIsAwesome.ipa',
+            verbose: nil
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq(6)
+        expect(result.size).to eq(7)
       end
 
       it "works with object argument with all" do
@@ -71,11 +72,12 @@ describe Fastlane do
             embed: 'Sure',
             identity: 'bourne',
             sdk: '10.0',
-            ipa: 'JoshIsAwesome.ipa'
+            ipa: 'JoshIsAwesome.ipa',
+            verbose: nil
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq(11)
+        expect(result.size).to eq(12)
         expect(result).to include('-w "Test.xcworkspace"')
         expect(result).to include('-p "Test.xcproject"')
         expect(result).to include('-c "Release"')
@@ -87,6 +89,7 @@ describe Fastlane do
         expect(result).to include('-i "bourne"')
         expect(result).to include('--sdk "10.0"')
         expect(result).to include('--ipa "JoshIsAwesome.ipa"')
+        expect(result).to include('--verbose')
       end
 
       it "works with object argument with all and extras" do
@@ -104,11 +107,12 @@ describe Fastlane do
             identity: 'bourne',
             sdk: '10.0',
             ipa: 'JoshIsAwesome.ipa',
+            verbose: nil,
             hehehe: 'hahah'
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq(11)
+        expect(result.size).to eq(12)
       end
 
     end


### PR DESCRIPTION
I'm using fastlane with CircleCI that will be timeout if no output more thant 10 minutes since last output.

I created a PR in order to use `ipa build --verbose`.

CircleCI's log

```
INFO [2015-03-01 08:15:34.74]: -----------------
INFO [2015-03-01 08:15:34.74]: --- Step: ipa ---
INFO [2015-03-01 08:15:34.74]: -----------------
DEBUG [2015-03-01 08:15:34.74]: ipa build -w "Clip.xcworkspace" -c "Adhoc" -s "ClipAdhoc"
INFO [2015-03-01 08:15:34.74]: [SHELL COMMAND]: ipa build -w "Clip.xcworkspace" -c "Adhoc" -s "ClipAdhoc"
INFO [2015-03-01 08:15:47.21]: [SHELL OUTPUT]: xcodebuild  Clip.xcworkspace

INFO [2015-03-01 08:15:55.10]: [SHELL OUTPUT]: 2015-03-01 08:15:55.102 xcodebuild[22971:5907] DeveloperPortal: Using pre-existing current store at URL (file:///Users/distiller/Library/Developer/Xcode/DeveloperPortal%206.1.1.db). command bundle exec fastlane team took more than 10 minutes since last output
```
