### PR TITLE
Allows users to specify a git tag

### DIFF
--- a/lib/fastlane/actions/add_git_tag.rb
+++ b/lib/fastlane/actions/add_git_tag.rb
@@ -5,15 +5,17 @@ module Fastlane
       def self.run(params)
         params = params.first
 
+        specified_tag = (params && params[:tag])
         grouping      = (params && params[:grouping]) || 'builds'
         prefix        = (params && params[:prefix]) || ''
         build_number  = (params && params[:build_number]) || Actions.lane_context[Actions::SharedValues::BUILD_NUMBER]
         
         lane_name     = Actions.lane_context[Actions::SharedValues::LANE_NAME]
 
-        Actions.sh("git tag #{grouping}/#{lane_name}/#{prefix}#{build_number}")
+        tag = specified_tag || "#{grouping}/#{lane_name}/#{prefix}#{build_number}"
 
-        Helper.log.info 'Added git tag 🎯.'
+        Helper.log.info 'Adding git tag "#{tag}" 🎯.'
+        Actions.sh("git tag #{tag}")
       end
     end
   end

--- a/spec/actions_specs/add_git_tag_spec.rb
+++ b/spec/actions_specs/add_git_tag_spec.rb
@@ -1,0 +1,74 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Add Git Tag Integration" do
+      require 'shellwords'
+
+      build_number = 1337
+
+      before :each do
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER] = build_number
+      end
+
+      it "generates a tag based on existing context" do
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          add_git_tag
+        end").runner.execute(:test)
+
+        expect(result).to eq("git tag builds/test/1337")
+      end
+
+      it "allows you to specify grouping and build number" do
+        specified_build_number = 42
+        grouping = 'grouping'
+
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          add_git_tag ({
+            grouping: '#{grouping}',
+            build_number: #{specified_build_number},
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("git tag #{grouping}/test/#{specified_build_number}")
+      end
+
+      it "allows you to specify a prefix" do
+        prefix = '16309-'
+
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          add_git_tag ({
+            prefix: '#{prefix}',
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("git tag builds/test/#{prefix}#{build_number}")
+      end
+
+      it "allows you to specify your own tag" do
+        tag = '2.0.0'
+
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          add_git_tag ({
+            tag: '#{tag}',
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("git tag #{tag}")
+      end
+
+      it "specified tag overrides generate tag" do
+        tag = '2.0.0'
+
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          add_git_tag ({
+            tag: '#{tag}',
+            grouping: 'grouping',
+            build_number: 'build_number',
+            prefix: 'prefix',
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("git tag #{tag}")
+      end      
+    end
+  end
+end


### PR DESCRIPTION
I'd like to be able to specify a tag instead of having `add_git_tag` generate one for me. Added some tests for the existing code and for the new behaviour. 

Documentation on `add_git_tag` needs to be updated, but I'm holding off until [this](https://github.com/KrauseFx/fastlane/pull/173) is dealt with. 
