### PR TITLE
Feature/options for cocoapods

### DIFF
--- a/lib/fastlane/actions/install_cocapods.rb
+++ b/lib/fastlane/actions/install_cocapods.rb
@@ -37,7 +37,7 @@ module Fastlane
                                        env_name: "FL_COCOAPODS_SILENT",
                                        description: "Show nothing",
                                        default_value: false),
-          FastlaneCore::ConfigItem.new(key: :verbode,
+          FastlaneCore::ConfigItem.new(key: :verbose,
                                        env_name: "FL_COCOAPODS_VERBOSE",
                                        description: "Show more debugging information",
                                        default_value: false),

--- a/lib/fastlane/actions/install_cocapods.rb
+++ b/lib/fastlane/actions/install_cocapods.rb
@@ -2,11 +2,50 @@ module Fastlane
   module Actions
     class CocoapodsAction < Action
       def self.run(params)
-        Actions.sh('pod install')
+
+        cmd = ['pod install']
+
+        cmd << '--no-clean' unless params[:clean]
+        cmd << '--no-integrate' unless params[:integrate]
+        cmd << '--no-repo-update' unless params[:repo_update]
+        cmd << '--silent' if params[:silent]
+        cmd << '--verbose' if params[:verbose]
+        cmd << '--no-ansi' unless params[:ansi]
+
+        Actions.sh(cmd.join(' '))
       end
 
       def self.description
         "Runs `pod install` for the project"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :clean,
+                                       env_name: "FL_COCOAPODS_CLEAN",
+                                       description: "Remove SCM directories",
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :integrate,
+                                       env_name: "FL_COCOAPODS_INTEGRATE",
+                                       description: "Integrate the Pods libraries into the Xcode project(s)",
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :repo_update,
+                                       env_name: "FL_COCOAPODS_REPO_UPDATE",
+                                       description: "Run `pod repo update` before install",
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :silent,
+                                       env_name: "FL_COCOAPODS_SILENT",
+                                       description: "Show nothing",
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :verbode,
+                                       env_name: "FL_COCOAPODS_VERBOSE",
+                                       description: "Show more debugging information",
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :ansi,
+                                       env_name: "FL_COCOAPODS_ANSI",
+                                       description: "Show output with ANSI codes",
+                                       default_value: true),
+        ]
       end
 
       def self.is_supported?(platform)
@@ -15,3 +54,4 @@ module Fastlane
     end
   end
 end
+#  vim: set et sw=2 ts=2 :


### PR DESCRIPTION
Added the command line options to the `pod install` command to the Cocoapod action.  There are some useful ones in there, like --no-integrate, that I use in my workflows.
