### PR TITLE
Import a Fastfile from a git repository

### DIFF
--- a/docs/Advanced.md
+++ b/docs/Advanced.md
@@ -78,6 +78,10 @@ output = sh("pod update")
 
 Within your `Fastfile` you can import another `Fastfile`. 
 
+### `import`
+
+Import from a local path
+
 ```ruby
 import "../GeneralFastfile"
 
@@ -85,6 +89,25 @@ override_lane :from_general do
   ...
 end
 ```
+
+### `import_git`
+
+Import from a git repo which you could use as standard Fastlane resource for all your `Fastfile`.
+
+```ruby
+import_git("git@github.com:MyAwesomeRepo/MyAwesomeFastlaneStandardSetup.git","fastlane/Fastfile")
+
+lane :new_main_lane do
+  "such new main lane"
+end
+
+platform :ios do
+
+
+end
+```
+
+### Note
 
 You should import the other `Fastfile` on the top above your lane declarations. When defining a new lane `fastlane` will make sure to not run into any name conflicts. If you want to overwrite an existing lane (from the imported one), use the `override_lane` keyword. 
 

--- a/docs/Advanced.md
+++ b/docs/Advanced.md
@@ -94,8 +94,13 @@ end
 
 Import from a git repo which you could use as standard Fastlane resource for all your `Fastfile`.
 
+It takes up to two parameters:
+ 
+ 1) the repo address
+ 2) the file path of your Fastfile in your repo (Default to 'fastlane/Fastfile')
+
 ```ruby
-import_git("git@github.com:MyAwesomeRepo/MyAwesomeFastlaneStandardSetup.git","fastlane/Fastfile")
+import_git 'git@github.com:MyAwesomeRepo/MyAwesomeFastlaneStandardSetup.git','MyFastlaneFolder/Fastfile'
 
 lane :new_main_lane do
   "such new main lane"

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -178,6 +178,21 @@ module Fastlane
       Fastlane::Actions.load_external_actions(actions_path) if File.directory?(actions_path)
     end
 
+    def import_git(git_path = nil, fastfile_path = 'Fastfile')
+      raise "Please pass a path to the `import` action".red unless git_path
+
+      # Checkout the repo
+      git_split = git_path.split("/")
+
+      begin
+       Fastlane::Actions.sh("if cd /tmp/#{git_split.last}; then git pull; else git clone #{git_path} /tmp/#{git_split.last}; fi")
+      rescue ex
+        raise "#{ex.message}".red
+      end
+
+      import("/tmp/#{git_split.last}/#{fastfile_path}")
+    end
+
     #####################################################
     # @!group Overwriting Ruby methods
     #####################################################

--- a/spec/actions_specs/import_git_spec.rb
+++ b/spec/actions_specs/import_git_spec.rb
@@ -1,0 +1,24 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "import_git" do
+      it "allows the user to import a separate Fastfile from GIT source" do
+        ff = Fastlane::FastFile.new('./spec/fixtures/fastfiles/ImportGitFastfile')
+
+        expect(ff.runner.execute(:main_lane)).to eq('such main') # from the git Fastfile
+        expect(ff.runner.execute(:extended, :ios)).to eq('extended') # from the git Fastfile
+        expect(ff.runner.execute(:test)).to eq(1) # from the git Fastfile
+        expect(ff.runner.execute(:new_main_lane)).to eq('such new main lane') # from the original Fastfile
+
+        # This should not raise an exception
+      end
+
+      it "raises an exception when no path is given" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+            import_git
+          end").runner.execute(:test)
+        }.to raise_error("Please pass a path to the `import` action".red)
+      end
+    end
+  end
+end

--- a/spec/fixtures/fastfiles/ImportGitFastfile
+++ b/spec/fixtures/fastfiles/ImportGitFastfile
@@ -1,0 +1,11 @@
+
+import_git("git@github.com:KrauseFx/fastlane.git","spec/fixtures/fastfiles/ImportFastfile")
+
+lane :new_main_lane do
+  "such new main lane"
+end
+
+platform :ios do
+
+
+end

--- a/spec/fixtures/fastfiles/ImportGitFastfile
+++ b/spec/fixtures/fastfiles/ImportGitFastfile
@@ -1,5 +1,5 @@
 
-import_git("git@github.com:KrauseFx/fastlane.git","spec/fixtures/fastfiles/ImportFastfile")
+import_git 'git@github.com:KrauseFx/fastlane.git','spec/fixtures/fastfiles/ImportFastfile'
 
 lane :new_main_lane do
   "such new main lane"


### PR DESCRIPTION
# Summary

Added a new action that supports to import a `Fastfile` (and related local actions) from a specified git repo.
# Why

It is an useful feature to create `Fastfile`s which can inherit default lanes from a remote repo.
# How I use it

It takes up to two parameters:

 1) the repo address
 2) the file path of your Fastfile in your repo (Default to 'fastlane/Fastfile')

``` ruby
import_git 'git@github.com:MyAwesomeRepo/MyAwesomeFastlaneStandardSetup.git','MyFastlaneFolder/Fastfile'

platform :ios do

  lane :new_main_lane do
    "such new main lane"
  end

end
```
