### PR TITLE
get_info_plist_value and set_info_plist_value actions

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'terminal-table', '~> 1.4.5' # Actions documentation
   spec.add_dependency 'pbxplorer', '~> 1.0.0' # Manipulate xcproject files for provisioning profiles
   spec.add_dependency 'rest-client', '~> 1.8.0' # Needed for mailgun action
+  spec.add_dependency 'plist', '~> 3.1.0' # Needed for set_build_number_repository and get_info_plist_value actions
 
   spec.add_dependency 'fastlane_core', '>= 0.14.0', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'credentials_manager', '>= 0.7.4', '< 1.0.0' # Password Manager

--- a/lib/fastlane/actions/get_info_plist_value.rb
+++ b/lib/fastlane/actions/get_info_plist_value.rb
@@ -6,14 +6,14 @@ module Fastlane
 
     class GetInfoPlistValueAction < Action
       def self.run(params)
-      require "plist"
-      begin
-	     path = File.expand_path(params[:plist_path])
-	     plist = Plist::parse_xml(path)
- 	     Actions.lane_context[SharedValues::INFO_PLIST_VALUE] = plist[params[:param_name]]
- 	     rescue
-	     	Helper.log.info "Unable to find plist file at #{path}".red
- 	     end
+        require "plist"
+        begin
+          path = File.expand_path(params[:plist_path])
+	      plist = Plist::parse_xml(path)
+ 	      Actions.lane_context[SharedValues::INFO_PLIST_VALUE] = plist[params[:param_name]]
+        rescue
+          Helper.log.info "Unable to find plist file at #{path}".red
+ 	    end
       end
 
       def self.description
@@ -22,7 +22,6 @@ module Fastlane
 
       def self.available_options
         [
-        
 		  FastlaneCore::ConfigItem.new(key: :param_name,
                                        env_name: "FL_GET_INFO_PLIST_PARAM_NAME",
                                        description: "Name of parameter",
@@ -31,7 +30,6 @@ module Fastlane
                                        env_name: "FL_GET_INFO_PLIST_PATH",
                                        description: "Path to Info.plist",
                                        optional: false)
-
         ]
       end
 
@@ -46,7 +44,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-         platform == :ios
+	    [:ios, :mac].include?platform
       end
     end
   end

--- a/lib/fastlane/actions/get_info_plist_value.rb
+++ b/lib/fastlane/actions/get_info_plist_value.rb
@@ -9,11 +9,11 @@ module Fastlane
         require "plist"
         begin
           path = File.expand_path(params[:plist_path])
-	      plist = Plist::parse_xml(path)
- 	      Actions.lane_context[SharedValues::INFO_PLIST_VALUE] = plist[params[:param_name]]
+          plist = Plist::parse_xml(path)
+          Actions.lane_context[SharedValues::GET_INFO_PLIST_VALUE_CUSTOM_VALUE] = plist[params[:param_name]]
         rescue
           Helper.log.info "Unable to find plist file at #{path}".red
- 	    end
+        end
       end
 
       def self.description
@@ -22,7 +22,7 @@ module Fastlane
 
       def self.available_options
         [
-		  FastlaneCore::ConfigItem.new(key: :param_name,
+          FastlaneCore::ConfigItem.new(key: :param_name,
                                        env_name: "FL_GET_INFO_PLIST_PARAM_NAME",
                                        description: "Name of parameter",
                                        optional: false),
@@ -44,7 +44,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-	    [:ios, :mac].include?platform
+        [:ios, :mac].include?platform
       end
     end
   end

--- a/lib/fastlane/actions/get_info_plist_value.rb
+++ b/lib/fastlane/actions/get_info_plist_value.rb
@@ -1,0 +1,53 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      GET_INFO_PLIST_VALUE_CUSTOM_VALUE = :GET_INFO_PLIST_VALUE_CUSTOM_VALUE
+    end
+
+    class GetInfoPlistValueAction < Action
+      def self.run(params)
+      require "plist"
+      begin
+	     path = File.expand_path(params[:plist_path])
+	     plist = Plist::parse_xml(path)
+ 	     Actions.lane_context[SharedValues::INFO_PLIST_VALUE] = plist[params[:param_name]]
+ 	     rescue
+	     	Helper.log.info "Unable to find plist file at #{path}".red
+ 	     end
+      end
+
+      def self.description
+        "returns value from Info.plist of your project as native Ruby data structures"
+      end
+
+      def self.available_options
+        [
+        
+		  FastlaneCore::ConfigItem.new(key: :param_name,
+                                       env_name: "FL_GET_INFO_PLIST_PARAM_NAME",
+                                       description: "Name of parameter",
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :plist_path,
+                                       env_name: "FL_GET_INFO_PLIST_PATH",
+                                       description: "Path to Info.plist",
+                                       optional: false)
+
+        ]
+      end
+
+      def self.output
+        [
+          ['GET_INFO_PLIST_VALUE_CUSTOM_VALUE', 'A description of what this value contains']
+        ]
+      end
+
+      def self.authors
+        ["kohtenko"]
+      end
+
+      def self.is_supported?(platform)
+         platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/set_info_plist_value.rb
+++ b/lib/fastlane/actions/set_info_plist_value.rb
@@ -1,0 +1,58 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      SET_INFO_PLIST_VALUE_CUSTOM_VALUE = :SET_INFO_PLIST_VALUE_CUSTOM_VALUE
+    end
+
+    class SetInfoPlistValueAction < Action
+      def self.run(params)
+      require "plist"
+       begin 
+         path = File.expand_path(params[:plist_path])
+	     plist = Plist::parse_xml(path)
+	     plist[params[:param_name]] = params[:param_value]
+	     new_plist = plist.to_plist
+	     File.open(path, 'w') { |file| file.write(new_plist) }
+	     
+ 	     rescue
+	     	Helper.log.info "Unable to set value to plist file at #{path}".red
+ 	     end
+	  end
+
+      def self.description
+        "Sets value to Info.plist of your project as native Ruby data structures"
+      end
+
+      def self.available_options
+
+        [
+ 		  FastlaneCore::ConfigItem.new(key: :param_name,
+                                       env_name: "FL_SET_INFO_PLIST_PARAM_NAME",
+                                       description: "Name of parameter",
+                                       optional: false),
+ 		  FastlaneCore::ConfigItem.new(key: :param_value,
+                                       env_name: "FL_SET_INFO_PLIST_PARAM_VALUE",
+                                       description: "Name of parameter",
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :plist_path,
+                                       env_name: "FL_SET_INFO_PLIST_PATH",
+                                       description: "Path to Info.plist",
+                                       optional: false)
+
+        ]
+      end
+
+      def self.output
+        [ ]
+      end
+
+      def self.authors
+        ["kohtenko"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/set_info_plist_value.rb
+++ b/lib/fastlane/actions/set_info_plist_value.rb
@@ -7,16 +7,15 @@ module Fastlane
     class SetInfoPlistValueAction < Action
       def self.run(params)
       require "plist"
-       begin 
-         path = File.expand_path(params[:plist_path])
-	     plist = Plist::parse_xml(path)
-	     plist[params[:param_name]] = params[:param_value]
-	     new_plist = plist.to_plist
-	     File.open(path, 'w') { |file| file.write(new_plist) }
-	     
- 	     rescue
-	     	Helper.log.info "Unable to set value to plist file at #{path}".red
- 	     end
+        begin
+          path = File.expand_path(params[:plist_path])
+	      plist = Plist::parse_xml(path)
+	      plist[params[:param_name]] = params[:param_value]
+	      new_plist = plist.to_plist
+	      File.open(path, 'w') { |file| file.write(new_plist) }
+        rescue
+          Helper.log.info "Unable to set value to plist file at #{path}".red
+        end
 	  end
 
       def self.description
@@ -38,7 +37,6 @@ module Fastlane
                                        env_name: "FL_SET_INFO_PLIST_PATH",
                                        description: "Path to Info.plist",
                                        optional: false)
-
         ]
       end
 
@@ -51,7 +49,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include?platform
       end
     end
   end

--- a/lib/fastlane/actions/set_info_plist_value.rb
+++ b/lib/fastlane/actions/set_info_plist_value.rb
@@ -1,7 +1,6 @@
 module Fastlane
   module Actions
     module SharedValues
-      SET_INFO_PLIST_VALUE_CUSTOM_VALUE = :SET_INFO_PLIST_VALUE_CUSTOM_VALUE
     end
 
     class SetInfoPlistValueAction < Action
@@ -9,29 +8,28 @@ module Fastlane
       require "plist"
         begin
           path = File.expand_path(params[:plist_path])
-	      plist = Plist::parse_xml(path)
-	      plist[params[:param_name]] = params[:param_value]
-	      new_plist = plist.to_plist
-	      File.open(path, 'w') { |file| file.write(new_plist) }
+          plist = Plist::parse_xml(path)
+          plist[params[:param_name]] = params[:param_value]
+          new_plist = plist.to_plist
+          File.write(path, new_plist)
         rescue
           Helper.log.info "Unable to set value to plist file at #{path}".red
         end
-	  end
+      end
 
       def self.description
         "Sets value to Info.plist of your project as native Ruby data structures"
       end
 
       def self.available_options
-
         [
- 		  FastlaneCore::ConfigItem.new(key: :param_name,
+          FastlaneCore::ConfigItem.new(key: :param_name,
                                        env_name: "FL_SET_INFO_PLIST_PARAM_NAME",
-                                       description: "Name of parameter",
+                                       description: "Name of key in plist",
                                        optional: false),
- 		  FastlaneCore::ConfigItem.new(key: :param_value,
+          FastlaneCore::ConfigItem.new(key: :param_value,
                                        env_name: "FL_SET_INFO_PLIST_PARAM_VALUE",
-                                       description: "Name of parameter",
+                                       description: "Value to setup",
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :plist_path,
                                        env_name: "FL_SET_INFO_PLIST_PATH",


### PR DESCRIPTION
I want separate `gym` building for `Development`, `Staging` and `Release` configurations (for example change server address). This why I use something like `Environment` key in my `Info.plist` file. This actions are very useful for automatically change such values dependent of current lane
