### PR TITLE
s3 command will include a version.json

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -348,9 +348,9 @@ s3(
   bucket: ENV['S3_BUCKET'],                       # Required from user.
   file: 'AppName.ipa',                            # This would come from IpaAction.
   dsym: 'AppName.app.dSYM.zip',                   # This would come from IpaAction.
-  path: 'v{CFBundleShortVersionString}_b{CFBundleVersion}/' # This is actually the default.
-  version_file_name,                              # Name of the file to upload to S3. Defaults to 'version.son'
-  version_template_path                           # Path to an ERB to configure the structure of the version JSON file
+  path: 'v{CFBundleShortVersionString}_b{CFBundleVersion}/', # This is actually the default.
+  version_file_name: 'index.html',                # Name of the file to upload to S3. Defaults to 'version.son'
+  version_template_path: 'path/to/erb'            # Path to an ERB to configure the structure of the version JSON file
 )
 ```
 

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -349,7 +349,7 @@ s3(
   file: 'AppName.ipa',                            # This would come from IpaAction.
   dsym: 'AppName.app.dSYM.zip',                   # This would come from IpaAction.
   path: 'v{CFBundleShortVersionString}_b{CFBundleVersion}/', # This is actually the default.
-  version_file_name: 'index.html',                # Name of the file to upload to S3. Defaults to 'version.son'
+  version_file_name: 'app_version.json',          # Name of the file to upload to S3. Defaults to 'version.json'
   version_template_path: 'path/to/erb'            # Path to an ERB to configure the structure of the version JSON file
 )
 ```

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -331,7 +331,7 @@ The following environment variables may be used in place of parameters: `CRASHLY
 
 ### AWS S3 Distribution
 
-Upload a new build to Amazon S3 to distribute the build to beta testers. Works for both Ad Hoc and Enterprise signed applications. This step will generate the necessary HTML and plist files for you.
+Upload a new build to Amazon S3 to distribute the build to beta testers. Works for both Ad Hoc and Enterprise signed applications. This step will generate the necessary HTML, plist, and version files for you. 
 
 Add the `s3` action after the `ipa` step:
 
@@ -349,10 +349,21 @@ s3(
   file: 'AppName.ipa',                            # This would come from IpaAction.
   dsym: 'AppName.app.dSYM.zip',                   # This would come from IpaAction.
   path: 'v{CFBundleShortVersionString}_b{CFBundleVersion}/' # This is actually the default.
+  version_file_name,                              # Name of the file to upload to S3. Defaults to 'version.son'
+  version_template_path                           # Path to an ERB to configure the structure of the version JSON file
 )
 ```
 
 It is recommended to **not** store the AWS access keys in the `Fastfile`.
+
+The uploaded `version.json` file provides an easy way for apps to poll if a new update is available. The JSON looks like:
+
+```json
+{ 
+    "latestVersion": "<%= full_version %>",
+    "updateUrl": "itms-services://?action=download-manifest&url=<%= url %>"
+}
+```
 
 ### [DeployGate](https://deploygate.com/)
 

--- a/lib/assets/s3_version_template.erb
+++ b/lib/assets/s3_version_template.erb
@@ -1,0 +1,4 @@
+{ 
+    "latestVersion": "<%= full_version %>",
+    "updateUrl": "itms-services://?action=download-manifest&url=<%= url %>"
+}


### PR DESCRIPTION
For enterprise distribution via S3, it's useful to have a `version.json` that apps can poll to see if there are app updates.

This change will upload a `version.json` next to the `index.html` with the following structure:

``` json
{ 
    "latestVersion": "<%= full_version %>",
    "updateUrl": "itms-services://?action=download-manifest&url=<%= url %>"
}
```

Callers to the `s3` command can pass the following parameters:

``` ruby
s3(
  version_file_name, # Name of the file to upload to S3. Defaults to 'version.son'
  version_template_path # Path to an ERB to configure the structure of the JSON file
)
```
