### PR TITLE
Improved Crashlytics action

### DIFF
--- a/lib/fastlane/actions/crashlytics.rb
+++ b/lib/fastlane/actions/crashlytics.rb
@@ -51,7 +51,7 @@ module Fastlane
 
         client = Shenzhen::Plugins::Crashlytics::Client.new(params[:crashlytics_path], params[:api_token], params[:build_secret])
 
-        response = client.upload_build(params[:ipa_path], file: params[:ipa_path], notes: params[:notes_path], emails: params[:emails], groups: params[:groups], notifications: notifications)
+        response = client.upload_build(params[:ipa_path], file: params[:ipa_path], notes: params[:notes_path], emails: params[:emails], groups: groups, notifications: notifications)
 
         if response
           Helper.log.info 'Build successfully uploaded to Crashlytics'.green

--- a/lib/fastlane/actions/crashlytics.rb
+++ b/lib/fastlane/actions/crashlytics.rb
@@ -28,7 +28,7 @@ module Fastlane
         # 'YES' or 'NO' - String
         case params[:notifications]
           when String
-            if (param[:notifications] == 'YES' || param[:notifications] == 'NO')
+            if param[:notifications] == 'YES' || param[:notifications] == 'NO'
               notifications = params[:notifications]
             else
               notifications = 'YES' if params[:notifications] == 'true'
@@ -38,7 +38,7 @@ module Fastlane
             notifications = 'YES'
           when FalseClass
             notifications = 'NO'
-          when NilClass
+          else
             notifications = nil
         end
 

--- a/lib/fastlane/actions/crashlytics.rb
+++ b/lib/fastlane/actions/crashlytics.rb
@@ -28,7 +28,7 @@ module Fastlane
         # 'YES' or 'NO' - String
         case params[:notifications]
           when String
-            if param[:notifications] == 'YES' || param[:notifications] == 'NO'
+            if params[:notifications] == 'YES' || params[:notifications] == 'NO'
               notifications = params[:notifications]
             else
               notifications = 'YES' if params[:notifications] == 'true'
@@ -46,7 +46,7 @@ module Fastlane
 
         if Helper.test?
           # Access all values, to do the verify
-          return params[:crashlytics_path], params[:api_token], params[:build_secret], params[:ipa_path], params[:build_secret], params[:ipa_path], params[:notes_path], params[:emails], params[:groups], params[:notifications]
+          return params[:crashlytics_path], params[:api_token], params[:build_secret], params[:ipa_path], params[:build_secret], params[:ipa_path], params[:notes_path], params[:emails], groups, notifications
         end
 
         client = Shenzhen::Plugins::Crashlytics::Client.new(params[:crashlytics_path], params[:api_token], params[:build_secret])
@@ -110,7 +110,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :notifications,
                                        env_name: "CRASHLYTICS_NOTIFICATIONS",
                                        description: "Crashlytics notification option (true/false)",
-                                       optional: true)
+                                       optional: true,
+                                       is_string: false,
+                                       verify_block: Proc.new do |value|
+                                         raise "Crashlytics supported notifications options: TrueClass, FalseClass, 'true', 'false', 'YES', 'NO'".red unless (value.is_a?(TrueClass) || value.is_a?(FalseClass) || value.is_a?(String))
+                                       end)
         ]
       end
 

--- a/lib/fastlane/actions/crashlytics.rb
+++ b/lib/fastlane/actions/crashlytics.rb
@@ -13,7 +13,7 @@ module Fastlane
       def self.run(params)
         require 'shenzhen'
         require 'shenzhen/plugins/crashlytics'
-        
+
         # can pass groups param either as an Array or a String
         case params[:groups]
         when NilClass
@@ -22,6 +22,24 @@ module Fastlane
           groups = params[:groups].join(',')
         when String
           groups = params[:groups]
+        end
+
+        # Normalized notification to Crashlytics notification parameter requirement
+        # 'YES' or 'NO' - String
+        case params[:notifications]
+          when String
+            if (param[:notifications] == 'YES' || param[:notifications] == 'NO')
+              notifications = params[:notifications]
+            else
+              notifications = 'YES' if params[:notifications] == 'true'
+              notifications = 'NO' if params[:notifications] == 'false'
+            end
+          when TrueClass
+            notifications = 'YES'
+          when FalseClass
+            notifications = 'NO'
+          when NilClass
+            notifications = nil
         end
 
         Helper.log.info 'Uploading the IPA to Crashlytics. Go for a coffee ☕️.'.green
@@ -33,7 +51,7 @@ module Fastlane
 
         client = Shenzhen::Plugins::Crashlytics::Client.new(params[:crashlytics_path], params[:api_token], params[:build_secret])
 
-        response = client.upload_build(params[:ipa_path], file: params[:ipa_path], notes: params[:notes_path], emails: params[:emails], groups: params[:groups], notifications: params[:notifications])
+        response = client.upload_build(params[:ipa_path], file: params[:ipa_path], notes: params[:notes_path], emails: params[:emails], groups: params[:groups], notifications: notifications)
 
         if response
           Helper.log.info 'Build successfully uploaded to Crashlytics'.green

--- a/spec/actions_specs/crashlytics_spec.rb
+++ b/spec/actions_specs/crashlytics_spec.rb
@@ -120,7 +120,7 @@ describe Fastlane do
 
         Fastlane::FastFile.new.parse("lane :test do
           crashlytics({
-            ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1'
+            ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
             notifications: true
           })
         end").runner.execute(:test)
@@ -133,7 +133,7 @@ describe Fastlane do
 
         Fastlane::FastFile.new.parse("lane :test do
           crashlytics({
-            ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1'
+            ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
             notifications: 'false'
           })
         end").runner.execute(:test)

--- a/spec/actions_specs/crashlytics_spec.rb
+++ b/spec/actions_specs/crashlytics_spec.rb
@@ -112,6 +112,32 @@ describe Fastlane do
           })
         end").runner.execute(:test)
       end
+
+      it "works when using TrueClass variable in place of notifications parameter" do
+        ENV["CRASHLYTICS_API_TOKEN"] = "wadus"
+        ENV["CRASHLYTICS_BUILD_SECRET"] = "wadus"
+        ENV["CRASHLYTICS_FRAMEWORK_PATH"] = "./fastlane/spec/fixtures/fastfiles/Fastfile1"
+
+        Fastlane::FastFile.new.parse("lane :test do
+          crashlytics({
+            ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1'
+            notifications: true
+          })
+        end").runner.execute(:test)
+      end
+
+      it "works when using 'false' String variable in place of notifications parameter" do
+        ENV["CRASHLYTICS_API_TOKEN"] = "wadus"
+        ENV["CRASHLYTICS_BUILD_SECRET"] = "wadus"
+        ENV["CRASHLYTICS_FRAMEWORK_PATH"] = "./fastlane/spec/fixtures/fastfiles/Fastfile1"
+
+        Fastlane::FastFile.new.parse("lane :test do
+          crashlytics({
+            ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1'
+            notifications: 'false'
+          })
+        end").runner.execute(:test)
+      end
     end
   end
 end


### PR DESCRIPTION
# Summary

Added support for different value type when specifying the `notifications` parameter.
# Why

From Crashlytics docs the notifications parameter must be a string: 'YES' or 'NO'.
This might be an annoying constraint for users of this action that would like to express this value as: true, false, 'true', 'false'
# How I use it

Use the Crashlytics action with one of new supported value types for the `notifications` parameter:

`TrueClass`

``` ruby
crashlytics({
            ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
            notifications: true
          })
```

`FalseClass`

``` ruby
crashlytics({
            ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
            notifications: false
          })
```

'true' String

``` ruby
crashlytics({
            ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
            notifications: 'true'
          })
```

'false' String

``` ruby
crashlytics({
            ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
            notifications: 'false'
          })
```
# Note

I've noticed the feature of passing groups parameter either as an Array or a String was not properly integrated. Hence I've fixed that too.
