### PR TITLE
Bugfix 240 handle bad behavior of action collector

### DIFF
--- a/lib/fastlane/action_collector.rb
+++ b/lib/fastlane/action_collector.rb
@@ -16,25 +16,28 @@ module Fastlane
     def did_finish
       Thread.new do
         unless ENV["FASTLANE_OPT_OUT_USAGE"]
-          
-          unless did_show_message?
-            Helper.log.debug("Sending Crash/Success information. More information on: https://github.com/fastlane/enhancer")
-            Helper.log.debug("No personal/sensitive data is sent. Only sharing the following:")
-            Helper.log.debug(launches)
-            Helper.log.debug(@error) if @error
-            Helper.log.debug("This information is used to fix failing actions and improve integrations that are often used.")
-            Helper.log.debug("You can disable this by adding `opt_out_usage` to your Fastfile")
-          end
+          begin
+            unless did_show_message?
+              Helper.log.debug("Sending Crash/Success information. More information on: https://github.com/fastlane/enhancer")
+              Helper.log.debug("No personal/sensitive data is sent. Only sharing the following:")
+              Helper.log.debug(launches)
+              Helper.log.debug(@error) if @error
+              Helper.log.debug("This information is used to fix failing actions and improve integrations that are often used.")
+              Helper.log.debug("You can disable this by adding `opt_out_usage` to your Fastfile")
+            end
 
-          require 'excon'
-          url = HOST_URL + '/did_launch?'
-          url += URI.encode_www_form(
-                  steps: launches.to_json,
-                  error: @error
-                )
+            require 'excon'
+            url = HOST_URL + '/did_launch?'
+            url += URI.encode_www_form(
+                    steps: launches.to_json,
+                    error: @error
+                  )
 
-          unless Helper.is_test? # don't send test data
-            Excon.post(url)
+            unless Helper.is_test? # don't send test data
+              Excon.post(url)
+            end
+          rescue
+            Helper.log.info("Failed sending usage data")
           end
         end
       end
@@ -46,7 +49,7 @@ module Fastlane
 
     def did_show_message?
       path = File.join(File.expand_path('~'), '.did_show_opt_info')
-      
+
       did_show = File.exists?path
       File.write(path, '1')
       did_show

--- a/lib/fastlane/lane_manager.rb
+++ b/lib/fastlane/lane_manager.rb
@@ -48,18 +48,13 @@ module Fastlane
     # All the finishing up that needs to be done
     def self.finish_fastlane(ff, duration, error)
       thread = ff.did_finish
+      thread.join 5 # https://github.com/KrauseFx/fastlane/issues/240
 
       # Finished with all the lanes
       Fastlane::JUnitGenerator.generate(Fastlane::Actions.executed_actions)
 
 
       unless error
-        begin
-          thread.join # to wait for the request to be finished
-        rescue
-          # We don't care about errors here
-          # https://github.com/KrauseFx/fastlane/issues/240
-        end
 
         if duration > 5
           Helper.log.info "fastlane.tools just saved you #{duration} minutes! 🎉".green
@@ -67,7 +62,6 @@ module Fastlane
           Helper.log.info 'fastlane.tools finished successfully 🎉'.green
         end
       else
-        thread.join # to wait for the request to be finished
         Helper.log.fatal 'fastlane finished with errors'.red
         raise error
       end


### PR DESCRIPTION
When the action collector fails to connect to the remote host, or in any other way fails.
The thread was stopped somehow causing the deadlock.

Now we do the error handling inside the thread
And added a timeout to join() to prevent the "No live threads left Deadlock?" error.
