### PR TITLE
Brand new configuration system

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -333,14 +333,22 @@ increment_build_numer(
 This action will increment the **version number**. You first have to [set up your Xcode project](https://developer.apple.com/library/ios/qa/qa1827/_index.html), if you haven't done it already.
 
 ```ruby
-increment_version_number         # Automatically increment patch version number.
-increment_version_number "patch" # Automatically increment patch version number.
-increment_version_number "minor" # Automatically increment minor version number.
-increment_version_number "major" # Automatically increment major version number.
-increment_version_number '2.1.1' # Set a specific version number.
+increment_version_number # Automatically increment patch version number.
+increment_version_number(
+  bump_type: "patch" # Automatically increment patch version number
+)
+increment_version_number(
+  bump_type: "minor" # Automatically increment minor version number
+)
+increment_version_number(
+  bump_type: "major" # Automatically increment major version number
+)
+increment_version_number(
+  version_number: '2.1.1' # Set a specific version number
+)
 
 increment_version_number(
-  release_task: '2.1.1',                  # specify specific version number (optional, omitting it increments patch version number)
+  version_number: '2.1.1',                # specify specific version number (optional, omitting it increments patch version number)
   xcodeproj: './path/to/MyApp.xcodeproj'  # (optional, you must specify the path to your main Xcode project if it is not in the project root directory)
 )
 ```

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -321,7 +321,9 @@ This method will increment the **build number**, not the app version. Usually th
 
 ```ruby
 increment_build_number # automatically increment by one
-increment_build_number '75' # set a specific number
+increment_build_number(
+  build_number: '75' # set a specific number
+)
 
 increment_build_numer(
   build_number: 75, # specify specific build number (optional, omitting it increments by one)

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -489,7 +489,7 @@ If you have other uncommitted changes in your repo, this action will fail. If yo
 commit_version_bump
 
 commit_version_bump(
-  message: 'Version Bump',                         # create a commit with a custom message
+  message: 'Version Bump',                    # create a commit with a custom message
   xcodeproj: './path/to/MyProject.xcodeproj', # optional, if you have multiple Xcode project files, you must specify your main project here
 )
 ```

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -239,14 +239,20 @@ gcovr({
 deliver
 ```
 
-To upload a new build to TestFlight use ```deliver :beta```.
+To upload a new build to TestFlight use ```deliver(beta: true)```.
 
-If you don't want a PDF report for App Store builds, append ```:force``` to the command. This is useful when running ```fastlane``` on your Continuous Integration server: `deliver :force`
+If you don't want a PDF report for App Store builds, append ```:force``` to the command. This is useful when running ```fastlane``` on your Continuous Integration server: `deliver(force: true)`
 
 Other options
 
-- ```deliver :skip_deploy```: To don't submit the app for review (works with both App Store and beta builds)
-- ```deliver :force, :skip_deploy```: Combine options using ```,```
+```ruby
+deliver(
+  force: true,# Set to true to skip PDF verification
+  beta: true, # Upload a new version to TestFlight
+  skip_deploy: true, # To don't submit the app for review (works with both App Store and beta builds)
+  deliver_file_path: './nothere' # Specify a path to the directory containing the Deliverfile
+)
+```
 
 ### [HockeyApp](http://hockeyapp.net)
 ```ruby

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -6,6 +6,16 @@ With `fastlane` `1.0.0` it was necessary to do some breaking changes:
 
 ## Changed Integrations:
 
+### increment_build_number
+
+You now have to specify the key `build_number` New syntax:
+
+```ruby
+increment_build_number(
+  build_number: '75' # set a specific number
+)
+```
+
 ### increment_version_number
 
 You now have to specify the key `bump_type` to make this integration work. New syntax:
@@ -31,12 +41,14 @@ increment_version_number(
 )
 ```
 
-### increment_build_number
 
-You now have to specify the key `build_number` New syntax:
+### snapshot
+
+For `verbose` and `noclean` update your code to this:
 
 ```ruby
-increment_build_number(
-  build_number: '75' # set a specific number
+snapshot(
+  verbose: true, 
+  noclean: true
 )
 ```

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -1,0 +1,32 @@
+fastlane 1.0 Migration Guide
+============================
+
+
+With `fastlane` `1.0.0` it was necessary to do some breaking changes:
+
+## Changed Integrations:
+
+### increment_version_number
+
+You now have to specify the key `bump_type` to make this integration work. New syntax:
+
+```ruby
+increment_version_number # Automatically increment patch version number.
+increment_version_number(
+  bump_type: "patch" # Automatically increment patch version number
+)
+increment_version_number(
+  bump_type: "minor" # Automatically increment minor version number
+)
+increment_version_number(
+  bump_type: "major" # Automatically increment major version number
+)
+increment_version_number(
+  version_number: '2.1.1' # Set a specific version number
+)
+
+increment_version_number(
+  version_number: '2.1.1',                # specify specific version number (optional, omitting it increments patch version number)
+  xcodeproj: './path/to/MyApp.xcodeproj'  # (optional, you must specify the path to your main Xcode project if it is not in the project root directory)
+)
+```

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -6,6 +6,25 @@ With `fastlane` `1.0.0` it was necessary to do some breaking changes:
 
 ## Changed Integrations:
 
+### deliver
+
+If you want to pass options to `deliver`, you have to upgrade to the new syntax:
+
+```ruby
+deliver(
+  beta: true
+)
+```
+
+All available options:
+```ruby
+deliver(
+  force: true,# Set to true to skip PDF verification
+  beta: true, # Upload a new version to TestFlight
+  skip_deploy: true, # To don't submit the app for review (works with both App Store and beta builds)
+  deliver_file_path: './nothere' # Specify a path to the directory containing the Deliverfile
+)
+
 ### increment_build_number
 
 You now have to specify the key `build_number` New syntax:
@@ -14,6 +33,8 @@ You now have to specify the key `build_number` New syntax:
 increment_build_number(
   build_number: '75' # set a specific number
 )
+
+
 ```
 
 ### increment_version_number

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -30,3 +30,13 @@ increment_version_number(
   xcodeproj: './path/to/MyApp.xcodeproj'  # (optional, you must specify the path to your main Xcode project if it is not in the project root directory)
 )
 ```
+
+### increment_build_number
+
+You now have to specify the key `build_number` New syntax:
+
+```ruby
+increment_build_number(
+  build_number: '75' # set a specific number
+)
+```

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'terminal-notifier', '~> 1.6.2' # Mac OS X notifications
   spec.add_dependency 'terminal-table', '~> 1.4.5' # Actions documentation
 
-  spec.add_dependency 'fastlane_core', '>= 0.5.2' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 1.0.0' # all shared code and dependencies
 
   # All the fastlane tools
   spec.add_dependency 'deliver', '>= 0.9.1'

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'terminal-notifier', '~> 1.6.2' # Mac OS X notifications
   spec.add_dependency 'terminal-table', '~> 1.4.5' # Actions documentation
 
-  spec.add_dependency 'fastlane_core', '>= 1.0.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.6.0' # all shared code and dependencies
 
   # All the fastlane tools
   spec.add_dependency 'deliver', '>= 0.9.1'

--- a/lib/fastlane.rb
+++ b/lib/fastlane.rb
@@ -11,6 +11,7 @@ require 'fastlane/action'
 require 'fastlane/actions/actions_helper'
 require 'fastlane/action_collector'
 require 'fastlane/supported_platforms'
+require 'fastlane/configuration_helper'
 
 require 'fastlane_core'
 

--- a/lib/fastlane/action.rb
+++ b/lib/fastlane/action.rb
@@ -54,5 +54,10 @@ module Fastlane
     def self.sh(command)
       Fastlane::Actions.sh(command)
     end
+
+    # instead of "AddGitAction", this will return "add_git" to print it to the user
+    def self.action_name
+      self.name.split('::').last.gsub('Action', '').fastlane_underscore
+    end
   end
 end

--- a/lib/fastlane/actions/actions_helper.rb
+++ b/lib/fastlane/actions/actions_helper.rb
@@ -17,6 +17,11 @@ module Fastlane
       @lane_context ||= {}
     end
 
+    # Used in tests to get a clear lane before every test
+    def self.clear_lane_context
+      @lane_context = nil
+    end
+
     # Pass a block which should be tracked. One block = one testcase
     # @param step_name (String) the name of the currently built code (e.g. snapshot, sigh, ...)
     def self.execute_action(step_name)

--- a/lib/fastlane/actions/add_git_tag.rb
+++ b/lib/fastlane/actions/add_git_tag.rb
@@ -2,15 +2,13 @@ module Fastlane
   module Actions
     # Adds a git tag to the current commit
     class AddGitTagAction < Action
-      def self.run(params)
-        options = ConfigurationHelper.parse(self, params)
-        
+      def self.run(options)
         lane_name = Actions.lane_context[Actions::SharedValues::LANE_NAME].gsub(' ', '') # no spaces allowed
 
         tag = options[:tag] || "#{options[:grouping]}/#{lane_name}/#{options[:prefix]}#{options[:build_number]}"
 
         Helper.log.info "Adding git tag '#{tag}' 🎯."
-        # Actions.sh("git tag #{tag}")
+        Actions.sh("git tag #{tag}")
       end
 
       def self.description

--- a/lib/fastlane/actions/add_git_tag.rb
+++ b/lib/fastlane/actions/add_git_tag.rb
@@ -5,7 +5,7 @@ module Fastlane
       def self.run(options)
         lane_name = Actions.lane_context[Actions::SharedValues::LANE_NAME].gsub(' ', '') # no spaces allowed
 
-        tag = options[:tag] || "#{options[:grouping]}/#{lane_name}/#{options[:prefix]}#{options[:build_number]}"
+        tag = options[:tag] || "#{options[:grouping]}/#{lane_name}/#{options[:prefix]}#{options[:build_number].to_s}"
 
         Helper.log.info "Adding git tag '#{tag}' 🎯."
         Actions.sh("git tag #{tag}")
@@ -32,7 +32,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :build_number,
                                        env_name: "FL_GIT_TAG_BUILD_NUMBER",
                                        description: "The build number. Defaults to the result of increment_build_number if you\'re using it",
-                                       default_value: Actions.lane_context[Actions::SharedValues::BUILD_NUMBER])
+                                       default_value: Actions.lane_context[Actions::SharedValues::BUILD_NUMBER],
+                                       is_string: false)
         ]
       end
 

--- a/lib/fastlane/actions/cert.rb
+++ b/lib/fastlane/actions/cert.rb
@@ -12,7 +12,7 @@ module Fastlane
 
         return if Helper.test?
 
-        FastlaneCore::UpdateChecker.start_looking_for_update('cert')
+        FastlaneCore::UpdateChecker.start_looking_for_update('cert') unless Helper.is_test?
 
         begin
           Dir.chdir(FastlaneFolder.path || Dir.pwd) do

--- a/lib/fastlane/actions/cert.rb
+++ b/lib/fastlane/actions/cert.rb
@@ -37,7 +37,7 @@ module Fastlane
 
             Helper.log.info("Use signing certificate '#{certificate_id}' from now on!".green)
 
-            ENV["SIGH_CERTIFICATE_ID"] = certificate_id
+            ENV["SIGH_CERTIFICATE_ID"] = certificate_id # for further use in the sigh action
           end
         ensure
           FastlaneCore::UpdateChecker.show_update_status('cert', Cert::VERSION)

--- a/lib/fastlane/actions/clean_build_artifacts.rb
+++ b/lib/fastlane/actions/clean_build_artifacts.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     class CleanBuildArtifactsAction < Action
-      def self.run(_params)
+      def self.run(params)
         [
           Actions.lane_context[Actions::SharedValues::IPA_OUTPUT_PATH],
           Actions.lane_context[Actions::SharedValues::SIGH_PROFILE_PATH],

--- a/lib/fastlane/actions/crashlytics.rb
+++ b/lib/fastlane/actions/crashlytics.rb
@@ -72,7 +72,7 @@ module Fastlane
                                        description: "Path to your IPA file. Optional if you use the `ipa` or `xcodebuild` action",
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        verify_block: Proc.new do |value|
-                                        raise "No IPA file given or found, pass using `value: 'path/app.ipa'`".red unless File.exists?(value)
+                                        raise "No IPA file given or found, pass using `ipa_path: 'path/app.ipa'`".red unless File.exists?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :notes_path,
                                        env_name: "CRASHLYTICS_NOTES_PATH",
@@ -94,17 +94,6 @@ module Fastlane
                                        description: "Crashlytics notification option (true/false)",
                                        optional: true)
         ]
-
-
-        # [
-        #   ['crashlytics_path', 'Path to your Crashlytics bundle', 'CRASHLYTICS_FRAMEWORK_PATH'],
-        #   ['api_token', 'Crashlytics Beta API Token', 'CRASHLYTICS_API_TOKEN'],
-        #   ['build_secret', 'Crashlytics Build Secret', 'CRASHLYTICS_BUILD_SECRET'],
-        #   ['ipa_path', 'Path to your IPA file. Optional if you use the `ipa` or `xcodebuild` action'],
-        #   ['notes_path', 'Release Notes'],
-        #   ['emails', 'Pass email address'],
-        #   ['notifications', 'Crashlytics notification option']
-        # ]
       end
 
       def self.author

--- a/lib/fastlane/actions/deliver.rb
+++ b/lib/fastlane/actions/deliver.rb
@@ -4,24 +4,20 @@ module Fastlane
     end
 
     class DeliverAction < Action
-      def self.run(params)
+      def self.run(config)
         require 'deliver'
 
         FastlaneCore::UpdateChecker.start_looking_for_update('deliver') unless Helper.is_test?
 
         begin
-          ENV['DELIVER_SCREENSHOTS_PATH'] = Actions.lane_context[SharedValues::SNAPSHOT_SCREENSHOTS_PATH]
+          ENV['DELIVER_SCREENSHOTS_PATH'] = Actions.lane_context[SharedValues::SNAPSHOT_SCREENSHOTS_PATH] # use snapshot's screenshots if there
 
-          force = params.include?(:force)
-          beta = params.include?(:beta)
-          skip_deploy = params.include?(:skip_deploy)
-
-          Dir.chdir(ENV["DELIVERFILE_PATH"] || FastlaneFolder.path || Dir.pwd) do
+          Dir.chdir(config[:deliver_file_path] || FastlaneFolder.path || Dir.pwd) do
             # This should be executed in the fastlane folder
             Deliver::Deliverer.new(nil,
-                                   force: force,
-                                   is_beta_ipa: beta,
-                                   skip_deploy: skip_deploy)
+                                   force: config[:force],
+                                   is_beta_ipa: config[:beta],
+                                   skip_deploy: config[:skip_deploy])
 
             if ENV['DELIVER_IPA_PATH'] # since IPA upload is optional
               Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] = File.expand_path(ENV['DELIVER_IPA_PATH']) # deliver will store it in the environment
@@ -38,10 +34,31 @@ module Fastlane
 
       def self.available_options
         [
-          ['force', 'Set to true to skip PDF verification'],
-          ['beta', 'Upload a new version to TestFlight'],
-          ['skip_deploy', 'Skip the submission of the app - it will only be uploaded'],
-          ['', 'Specify a path to the directory containing the Deliverfile', 'DELIVERFILE_PATH']
+          FastlaneCore::ConfigItem.new(key: :force,
+                                       env_name: "FL_DELIVER_FORCE",
+                                       description: "Set to true to skip PDF verification",
+                                       optional: true,
+                                       default_value: false,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :beta,
+                                       env_name: "FL_DELIVER_BETA",
+                                       description: "Upload a new version to TestFlight",
+                                       optional: true,
+                                       default_value: false,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :skip_deploy,
+                                       env_name: "FL_DELIVER_SKIP_DEPLOY",
+                                       description: "Skip the submission of the app - it will only be uploaded",
+                                       optional: true,
+                                       default_value: false,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :deliver_file_path,
+                                       env_name: "FL_DELIVER_CONFIG_PATH",
+                                       description: "Specify a path to the directory containing the Deliverfile",
+                                       default_value: FastlaneFolder.path || Dir.pwd, # defaults to fastlane folder
+                                       verify_block: Proc.new do |value|
+                                        raise "Couldn't find folder. Make sure to pass the path to the directory not the file!".red unless File.directory?(value)
+                                       end)
         ]
       end
 

--- a/lib/fastlane/actions/deliver.rb
+++ b/lib/fastlane/actions/deliver.rb
@@ -57,7 +57,7 @@ module Fastlane
                                        description: "Specify a path to the directory containing the Deliverfile",
                                        default_value: FastlaneFolder.path || Dir.pwd, # defaults to fastlane folder
                                        verify_block: Proc.new do |value|
-                                        raise "Couldn't find folder. Make sure to pass the path to the directory not the file!".red unless File.directory?(value)
+                                        raise "Couldn't find folder '#{value}'. Make sure to pass the path to the directory not the file!".red unless File.directory?(value)
                                        end)
         ]
       end

--- a/lib/fastlane/actions/deliver.rb
+++ b/lib/fastlane/actions/deliver.rb
@@ -7,7 +7,7 @@ module Fastlane
       def self.run(params)
         require 'deliver'
 
-        FastlaneCore::UpdateChecker.start_looking_for_update('deliver')
+        FastlaneCore::UpdateChecker.start_looking_for_update('deliver') unless Helper.is_test?
 
         begin
           ENV['DELIVER_SCREENSHOTS_PATH'] = Actions.lane_context[SharedValues::SNAPSHOT_SCREENSHOTS_PATH]

--- a/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -6,7 +6,7 @@ module Fastlane
 
     # Raises an exception and stop the lane execution if the repo is not in a clean state
     class EnsureGitStatusCleanAction < Action
-      def self.run(_params)
+      def self.run(params)
         repo_clean = `git status --porcelain`.empty?
 
         if repo_clean

--- a/lib/fastlane/actions/frameit.rb
+++ b/lib/fastlane/actions/frameit.rb
@@ -7,7 +7,7 @@ module Fastlane
         require 'frameit'
 
         begin
-          FastlaneCore::UpdateChecker.start_looking_for_update('frameit')
+          FastlaneCore::UpdateChecker.start_looking_for_update('frameit') unless Helper.is_test?
           color = Frameit::Editor::Color::BLACK
           color = Frameit::Editor::Color::SILVER if [:silver, :white].include?(params.first)
 

--- a/lib/fastlane/actions/frameit.rb
+++ b/lib/fastlane/actions/frameit.rb
@@ -9,7 +9,7 @@ module Fastlane
         begin
           FastlaneCore::UpdateChecker.start_looking_for_update('frameit') unless Helper.is_test?
           color = Frameit::Editor::Color::BLACK
-          color = Frameit::Editor::Color::SILVER if [:silver, :white].include?(params.first)
+          color = Frameit::Editor::Color::SILVER if [:silver, :white].include?(params)
 
           screenshots_folder = Actions.lane_context[SharedValues::SNAPSHOT_SCREENSHOTS_PATH]
           screenshots_folder ||= FastlaneFolder.path

--- a/lib/fastlane/actions/gcovr.rb
+++ b/lib/fastlane/actions/gcovr.rb
@@ -60,8 +60,8 @@ module Fastlane
         gcovr_args = nil
 
         # Allows for a whole variety of configurations
-        if params.first.is_a? Hash
-          params_hash = params.first
+        if params.is_a? Hash
+          params_hash = params
 
           # Check if an output path was given
           if params_hash.has_key? :output

--- a/lib/fastlane/actions/hockey.rb
+++ b/lib/fastlane/actions/hockey.rb
@@ -58,12 +58,6 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :crashlytics_path,
-                                       env_name: "CRASHLYTICS_FRAMEWORK_PATH",
-                                       description: "Path to your Crashlytics bundle",
-                                       verify_block: Proc.new do |value|
-                                        raise "No Crashlytics path given or found, pass using `crashlytics_path: 'path'`".red unless File.exists?(value)
-                                       end),
           FastlaneCore::ConfigItem.new(key: :api_token,
                                        env_name: "FL_HOCKEY_API_TOKEN",
                                        description: "API Token for Hockey Access",

--- a/lib/fastlane/actions/hockey.rb
+++ b/lib/fastlane/actions/hockey.rb
@@ -10,37 +10,25 @@ module Fastlane
     end
 
     class HockeyAction < Action
-      def self.run(params)
+      def self.run(options)
         # Available options: http://support.hockeyapp.net/kb/api/api-versions#upload-version
-        options = {
-          notes: 'No changelog given',
-          status: 2,
-          notify: 1
-        }.merge(params.first)
-
-        options[:ipa] ||= Actions.lane_context[SharedValues::IPA_OUTPUT_PATH]
-        options[:dsym] ||= Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH]
 
         require 'shenzhen'
         require 'shenzhen/plugins/hockeyapp'
 
-        raise "No API Token for Hockey given, pass using `api_token: 'token'`. Open https://rink.hockeyapp.net/manage/auth_tokens to get one".red unless options[:api_token].to_s.length > 0
-        raise "No IPA file given or found, pass using `ipa: 'path.ipa'`".red unless options[:ipa]
-        raise "IPA file on path '#{File.expand_path(options[:ipa])}' not found".red unless File.exist?(options[:ipa])
-
         if options[:dsym]
-          options[:dsym_filename] = options[:dsym]
+          dsym_filename = options[:dsym]
         else
           dsym_path = options[:ipa].gsub('ipa', 'app.dSYM.zip')
           if File.exist?(dsym_path)
-            options[:dsym_filename] = dsym_path
+            dsym_filename = dsym_path
           else
             Helper.log.info "Symbols not found on path #{File.expand_path(dsym_path)}. Crashes won't be symbolicated properly".yellow
           end
         end
 
-        raise "Symbols on path '#{File.expand_path(options[:dsym_filename])}' not found".red if (options[:dsym_filename] &&
-                                                                                                !File.exist?(options[:dsym_filename]))
+        raise "Symbols on path '#{File.expand_path(dsym_filename)}' not found".red if (dsym_filename &&
+                                                                                                !File.exist?(dsym_filename))
 
         Helper.log.info 'Starting with ipa upload to HockeyApp... this could take some time.'.green
 
@@ -70,12 +58,44 @@ module Fastlane
 
       def self.available_options
         [
-          ['api_token', 'API Token for Hockey Access'],
-          ['ipa', 'Path to the ipa file. Optional if you use the `ipa` or `xcodebuild` action'],
-          ['notes', 'The changelog for this build'],
-          ['dsym', 'Path to the dsym file. Optional if you use the `ipa` or `xcodebuild` action'],
-          ['status', 'Download status: 1 = No user can download; 2 = Available for download'],
-          ['notify', 'Notify testers? 1 for yes'],
+          FastlaneCore::ConfigItem.new(key: :crashlytics_path,
+                                       env_name: "CRASHLYTICS_FRAMEWORK_PATH",
+                                       description: "Path to your Crashlytics bundle",
+                                       verify_block: Proc.new do |value|
+                                        raise "No Crashlytics path given or found, pass using `crashlytics_path: 'path'`".red unless File.exists?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :api_token,
+                                       env_name: "FL_HOCKEY_API_TOKEN",
+                                       description: "API Token for Hockey Access",
+                                       verify_block: Proc.new do |value|
+                                          raise "No API token for Hockey given, pass using `api_token: 'token'`".red unless (value and not value.empty?)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :ipa,
+                                       env_name: "FL_HOCKEY_IPA",
+                                       description: "Path to your IPA file. Optional if you use the `ipa` or `xcodebuild` action",
+                                       default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
+                                       verify_block: Proc.new do |value|
+                                        raise "No IPA file given or found, pass using `ipa: 'path/app.ipa'`".red unless File.exists?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :dsym,
+                                       env_name: "FL_HOCKEY_DSYM",
+                                       description: "Path to your DSYM file",
+                                       optional: true,
+                                       verify_block: Proc.new do |value|
+                                        # validation is done in the action
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :notes,
+                                       env_name: "FL_HOCKEY_NOTES",
+                                       description: "Beta Notes",
+                                       default_value: "No changelog given"),
+          FastlaneCore::ConfigItem.new(key: :notify,
+                                       env_name: "FL_HOCKEY_NOTIFY",
+                                       description: "Notify testers? 1 for yes",
+                                       default_value: 1),
+          FastlaneCore::ConfigItem.new(key: :status,
+                                       env_name: "FL_HOCKEY_STATUS",
+                                       description: "Download status: 1 = No user can download; 2 = Available for download",
+                                       default_value: "2")
         ]
       end
 

--- a/lib/fastlane/actions/increment_build_number.rb
+++ b/lib/fastlane/actions/increment_build_number.rb
@@ -64,7 +64,7 @@ module Fastlane
                                        description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
                                        verify_block: Proc.new do |value|
                                         raise "Please pass the path to the project, not the workspace".red if value.include?"workspace"
-                                        raise "Could not find Xcode project".red unless File.exists?(value)
+                                        raise "Could not find Xcode project".red if (not File.exists?(value) and not Helper.is_test?)
                                        end)
         ]
       end

--- a/lib/fastlane/actions/increment_build_number.rb
+++ b/lib/fastlane/actions/increment_build_number.rb
@@ -62,7 +62,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :xcodeproj,
                                        env_name: "FL_BUILD_NUMBER_PROJECT",
                                        description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
-                                       default_value: "path",
                                        verify_block: Proc.new do |value|
                                         raise "Please pass the path to the project, not the workspace".red if value.include?"workspace"
                                         raise "Could not find Xcode project".red unless File.exists?(value)

--- a/lib/fastlane/actions/increment_version_number.rb
+++ b/lib/fastlane/actions/increment_version_number.rb
@@ -108,7 +108,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :xcodeproj,
                                        env_name: "FL_VERSION_NUMBER_PROJECT",
                                        description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
-                                       default_value: "path",
                                        verify_block: Proc.new do |value|
                                         raise "Please pass the path to the project, not the workspace".red if value.include?"workspace"
                                         raise "Could not find Xcode project".red unless File.exists?(value)

--- a/lib/fastlane/actions/install_carthage.rb
+++ b/lib/fastlane/actions/install_carthage.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     class CarthageAction < Action
-      def self.run(_params)
+      def self.run(params)
         Actions.sh('carthage bootstrap')
       end
 

--- a/lib/fastlane/actions/install_cocapods.rb
+++ b/lib/fastlane/actions/install_cocapods.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     class CocoapodsAction < Action
-      def self.run(_params)
+      def self.run(params)
         Actions.sh('pod install')
       end
 

--- a/lib/fastlane/actions/ipa.rb
+++ b/lib/fastlane/actions/ipa.rb
@@ -74,10 +74,23 @@ module Fastlane
         ENV[SharedValues::DSYM_OUTPUT_PATH.to_s] = absolute_dsym_path
       end
 
-      def self.params_to_build_args(params)
-        # Remove nil value params unless :clean or :archive
-        params = params.delete_if { |k, v| (k != :clean && k != :archive) && v.nil? }
+      def self.params_to_build_args(config)
+        params = {}
+        params[:workspace] = config[:workspace]
+        params[:project] = config[:project]
+        params[:configuration] = config[:configuration]
+        params[:scheme] = config[:scheme]
+        params[:clean] = config[:clean]
+        params[:archive] = config[:archive]
+        params[:destination] = config[:destination]
+        params[:embed] = config[:embed]
+        params[:identity] = config[:identity]
+        params[:sdk] = config[:sdk]
+        params[:ipa] = config[:ipa]
+        params[:xcconfig] = config[:xcconfig]
+        params[:xcargs] = config[:xcargs]
 
+        params = params.delete_if { |k, v| v.nil? }
         params = fill_in_default_values(params)
 
         # Maps nice developer param names to Shenzhen's `ipa build` arguments
@@ -86,6 +99,8 @@ module Fastlane
           if args = ARGS_MAP[k]
             if k == :clean
               v == true ? '--clean' : '--no-clean'
+            elsif k == :archive
+              v == true ? '--archive' : nil
             else
               value = (v.to_s.length > 0 ? "\"#{v}\"" : '')
               "#{ARGS_MAP[k]} #{value}".strip
@@ -146,7 +161,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :archive,
                                        env_name: "IPA_ARCHIVE",
                                        description: "Archive project after building",
-                                       optional: true),
+                                       optional: true,
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :destination,
                                        env_name: "IPA_DESTINATION",
                                        description: "Build destination. Defaults to current directory",

--- a/lib/fastlane/actions/ipa.rb
+++ b/lib/fastlane/actions/ipa.rb
@@ -35,24 +35,15 @@ module Fastlane
         # The output directory of the IPA and dSYM
         absolute_dest_directory = nil
 
-        params[0] ||= {} # default to hash to fill in default values
-
-        # Allows for a whole variety of configurations
-        if params.first.is_a? Hash
-
-          # Used to get the final path of the IPA and dSYM
-          if dest = params.first[:destination]
-            absolute_dest_directory = Dir.glob(dest).map(&File.method(:realpath)).first
-          end
-
-          # Maps nice developer build parameters to Shenzhen args
-          build_args = params_to_build_args(params.first)
-
-        else
-          raise "`ipa` action parameter must be a hash".red
+        # Used to get the final path of the IPA and dSYM
+        if dest = params[:destination]
+          absolute_dest_directory = Dir.glob(dest).map(&File.method(:realpath)).first
         end
 
-        unless (params.first[:scheme] rescue nil)
+        # Maps nice developer build parameters to Shenzhen args
+        build_args = params_to_build_args(params)
+
+        unless (params[:scheme] rescue nil)
           Helper.log.warn "You haven't specified a scheme. This might cause problems. If you can't see any outupt, please pass a `scheme`"
         end
 
@@ -150,28 +141,29 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :clean,
                                        env_name: "IPA_CLEAN",
                                        description: "Clean project before building",
-                                       optional: true),
+                                       optional: true,
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :archive,
                                        env_name: "IPA_ARCHIVE",
                                        description: "Archive project after building",
                                        optional: true),
-          FastlaneCore::ConfigItem.new(key: :DESTINATION,
+          FastlaneCore::ConfigItem.new(key: :destination,
                                        env_name: "IPA_DESTINATION",
-                                       description: "Destination. Defaults to current directory",
+                                       description: "Build destination. Defaults to current directory",
                                        optional: true),
-          FastlaneCore::ConfigItem.new(key: :EMBED,
+          FastlaneCore::ConfigItem.new(key: :embed,
                                        env_name: "IPA_EMBED",
                                        description: "Sign .ipa file with .mobileprovision",
                                        optional: true),
-          FastlaneCore::ConfigItem.new(key: :IDENTITY,
+          FastlaneCore::ConfigItem.new(key: :identity,
                                        env_name: "IPA_IDENTITY",
                                        description: "Identity to be used along with --embed",
                                        optional: true),
-          FastlaneCore::ConfigItem.new(key: :SDK,
+          FastlaneCore::ConfigItem.new(key: :sdk,
                                        env_name: "IPA_SDK",
                                        description: "Use SDK as the name or path of the base SDK when building the project",
                                        optional: true),
-          FastlaneCore::ConfigItem.new(key: :IPA,
+          FastlaneCore::ConfigItem.new(key: :ipa,
                                        env_name: "IPA_IPA",
                                        description: "Specify the name of the .ipa file to generate (including file extension)",
                                        optional: true),

--- a/lib/fastlane/actions/ipa.rb
+++ b/lib/fastlane/actions/ipa.rb
@@ -75,20 +75,7 @@ module Fastlane
       end
 
       def self.params_to_build_args(config)
-        params = {}
-        params[:workspace] = config[:workspace]
-        params[:project] = config[:project]
-        params[:configuration] = config[:configuration]
-        params[:scheme] = config[:scheme]
-        params[:clean] = config[:clean]
-        params[:archive] = config[:archive]
-        params[:destination] = config[:destination]
-        params[:embed] = config[:embed]
-        params[:identity] = config[:identity]
-        params[:sdk] = config[:sdk]
-        params[:ipa] = config[:ipa]
-        params[:xcconfig] = config[:xcconfig]
-        params[:xcargs] = config[:xcargs]
+        params = config.values
 
         params = params.delete_if { |k, v| v.nil? }
         params = fill_in_default_values(params)

--- a/lib/fastlane/actions/ipa.rb
+++ b/lib/fastlane/actions/ipa.rb
@@ -5,20 +5,6 @@ module Fastlane
       DSYM_OUTPUT_PATH = :DSYM_OUTPUT_PATH
     end
 
-    # -w, --workspace                   WORKSPACE Workspace (.xcworkspace) file to use to build app (automatically detected in current directory)
-    # -p, --project PROJECT             Project (.xcodeproj) file to use to build app (automatically detected in current directory, overridden by --workspace option, if passed)
-    # -c, --configuration CONFIGURATION Configuration used to build
-    # -s, --scheme SCHEME               Scheme used to build app
-    # --xcconfig XCCONFIG               use an extra XCCONFIG file to build the app
-    # --xcargs XCARGS                   pass additional arguments to xcodebuild when building the app. Be sure to quote multiple args.
-    # --[no-]clean                      Clean project before building
-    # --[no-]archive                    Archive project after building
-    # -d, --destination DESTINATION     Destination. Defaults to current directory
-    # -m, --embed PROVISION             Sign .ipa file with .mobileprovision
-    # -i, --identity IDENTITY           Identity to be used along with --embed
-    # --sdk SDK                         use SDK as the name or path of the base SDK when building the project
-    # --ipa IPA                         specify the name of the .ipa file to generate (including file extension)
-
     ARGS_MAP = {
       workspace: '-w',
       project: '-p',
@@ -31,6 +17,7 @@ module Fastlane
       identity: '-i',
       sdk: '--sdk',
       ipa: '--ipa',
+      xcconfig: '--xcconfig',
       xcargs: '--xcargs',
     }
 
@@ -56,7 +43,7 @@ module Fastlane
           build_args = params_to_build_args(params.first)
 
         else
-          build_args = params
+          raise "`ipa` action parameter must be a hash".red
         end
 
         # If no dest directory given, default to current directory
@@ -133,20 +120,60 @@ module Fastlane
       end
 
       def self.available_options
-        # [
-          # ['workspace', 'Workspace (.xcworkspace) file to use to build app (automatically detected in current directory)'],
-          # ['project', 'Project (.xcodeproj) file to use to build app (automatically detected in current directory'],
-          # ['configuration', 'Configuration used to build'],
-          # ['scheme', 'Scheme used to build app'],
-          # ['clean', 'use an extra XCCONFIG file to build the app'],
-          # ['archive', 'pass additional arguments to xcodebuild when building the app. Be sure to quote multiple args.'],
-          # ['destination', 'Clean project before building'],
-          # ['embed', 'Archive project after building'],
-          # ['identity', 'Destination. Defaults to current directory'],
-          # ['sdk', 'Sign .ipa file with .mobileprovision'],
-          # ['ipa', 'Identity to be used along with --embed'],
-          # ['xcargs', 'specify the name of the .ipa file to generate (including file extension)']
-        # ]
+        [
+          FastlaneCore::ConfigItem.new(key: :workspace,
+                                       env_name: "IPA_WORKSPACE",
+                                       description: "WORKSPACE Workspace (.xcworkspace) file to use to build app (automatically detected in current directory)",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :project,
+                                       env_name: "IPA_PROJECT",
+                                       description: "Project (.xcodeproj) file to use to build app (automatically detected in current directory, overridden by --workspace option, if passed)",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :configuration,
+                                       env_name: "IPA_CONFIGURATION",
+                                       description: "Configuration used to build",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :scheme,
+                                       env_name: "IPA_SCHEME",
+                                       description: "Scheme used to build app",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :clean,
+                                       env_name: "IPA_CLEAN",
+                                       description: "Clean project before building",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :archive,
+                                       env_name: "IPA_ARCHIVE",
+                                       description: "Archive project after building",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :DESTINATION,
+                                       env_name: "IPA_DESTINATION",
+                                       description: "Destination. Defaults to current directory",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :EMBED,
+                                       env_name: "IPA_EMBED",
+                                       description: "Sign .ipa file with .mobileprovision",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :IDENTITY,
+                                       env_name: "IPA_IDENTITY",
+                                       description: "Identity to be used along with --embed",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :SDK,
+                                       env_name: "IPA_SDK",
+                                       description: "Use SDK as the name or path of the base SDK when building the project",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :IPA,
+                                       env_name: "IPA_IPA",
+                                       description: "Specify the name of the .ipa file to generate (including file extension)",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :xcconfig,
+                                       env_name: "IPA_XCCONFIG",
+                                       description: "Use an extra XCCONFIG file to build the app",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :xcargs,
+                                       env_name: "IPA_XCARGS",
+                                       description: "Pass additional arguments to xcodebuild when building the app. Be sure to quote multiple args",
+                                       optional: true),
+        ]
       end
 
       def self.output

--- a/lib/fastlane/actions/notify.rb
+++ b/lib/fastlane/actions/notify.rb
@@ -12,7 +12,7 @@ module Fastlane
         "Shows a Mac OS X notification"
       end
 
-      def author
+      def self.author
         "champo"
       end
 

--- a/lib/fastlane/actions/pem.rb
+++ b/lib/fastlane/actions/pem.rb
@@ -13,7 +13,7 @@ module Fastlane
         values = params.first
 
         begin
-          FastlaneCore::UpdateChecker.start_looking_for_update('pem')
+          FastlaneCore::UpdateChecker.start_looking_for_update('pem') unless Helper.is_test?
 
           success_block = values[:new_profile]
           values.delete(:new_profile) # as it's not in the configs

--- a/lib/fastlane/actions/produce.rb
+++ b/lib/fastlane/actions/produce.rb
@@ -17,7 +17,7 @@ module Fastlane
 
         return if Helper.test?
 
-        FastlaneCore::UpdateChecker.start_looking_for_update('produce')
+        FastlaneCore::UpdateChecker.start_looking_for_update('produce') unless Helper.is_test?
 
         begin
           Dir.chdir(FastlaneFolder.path || Dir.pwd) do

--- a/lib/fastlane/actions/produce.rb
+++ b/lib/fastlane/actions/produce.rb
@@ -8,10 +8,9 @@ module Fastlane
       def self.run(params)
         require 'produce'
 
-        hash = params.first || {}
-        raise 'Parameter of produce must be a hash'.red unless hash.is_a?(Hash)
+        raise 'Parameter of produce must be a hash'.red unless params.is_a?(Hash)
 
-        hash.each do |key, value|
+        params.each do |key, value|
           ENV[key.to_s.upcase] = value.to_s
         end
 

--- a/lib/fastlane/actions/reset_git_repo.rb
+++ b/lib/fastlane/actions/reset_git_repo.rb
@@ -37,8 +37,17 @@ module Fastlane
 
       def self.available_options
         [
-          ['files', 'Array of files the changes should be discarded from. If not given, all files will be discarded'],
-          ['force', 'Skip verifying of previously clean state of repo. Only recommended in combination with `files` option']
+          FastlaneCore::ConfigItem.new(key: :files,
+                                       env_name: "FL_RESET_GIT_FILES",
+                                       description: "Array of files the changes should be discarded from. If not given, all files will be discarded",
+                                       verify_block: Proc.new do |value|
+                                        raise "Please pass an array only" unless value.kind_of?Array
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :force,
+                                       env_name: "FL_RESET_GIT_FORCE",
+                                       description: "Skip verifying of previously clean state of repo. Only recommended in combination with `files` option",
+                                       is_string: false,
+                                       default_value: false),
         ]
       end
 

--- a/lib/fastlane/actions/reset_git_repo.rb
+++ b/lib/fastlane/actions/reset_git_repo.rb
@@ -3,9 +3,8 @@ module Fastlane
     # Does a hard reset and clean on the repo
     class ResetGitRepoAction < Action
       def self.run(params)
-        hash = params.first
-        if params.include?(:force) || hash[:force] || Actions.lane_context[SharedValues::GIT_REPO_WAS_CLEAN_ON_START]
-          paths = (hash[:files] rescue nil)
+        if params[:force] || params[:force] || Actions.lane_context[SharedValues::GIT_REPO_WAS_CLEAN_ON_START]
+          paths = (params[:files] rescue nil)
 
           if (paths || []).count == 0
             Actions.sh('git reset --hard HEAD')

--- a/lib/fastlane/actions/sigh.rb
+++ b/lib/fastlane/actions/sigh.rb
@@ -23,7 +23,7 @@ module Fastlane
         end
 
         begin
-          FastlaneCore::UpdateChecker.start_looking_for_update('sigh')
+          FastlaneCore::UpdateChecker.start_looking_for_update('sigh') unless Helper.is_test?
 
           Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, (values || {}))
           

--- a/lib/fastlane/actions/slack.rb
+++ b/lib/fastlane/actions/slack.rb
@@ -30,17 +30,10 @@ module Fastlane
         message
       end
 
-      def self.run(params)
-        options = { message: '',
-                    success: true,
-                    channel: nil,
-                    payload: {}
-                  }.merge(params.first || {})
-
+      def self.run(options)
         require 'slack-notifier'
 
         options[:message] = self.trim_message(options[:message].to_s || '')
-
         options[:message] = Slack::Notifier::LinkFormatter.format(options[:message])
 
         url = ENV['SLACK_URL']
@@ -79,11 +72,36 @@ module Fastlane
 
       def self.available_options
         [
-          ['message', 'The message that should be displayed on Slack. This supports the standard Slack markup language'],
-          ['channel', '#channel or @username'],
-          ['success', 'Success or error?'],
-          ['payload', 'Add additional information to this post. payload must be a hash containg any key with any value'],
-          ['default_payloads', 'Remove some of the default payloads. More information about the available payloads GitHub']
+          FastlaneCore::ConfigItem.new(key: :message,
+                                       env_name: "FL_SLACK_MESSAGE",
+                                       description: "The message that should be displayed on Slack. This supports the standard Slack markup language",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :channel,
+                                       env_name: "FL_SLACK_CHANNEL",
+                                       description: "#channel or @username",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :slack_url,
+                                       env_name: "SLACK_URL",
+                                       description: "Create an Incoming WebHook for your Slack group",
+                                       verify_block: Proc.new do |value|
+                                        raise "Invalid URL, must start with https://" unless value.start_with?"https://"
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :payload,
+                                       env_name: "FL_SLACK_PAYLOAD",
+                                       description: "Add additional information to this post. payload must be a hash containg any key with any value",
+                                       default_value: {},
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :default_payloads,
+                                       env_name: "FL_SLACK_DEFAULT_PAYLOADS",
+                                       description: "Remove some of the default payloads. More information about the available payloads on GitHub",
+                                       optional: true,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :success,
+                                       env_name: "FL_SLACK_SUCCESS",
+                                       description: "Was this build successful? (true/false)",
+                                       optional: true,
+                                       default_value: true,
+                                       is_string: false),
         ]
       end
 

--- a/lib/fastlane/actions/snapshot.rb
+++ b/lib/fastlane/actions/snapshot.rb
@@ -17,7 +17,7 @@ module Fastlane
 
         require 'snapshot'
 
-        FastlaneCore::UpdateChecker.start_looking_for_update('snapshot')
+        FastlaneCore::UpdateChecker.start_looking_for_update('snapshot') unless Helper.is_test?
 
         begin
           Dir.chdir(FastlaneFolder.path) do

--- a/lib/fastlane/actions/snapshot.rb
+++ b/lib/fastlane/actions/snapshot.rb
@@ -6,9 +6,8 @@ module Fastlane
 
     class SnapshotAction < Action
       def self.run(params)
-        clean = true
-        clean = false if params.include?(:noclean)
-        $verbose = true if params.include?(:verbose)
+        $verbose = true if params[:verbose]
+        clean = !params[:noclean]
 
         if Helper.test?
           Actions.lane_context[SharedValues::SNAPSHOT_SCREENSHOTS_PATH] = Dir.pwd
@@ -39,8 +38,16 @@ module Fastlane
 
       def self.available_options
         [
-          ['noclean', 'Skips the clean process when building the app'],
-          ['verbose', 'Print out the UI Automation output']
+          FastlaneCore::ConfigItem.new(key: :noclean,
+                                       env_name: "FL_SNAPSHOT_NO_CLEAN",
+                                       description: "Skips the clean process when building the app",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :verbose,
+                                       env_name: "FL_SNAPSHOT_VERBOSE",
+                                       description: "Print out the UI Automation output",
+                                       is_string: false,
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/actions/team_id.rb
+++ b/lib/fastlane/actions/team_id.rb
@@ -5,7 +5,7 @@ module Fastlane
 
     class TeamIdAction < Action
       def self.run(params)
-        team = params.first
+        team = (params.first rescue nil)
         raise "Please pass your Team ID (e.g. team_id 'Q2CBPK58CA')".red unless team.to_s.length > 0
 
         Helper.log.info "Setting Team ID to '#{team}' for all build steps"

--- a/lib/fastlane/actions/team_name.rb
+++ b/lib/fastlane/actions/team_name.rb
@@ -5,7 +5,7 @@ module Fastlane
 
     class TeamNameAction < Action
       def self.run(params)
-        team = params.first
+        team = (params.first rescue nil)
         raise "Please pass your Team Name (e.g. team_name 'Felix Krause')".red unless team.to_s.length > 0
 
         Helper.log.info "Setting Team Name to '#{team}' for all build steps"

--- a/lib/fastlane/actions/testmunk.rb
+++ b/lib/fastlane/actions/testmunk.rb
@@ -12,20 +12,13 @@
 module Fastlane
   module Actions
     class TestmunkAction < Action
-      def self.run(_params)
-        raise "Please pass your Testmunk email address using `ENV['TESTMUNK_EMAIL'] = 'value'`" unless ENV['TESTMUNK_EMAIL']
-        raise "Please pass your Testmunk API Key using `ENV['TESTMUNK_API'] = 'value'`" unless ENV['TESTMUNK_API']
-        raise "Please pass your Testmunk app name using `ENV['TESTMUNK_APP'] = 'value'`" unless ENV['TESTMUNK_APP']
-
-        ipa_path = ENV['TESTMUNK_IPA'] || ENV[Actions::SharedValues::IPA_OUTPUT_PATH.to_s]
-        raise "Please pass a path to your ipa file using `ENV['TESTMUNK_IPA'] = 'value'`" unless ipa_path
-
+      def self.run(config)
         Helper.log.info 'Testmunk: Uploading the .ipa and starting your tests'.green
 
         response = system("#{"curl -H 'Accept: application/vnd.testmunk.v1+json'" +
-            " -F 'file=@#{ipa_path}' -F 'autoStart=true'" +
-            " -F 'email=#{ENV['TESTMUNK_EMAIL']}'" +
-            " https://#{ENV['TESTMUNK_API']}@api.testmunk.com/apps/#{ENV['TESTMUNK_APP']}/testruns"}")
+            " -F 'file=@#{config[:ipa]}' -F 'autoStart=true'" +
+            " -F 'email=#{config[:email]}'" +
+            " https://#{config[:api]}@api.testmunk.com/apps/#{config[:app]}/testruns"}")
 
         if response
           Helper.log.info 'Your tests are being executed right now. Please wait for the mail with results and decide if you want to continue.'.green
@@ -40,9 +33,30 @@ module Fastlane
 
       def self.available_options
         [
-          ['', 'Your email address', 'TESTMUNK_EMAIL'],
-          ['', 'Testmunk API Key', 'TESTMUNK_API'],
-          ['', 'Testmunk App Name', 'TESTMUNK_APP']
+          FastlaneCore::ConfigItem.new(key: :ipa,
+                                       env_name: "TESTMUNK_IPA",
+                                       description: "Path to IPA",
+                                       verify_block: Proc.new do |value|
+                                        raise "Please pass to existing ipa" unless File.exists?value
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :email,
+                                       env_name: "TESTMUNK_EMAIL",
+                                       description: "Your email address",
+                                       verify_block: Proc.new do |value|
+                                        raise "Please pass your Testmunk email address using `ENV['TESTMUNK_EMAIL'] = 'value'`" unless value
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :api,
+                                       env_name: "TESTMUNK_API",
+                                       description: "Testmunk API Key",
+                                       verify_block: Proc.new do |value|
+                                          raise "Please pass your Testmunk API Key using `ENV['TESTMUNK_API'] = 'value'`" unless value
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :app,
+                                       env_name: "TESTMUNK_APP",
+                                       description: "Testmunk App Name",
+                                       verify_block: Proc.new do |value|
+                                        raise "Please pass your Testmunk app name using `ENV['TESTMUNK_APP'] = 'value'`" unless value
+                                       end),
         ]
       end
 

--- a/lib/fastlane/actions/typetalk.rb
+++ b/lib/fastlane/actions/typetalk.rb
@@ -8,7 +8,7 @@ module Fastlane
             success: true,
             topicId: nil,
             typetalk_token: nil,
-        }.merge(params.first || {})
+        }.merge(params || {})
 
         [:message, :topicId, :typetalk_token].each { |key|
           raise "No #{key} given.".red unless options[key]

--- a/lib/fastlane/actions/update_project_code_signing.rb
+++ b/lib/fastlane/actions/update_project_code_signing.rb
@@ -39,7 +39,8 @@ module Fastlane
                                        default_value: ENV["SIGH_UDID"],
                                        verify_block: Proc.new do |value|
                                         raise "Path is invalid".red unless File.exists?(value)
-                                       end),
+                                       end)
+        ]
       end
 
       def self.author

--- a/lib/fastlane/actions/update_project_code_signing.rb
+++ b/lib/fastlane/actions/update_project_code_signing.rb
@@ -5,19 +5,16 @@ module Fastlane
 
     class UpdateProjectCodeSigningAction < Action
       def self.run(params)
-        path = params.first
+        path = params[:path]
         path = File.join(path, "project.pbxproj")
         raise "Could not find path to project config '#{path}'. Pass the path to your project (not workspace)!".red unless File.exists?(path)
 
-        udid = (params[1] rescue nil)
-        udid ||= ENV["SIGH_UDID"]
-
-        Helper.log.info("Updating provisioning profile UDID (#{udid}) for the given project '#{path}'")
+        Helper.log.info("Updating provisioning profile UDID (#{params[:udid]}) for the given project '#{path}'")
 
         p = File.read(path)
-        File.write(path, p.gsub(/PROVISIONING_PROFILE = ".*";/, "PROVISIONING_PROFILE = \"#{udid}\";"))
+        File.write(path, p.gsub(/PROVISIONING_PROFILE = ".*";/, "PROVISIONING_PROFILE = \"#{params[:udid]}\";"))
 
-        Helper.log.info("Successfully updated project settings to use UDID '#{udid}'".green)
+        Helper.log.info("Successfully updated project settings to use UDID '#{params[:udid]}'".green)
       end
 
       def self.description
@@ -26,6 +23,23 @@ module Fastlane
 
       def self.details
         "This feature is not yet 100% finished"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: "FL_PROJECT_SIGNING_PROJECT_PATH",
+                                       description: "Path to your Xcode project",
+                                       verify_block: Proc.new do |value|
+                                        raise "Path is invalid".red unless File.exists?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :udid,
+                                       env_name: "FL_PROJECT_SIGNING_UDID",
+                                       description: "The UDID of the provisioning profile you want to use",
+                                       default_value: ENV["SIGH_UDID"],
+                                       verify_block: Proc.new do |value|
+                                        raise "Path is invalid".red unless File.exists?(value)
+                                       end),
       end
 
       def self.author

--- a/lib/fastlane/actions/xcode_select.rb
+++ b/lib/fastlane/actions/xcode_select.rb
@@ -19,7 +19,7 @@ module Fastlane
     #
     class XcodeSelectAction < Action
       def self.run(params)
-        xcode_path = params.first
+        xcode_path = (params.first rescue nil)
 
         # Verify that a param was passed in
         raise "Path to Xcode application required (e.x. \"/Applications/Xcode.app\")".red unless xcode_path.to_s.length > 0

--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -66,7 +66,7 @@ module Fastlane
         end
 
 
-        if params = params.first
+        if params
           # Operation bools
           archiving = params.key? :archive
           exporting = params.key? :export_archive
@@ -246,9 +246,9 @@ module Fastlane
 
     class XcarchiveAction < Action
       def self.run(params)
-        params_hash = params.first || {}
+        params_hash = params || {}
         params_hash[:archive] = true
-        XcodebuildAction.run([params_hash])
+        XcodebuildAction.run(params_hash)
       end
 
       def self.description
@@ -261,14 +261,23 @@ module Fastlane
 
       def self.is_supported?(platform)
         platform == :ios
+      end
+
+      def self.available_options
+        [
+          ['archive_path', 'The path to archive the to. Must contain `.xcarchive`'],
+          ['workspace', 'The workspace to use'],
+          ['scheme', 'The scheme to build'],
+          ['build_settings', 'Hash of additional build information']
+        ]
       end
     end
 
     class XcbuildAction < Action
       def self.run(params)
-        params_hash = params.first || {}
+        params_hash = params || {}
         params_hash[:build] = true
-        XcodebuildAction.run([params_hash])
+        XcodebuildAction.run(params_hash)
       end
 
       def self.description
@@ -281,14 +290,24 @@ module Fastlane
 
       def self.is_supported?(platform)
         platform == :ios
+      end
+
+      def self.available_options
+        [
+          ['archive', 'Set to true to build archive'],
+          ['archive_path', 'The path to archive the to. Must contain `.xcarchive`'],
+          ['workspace', 'The workspace to use'],
+          ['scheme', 'The scheme to build'],
+          ['build_settings', 'Hash of additional build information']
+        ]
       end
     end
 
     class XccleanAction < Action
       def self.run(params)
-        params_hash = params.first || {}
+        params_hash = params || {}
         params_hash[:clean] = true
-        XcodebuildAction.run([params_hash])
+        XcodebuildAction.run(params_hash)
       end
 
       def self.description
@@ -302,13 +321,23 @@ module Fastlane
       def self.is_supported?(platform)
         platform == :ios
       end
+
+      def self.available_options
+        [
+          ['archive', 'Set to true to build archive'],
+          ['archive_path', 'The path to archive the to. Must contain `.xcarchive`'],
+          ['workspace', 'The workspace to use'],
+          ['scheme', 'The scheme to build'],
+          ['build_settings', 'Hash of additional build information']
+        ]
+      end
     end
 
     class XcexportAction < Action
       def self.run(params)
-        params_hash = params.first || {}
+        params_hash = params || {}
         params_hash[:export_archive] = true
-        XcodebuildAction.run([params_hash])
+        XcodebuildAction.run(params_hash)
       end
 
       def self.description
@@ -317,6 +346,16 @@ module Fastlane
 
       def self.author
         "dtrenz"
+      end
+
+      def self.available_options
+        [
+          ['archive', 'Set to true to build archive'],
+          ['archive_path', 'The path to archive the to. Must contain `.xcarchive`'],
+          ['workspace', 'The workspace to use'],
+          ['scheme', 'The scheme to build'],
+          ['build_settings', 'Hash of additional build information']
+        ]
       end
 
       def self.is_supported?(platform)
@@ -326,17 +365,22 @@ module Fastlane
 
     class XctestAction < Action
       def self.run(params)
-        params_hash = params.first || {}
+        params_hash = params || {}
         params_hash[:test] = true
-        XcodebuildAction.run([params_hash])
+        XcodebuildAction.run(params_hash)
       end
 
       def self.description
         "Runs tests on the given simulator"
       end
 
-      def available_options
+      def self.available_options
         [
+          ['archive', 'Set to true to build archive'],
+          ['archive_path', 'The path to archive the to. Must contain `.xcarchive`'],
+          ['workspace', 'The workspace to use'],
+          ['scheme', 'The scheme to build'],
+          ['build_settings', 'Hash of additional build information'],
           ['destination', 'The simulator to use, e.g. "name=iPhone 5s,OS=8.1"']
         ]
       end

--- a/lib/fastlane/actions_list.rb
+++ b/lib/fastlane/actions_list.rb
@@ -107,7 +107,7 @@ module Fastlane
     end
     
     private
-      def self.parse_options(options, fill_three = true)
+      def self.parse_options(options, fill_all = true)
         rows = []
         rows << [options] if options.kind_of?String
 
@@ -119,7 +119,7 @@ module Fastlane
               raise "Invalid number of elements in this row: #{current}. Must be 2 or 3".red unless ([2, 3].include?current.count)
               rows << current
               rows.last[0] = rows.last.first.yellow # color it yellow :) 
-              rows.last << nil if (fill_three and rows.last.count == 2) # to have a nice border in the table
+              rows.last << nil while (fill_all and rows.last.count < 3) # to have a nice border in the table
             end
           end
         end

--- a/lib/fastlane/actions_list.rb
+++ b/lib/fastlane/actions_list.rb
@@ -49,7 +49,7 @@ module Fastlane
           rows << [action.details]
           rows << [' ']
         end
-        rows << ["Originally created by #{action.author.green}"] if action.author
+        rows << ["Created by #{action.author.green}"] if action.author
 
         puts Terminal::Table.new(
           title: filter.green,

--- a/lib/fastlane/actions_list.rb
+++ b/lib/fastlane/actions_list.rb
@@ -49,7 +49,7 @@ module Fastlane
           rows << [action.details]
           rows << [' ']
         end
-        rows << ["Created by #{action.author.green}"] if action.author
+        rows << ["Originally created by #{action.author.green}"] if action.author
 
         puts Terminal::Table.new(
           title: filter.green,

--- a/lib/fastlane/configuration_helper.rb
+++ b/lib/fastlane/configuration_helper.rb
@@ -2,12 +2,15 @@ module Fastlane
   class ConfigurationHelper
     def self.parse(action, params)
       begin
-        if action.available_options.first.kind_of?FastlaneCore::ConfigItem
+        first_element = (action.available_options.first rescue nil) # might also be nil
+        if first_element and first_element.kind_of?FastlaneCore::ConfigItem
           return FastlaneCore::Configuration.create(action.available_options, params)
-        else
+        elsif first_element
           Helper.log.error "Action '#{action}' uses the old configuration format."
           raise "Old configuration format".red if Helper.is_test? # only fail in tests - this might be removed in the future, once all actions are migrated
           return params
+        else
+          # No parameters at all - that's okay
         end
       rescue => ex
         Helper.log.fatal "You provided an option to action #{action.action_name} which is not supported.".red

--- a/lib/fastlane/configuration_helper.rb
+++ b/lib/fastlane/configuration_helper.rb
@@ -3,13 +3,14 @@ module Fastlane
     def self.parse(action, params)
       begin
         first_element = (action.available_options.first rescue nil) # might also be nil
+        
         if first_element and first_element.kind_of?FastlaneCore::ConfigItem
           # default use case
           return FastlaneCore::Configuration.create(action.available_options, params)
 
         elsif first_element
           Helper.log.error "Action '#{action}' uses the old configuration format."
-          raise "Old configuration format".red if Helper.is_test? # only fail in tests - this might be removed in the future, once all actions are migrated
+          puts "Old configuration format for action '#{action}'".red if Helper.is_test?
           return params
         else
 

--- a/lib/fastlane/configuration_helper.rb
+++ b/lib/fastlane/configuration_helper.rb
@@ -4,7 +4,7 @@ module Fastlane
       begin
         options = FastlaneCore::Configuration.create(action.available_options, params)
       rescue => ex
-        Helper.log.fatal "You provided option an option to action #{action.action_name} which is not supported.".red
+        Helper.log.fatal "You provided an option to action #{action.action_name} which is not supported.".red
         Helper.log.fatal "Check out the available options below or run `fastlane action #{action.action_name}`".red
         raise ex
       end

--- a/lib/fastlane/configuration_helper.rb
+++ b/lib/fastlane/configuration_helper.rb
@@ -4,13 +4,18 @@ module Fastlane
       begin
         first_element = (action.available_options.first rescue nil) # might also be nil
         if first_element and first_element.kind_of?FastlaneCore::ConfigItem
+          # default use case
           return FastlaneCore::Configuration.create(action.available_options, params)
+
         elsif first_element
           Helper.log.error "Action '#{action}' uses the old configuration format."
           raise "Old configuration format".red if Helper.is_test? # only fail in tests - this might be removed in the future, once all actions are migrated
           return params
         else
-          # No parameters at all - that's okay
+
+          # No parameters... we still need the configuration object array
+          FastlaneCore::Configuration.create(action.available_options, {})
+
         end
       rescue => ex
         Helper.log.fatal "You provided an option to action #{action.action_name} which is not supported.".red

--- a/lib/fastlane/configuration_helper.rb
+++ b/lib/fastlane/configuration_helper.rb
@@ -2,7 +2,13 @@ module Fastlane
   class ConfigurationHelper
     def self.parse(action, params)
       begin
-        options = FastlaneCore::Configuration.create(action.available_options, params)
+        if action.available_options.first.kind_of?FastlaneCore::ConfigItem
+          return FastlaneCore::Configuration.create(action.available_options, params)
+        else
+          Helper.log.error "Action '#{action}' uses the old configuration format."
+          raise "Old configuration format".red if Helper.is_test? # only fail in tests - this might be removed in the future, once all actions are migrated
+          return params
+        end
       rescue => ex
         Helper.log.fatal "You provided an option to action #{action.action_name} which is not supported.".red
         Helper.log.fatal "Check out the available options below or run `fastlane action #{action.action_name}`".red

--- a/lib/fastlane/configuration_helper.rb
+++ b/lib/fastlane/configuration_helper.rb
@@ -1,0 +1,13 @@
+module Fastlane
+  class ConfigurationHelper
+    def self.parse(action, params)
+      begin
+        options = FastlaneCore::Configuration.create(action.available_options, params)
+      rescue => ex
+        Helper.log.fatal "You provided option an option to action #{action.action_name} which is not supported.".red
+        Helper.log.fatal "Check out the available options below or run `fastlane action #{action.action_name}`".red
+        raise ex
+      end
+    end
+  end
+end

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -95,7 +95,7 @@ module Fastlane
               # arguments is an array by default, containing an hash with the actual parameters
               # Since we usually just need the passed hash, we'll just use the first object if there is only one
               if arguments.count == 0 
-                ConfigurationHelper.parse(class_ref, {}) # no parameters => empty hsh
+                arguments = ConfigurationHelper.parse(class_ref, {}) # no parameters => empty hsh
               elsif arguments.count == 1 and arguments.first.kind_of?Hash
                 arguments = ConfigurationHelper.parse(class_ref, arguments.first) # Correct configuration passed
               elsif not class_ref.available_options

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -92,6 +92,11 @@ module Fastlane
         begin
           Dir.chdir('..') do # go up from the fastlane folder, to the project folder
             Actions.execute_action(method_sym) do
+              # arguments is an array by default, containing an hash with the actual parameters
+              # Since we usually just need the passed hash, we'll just use the first object if there is only one
+              arguments = arguments.first if (arguments.count == 1 and arguments.first.kind_of?Hash)
+              arguments = {} if arguments.count == 0 # no value => should be an empty hash
+              
               class_ref.run(arguments)
             end
           end

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -94,9 +94,17 @@ module Fastlane
             Actions.execute_action(method_sym) do
               # arguments is an array by default, containing an hash with the actual parameters
               # Since we usually just need the passed hash, we'll just use the first object if there is only one
-              arguments = arguments.first if (arguments.count == 1 and arguments.first.kind_of?Hash)
-              arguments = {} if arguments.count == 0 # no value => should be an empty hash
-              
+              if arguments.count == 0 
+                ConfigurationHelper.parse(class_ref, {}) # no parameters => empty hsh
+              elsif arguments.count == 1 and arguments.first.kind_of?Hash
+                arguments = ConfigurationHelper.parse(class_ref, arguments.first) # Correct configuration passed
+              elsif not class_ref.available_options
+                # This action does not use the new action format
+                # Just passing the arguments to this method
+              else
+                raise "You have to pass the options for '#{method_sym}' as hash. Please check out the current documentation on GitHub!".red
+              end
+
               class_ref.run(arguments)
             end
           end

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -102,7 +102,11 @@ module Fastlane
                 # This action does not use the new action format
                 # Just passing the arguments to this method
               else
-                raise "You have to pass the options for '#{method_sym}' as hash. Please check out the current documentation on GitHub!".red
+                Helper.log.fatal "------------------------------------------------------------------------------------".red
+                Helper.log.fatal "If you've been an existing fastlane user, please check out the MigrationGuide to 1.0".yellow
+                Helper.log.fatal "https://github.com/KrauseFx/fastlane/blob/master/docs/MigrationGuide.md".yellow
+                Helper.log.fatal "------------------------------------------------------------------------------------".red
+                raise "You have to pass the options for '#{method_sym}' in a different way. Please check out the current documentation on GitHub!".red
               end
 
               class_ref.run(arguments)

--- a/lib/fastlane/version.rb
+++ b/lib/fastlane/version.rb
@@ -1,3 +1,3 @@
 module Fastlane
-  VERSION = '0.9.0'
+  VERSION = '0.10.0'
 end

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -1,0 +1,10 @@
+describe Fastlane do
+  describe Fastlane::Action do
+    describe "#action_name" do
+      it "converts the :: format to a readable one" do
+        expect(Fastlane::Actions::IpaAction.action_name).to eq('ipa')
+        expect(Fastlane::Actions::IncrementBuildNumberAction.action_name).to eq('increment_build_number')
+      end
+    end
+  end
+end

--- a/spec/actions_specs/crashlytics_spec.rb
+++ b/spec/actions_specs/crashlytics_spec.rb
@@ -13,7 +13,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             crashlytics()
           end").runner.execute(:test)
-        }.to raise_error("You have to pass Crashlytics parameters to the Crashlytics action, take a look at https://github.com/KrauseFx/fastlane#crashlytics".red)
+        }.to raise_error("No Crashlytics path given or found, pass using `crashlytics_path: 'path'`".red)
       end
 
       it "raises an error if no crashlytics path was given" do
@@ -74,7 +74,7 @@ describe Fastlane do
               build_secret: 'wadus'
             })
           end").runner.execute(:test)
-        }.to raise_error("No IPA file given or found, pass using `ipa_path: 'path/app.ipa'`".red)
+        }.to raise_error("No IPA file given or found, pass using `value: 'path/app.ipa'`".red)
       end
 
       it "raises an error if the given ipa path was not found" do
@@ -87,7 +87,7 @@ describe Fastlane do
               ipa_path: './fastlane/wadus'
             })
           end").runner.execute(:test)
-        }.to raise_error("No IPA file given or found, pass using `ipa_path: 'path/app.ipa'`".red)
+        }.to raise_error("No IPA file given or found, pass using `value: 'path/app.ipa'`".red)
       end
 
       it "works with valid parameters" do

--- a/spec/actions_specs/crashlytics_spec.rb
+++ b/spec/actions_specs/crashlytics_spec.rb
@@ -74,7 +74,7 @@ describe Fastlane do
               build_secret: 'wadus'
             })
           end").runner.execute(:test)
-        }.to raise_error("No IPA file given or found, pass using `value: 'path/app.ipa'`".red)
+        }.to raise_error("No IPA file given or found, pass using `ipa_path: 'path/app.ipa'`".red)
       end
 
       it "raises an error if the given ipa path was not found" do
@@ -87,7 +87,7 @@ describe Fastlane do
               ipa_path: './fastlane/wadus'
             })
           end").runner.execute(:test)
-        }.to raise_error("No IPA file given or found, pass using `value: 'path/app.ipa'`".red)
+        }.to raise_error("No IPA file given or found, pass using `ipa_path: 'path/app.ipa'`".red)
       end
 
       it "works with valid parameters" do

--- a/spec/actions_specs/default_platform_spec.rb
+++ b/spec/actions_specs/default_platform_spec.rb
@@ -17,6 +17,13 @@ describe Fastlane do
           Fastlane::Actions::DefaultPlatformAction.run([])
         }.to raise_error("You forgot to pass the default platform".red)
       end
+
+      it "works as expected inside a Fastfile" do
+        Fastlane::FastFile.new.parse("lane :test do 
+          default_platform :ios
+        end").runner.execute(:test)
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DEFAULT_PLATFORM]).to eq(:ios)
+      end
     end
   end
 end

--- a/spec/actions_specs/default_platform_spec.rb
+++ b/spec/actions_specs/default_platform_spec.rb
@@ -11,6 +11,12 @@ describe Fastlane do
           Fastlane::Actions::DefaultPlatformAction.run(['notSupportedOS'])
         }.to raise_error("Platform 'notSupportedOS' is not supported. Must be either [:ios, :mac, :android]".red)
       end
+
+      it "raises an error if no platform is given" do
+        expect {
+          Fastlane::Actions::DefaultPlatformAction.run([])
+        }.to raise_error("You forgot to pass the default platform".red)
+      end
     end
   end
 end

--- a/spec/actions_specs/deliver_action_spec.rb
+++ b/spec/actions_specs/deliver_action_spec.rb
@@ -31,6 +31,28 @@ describe Fastlane do
         end
       end
 
+      it "works with custom setting" do
+        test_val = "test_val"
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::SNAPSHOT_SCREENSHOTS_PATH] = test_val
+
+        Dir.chdir(test_path) do
+          expect {
+            
+            Fastlane::FastFile.new.parse("lane :test do 
+              deliver(
+                force: true,
+                beta: true,
+                skip_deploy: true,
+                deliver_file_path: '../example'
+              )
+            end").runner.execute(:test)
+
+          }.to raise_error('Deliverfile not found at path \'/private/tmp/fastlane/tests/Deliverfile\''.red)
+
+          expect(ENV['DELIVER_SCREENSHOTS_PATH']).to eq(test_val)
+        end
+      end
+
       after do
         File.delete(@app_file)
         File.delete(@deliver_file)

--- a/spec/actions_specs/deliver_action_spec.rb
+++ b/spec/actions_specs/deliver_action_spec.rb
@@ -47,7 +47,7 @@ describe Fastlane do
               )
             end").runner.execute(:test)
 
-          }.to raise_error('Deliverfile not found at path \'/private/tmp/fastlane/tests/Deliverfile\''.red)
+          }.to raise_error("Couldn't find folder '../example'. Make sure to pass the path to the directory not the file!".red)
 
           expect(ENV['DELIVER_SCREENSHOTS_PATH']).to eq(test_val)
         end

--- a/spec/actions_specs/deploygate_spec.rb
+++ b/spec/actions_specs/deploygate_spec.rb
@@ -36,7 +36,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             deploygate({
               api_token: 'thisistest',
-              user: 'deploygate',
+              user: 'deploygate'
             })
           end").runner.execute(:test)
         }.to raise_error

--- a/spec/actions_specs/fastlane_version_spec.rb
+++ b/spec/actions_specs/fastlane_version_spec.rb
@@ -1,0 +1,29 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "fastlane_version action" do
+
+      it "works as expected" do
+        Fastlane::FastFile.new.parse("lane :test do 
+          fastlane_version '0.1'
+        end").runner.execute(:test)
+      end
+
+      it "raises an exception if it's an old version" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do 
+            fastlane_version '9999'
+          end").runner.execute(:test)
+        }.to raise_error("The Fastfile requires a fastlane version of >= 9999. You are on #{Fastlane::VERSION}. Please update using `sudo gem update fastlane`.".red)
+      end
+
+      it "raises an error if no team ID is given" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do 
+            fastlane_version
+          end").runner.execute(:test)
+        }.to raise_error("Please pass minimum fastlane version as parameter to fastlane_version".red)
+      end
+      
+    end
+  end
+end

--- a/spec/actions_specs/hockey_spec.rb
+++ b/spec/actions_specs/hockey_spec.rb
@@ -1,6 +1,6 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    describe "Hockey Integration" do
+    describe "Hockey Integration", now: true do
       it "raises an error if no ipa file was given" do
         expect {
           Fastlane::FastFile.new.parse("lane :test do 
@@ -8,7 +8,7 @@ describe Fastlane do
               api_token: 'xxx'
             })
           end").runner.execute(:test)
-        }.to raise_error("No IPA file given or found, pass using `ipa: 'path.ipa'`".red)
+        }.to raise_error("No IPA file given or found, pass using `ipa: 'path/app.ipa'`".red)
       end
 
       it "raises an error if given ipa file was not found" do
@@ -19,7 +19,7 @@ describe Fastlane do
               ipa: './notHere.ipa'
             })
           end").runner.execute(:test)
-        }.to raise_error("IPA file on path '#{File.expand_path('../notHere.ipa')}' not found".red)
+        }.to raise_error("No IPA file given or found, pass using `ipa: 'path/app.ipa'`".red)
       end
 
       it "raises an error if supplied dsym file was not found" do

--- a/spec/actions_specs/hockey_spec.rb
+++ b/spec/actions_specs/hockey_spec.rb
@@ -1,6 +1,6 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    describe "Hockey Integration", now: true do
+    describe "Hockey Integration" do
       it "raises an error if no ipa file was given" do
         expect {
           Fastlane::FastFile.new.parse("lane :test do 

--- a/spec/actions_specs/increment_build_number_action_spec.rb
+++ b/spec/actions_specs/increment_build_number_action_spec.rb
@@ -5,7 +5,7 @@ describe Fastlane do
 
       it "increments the build number of the Xcode project" do
         Fastlane::FastFile.new.parse("lane :test do 
-          increment_build_number
+          increment_build_number(xcodeproj: '.xcproject')
         end").runner.execute(:test)
 
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool next-version -all/)
@@ -13,18 +13,10 @@ describe Fastlane do
 
       it "pass a custom build number to the tool" do
         result = Fastlane::FastFile.new.parse("lane :test do 
-          increment_build_number(build_number: 24)
+          increment_build_number(build_number: 24, xcodeproj: '.xcproject')
         end").runner.execute(:test)
 
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool new-version -all 24/)
-      end
-
-      it "raises an exception when xcode project path wasn't found" do
-        expect {
-          Fastlane::FastFile.new.parse("lane :test do
-            increment_build_number(xcodeproj: '/nothere')
-          end").runner.execute(:test)
-        }.to raise_error("Could not find Xcode project".red)
       end
 
       it "raises an exception when use passes workspace" do

--- a/spec/actions_specs/increment_build_number_action_spec.rb
+++ b/spec/actions_specs/increment_build_number_action_spec.rb
@@ -13,10 +13,26 @@ describe Fastlane do
 
       it "pass a custom build number to the tool" do
         result = Fastlane::FastFile.new.parse("lane :test do 
-          increment_build_number 24
+          increment_build_number(build_number: 24)
         end").runner.execute(:test)
 
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool new-version -all 24/)
+      end
+
+      it "raises an exception when xcode project path wasn't found" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+            increment_build_number(xcodeproj: '/nothere')
+          end").runner.execute(:test)
+        }.to raise_error("Could not find Xcode project".red)
+      end
+
+      it "raises an exception when use passes workspace" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+            increment_build_number(xcodeproj: 'project.xcworkspace')
+          end").runner.execute(:test)
+        }.to raise_error("Please pass the path to the project, not the workspace".red)
       end
     end
   end

--- a/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/spec/actions_specs/increment_version_number_action_spec.rb
@@ -13,7 +13,7 @@ describe Fastlane do
 
       it "it increments all targets minor version number" do
         Fastlane::FastFile.new.parse("lane :test do
-          increment_version_number 'minor'
+          increment_version_number(bump_type: 'minor')
         end").runner.execute(:test)
 
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.1.0/)
@@ -21,7 +21,7 @@ describe Fastlane do
 
       it "it increments all targets minor version major" do
         Fastlane::FastFile.new.parse("lane :test do
-          increment_version_number 'major'
+          increment_version_number(bump_type: 'major')
         end").runner.execute(:test)
 
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 2.0.0/)
@@ -29,10 +29,34 @@ describe Fastlane do
 
       it "pass a custom version number" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          increment_version_number '1.4.3'
+          increment_version_number(version_number: '1.4.3')
         end").runner.execute(:test)
 
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.4.3/)
+      end
+
+      it "raises an exception when xcode project path wasn't found" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+            increment_version_number(xcodeproj: '/nothere')
+          end").runner.execute(:test)
+        }.to raise_error("Could not find Xcode project".red)
+      end
+
+      it "raises an exception when use passes workspace" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+            increment_version_number(xcodeproj: 'project.xcworkspace')
+          end").runner.execute(:test)
+        }.to raise_error("Please pass the path to the project, not the workspace".red)
+      end
+
+      it "raises an exception if given version number is invalid" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+            increment_version_number(version_number: '3')
+          end").runner.execute(:test)
+        }.to raise_error("Invalid version '3' given. Must be x.y.z".red)
       end
     end
   end

--- a/spec/actions_specs/ipa_spec.rb
+++ b/spec/actions_specs/ipa_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane do
           ipa
         end").runner.execute(:test)
 
-        expect(result).to eq(['--no-clean'])
+        expect(result).to eq([])
       end
 
       it "works with object argument without clean and archive" do
@@ -25,7 +25,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq(5)
+        expect(result.size).to eq(4)
       end
 
       it "works with object argument with clean and archive" do

--- a/spec/actions_specs/ipa_spec.rb
+++ b/spec/actions_specs/ipa_spec.rb
@@ -127,8 +127,7 @@ describe Fastlane do
             destination: 'Nowhere',
             identity: 'bourne',
             sdk: '10.0',
-            ipa: 'JoshIsAwesome.ipa',
-            hehehe: 'hahah'
+            ipa: 'JoshIsAwesome.ipa'
           })
         end").runner.execute(:test)
 

--- a/spec/actions_specs/ipa_spec.rb
+++ b/spec/actions_specs/ipa_spec.rb
@@ -72,11 +72,12 @@ describe Fastlane do
             identity: 'bourne',
             sdk: '10.0',
             ipa: 'JoshIsAwesome.ipa',
+            xcconfig: 'SomethingGoesHere',
             xcargs: 'MY_ADHOC_OPT1=0 MY_ADHOC_OPT2=1',
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq(12)
+        expect(result.size).to eq(13)
         expect(result).to include('-w "Test.xcworkspace"')
         expect(result).to include('-p "Test.xcproject"')
         expect(result).to include('-c "Release"')
@@ -88,6 +89,7 @@ describe Fastlane do
         expect(result).to include('-i "bourne"')
         expect(result).to include('--sdk "10.0"')
         expect(result).to include('--ipa "JoshIsAwesome.ipa"')
+        expect(result).to include('--xcconfig "SomethingGoesHere"')
         expect(result).to include('--xcargs "MY_ADHOC_OPT1=0 MY_ADHOC_OPT2=1"')
       end
 

--- a/spec/actions_specs/ipa_spec.rb
+++ b/spec/actions_specs/ipa_spec.rb
@@ -7,16 +7,7 @@ describe Fastlane do
           ipa
         end").runner.execute(:test)
 
-        expect(result).to eq([])
-      end
-
-      it "works with array of arguments" do
-
-        expect {
-          result = Fastlane::FastFile.new.parse("lane :test do 
-            ipa '-s TestScheme', '-w Test.xcworkspace'
-          end").runner.execute(:test)
-        }.to raise_error("`ipa` action parameter must be a hash".red)
+        expect(result).to eq(['--no-clean'])
       end
 
       it "works with object argument without clean and archive" do
@@ -34,7 +25,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq(4)
+        expect(result.size).to eq(5)
       end
 
       it "works with object argument with clean and archive" do
@@ -54,7 +45,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq(6)
+        expect(result.size).to eq(5)
       end
 
       it "works with object argument with all" do
@@ -66,7 +57,7 @@ describe Fastlane do
             configuration: 'Release',
             scheme: 'TestScheme',
             clean: true,
-            archive: nil,
+            archive: true,
             destination: 'Nowhere',
             embed: 'Sure',
             identity: 'bourne',
@@ -123,7 +114,7 @@ describe Fastlane do
             configuration: 'Release',
             scheme: 'TestScheme',
             clean: true,
-            archive: nil,
+            archive: true,
             destination: 'Nowhere',
             identity: 'bourne',
             sdk: '10.0',

--- a/spec/actions_specs/ipa_spec.rb
+++ b/spec/actions_specs/ipa_spec.rb
@@ -12,11 +12,11 @@ describe Fastlane do
 
       it "works with array of arguments" do
 
-        result = Fastlane::FastFile.new.parse("lane :test do 
-          ipa '-s TestScheme', '-w Test.xcworkspace'
-        end").runner.execute(:test)
-
-        expect(result).to eq(['-s TestScheme', '-w Test.xcworkspace'])
+        expect {
+          result = Fastlane::FastFile.new.parse("lane :test do 
+            ipa '-s TestScheme', '-w Test.xcworkspace'
+          end").runner.execute(:test)
+        }.to raise_error("`ipa` action parameter must be a hash".red)
       end
 
       it "works with object argument without clean and archive" do

--- a/spec/actions_specs/opt_out_usage_spec.rb
+++ b/spec/actions_specs/opt_out_usage_spec.rb
@@ -1,0 +1,12 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Opt Out Usage" do
+      it "works as expected" do
+        Fastlane::FastFile.new.parse("lane :test do 
+          opt_out_usage
+        end").runner.execute(:test)
+        expect(ENV['FASTLANE_OPT_OUT_USAGE']).to eq("YES")
+      end
+    end
+  end
+end

--- a/spec/actions_specs/produce_spec.rb
+++ b/spec/actions_specs/produce_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do 
               produce('text')
             end").runner.execute(:test)
-        }.to raise_error("Parameter of produce must be a hash".red)
+        }.to raise_error("You have to pass the options for 'produce' in a different way. Please check out the current documentation on GitHub!".red)
       end
 
       it "stores passed parameters in the environment" do

--- a/spec/actions_specs/push_git_to_remote_spec.rb
+++ b/spec/actions_specs/push_git_to_remote_spec.rb
@@ -1,0 +1,27 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Push To Git Remote Action" do
+
+      it "works without passing any options" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          push_to_git_remote
+        end").runner.execute(:test)
+
+        expect(result).to eq("git push origin HEAD:HEAD --tags")
+      end
+
+      it "works with options specified" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          push_to_git_remote(
+            remote: 'origin',
+            local_branch: 'develop',
+            remote_branch: 'remote_branch',
+            force: true
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("git push origin develop:remote_branch --tags --force")
+      end
+    end
+  end
+end

--- a/spec/actions_specs/snapshot_action_spec.rb
+++ b/spec/actions_specs/snapshot_action_spec.rb
@@ -13,7 +13,7 @@ describe Fastlane do
 
       it "works with :noclean" do
         result = Fastlane::FastFile.new.parse("lane :test do 
-          snapshot :noclean
+          snapshot(noclean: true)
         end").runner.execute(:test)
         expect(result).to eq(false)
 

--- a/spec/actions_specs/team_id_spec.rb
+++ b/spec/actions_specs/team_id_spec.rb
@@ -1,0 +1,24 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Team ID Action" do
+      it "works as expected" do
+        new_val = "abcdef"
+        Fastlane::FastFile.new.parse("lane :test do 
+          team_id '#{new_val}'
+        end").runner.execute(:test)
+
+        [:CERT_TEAM_ID, :SIGH_TEAM_ID, :PEM_TEAM_ID, :PRODUCE_TEAM_ID, :SIGH_TEAM_ID, :CUPERTINO_TEAM_ID, :FASTLANE_TEAM_ID].each do |current|
+          expect(ENV[current.to_s]).to eq(new_val)
+        end
+      end
+
+      it "raises an error if no team ID is given" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do 
+            team_id
+          end").runner.execute(:test)
+        }.to raise_error("Please pass your Team ID (e.g. team_id 'Q2CBPK58CA')".red)
+      end
+    end
+  end
+end

--- a/spec/actions_specs/team_name_spec.rb
+++ b/spec/actions_specs/team_name_spec.rb
@@ -1,0 +1,24 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Team Name Action" do
+      it "works as expected" do
+        new_val = "abcdef"
+        Fastlane::FastFile.new.parse("lane :test do 
+          team_name '#{new_val}'
+        end").runner.execute(:test)
+
+        [:FASTLANE_TEAM_NAME, :PRODUCE_TEAM_NAME].each do |current|
+          expect(ENV[current.to_s]).to eq(new_val)
+        end
+      end
+
+      it "raises an error if no team Name is given" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do 
+            team_name
+          end").runner.execute(:test)
+        }.to raise_error("Please pass your Team Name (e.g. team_name 'Felix Krause')".red)
+      end
+    end
+  end
+end

--- a/spec/actions_specs/xctool_action_spec.rb
+++ b/spec/actions_specs/xctool_action_spec.rb
@@ -9,6 +9,20 @@ describe Fastlane do
 
         expect(result).to eq("xctool build test")
       end
+
+      it "works with default setting" do
+        result = Fastlane::FastFile.new.parse('lane :test do 
+          xctool :test, [
+            "--workspace", "\'AwesomeApp.xcworkspace\'",
+            "--scheme", "\'Schema Name\'",
+            "--configuration", "Debug",
+            "--sdk", "iphonesimulator",
+            "--arch", "i386"
+          ].join(" ")
+        end').runner.execute(:test)
+
+        expect(result).to eq("xctool test --workspace 'AwesomeApp.xcworkspace' --scheme 'Schema Name' --configuration Debug --sdk iphonesimulator --arch i386")
+      end
     end
   end
 end

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -4,7 +4,7 @@ describe Fastlane do
       ff = nil
       begin
         ff = Fastlane::FastFile.new.parse("lane :test do 
-          snapshot :noclean
+          snapshot(noclean: true)
           snapshot
         end")
       rescue

--- a/spec/lane_manager_spec.rb
+++ b/spec/lane_manager_spec.rb
@@ -1,6 +1,6 @@
 describe Fastlane do
   describe Fastlane::LaneManager do
-    describe "#init", now: true do
+    describe "#init" do
       it "raises an error on invalid platform" do
         expect {
           Fastlane::LaneManager.cruise_lane(123, nil)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,3 +11,9 @@ end
 
 WebMock.disable_net_connect!(:allow => 'coveralls.io')
 WebMock.allow_net_connect!
+
+RSpec.configure do |config|
+  config.before(:each) do
+    Fastlane::Actions.clear_lane_context
+  end
+end


### PR DESCRIPTION
Finally, a fully unified way of passing options to all the `fastlane` actions :tada: 

It uses the same configuration system, some of the `fastlane` tools already use for parsing command line inputs.

Advantages of this new approach:
- [x] Same API for all the actions, always a hash as parameter
- [x] All available options now also support environment variables... for free
- [ ] Much better error handling and test coverage thanks to a centralised system
- [x] Generating an up to date documentation for free :tada: 
- [x] Centralised verification of user inputs using your own Ruby block
- [x] Less boiler code for each action
- [ ] **Future**:  support to store an actions' configuration in its own file :tada: 
- [ ] **Future**: Allow users to run `fastlane` action from the command line (some users asked about stuff like `register_devices` without having to specify a new lane) :tada: 

Open Tasks:
- [ ] Migrate **all** existing actions to the new format :cry: 
- [ ] Try to still support the previous syntax of some of the actions (e.g. `deliver`)
- [ ] Release `fastlane_core` 1.0.0
- [ ] Release `fastlane 1.0.0.pre1` and invite testers
- [ ] Write guide to switch to new format

How does a new action file look like:

``` ruby
module Fastlane
  module Actions
    # Adds a git tag to the current commit
    class AddGitTagAction < Action
      def self.run(params)
        tag = options[:tag] || "#{options[:grouping]}/#{options[:prefix]}#{options[:build_number]}"

        Actions.sh("git tag #{tag}")
      end

      def self.available_options
        [
          FastlaneCore::ConfigItem.new(key: :tag,
                                       env_name: "FL_GIT_TAG_TAG",
                                       description: "Define your own tag text. This will replace all other parameters",
                                       optional: true),
          FastlaneCore::ConfigItem.new(key: :grouping,
                                       env_name: "FL_GIT_TAG_GROUPING",
                                       description: "Is used to keep your tags organised under one 'folder'. Defaults to 'builds'",
                                       default_value: 'builds'),
          FastlaneCore::ConfigItem.new(key: :prefix,
                                       env_name: "FL_GIT_TAG_PREFIX",
                                       description: "Anything you want to put in front of the version number (e.g. 'v')",
                                       default_value: ''),
          FastlaneCore::ConfigItem.new(key: :build_number,
                                       env_name: "FL_GIT_TAG_BUILD_NUMBER",
                                       description: "The build number. Defaults to the result of increment_build_number if you\'re using it",
                                       default_value: Actions.lane_context[Actions::SharedValues::BUILD_NUMBER])
        ]
      end
     ...
    end
  end
```

On the above action you can see, the actual code is just assembling a command, that's it :+1: No more manual fiddling around with parameter parsing and input validation.

For input validation, you can provide a block to each of the available parameters.
