### PR TITLE
Do not call slack if SLACK_URL is not set.

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,21 +58,25 @@ lane :release do |options|
 
   # After publishing
   # 
-  slack(
-    channel: "releases",
-    default_payloads: [],
-    message: "Successfully released [#{tool_name} #{version}](#{github_release['html_url']}) :rocket:",
-    payload: {
-      "New" => github_release['body']
-    }
-  )
+  if ENV['SLACK_URL']
+    slack(
+      channel: "releases",
+      default_payloads: [],
+      message: "Successfully released [#{tool_name} #{version}](#{github_release['html_url']}) :rocket:",
+      payload: {
+        "New" => github_release['body']
+      }
+    )
+  end
 
   puts "You can now tweet:".green
   puts "[#{tool_name}] #{github_release['name']} #{github_release['html_url']}"
 end
 
 error do |lane, exception|
-  slack(channel: "testing", message: exception.to_s)
+  if ENV['SLACK_URL']
+    slack(channel: "testing", message: exception.to_s)
+  end
 end
 
 desc "Verifies all tests pass and the current state of the repo is valid" 


### PR DESCRIPTION
Hi @KrauseFx !

I've tried to look into the `dsym` issue [#31](https://github.com/fastlane/gym/issues/31) in `gym` an have bump into a `No SLACK_URL given.` error when running `fastlane test`.
So my guess is to prevent slack from being called in this generic `Fastfile` if the environment variable is not set because it can prevent the local build of all Fastlane tools.
