### PR TITLE
Add release_type as ConfigItem for hockey action

### DIFF
--- a/lib/fastlane/actions/hockey.rb
+++ b/lib/fastlane/actions/hockey.rb
@@ -96,7 +96,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :notes_type,
                                       env_name: "FL_HOCKEY_NOTES_TYPE",
                                       description: "Notes type for your :notes, 0 = Textile, 1 = Markdown (default)",
-                                      default_value: "1")
+                                      default_value: "1"),
+          FastlaneCore::ConfigItem.new(key: :release_type,
+                                      env_name: "FL_HOCKEY_RELEASE_TYPE",
+                                      description: "Release type of the app",
+                                      default_value: "0")
         ]
       end
 

--- a/spec/actions_specs/hockey_spec.rb
+++ b/spec/actions_specs/hockey_spec.rb
@@ -54,6 +54,7 @@ describe Fastlane do
         expect(values[:notify]).to eq(1.to_s)
         expect(values[:status]).to eq(2.to_s)
         expect(values[:notes]).to eq("No changelog given")
+        expect(values[:release_type]).to eq(0.to_s)
       end
       
       it "has the correct default notes_type value" do
@@ -77,6 +78,18 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(values[:notes_type]).to eq("0")
+      end
+
+      it "can change the release_type " do
+        values = Fastlane::FastFile.new.parse("lane :test do 
+          hockey({
+            api_token: 'xxx',
+            ipa: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+            release_type: '1'
+          })
+        end").runner.execute(:test)
+
+        expect(values[:release_type]).to eq(1.to_s)
       end
       
     end


### PR DESCRIPTION
This is useful when you need to support uploading to an app on
HockeyApp with different release types. Because they usually have the
same bundle identifier, HockeyApp doesn’t know which app to upload the new
IPA to, and currently defaults to the Beta app.
### Current situation

If one uses `fastlane`'s `hockey` action for multiple release types (for example, Beta and Store), there is no way to pass the `release_type` to the HockeyApp API, now that `available_options` has been introduced.

So when I'm uploading a build and not specifying the public_identifier (also not in `available_options`), the Shenzhen HockeyApp client defaults to the generic App Upload endpoint (see here): https://github.com/nomad/shenzhen/blob/0.14.0/lib/shenzhen/plugins/hockeyapp.rb#L30-L34

Then when HockeyApp receives my Release IPA with bundle ID `com.org.app`, it finds that I have two existing apps with that bundle ID, and not knowing more information, always uploads it to the Beta version by default.

My options were to either introduce `public_identifier` to be passed to Shenzhen, or use `release_type` like I had been using before. I had an issue with using `public_identifier` because I still wanted to leave it optional. However, `default_value: nil`, cause fastlane to prompt me for the value. I think if I were to change it to `default_value: ''`, then it would behave incorrectly with Shenzhen.
