### PR TITLE
Provide different Appfile configs for each lanes

### DIFF
--- a/lib/fastlane/runner.rb
+++ b/lib/fastlane/runner.rb
@@ -5,7 +5,7 @@ module Fastlane
       key = key.to_sym
       Helper.log.info "Driving the lane '#{key}'".green
       Actions.lane_context[Actions::SharedValues::LANE_NAME] = key
-      ENV["FASTLANE_LANE_NAME"] = key
+      ENV["FASTLANE_LANE_NAME"] = key.to_s
 
       return_val = nil
 

--- a/lib/fastlane/runner.rb
+++ b/lib/fastlane/runner.rb
@@ -5,6 +5,7 @@ module Fastlane
       key = key.to_sym
       Helper.log.info "Driving the lane '#{key}'".green
       Actions.lane_context[Actions::SharedValues::LANE_NAME] = key
+      ENV["FASTLANE_LANE_NAME"] = key
 
       return_val = nil
 


### PR DESCRIPTION
# Summary

Saved lane name as environment variable.
# Why

Give the opportunity to all fastlane tools to invoke different actions based on the lane name.
This Integration is made possible by this [Credentials Manager feature](https://github.com/KrauseFx/CredentialsManager/pull/4)
# Example

Use Appfile configuration for_lane block as fastlane lane #146
