### PR TITLE
Add the ability to add dependencies to lanes

### DIFF
--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -208,8 +208,6 @@ module Fastlane
 
     def depends_on(*args, **env)
       raise "Please provide the names of dependencies as a list of symbols".red unless args.is_a? Array and args.all? {|a| a.is_a? Symbol}
-      #args.each do |lane_name|
-      #end
       depends_collection << args
     end
 

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -178,10 +178,10 @@ module Fastlane
     def verify_dependencies
       self.runner.configs.each do |current_platform, lanes|
         # Lanes available to all platforms + lanes only available to current platform
-        available = lanes.keys | self.runner.configs[nil].keys
+        available = lanes.keys | (self.runner.configs[nil] || {}).keys
         lanes.each do |lane_name, config|
           config.dependencies.each do |dependency|
-            raise "There is no lane called #{dependency} on platform #{current_platform} that we could use as dependency for #{lane_name}".red unless available.include? dependency
+            raise "There is no lane called #{dependency} on platform '#{current_platform}' that we could use as dependency for #{lane_name}".red unless available.include? dependency
           end
         end
       end
@@ -196,7 +196,7 @@ module Fastlane
       desc_collection << string
     end
 
-    def depends_on(*args)
+    def depends_on(*args, **env)
       raise "Please provide the names of dependencies as a list of symbols".red unless args.is_a? Array and args.all? {|a| a.is_a? Symbol}
       #args.each do |lane_name|
       #end

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -185,6 +185,16 @@ module Fastlane
           end
         end
       end
+
+      verify_no_circular_dependencies(self.runner.configs)
+    end
+
+    def verify_no_circular_dependencies(configs)
+      configs.each do |current_platform, lanes|
+        lanes.each do |lane_name, config|
+          config.verify_no_circular_dependencies(self.runner, current_platform)
+        end
+      end
     end
 
     # Fastfile was finished executing

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -36,12 +36,14 @@ module Fastlane
       
       desc = desc_collection.join("\n\n")
       dependencies = depends_collection.flatten
+      environment = env_collection
       platform = @current_platform
 
-      @runner.set_block(lane_name, platform, block, dependencies, desc)
+      @runner.set_block(lane_name, platform, block, dependencies, environment, desc)
 
       @desc_collection = nil # reset the collected description again for the next lane
       @depends_collection = nil # reset the dependencies as well
+      @env_collection = nil # ... and the environment collection
     end
     
     # User defines a platform block
@@ -209,10 +211,15 @@ module Fastlane
     def depends_on(*args, **env)
       raise "Please provide the names of dependencies as a list of symbols".red unless args.is_a? Array and args.all? {|a| a.is_a? Symbol}
       depends_collection << args
+      env_collection.merge! env
     end
 
     def collector
       @collector ||= ActionCollector.new
+    end
+
+    def env_collection 
+      @env_collection ||= {}
     end
 
     def desc_collection

--- a/lib/fastlane/runner.rb
+++ b/lib/fastlane/runner.rb
@@ -1,6 +1,10 @@
 module Fastlane
   class Runner
-    LaneConfig = Struct.new(:block, :dependencies, :description)
+    LaneConfig = Struct.new(:block, :dependencies, :description) do
+      def call
+        block.call
+      end
+    end
 
     # This will take care of executing **one** lane. 
     # @param lane_name The name of the lane to execute
@@ -97,6 +101,22 @@ module Fastlane
 
     def configs
       @configs ||= {}
+    end
+
+    # Keep old inteface to outside the same
+    def blocks
+      configs
+    end
+    def description_blocks
+      desc_blocks = {}
+      configs.each do |platform, lanes|
+        desc_blocks[platform] = {}
+        lanes.each do |lane_name, config| 
+          desc_blocks[platform][lane_name] = config.description
+        end
+      end
+
+      desc_blocks
     end
 
     def before_all_blocks

--- a/spec/fast_file_spec.rb
+++ b/spec/fast_file_spec.rb
@@ -251,5 +251,24 @@ describe Fastlane do
       puts ff.runner.configs
       expect(ff.runner.configs[:ios][:test2].dependencies).to eq([:test])
     end
+
+    it "prevents circular dependencies" do
+      expect {
+        Fastlane::FastFile.new.parse("
+                                     depends_on :test2
+                                     lane :test do
+                                     end
+                                    depends_on :test
+                                    lane :test2 do
+                                    end
+                                     ")
+      }.to raise_exception("Circular dependencies detected for lane 'test' with dependency chain: test -> test2 -> test".red)
+    end
+
+    it "prevents longer circular dependency chains" do
+      expect {
+        Fastlane::FastFile.new("./spec/fixtures/fastfiles/FastfileWithDependencyChain")
+      }.to raise_exception("Circular dependencies detected for lane 'one' with dependency chain: one -> seven -> six -> three -> two -> one".red)
+    end
   end
 end

--- a/spec/fixtures/fastfiles/FastfileWithDependencies
+++ b/spec/fixtures/fastfiles/FastfileWithDependencies
@@ -1,0 +1,36 @@
+# vim: ft=ruby
+
+nums = []
+
+lane :one do
+  nums << 1
+end
+
+depends_on :one
+lane :two do
+  nums << 2
+end
+
+depends_on :two
+lane :three do
+  nums << 3
+end
+
+lane :four do
+  nums << 4
+end
+
+lane :five do
+  nums << 5
+end
+
+depends_on :three, :four, :five
+lane :six do
+  nums << 6
+end
+
+depends_on :six
+lane :seven do
+  nums << 7
+  nums
+end

--- a/spec/fixtures/fastfiles/FastfileWithDependencyChain
+++ b/spec/fixtures/fastfiles/FastfileWithDependencyChain
@@ -1,0 +1,29 @@
+# vim: ft=ruby
+
+depends_on :seven
+lane :one do
+end
+
+depends_on :one
+lane :two do
+end
+
+depends_on :two
+lane :three do
+end
+
+depends_on :five
+lane :four do
+end
+
+depends_on :one
+lane :five do
+end
+
+depends_on :three, :four, :five
+lane :six do
+end
+
+depends_on :six
+lane :seven do
+end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -17,5 +17,12 @@ describe Fastlane do
         expect(@ff.runner.available_lanes('asdfasdfasdf')).to eq([])
       end
     end
+
+    describe "dependencies" do 
+      it "runs the dependencies in the defined order" do
+        ff = Fastlane::FastFile.new("./spec/fixtures/fastfiles/FastfileWithDependencies")
+        expect(ff.runner.execute(:seven)).to eq([1, 2, 3, 4, 5, 6, 7])
+      end
+    end
   end
 end


### PR DESCRIPTION
I added the ability to create dependencies between lanes, see this simple example:

``` ruby
desc "Build the product"
lane :build do
    puts "I am performing the build right now!"
    sleep 2
end

platform :ios do
    desc "Make screenshots"
    lane :screenshots do
        puts "Making screenshots..."
        sleep 2
    end

    desc "Perform tests"
    depends_on :screenshots
    lane :test do
        puts "I am performing the tests right now!"
        sleep 2
    end

    desc "Publish to the App Store"
    depends_on :test, :build
    lane :distribute do
        puts "Now that test and build were run, it's my turn!"
        sleep 2
        puts "Done!"
    end
end

platform :mac do
    desc "This is only available on Mac"
    depends_on :build
    lane :only_mac do
        puts "I'm on a Mac!"
    end
end
```

And here it is in action:

![fastlane_distribute](https://cloud.githubusercontent.com/assets/279407/8624160/47d40f90-2736-11e5-846d-8b26ff8c4b0f.gif)
