### PR TITLE
Mercurial support (ensure clean status, version bump, tag, push)

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -733,7 +733,7 @@ reset_git_repo(
 ## Using mercurial
 
 ### hg_ensure_clean_status
-Along the same lines as the [`ensure_git_status_clean`](#ensure_git_status_clean) action, this is a sanity check to ensure the working mercurial repo is clean.  Especially useful to put at the beginning of your Fastfile in the `before_all` block.
+Along the same lines as the [`ensure_git_status_clean`](#ensure_git_status_clean) action, this is a sanity check to ensure the working mercurial repo is clean. Especially useful to put at the beginning of your Fastfile in the `before_all` block.
 
 ```ruby
 hg_ensure_clean_status

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -15,6 +15,7 @@ fastlane action [action_name]:
 - [Modifying Project](#modifying-project)
 - [Developer Portal](#developer-portal)
 - [Using git](#using-git)
+- [Using mercurial](#using-mercurial)
 - [Notifications](#notifications)
 
 ## Building
@@ -728,6 +729,58 @@ reset_git_repo(
 ```
 
 [MindNode](https://github.com/fastlane/examples/blob/master/MindNode/Fastfile) uses this action to reset temporary changes of the project configuration after successfully building it.
+
+## Using mercurial
+
+### hg_ensure_clean_status
+Along the same lines as the [`ensure_git_status_clean`](#ensure_git_status_clean) action, this is a sanity check to ensure the working mercurial repo is clean.  Especially useful to put at the beginning of your Fastfile in the `before_all` block.
+
+```ruby
+hg_ensure_clean_status
+```
+
+### hg_commit_version_bump
+The mercurial equivalent of the [`commit_version_bump`](#commit_version_bump) git action. Like the git version, it is useful in conjunction with [`increment_build_number`](#increment_build_number).
+
+It checks the repo to make sure that only the relevant files have changed, these are the files that `increment_build_number` (`agvtool`) touches:
+- All .plist files
+- The `.xcodeproj/project.pbxproj` file
+
+Then commits those files to the repo.
+
+Customise the message with the `:message` option, defaults to "Version Bump"
+
+If you have other uncommitted changes in your repo, this action will fail. If you started off in a clean repo, and used the `ipa` and or `sigh` actions, then you can use the [`clean_build_artifacts`](#clean_build_artifacts) action to clean those temporary files up before running this action.
+
+```ruby
+hg_commit_version_bump
+
+hg_commit_version_bump(
+  message: 'Version Bump',                    # create a commit with a custom message
+  xcodeproj: './path/to/MyProject.xcodeproj', # optional, if you have multiple Xcode project files, you must specify your main project here
+)
+```
+
+### hg_add_tag
+A simplified version of git action [`add_git_tag`](#add_git_tag). It adds a given tag to the mercurial repo.
+
+Specify the tag name with the `:tag` option.
+
+```ruby
+hg_add_tag tag: version_number
+```
+
+### hg_push
+The mercurial equivalent of [`push_to_git_remote`](#push_to_git_remote) — pushes your local commits to a remote mercurial repo. Useful when local changes such as adding a version bump commit or adding a tag are part of your lane’s actions.
+
+```ruby
+hg_push # simple version. pushes commits from current branch to default destination
+
+hg_push(
+  destination: 'ssh://hg@repohost.com/owner/repo', # optional
+  force: true,                                     # optional, default: false
+)
+```
 
 ## Notifications
 

--- a/lib/fastlane/actions/hg_add_tag.rb
+++ b/lib/fastlane/actions/hg_add_tag.rb
@@ -5,8 +5,11 @@ module Fastlane
       def self.run(options)
         tag = options[:tag]
 
+        command = "hg tag \"#{tag}\""
+        return command if Helper.is_test?
+
         Helper.log.info "Adding mercurial tag '#{tag}' 🎯."
-        Actions.sh("hg tag \"#{tag}\"")
+        Actions.sh(command)
       end
 
       def self.description
@@ -17,8 +20,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :tag,
                                        env_name: "FL_HG_TAG_TAG",
-                                       description: "Tag to create",
-                                       optional: false)
+                                       description: "Tag to create")
         ]
       end
 

--- a/lib/fastlane/actions/hg_add_tag.rb
+++ b/lib/fastlane/actions/hg_add_tag.rb
@@ -23,6 +23,7 @@ module Fastlane
       end
 
       def self.author
+        # credits to lmirosevic for original git version
         "sjrmanning"
       end
 

--- a/lib/fastlane/actions/hg_add_tag.rb
+++ b/lib/fastlane/actions/hg_add_tag.rb
@@ -5,10 +5,11 @@ module Fastlane
       def self.run(options)
         tag = options[:tag]
 
+        Helper.log.info "Adding mercurial tag '#{tag}' 🎯."
+
         command = "hg tag \"#{tag}\""
         return command if Helper.is_test?
 
-        Helper.log.info "Adding mercurial tag '#{tag}' 🎯."
         Actions.sh(command)
       end
 

--- a/lib/fastlane/actions/hg_add_tag.rb
+++ b/lib/fastlane/actions/hg_add_tag.rb
@@ -1,0 +1,34 @@
+module Fastlane
+  module Actions
+    # Adds a hg tag to the current commit
+    class HgAddTagAction < Action
+      def self.run(options)
+        tag = options[:tag]
+
+        Helper.log.info "Adding mercurial tag '#{tag}' 🎯."
+        Actions.sh("hg tag \"#{tag}\"")
+      end
+
+      def self.description
+        "This will add a hg tag to the current branch"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :tag,
+                                       env_name: "FL_HG_TAG_TAG",
+                                       description: "Tag to create",
+                                       optional: false)
+        ]
+      end
+
+      def self.author
+        "sjrmanning"
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/hg_commit_version_bump.rb
+++ b/lib/fastlane/actions/hg_commit_version_bump.rb
@@ -1,0 +1,110 @@
+module Fastlane
+  module Actions
+    # Commits version bump.
+    class HgCommitVersionBumpAction < Action
+      def self.run(params)
+        require 'xcodeproj'
+
+        xcodeproj_path = params[:xcodeproj] ? File.expand_path(File.join('.', params[:xcodeproj])) : nil
+
+        # get the repo root path
+        repo_path = Actions.sh('hg root').strip
+        repo_pathname = Pathname.new(repo_path)
+
+        if xcodeproj_path
+          # ensure that the xcodeproj passed in was OK
+          raise "Could not find the specified xcodeproj: #{xcodeproj_path}" unless File.directory?(xcodeproj_path)
+        else
+          # find an xcodeproj (ignoring the Cocoapods one)
+          xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))].reject { |path| /Pods\/.*.xcodeproj/ =~ path }
+
+          # no projects found: error
+          raise 'Could not find a .xcodeproj in the current repository\'s working directory.'.red if xcodeproj_paths.count == 0
+
+          # too many projects found: error
+          if xcodeproj_paths.count > 1
+            relative_projects = xcodeproj_paths.map { |e| Pathname.new(e).relative_path_from(repo_pathname).to_s }.join("\n")
+            raise "Found multiple .xcodeproj projects in the current repository's working directory. Please specify your app's main project: \n#{relative_projects}".red
+          end
+
+          # one project found: great
+          xcodeproj_path = xcodeproj_paths.first
+
+          # find the pbxproj path, relative to hg directory
+          pbxproj_pathname = Pathname.new(File.join(xcodeproj_path, 'project.pbxproj'))
+          pbxproj_path = pbxproj_pathname.relative_path_from(repo_pathname).to_s
+
+          # find the info_plist files
+          project = Xcodeproj::Project.open(xcodeproj_path)
+          info_plist_files = project.objects.select { |object| object.isa == 'XCBuildConfiguration' }.map(&:to_hash).map { |object_hash| object_hash['buildSettings'] }.select { |build_settings| build_settings.key?('INFOPLIST_FILE') }.map { |build_settings| build_settings['INFOPLIST_FILE'] }.uniq.map { |info_plist_path| Pathname.new(File.expand_path(File.join(xcodeproj_path, '..', info_plist_path))).relative_path_from(repo_pathname).to_s }
+
+          # create our list of files that we expect to have changed, they should all be relative to the project root, which should be equal to the hg workdir root
+          expected_changed_files = []
+          expected_changed_files << pbxproj_path
+          expected_changed_files << info_plist_files
+          expected_changed_files.flatten!.uniq!
+
+          # get the list of files that have actually changed in our hg workdir
+          hg_dirty_files = Actions.sh('hg status -n').split("\n")
+
+          # little user hint
+          raise 'No file changes picked up. Make sure you run the `increment_build_number` action first.'.red if hg_dirty_files.empty?
+
+          # check if the files changed are the ones we expected to change (these should be only the files that have version info in them)
+          dirty_set = Set.new(hg_dirty_files.map(&:downcase))
+          expected_set = Set.new(expected_changed_files.map(&:downcase))
+          changed_files_as_expected = dirty_set.subset? expected_set
+          unless changed_files_as_expected
+            unless params[:force]
+              raise "Found unexpected uncommited changes in the working directory. Expected these files to have changed: \n#{expected_changed_files.join("\n")}.\nBut found these actual changes: \n#{hg_dirty_files.join("\n")}.\nMake sure you have cleaned up the build artifacts and are only left with the changed version files at this stage in your lane, and don't touch the working directory while your lane is running. You can also use the :force option to bypass this check, and always commit a version bump regardless of the state of the working directory.".red
+            end
+          end
+
+          # create a commit with a message
+          begin
+            Actions.sh("hg commit -m '#{params[:message]}'")
+
+            Helper.log.info "Committed \"#{params[:message]}\" 💾.".green
+          rescue => ex
+            Helper.log.info "Didn't commit any changes. 😐".yellow
+          end
+        end
+      end
+
+      def self.description
+        "This will commit a version bump to the hg repo"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :message,
+                                       env_name: "FL_COMMIT_BUMP_MESSAGE",
+                                       description: "The commit message when committing the version bump",
+                                       default_value: "Version Bump"),
+          FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                                       env_name: "FL_BUILD_NUMBER_PROJECT",
+                                       description: "The path to your project file (Not the workspace). If you have only one, this is optional",
+                                       optional: true,
+                                       verify_block: Proc.new do |value|
+                                        raise "Please pass the path to the project, not the workspace".red if value.include?"workspace"
+                                        raise "Could not find Xcode project".red unless File.exists?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :force,
+                                       env_name: "FL_FORCE_COMMIT",
+                                       description: "Forces the commit, even if other files than the ones containing the version number have been modified",
+                                       optional: true,
+                                       default_value: false,
+                                       is_string: false)
+        ]
+      end
+
+      def self.author
+        "lmirosevic (original git version), sjrmanning (hg adaptation)"
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/hg_commit_version_bump.rb
+++ b/lib/fastlane/actions/hg_commit_version_bump.rb
@@ -99,7 +99,8 @@ module Fastlane
       end
 
       def self.author
-        "lmirosevic (original git version), sjrmanning (hg adaptation)"
+        # credits to lmirosevic for original git version
+        "sjrmanning"
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/actions/hg_ensure_clean_status.rb
+++ b/lib/fastlane/actions/hg_ensure_clean_status.rb
@@ -27,7 +27,8 @@ module Fastlane
       end
 
       def self.author
-        "sjrmanning (modified from lmirosevic's git version)"
+        # credits to lmirosevic for original git version
+        "sjrmanning"
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/actions/hg_ensure_clean_status.rb
+++ b/lib/fastlane/actions/hg_ensure_clean_status.rb
@@ -1,0 +1,38 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      HG_REPO_WAS_CLEAN_ON_START = :HG_REPO_WAS_CLEAN_ON_START
+    end
+    # Raises an exception and stop the lane execution if the repo is not in a clean state
+    class HgEnsureCleanStatusAction < Action
+      def self.run(params)
+        repo_clean = `hg status`.empty?
+
+        if repo_clean
+          Helper.log.info 'Mercurial status is clean, all good! 😎'.green
+          Actions.lane_context[SharedValues::HG_REPO_WAS_CLEAN_ON_START] = true
+        else
+          raise 'Mercurial repository is dirty! Please ensure the repo is in a clean state by commiting/stashing/discarding all changes first.'.red
+        end
+      end
+
+      def self.description
+        "Raises an exception if there are uncommited hg changes"
+      end
+
+      def self.output
+        [
+          ['HG_REPO_WAS_CLEAN_ON_START', 'Stores the fact that the hg repo was clean at some point']
+        ]
+      end
+
+      def self.author
+        "sjrmanning (modified from lmirosevic's git version)"
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/hg_push.rb
+++ b/lib/fastlane/actions/hg_push.rb
@@ -2,12 +2,14 @@ module Fastlane
   module Actions
     # Pushes commits to the remote hg repo
     class HgPushAction < Action
-      def self.run(options)
+      def self.run(params)
 
         command = ['hg', 'push']
 
         command << '--force' if params[:force]
         command << params[:destination] unless params[:destination].empty?
+
+        return command.join(' ') if Helper.is_test?
 
         Actions.sh(command.join(' '))
         Helper.log.info 'Successfully pushed changes to remote 🚀.'.green
@@ -27,6 +29,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :destination,
                                        env_name: "FL_HG_PUSH_DESTINATION",
                                        description: "The destination to push to",
+                                       default_value: '',
                                        optional: true)
         ]
       end

--- a/lib/fastlane/actions/hg_push.rb
+++ b/lib/fastlane/actions/hg_push.rb
@@ -1,0 +1,43 @@
+module Fastlane
+  module Actions
+    # Pushes commits to the remote hg repo
+    class HgPushAction < Action
+      def self.run(options)
+
+        command = ['hg', 'push']
+
+        command << '--force' if params[:force]
+        command << params[:destination] unless params[:destination].empty?
+
+        Actions.sh(command.join(' '))
+        Helper.log.info 'Successfully pushed changes to remote 🚀.'.green
+      end
+
+      def self.description
+        "This will push changes to the remote hg repository"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :force,
+                                       env_name: "FL_HG_PUSH_FORCE",
+                                       description: "Force push to remote. Defaults to false",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :destination,
+                                       env_name: "FL_HG_PUSH_DESTINATION",
+                                       description: "The destination to push to",
+                                       optional: true)
+        ]
+      end
+
+      def self.author
+        "sjrmanning (adapted from lmirosevic's push_to_git_remote)"
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/hg_push.rb
+++ b/lib/fastlane/actions/hg_push.rb
@@ -32,7 +32,8 @@ module Fastlane
       end
 
       def self.author
-        "sjrmanning (adapted from lmirosevic's push_to_git_remote)"
+        # credits to lmirosevic for original git version
+        "sjrmanning"
       end
 
       def self.is_supported?(platform)

--- a/spec/actions_specs/hg_add_tag_spec.rb
+++ b/spec/actions_specs/hg_add_tag_spec.rb
@@ -1,0 +1,17 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Mercurial Add Tag Action" do
+      it "allows you to specify your own tag" do
+        tag = '2.0.0'
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          hg_add_tag ({
+            tag: '#{tag}',
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("hg tag \"#{tag}\"")
+      end
+    end
+  end
+end

--- a/spec/actions_specs/hg_commit_version_bump_spec.rb
+++ b/spec/actions_specs/hg_commit_version_bump_spec.rb
@@ -1,0 +1,60 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Mercurial Commit Version Bump Action" do
+      it "passes when modified files are a subset of expected changed files" do
+        dirty_files = "file1,file2"
+        expected_files = "file1,file2"
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          hg_commit_version_bump ({
+            test_dirty_files: '#{dirty_files}',
+            test_expected_files: '#{expected_files}',
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("hg commit -m 'Version Bump'")
+      end
+
+      it "passes when modified files are not a subset of expected files, but :force is true" do
+        dirty_files = "file1,file3,file5"
+        expected_files = "file1"
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          hg_commit_version_bump ({
+            test_dirty_files: '#{dirty_files}',
+            test_expected_files: '#{expected_files}',
+            force: true
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("hg commit -m 'Version Bump'")
+      end
+
+      it "works with a custom commit message" do
+        message = "custom message"
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          hg_commit_version_bump ({
+            message: '#{message}',
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("hg commit -m '#{message}'")
+      end
+
+      it "raises an exception with no files changed" do
+        dirty_files = ""
+        expected_files = "file1"
+
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+          hg_commit_version_bump ({
+            test_dirty_files: '#{dirty_files}',
+            test_expected_files: '#{expected_files}',
+          })
+        end").runner.execute(:test)
+        }.to raise_exception('No file changes picked up. Make sure you run the `increment_build_number` action first.'.red)
+      end
+    end
+  end
+end

--- a/spec/actions_specs/hg_push_spec.rb
+++ b/spec/actions_specs/hg_push_spec.rb
@@ -1,0 +1,25 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Mercurial Push to Remote Action" do
+
+      it "works without passing any options" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          hg_push
+        end").runner.execute(:test)
+
+        expect(result).to include("hg push")
+      end
+
+      it "works with options specified" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          hg_push(
+            destination: 'https://test/owner/repo',
+            force: true
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("hg push --force https://test/owner/repo")
+      end
+    end
+  end
+end


### PR DESCRIPTION
First of all thanks for all of your work on this project, it is amazing and a total revelation! I've started bringing it in at my workplace and setting it up for all of our projects.

My company is using mercurial for source control, so there were a few custom actions I had to implement to mimic the support fastlane has for git. I'm not sure if this is much use to anyone else as mercurial isn't too widely used, but I thought I'd share these back just in case.

All credit and my thanks to @lmirosevic for his git actions, which these were largely based off (especially the `hg_commit_version_bump` action). Cheers!
