### PR TITLE
commit_version_bump was failing - fixed error

### DIFF
--- a/lib/fastlane/actions/commit_version_bump.rb
+++ b/lib/fastlane/actions/commit_version_bump.rb
@@ -68,7 +68,7 @@ module Fastlane
         # then create a commit with a message
         Actions.sh("git add #{git_add_paths.map(&:shellescape).join(' ')}")
 
-        #begin
+        begin
           build_number = Actions.lane_context[SharedValues::BUILD_NUMBER]
 
           params[:message] ||= (build_number ? "Version Bump to #{build_number}" : "Version Bump")
@@ -76,9 +76,9 @@ module Fastlane
           Actions.sh("git commit -m '#{params[:message]}'")
 
           Helper.log.info "Committed \"#{params[:message]}\" 💾.".green
-        #rescue => ex
-        #  Helper.log.info "Didn't commit any changes.".yellow
-        #end
+        rescue => ex
+         Helper.log.info "Didn't commit any changes.".yellow
+        end
       end
 
       def self.description

--- a/lib/fastlane/actions/commit_version_bump.rb
+++ b/lib/fastlane/actions/commit_version_bump.rb
@@ -68,17 +68,17 @@ module Fastlane
         # then create a commit with a message
         Actions.sh("git add #{git_add_paths.map(&:shellescape).join(' ')}")
 
-        begin
-          build_number = lane_context[SharedValues::BUILD_NUMBER] 
-          
+        #begin
+          build_number = lane_context[SharedValues::BUILD_NUMBER]
+
           params[:message] ||= (build_number ? "Version Bump to #{build_number}" : "Version Bump")
-          
+
           Actions.sh("git commit -m '#{params[:message]}'")
 
           Helper.log.info "Committed \"#{params[:message]}\" 💾.".green
-        rescue => ex
-          Helper.log.info "Didn't commit any changes.".yellow
-        end
+        #rescue => ex
+        #  Helper.log.info "Didn't commit any changes.".yellow
+        #end
       end
 
       def self.description

--- a/lib/fastlane/actions/commit_version_bump.rb
+++ b/lib/fastlane/actions/commit_version_bump.rb
@@ -69,7 +69,7 @@ module Fastlane
         Actions.sh("git add #{git_add_paths.map(&:shellescape).join(' ')}")
 
         #begin
-          build_number = lane_context[SharedValues::BUILD_NUMBER]
+          build_number = Actions.lane_context[SharedValues::BUILD_NUMBER]
 
           params[:message] ||= (build_number ? "Version Bump to #{build_number}" : "Version Bump")
 


### PR DESCRIPTION
commit_version_bump was failing because `lane_context` was undefined in that scope... Changed to `Actions.lane_context` to resolve problem
