### PR TITLE
Added support for setting Crashlytics' notifications option

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ crashlytics({
   ipa_path: './app.ipa'
 })
 ```
-Additionally you can specify `notes_path`, `emails` and `groups`.
+Additionally you can specify `notes_path`, `emails`, `groups` and `notifications`.
 
 #### [DeployGate](https://deploygate.com/)
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'nokogiri', '~> 1.6.5' # generating JUnit reports for Jenkins
-  spec.add_dependency 'shenzhen', '~> 0.11.0' # to upload to Hockey and Crashlytics
+  spec.add_dependency 'shenzhen', '~> 0.12.1' # to upload to Hockey and Crashlytics
   spec.add_dependency 'slack-notifier', '~> 1.0' # Slack notifications
   spec.add_dependency "aws-sdk", "~> 1.0" # Upload ipa files to S3
 

--- a/lib/fastlane/actions/crashlytics.rb
+++ b/lib/fastlane/actions/crashlytics.rb
@@ -20,6 +20,7 @@ module Fastlane
         notes_path       = params[:notes_path]
         emails           = params[:emails]
         groups           = params[:groups]
+        notifications    = params[:notifications]
 
         assert_valid_params!(crashlytics_path, api_token, build_secret, ipa_path)
 
@@ -29,7 +30,7 @@ module Fastlane
 
         client = Shenzhen::Plugins::Crashlytics::Client.new(crashlytics_path, api_token, build_secret)
 
-        response = client.upload_build(ipa_path, file: ipa_path, notes: notes_path, emails: emails, groups: groups)
+        response = client.upload_build(ipa_path, file: ipa_path, notes: notes_path, emails: emails, groups: groups, notifications: notifications)
 
         if response
           Helper.log.info 'Build successfully uploaded to Crashlytics'.green


### PR DESCRIPTION
Added support for suppressing the Crashlytics email notification.

Use case: I am setting up a build server which automatically builds the app and distributes it to testers whenever a commit is made on master, so they can always test the latest version. However I don't want to spam all my testers to death.

Relies on pending PR to Shenzen: https://github.com/nomad/shenzhen/pull/218
