### PR TITLE
Fix name collision with ActiveSupport

### DIFF
--- a/lib/fastlane/actions/actions_helper.rb
+++ b/lib/fastlane/actions/actions_helper.rb
@@ -91,7 +91,7 @@ module Fastlane
 
         file_name = File.basename(file).gsub('.rb', '')
 
-        class_name = file_name.classify + 'Action'
+        class_name = file_name.fastlane_class + 'Action'
         class_ref = nil
         begin
           class_ref = Fastlane::Actions.const_get(class_name)

--- a/lib/fastlane/core_ext/string.rb
+++ b/lib/fastlane/core_ext/string.rb
@@ -1,5 +1,5 @@
 class String
-  def classify
+  def fastlane_class
     split('_').collect!(&:capitalize).join
   end
 end

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -63,7 +63,7 @@ module Fastlane
     def method_missing(method_sym, *arguments, &_block)
       # First, check if there is a predefined method in the actions folder
 
-      class_name = method_sym.to_s.classify + 'Action'
+      class_name = method_sym.to_s.fastlane_class + 'Action'
       class_ref = nil
       begin
         class_ref = Fastlane::Actions.const_get(class_name)

--- a/lib/fastlane/new_action.rb
+++ b/lib/fastlane/new_action.rb
@@ -21,7 +21,7 @@ module Fastlane
       template = File.read("#{Helper.gem_path('fastlane')}/lib/assets/custom_action_template.rb")
       template.gsub!('[[NAME]]', name)
       template.gsub!('[[NAME_UP]]', name.upcase)
-      template.gsub!('[[NAME_CLASS]]', name.classify + 'Action')
+      template.gsub!('[[NAME_CLASS]]', name.fastlane_class + 'Action')
 
       actions_path = File.join((FastlaneFolder.path || Dir.pwd), 'actions')
       FileUtils.mkdir_p(actions_path) unless File.directory?(actions_path)


### PR DESCRIPTION
I renamed the `String.classify` method to `fastlane_class`, because `classify` is already used by ActiveSupport [as you can see here](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/string/inflections.rb#L187-L189). `ActiveSupport` is needed by the `xcodeproj` gem. 
