### PR TITLE
Fixed IPA_OUTPUT_PATH and DSYM_OUTPUT_PATH not set when the provided ipa destination doesn’t exist yet

### DIFF
--- a/lib/fastlane/actions/ipa.rb
+++ b/lib/fastlane/actions/ipa.rb
@@ -37,7 +37,7 @@ module Fastlane
 
         # Used to get the final path of the IPA and dSYM
         if dest = params[:destination]
-          absolute_dest_directory = Dir.glob(dest).map(&File.method(:realpath)).first
+          absolute_dest_directory = File.expand_path(dest)
         end
 
         # Maps nice developer build parameters to Shenzhen args

--- a/spec/actions_specs/ipa_spec.rb
+++ b/spec/actions_specs/ipa_spec.rb
@@ -145,6 +145,10 @@ describe Fastlane do
         expect(result).to include("-m \"#{ENV['SIGH_PROFILE_PATH']}\"")
         expect(result.size).to eq(11)
 
+        dest_path = File.expand_path(File.join('..', 'Nowhere'))
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::IPA_OUTPUT_PATH]).to eq(File.join(dest_path, 'test.ipa'))
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DSYM_OUTPUT_PATH]).to eq(File.join(dest_path, 'test.app.dSYM.zip'))
+
         ENV["SIGH_PROFILE_PATH"] = nil
       end
 


### PR DESCRIPTION
The destination folder will only be created once `shenzhen` has run.
So using `Dir.glob` beforehand would return a `nil` `absolute_dest_directory` if the directory didn’t actually exist.
And hence `IPA_OUTPUT_PATH` and `DSYM_OUTPUT_PATH` would be set to nil. Breaking following actions.
