### PR TITLE
add note_path option to typetalk action for appending message like a change log

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Send a message to **topic** with success (:smile:) or failure (:rage:) status.
 ```ruby
   typetalk({
     message: "App successfully released!",
+    note_path: 'ChangeLog.md',
     topicId: 1,
     success: true,
     typetalk_token: 'Your Typetalk Token'

--- a/lib/fastlane/actions/typetalk.rb
+++ b/lib/fastlane/actions/typetalk.rb
@@ -37,7 +37,7 @@ module Fastlane
 
         uri = URI.parse("https://typetalk.in/api/v1/topics/#{topicId}")
         response = Net::HTTP.post_form(uri, {'message' => message,
-                                             'typetalk_token' => typetalk_token})
+                                             'typetalkToken' => typetalk_token})
 
         self.check_response(response)
       end

--- a/lib/fastlane/actions/typetalk.rb
+++ b/lib/fastlane/actions/typetalk.rb
@@ -4,6 +4,7 @@ module Fastlane
       def self.run(params)
         options = {
             message: nil,
+            note_path: nil,
             success: true,
             topicId: nil,
             typetalk_token: nil,
@@ -15,6 +16,13 @@ module Fastlane
 
         emoticon = (options[:success] ? ':smile:' : ':rage:')
         message = "#{emoticon} #{options[:message].to_s}"
+
+        note_path = options[:note_path]
+        if File.exist?(File.expand_path(note_path))
+          contents = File.read(note_path)
+          message += "\n\n```\n#{contents}\n```"
+        end
+
         topicId = options[:topicId]
         typetalk_token = options[:typetalk_token]
 

--- a/lib/fastlane/actions/typetalk.rb
+++ b/lib/fastlane/actions/typetalk.rb
@@ -17,8 +17,8 @@ module Fastlane
         emoticon = (options[:success] ? ':smile:' : ':rage:')
         message = "#{emoticon} #{options[:message].to_s}"
 
-        note_path = options[:note_path]
-        if File.exist?(File.expand_path(note_path))
+        note_path = File.expand_path(options[:note_path]) if options[:note_path]
+        if note_path and File.exist?(note_path)
           contents = File.read(note_path)
           message += "\n\n```\n#{contents}\n```"
         end


### PR DESCRIPTION
I added note_path option to typetalk action, since we want to notify to typetalk with a change log:smile:
