### PR TITLE
Fixed hockey action handling of dsym parameter

### DIFF
--- a/lib/fastlane/actions/hockey.rb
+++ b/lib/fastlane/actions/hockey.rb
@@ -35,7 +35,7 @@ module Fastlane
         client = Shenzhen::Plugins::HockeyApp::Client.new(options[:api_token])
 
         values = options.values
-        values[:dsym_filename] = dsym_path
+        values[:dsym_filename] = dsym_filename
         values[:notes_type] = options[:notes_type]
 
         return values if Helper.test?


### PR DESCRIPTION
Including the dsym param on the hockey action would cause the dsym to not be uploaded, but auto-discovery of the dsym would work fine. This fixes by using the filename var that's being set rather than the path var.
