### PR TITLE
Added :all option to dsym_zip to include all dSYMs not just the app one.

### DIFF
--- a/lib/fastlane/actions/dsym_zip.rb
+++ b/lib/fastlane/actions/dsym_zip.rb
@@ -10,16 +10,22 @@ module Fastlane
       def self.run(params)
         archive = params[:archive_path]
         params[:dsym_path] ||= File.join("#{File.basename(archive, '.*')}.app.dSYM.zip")
+        params[:all] ||= false
 
-        plist = Plist::parse_xml(File.join(archive, 'Info.plist'))
-        app_name = Helper.test? ? 'MyApp.app' : File.basename(plist['ApplicationProperties']['ApplicationPath'])
-        dsym_name = "#{app_name}.dSYM"
         dsym_folder_path = File.expand_path(File.join(archive, 'dSYMs'))
         zipped_dsym_path = File.expand_path(params[:dsym_path])
 
         Actions.lane_context[SharedValues::DSYM_ZIP_PATH] = zipped_dsym_path
 
-        Actions.sh(%Q[cd "#{dsym_folder_path}" && zip -r "#{zipped_dsym_path}" "#{dsym_name}"])
+        if params[:all]
+          Actions.sh(%Q[cd "#{dsym_folder_path}" && zip -r "#{zipped_dsym_path}" "#{dsym_folder_path}"/*.dSYM])
+        else
+          plist = Plist::parse_xml(File.join(archive, 'Info.plist'))
+          app_name = Helper.test? ? 'MyApp.app' : File.basename(plist['ApplicationProperties']['ApplicationPath'])
+          dsym_name = "#{app_name}.dSYM"
+          Actions.sh(%Q[cd "#{dsym_folder_path}" && zip -r "#{zipped_dsym_path}" "#{dsym_name}"])
+        end
+
       end
 
 
@@ -48,7 +54,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :dsym_path,
                                        description: 'Path for generated dsym. Optional, default is your apps root directory',
                                        optional: true,
-                                       env_name: 'DSYM_ZIP_DSYM_PATH')
+                                       env_name: 'DSYM_ZIP_DSYM_PATH'),
+          FastlaneCore::ConfigItem.new(key: :all,
+                                       description: 'Whether or not all dSYM files are to be included. Optional, default is false in which only your app dSYM is included',
+                                       default_value: false,
+                                       optional: true,
+                                       is_string: false,
+                                       env_name: 'DSYM_ZIP_ALL')
         ]
       end
 

--- a/lib/fastlane/actions/dsym_zip.rb
+++ b/lib/fastlane/actions/dsym_zip.rb
@@ -10,8 +10,7 @@ module Fastlane
       def self.run(params)
         archive = params[:archive_path]
         params[:dsym_path] ||= File.join("#{File.basename(archive, '.*')}.app.dSYM.zip")
-        params[:all] ||= false
-
+        
         dsym_folder_path = File.expand_path(File.join(archive, 'dSYMs'))
         zipped_dsym_path = File.expand_path(params[:dsym_path])
 


### PR DESCRIPTION
Fixes #484 and verified the resulting .zip is accepted by HockeyApp and HockeyApp has visibility across all symbol files!
