### PR TITLE
Using new sigh that extends fastlane_core classes

### DIFF
--- a/lib/fastlane/actions/sigh.rb
+++ b/lib/fastlane/actions/sigh.rb
@@ -10,9 +10,9 @@ module Fastlane
         require 'sigh'
         require 'credentials_manager/appfile_config'
 
-        type = FastlaneCore::DeveloperCenter::APPSTORE
-        type = FastlaneCore::DeveloperCenter::ADHOC if params.include? :adhoc
-        type = FastlaneCore::DeveloperCenter::DEVELOPMENT if params.include? :development
+        type = Sigh::DeveloperCenter::APPSTORE
+        type = Sigh::DeveloperCenter::ADHOC if params.include? :adhoc
+        type = Sigh::DeveloperCenter::DEVELOPMENT if params.include? :development
         force = params.include? :force
 
         return type if Helper.test?
@@ -21,7 +21,7 @@ module Fastlane
         raise 'No app_identifier definied in `./fastlane/Appfile`'.red unless app
 
         CredentialsManager::PasswordManager.shared_manager(ENV['SIGH_USERNAME']) if ENV['SIGH_USERNAME']
-        path = FastlaneCore::DeveloperCenter.new.run(app, type, nil, force)
+        path = Sigh::DeveloperCenter.new.run(app, type, nil, force)
         output_path = File.expand_path(File.join('.', File.basename(path)))
         FileUtils.mv(path, output_path)
         Helper.log.info "Exported provisioning profile to '#{output_path}'".green


### PR DESCRIPTION
@KrauseFx I am creating this PR right on `fastlane` because this will need your collaboration as well

Unit tests would not pass locally because they depended on changes from a gem that has not yet be released because the changes are in this PR - https://github.com/KrauseFx/sigh/pull/54

Should close #91 
