### PR TITLE
Add `add_git_tag` action

### DIFF
--- a/lib/fastlane/actions/add_git_tag.rb
+++ b/lib/fastlane/actions/add_git_tag.rb
@@ -5,13 +5,13 @@ module Fastlane
       def self.run(params)
         params = params.first
 
-        grouping  = (params && params[:grouping]) || 'builds'
-        prefix    = (params && params[:prefix]) || ''
+        grouping      = (params && params[:grouping]) || 'builds'
+        prefix        = (params && params[:prefix]) || ''
+        build_number  = (params && params[:build_number]) || Actions.lane_context[Actions::SharedValues::BUILD_NUMBER]
+        
+        lane_name     = Actions.lane_context[Actions::SharedValues::LANE_NAME]
 
-        lane_name = Actions.lane_context[Actions::SharedValues::LANE_NAME]
-        build_version = Actions.lane_context[Actions::SharedValues::BUILD_NUMBER]
-
-        Actions.sh("git tag #{grouping}/#{lane_name}/#{prefix}#{build_version}")
+        Actions.sh("git tag #{grouping}/#{lane_name}/#{prefix}#{build_number}")
 
         Helper.log.info 'Added git tag 🎯.'
       end

--- a/lib/fastlane/actions/add_git_tag.rb
+++ b/lib/fastlane/actions/add_git_tag.rb
@@ -1,0 +1,20 @@
+module Fastlane
+  module Actions
+    # Adds a git tag to the current commit
+    class AddGitTagAction
+      def self.run(params)
+        params = params.first
+
+        grouping  = (params && params[:grouping]) || 'builds'
+        prefix    = (params && params[:prefix]) || ''
+
+        lane_name = Actions.lane_context[Actions::SharedValues::LANE_NAME]
+        build_version = Actions.lane_context[Actions::SharedValues::BUILD_NUMBER]
+
+        Actions.sh("git tag #{grouping}/#{lane_name}/#{prefix}#{build_version}")
+
+        Helper.log.info 'Added git tag 🎯.'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Real world use case:
1. Crash report comes in from Crashlytics and brings with it a beautiful stack trace, build number and some other moderately relevant info.
2. You decide to work on a fix for the bug, first step: reproduce the problem.
3. You fire up Xcode and want to build & run the exact version of the app for which you have the stack trace.
4. Fix bug :confetti_ball: 

Step 3 is kind of impossible unless you know exactly what commit this problematic build came from, but who has time to tag commits manually...

This will automatically tag your build with the following format: `<grouping>/<lane>/<prefix><build_number>`, where: 
- `grouping` is just to keep your tags organised under one "folder", defaults to 'builds'
- `lane` is the name of the current fastlane lane
- `prefix` is anything you want to stick in front of the version number, e.g. "v"
- `build_number` is the build number, which defaults to the value emitted by the `increment_build_number` action

For example for build 1234 in the "appstore" lane it will tag the commit with `builds/appstore/1234`
