### PR TITLE
Improve support for xcpretty report options

### DIFF
--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -117,8 +117,20 @@ module Fastlane
         xcpretty_args = [ "--color" ]
 
         if testing
-          # Test report file format
-          if params[:report_formats]
+          if params[:reports]
+            # New report options format
+            reports = params[:reports].map do |report|
+              unless report[:screenshots]
+                "--report #{report[:report]} --output #{report[:output]}"
+              else
+                "--report #{report[:report]} --output #{report[:output]} --screenshots"
+              end
+            end
+
+            xcpretty_args.push reports.join(" ")
+
+          elsif params[:report_formats]
+            # Test report file format
             report_formats = params[:report_formats].map do |format|
               "--report #{format}"
             end.sort().join(" ")

--- a/spec/actions_specs/xcodebuild_spec.rb
+++ b/spec/actions_specs/xcodebuild_spec.rb
@@ -374,6 +374,41 @@ describe Fastlane do
         )
       end
 
+      it "should support multiple reports " do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          xctest(
+            destination: 'name=iPhone 5s,OS=8.1',
+            scheme: 'MyApp',
+            workspace: 'MyApp.xcworkspace',
+            reports: [{
+              report: 'html',
+              output: './build-dir/test-report.html',
+              screenshots: 1
+            },
+            {
+              report: 'junit',
+              output: './build-dir/test-report.xml'
+            }],
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq(
+          "set -o pipefail && " \
+          + "xcodebuild " \
+          + "-destination \"name=iPhone 5s,OS=8.1\" " \
+          + "-scheme \"MyApp\" " \
+          + "-workspace \"MyApp.xcworkspace\" " \
+          + "test " \
+          + "| xcpretty --color " \
+          + "--report html " \
+          + "--output \"./build-dir/test-report.html\" " \
+          + "--screenshots " \
+          + "--report junit " \
+          + "--output \"./build-dir/test-report.xml\" " \
+          + "--test"
+        )
+      end
+
       it "should detect and use the workspace, when a workspace is present" do
         allow(Dir).to receive(:glob).with("*.xcworkspace").and_return([ "MyApp.xcworkspace" ])
 

--- a/spec/actions_specs/xcodebuild_spec.rb
+++ b/spec/actions_specs/xcodebuild_spec.rb
@@ -401,10 +401,10 @@ describe Fastlane do
           + "test " \
           + "| xcpretty --color " \
           + "--report html " \
-          + "--output \"./build-dir/test-report.html\" " \
+          + "--output ./build-dir/test-report.html " \
           + "--screenshots " \
           + "--report junit " \
-          + "--output \"./build-dir/test-report.xml\" " \
+          + "--output ./build-dir/test-report.xml " \
           + "--test"
         )
       end


### PR DESCRIPTION
This pull request addresses the following issue:
Although a user can set multiple xcpretty reports with the ":report_formats" argument, Fastlane is unable to accept multiple values for ":report_path". This means a user can only define the output path for one of the reports even if they specify more than one.

This pull request defines a new parameter ":reports", which takes an array of hashes. The keys of the has map exactly to the parameters taken by xcpretty. This enables the user to specify all options for each report they want to generate.

The old options were left intact for backwards compatibility - those can be removed if desired.

This was my best first guess at how to implement, feedback welcome.
