### PR TITLE
Share builds using email with mailgun

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -622,6 +622,32 @@ slack(
 )
 ```
 
+### [Mailgun](http://www.mailgun.com)
+Send email notifications from within your builds.No need to setup a mail server to send emails from fastlane.You only need to provide your mailgun **apikey** **sandbox_domain** and **sandbox_postmaster**, all this is avaible as soon as your signup on mailgun. Also you have to specify another two required params: **to** and **message** . Additional not required params like **success** and **subject** could be omitted for default values.
+
+```ruby
+ENV['MAILGUN_SANDBOX_DOMAIN'] = '{MY_SANDBOX_DOMAIN}'
+ENV['MAILGUN_SANDBOX_POSTMASTER'] = '{MY_POSTMASTER}'
+ENV['MAILGUN_APIKEY'] = '{MY_API_KEY}'
+
+mailgun({
+  :to => "{DESTINATION_EMAIL}",
+  :success => true,
+  :message => "mail from inside a lane with mailgun"
+})
+
+or
+
+mailgun({
+  :mailgun_sandbox_domain => '{MY_SANDBOX_DOMAIN}',
+  :mailgun_sandbox_postmaster => '{MY_POSTMASTER}',
+  :mailgun_apikey => '{MY_API_KEY}',
+  :to => "{DESTINATION_EMAIL}",
+  :success => true,
+  :message => "mail from inside a lane with mailgun"
+})
+```
+
 ### [HipChat](http://www.hipchat.com/)
 Send a message to **room** (by default) or a direct message to **@username** with success (green) or failure (red) status.
 
@@ -683,9 +709,9 @@ testmunk
 
 ### update_fastlane
 
-This action will look at all installed fastlane tools and update them to the next available minor version - major version updates will not be performed automatically, as they might include breaking changes. If an update was performed, fastlane will be restarted before the run continues. 
+This action will look at all installed fastlane tools and update them to the next available minor version - major version updates will not be performed automatically, as they might include breaking changes. If an update was performed, fastlane will be restarted before the run continues.
 
-If you are using rbenv or rvm, everything should be good to go. However, if you are using the system's default ruby, some additional setup is needed for this action to work correctly. In short, fastlane needs to be able to access your gem library without running in `sudo` mode. 
+If you are using rbenv or rvm, everything should be good to go. However, if you are using the system's default ruby, some additional setup is needed for this action to work correctly. In short, fastlane needs to be able to access your gem library without running in `sudo` mode.
 
 The simplest possible fix for this is putting the following lines into your `~/.bashrc` or `~/.zshrc` file:
 
@@ -707,4 +733,3 @@ Recommended usage of the `update_fastlane` action is at the top of the `before_a
     ...
   end
 ```
-

--- a/lib/fastlane/actions/actions_helper.rb
+++ b/lib/fastlane/actions/actions_helper.rb
@@ -12,6 +12,22 @@ module Fastlane
       @executed_actions ||= []
     end
 
+    def self.git_author
+      s = `git log --name-status HEAD^..HEAD`
+      s = s.match(/Author:.*<(.*)>/)[1]
+      return s if s.to_s.length > 0
+      return nil
+    rescue
+      return nil
+    end
+
+    def self.last_git_commit
+      s = `git log -1 --pretty=%B`.strip
+      return s if s.to_s.length > 0
+      nil
+    end
+
+
     # The shared hash can be accessed by any action and contains information like the screenshots path or beta URL
     def self.lane_context
       @lane_context ||= {}

--- a/lib/fastlane/actions/mailgun.rb
+++ b/lib/fastlane/actions/mailgun.rb
@@ -40,13 +40,13 @@ module Fastlane
                                        description: "Destination of your mail"),
           FastlaneCore::ConfigItem.new(key: :message,
                                        env_name: "MAILGUN_MESSAGE",
-                                       description: "Text of your mail"),
+                                       description: "Message of your mail"),
           FastlaneCore::ConfigItem.new(key: :subject,
                                        env_name: "MAILGUN_SUBJECT",
                                        description: "Subject of your mail",
                                        optional: true,
                                        is_string: true,
-                                       default_value: "Fastlane Build"),
+                                       default_value: "fastlane build"),
           FastlaneCore::ConfigItem.new(key: :success,
                                       env_name: "MAILGUN_SUCCESS",
                                       description: "Was this build successful? (true/false)",
@@ -69,17 +69,17 @@ module Fastlane
       end
 
       def self.handle_exceptions(options)
-          unless ENV['MAILGUN_APIKEY']
+          unless (options[:mailgun_apikey] rescue nil)
             Helper.log.fatal "Please add 'ENV[\"MAILGUN_APIKEY\"] = \"a_valid_mailgun_apikey\"' to your Fastfile's `before_all` section.".red
             raise 'No MAILGUN_APIKEY given.'.red
           end
 
-          unless ENV['MAILGUN_SANDBOX_DOMAIN']
+          unless (options[:mailgun_sandbox_domain] rescue nil)
             Helper.log.fatal "Please add 'ENV[\"MAILGUN_SANDBOX_DOMAIN\"] = \"a_valid_mailgun_sandbox_domain\"' to your Fastfile's `before_all` section.".red
             raise 'No MAILGUN_SANDBOX_DOMAIN given.'.red
           end
 
-          unless ENV['MAILGUN_SANDBOX_POSTMASTER']
+          unless (options[:mailgun_sandbox_postmaster] rescue nil)
             Helper.log.fatal "Please add 'ENV[\"MAILGUN_SANDBOX_POSTMASTER\"] = \"a_valid_mailgun_sandbox_postmaster\"' to your Fastfile's `before_all` section.".red
             raise 'No MAILGUN_SANDBOX_POSTMASTER given.'.red
           end
@@ -97,7 +97,7 @@ module Fastlane
 
       def self.mailgunit(api_key,sandbox_domain,sandbox_postmaster,to,subject,text)
         RestClient.post "https://api:#{api_key}@api.mailgun.net/v3/#{sandbox_domain}/messages",
-        :from => "Mailgun Sandbox <#{sandbox_postmaster}>",
+        :from => "Mailgun Sandbox<#{sandbox_postmaster}>",
         :to => "#{to}",
         :subject => subject,
         :text => text

--- a/lib/fastlane/actions/mailgun.rb
+++ b/lib/fastlane/actions/mailgun.rb
@@ -1,0 +1,136 @@
+module Fastlane
+  module Actions
+    class MailgunAction < Action
+      def self.git_author
+        s = `git log --name-status HEAD^..HEAD`
+        s = s.match(/Author:.*<(.*)>/)[1]
+        return s if s.to_s.length > 0
+        return nil
+      rescue
+        return nil
+      end
+
+      def self.last_git_commit
+        s = `git log -1 --pretty=%B`.strip
+        return s if s.to_s.length > 0
+        nil
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      # As there is a text limit in the notifications, we are
+      # usually interested in the last part of the message
+      # e.g. for tests
+      def self.trim_message(message)
+        # We want the last 7000 characters, instead of the first 7000, as the error is at the bottom
+        start_index = [message.length - 7000, 0].max
+        message = message[start_index..-1]
+        message
+      end
+
+      def self.run(options)
+        require 'rest_client'
+
+        handle_exceptions(options)
+
+        options[:message] = self.trim_message(options[:message].to_s || '')
+
+        mailgunit(ENV['MAILGUN_APIKEY'],
+                  ENV['MAILGUN_SANDBOX_DOMAIN'],
+                  ENV['MAILGUN_SANDBOX_POSTMASTER'],
+                  options[:to],
+                  options[:subject],
+                  compose_mail(options[:message],options[:success]))
+
+      end
+
+      def self.description
+        "Send a success/error message to an email group"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :mailgun_sandbox_domain,
+                                       env_name: "MAILGUN_SANDBOX_DOMAIN",
+                                       description: "Mailgun sandbox domain for your mail"),
+          FastlaneCore::ConfigItem.new(key: :mailgun_sandbox_postmaster,
+                                       env_name: "MAILGUN_SANDBOX_POSTMASTER",
+                                       description: "Mailgun sandbox domain postmaster for your mail"),
+          FastlaneCore::ConfigItem.new(key: :mailgun_apikey,
+                                       env_name: "MAILGUN_APIKEY",
+                                       description: "Mailgun apikey for your mail"),
+          FastlaneCore::ConfigItem.new(key: :to,
+                                       env_name: "MAILGUN_TO",
+                                       description: "Destination of your mail"),
+          FastlaneCore::ConfigItem.new(key: :message,
+                                       env_name: "MAILGUN_MESSAGE",
+                                       description: "Text of your mail"),
+          FastlaneCore::ConfigItem.new(key: :subject,
+                                       env_name: "MAILGUN_SUBJECT",
+                                       description: "Subject of your mail"),
+          FastlaneCore::ConfigItem.new(key: :success,
+                                      env_name: "MAILGUN_SUCCESS",
+                                      description: "Was this build successful? (true/false)",
+                                      optional: true,
+                                      default_value: true,
+                                      is_string: false)
+
+        ]
+      end
+
+      def self.author
+        "thiagolioy"
+      end
+
+      private
+      def self.compose_mail(text,success)
+        text << "\n Git Author: #{git_author}"
+        text << "\n Last Commit: #{last_git_commit}"
+        text << "\n Success: #{success}"
+      end
+
+      def self.handle_exceptions(options)
+          unless ENV['MAILGUN_APIKEY']
+            Helper.log.fatal "Please add 'ENV[\"MAILGUN_APIKEY\"] = \"a_valid_mailgun_apikey\"' to your Fastfile's `before_all` section.".red
+            raise 'No MAILGUN_APIKEY given.'.red
+          end
+
+          unless ENV['MAILGUN_SANDBOX_DOMAIN']
+            Helper.log.fatal "Please add 'ENV[\"MAILGUN_SANDBOX_DOMAIN\"] = \"a_valid_mailgun_sandbox_domain\"' to your Fastfile's `before_all` section.".red
+            raise 'No MAILGUN_SANDBOX_DOMAIN given.'.red
+          end
+
+          unless ENV['MAILGUN_SANDBOX_POSTMASTER']
+            Helper.log.fatal "Please add 'ENV[\"MAILGUN_SANDBOX_POSTMASTER\"] = \"a_valid_mailgun_sandbox_postmaster\"' to your Fastfile's `before_all` section.".red
+            raise 'No MAILGUN_SANDBOX_POSTMASTER given.'.red
+          end
+
+          unless (options[:to] rescue nil)
+            Helper.log.fatal "Please provide a valid :to  = \"a_valid_mailgun_to\"".red
+            raise 'No MAILGUN_TO given.'.red
+          end
+
+          unless (options[:message] rescue nil)
+            Helper.log.fatal "Please provide a valid :message  = \"a_valid_mailgun_text\"".red
+            raise 'No MAILGUN_MESSAGE given.'.red
+          end
+
+          unless (options[:subject] rescue nil)
+            Helper.log.fatal "Please provide a valid :subject  = \"a_valid_mailgun_subject\"".red
+            raise 'No MAILGUN_SUBJECT given.'.red
+          end
+      end
+
+      def self.mailgunit(api_key,sandbox_domain,sandbox_postmaster,to,subject,text)
+        RestClient.post "https://api:#{api_key}@api.mailgun.net/v3/#{sandbox_domain}/messages",
+        :from => "Mailgun Sandbox <#{sandbox_postmaster}>",
+        :to => "#{to}",
+        :subject => subject,
+        :text => text
+      end
+
+    end
+  end
+end

--- a/lib/fastlane/actions/slack.rb
+++ b/lib/fastlane/actions/slack.rb
@@ -1,26 +1,12 @@
 module Fastlane
   module Actions
     class SlackAction < Action
-      def self.git_author
-        s = `git log --name-status HEAD^..HEAD`
-        s = s.match(/Author:.*<(.*)>/)[1]
-        return s if s.to_s.length > 0
-        return nil
-      rescue
-        return nil
-      end
-
-      def self.last_git_commit
-        s = `git log -1 --pretty=%B`.strip
-        return s if s.to_s.length > 0
-        nil
-      end
 
       def self.is_supported?(platform)
         true
       end
 
-      # As there is a text limit in the notifications, we are 
+      # As there is a text limit in the notifications, we are
       # usually interested in the last part of the message
       # e.g. for tests
       def self.trim_message(message)
@@ -158,23 +144,23 @@ module Fastlane
           end
 
           # git_author
-          if git_author && should_add_payload[:git_author]
+          if Actions.git_author && should_add_payload[:git_author]
             if ENV['FASTLANE_SLACK_HIDE_AUTHOR_ON_SUCCESS'] && options[:success]
               # We only show the git author if the build failed
             else
               slack_attachment[:fields] << {
                 title: 'Git Author',
-                value: git_author,
+                value: Actions.git_author,
                 short: true
               }
             end
           end
 
           # last_git_commit
-          if last_git_commit && should_add_payload[:last_git_commit]
+          if Actions.last_git_commit && should_add_payload[:last_git_commit]
             slack_attachment[:fields] << {
               title: 'Git Commit',
-              value: last_git_commit,
+              value: Actions.last_git_commit,
               short: false
             }
           end

--- a/spec/actions_specs/mailgun_spec.rb
+++ b/spec/actions_specs/mailgun_spec.rb
@@ -7,10 +7,6 @@ describe Fastlane do
         ENV['MAILGUN_APIKEY'] = 'key-73827fakeapikey2329'
       end
 
-      it "trims long messages to show the bottom of the messages" do
-        long_text = "a" * 10000
-        expect(Fastlane::Actions::MailgunAction.trim_message(long_text).length).to eq(7000)
-      end
 
       it "raises an error if no mailgun sandbox domain is given" do
         ENV.delete 'MAILGUN_SANDBOX_DOMAIN'
@@ -44,8 +40,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
           mailgun({
             :to => 'valid@gmail.com',
-            :message => 'A valid email text',
-            :subject => 'A valid subject'
+            :message => 'A valid email text'
             })
           end").runner.execute(:test)
         }.to raise_exception('No MAILGUN_APIKEY given.'.red)
@@ -55,8 +50,7 @@ describe Fastlane do
         expect {
           Fastlane::FastFile.new.parse("lane :test do
           mailgun({
-            :message => 'A valid email text',
-            :subject => 'A valid subject'
+            :message => 'A valid email text'
             })
           end").runner.execute(:test)
         }.to raise_exception('No MAILGUN_TO given.'.red)
@@ -66,22 +60,10 @@ describe Fastlane do
         expect {
           Fastlane::FastFile.new.parse("lane :test do
           mailgun({
-            :to => 'valid@gmail.com',
-            :subject => 'A valid subject'
+            :to => 'valid@gmail.com'
             })
           end").runner.execute(:test)
         }.to raise_exception('No MAILGUN_MESSAGE given.'.red)
-      end
-
-      it "raises an error if no mailgun subject is given" do
-        expect {
-          Fastlane::FastFile.new.parse("lane :test do
-          mailgun({
-            :to => 'valid@gmail.com',
-            :message => 'A valid email text'
-            })
-          end").runner.execute(:test)
-        }.to raise_exception('No MAILGUN_SUBJECT given.'.red)
       end
 
     end

--- a/spec/actions_specs/mailgun_spec.rb
+++ b/spec/actions_specs/mailgun_spec.rb
@@ -1,0 +1,89 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Mailgun Action" do
+      before :each do
+        ENV['MAILGUN_SANDBOX_DOMAIN'] = 'fakesandboxtest.mailgun.org'
+        ENV['MAILGUN_SANDBOX_POSTMASTER'] = 'fakepostmaster@fakesandboxtest.mailgun.org'
+        ENV['MAILGUN_APIKEY'] = 'key-73827fakeapikey2329'
+      end
+
+      it "trims long messages to show the bottom of the messages" do
+        long_text = "a" * 10000
+        expect(Fastlane::Actions::MailgunAction.trim_message(long_text).length).to eq(7000)
+      end
+
+      it "raises an error if no mailgun sandbox domain is given" do
+        ENV.delete 'MAILGUN_SANDBOX_DOMAIN'
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+            mailgun({
+              :to => 'valid@gmail.com',
+              :message => 'A valid email text',
+              :subject => 'A valid subject'
+              })
+          end").runner.execute(:test)
+        }.to raise_exception('No MAILGUN_SANDBOX_DOMAIN given.'.red)
+      end
+
+      it "raises an error if no mailgun sandbox postmaster is given" do
+        ENV.delete 'MAILGUN_SANDBOX_POSTMASTER'
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+          mailgun({
+            :to => 'valid@gmail.com',
+            :message => 'A valid email text',
+            :subject => 'A valid subject'
+            })
+          end").runner.execute(:test)
+        }.to raise_exception('No MAILGUN_SANDBOX_POSTMASTER given.'.red)
+      end
+
+      it "raises an error if no mailgun apikey is given" do
+        ENV.delete 'MAILGUN_APIKEY'
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+          mailgun({
+            :to => 'valid@gmail.com',
+            :message => 'A valid email text',
+            :subject => 'A valid subject'
+            })
+          end").runner.execute(:test)
+        }.to raise_exception('No MAILGUN_APIKEY given.'.red)
+      end
+
+      it "raises an error if no mailgun to is given" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+          mailgun({
+            :message => 'A valid email text',
+            :subject => 'A valid subject'
+            })
+          end").runner.execute(:test)
+        }.to raise_exception('No MAILGUN_TO given.'.red)
+      end
+
+      it "raises an error if no mailgun message is given" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+          mailgun({
+            :to => 'valid@gmail.com',
+            :subject => 'A valid subject'
+            })
+          end").runner.execute(:test)
+        }.to raise_exception('No MAILGUN_MESSAGE given.'.red)
+      end
+
+      it "raises an error if no mailgun subject is given" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+          mailgun({
+            :to => 'valid@gmail.com',
+            :message => 'A valid email text'
+            })
+          end").runner.execute(:test)
+        }.to raise_exception('No MAILGUN_SUBJECT given.'.red)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
added spec and action to send email using mailgun, now users can share builds using there mailgun accounts. Still needs to implement an email template and better test coverage
