### PR TITLE
Stop suggesting sudo to install gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ I recommend following the [fastlane guide](https://github.com/KrauseFx/fastlane/
 
 If you are familiar with the command line and Ruby, install `fastlane` yourself:
 
-    sudo gem install fastlane
+    gem install fastlane
 
 Make sure, you have the latest version of the Xcode command line tools installed:
 

--- a/lib/fastlane/actions/fastlane_version.rb
+++ b/lib/fastlane/actions/fastlane_version.rb
@@ -10,7 +10,7 @@ module Fastlane
         raise "Please pass minimum fastlane version as parameter to fastlane_version".red unless defined_version
 
         if Gem::Version.new(Fastlane::VERSION) < defined_version
-          raise "The Fastfile requires a fastlane version of >= #{defined_version}. You are on #{Fastlane::VERSION}. Please update using `sudo gem update fastlane`.".red
+          raise "The Fastfile requires a fastlane version of >= #{defined_version}. You are on #{Fastlane::VERSION}. Please update using `gem update fastlane`.".red
         end
 
         Helper.log.info "fastlane version valid"


### PR DESCRIPTION
Fastlane is great, thanks! However I don't feel it should suggest `sudo` to install itself. I'd rather see the guide recommend installation of `rbenv` (or another ruby version manager) and `bundler`, or anything else than relying on `sudo`. :)
