### PR TITLE
Adds `clean_build_artifacts` action

### DIFF
--- a/lib/fastlane/actions/clean_build_artifacts.rb
+++ b/lib/fastlane/actions/clean_build_artifacts.rb
@@ -1,0 +1,15 @@
+module Fastlane
+  module Actions
+    class CleanBuildArtifactsAction
+      def self.run(_params)
+        [
+          Actions.lane_context[Actions::SharedValues::IPA_OUTPUT_PATH],
+          Actions.lane_context[Actions::SharedValues::SIGH_PROFILE_PATH],
+          Actions.lane_context[Actions::SharedValues::DSYM_OUTPUT_PATH],
+        ].reject { |file| file.nil? || !File.exist?(file) }.each { |file| File.delete(file) }
+
+        Helper.log.info 'Cleaned up build artefacts 🐙'.green
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a `clean_build_artifacts` action which deletes the files that get put in your repo as a result of running the `ipa` and `sigh` commands. It doesn't delete the `fastlane/report.xml` though, this is probably more suited for the .gitignore.

Useful if you quickly want to send out a test build by dropping down to the command line and typing `fastlane beta`, without leaving your repo in a messy state.
