### PR TITLE
Mac support for many mutli-platform actions

### DIFF
--- a/lib/fastlane/actions/commit_version_bump.rb
+++ b/lib/fastlane/actions/commit_version_bump.rb
@@ -110,7 +110,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include?platform
       end
     end
   end

--- a/lib/fastlane/actions/crashlytics.rb
+++ b/lib/fastlane/actions/crashlytics.rb
@@ -7,7 +7,7 @@ module Fastlane
     class CrashlyticsAction < Action
       
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include?platform
       end
 
       def self.run(params)

--- a/lib/fastlane/actions/dsym_zip.rb
+++ b/lib/fastlane/actions/dsym_zip.rb
@@ -28,7 +28,7 @@ module Fastlane
       #####################################################
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include?platform
       end
 
       def self.description

--- a/lib/fastlane/actions/increment_build_number.rb
+++ b/lib/fastlane/actions/increment_build_number.rb
@@ -8,7 +8,7 @@ module Fastlane
       require 'shellwords'
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include?platform
       end
 
       def self.run(params)

--- a/lib/fastlane/actions/increment_version_number.rb
+++ b/lib/fastlane/actions/increment_version_number.rb
@@ -8,7 +8,7 @@ module Fastlane
       require 'shellwords'
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include?platform
       end
 
       def self.run(params)

--- a/lib/fastlane/actions/install_cocapods.rb
+++ b/lib/fastlane/actions/install_cocapods.rb
@@ -10,7 +10,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include?platform
       end
     end
   end

--- a/lib/fastlane/actions/xcode_select.rb
+++ b/lib/fastlane/actions/xcode_select.rb
@@ -41,7 +41,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include?platform
       end
     end
   end

--- a/lib/fastlane/actions/xctool.rb
+++ b/lib/fastlane/actions/xctool.rb
@@ -27,7 +27,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include?platform
       end
     end
   end


### PR DESCRIPTION
Many of the actions unnecessarily had only iOS support declared, even though most of them work for Mac projects too, so I fixed them. (I must be literally the first Mac dev trying to do this 😄.)
