### PR TITLE
Custom dsym path + minor fix to commit version bump

### DIFF
--- a/lib/fastlane/actions/commit_version_bump.rb
+++ b/lib/fastlane/actions/commit_version_bump.rb
@@ -96,7 +96,7 @@ module Fastlane
                                        optional: true,
                                        default_value: false,
                                        is_string: false
-                                       ),
+                                       )
         ]
       end
 

--- a/lib/fastlane/actions/dsym_zip.rb
+++ b/lib/fastlane/actions/dsym_zip.rb
@@ -9,12 +9,13 @@ module Fastlane
     class DsymZipAction < Action
       def self.run(params)
         archive = params[:archive_path]
+        params[:dsym_path] ||= File.join("#{File.basename(archive, '.*')}.app.dSYM.zip")
 
         plist = Plist::parse_xml(File.join(archive, 'Info.plist'))
         app_name = Helper.test? ? 'MyApp.app' : File.basename(plist['ApplicationProperties']['ApplicationPath'])
         dsym_name = "#{app_name}.dSYM"
         dsym_folder_path = File.expand_path(File.join(archive, 'dSYMs'))
-        zipped_dsym_path = File.expand_path(File.join("#{File.basename(archive, '.*')}.app.dSYM.zip"))
+        zipped_dsym_path = File.expand_path(params[:dsym_path])
 
         Actions.lane_context[SharedValues::DSYM_ZIP_PATH] = zipped_dsym_path
 
@@ -43,7 +44,12 @@ module Fastlane
                                        env_name: 'DSYM_ZIP_XCARCHIVE_PATH',
                                        verify_block: Proc.new do |value|
                                         raise "Couldn't find xcarchive file at path '#{value}'".red if !Helper.test? && !File.exists?(value)
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :dsym_path,
+                                       description: 'Path for generated dsym. Optional, default is your apps root directory',
+                                       default_value: Actions.lane_context[SharedValues::XCODEBUILD_ARCHIVE],
+                                       optional: true,
+                                       env_name: 'DSYM_ZIP_DSYM_PATH')
         ]
       end
 

--- a/lib/fastlane/actions/dsym_zip.rb
+++ b/lib/fastlane/actions/dsym_zip.rb
@@ -47,7 +47,6 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :dsym_path,
                                        description: 'Path for generated dsym. Optional, default is your apps root directory',
-                                       default_value: Actions.lane_context[SharedValues::XCODEBUILD_ARCHIVE],
                                        optional: true,
                                        env_name: 'DSYM_ZIP_DSYM_PATH')
         ]

--- a/spec/actions_specs/dsym_zip_spec.rb
+++ b/spec/actions_specs/dsym_zip_spec.rb
@@ -18,7 +18,6 @@ describe Fastlane do
         end
 
         it "creates a zip file with default archive_path from xcodebuild" do
-
           # Move one folder above as specs are execute in fastlane folder
           root_path = File.expand_path("..")
           file_basename = File.basename(xcodebuild_archive, '.*')
@@ -42,7 +41,7 @@ describe Fastlane do
           end").runner.execute(:test)
         end
 
-        it "creates a zip file with a custom archive_path" do
+        it "creates a zip file with a custom archive path" do
           custom_app_path = 'CustomApp.xcarchive'
 
           # Move one folder above as specs are execute in fastlane folder
@@ -53,6 +52,30 @@ describe Fastlane do
           zipped_dsym_path = File.join(root_path, "#{file_basename}.app.dSYM.zip")
 
           # MyApp is hardcoded into tested class so we'll just use that here
+          expect(result).to eq(%Q[cd "#{dsym_folder_path}" && zip -r "#{zipped_dsym_path}" "MyApp.app.dSYM"])
+        end
+      end
+
+      context "when there's a custom dsym path" do
+
+        result = nil
+
+        before :each do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            dsym_zip(
+              dsym_path: 'CustomPath/MyApp.app.dSYM.zip'
+            )
+          end").runner.execute(:test)
+        end
+
+        it "creates a zip file with a custom dsym path" do
+          # Move one folder above as specs are execute in fastlane folder
+          root_path = File.expand_path("..")
+          file_basename = File.basename(xcodebuild_archive, '.*')
+
+          dsym_folder_path = File.join(root_path, File.join(xcodebuild_archive, 'dSYMs'))
+          zipped_dsym_path = File.join(File.join(root_path, 'CustomPath'), "#{file_basename}.app.dSYM.zip")
+
           expect(result).to eq(%Q[cd "#{dsym_folder_path}" && zip -r "#{zipped_dsym_path}" "MyApp.app.dSYM"])
         end
       end

--- a/spec/actions_specs/dsym_zip_spec.rb
+++ b/spec/actions_specs/dsym_zip_spec.rb
@@ -7,28 +7,54 @@ describe Fastlane do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::XCODEBUILD_ARCHIVE] = xcodebuild_archive
       end
 
-      it "creates a zip file with default archive_path from xcodebuild" do
-        result = Fastlane::FastFile.new.parse("lane :test do 
-          dsym_zip
-        end").runner.execute(:test)
+      context "when there's no custom zip path" do
 
-        dsym_folder_path = File.expand_path(File.join(xcodebuild_archive, 'dSYMs'))
-        zipped_dsym_path = File.expand_path(File.join("#{File.basename(xcodebuild_archive, '.*')}.app.dSYM.zip"))
+        result = nil
 
-        expect(result).to eq(%Q[cd "#{dsym_folder_path}" && zip -r "#{zipped_dsym_path}" "MyApp.app.dSYM"])
+        before :each do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            dsym_zip
+          end").runner.execute(:test)
+        end
+
+        it "creates a zip file with default archive_path from xcodebuild" do
+
+          # Move one folder above as specs are execute in fastlane folder
+          root_path = File.expand_path("..")
+          file_basename = File.basename(xcodebuild_archive, '.*')
+
+          dsym_folder_path = File.join(root_path, File.join(xcodebuild_archive, 'dSYMs'))
+          zipped_dsym_path = File.join(root_path, "#{file_basename}.app.dSYM.zip")
+
+          expect(result).to eq(%Q[cd "#{dsym_folder_path}" && zip -r "#{zipped_dsym_path}" "MyApp.app.dSYM"])
+        end
       end
 
-      it "creates a zip file with a custom archive_path" do
-        result = Fastlane::FastFile.new.parse("lane :test do 
-          dsym_zip(
-            archive_path: 'MyApp.xcarchive'
-          )
-        end").runner.execute(:test)
+      context "when there's a custom zip path" do
 
-        dsym_folder_path = File.expand_path(File.join(xcodebuild_archive, 'dSYMs'))
-        zipped_dsym_path = File.expand_path(File.join("#{File.basename(xcodebuild_archive, '.*')}.app.dSYM.zip"))
+        result = nil
 
-        expect(result).to eq(%Q[cd "#{dsym_folder_path}" && zip -r "#{zipped_dsym_path}" "MyApp.app.dSYM"])
+        before :each do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            dsym_zip(
+              archive_path: 'CustomApp.xcarchive'
+            )
+          end").runner.execute(:test)
+        end
+
+        it "creates a zip file with a custom archive_path" do
+          custom_app_path = 'CustomApp.xcarchive'
+
+          # Move one folder above as specs are execute in fastlane folder
+          root_path = File.expand_path("..")
+          file_basename = File.basename("#{custom_app_path}", '.*')
+
+          dsym_folder_path = File.join(root_path, File.join("#{custom_app_path}", 'dSYMs'))
+          zipped_dsym_path = File.join(root_path, "#{file_basename}.app.dSYM.zip")
+
+          # MyApp is hardcoded into tested class so we'll just use that here
+          expect(result).to eq(%Q[cd "#{dsym_folder_path}" && zip -r "#{zipped_dsym_path}" "MyApp.app.dSYM"])
+        end
       end
     end
   end


### PR DESCRIPTION
This PR fixes minor issue with commit version bump (badly placed comma resulted in one option missing, which then resulted in assertion during execution). 

Moreover I've added an optional custom path for zipping dsym action. I've also rewritten dsym zip tests which were apparently failing due to invalid paths :cry:
