### PR TITLE
Allows user not to archive on ipa command

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -126,7 +126,7 @@ ipa(
   embed: "my.mobileprovision",     # Sign .ipa file with .mobileprovision
   identity: "MyIdentity",          # Identity to be used along with --embed
   sdk: "10.0",                     # use SDK as the name or path of the base SDK when building the project.
-  archive: nil                     # this means 'Do Archive'. Archive project after building.
+  archive: true                    # this means 'Do Archive'. Archive project after building (the default if not specified).
 )
 ```
 

--- a/lib/fastlane/actions/ipa.rb
+++ b/lib/fastlane/actions/ipa.rb
@@ -108,7 +108,7 @@ module Fastlane
             if k == :clean
               v == true ? '--clean' : '--no-clean'
             elsif k == :archive
-              v == true ? '--archive' : nil
+              v == true ? '--archive' : '--no-archive'
             else
               value = (v.to_s.length > 0 ? "\"#{v}\"" : '')
               "#{ARGS_MAP[k]} #{value}".strip

--- a/spec/actions_specs/ipa_spec.rb
+++ b/spec/actions_specs/ipa_spec.rb
@@ -37,7 +37,7 @@ describe Fastlane do
             configuration: 'Release',
             scheme: 'TestScheme',
             clean: true,
-            archive: nil,
+            archive: true,
             destination: nil,
             embed: nil,
             identity: nil,
@@ -45,7 +45,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq(5)
+        expect(result.size).to eq(6)
       end
 
       it "works with object argument with all" do
@@ -102,6 +102,26 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result).to include("--no-clean")
+      end
+
+      it "respects the archive argument when true" do
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          ipa ({
+            archive: true,
+          })
+        end").runner.execute(:test)
+
+        expect(result).to include("--archive")
+      end
+
+      it "respects the archive argument when false" do
+        result = Fastlane::FastFile.new.parse("lane :test do 
+          ipa ({
+            archive: false,
+          })
+        end").runner.execute(:test)
+
+        expect(result).to include("--no-archive")
       end
 
       it "works with object argument with all and extras and auto-use sigh profile if not given" do


### PR DESCRIPTION
I needed to use the `--no-archive` option from shenzhen.
So here I modified the `ipa` action to support it.
The behavior is similar to the `clean: true|false` option that was previously `clean: nil`.
