### PR TITLE
[Hockey] Adds the notes_type value to the Actions DSL so you can send markdown notes

### DIFF
--- a/lib/fastlane/actions/hockey.rb
+++ b/lib/fastlane/actions/hockey.rb
@@ -35,6 +35,7 @@ module Fastlane
 
         values = options.values
         values[:dsym_filename] = dsym_path
+        values[:notes_type] = options[:notes_type]
 
         return values if Helper.test?
 
@@ -91,7 +92,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :status,
                                        env_name: "FL_HOCKEY_STATUS",
                                        description: "Download status: 1 = No user can download; 2 = Available for download",
-                                       default_value: "2")
+                                       default_value: "2"),
+          FastlaneCore::ConfigItem.new(key: :notes_type,
+                                      env_name: "FL_HOCKEY_NOTES_TYPE",
+                                      description: "Notes type for your :notes, 0 = Textile, 1 = Markdown (default)",
+                                      default_value: "1")
         ]
       end
 

--- a/spec/actions_specs/hockey_spec.rb
+++ b/spec/actions_specs/hockey_spec.rb
@@ -55,6 +55,30 @@ describe Fastlane do
         expect(values[:status]).to eq(2.to_s)
         expect(values[:notes]).to eq("No changelog given")
       end
+      
+      it "has the correct default notes_type value" do
+        values = Fastlane::FastFile.new.parse("lane :test do 
+          hockey({
+            api_token: 'xxx',
+            ipa: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+          })
+        end").runner.execute(:test)
+
+        expect(values[:notes_type]).to eq("1")
+      end
+      
+      it "can change the notes_type " do
+        values = Fastlane::FastFile.new.parse("lane :test do 
+          hockey({
+            api_token: 'xxx',
+            ipa: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+            notes_type: '0'
+          })
+        end").runner.execute(:test)
+
+        expect(values[:notes_type]).to eq("0")
+      end
+      
     end
   end
 end


### PR DESCRIPTION
I think using an older build of fastlane options would be [passed through](https://github.com/artsy/eidolon/blob/master/fastlane/Fastfile#L72)? WhenI updated to `0.12.x` this broke.

In any case we need access to set the `notes_type` in the API for hockey, cause their default is textile. No-one uses that anymore, so I made the default markdown.
