### PR TITLE
Fix for #48 (Colour codes included in slack message)

### DIFF
--- a/lib/fastlane/runner.rb
+++ b/lib/fastlane/runner.rb
@@ -26,7 +26,9 @@ module Fastlane
       return return_val
     rescue => ex
       Dir.chdir(path_to_use) do
-        @error.call(key, ex) if @error # notify the block
+        # Provide error block exception without colour code
+        error_ex = ex.exception(ex.message.gsub(/\033\[\d+m/, ''))
+        @error.call(key, error_ex) if @error # notify the block
       end
       raise ex
     end


### PR DESCRIPTION
Fix proposal for https://github.com/KrauseFx/fastlane/issues/48

Coloured console output is preserved but message of exception passed to error block is plain.
