### PR TITLE
Fix pull step in import_from_git

### DIFF
--- a/lib/fastlane/actions/import_from_git.rb
+++ b/lib/fastlane/actions/import_from_git.rb
@@ -21,7 +21,17 @@ module Fastlane
       end
 
       def self.available_options
-        
+        [
+          FastlaneCore::ConfigItem.new(key: :url,
+                                       description: "The url of the repository to import the Fastfile from",
+                                       default_value: nil
+                                       ),
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       description: "The path of the Fastfile in the repository",
+                                       default_value: 'fastlane/Fastfile',
+                                       optional: true,
+                                       ),
+      ]
       end
 
       def self.output

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -195,7 +195,7 @@ module Fastlane
 
         if File.directory?folder
           Helper.log.info "Using existing git repo..."
-          Actions.sh("git pull")
+          Actions.sh("cd '#{folder}' && git pull")
         else
           # When this fails, we have to clone the git repo
           Helper.log.info "Cloning remote git repo..."


### PR DESCRIPTION
In `import_from_git` action, there was a missing `cd` call before calling `git pull`. This was not updating the repo.
At the same time, I've also added the missing documentation to the action.
