### PR TITLE
Add notify action that uses OS X notification center

### DIFF
--- a/Actions.md
+++ b/Actions.md
@@ -329,6 +329,13 @@ Send a message to **topic** with success (:smile:) or failure (:rage:) status.
   })
 ```
 
+#### Notify
+Display an OS X notification. Uses [terminal-notifier](https://github.com/alloy/terminal-notifier).
+
+```ruby
+  notify "Finished driving lane"
+```
+
 #### [Testmunk](http://testmunk.com)
 Run your functional tests on real iOS devices over the cloud (for free on an iPod). With this simple [testcase](https://github.com/testmunk/TMSample/blob/master/testcases/smoke/smoke_features.zip) you can ensure your app launches and there is no crash at launch. Tests can be extended with [Testmunk's library](http://docs.testmunk.com/en/latest/steps.html) or custom steps. More details about this action can be found in [`testmunk.rb`](https://github.com/KrauseFx/fastlane/blob/master/lib/fastlane/actions/testmunk.rb).
 ```ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ PATH
       sigh (>= 0.4.5)
       slack-notifier (~> 1.0)
       snapshot (>= 0.4.0)
+      terminal-notifier (~> 1.6.2)
       xcodeproj (~> 0.22)
 
 GEM
@@ -179,6 +180,7 @@ GEM
     snapshot (0.4.13)
       fastimage (~> 1.6.3)
       fastlane_core (>= 0.2.0)
+    terminal-notifier (1.6.2)
     terminal-table (1.4.5)
     thread_safe (0.3.4)
     ttfunk (1.4.0)

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Send success and error messages:
 - [Slack](https://github.com/KrauseFx/fastlane/blob/master/Actions.md#slack)
 - [HipChat](https://github.com/KrauseFx/fastlane/blob/master/Actions.md#hipchat)
 - [Typetalk](https://github.com/KrauseFx/fastlane/blob/master/Actions.md#typetalk)
+- [Notify](https://github.com/KrauseFx/fastlane/blob/master/Actions.md#notify)
 
 ### Misc
 - [frameit](https://github.com/KrauseFx/fastlane/blob/master/Actions.md#frameit): Put your screenshots into the right device frames

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -37,6 +37,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'produce', '>= 0.1.6'
   spec.add_dependency 'cert', '>= 0.1.3'
 
+  spec.add_dependency 'terminal-notifier', '~> 1.6.2'
+
   # Development only
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/fastlane/actions/notify.rb
+++ b/lib/fastlane/actions/notify.rb
@@ -1,0 +1,14 @@
+module Fastlane
+  module Actions
+    class NotifyAction
+      def self.run(params)
+        require 'terminal-notifier'
+
+        text = params.join(' ')
+        TerminalNotifier.notify(text,
+                                :title => 'Fastlane',
+                               )
+      end
+    end
+  end
+end


### PR DESCRIPTION
It uses https://github.com/alloy/terminal-notifier to show a simple notification. For example:

``` ruby
 after_all do |lane|
  notify "Finished driving lane #{lane}"
   reset_git_repo
 end
```
