### PR TITLE
Allow security itself to access imported certs

### DIFF
--- a/lib/fastlane/actions/import_certificate.rb
+++ b/lib/fastlane/actions/import_certificate.rb
@@ -7,6 +7,7 @@ module Fastlane
         command = "security import #{params[:certificate_path].shellescape} -k ~/Library/Keychains/#{params[:keychain_name].shellescape}"
         command << " -P #{params[:certificate_password].shellescape}" if params[:certificate_password]
         command << " -T /usr/bin/codesign"
+        command << " -T /usr/bin/security"
 
         Fastlane::Actions.sh command, log: false
       end

--- a/spec/actions_specs/import_certificate_spec.rb
+++ b/spec/actions_specs/import_certificate_spec.rb
@@ -11,7 +11,6 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq 98
         expect(result).to start_with 'security'
         expect(result).to include 'import test.cer'
         expect(result).to include '-k ~/Library/Keychains/test.keychain'
@@ -29,7 +28,6 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq 120
         expect(result).to start_with 'security'
         expect(result).to include %(import \\\"\\ test\\ \\\".cer)
         expect(result).to include %(-k ~/Library/Keychains/\\\"\\ test\\ \\\".keychain)
@@ -47,7 +45,6 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq 82
         expect(result).to start_with 'security'
         expect(result).to include 'import test.cer'
         expect(result).to include '-k ~/Library/Keychains/test.keychain'

--- a/spec/actions_specs/import_certificate_spec.rb
+++ b/spec/actions_specs/import_certificate_spec.rb
@@ -17,6 +17,7 @@ describe Fastlane do
         expect(result).to include '-k ~/Library/Keychains/test.keychain'
         expect(result).to include '-P testpassword'
         expect(result).to include '-T /usr/bin/codesign'
+        expect(result).to include '-T /usr/bin/security'
       end
 
       it "works with certificate and password that contain spaces or `\"`" do
@@ -34,6 +35,7 @@ describe Fastlane do
         expect(result).to include %(-k ~/Library/Keychains/\\\"\\ test\\ \\\".keychain)
         expect(result).to include %(-P \\\"test\\ password\\\")
         expect(result).to include '-T /usr/bin/codesign'
+        expect(result).to include '-T /usr/bin/security'
 
       end
 
@@ -51,6 +53,7 @@ describe Fastlane do
         expect(result).to include '-k ~/Library/Keychains/test.keychain'
         expect(result).to_not include '-P'
         expect(result).to include '-T /usr/bin/codesign'
+        expect(result).to include '-T /usr/bin/security'
       end
     end
   end


### PR DESCRIPTION
Otherwise you can get a popup when using it later
