### PR TITLE
Fix action output streams

### DIFF
--- a/lib/fastlane/actions/actions_helper.rb
+++ b/lib/fastlane/actions/actions_helper.rb
@@ -1,5 +1,3 @@
-require 'pty'
-
 module Fastlane
   module Actions
     module SharedValues


### PR DESCRIPTION
`IO.popen` has some quirks with combing output streams which can mess up tools that expect a `pty`.

Instead of doing that, we should start a non-pty stream using `Open3.popen3` and combine the streams ourselves.

Fixes buildkite/agent#171
