### PR TITLE
fix increment version number action: allow xcodeproj path override

### DIFF
--- a/lib/fastlane/actions/increment_version_number.rb
+++ b/lib/fastlane/actions/increment_version_number.rb
@@ -16,7 +16,7 @@ module Fastlane
         # https://developer.apple.com/library/ios/qa/qa1827/_index.html
 
         begin
-          folder = '.' #Current folder is the default folder
+          folder = params[:xcodeproj] ? File.join('.', params[:xcodeproj], '..') : '.'
 
           command_prefix = [
               'cd',


### PR DESCRIPTION
Fixes:
- Allow increment_version_number.rb action to override the xcodeproj path using the already existing parameter (as in increment_build_number.rb:20).
