### PR TITLE
Streaming shell output

### DIFF
--- a/lib/fastlane/actions/actions_helper.rb
+++ b/lib/fastlane/actions/actions_helper.rb
@@ -109,7 +109,7 @@ module Fastlane
             rescue Errno::EIO
             end
           end
-          exit_status = 0
+          exit_status = $?.to_i
         rescue PTY::ChildExited => e
           exit_status = e.status.to_i
         end

--- a/lib/fastlane/actions/actions_helper.rb
+++ b/lib/fastlane/actions/actions_helper.rb
@@ -102,8 +102,8 @@ module Fastlane
         begin
           PTY.spawn(command) do |r, w, pid|
             begin
-              r.each do |line|
-                Helper.log.info ['[SHELL]', line.strip].join(': ')
+              r.each_line do |line|
+                Helper.log << line
                 result << line
               end
             rescue Errno::EIO

--- a/lib/fastlane/actions/actions_helper.rb
+++ b/lib/fastlane/actions/actions_helper.rb
@@ -116,7 +116,7 @@ module Fastlane
 
         if exit_status != 0
           # this will also append the output to the exception (for the Jenkins reports)
-          raise "Exit status of command '#{command}' was #{exit_status} instead of 0. \n#{result}"
+          raise "Exit status of command '#{command}' was #{exit_status} instead of 0."
         end
       else
         result << command # only for the tests


### PR DESCRIPTION
IO.popen doesn't help out subprocesses that don't explicity flush their stdout buffers, C by default manages these to avoid excessive IO but for small packets of data like STDOUT logs they never get sent until the process closes.

This helps subprocess commands like carthage / xctool which by default don't ever flush their buffers and thus the command sits forever until all the output is flushed at once when it closes.
