### PR TITLE
New Action: Update Info Plist (App Identifier and Display Name)

### DIFF
--- a/lib/fastlane/actions/update_info_plist.rb
+++ b/lib/fastlane/actions/update_info_plist.rb
@@ -1,0 +1,85 @@
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+    class UpdateInfoPlistAction < Action
+      def self.run(params)
+        require 'plist'
+                
+        # Check if parameters are set
+        if params[:app_identifier] or params[:display_name]
+          
+          # Assign folder from parameter or search for xcodeproj file
+          folder = params[:xcodeproj] || Dir["*.xcodeproj"].first
+        
+          # Read existing plist file 
+          info_plist_path = File.join(folder, "..", params[:plist_path])
+          raise "Couldn't find info plist file at path '#{params[:plist_path]}'".red unless File.exists?(info_plist_path)
+          plist = Plist::parse_xml(info_plist_path)
+          
+          # Update plist values
+          plist['CFBundleIdentifier'] = params[:app_identifier] if params[:app_identifier]
+          plist['CFBundleDisplayName'] = params[:display_name] if params[:display_name]
+          
+          # Write changes to file
+          plist_string = Plist::Emit.dump(plist)
+          File.write(info_plist_path, plist_string)
+          
+          Helper.log.info "Updated #{params[:plist_path]} 💾.".green
+          plist_string
+        else
+          Helper.log.warn("You haven't specified any parameters to update your plist.")
+          false
+        end
+        
+      end
+
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.is_supported?(platform)
+        [:ios].include?(platform)
+      end
+
+      def self.description
+        'Update a Info.plist file with bundle identifier and display name'
+      end
+
+      def self.available_options
+        [
+          
+          FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                                       env_name: "FL_UPDATE_PLIST_PROJECT_PATH",
+                                       description: "Path to your Xcode project",
+                                       optional: true,
+                                       verify_block: Proc.new do |value|
+                                        raise "Please pass the path to the project, not the workspace".red if value.include?"workspace"
+                                        raise "Could not find Xcode project".red unless File.exists?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :plist_path,
+                                       env_name: "FL_UPDATE_PLIST_PATH",
+                                       description: "Path to info plist",
+                                       verify_block: Proc.new do |value|
+                                         raise "Invalid plist file".red unless value[-6..-1].downcase == ".plist"
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :app_identifier,
+                                       env_name: 'FL_UPDATE_PLIST_APP_IDENTIFIER',
+                                       description: 'The App Identifier of your app',
+                                       default_value: ENV['PRODUCE_APP_IDENTIFIER'],
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :display_name,
+                                       env_name: 'FL_UPDATE_PLIST_DISPLAY_NAME',
+                                       description: 'The Display Name of your app',
+                                       optional: true)
+        ]
+      end
+
+      def self.author
+        'tobiasstrebitzer'
+      end
+    end
+  end
+end

--- a/spec/actions_specs/update_info_plist_spec.rb
+++ b/spec/actions_specs/update_info_plist_spec.rb
@@ -1,0 +1,61 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Update Info Plist Integration" do
+      let (:test_path) { "/tmp/fastlane/tests/fastlane" }
+      let (:xcodeproj) { "/tmp/fastlane/tests/fastlane/Test.xcodeproj" }
+      let (:plist_path) { "com.test.plist" }
+      let (:app_identifier) { "com.test.plist" }
+      let (:display_name) { "Update Info Plist Test" }
+
+      before do
+        # Set up example info.plist
+        FileUtils.mkdir_p(test_path)
+        FileUtils.mkdir_p(xcodeproj)
+        File.write(File.join(test_path, plist_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>CFBundleDisplayName</key><string>empty</string><key>CFBundleIdentifier</key><string>empty</string></dict></plist>')
+      end
+
+      it "updates the info plist based on the given properties" do
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          update_info_plist ({
+            xcodeproj: '#{xcodeproj}',
+            plist_path: '#{plist_path}',
+            app_identifier: '#{app_identifier}',
+            display_name: '#{display_name}'
+          })
+        end").runner.execute(:test)
+        expect(result).to include("<string>#{display_name}</string>")
+        expect(result).to include("<string>#{app_identifier}</string>")
+      end
+
+      it "throws an error when the info plist file does not exist" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do 
+            update_info_plist ({
+              xcodeproj: '#{xcodeproj}',
+              plist_path: 'NOEXIST-#{plist_path}',
+              app_identifier: '#{app_identifier}',
+              display_name: '#{display_name}'
+            })
+          end").runner.execute(:test)
+        }.to raise_error("Couldn't find info plist file at path 'NOEXIST-#{plist_path}'".red)
+      end
+      
+      it "returns 'false' if no plist parameters are specified" do
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          update_info_plist ({
+            xcodeproj: '#{xcodeproj}',
+            plist_path: 'NOEXIST-#{plist_path}'
+          })
+        end").runner.execute(:test)
+        expect(result).to eq false
+      end
+      
+      after do
+        # Clean up files
+        File.delete(File.join(test_path, plist_path))
+        FileUtils.rm_rf(xcodeproj)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Features:
- The update_info_plist action allows changing the app/bundle identifier and display name. This is useful if you create different apps from a single lane, using the same source project.

```
+------------------------------------------------------------------+
|                        update_info_plist                         |
+------------------------------------------------------------------+
| Update a Info.plist file with bundle identifier and display name |
|                                                                  |
| Created by tobiasstrebitzer                                      |
+------------------------------------------------------------------+

+----------------+--------------------------------+--------------------------------+
|                                update_info_plist                                 |
+----------------+--------------------------------+--------------------------------+
| Key            | Description                    | Env Var                        |
+----------------+--------------------------------+--------------------------------+
| xcodeproj      | Path to your Xcode project     | FL_UPDATE_PLIST_PROJECT_PATH   |
| plist_path     | Path to info plist             | FL_UPDATE_PLIST_PATH           |
| app_identifier | The App Identifier of your app | FL_UPDATE_PLIST_APP_IDENTIFIER |
| display_name   | The Display Name of your app   | FL_UPDATE_PLIST_DISPLAY_NAME   |
+----------------+--------------------------------+--------------------------------+
```
