### PR TITLE
Adds `resign` action

### DIFF
--- a/lib/fastlane/actions/resign.rb
+++ b/lib/fastlane/actions/resign.rb
@@ -1,0 +1,29 @@
+module Fastlane
+  module Actions
+    # Resigns the ipa
+    class ResignAction
+      def self.run(params)
+        require 'sigh'
+
+        params = params.first
+
+        raise 'You must pass valid params to the resign action. Please check the README.md'.red if (params.nil? || params.empty?)
+
+        ipa                   = params[:ipa] || Actions.lane_context[SharedValues::IPA_OUTPUT_PATH]
+        signing_identity      = params[:signing_identity]
+        provisioning_profile  = params[:provisioning_profile] || Actions.lane_context[SharedValues::SIGH_PROFILE_PATH]
+
+        raise 'Please pass a valid ipa which should be a path to an ipa on disk'.red unless ipa
+        raise 'Please pass a valid signing_identity'.red unless signing_identity
+        raise 'Please pass a valid provisioning_profile which should be a path to a profile on disk.'.red unless provisioning_profile
+
+        # try to resign the ipa
+        if Sigh::Resign.resign(ipa, signing_identity, provisioning_profile)
+          Helper.log.info 'Successfully re-signed .ipa 🔏.'.green
+        else
+          raise 'Failed to re-sign .ipa'.red
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds an action to fastlane for resigning an already built ipa. Useful in cases where you build an ipa and then want to sign it after the fact.

A somewhat live-world example:

``` ruby
before_all do |lane|
  cocoapods

  # builds ipa for all lanes
  ipa(
    workspace: '...',
    scheme: '...',
  )
end

lane :crashlytics do
  cert
  sigh :adhoc

  resign(
    signing_identity: '<ad hoc signing identity>'
  )

  crashlytics(
    groups: '...',
    crashlytics_path: './Pods/CrashlyticsFramework/Crashlytics.framework',
    api_token: '...',
    build_secret: '...',
  )
end

lane :appstore do
  cert
  sigh

  resign(
    signing_identity: '<distribution signing identity>'
  )

  deliver
end
```

Warning: .gemspec should be updated to require the latest sigh as this depends on the functionality from https://github.com/KrauseFx/sigh/pull/55
