### PR TITLE
Adds `ensure_git_status_clean` action

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'shenzhen', '~> 0.11.0' # to upload to Hockey and Crashlytics
   spec.add_dependency 'slack-notifier', '~> 1.0' # Slack notifications
   spec.add_dependency "aws-sdk", "~> 1.0" # Upload ipa files to S3
+  spec.add_dependency 'rugged', '~> 0.21'
 
   spec.add_dependency 'fastlane_core', '>= 0.2.1' # all shared code and dependencies
   

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'shenzhen', '~> 0.11.0' # to upload to Hockey and Crashlytics
   spec.add_dependency 'slack-notifier', '~> 1.0' # Slack notifications
   spec.add_dependency "aws-sdk", "~> 1.0" # Upload ipa files to S3
-  spec.add_dependency 'xcodeproj', '~> 0.22'
 
   spec.add_dependency 'fastlane_core', '>= 0.2.1' # all shared code and dependencies
   

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'shenzhen', '~> 0.11.0' # to upload to Hockey and Crashlytics
   spec.add_dependency 'slack-notifier', '~> 1.0' # Slack notifications
   spec.add_dependency "aws-sdk", "~> 1.0" # Upload ipa files to S3
-  spec.add_dependency 'rugged', '~> 0.21'
+  spec.add_dependency 'xcodeproj', '~> 0.22'
 
   spec.add_dependency 'fastlane_core', '>= 0.2.1' # all shared code and dependencies
   

--- a/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -7,19 +7,13 @@ module Fastlane
     # Raises an exception and stop the lane execution if the repo is not in a clean state
     class EnsureGitStatusCleanAction
       def self.run(_params)
-        require 'rugged'
+        repo_clean = `git status --porcelain`.empty?
 
-        repo = Rugged::Repository.discover(File.expand_path(Dir.pwd))
-
-        statuses = []
-        repo.status { |_, status| statuses << status }
-        dirty = statuses.flatten.reject { |status| status == :ignored }.count > 0
-
-        if !dirty
+        if repo_clean
           Helper.log.info 'Git status is clean, all good! 💪'.green
           Actions.lane_context[SharedValues::GIT_REPO_WAS_CLEAN_ON_START] = true
         else
-          raise 'git repository is dirty! Please commit or discard all changes first.'.red if dirty
+          raise 'Git repository is dirty! Please ensure the repo is in a clean state by commiting/stashing/discarding all changes first.'.red
         end
       end
     end

--- a/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -1,0 +1,27 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      GIT_REPO_WAS_CLEAN_ON_START = :GIT_REPO_WAS_CLEAN_ON_START
+    end
+
+    # Raises an exception and stop the lane execution if the repo is not in a clean state
+    class EnsureGitStatusCleanAction
+      def self.run(_params)
+        require 'rugged'
+
+        repo = Rugged::Repository.discover(File.expand_path(Dir.pwd))
+
+        statuses = []
+        repo.status { |_, status| statuses << status }
+        dirty = statuses.flatten.reject { |status| status == :ignored }.count > 0
+
+        if !dirty
+          Helper.log.info 'Git status is clean, all good! 💪'.green
+          Actions.lane_context[SharedValues::GIT_REPO_WAS_CLEAN_ON_START] = true
+        else
+          raise 'git repository is dirty! Please commit or discard all changes first.'.red if dirty
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
A sanity check to make sure you are working in a repo that is clean. Especially useful to put at the beginning if some of your other actions will touch your filesystem, or do things to your git repo. Also needed as a prerequisite for some other actions.

This does rely on `rugged`, which is a gem with a native extension... Hope that's not an issue.
