### PR TITLE
[Action] increment version number

### DIFF
--- a/Actions.md
+++ b/Actions.md
@@ -151,6 +151,22 @@ increment_build_numer(
 )
 ```
 
+#### [increment_version_number](https://developer.apple.com/library/ios/qa/qa1827/_index.html)
+This action will increment the **version number**. You first have to [set up your Xcode project](https://developer.apple.com/library/ios/qa/qa1827/_index.html), if you haven't done it already.
+
+```ruby
+increment_version_number # automatically increment patch version number
+increment_version_number "patch" # automatically increment patch version number
+increment_version_number "minor" # automatically increment minor version number
+increment_version_number "major" # automatically increment major version number
+increment_version_number '2.1.1' # set a specific version number
+
+increment_version_number(
+  release_task: '2.1.1', # specify specific version number (optional, omitting it increments patch version number)
+  xcodeproj: './path/to/MyApp.xcodeproj' (optional, you must specify the path to your main Xcode project if it is not in the project root directory)
+)
+```
+
 #### [resign](https://github.com/krausefx/sigh#resign)
 This will resign an ipa with another signing identity and provisioning profile.
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ When one command fails, the execution will be aborted.
 - [CocoaPods](https://github.com/KrauseFx/fastlane/blob/master/Actions.md#cocoapods): Setup your CocoaPods project
 - [Carthage](https://github.com/KrauseFx/fastlane/blob/master/Actions.md#carthage): Setup your Carthage project
 - [increment_build_number](https://github.com/KrauseFx/fastlane/blob/master/Actions.md#increment_build_number): Increment the Xcode build number before building the app
+- - [increment_build_number](https://github.com/KrauseFx/fastlane/blob/master/Actions.md#increment_version_number): Increment the Xcode version number before building the app
 
 ### Testing
 - [snapshot](https://github.com/KrauseFx/fastlane/blob/master/Actions.md#snapshot): Automate taking localized screenshots of your iOS app on every device

--- a/lib/fastlane/actions/increment_version_number.rb
+++ b/lib/fastlane/actions/increment_version_number.rb
@@ -46,22 +46,18 @@ module Fastlane
               '&&'
           ].join(' ')
 
-          current_version= `#{command_prefix} agvtool what-marketing-version -terse1`.split("\n").last
-
-          if !current_version.match(/\d.\d.\d/) && !Helper.test?
-            raise 'Your current version does not respect the format A.B.C'
-
+          if Helper.test?
+            version_array = [1,0,0]
+          else
+            current_version= `#{command_prefix} agvtool what-marketing-version -terse1`.split("\n").last
+            raise 'Your current version does not respect the format A.B.C' unless current_version.match(/\d.\d.\d/)
             #Check if CFBundleShortVersionString is the same for each occurrence
             allBundles = `#{command_prefix} agvtool what-marketing-version -terse`.split("\n")
             allBundles.each do |bundle|
               raise 'Ensure all you CFBundleShortVersionString are equals in your project ' unless bundle.end_with? "=#{current_version}"
             end
+            version_array = current_version.split(".").map(&:to_i)
           end
-
-          version_array = current_version.split(".").map(&:to_i)
-
-          # Define default test version number
-          version_array = [1,0,0] if Helper.test?
 
           case release_task
             when "patch"
@@ -84,7 +80,6 @@ module Fastlane
               command_prefix,
               "agvtool new-marketing-version #{next_version_number}"
           ].join(' ')
-          puts(command)
 
           if Helper.test?
             Actions.lane_context[SharedValues::VERSION_NUMBER] = command

--- a/lib/fastlane/actions/increment_version_number.rb
+++ b/lib/fastlane/actions/increment_version_number.rb
@@ -1,0 +1,103 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      VERSION_NUMBER = :VERSION_NUMBER
+    end
+
+    class IncrementVersionNumberAction
+      require 'shellwords'
+
+      def self.run(params)
+        # More information about how to set up your project and how it works:
+        # https://developer.apple.com/library/ios/qa/qa1827/_index.html
+
+        begin
+          first_param = (params.first rescue nil)
+          folder = '.' #Current folder is the default folder
+
+          case first_param
+            when NilClass
+              release_task = 'patch' #Patch is the default action
+            when String
+              release_task = first_param
+            when Hash
+              release_task = first_param[:release_task] ? first_param[:release_task] : "patch"
+              folder = first_param[:xcodeproj] ? File.join('.', first_param[:xcodeproj], '..') : '.'
+          end
+
+          # Verify integrity
+          case release_task
+            when /\d.\d.\d/
+              specific_version_number = release_task
+              release_task = 'specific_version'
+            when "patch"
+              release_task = 'patch'
+            when "minor"
+              release_task = 'minor'
+            when "major"
+              release_task = "major"
+            else
+              raise 'Invalid parameter #{release_task}'
+          end
+
+          command_prefix = [
+              'cd',
+              File.expand_path(folder).shellescape,
+              '&&'
+          ].join(' ')
+
+          current_version= `#{command_prefix} agvtool what-marketing-version -terse1`.split("\n").last
+
+          if !current_version.match(/\d.\d.\d/) && !Helper.test?
+            raise 'Your current version does not respect the format A.B.C'
+
+            #Check if CFBundleShortVersionString is the same for each occurrence
+            allBundles = `#{command_prefix} agvtool what-marketing-version -terse`.split("\n")
+            allBundles.each do |bundle|
+              raise 'Ensure all you CFBundleShortVersionString are equals in your project ' unless bundle.end_with? "=#{current_version}"
+            end
+          end
+
+          version_array = current_version.split(".").map(&:to_i)
+
+          # Define default test version number
+          version_array = [1,0,0] if Helper.test?
+
+          case release_task
+            when "patch"
+              version_array[2] = version_array[2]+1
+              next_version_number = version_array.join(".")
+            when "minor"
+              version_array[1] = version_array[1]+1
+              version_array[2] = version_array[2]=0
+              next_version_number = version_array.join(".")
+            when "major"
+              version_array[0] = version_array[0]+1
+              version_array[1] = version_array[1]=0
+              version_array[1] = version_array[2]=0
+              next_version_number = version_array.join(".")
+            when "specific_version"
+              next_version_number = specific_version_number
+          end
+
+          command = [
+              command_prefix,
+              "agvtool new-marketing-version #{next_version_number}"
+          ].join(' ')
+          puts(command)
+
+          if Helper.test?
+            Actions.lane_context[SharedValues::VERSION_NUMBER] = command
+          else
+            Actions.sh command
+            Actions.lane_context[SharedValues::VERSION_NUMBER] = next_version_number
+          end
+
+        rescue => ex
+          Helper.log.error 'Make sure to to follow the steps to setup your Xcode project: https://developer.apple.com/library/ios/qa/qa1827/_index.html'.yellow
+          raise ex
+        end
+      end
+    end
+  end
+end

--- a/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/spec/actions_specs/increment_version_number_action_spec.rb
@@ -1,0 +1,39 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Increment Version Number Integration" do
+      require 'shellwords'
+
+      it "it increments all targets patch version number" do
+        Fastlane::FastFile.new.parse("lane :test do
+          increment_version_number
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.0.1/)
+      end
+
+      it "it increments all targets minor version number" do
+        Fastlane::FastFile.new.parse("lane :test do
+          increment_version_number 'minor'
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.1.0/)
+      end
+
+      it "it increments all targets minor version major" do
+        Fastlane::FastFile.new.parse("lane :test do
+          increment_version_number 'major'
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 2.0.0/)
+      end
+
+      it "pass a custom version number" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          increment_version_number '1.4.3'
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.4.3/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

New action responsible to increment the app version number using standard format: `major.minor.patch`.
See #118
### Why

Improve versioning management of project’s targets when releasing a new app version.
### Example

You can use the action as follow:

```
increment_version_number #The default action is patch
increment_version_number “patch”
increment_version_number “minor”
increment_version_number “major”
increment_version_number “1.4.3”
increment_version_number(
  release_task: “patch”,
  xcodeproj: ‘path/project.xcodeproj’ 
)
```
