### PR TITLE
Version getters

### DIFF
--- a/lib/fastlane/actions/get_build_number.rb
+++ b/lib/fastlane/actions/get_build_number.rb
@@ -1,0 +1,89 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      BUILD_NUMBER = :BUILD_NUMBER
+    end
+
+    class GetBuildNumberAction < Action
+      require 'shellwords'
+
+      def self.run(params)
+        # More information about how to set up your project and how it works:
+        # https://developer.apple.com/library/ios/qa/qa1827/_index.html
+
+        begin
+          folder = params[:xcodeproj] ? File.join('.', params[:xcodeproj], '..') : '.'
+
+          command_prefix = [
+            'cd',
+            File.expand_path(folder).shellescape,
+            '&&'
+          ].join(' ')
+
+          command = [
+            command_prefix,
+            'agvtool',
+            'what-version',
+            '-terse'
+          ].join(' ')
+
+          if Helper.test?
+            Actions.lane_context[SharedValues::BUILD_NUMBER] = command
+          else
+
+            build_number = (Actions.sh command).split("\n").last.to_i
+
+            # Store the number in the shared hash
+            Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number
+          end          
+        rescue => ex
+          Helper.log.error 'Make sure to to follow the steps to setup your Xcode project: https://developer.apple.com/library/ios/qa/qa1827/_index.html'.yellow
+          raise ex
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Get the build number of your project"
+      end
+
+      def self.details
+        [
+          "This action will return the current build number set on your project.",
+          "You first have to set up your Xcode project, if you haven't done it already:",
+          "https://developer.apple.com/library/ios/qa/qa1827/_index.html"
+          ].join(' ')
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                             env_name: "FL_BUILD_NUMBER_PROJECT",
+                             description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
+                             optional: true,
+                             verify_block: Proc.new do |value|
+                              raise "Please pass the path to the project, not the workspace".red if value.include?"workspace"
+                              raise "Could not find Xcode project".red if (not File.exists?(value) and not Helper.is_test?)
+                             end)
+        ]
+      end
+
+      def self.output
+        [
+          ['BUILD_NUMBER', 'The build number']
+        ]
+      end
+
+      def self.authors
+        ["Liquidsoul"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?platform
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/get_version_number.rb
+++ b/lib/fastlane/actions/get_version_number.rb
@@ -61,13 +61,13 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :xcodeproj,
-                                       env_name: "FL_VERSION_NUMBER_PROJECT",
-                                       description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
-                                       verify_block: Proc.new do |value|
-                                        raise "Please pass the path to the project, not the workspace".red if value.include?"workspace"
-                                        raise "Could not find Xcode project".red unless File.exists?(value)
-                                       end,
-                                       optional: true)
+                             env_name: "FL_VERSION_NUMBER_PROJECT",
+                             description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
+                             optional: true,
+                             verify_block: Proc.new do |value|
+                              raise "Please pass the path to the project, not the workspace".red if value.include?"workspace"
+                              raise "Could not find Xcode project".red if (not File.exists?(value) and not Helper.is_test?)
+                             end)
         ]
       end
 

--- a/lib/fastlane/actions/get_version_number.rb
+++ b/lib/fastlane/actions/get_version_number.rb
@@ -1,0 +1,89 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      VERSION_NUMBER = :VERSION_NUMBER
+    end
+
+    class GetVersionNumberAction < Action
+      require 'shellwords'
+
+      def self.run(params)
+        # More information about how to set up your project and how it works:
+        # https://developer.apple.com/library/ios/qa/qa1827/_index.html
+
+        begin
+          folder = params[:xcodeproj] ? File.join('.', params[:xcodeproj], '..') : '.'
+            
+          command_prefix = [
+            'cd',
+            File.expand_path(folder).shellescape,
+            '&&'
+          ].join(' ')
+
+          command = [
+            command_prefix,
+            'agvtool',
+            'what-marketing-version',
+            '-terse1'
+          ].join(' ')
+
+          if Helper.test?
+            Actions.lane_context[SharedValues::VERSION_NUMBER] = command
+          else
+
+            version_number = (Actions.sh command).split("\n").last
+
+            # Store the number in the shared hash
+            Actions.lane_context[SharedValues::VERSION_NUMBER] = version_number
+          end
+        rescue => ex
+          Helper.log.error 'Make sure to to follow the steps to setup your Xcode project: https://developer.apple.com/library/ios/qa/qa1827/_index.html'.yellow
+          raise ex
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Get the version number of your project"
+      end
+
+      def self.details
+        [
+          "This action will return the current version number set on your project.",
+          "You first have to set up your Xcode project, if you haven't done it already:",
+          "https://developer.apple.com/library/ios/qa/qa1827/_index.html"
+          ].join(' ')
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                                       env_name: "FL_VERSION_NUMBER_PROJECT",
+                                       description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
+                                       verify_block: Proc.new do |value|
+                                        raise "Please pass the path to the project, not the workspace".red if value.include?"workspace"
+                                        raise "Could not find Xcode project".red unless File.exists?(value)
+                                       end,
+                                       optional: true)
+        ]
+      end
+
+      def self.output
+        [
+          ['VERSION_NUMBER', 'The version number']
+        ]
+      end
+
+      def self.authors
+        ["Liquidsoul"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?platform
+      end
+    end
+  end
+end

--- a/spec/actions_specs/get_build_number_action_spec.rb
+++ b/spec/actions_specs/get_build_number_action_spec.rb
@@ -1,0 +1,23 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Get Build Number Integration" do
+      require 'shellwords'
+
+      it "gets the build number of the Xcode project" do
+        Fastlane::FastFile.new.parse("lane :test do 
+          get_build_number(xcodeproj: '.xcproject')
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool what-version -terse/)
+      end
+
+      it "raises an exception when user passes workspace" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+            get_build_number(xcodeproj: 'project.xcworkspace')
+          end").runner.execute(:test)
+        }.to raise_error("Please pass the path to the project, not the workspace".red)
+      end
+    end
+  end
+end

--- a/spec/actions_specs/get_version_number_action_spec.rb
+++ b/spec/actions_specs/get_version_number_action_spec.rb
@@ -1,0 +1,23 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Get Version Number Integration" do
+      require 'shellwords'
+
+      it "gets the version number of the Xcode project" do
+        Fastlane::FastFile.new.parse("lane :test do 
+          get_version_number(xcodeproj: '.xcproject')
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool what-marketing-version -terse1/)
+      end
+
+      it "raises an exception when use passes workspace" do
+        expect {
+          Fastlane::FastFile.new.parse("lane :test do
+            get_version_number(xcodeproj: 'project.xcworkspace')
+          end").runner.execute(:test)
+        }.to raise_error("Please pass the path to the project, not the workspace".red)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an implementation for [#501](https://github.com/KrauseFx/fastlane/issues/501).
It is mostly a copy/paste adaptation of [increment_build_number](https://github.com/KrauseFx/fastlane/blob/master/lib/fastlane/actions/increment_build_number.rb) and [increment_version_number](https://github.com/KrauseFx/fastlane/blob/master/lib/fastlane/actions/increment_version_number.rb) to output the same variables.
Maybe this can be factorized a bit but I don't know how this can be done here.

First Ruby code contribution, so any feedback welcomed :smiley: 
