### PR TITLE
use annotated tagging to create a commitobject with the tag

### DIFF
--- a/lib/fastlane/actions/add_git_tag.rb
+++ b/lib/fastlane/actions/add_git_tag.rb
@@ -8,11 +8,11 @@ module Fastlane
         tag = options[:tag] || "#{options[:grouping]}/#{lane_name}/#{options[:prefix]}#{options[:build_number].to_s}"
 
         Helper.log.info "Adding git tag '#{tag}' 🎯."
-        Actions.sh("git tag \"#{tag}\"")
+        Actions.sh("git tag -am '#{tag} (fastlane)' #{tag}")
       end
 
       def self.description
-        "This will add a git tag to the current branch"
+        "This will add an annotated git tag to the current branch"
       end
 
       def self.available_options


### PR DESCRIPTION
Also using ' '  is safer for command line and that way tags that hold env variables or anything won't be executed by the command line
