### PR TITLE
support -destination-timeout for xctest action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -278,6 +278,7 @@ When running tests, coverage reports can be generated via [xcpretty](https://git
   # Run tests in given simulator
   xctest(
     destination: "name=iPhone 5s,OS=8.1",
+    destination_timeout: 120, # increase device/simulator timeout, usually used on slow CI boxes
     reports: [{
       report: 'html',
       output: './build-dir/test-report.html',  # will use XCODE_BUILD_PATH/report, if output is not provided

--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -25,6 +25,7 @@ module Fastlane
         configuration: "-configuration",
         derivedDataPath: "-derivedDataPath",
         destination: "-destination",
+        destination_timeout: "-destination-timeout",
         export_archive: "-exportArchive",
         export_format: "-exportFormat",
         export_installer_identity: "-exportInstallerIdentity",
@@ -402,6 +403,7 @@ module Fastlane
           ['scheme', 'The scheme to build'],
           ['build_settings', 'Hash of additional build information'],
           ['destination', 'The simulator to use, e.g. "name=iPhone 5s,OS=8.1"'],
+          ['destination_timeout', 'The timeout for connecting to the simulator, in seconds'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII outout)']
         ]
       end

--- a/spec/actions_specs/xcodebuild_spec.rb
+++ b/spec/actions_specs/xcodebuild_spec.rb
@@ -22,6 +22,7 @@ describe Fastlane do
             configuration: 'Debug',
             derived_data_path: '/derived/data/path',
             destination: 'name=iPhone 5s,OS=8.1',
+            destination_timeout: 240,
             export_archive: true,
             export_format: 'ipa',
             export_installer_identity: true,
@@ -49,6 +50,7 @@ describe Fastlane do
           + "-archivePath \"./build/MyApp.xcarchive\" " \
           + "-configuration \"Debug\" " \
           + "-destination \"name=iPhone 5s,OS=8.1\" " \
+          + "-destination-timeout \"240\" " \
           + "-exportArchive " \
           + "-exportFormat \"ipa\" " \
           + "-exportInstallerIdentity " \
@@ -276,6 +278,7 @@ describe Fastlane do
         result = Fastlane::FastFile.new.parse("lane :test do
           xctest(
             destination: 'name=iPhone 5s,OS=8.1',
+            destination_timeout: 240,
             scheme: 'MyApp',
             workspace: 'MyApp.xcworkspace'
           )
@@ -285,6 +288,7 @@ describe Fastlane do
           "set -o pipefail && " \
           + "xcodebuild " \
           + "-destination \"name=iPhone 5s,OS=8.1\" " \
+          + "-destination-timeout \"240\" " \
           + "-scheme \"MyApp\" " \
           + "-workspace \"MyApp.xcworkspace\" " \
           + "test " \


### PR DESCRIPTION
This adds support for passing a destination timeout to xcodebuild via the `xctest` action. This is useful for continuous integration environments that sometimes face resource allocation issues, making things reeeaaally slow.

edit: If this gets merged it means that I don't have do something like this in my Fastfile:

```
Fastlane::Actions::XcodebuildAction::ARGS_MAP[:destination_timeout] = '-destination-timeout'
```

:grimacing: 
