### PR TITLE
commit_version_bump now using `Actions.sh`

### DIFF
--- a/lib/fastlane/actions/commit_version_bump.rb
+++ b/lib/fastlane/actions/commit_version_bump.rb
@@ -11,7 +11,7 @@ module Fastlane
         xcodeproj_path = params[:xcodeproj] ? File.expand_path(File.join('.', params[:xcodeproj])) : nil
 
         # find the repo root path
-        repo_path = `git rev-parse --show-toplevel`.strip
+        repo_path = Actions.sh('git rev-parse --show-toplevel').strip
         repo_pathname = Pathname.new(repo_path)
 
         if xcodeproj_path
@@ -49,7 +49,7 @@ module Fastlane
         expected_changed_files.flatten!.uniq!
 
         # get the list of files that have actually changed in our git workdir
-        git_dirty_files = `git diff --name-only HEAD`.split("\n") + `git ls-files --other --exclude-standard`.split("\n")
+        git_dirty_files = Actions.sh('git diff --name-only HEAD').split("\n") + Actions.sh('git ls-files --other --exclude-standard').split("\n")
 
         # little user hint
         raise 'No file changes picked up. Make sure you run the `increment_build_number` action first.'.red if git_dirty_files.empty?

--- a/lib/fastlane/actions/commit_version_bump.rb
+++ b/lib/fastlane/actions/commit_version_bump.rb
@@ -58,7 +58,7 @@ module Fastlane
         changed_files_as_expected = (Set.new(git_dirty_files.map(&:downcase)) == Set.new(expected_changed_files.map(&:downcase)))
         unless changed_files_as_expected
           unless params[:force]
-            raise "Found unexpected uncommited changes in the working directory. Expected these files to have changed: #{expected_changed_files}. But found these actual changes: #{git_dirty_files}. Make sure you have cleaned up the build artifacts and are only left with the changed version files at this stage in your lane, and don't touch the working directory while your lane is running. You can also use the :force option to bypass this check, and always commit a version bump regardless of the state of the working directory.".red
+            raise "Found unexpected uncommited changes in the working directory. Expected these files to have changed: \n#{expected_changed_files.join("\n")}.\nBut found these actual changes: \n#{git_dirty_files.join("\n")}.\nMake sure you have cleaned up the build artifacts and are only left with the changed version files at this stage in your lane, and don't touch the working directory while your lane is running. You can also use the :force option to bypass this check, and always commit a version bump regardless of the state of the working directory.".red
           end
         end
 


### PR DESCRIPTION
... also snuck in a small improvement to the error message formatting.
