### PR TITLE
Load `Appfile` configurations accordingly to running platform

### DIFF
--- a/docs/Advanced.md
+++ b/docs/Advanced.md
@@ -66,7 +66,7 @@ apple_id "felix@krausefx.com" # Your Apple email address
 # team_id "Q2CBPJ58CA"
 ```
 
-If your project has different bundle identifiers per environment (i.e. beta, app store), you can define that by using `for_lane` block declaration. 
+If your project has different bundle identifiers per environment (i.e. beta, app store), you can define that by using `for_platform` and/or `for_lane` block declaration. 
 
 ```ruby
 app_identifier "net.sunapps.1"
@@ -79,6 +79,13 @@ end
 
 for_lane :enterprise do
   app_identifier "enterprise.com"
+end
+
+for_platform :ios do
+  team_id '123' # for all iOS related things
+  for_lane :test do
+    app_identifier 'com.app.test'
+  end
 end
 ```
 

--- a/lib/fastlane/runner.rb
+++ b/lib/fastlane/runner.rb
@@ -16,8 +16,8 @@ module Fastlane
       full_lane_name = [platform, lane].reject(&:nil?).join(' ')
       Helper.log.info "Driving the lane '#{full_lane_name}'".green
       Actions.lane_context[Actions::SharedValues::LANE_NAME] = full_lane_name
-      ENV["FASTLANE_LANE_NAME"] = lane
-      ENV["FASTLANE_PLATFORM_NAME"] = platform
+      ENV["FASTLANE_LANE_NAME"] = lane.to_s
+      ENV["FASTLANE_PLATFORM_NAME"] = platform.to_s
 
       return_val = nil
 

--- a/lib/fastlane/runner.rb
+++ b/lib/fastlane/runner.rb
@@ -16,7 +16,8 @@ module Fastlane
       full_lane_name = [platform, lane].reject(&:nil?).join(' ')
       Helper.log.info "Driving the lane '#{full_lane_name}'".green
       Actions.lane_context[Actions::SharedValues::LANE_NAME] = full_lane_name
-      ENV["FASTLANE_LANE_NAME"] = full_lane_name
+      ENV["FASTLANE_LANE_NAME"] = lane
+      ENV["FASTLANE_PLATFORM_NAME"] = platform
 
       return_val = nil
 


### PR DESCRIPTION
# Summary

Saved platform name as environment variable.
# Why

Give the opportunity to all fastlane tools to invoke different actions based on the platform and/or lane name.
This Integration is made possible by this [Credentials Manager feature](https://github.com/fastlane/CredentialsManager/pull/7)
# Example

``` ruby
app_identifier "net.sunapps.1"
apple_id "felix@sunapps.net"
team_id "Q2CBPJ58CC"

for_platform :ios do
  team_id 'Q2CBPJ58AA' # for all iOS related things
  for_lane :enterprise do
    app_identifier 'net.sunapps.enterprise'
  end
end
```
