### PR TITLE
update_project_provisioning improvements

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -168,32 +168,24 @@ See how [Product Hunt](https://github.com/fastlane/examples/blob/master/ProductH
 
 ### update_project_provisioning
 
-This integration is **outdated**, you should check out the [code signing guide](https://github.com/KrauseFx/fastlane/blob/master/docs/CodeSigning.md).
+You should check out the [code signing guide](https://github.com/KrauseFx/fastlane/blob/master/docs/CodeSigning.md) before using this action.
 
-Updated your Xcode project to use a specific provisioning profile for code signing, so that you can properly build and sign the .ipa file using the [ipa](#ipa) action.
+Updates your Xcode project to use a specific provisioning profile for code signing, so that you can properly build and sign the .ipa file using the [ipa](#ipa) action or a CI service.
 
-```ruby
-update_project_provisioning(
-  xcodeproj: "Project.xcodeproj",
-  profile: "./app_store.mobileprovision" # optional if you use sigh
-)
-```
-
-Since you have to use different provisioning profile for various targets (WatchKit, Extension, etc.) you can use the `filter` option:
+Since you have to use different provisioning profile for various targets (WatchKit, Extension, etc.) and configurations (Debug, Release) you can use the `target_filter` and `build_configuration` options:
 
 ```ruby
 update_project_provisioning(
   xcodeproj: "Project.xcodeproj",
-  profile: "./app_store.mobileprovision", # optional if you use sigh
-  build_configuration_filter: ".*WatchKit Extension.*"
+  profile: "./watch_app_store.mobileprovision", # optional if you use sigh
+  target_filter: ".*WatchKit Extension.*", # matches name or type of a target
+  build_configuration: "Release" #
 )
 ```
 
-The `build_configuration_filter` is a standard regex.
+The `target_filter` and `build_configuration` options use standard regex, so if you want an exact match for a target, use `^MyTargetName$` to prevent a match for the `Pods - MyTargetName` target, for instance.
 
-Since you'll probably not want to commit this change into version control, take a look at how [MindNode](https://github.com/fastlane/examples/blob/4fea7d2f16b095e09af409beb4da8a264be2301e/MindNode/Fastfile#L5-L47) uses this technique to temporary set the code signing, then build and upload the `ipa` file.
-
-**[Show Example Usage](https://github.com/fastlane/examples/blob/4fea7d2f16b095e09af409beb4da8a264be2301e/MindNode/Fastfile#L5-L47)**
+**[Example Usage at MindNode](https://github.com/fastlane/examples/blob/4fea7d2f16b095e09af409beb4da8a264be2301e/MindNode/Fastfile#L5-L47)**
 
 ### update_app_group_identifiers
 Updates the App Group Identifiers in the given Entitlements file, so you can have app groups for the app store build and app groups for an enterprise build.

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -172,14 +172,14 @@ You should check out the [code signing guide](https://github.com/KrauseFx/fastla
 
 Updates your Xcode project to use a specific provisioning profile for code signing, so that you can properly build and sign the .ipa file using the [ipa](#ipa) action or a CI service.
 
-Since you have to use different provisioning profile for various targets (WatchKit, Extension, etc.) and configurations (Debug, Release) you can use the `target_filter` and `build_configuration` options:
+Since you have to use different provisioning profiles for various targets (WatchKit, Extension, etc.) and configurations (Debug, Release) you can use the `target_filter` and `build_configuration` options:
 
 ```ruby
 update_project_provisioning(
   xcodeproj: "Project.xcodeproj",
   profile: "./watch_app_store.mobileprovision", # optional if you use sigh
   target_filter: ".*WatchKit Extension.*", # matches name or type of a target
-  build_configuration: "Release" #
+  build_configuration: "Release"
 )
 ```
 

--- a/docs/CodeSigning.md
+++ b/docs/CodeSigning.md
@@ -41,12 +41,13 @@ Using the [update_project_provisioning](https://github.com/KrauseFx/fastlane/blo
 ```ruby
 update_project_provisioning(
   xcodeproj: "Project.xcodeproj",
-  profile: "./AppStore.mobileprovision", # optional if you use sigh
-  build_configuration_filter: ".*WatchKit Extension.*"
+  profile: "./watch_app_store.mobileprovision", # optional if you use sigh
+  target_filter: ".*WatchKit Extension.*", # matches name or type of a target
+  build_configuration: "Release" #
 )
 ```
 
-As this will modify the project file, you'll have to reset the git changes of the project files after successfully building your application:
+As this will modify the project file, you should either commit the changes if you want to keep them (for your CI service to know how to code sign your app) or you should reset the git changes of the project files after successfully building your application, if you're building locally:
 ```ruby
 ensure_git_status_clean
 sigh

--- a/docs/CodeSigning.md
+++ b/docs/CodeSigning.md
@@ -43,7 +43,7 @@ update_project_provisioning(
   xcodeproj: "Project.xcodeproj",
   profile: "./watch_app_store.mobileprovision", # optional if you use sigh
   target_filter: ".*WatchKit Extension.*", # matches name or type of a target
-  build_configuration: "Release" #
+  build_configuration: "Release"
 )
 ```
 

--- a/lib/fastlane/actions/update_project_provisioning.rb
+++ b/lib/fastlane/actions/update_project_provisioning.rb
@@ -63,7 +63,6 @@ module Fastlane
             end
 
             build_configuration.build_settings["PROVISIONING_PROFILE"] = data["UUID"]
-            build_configuration.build_settings["CODE_SIGN_RESOURCE_RULES_PATH[sdk=*]"] = "$(SDKROOT)/ResourceRules.plist"
           end
         end
 

--- a/lib/fastlane/actions/update_project_provisioning.rb
+++ b/lib/fastlane/actions/update_project_provisioning.rb
@@ -35,7 +35,7 @@ module Fastlane
         verification = p7.verify([cert], store)
         data = Plist::parse_xml(p7.data)
         
-        target_filter = params[:target_filter]
+        target_filter = params[:target_filter] || params[:build_configuration_filter]
         configuration = params[:build_configuration]
 
         # manipulate project file
@@ -90,31 +90,35 @@ module Fastlane
         def self.available_options
           [
             FastlaneCore::ConfigItem.new(key: :xcodeproj,
-             env_name: "FL_PROJECT_PROVISIONING_PROJECT_PATH",
-             description: "Path to your Xcode project",
-             optional: true,
-             verify_block: Proc.new do |value|
-              raise "Path to xcode project is invalid".red unless File.exists?(value)
-            end),
+                                         env_name: "FL_PROJECT_PROVISIONING_PROJECT_PATH",
+                                         description: "Path to your Xcode project",
+                                         optional: true,
+                                         verify_block: Proc.new do |value|
+                                          raise "Path to xcode project is invalid".red unless File.exists?(value)
+                                         end),
             FastlaneCore::ConfigItem.new(key: :profile,
-             env_name: "FL_PROJECT_PROVISIONING_PROFILE_FILE",
-             description: "Path to provisioning profile (.mobileprovision)",
-             default_value: Actions.lane_context[SharedValues::SIGH_PROFILE_PATH],
-             verify_block: Proc.new do |value|
-              raise "Path to provisioning profile is invalid".red unless File.exists?(value)
-            end),
+                                         env_name: "FL_PROJECT_PROVISIONING_PROFILE_FILE",
+                                         description: "Path to provisioning profile (.mobileprovision)",
+                                         default_value: Actions.lane_context[SharedValues::SIGH_PROFILE_PATH],
+                                         verify_block: Proc.new do |value|
+                                          raise "Path to provisioning profile is invalid".red unless File.exists?(value)
+                                         end),
             FastlaneCore::ConfigItem.new(key: :target_filter,
-             env_name: "FL_PROJECT_PROVISIONING_PROFILE_TARGET_FILTER",
-             description: "A filter for the target name. Use a standard regex",
-             optional: true),
+                                         env_name: "FL_PROJECT_PROVISIONING_PROFILE_TARGET_FILTER",
+                                         description: "A filter for the target name. Use a standard regex",
+                                         optional: true),
+            FastlaneCore::ConfigItem.new(key: :build_configuration_filter,
+                                         env_name: "FL_PROJECT_PROVISIONING_PROFILE_FILTER",
+                                         description: "Legacy option, use 'target_filter' instead",
+                                         optional: true),
             FastlaneCore::ConfigItem.new(key: :build_configuration,
-             env_name: "FL_PROJECT_PROVISIONING_PROFILE_BUILD_CONFIGURATION",
-             description: "A filter for the build configuration name. Use a standard regex. Applied to all configurations if not specified",
-             optional: true),
+                                         env_name: "FL_PROJECT_PROVISIONING_PROFILE_BUILD_CONFIGURATION",
+                                         description: "A filter for the build configuration name. Use a standard regex. Applied to all configurations if not specified",
+                                         optional: true),
             FastlaneCore::ConfigItem.new(key: :certificate,
-             env_name: "FL_PROJECT_PROVISIONING_CERTIFICATE_PATH",
-             description: "Path to apple root certificate",
-             default_value: "/tmp/AppleIncRootCertificate.cer")
+                                         env_name: "FL_PROJECT_PROVISIONING_CERTIFICATE_PATH",
+                                         description: "Path to apple root certificate",
+                                         default_value: "/tmp/AppleIncRootCertificate.cer")
           ]
         end
 

--- a/lib/fastlane/actions/update_project_provisioning.rb
+++ b/lib/fastlane/actions/update_project_provisioning.rb
@@ -1,19 +1,19 @@
 module Fastlane
   module Actions
     module SharedValues
-      
+
     end
 
     class UpdateProjectProvisioningAction < Action
       ROOT_CERTIFICATE_URL = "http://www.apple.com/appleca/AppleIncRootCertificate.cer"
       def self.run(params)
-        
+
         # assign folder from parameter or search for xcodeproj file
         folder = params[:xcodeproj] || Dir["*.xcodeproj"].first
         
         # validate folder
-        folder = File.join(folder, "project.pbxproj")
-        raise "Could not find path to project config '#{folder}'. Pass the path to your project (not workspace)!".red unless File.exists?(folder)
+        project_file_path = File.join(folder, "project.pbxproj")
+        raise "Could not find path to project config '#{project_file_path}'. Pass the path to your project (not workspace)!".red unless File.exists?(project_file_path)
 
         # download certificate
         if not File.exists?(params[:certificate])
@@ -35,32 +35,39 @@ module Fastlane
         verification = p7.verify([cert], store)
         data = Plist::parse_xml(p7.data)
         
-        filter = params[:build_configuration_filter]
+        target_filter = params[:target_filter]
+        configuration = params[:build_configuration]
 
         # manipulate project file
         Helper.log.info("Going to update project '#{folder}' with UUID".green)
-        require 'pbxplorer'
+        require 'xcodeproj'
 
-        project_file = XCProjectFile.new(folder)
-        project_file.project.targets.each do |target|
-          if filter
-            if target['productName'].match(filter) or target['productType'].match(filter)
-              Helper.log.info "Updating target #{target['productName']}...".green
-            else
-              Helper.log.info "Skipping target #{target['productName']} as it doesn't match the filter '#{filter}'".yellow
-              next
-            end
+        project = Xcodeproj::Project.open(folder)
+        project.targets.each do |target|
+
+          if !target_filter || target.product_name.match(target_filter) || target.product_type.match(target_filter)
+            Helper.log.info "Updating target #{target.product_name}...".green
           else
-            Helper.log.info "Updating target #{target['productName']}...".green
+            Helper.log.info "Skipping target #{target.product_name} as it doesn't match the filter '#{target_filter}'".yellow
+            next
           end
 
           target.build_configuration_list.build_configurations.each do |build_configuration|
-            build_configuration["buildSettings"]["PROVISIONING_PROFILE"] = data["UUID"]
-            build_configuration["buildSettings"]["CODE_SIGN_RESOURCE_RULES_PATH[sdk=*]"] = "$(SDKROOT)/ResourceRules.plist"
+
+            config_name = build_configuration.name
+            if !configuration || config_name.match(configuration)
+              Helper.log.info "Updating configuration #{config_name}...".green
+            else
+              Helper.log.info "Skipping configuration #{config_name} as it doesn't match the filter '#{configuration}'".yellow
+              next
+            end
+
+            build_configuration.build_settings["PROVISIONING_PROFILE"] = data["UUID"]
+            build_configuration.build_settings["CODE_SIGN_RESOURCE_RULES_PATH[sdk=*]"] = "$(SDKROOT)/ResourceRules.plist"
           end
         end
 
-        project_file.save
+        project.save
 
         # complete
         Helper.log.info("Successfully updated project settings in'#{params[:xcodeproj]}'".green)
@@ -74,47 +81,51 @@ module Fastlane
         [
           "This action retrieves a provisioning profile UUID from a provisioning profile (.mobileprovision) to set",
           "up the xcode projects' code signing settings in *.xcodeproj/project.pbxproj",
-          "",
-          "The `build_configuration_filter` value can be used to only update code signing for one target",
+          "The `target_filter` value can be used to only update code signing for specified targets",
+          "The `build_configuration` value can be used to only update code signing for specified build configurations of the targets passing through the `target_filter`",
           "Example Usage is the WatchKit Extension or WatchKit App, where you need separate provisioning profiles",
-          "Example: `update_project_provisioning(xcodeproj: \"..\", build_configuration_filter: \".*WatchKit App.*\")"
-        ].join("\n")
-      end
+          "Example: `update_project_provisioning(xcodeproj: \"..\", target_filter: \".*WatchKit App.*\")"
+          ].join("\n")
+        end
 
-      def self.available_options
-        [
-          FastlaneCore::ConfigItem.new(key: :xcodeproj,
-                                       env_name: "FL_PROJECT_PROVISIONING_PROJECT_PATH",
-                                       description: "Path to your Xcode project",
-                                       optional: true,
-                                       verify_block: Proc.new do |value|
-                                        raise "Path to xcode project is invalid".red unless File.exists?(value)
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :profile,
-                                       env_name: "FL_PROJECT_PROVISIONING_PROFILE_FILE",
-                                       description: "Path to provisioning profile (.mobileprovision)",
-                                       default_value: Actions.lane_context[SharedValues::SIGH_PROFILE_PATH],
-                                       verify_block: Proc.new do |value|
-                                        raise "Path to provisioning profile is invalid".red unless File.exists?(value)
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :build_configuration_filter,
-                                       env_name: "FL_PROJECT_PROVISIONING_PROFILE_FILTER",
-                                       description: "A filter for the target name. Use a standard regex",
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :certificate,
-                                       env_name: "FL_PROJECT_PROVISIONING_CERTIFICATE_PATH",
-                                       description: "Path to apple root certificate",
-                                       default_value: "/tmp/AppleIncRootCertificate.cer")
-        ]
-      end
+        def self.available_options
+          [
+            FastlaneCore::ConfigItem.new(key: :xcodeproj,
+             env_name: "FL_PROJECT_PROVISIONING_PROJECT_PATH",
+             description: "Path to your Xcode project",
+             optional: true,
+             verify_block: Proc.new do |value|
+              raise "Path to xcode project is invalid".red unless File.exists?(value)
+            end),
+            FastlaneCore::ConfigItem.new(key: :profile,
+             env_name: "FL_PROJECT_PROVISIONING_PROFILE_FILE",
+             description: "Path to provisioning profile (.mobileprovision)",
+             default_value: Actions.lane_context[SharedValues::SIGH_PROFILE_PATH],
+             verify_block: Proc.new do |value|
+              raise "Path to provisioning profile is invalid".red unless File.exists?(value)
+            end),
+            FastlaneCore::ConfigItem.new(key: :target_filter,
+             env_name: "FL_PROJECT_PROVISIONING_PROFILE_TARGET_FILTER",
+             description: "A filter for the target name. Use a standard regex",
+             optional: true),
+            FastlaneCore::ConfigItem.new(key: :build_configuration,
+             env_name: "FL_PROJECT_PROVISIONING_PROFILE_BUILD_CONFIGURATION",
+             description: "A filter for the build configuration name. Use a standard regex. Applied to all configurations if not specified",
+             optional: true),
+            FastlaneCore::ConfigItem.new(key: :certificate,
+             env_name: "FL_PROJECT_PROVISIONING_CERTIFICATE_PATH",
+             description: "Path to apple root certificate",
+             default_value: "/tmp/AppleIncRootCertificate.cer")
+          ]
+        end
 
-      def self.author
-        "tobiasstrebitzer"
-      end
+        def self.authors
+          ["tobiasstrebitzer", "czechboy0"]
+        end
 
-      def self.is_supported?(platform)
-        platform == :ios
+        def self.is_supported?(platform)
+          [:ios, :mac].include?platform
+        end
       end
     end
   end
-end


### PR DESCRIPTION
Several improvements to the `update_project_provisioning`
- migrated the underlying parsing of the Xcode project to [Xcodeproj](https://github.com/CocoaPods/Xcodeproj), which doesn't reformat the whole project on every save, meaning after running the action now, your `git diff` is only the actual changes
- added a way to specify configurations, in addition to targets, so now you can specify Debug and Release to each have different provisioning profiles (very much needed if you use Xcode Server, for instance)
- the action now also declares support for Mac

:warning: Breaking changes
- I had to rename one option from `build_configuration_filter` to `target_filter` and the new option is called `build_configuration`. The problem with the old name is that even though it was specifying a target, the name was `build_configuration_...`, which was confusing. Now both options are there and each have a easily understandable name. However, people will have to update their Fastfiles (@krausefx not sure how you handle breaking changes to actions).
- Also, the old implementation didn't include in docs that standard regex is a bit more eager than I expected - so if you specify a target name like `MyApp` in the option, all of the following targets will get matched and modified: `MyApp`, `Pods-MyApp`, `Pods-MyApp-AFNetworking` etc. So I added a bit more documentation on this fact and recommended to use `^Blah$` for exact-matching `Blah`. Let me know if there's an easier way.
