### PR TITLE
Added `reset_git_repo` action

### DIFF
--- a/lib/fastlane/actions/reset_git_repo.rb
+++ b/lib/fastlane/actions/reset_git_repo.rb
@@ -1,0 +1,16 @@
+module Fastlane
+  module Actions
+    # Does a hard reset and clean on the repo
+    class ResetGitRepoAction
+      def self.run(params)
+        if params.include?(:force) || Actions.lane_context[SharedValues::GIT_REPO_WAS_CLEAN_ON_START]
+          Actions.sh('git reset --hard HEAD')
+          Actions.sh('git clean -qfdx')
+          Helper.log.info 'Git repo was reset and cleaned back to a pristine state.'.green
+        else
+          raise 'This is a destructive and potentially dangerous action. To protect from data loss, please add the `ensure_git_status_clean` action to the beginning of your lane, or if you\'re absolutely sure of what you\'re doing then call this action with the :force option.'.red
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Useful in case you need to revert the repo back to a clean state after the fastlane run.

It's a pretty drastic action so it comes with a sort of safety latch. So it will only go through with the reset if either of these conditions are met:
- You have to call the `ensure_git_status_clean` action prior to calling this action. This ensures that your repo started off in a clean state, so the only things that will get destroyed by this action are files that are created as a byproduct of the fastlane run.
- You call it with the `:force` option, in which case "you have been warned".

Example (see the error block):

``` ruby
before_all do |lane|
  ensure_git_status_clean

  cocoapods

  # builds ipa for all lanes
  ipa(
    workspace: '...',
    scheme: '...',
  )
end

lane :crashlytics do
  cert
  sigh :adhoc

  resign(
    signing_identity: '<ad hoc signing identity>'
  )

  crashlytics(
    groups: '...',
    crashlytics_path: './Pods/CrashlyticsFramework/Crashlytics.framework',
    api_token: '...',
    build_secret: '...',
  )
end

error do |lane, exception|
  reset_git_repo
end
```
