### PR TITLE
Fix incorrect syntax in FastfileTemplate

### DIFF
--- a/lib/assets/FastfileTemplate
+++ b/lib/assets/FastfileTemplate
@@ -71,7 +71,7 @@ platform :ios do
 
   error do |lane, exception|
     # slack({
-    #   message: exception.message
+    #   message: exception.message,
     #   success: false
     # })
   end


### PR DESCRIPTION
A quick commenting out won't make this run since it's missing a comma.
