### PR TITLE
[increment version number] Show failing current SemVer

### DIFF
--- a/lib/fastlane/actions/increment_version_number.rb
+++ b/lib/fastlane/actions/increment_version_number.rb
@@ -49,8 +49,8 @@ module Fastlane
           if Helper.test?
             version_array = [1,0,0]
           else
-            current_version= `#{command_prefix} agvtool what-marketing-version -terse1`.split("\n").last
-            raise 'Your current version does not respect the format A.B.C' unless current_version.match(/\d.\d.\d/)
+            current_version = `#{command_prefix} agvtool what-marketing-version -terse1`.split("\n").last
+            raise 'Your current version (#{current_version}) does not respect the format A.B.C' unless current_version.match(/\d.\d.\d/)
             #Check if CFBundleShortVersionString is the same for each occurrence
             allBundles = `#{command_prefix} agvtool what-marketing-version -terse`.split("\n")
             allBundles.each do |bundle|


### PR DESCRIPTION
Apple's tool `agvtool` was giving back a version `1.0` for my app at version at `2.1.0` I had no idea why this was happening, or even what the failing number was.

For people who may be here to figure the answer, `agvtool` would return the version for my Tests Target, which was just default `1.0` instead of main app target. I ended up just using plist_buddy to ensure it is changing the right plist ( `/usr/libexec/PlistBuddy -c "Set CFBundleVersion #{latest_version}" "Supporting Files/info.plist` )
