### PR TITLE
Adds an action to reset the simulators through xcrun

### DIFF
--- a/lib/fastlane/actions/reset_simulators.rb
+++ b/lib/fastlane/actions/reset_simulators.rb
@@ -1,0 +1,38 @@
+module Fastlane
+  module Actions
+    class ResetSimulatorsAction < Action
+      def self.run(params)
+        Helper.log.info 'Quitting the iOS Simulator app'.green
+        sh "osascript -e 'tell application \"iOS Simulator\" to quit'"
+
+        Helper.log.info 'Resetting the contents of all the simulators'.green
+        sh "xcrun simctl list devices | grep -v '^[-=]' | cut -d \"(\" -f2 | cut -d \")\" -f1 | xargs -I {} xcrun simctl erase \"{}\" || true"
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Closes the iOS Simulator app and resets the contents of all the existing simulators'
+      end
+
+      def self.details
+        'You can use this action to reset the simulators to a clean state before running tests or using snapshot'
+      end
+
+      def self.available_options
+        [
+        ]
+      end
+
+      def self.author
+        '@vittoriom'
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end


### PR DESCRIPTION
I saw that you already have a `snapshot reset_simulators` but this one is kind of "softer" and one can use it in the FastFile without calling snapshot. 
As for the previous PR, don't know if you find it useful, but it was a quick one.
