### PR TITLE
Optionally use template_path variables for loading custom S3 templates.

### DIFF
--- a/lib/fastlane/actions/s3.rb
+++ b/lib/fastlane/actions/s3.rb
@@ -120,8 +120,14 @@ module Fastlane
 
         #grabs module
         eth = Fastlane::ErbTemplateHelper
+
         # Creates plist from template
-        plist_render = eth.render(eth.load("s3_plist_template"),{
+        if plist_template_path && File.exists?(plist_template_path)
+          plist_template = eth.load_from_path(plist_template_path)
+        else
+          plist_template = eth.load("s3_plist_template")
+        end
+        plist_render = eth.render(plist_template,{
           url: ipa_url,
           bundle_id: bundle_id,
           bundle_version: bundle_version,
@@ -129,16 +135,25 @@ module Fastlane
         })
 
         # Creates html from template
-        html_render = eth.render(eth.load("s3_html_template"),{
+        if html_template_path && File.exists?(html_template_path)
+          html_template = eth.load_from_path(html_template_path)
+        else
+          html_template = eth.load("s3_html_template")
+        end
+        html_render = eth.render(html_template,{
           url: plist_url,
           bundle_id: bundle_id,
           bundle_version: bundle_version,
           title: title
         })
 
-
         # Creates version from template
-        version_render = eth.render(eth.load("s3_version_template"),{
+        if version_template_path && File.exists?(version_template_path)
+          version_template = eth.load_from_path(version_template_path)
+        else
+          version_template = eth.load("s3_version_template")
+        end
+        version_render = eth.render(version_template,{
           url: plist_url,
           full_version: full_version
         })

--- a/lib/fastlane/erb_template_helper.rb
+++ b/lib/fastlane/erb_template_helper.rb
@@ -3,8 +3,14 @@ module Fastlane
     require "erb"
     def self.load(template_name)
       path = "#{Helper.gem_path('fastlane')}/lib/assets/#{template_name}.erb"
-      raise "Could not find Template at path '#{path}'".red unless File.exist?(path)
-      File.read(path)
+      load_from_path(path)
+    end
+
+    def self.load_from_path(template_filepath)
+      unless File.exist?(template_filepath)
+        raise "Could not find Template at path '#{template_filepath}'".red
+      end
+      File.read(template_filepath)
     end
 
     def self.render(template,template_vars_hash)


### PR DESCRIPTION
Resolves #451. I'm happy to amend this pull request as needed, just let me know.

This allows for a user to pass in the path to an ERB template for install plists, index.html pages, and version.json files (and actually have the S3 process use them). This functionality existed before (or it was possible to pass in the parameters to `#s3`), but it was not used in the process of rendering the templates.
