### PR TITLE
Allow setting any attachment property supported by the Slack API

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -861,7 +861,15 @@ slack(
     'Build Date' => Time.new.to_s,
     'Built by' => 'Jenkins',
   },
-  default_payloads: [:git_branch, :git_author] # Optional, lets you specify a whitelist of default payloads to include. Pass an empty array to suppress all the default payloads. Don't add this key, or pass nil, if you want all the default payloads. The available default payloads are: `lane`, `test_result`, `git_branch`, `git_author`, `last_git_commit`.
+  default_payloads: [:git_branch, :git_author], # Optional, lets you specify a whitelist of default payloads to include. Pass an empty array to suppress all the default payloads. Don't add this key, or pass nil, if you want all the default payloads. The available default payloads are: `lane`, `test_result`, `git_branch`, `git_author`, `last_git_commit`.
+  attachment_properties: { # Optional, lets you specify any other properties available for attachments in the slack API (see https://api.slack.com/docs/attachments). This hash is deep merged with the existing properties set using the other properties above. This allows your own fields properties to be appended to the existings fields that were created using the `payload` property for instance.
+    thumb_url: 'http://example.com/path/to/thumb.png',
+    fields: [{
+      title: 'My Field',
+      value: 'My Value',
+      short: true
+    }]
+  }
 )
 ```
 

--- a/lib/fastlane/actions/slack.rb
+++ b/lib/fastlane/actions/slack.rb
@@ -82,6 +82,11 @@ module Fastlane
                                        description: "Remove some of the default payloads. More information about the available payloads on GitHub",
                                        optional: true,
                                        is_string: false),
+          FastlaneCore::ConfigItem.new(key: :attachment_properties,
+                                       env_name: "FL_SLACK_ATTACHMENT_PROPERTIES",
+                                       description: "Merge additional properties in the slack attachment, see https://api.slack.com/docs/attachments",
+                                       default_value: {},
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :success,
                                        env_name: "FL_SLACK_SUCCESS",
                                        description: "Was this build successful? (true/false)",
@@ -165,7 +170,16 @@ module Fastlane
             }
           end
 
-          slack_attachment
+          # merge additional properties
+          deep_merge(slack_attachment, options[:attachment_properties])
+        end
+
+        # Adapted from http://stackoverflow.com/a/30225093/158525
+        def self.deep_merge(a, b)
+          merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? 
+                            v1.merge(v2, &merger) : Array === v1 && Array === v2 ? 
+                              v1 | v2 : [:undefined, nil, :nil].include?(v2) ? v1 : v2 }
+          a.merge(b, &merger)
         end
     end
   end

--- a/spec/actions_specs/slack_spec.rb
+++ b/spec/actions_specs/slack_spec.rb
@@ -57,6 +57,43 @@ describe Fastlane do
         expect(fields[3][:title]).to eq('Result')
         expect(fields[3][:value]).to eq('Error')
       end
+
+      it "merges attachment_properties when specified" do
+        channel = "#myChannel"
+        message = "Custom Message"
+        lane_name = "lane_name"
+
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
+
+        require 'fastlane/actions/slack'
+        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+          message: message,
+          success: false,
+          channel: channel,
+          default_payloads: [:lane],
+          attachment_properties: {
+            thumb_url: 'http://example.com/path/to/thumb.png',
+            fields: [{
+              title: 'My Field',
+              value: 'My Value',
+              short: true
+            }]
+          }
+        })
+
+        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+
+        fields = attachments[:fields]
+
+        expect(fields[0][:title]).to eq('Lane')
+        expect(fields[0][:value]).to eq(lane_name)
+
+        expect(fields[1][:title]).to eq('My Field')
+        expect(fields[1][:value]).to eq('My Value')
+        expect(fields[1][:short]).to eq(true)
+
+        expect(attachments[:thumb_url]).to eq('http://example.com/path/to/thumb.png')
+      end
     end
   end
 end


### PR DESCRIPTION
Hi,

I wanted to add custom short fields when sending a slack notification and also specify the `thumb_url` property in the slack attachment so I could get a nice notification like this:

![sample_slack_notification](https://cloud.githubusercontent.com/assets/57791/8721756/e86efea2-2bbd-11e5-978f-7f42ba2450a7.png)

I modified the Slack action to support this using a new `attachment_properties` key.
I also updated the spec and docs.

What do you think?
