### PR TITLE
Lcov coverage

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -301,6 +301,17 @@ gcovr(
 )
 ```
 
+### [lcov](http://ltp.sourceforge.net/coverage/lcov.php)
+Generate code coverage reports based on lcov.
+
+```ruby
+lcov(
+      project_name: "yourProjectName",
+      scheme: "yourScheme",
+      output_dir: "cov_reports" # This value is optional. Default is coverage_reports
+)
+```
+
 ### [OCLint](http://oclint.org)
 Run the static analyzer tool [OCLint](http://oclint.org) for your project. You need to have a `compile_commands.json` file in your `fastlane` directory or pass a path to your file.
 
@@ -830,7 +841,7 @@ mailgun(
   success: true,
   message: "Mail Body",
   app_link: "http://www.myapplink.com",
-  ci_build_link: "http://www.mycibuildlink.com" 
+  ci_build_link: "http://www.mycibuildlink.com"
 )
 ```
 

--- a/lib/fastlane/actions/lcov.rb
+++ b/lib/fastlane/actions/lcov.rb
@@ -3,7 +3,7 @@ module Fastlane
     class LcovAction < Action
 
       def self.is_supported?(platform)
-        true
+        [:ios, :mac].include? platform
       end
 
       def self.run(options)
@@ -22,15 +22,15 @@ module Fastlane
         [
 
           FastlaneCore::ConfigItem.new(key: :project_name,
-                                       env_name: "PROJECT_NAME",
+                                       env_name: "FL_LCOV_PROJECT_NAME",
                                        description: "Name of the project"),
 
           FastlaneCore::ConfigItem.new(key: :scheme,
-                                       env_name: "SCHEME",
+                                       env_name: "FL_LCOV_SCHEME",
                                        description: "Scheme of the project"),
 
           FastlaneCore::ConfigItem.new(key: :output_dir,
-                                       env_name: "OUTPUT_DIR",
+                                       env_name: "FL_LCOV_OUTPUT_DIR",
                                        description: "The output directory that coverage data will be stored. If not passed will use coverage_reports as default value",
                                        optional: true,
                                        is_string: true,
@@ -47,13 +47,13 @@ module Fastlane
       private
         def self.handle_exceptions(options)
             unless (options[:project_name] rescue nil)
-              Helper.log.fatal "Please add 'ENV[\"PROJECT_NAME\"] = \"a_valid_project_name\"' to your Fastfile's `before_all` section.".red
-              raise 'No PROJECT_NAME given.'.red
+              Helper.log.fatal "Please add 'ENV[\"FL_LCOV_PROJECT_NAME\"] = \"a_valid_project_name\"' to your Fastfile's `before_all` section.".red
+              raise 'No FL_LCOV_PROJECT_NAME given.'.red
             end
 
             unless (options[:scheme] rescue nil)
-              Helper.log.fatal "Please add 'ENV[\"SCHEME\"] = \"a_valid_scheme\"' to your Fastfile's `before_all` section.".red
-              raise 'No SCHEME given.'.red
+              Helper.log.fatal "Please add 'ENV[\"FL_LCOV_SCHEME\"] = \"a_valid_scheme\"' to your Fastfile's `before_all` section.".red
+              raise 'No FL_LCOV_SCHEME given.'.red
             end
         end
 

--- a/lib/fastlane/actions/lcov.rb
+++ b/lib/fastlane/actions/lcov.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     class LcovAction < Action
-      @@derived_data_path = "#{File.expand_path('~')}/Library/Developer/Xcode/DerivedData/"
+      @@derived_data_path = "#{Dir.home}/Library/Developer/Xcode/DerivedData/"
       @@out_cov_file = "/tmp/coverage.info"
       @@exclude_dirs = ["/Applications/*","/Frameworks/*"]
 
@@ -48,35 +48,43 @@ module Fastlane
       end
 
       private
-      def self.handle_exceptions(options)
-          unless (options[:project_name] rescue nil)
-            Helper.log.fatal "Please add 'ENV[\"PROJECT_NAME\"] = \"a_valid_project_name\"' to your Fastfile's `before_all` section.".red
-            raise 'No PROJECT_NAME given.'.red
-          end
+        def self.handle_exceptions(options)
+            unless (options[:project_name] rescue nil)
+              Helper.log.fatal "Please add 'ENV[\"PROJECT_NAME\"] = \"a_valid_project_name\"' to your Fastfile's `before_all` section.".red
+              raise 'No PROJECT_NAME given.'.red
+            end
 
-          unless (options[:scheme] rescue nil)
-            Helper.log.fatal "Please add 'ENV[\"SCHEME\"] = \"a_valid_scheme\"' to your Fastfile's `before_all` section.".red
-            raise 'No SCHEME given.'.red
-          end
-      end
-
-      def self.gen_cov(options)
-        system("lcov --capture --directory \"#{derived_data_dir(options)}\" --output-file #{@@out_cov_file}")
-        cmd = "lcov "
-        @@exclude_dirs.each do |e|
-          cmd << "--remove #{@@out_cov_file} \"#{e}\" "
+            unless (options[:scheme] rescue nil)
+              Helper.log.fatal "Please add 'ENV[\"SCHEME\"] = \"a_valid_scheme\"' to your Fastfile's `before_all` section.".red
+              raise 'No SCHEME given.'.red
+            end
         end
-        cmd << "--output #{@@out_cov_file} "
-        system(cmd)
-        system("genhtml #{@@out_cov_file} --output-directory #{options[:output_dir]}")
-      end
+
+        def self.gen_cov(options)
+          system("lcov --capture --directory \"#{derived_data_dir(options)}\" --output-file #{@@out_cov_file}")
+          cmd = "lcov "
+          @@exclude_dirs.each do |e|
+            cmd << "--remove #{@@out_cov_file} \"#{e}\" "
+          end
+          cmd << "--output #{@@out_cov_file} "
+          system(cmd)
+          system("genhtml #{@@out_cov_file} --output-directory #{options[:output_dir]}")
+        end
 
 
-      def self.derived_data_dir(options)
-         match = `ls -t #{@@derived_data_path}| grep #{options[:project_name]} | head -1`.to_s.gsub(/\n/, "")
-         derived_data_end_path = "/Build/Intermediates/#{options[:project_name]}.build/Debug-iphonesimulator/#{options[:scheme]}.build/Objects-normal/i386/"
-         "#{@@derived_data_path}#{match}#{derived_data_end_path}"
-      end
+        def self.derived_data_dir(options)
+           pn = options[:project_name]
+           sc = options[:scheme]
+
+           match = find_project_dir(pn)
+
+           derived_data_end_path = "/Build/Intermediates/#{pn}.build/Debug-iphonesimulator/#{sc}.build/Objects-normal/i386/"
+           "#{@@derived_data_path}#{match}#{derived_data_end_path}"
+        end
+
+        def self.find_project_dir(project_name)
+          `ls -t #{@@derived_data_path}| grep #{project_name} | head -1`.to_s.gsub(/\n/, "")
+        end
 
     end
   end

--- a/lib/fastlane/actions/lcov.rb
+++ b/lib/fastlane/actions/lcov.rb
@@ -1,0 +1,83 @@
+module Fastlane
+  module Actions
+    class LcovAction < Action
+      @@derived_data_path = "#{File.expand_path('~')}/Library/Developer/Xcode/DerivedData/"
+      @@out_cov_file = "/tmp/coverage.info"
+      @@exclude_dirs = ["/Applications/*","/Frameworks/*"]
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.run(options)
+        unless Helper.test?
+          raise 'lcov not installed, please install using `brew install lcov`'.red if `which lcov`.length == 0
+        end
+        handle_exceptions(options)
+        gen_cov(options)
+      end
+
+      def self.description
+        "Generates coverage data using lcov"
+      end
+
+      def self.available_options
+        [
+
+          FastlaneCore::ConfigItem.new(key: :project_name,
+                                       env_name: "PROJECT_NAME",
+                                       description: "Name of the project"),
+
+          FastlaneCore::ConfigItem.new(key: :scheme,
+                                       env_name: "SCHEME",
+                                       description: "Scheme of the project"),
+
+          FastlaneCore::ConfigItem.new(key: :output_dir,
+                                       env_name: "OUTPUT_DIR",
+                                       description: "The output directory that coverage data will be stored. If not passed will use coverage_reports as default value",
+                                       optional: true,
+                                       is_string: true,
+                                       default_value: "coverage_reports")
+
+
+        ]
+      end
+
+      def self.author
+        "thiagolioy"
+      end
+
+      private
+      def self.handle_exceptions(options)
+          unless (options[:project_name] rescue nil)
+            Helper.log.fatal "Please add 'ENV[\"PROJECT_NAME\"] = \"a_valid_project_name\"' to your Fastfile's `before_all` section.".red
+            raise 'No PROJECT_NAME given.'.red
+          end
+
+          unless (options[:scheme] rescue nil)
+            Helper.log.fatal "Please add 'ENV[\"SCHEME\"] = \"a_valid_scheme\"' to your Fastfile's `before_all` section.".red
+            raise 'No SCHEME given.'.red
+          end
+      end
+
+      def self.gen_cov(options)
+        system("lcov --capture --directory \"#{derived_data_dir(options)}\" --output-file #{@@out_cov_file}")
+        cmd = "lcov "
+        @@exclude_dirs.each do |e|
+          cmd << "--remove #{@@out_cov_file} \"#{e}\" "
+        end
+        cmd << "--output #{@@out_cov_file} "
+        system(cmd)
+        system("genhtml #{@@out_cov_file} --output-directory #{options[:output_dir]}")
+      end
+
+
+      def self.derived_data_dir(options)
+         match = `ls -t #{@@derived_data_path}| grep #{options[:project_name]} | head -1`.to_s.gsub(/\n/, "")
+         derived_data_end_path = "/Build/Intermediates/#{options[:project_name]}.build/Debug-iphonesimulator/#{options[:scheme]}.build/Objects-normal/i386/"
+         "#{@@derived_data_path}#{match}#{derived_data_end_path}"
+      end
+
+    end
+  end
+end

--- a/spec/actions_specs/lcov_spec.rb
+++ b/spec/actions_specs/lcov_spec.rb
@@ -2,32 +2,32 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Lcov Action" do
       before :each do
-        ENV['PROJECT_NAME'] = 'a_project_name'
-        ENV['SCHEME'] = 'a_scheme'
+        ENV['FL_LCOV_PROJECT_NAME'] = 'a_project_name'
+        ENV['FL_LCOV_SCHEME'] = 'a_scheme'
       end
 
 
 
       it "raises an error if no project name is given" do
-        ENV.delete 'PROJECT_NAME'
+        ENV.delete 'FL_LCOV_PROJECT_NAME'
         expect {
           Fastlane::FastFile.new.parse("lane :test do
           lcov({
             :scheme => 'a_valid_scheme'
             })
           end").runner.execute(:test)
-        }.to raise_exception('No PROJECT_NAME given.'.red)
+        }.to raise_exception('No FL_LCOV_PROJECT_NAME given.'.red)
       end
 
       it "raises an error if no scheme is given" do
-        ENV.delete 'SCHEME'
+        ENV.delete 'FL_LCOV_SCHEME'
         expect {
           Fastlane::FastFile.new.parse("lane :test do
           lcov({
             :project_name => 'a_valid_project_name'
             })
           end").runner.execute(:test)
-        }.to raise_exception('No SCHEME given.'.red)
+        }.to raise_exception('No FL_LCOV_SCHEME given.'.red)
       end
 
     end

--- a/spec/actions_specs/lcov_spec.rb
+++ b/spec/actions_specs/lcov_spec.rb
@@ -1,0 +1,35 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Lcov Action" do
+      before :each do
+        ENV['PROJECT_NAME'] = 'a_project_name'
+        ENV['SCHEME'] = 'a_scheme'
+      end
+
+
+
+      it "raises an error if no project name is given" do
+        ENV.delete 'PROJECT_NAME'
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+          lcov({
+            :scheme => 'a_valid_scheme'
+            })
+          end").runner.execute(:test)
+        }.to raise_exception('No PROJECT_NAME given.'.red)
+      end
+
+      it "raises an error if no scheme is given" do
+        ENV.delete 'SCHEME'
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+          lcov({
+            :project_name => 'a_valid_project_name'
+            })
+          end").runner.execute(:test)
+        }.to raise_exception('No SCHEME given.'.red)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Added action to generate code coverage using lcov.

My lane as example : 

``` ruby
desc "Runs all the tests"
  lane :test do
    xctool :test , [
      "-workspace", "MyWorkspace.xcworkspace",
      "-scheme", "MyScheme",
      "-configuration", "Debug",
      "-reporter", "plain",
      "-sdk","iphonesimulator",
      "GCC_GENERATE_TEST_COVERAGE_FILES=YES", #Needed to gen coverage files used by lcov
      "GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES"#Needed to gen coverage files used by lcov
    ].join(" ")

    lcov(
      project_name: "MyProjectName",
      scheme: "MyScheme",
      output_dir: "cov_reports" #Optional value . Default is coverage_reports
    )
  end
```
