### PR TITLE
[Resolves #138] xcodebuild: no scheme, use archive filename as ipa filename

### DIFF
--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -75,7 +75,10 @@ module Fastlane
             params[:export_format] ||= "ipa"
 
             # If not passed, construct export path from env vars
-            params[:export_path] ||= "#{build_path}#{scheme}"
+            if params[:export_path] == nil
+              ipa_filename = scheme ? scheme : File.basename(params[:archive_path], ".*")
+              params[:export_path] = "#{build_path}#{ipa_filename}"
+            end
 
             # Store IPA path for later deploy steps (i.e. Crashlytics)
             Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] = params[:export_path] + "." + params[:export_format].downcase

--- a/spec/actions_specs/xcodebuild_spec.rb
+++ b/spec/actions_specs/xcodebuild_spec.rb
@@ -175,6 +175,8 @@ describe Fastlane do
       end
 
       it "can export" do
+        ENV.delete("XCODE_SCHEME")
+        ENV.delete("XCODE_WORKSPACE")
         result = Fastlane::FastFile.new.parse("lane :test do
           xcodebuild(
             archive_path: './build-dir/MyApp.xcarchive',


### PR DESCRIPTION
When exporting via xcodebuild, and no scheme is provided, the xcarchive filename will be used as the binary filename.
