### PR TITLE
Increment build number

### DIFF
--- a/Actions.md
+++ b/Actions.md
@@ -139,6 +139,11 @@ This method will increment the **build number**, not the app version. Usually th
 ```ruby
 increment_build_number # automatically increment by one
 increment_build_number '75' # set a specific number
+
+increment_build_numer(
+  build_number: 75, # specify specific build number (optional, omitting it increments by one)
+  xcodeproj: './path/to/MyApp.xcodeproj' (optional, you must specify the path to your main Xcode project if it is not in the project root directory)
+)
 ```
 
 #### [resign](https://github.com/krausefx/sigh#resign)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Thanks to all sponsors and contributors for extending and improving the `fastlan
 - [Detroit Labs](http://www.detroitlabs.com/)
 - Josh Holtz ([@joshdholtz](https://twitter.com/joshdholtz))
 - Dan Trenz ([@dtrenz](https://twitter.com/dtrenz))
-- Lukas Mirosevic ([@lmirosevic](https://twitter.com/lmirosevic))
+- Luka Mirosevic ([@lmirosevic](https://twitter.com/lmirosevic))
 - Almas Sapargali ([@almassapargali](https://twitter.com/almassapargali))
 - Manuel Wallner ([@milch](https://github.com/milch))
 - Pawel Dudek ([@eldudi](https://twitter.com/eldudi))

--- a/lib/fastlane/actions/increment_build_number.rb
+++ b/lib/fastlane/actions/increment_build_number.rb
@@ -5,20 +5,35 @@ module Fastlane
     end
 
     class IncrementBuildNumberAction
+      require 'shellwords'
+
       def self.run(params)
         # More information about how to set up your project and how it works:
         # https://developer.apple.com/library/ios/qa/qa1827/_index.html
         # Attention: This is NOT the version number - but the build number
 
         begin
-          custom_number = (params.first rescue nil)
+          first_param = (params.first rescue nil)
 
-          command = nil
-          if custom_number
-            command = "agvtool new-version -all #{custom_number}"
-          else
-            command = 'agvtool next-version -all'
+          case first_param
+          when NilClass
+            custom_number = nil
+            folder = '.'
+          when Fixnum
+            custom_number = first_param
+            folder = '.'
+          when Hash
+            custom_number = first_param[:build_number]
+            folder = first_param[:xcodeproj] ? File.join('.', first_param[:xcodeproj], '..') : '.'
           end
+            
+          command = [
+            'cd',
+            File.expand_path(folder).shellescape,
+            '&&',
+            'agvtool',
+            custom_number ? "new-version -all #{custom_number}" : 'next-version -all'
+          ].join(' ')
 
           if Helper.test?
             Actions.lane_context[SharedValues::BUILD_NUMBER] = command

--- a/lib/fastlane/actions/increment_build_number.rb
+++ b/lib/fastlane/actions/increment_build_number.rb
@@ -27,10 +27,14 @@ module Fastlane
             folder = first_param[:xcodeproj] ? File.join('.', first_param[:xcodeproj], '..') : '.'
           end
             
-          command = [
+          command_prefix = [
             'cd',
             File.expand_path(folder).shellescape,
-            '&&',
+            '&&'
+          ].join(' ')
+
+          command = [
+            command_prefix,
             'agvtool',
             custom_number ? "new-version -all #{custom_number}" : 'next-version -all'
           ].join(' ')
@@ -42,10 +46,9 @@ module Fastlane
             Actions.sh command
 
             # Store the new number in the shared hash
-            build_number = `agvtool what-version`.split("\n").last.to_i
+            build_number = `#{command_prefix} agvtool what-version`.split("\n").last.to_i
 
             Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number
-
           end
         rescue => ex
           Helper.log.error 'Make sure to to follow the steps to setup your Xcode project: https://developer.apple.com/library/ios/qa/qa1827/_index.html'.yellow

--- a/spec/actions_specs/increment_build_number_action_spec.rb
+++ b/spec/actions_specs/increment_build_number_action_spec.rb
@@ -1,21 +1,22 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Increment Build Number Integration" do
+      require 'shellwords'
 
       it "increments the build number of the Xcode project" do
         Fastlane::FastFile.new.parse("lane :test do 
           increment_build_number
         end").runner.execute(:test)
-        
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("agvtool next-version -all")
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("cd #{File.expand_path('.').shellescape} && agvtool next-version -all")
       end
 
       it "pass a custom build number to the tool" do
         result = Fastlane::FastFile.new.parse("lane :test do 
           increment_build_number 24
         end").runner.execute(:test)
-        
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("agvtool new-version -all 24")
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("cd #{File.expand_path('.').shellescape} && agvtool new-version -all 24")
       end
     end
   end

--- a/spec/actions_specs/increment_build_number_action_spec.rb
+++ b/spec/actions_specs/increment_build_number_action_spec.rb
@@ -8,7 +8,7 @@ describe Fastlane do
           increment_build_number
         end").runner.execute(:test)
 
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("cd #{File.expand_path('.').shellescape} && agvtool next-version -all")
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool next-version -all/)
       end
 
       it "pass a custom build number to the tool" do
@@ -16,7 +16,7 @@ describe Fastlane do
           increment_build_number 24
         end").runner.execute(:test)
 
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("cd #{File.expand_path('.').shellescape} && agvtool new-version -all 24")
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool new-version -all 24/)
       end
     end
   end


### PR DESCRIPTION
Previously `increment_build_number` would assume that your `.xcodeproj` was in the project root directory, which is not always the case. This adds the ability to specify where your `.xcodeproj` is. These changes are backwards compatible.

I also snuck in a cheeky typo fix for the readme into this PR.

EDIT: Thanks for the honourable mention BTW!
