### PR TITLE
Add oclint action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -232,6 +232,21 @@ gcovr({
 })
 ```
 
+### [OCLint](http://oclint.org)
+Lints implementation files with OCLint
+
+```
+oclint({
+  compile_commands: 'commands.json', # The json compilation database, use xctool reporter 'json-compilation-database'
+  select_reqex: /ViewController.m/,  # Select all files matching this reqex
+  report_type: 'pmd',                # The type of the report (default: html)
+  max_priority_1: 10,                # The max allowed number of priority 1 violations
+  max_priority_2: 100,               # The max allowed number of priority 2 violations
+  max_priority_3: 1000,              # The max allowed number of priority 3 violations
+  rc: 'LONG_LINE=200'                # Override the default behavior of rules
+})  
+```
+
 ## Deploying
 
 ### [deliver](https://github.com/KrauseFx/deliver)

--- a/lib/fastlane/actions/oclint.rb
+++ b/lib/fastlane/actions/oclint.rb
@@ -108,6 +108,10 @@ module Fastlane
       def self.author
         'HeEAaD'
       end
+      
+      def self.is_supported?(platform)
+        true
+      end
     end
   end
 end

--- a/lib/fastlane/actions/oclint.rb
+++ b/lib/fastlane/actions/oclint.rb
@@ -9,7 +9,10 @@ module Fastlane
 
         select_reqex = params[:select_reqex]
         
-        files = JSON.parse(File.read(params[:compile_commands])).map { |compile_command| compile_command['file'] }
+        compile_commands = params[:compile_commands]
+        raise "Could not find json compilation database at path '#{compile_commands}'".red unless File.exists?(compile_commands)
+        
+        files = JSON.parse(File.read(compile_commands)).map { |compile_command| compile_command['file'] }
         files.uniq!
         files.select! do |file|
           file_ruby = file.gsub('\ ', ' ')

--- a/lib/fastlane/actions/oclint.rb
+++ b/lib/fastlane/actions/oclint.rb
@@ -1,0 +1,110 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      FL_OCLINT_REPORT_PATH = :FL_OCLINT_REPORT_PATH
+    end
+
+    class OclintAction < Action
+      def self.run(params)
+
+        select_reqex = params[:select_reqex]
+        
+        files = JSON.parse(File.read(params[:compile_commands])).map { |compile_command| compile_command['file'] }
+        files.uniq!
+        files.select! do |file|
+          file_ruby = file.gsub('\ ', ' ')
+          File.exists?(file_ruby) and (!select_reqex or file_ruby =~ select_reqex)
+        end
+
+        command_prefix = [
+          'cd',
+          File.expand_path('.').shellescape,
+          '&&'
+        ].join(' ')
+        
+        report_type = params[:report_type]
+        report_path = params[:report_path] ? params[:report_path] : 'oclint_report.' + report_type
+        
+        oclint_args = ["-report-type=#{report_type}", "-o=#{report_path}"]
+        oclint_args << "-rc=#{params[:rc]}" if params[:rc]
+        oclint_args << "-max-priority-1=#{params[:max_priority_1]}" if params[:max_priority_1]
+        oclint_args << "-max-priority-2=#{params[:max_priority_2]}" if params[:max_priority_2]
+        oclint_args << "-max-priority-3=#{params[:max_priority_3]}" if params[:max_priority_3]
+                
+        command = [
+          command_prefix,
+          'oclint',
+          oclint_args,
+          '"' + files.join('" "') + '"'
+        ].join(' ')
+        
+        Action.sh command
+
+        Actions.lane_context[SharedValues::FL_OCLINT_REPORT_PATH] = File.expand_path(report_path)
+      end
+
+
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Lints implementation files with OCLint"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :compile_commands,
+                                       env_name: 'FL_OCLINT_COMPILE_COMMANDS',
+                                       description: 'The json compilation database, use xctool reporter \'json-compilation-database\'',
+                                       default_value: 'compile_commands.json',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :select_reqex,
+                                       env_name: 'FL_OCLINT_SELECT_REQEX',
+                                       description: 'Select all files matching this reqex',
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :report_type,
+                                       env_name: 'FL_OCLINT_REPORT_TYPE',
+                                       description: 'The type of the report (default: html)',
+                                       default_value: 'html',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :report_path,
+                                       env_name: 'FL_OCLINT_REPORT_PATH',
+                                       description: 'The reports file path',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :rc,
+                                       env_name: 'FL_OCLINT_RC',
+                                       description: 'Override the default behavior of rules',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :max_priority_1,
+                                       env_name: 'FL_OCLINT_MAX_PRIOTITY_1',
+                                       description: 'The max allowed number of priority 1 violations',
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :max_priority_2,
+                                       env_name: 'FL_OCLINT_MAX_PRIOTITY_2',
+                                       description: 'The max allowed number of priority 2 violations',
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :max_priority_3,
+                                       env_name: 'FL_OCLINT_MAX_PRIOTITY_3',
+                                       description: 'The max allowed number of priority 3 violations',
+                                       is_string: false,
+                                       optional: true)
+        ]
+      end
+
+      def self.output
+        [
+          ['FL_OCLINT_REPORT_PATH', 'The reports file path']
+        ]
+      end
+
+      def self.author
+        'HeEAaD'
+      end
+    end
+  end
+end

--- a/spec/actions_specs/oclint_spec.rb
+++ b/spec/actions_specs/oclint_spec.rb
@@ -1,0 +1,13 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "OCLint Integration" do
+      it "raises an exception when not the default compile_commands.json is present" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+            oclint
+          end").runner.execute(:test)
+        }.to raise_error("Could not find json compilation database at path 'compile_commands.json'".red)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We all want simple and documented code. Let's lint it with OCLint!

Works nicely with xctool in one lane:

```
lane :lint do
  xctool :clean, :build
  oclint
end
```

Just let the xctool report its output as a json-compilation-database.
