### PR TITLE
xcpretty report arg comes before output arg

### DIFF
--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -113,13 +113,6 @@ module Fastlane
         # Default args
         xcpretty_args = [ "--color" ]
 
-        # Stdout format
-        if testing && !archiving
-          xcpretty_args.push "--test"
-        else
-          xcpretty_args.push "--simple"
-        end
-
         if testing
           # Test report file format
           if params[:report_formats]
@@ -129,21 +122,30 @@ module Fastlane
 
             xcpretty_args.push report_formats
 
+            # Save screenshots flag
+            if params[:report_formats].include?("html") && params[:report_screenshots]
+              xcpretty_args.push "--screenshots"
+            end
+
+            xcpretty_args.sort!
+
             # Test report file path
             if params[:report_path]
               xcpretty_args.push "--output \"#{params[:report_path]}\""
             elsif build_path
               xcpretty_args.push "--output \"#{build_path}report\""
             end
-
-            # Save screenshots flag
-            if params[:report_formats].include?("html") && params[:report_screenshots]
-              xcpretty_args.push "--screenshots"
-            end
           end
         end
 
-        xcpretty_args = xcpretty_args.sort.join(" ")
+        # Stdout format
+        if testing && !archiving
+          xcpretty_args.push "--test"
+        else
+          xcpretty_args.push "--simple"
+        end
+
+        xcpretty_args = xcpretty_args.join(" ")
 
         Actions.sh "set -o pipefail && xcodebuild #{xcodebuild_args} | xcpretty #{xcpretty_args}"
       end

--- a/spec/actions_specs/xcodebuild_spec.rb
+++ b/spec/actions_specs/xcodebuild_spec.rb
@@ -311,8 +311,8 @@ describe Fastlane do
           + "-workspace \"MyApp.xcworkspace\" " \
           + "test " \
           + "| xcpretty --color " \
-          + "--output \"./build-dir/test-report\" " \
           + "--report junit " \
+          + "--output \"./build-dir/test-report\" " \
           + "--test"
         )
       end
@@ -338,9 +338,9 @@ describe Fastlane do
           + "-workspace \"MyApp.xcworkspace\" " \
           + "test " \
           + "| xcpretty --color " \
-          + "--output \"./build/report\" " \
           + "--report html " \
           + "--screenshots " \
+          + "--output \"./build/report\" " \
           + "--test"
         )
 


### PR DESCRIPTION
If you don't pass the report format arg(s) before the output arg to `xcpretty` it has a fatal error. I think this is silly, but either way this PR patches that scenario in `xcodebuild`.

Related: https://github.com/supermarin/xcpretty/issues/135
