### PR TITLE
xcodebuild now autodetects workspace, if present.

### DIFF
--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -89,7 +89,7 @@ module Fastlane
             # If no project or workspace was passed in or set as an environment
             # variable, attempt to autodetect the workspace.
             if params[:project].to_s.empty? && params[:workspace].to_s.empty?
-              params[:workspace] = detect_workspace()
+              params[:workspace] = detect_workspace
             end
           end
 
@@ -166,9 +166,19 @@ module Fastlane
       end
 
       def self.detect_workspace
-        # Dir["*.xcworkspace"].first
-        pp Dir.glob("*.xcworkspace")
-        Dir.glob("*.xcworkspace").first
+        workspace = nil
+        workspaces = Dir.glob("*.xcworkspace")
+
+        if workspaces.length > 1
+          Helper.log.warn "Multiple workspaces detected."
+        end
+
+        if !workspaces.empty?
+          workspace = workspaces.first
+          Helper.log.warn "Using workspace \"#{workspace}\""
+        end
+
+        return workspace
       end
     end
 

--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -61,6 +61,7 @@ module Fastlane
           build_path += "/"
         end
 
+
         if params = params.first
           # Operation bools
           archiving = params.key? :archive
@@ -84,6 +85,12 @@ module Fastlane
             params[:scheme] ||= scheme
             params[:workspace] ||= workspace
             params[:project] ||= project
+
+            # If no project or workspace was passed in or set as an environment
+            # variable, attempt to autodetect the workspace.
+            if params[:project].to_s.empty? && params[:workspace].to_s.empty?
+              params[:workspace] = detect_workspace()
+            end
           end
 
           if archiving
@@ -156,6 +163,12 @@ module Fastlane
             "OTHER_CODE_SIGN_FLAGS=\"--keychain #{v}\""
           end
         end.compact.sort
+      end
+
+      def self.detect_workspace
+        # Dir["*.xcworkspace"].first
+        pp Dir.glob("*.xcworkspace")
+        Dir.glob("*.xcworkspace").first
       end
     end
 

--- a/spec/actions_specs/xcodebuild_spec.rb
+++ b/spec/actions_specs/xcodebuild_spec.rb
@@ -355,6 +355,23 @@ describe Fastlane do
           + "--test"
         )
       end
+
+      it "should detect and use the workspace, when a workspace is present" do
+        allow(Dir).to receive(:glob).with("*.xcworkspace").and_return([ "MyApp.xcworkspace" ])
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          xcbuild
+        end").runner.execute(:test)
+
+        expect(result).to eq(
+          "set -o pipefail && " \
+          + "xcodebuild " \
+          + "-workspace \"MyApp.xcworkspace\" " \
+          + "build " \
+          + "| xcpretty --color " \
+          + "--simple"
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Default behavior of `xcodebuild` --  if no workspace is passed in -- is to use the `.xcodeproj`. This PR enables the `xcodebuild` action to autodetect and use the `.xcworkspace` instead, removing the need to specify the workspace.
