### PR TITLE
Fixed space handing in backup_xcarchive action.

### DIFF
--- a/lib/fastlane/actions/backup_xcarchive.rb
+++ b/lib/fastlane/actions/backup_xcarchive.rb
@@ -35,7 +35,7 @@ module Fastlane
           zip_file = File.expand_path(File.join("#{xcarchive_file}.zip"))
 
           # Create zip
-          Actions.sh(%Q[cd #{xcarchive_folder} && zip -r -X "#{zip_file}" "#{xcarchive_file}" > /dev/null])
+          Actions.sh(%Q[cd "#{xcarchive_folder}" && zip -r -X "#{zip_file}" "#{xcarchive_file}" > /dev/null])
 
           # Moved to its final destination
           FileUtils.mv(zip_file, full_destination)


### PR DESCRIPTION
If the path to archive has space inside you receive:

```
sh: line 0: cd: /XXX XX/out: No such file or directory
```

Solution is to use double quotes in `cd #{xcarchive_folder}`.
