### PR TITLE
[Resolves #101] Pass-thru Shenzhen Crashlytics ENV vars

### DIFF
--- a/Actions.md
+++ b/Actions.md
@@ -265,6 +265,8 @@ crashlytics({
 ```
 Additionally you can specify `notes_path`, `emails`, `groups` and `notifications`.
 
+The following environment variables may be used in place of parameters: `CRASHLYTICS_API_TOKEN`, `CRASHLYTICS_BUILD_SECRET`, and `CRASHLYTICS_FRAMEWORK_PATH`.
+
 #### AWS S3 Distribution
 
 Add the `s3` action after the `ipa` step:

--- a/lib/fastlane/actions/crashlytics.rb
+++ b/lib/fastlane/actions/crashlytics.rb
@@ -13,9 +13,9 @@ module Fastlane
 
         params = params.first
 
-        crashlytics_path = params[:crashlytics_path]
-        api_token        = params[:api_token]
-        build_secret     = params[:build_secret]
+        crashlytics_path = params[:crashlytics_path] || ENV["CRASHLYTICS_FRAMEWORK_PATH"]
+        api_token        = params[:api_token] || ENV["CRASHLYTICS_API_TOKEN"]
+        build_secret     = params[:build_secret] || ENV["CRASHLYTICS_BUILD_SECRET"]
         ipa_path         = params[:ipa_path] || Actions.lane_context[SharedValues::IPA_OUTPUT_PATH]
         notes_path       = params[:notes_path]
         emails           = params[:emails]

--- a/spec/actions_specs/crashlytics_spec.rb
+++ b/spec/actions_specs/crashlytics_spec.rb
@@ -1,6 +1,13 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Crashlytics Integration" do
+
+      before :each do
+        ENV.delete "CRASHLYTICS_API_TOKEN"
+        ENV.delete "CRASHLYTICS_BUILD_SECRET"
+        ENV.delete "CRASHLYTICS_FRAMEWORK_PATH"
+      end
+
       it "raises an error if no parameters were given" do
         expect {
           Fastlane::FastFile.new.parse("lane :test do
@@ -84,11 +91,23 @@ describe Fastlane do
       end
 
       it "works with valid parameters" do
-        Fastlane::FastFile.new.parse("lane :test do 
+        Fastlane::FastFile.new.parse("lane :test do
           crashlytics({
             crashlytics_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
             api_token: 'wadus',
             build_secret: 'wadus',
+            ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1'
+          })
+        end").runner.execute(:test)
+      end
+
+      it "works when using environment variables in place of parameters" do
+        ENV["CRASHLYTICS_API_TOKEN"] = "wadus"
+        ENV["CRASHLYTICS_BUILD_SECRET"] = "wadus"
+        ENV["CRASHLYTICS_FRAMEWORK_PATH"] = "./fastlane/spec/fixtures/fastfiles/Fastfile1"
+
+        Fastlane::FastFile.new.parse("lane :test do
+          crashlytics({
             ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1'
           })
         end").runner.execute(:test)


### PR DESCRIPTION
This allows the environment variables to be used in place of some parameters.
