### PR TITLE
Added xcode_select action

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/KrauseFx/frameit">frameit</a> &bull;
   <a href="https://github.com/KrauseFx/PEM">PEM</a> &bull;
   <a href="https://github.com/KrauseFx/sigh">sigh</a> &bull;
-  <a href="https://github.com/KrauseFx/produce">produce</a> &bull; 
+  <a href="https://github.com/KrauseFx/produce">produce</a> &bull;
   <a href="https://github.com/KrauseFx/cert">cert</a> &bull;
   <a href="https://github.com/KrauseFx/codes">codes</a>
 </p>
@@ -215,7 +215,7 @@ ipa({
 })
 ```
 
-The `ipa` action uses [shenzhen](https://github.com/nomad/shenzhen) under the hood. 
+The `ipa` action uses [shenzhen](https://github.com/nomad/shenzhen) under the hood.
 
 The path to the `ipa` is automatically used by `Crashlytics`, `Hockey` and `DeployGate`. To also use it in `deliver` update your `Deliverfile`:
 
@@ -355,6 +355,16 @@ gcovr({
   html_details: true,
   output: "./code-coverage/report.html"
 })
+```
+
+#### [xcode_select](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/xcode-select.1.html)
+Sets the active developer directory used by xcrun, xcodebuild, cc, and other Xcode
+and BSD development tools. This is very useful if you need to support multiple
+versions of Xcode in your build environment.
+
+```ruby
+# Select the desired Xcode version
+xcode_select "/Applications/Xcode6.1.app"
 ```
 
 #### Custom Shell Scripts
@@ -508,7 +518,7 @@ before_all do |lane|
   increment_build_number
   cocoapods
   xctool :test
-  
+
   ipa({
     workspace: "MyApp.xcworkspace"
   })

--- a/lib/fastlane/actions/xcode_select.rb
+++ b/lib/fastlane/actions/xcode_select.rb
@@ -1,0 +1,36 @@
+module Fastlane
+  module Actions
+    # See: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/xcode-select.1.html
+    #
+    # DESCRIPTION
+    #   xcode-select controls the location of the developer directory used by xcrun(1), xcodebuild(1), cc(1),
+    #   and other Xcode and BSD development tools. This also controls the locations that are searched for  by
+    #   man(1) for developer tool manpages.
+    #
+    # DEVELOPER_DIR
+    #   Overrides the active developer directory. When DEVELOPER_DIR  is  set,  its  value  will  be  used
+    #   instead of the system-wide active developer directory.
+    #
+    #   Note that for historical reason, the developer directory is considered to be the Developer content
+    #   directory inside the Xcode application (for  example  /Applications/Xcode.app/Contents/Developer).
+    #   You  can  set  the  environment variable to either the actual Developer contents directory, or the
+    #   Xcode application directory -- the xcode-select provided  shims  will  automatically  convert  the
+    #   environment variable into the full Developer content path.
+    #
+    class XcodeSelectAction
+      def self.run(params)
+        xcode_path = params.first
+
+        # Verify that a param was passed in
+        raise "Path to Xcode application required (e.x. \"/Applications/Xcode.app\")".red unless xcode_path.to_s.length > 0
+
+        # Verify that a path to a directory was passed in
+        raise "Nonexistent path provided".red unless Dir.exists? xcode_path
+
+        Helper.log.info "Setting Xcode version to #{xcode_path} for all build steps"
+
+        ENV["DEVELOPER_DIR"] = xcode_path + "/Contents/Developer"
+      end
+    end
+  end
+end

--- a/spec/actions_specs/xcode_select_spec.rb
+++ b/spec/actions_specs/xcode_select_spec.rb
@@ -22,7 +22,6 @@ describe Fastlane do
       end
 
       it "throws an exception if the Xcode path is not a valid directory" do
-
         expect {
           Fastlane::FastFile.new.parse("lane :test do
             xcode_select \"#{invalid_path}\"
@@ -31,7 +30,6 @@ describe Fastlane do
       end
 
       it "sets the DEVELOPER_DIR environment variable" do
-
         Fastlane::FastFile.new.parse("lane :test do
           xcode_select \"#{valid_path}\"
         end").runner.execute(:test)

--- a/spec/actions_specs/xcode_select_spec.rb
+++ b/spec/actions_specs/xcode_select_spec.rb
@@ -1,0 +1,43 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Xcode Select Integration" do
+      let(:invalid_path) { "/path/to/nonexistent/dir" }
+      let(:valid_path) { "/valid/path/to/xcode" }
+
+      before(:each) do
+        allow(Dir).to receive(:exists?).with(invalid_path).and_return(false)
+        allow(Dir).to receive(:exists?).with(valid_path).and_return(true)
+      end
+
+      after(:each) do
+        ENV.delete "DEVELOPER_DIR"
+      end
+
+      it "throws an exception if no params are passed" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+            xcode_select
+          end").runner.execute(:test)
+        }.to raise_error("Path to Xcode application required (e.x. \"/Applications/Xcode.app\")".red)
+      end
+
+      it "throws an exception if the Xcode path is not a valid directory" do
+
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+            xcode_select \"#{invalid_path}\"
+          end").runner.execute(:test)
+        }.to raise_error("Nonexistent path provided".red)
+      end
+
+      it "sets the DEVELOPER_DIR environment variable" do
+
+        Fastlane::FastFile.new.parse("lane :test do
+          xcode_select \"#{valid_path}\"
+        end").runner.execute(:test)
+
+        expect(ENV["DEVELOPER_DIR"]).to eq(valid_path + "/Contents/Developer")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The xcode_select action allows specific targeting Sets the active
developer directory used by xcrun, xcodebuild, cc, and other Xcode
and BSD development tools. This is very useful if you need to support
multiple versions of Xcode in your build environment.

Usage example:

``` ruby
# Select the desired Xcode version
xcode_select "/Applications/Xcode6.1.app"
```

Includes action, spec, & README description. :cake: 
