### PR TITLE
Fix SyntaxError

### DIFF
--- a/lib/assets/FastfileTemplate
+++ b/lib/assets/FastfileTemplate
@@ -56,7 +56,7 @@ platform :ios do
   lane :deploy do
     snapshot
     sigh
-    deliver(skip_deploy: true, :force: true)
+    deliver(skip_deploy: true, force: true)
     # frameit
   end
 


### PR DESCRIPTION
Fix for:
fastlane-1.2.1/lib/fastlane/fast_file.rb:19:in `eval': (eval):59: syntax error, unexpected ':', expecting => (SyntaxError)
    deliver(skip_deploy: true, :force: true)
                                      ^
(eval):85: syntax error, unexpected end-of-input, expecting keyword_end
