### PR TITLE
Added build settings to xcodebuild command

### DIFF
--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -151,6 +151,8 @@ module Fastlane
           if arg = ARGS_MAP[k]
             value = (v != true && v.to_s.length > 0 ? "\"#{v}\"" : "")
             "#{arg} #{value}".strip
+          elsif k == :build_settings
+            v.map{|setting,value| "#{setting}=\"#{value}\""}.join(' ')
           elsif k == :keychain && v.to_s.length > 0
             # If keychain is specified, append as OTHER_CODE_SIGN_FLAGS
             "OTHER_CODE_SIGN_FLAGS=\"--keychain #{v}\""

--- a/spec/actions_specs/xcodebuild_spec.rb
+++ b/spec/actions_specs/xcodebuild_spec.rb
@@ -37,7 +37,7 @@ describe Fastlane do
             skip_unavailable_actions: true,
             target: 'MyAppTarget',
             workspace: 'MyApp.xcworkspace',
-            xcconfig: 'my.xcconfig'
+            xcconfig: 'my.xcconfig',
           )
         end").runner.execute(:test)
 
@@ -74,6 +74,22 @@ describe Fastlane do
           + "test " \
           + "| xcpretty --color --simple"
       )
+    end
+
+    it "works with build settings" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        xcodebuild(
+          build_settings: {
+            'CODE_SIGN_IDENTITY' => 'iPhone Developer: Josh',
+            'JOBS' => 16,
+            'PROVISIONING_PROFILE' => 'JoshIsCoolProfile'
+          }
+        )
+      end").runner.execute(:test)
+
+      expect(result).to include('CODE_SIGN_IDENTITY="iPhone Developer: Josh"')
+      expect(result).to include('JOBS="16"')
+      expect(result).to include('PROVISIONING_PROFILE="JoshIsCoolProfile"')
     end
 
     it "when archiving, should cache the archive path for a later export step" do


### PR DESCRIPTION
@KrauseFx  :warning: Added rspecs but I need to actually run this yet (figure I would commit this before I go to bed though :zzz: :zzz: :zzz: )

Closes #131 

Here is a link to all the build settings (because I know I will want to find this link later) - https://developer.apple.com/library/mac/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-DontLinkElementID_10

``` ruby
xcodebuild(
  workspace: "...",
  scheme: "...",
  build_settings: {
    "CODE_SIGN_IDENTITY" => "iPhone Developer: ...",
    "PROVISIONING_PROFILE" => "...",
    "JOBS" => 16
  }
)
```
