### PR TITLE
Allows user not to clean on ipa command

### DIFF
--- a/Actions.md
+++ b/Actions.md
@@ -102,7 +102,7 @@ ipa({
   configuration: "Debug",
   scheme: "MyApp",
   # (optionals)
-  clean: nil,                      # this means 'Do Clean'. Clean project before building.
+  clean: true,                     # This means 'Do Clean'. Cleans project before building (the default if not specified).
   destination: "path/to/dir",      # Destination directory. Defaults to current directory.
   ipa: "my-app.ipa",               # specify the name of the .ipa file to generate (including file extension)
   xcargs: "MY_ADHOC=0",            # pass additional arguments to xcodebuild when building the app.

--- a/lib/fastlane/actions/ipa.rb
+++ b/lib/fastlane/actions/ipa.rb
@@ -97,8 +97,12 @@ module Fastlane
         params.collect do |k, v|
           v ||= ''
           if args = ARGS_MAP[k]
-            value = (v.to_s.length > 0 ? "\"#{v}\"" : '')
-            "#{ARGS_MAP[k]} #{value}".strip
+            if k == :clean
+              v == true ? '--clean' : '--no-clean'
+            else
+              value = (v.to_s.length > 0 ? "\"#{v}\"" : '')
+              "#{ARGS_MAP[k]} #{value}".strip
+            end
           end
         end.compact
       end

--- a/spec/actions_specs/ipa_spec.rb
+++ b/spec/actions_specs/ipa_spec.rb
@@ -45,7 +45,7 @@ describe Fastlane do
             project: nil,
             configuration: 'Release',
             scheme: 'TestScheme',
-            clean: nil,
+            clean: true,
             archive: nil,
             destination: nil,
             embed: nil,
@@ -66,7 +66,7 @@ describe Fastlane do
             project: 'Test.xcproject',
             configuration: 'Release',
             scheme: 'TestScheme',
-            clean: nil,
+            clean: true,
             archive: nil,
             destination: 'Nowhere',
             embed: 'Sure',
@@ -94,6 +94,26 @@ describe Fastlane do
         expect(result).to include('--xcargs "MY_ADHOC_OPT1=0 MY_ADHOC_OPT2=1"')
       end
 
+      it "respects the clean argument when true" do
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          ipa ({
+            clean: true,
+          })
+        end").runner.execute(:test)
+
+        expect(result).to include("--clean")
+      end
+
+      it "respects the clean argument when false" do
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          ipa ({
+            clean: false,
+          })
+        end").runner.execute(:test)
+
+        expect(result).to include("--no-clean")
+      end
+
       it "works with object argument with all and extras and auto-use sigh profile if not given" do
         ENV["SIGH_PROFILE_PATH"] = "some/great/value.file"
 
@@ -103,7 +123,7 @@ describe Fastlane do
             project: 'Test.xcproject',
             configuration: 'Release',
             scheme: 'TestScheme',
-            clean: nil,
+            clean: true,
             archive: nil,
             destination: 'Nowhere',
             identity: 'bourne',


### PR DESCRIPTION
Shenzhen [cleans by default](https://github.com/nomad/shenzhen/blob/b90d683c10630e367325dc74d5e3cea6277223f8/lib/shenzhen/commands/build.rb#L73) unless you specify the `--no-clean` flag. This is a problem, since some projects ([ours](https://github.com/artsy/eidolon/pull/409)) [cannot be successfully compiled on a clean build](https://twitter.com/jckarter/status/581507956769845250). 

The way the `ipa` command was set up lead to basically no being able to opt out of the default clean. 

There's probably a lot better way to do this, both syntactically and from a "[this is terrible code](https://github.com/artsy/eidolon/blob/44b808f217476c7d45f3a7c5a6f3e9ac842def44/fastlane/Fastfile#L91)" perspective. I couldn't figure out how to use `clean: false` or something equivalent, but would be happy to do so given a point in the right direction. 

Also I can add tests of course, when we get the implementation down. 
