### PR TITLE
Backup and restore file actions

### DIFF
--- a/lib/fastlane/actions/backup_file.rb
+++ b/lib/fastlane/actions/backup_file.rb
@@ -7,7 +7,7 @@ module Fastlane
       end
 
       def self.description
-        'This action backup your file to "[path].back".'
+        'This action backup your file to "[path].back"'
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/actions/backup_file.rb
+++ b/lib/fastlane/actions/backup_file.rb
@@ -1,0 +1,31 @@
+module Fastlane
+  module Actions
+    class BackupFileAction < Action
+      def self.run params
+        path = params[:path]
+        FileUtils.cp(path, "#{path}.back", {:preserve => true})
+      end
+
+      def self.description
+        'This action backup your file to "[path].back".'
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.author
+        "gin0606"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: "",
+                                       description: "File name you want to back up",
+                                       optional: false),
+        ]
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/restore_file.rb
+++ b/lib/fastlane/actions/restore_file.rb
@@ -1,0 +1,34 @@
+module Fastlane
+  module Actions
+    class RestoreFileAction < Action
+      def self.run params
+        path = params[:path]
+        backup_path = "#{path}.back"
+        raise "not exist #{backup_path}" unless File.exist? backup_path
+        FileUtils.cp(backup_path, path, {:preserve => true})
+        FileUtils.rm(backup_path)
+      end
+
+      def self.description
+        'This action restore your file that backuped in `backup_file` action.'
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.author
+        "gin0606"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: "",
+                                       description: "Original file name you want to restore",
+                                       optional: false),
+        ]
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/restore_file.rb
+++ b/lib/fastlane/actions/restore_file.rb
@@ -10,7 +10,7 @@ module Fastlane
       end
 
       def self.description
-        'This action restore your file that backuped in `backup_file` action.'
+        'This action restore your file that backuped in `backup_file` action'
       end
 
       def self.is_supported?(platform)

--- a/spec/actions_specs/backup_file_spec.rb
+++ b/spec/actions_specs/backup_file_spec.rb
@@ -1,0 +1,30 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Backup file Integration" do
+      let (:test_path) { "/tmp/fastlane/tests/fastlane" }
+      let (:file_path) { "file.txt" }
+      let (:backup_path) { "#{file_path}.back" }
+      let (:file_content) { Time.now.to_s }
+
+      before do
+        FileUtils.mkdir_p(test_path)
+        File.write(File.join(test_path, file_path), file_content)
+
+        Fastlane::FastFile.new.parse("lane :test do
+          backup_file path: '#{File.join(test_path, file_path)}'
+        end").runner.execute(:test)
+      end
+
+      it "backup file to `.back` file" do
+        expect(
+          File.open(File.join(test_path, backup_path))
+        ).to include file_content
+      end
+
+      after do
+        File.delete(File.join(test_path, file_path))
+        File.delete(File.join(test_path, backup_path))
+      end
+    end
+  end
+end

--- a/spec/actions_specs/restore_file_spec.rb
+++ b/spec/actions_specs/restore_file_spec.rb
@@ -1,0 +1,49 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Backup file Integration" do
+      let (:test_path) { "/tmp/fastlane/tests/fastlane" }
+      let (:file_path) { "file.txt" }
+      let (:backup_path) { "#{file_path}.back" }
+      let (:file_content) { Time.now.to_s }
+
+      before do
+        FileUtils.mkdir_p(test_path)
+        File.write(File.join(test_path, file_path), file_content)
+      end
+
+      describe "when use action after `backup_file` action" do
+        before do
+          Fastlane::FastFile.new.parse("lane :test do
+            backup_file path: '#{File.join(test_path, file_path)}'
+          end").runner.execute(:test)
+          File.write(File.join(test_path, file_path), file_content.reverse)
+        end
+
+        it "should be restore file" do
+          Fastlane::FastFile.new.parse("lane :test do
+            restore_file path: '#{File.join(test_path, file_path)}'
+          end").runner.execute(:test)
+          restored_file = File.open(File.join(test_path, file_path)).read
+
+          expect(restored_file).to include file_content
+          expect(File).not_to exist(File.join(test_path, backup_path))
+        end
+      end
+
+      describe "when use action without `backup_file` action" do
+        it "should raise error" do
+          expect {
+            Fastlane::FastFile.new.parse("lane :test do
+              restore_file path: '#{File.join(test_path, file_path)}'
+            end").runner.execute(:test)
+          }.to raise_error("not exist #{File.join(test_path, backup_path)}")
+        end
+      end
+
+      after do
+        File.delete(File.join(test_path, backup_path)) if File.exists? File.join(test_path, backup_path)
+        File.delete(File.join(test_path, file_path))
+      end
+    end
+  end
+end


### PR DESCRIPTION
hi!

I added general `backup` or `restore` file action.
# Usage

``` ruby
before_all do
  backup_file path: 'app/Info.plist'
end

lane :example do
  # something to update backuped file
  update_info_plist(
    plist_path: 'app/Info.plist',
    app_identifier: 'com.test.plist.example'
  )
end

after_all do |lane|
  restore_file path: 'app/Info.plist' # then restore to the previous state of `lane :example`
end
```
