### PR TITLE
Reset default keychain when using a temporary one

### DIFF
--- a/lib/fastlane/actions/delete_keychain.rb
+++ b/lib/fastlane/actions/delete_keychain.rb
@@ -5,6 +5,9 @@ module Fastlane
     class DeleteKeychainAction < Action
       def self.run(params)
         Fastlane::Actions.sh "security delete-keychain #{params[:name].shellescape}", log:false
+
+        original = Actions.lane_context[Actions::SharedValues::ORIGINAL_DEFAULT_KEYCHAIN]
+        Fastlane::Actions.sh("security default-keychain -s #{original}", log:false) unless original.nil?
       end
 
       def self.description

--- a/lib/fastlane/actions/delete_keychain.rb
+++ b/lib/fastlane/actions/delete_keychain.rb
@@ -4,10 +4,9 @@ module Fastlane
   module Actions
     class DeleteKeychainAction < Action
       def self.run(params)
-        Fastlane::Actions.sh "security delete-keychain #{params[:name].shellescape}", log:false
-
         original = Actions.lane_context[Actions::SharedValues::ORIGINAL_DEFAULT_KEYCHAIN]
         Fastlane::Actions.sh("security default-keychain -s #{original}", log:false) unless original.nil?
+        Fastlane::Actions.sh "security delete-keychain #{params[:name].shellescape}", log:false
       end
 
       def self.description


### PR DESCRIPTION
Really annoying, because every time the system tries to auto import a key, you get an error alert ("Could not import ... Reset to defaults") 
