### PR TITLE
Rename DSYM_ZIP_PATH to DSYM_OUTPUT_PATH

### DIFF
--- a/lib/fastlane/actions/actions_helper.rb
+++ b/lib/fastlane/actions/actions_helper.rb
@@ -109,7 +109,7 @@ module Fastlane
             rescue Errno::EIO
             end
           end
-          exit_status = 0
+          exit_status = $?.to_i
         rescue PTY::ChildExited => e
           exit_status = e.status.to_i
         end

--- a/lib/fastlane/actions/actions_helper.rb
+++ b/lib/fastlane/actions/actions_helper.rb
@@ -102,8 +102,8 @@ module Fastlane
         begin
           PTY.spawn(command) do |r, w, pid|
             begin
-              r.each do |line|
-                Helper.log.info ['[SHELL]', line.strip].join(': ')
+              r.each_line do |line|
+                Helper.log << line
                 result << line
               end
             rescue Errno::EIO

--- a/lib/fastlane/actions/actions_helper.rb
+++ b/lib/fastlane/actions/actions_helper.rb
@@ -116,7 +116,7 @@ module Fastlane
 
         if exit_status != 0
           # this will also append the output to the exception (for the Jenkins reports)
-          raise "Exit status of command '#{command}' was #{exit_status} instead of 0. \n#{result}"
+          raise "Exit status of command '#{command}' was #{exit_status} instead of 0."
         end
       else
         result << command # only for the tests

--- a/lib/fastlane/actions/dsym_zip.rb
+++ b/lib/fastlane/actions/dsym_zip.rb
@@ -14,7 +14,7 @@ module Fastlane
         dsym_folder_path = File.expand_path(File.join(archive, 'dSYMs'))
         zipped_dsym_path = File.expand_path(params[:dsym_path])
 
-        Actions.lane_context[SharedValues::DSYM_ZIP_PATH] = zipped_dsym_path
+        Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH] = zipped_dsym_path
 
         if params[:all]
           Actions.sh(%Q[cd "#{dsym_folder_path}" && zip -r "#{zipped_dsym_path}" "#{dsym_folder_path}"/*.dSYM])


### PR DESCRIPTION
This is necessary because the artifacts cleaner is looking for DSYM_OUTPUT_PATH
