### PR TITLE
Added missing important alias: xcexport

### DIFF
--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -150,6 +150,14 @@ module Fastlane
       end
     end
 
+    class XcexportAction
+      def self.run(params)
+        params_hash = params.first || {}
+        params_hash[:export_archive] = true
+        XcodebuildAction.run([params_hash])
+      end
+    end
+
     class XctestAction
       def self.run(params)
         params_hash = params.first || {}

--- a/spec/actions_specs/xcodebuild_spec.rb
+++ b/spec/actions_specs/xcodebuild_spec.rb
@@ -226,6 +226,26 @@ describe Fastlane do
       end
     end
 
+    describe "xcexport" do
+      it "is equivalent to 'xcodebuild -exportArchive'" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          xcexport(
+            archive_path: './build-dir/MyApp.xcarchive',
+            export_path: './build-dir/MyApp',
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq(
+          "xcodebuild " \
+          + "-archivePath \"./build-dir/MyApp.xcarchive\" " \
+          + "-exportArchive " \
+          + "-exportFormat \"ipa\" " \
+          + "-exportPath \"./build-dir/MyApp\" " \
+          + "| xcpretty --simple --color"
+        )
+      end
+    end
+
     describe "xctest" do
       it "is equivalent to 'xcodebuild test'" do
         result = Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
I forgot to include an alias action for one of the most useful xcodebuild tasks, exporting (xcexport).

``` ruby
# Export a signed binary (./build-dir/MyApp.ipa)
xcexport(
  archive_path: './build-dir/MyApp.xcarchive',
  export_path: './build-dir/MyApp',
)
```
