### PR TITLE
Set GitHub Release Action: Return JSON

### DIFF
--- a/lib/fastlane/actions/set_github_release.rb
+++ b/lib/fastlane/actions/set_github_release.rb
@@ -3,6 +3,7 @@ module Fastlane
     module SharedValues
       SET_GITHUB_RELEASE_HTML_LINK = :SET_GITHUB_RELEASE_HTML_LINK
       SET_GITHUB_RELEASE_RELEASE_ID = :SET_GITHUB_RELEASE_RELEASE_ID
+      SET_GITHUB_RELEASE_JSON = :SET_GITHUB_RELEASE_JSON
     end
 
     class SetGithubReleaseAction < Action
@@ -38,7 +39,8 @@ module Fastlane
           Helper.log.info "See release at \"#{html_url}\"".yellow
           Actions.lane_context[SharedValues::SET_GITHUB_RELEASE_HTML_LINK] = html_url
           Actions.lane_context[SharedValues::SET_GITHUB_RELEASE_RELEASE_ID] = release_id
-          return html_url
+          Actions.lane_context[SharedValues::SET_GITHUB_RELEASE_JSON] = body
+          return body
         when 422
           Helper.log.error "Release on tag #{params[:tag_name]} already exists!".red
         when 404
@@ -118,7 +120,8 @@ module Fastlane
       def self.output
         [
           ['SET_GITHUB_RELEASE_HTML_LINK', 'Link to your created release'],
-          ['SET_GITHUB_RELEASE_RELEASE_ID', 'Release id (useful for subsequent editing)']
+          ['SET_GITHUB_RELEASE_RELEASE_ID', 'Release id (useful for subsequent editing)'],
+          ['SET_GITHUB_RELEASE_JSON', 'The whole release JSON object']
         ]
       end
 


### PR DESCRIPTION
The set GitHub release action now returns the whole release JSON object instead of just `html_link`. Both `html_link` and `release_id` can still be accessed in vended shared values.
