### PR TITLE
Let's go with double-quotes!

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,6 @@ Metrics/LineLength:
 
 Metrics/MethodLength:
   Max: 20
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes


### PR DESCRIPTION
Since you setup houndci to preferred double-quotes, lets do the same with rubocop! 
http://viget.com/extend/just-use-double-quoted-ruby-strings
