### PR TITLE
Slather action

### DIFF
--- a/lib/fastlane/actions/slather.rb
+++ b/lib/fastlane/actions/slather.rb
@@ -135,7 +135,7 @@ Slather is available at https://github.com/venmo/slather
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ["@mattdelves"]
+        ["mattdelves"]
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/actions/slather.rb
+++ b/lib/fastlane/actions/slather.rb
@@ -1,0 +1,79 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      SLATHER_CUSTOM_VALUE = :SLATHER_CUSTOM_VALUE
+    end
+
+    class SlatherAction < Action
+      def self.run(params)
+        # fastlane will take care of reading in the parameter and fetching the environment variable:
+        Helper.log.info "Parameter API Token: #{params[:api_token]}"
+
+        # sh "shellcommand ./path"
+
+        # Actions.lane_context[SharedValues::SLATHER_CUSTOM_VALUE] = "my_val"
+      end
+
+
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "A short description with <= 80 characters of what this action does"
+      end
+
+      def self.details
+        # Optional:
+        # this is your change to provide a more detailed description of this action
+        "You can use this action to do cool things..."
+      end
+
+      def self.available_options
+        # Define all options your action supports. 
+        
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(key: :api_token,
+                                       env_name: "FL_SLATHER_API_TOKEN", # The name of the environment variable
+                                       description: "API Token for SlatherAction", # a short description of this parameter
+                                       verify_block: proc do |value|
+                                          raise "No API token for SlatherAction given, pass using `api_token: 'token'`".red unless (value and not value.empty?)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :development,
+                                       env_name: "FL_SLATHER_DEVELOPMENT",
+                                       description: "Create a development certificate instead of a distribution one",
+                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       default_value: false) # the default value if the user didn't provide one
+        ]
+      end
+
+      def self.output
+        # Define the shared values you are going to provide
+        # Example
+        [
+          ['SLATHER_CUSTOM_VALUE', 'A description of what this value contains']
+        ]
+      end
+
+      def self.authors
+        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+        ["Your GitHub/Twitter Name"]
+      end
+
+      def self.is_supported?(platform)
+        # you can do things like
+        # 
+        #  true
+        # 
+        #  platform == :ios
+        # 
+        #  [:ios, :mac].include? platform
+        # 
+
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/slather.rb
+++ b/lib/fastlane/actions/slather.rb
@@ -6,8 +6,77 @@ module Fastlane
 
     class SlatherAction < Action
       def self.run(params)
-        # fastlane will take care of reading in the parameter and fetching the environment variable:
-        Helper.log.info "Parameter API Token: #{params[:api_token]}"
+        command = "slather coverage "
+
+        if params[:input_format]
+          command += " --input-format #{params[:input_format]}"
+        end
+
+        if params[:build_directory]
+          command += " --build-directory #{params[:build_directory]}"
+        end
+
+        if params[:scheme]
+          command += " --scheme #{params[:scheme]}"
+        end
+
+        if params[:buildkite]
+          command += " --buildkite"
+        end
+
+        if params[:jenkins]
+          command += " --jenkins"
+        end
+
+        if params[:travis]
+          command += " --travis"
+        end
+
+        if params[:circleci]
+          command += " --circleci"
+        end
+
+        if params[:coveralls]
+          command += " --coveralls"
+        end
+
+        if params[:simple_output]
+          command += " --simple-output"
+        end
+
+        if params[:gutter_json]
+          command += " --gutter-json"
+        end
+
+        if params[:cobertura_xml]
+          command += " --cobertura-xml"
+        end
+
+        if params[:html]
+          command += " --html"
+        end
+
+        if params[:show]
+          command += " --show"
+        end
+
+        if params[:source_directory]
+          command += " --source-directory #{params[:source_directory]}"
+        end
+
+        if params[:output_directory]
+          command += " --output-directory #{params[:output_directory]}"
+        end
+
+        if params[:ignore]
+          command += " --ignore #{params[:ignore]}"
+        end
+
+        if params[:proj]
+          command += " #{params[:proj]}"
+        end
+
+        sh command
 
         # sh "shellcommand ./path"
 
@@ -21,58 +90,114 @@ module Fastlane
       #####################################################
 
       def self.description
-        "A short description with <= 80 characters of what this action does"
+        "Use slather to generate a code coverage report"
       end
 
       def self.details
         # Optional:
         # this is your change to provide a more detailed description of this action
-        "You can use this action to do cool things..."
+        "Slather works with multiple code coverage formats including Xcode7 code coverage.\n" +
+        "Slather is available at https://github.com/venmo/slather"
       end
 
       def self.available_options
-        # Define all options your action supports. 
-        
-        # Below a few examples
         [
-          FastlaneCore::ConfigItem.new(key: :api_token,
-                                       env_name: "FL_SLATHER_API_TOKEN", # The name of the environment variable
-                                       description: "API Token for SlatherAction", # a short description of this parameter
+          FastlaneCore::ConfigItem.new(key: :build_directory,
+                                       env_name: "FL_SLATHER_BUILD_DIRECTORY", # The name of the environment variable
+                                       description: "The location of the build output", # a short description of this parameter
                                        verify_block: proc do |value|
-                                          raise "No API token for SlatherAction given, pass using `api_token: 'token'`".red unless (value and not value.empty?)
+                                          raise "No Build Directory specified, pass using `build_directory: 'location/of/your/build/output'`".red unless (value and not value.empty?)
                                        end),
-          FastlaneCore::ConfigItem.new(key: :development,
-                                       env_name: "FL_SLATHER_DEVELOPMENT",
-                                       description: "Create a development certificate instead of a distribution one",
-                                       is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
+          FastlaneCore::ConfigItem.new(key: :proj,
+                                       env_name: "FL_SLATHER_PROJ", # The name of the environment variable
+                                       description: "The project file that slather looks at", # a short description of this parameter
+                                       verify_block: proc do |value|
+                                         raise "No project file specified, pass using `proj: 'Project.xcodeproj'`".red unless (value and not value.empty?)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :scheme,
+                                       env_name: "FL_SLATHER_SCHEME", # The name of the environment variable
+                                       description: "Scheme to use when calling slather"
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :input_format,
+                                       env_name: "FL_SLATHER_INPUT_FORMAT", # The name of the environment variable
+                                       description: "The input format that slather should look for"
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :buildkite,
+                                       env_name: "FL_SLATHER_BUILDKITE_ENABLED", # The name of the environment variable
+                                       description: "Tell slather that it is running on Buildkite",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :jenkins,
+                                       env_name: "FL_SLATHER_JENKINS_ENABLED", # The name of the environment variable
+                                       description: "Tell slather that it is running on Jenkins",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :travis,
+                                       env_name: "FL_SLATHER_TRAVIS_ENABLED", # The name of the environment variable
+                                       description: "Tell slather that it is running on TravisCI",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :circleci,
+                                       env_name: "FL_SLATHER_CIRCLECI_ENABLED",
+                                       description: "Tell slather that it is running on CircleCI",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :coveralls,
+                                       env_name: "FL_SLATHER_COVERALLS_ENABLED",
+                                       description: "Tell slather that it should post data to Coveralls",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :simple_output,
+                                       env_name: "FL_SLATHER_SIMPLE_OUTPUT_ENABLED",
+                                       description: "Tell slather that it should output results to the terminal",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :gutter_json,
+                                       env_name: "FL_SLATHER_GUTTER_JSON_ENABLED",
+                                       description: "Tell slather that it should output results as Gutter JSON format",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :cobertura_xml,
+                                       env_name: "FL_SLATHER_COBERTURA_XML_ENABLED",
+                                       description: "Tell slather that it should output results as Cobertura XML format",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :html,
+                                       env_name: "FL_SLATHER_HTML_ENABLED",
+                                       description: "Tell slather that it should output results as static HTML pages",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :show,
+                                       env_name: "FL_SLATHER_SHOW_ENABLED",
+                                       description: "Tell slather that it should oupen static html pages automatically",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :source_directory,
+                                       env_name: "FL_SLATHER_SOURCE_DIRECTORY",
+                                       description: "Tell slather the location of your source files",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :output_directory,
+                                       env_name: "FL_SLATHER_OUTPUT_DIRECTORY",
+                                       description: "Tell slather the location of for your output files",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :ignore,
+                                       env_name: "FL_SLATHER_IGNORE",
+                                       description: "Tell slather to ignore files matching a path",
+                                       optional: true),
         ]
       end
 
       def self.output
         # Define the shared values you are going to provide
-        # Example
-        [
-          ['SLATHER_CUSTOM_VALUE', 'A description of what this value contains']
-        ]
       end
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ["Your GitHub/Twitter Name"]
+        ["@mattdelves"]
       end
 
       def self.is_supported?(platform)
-        # you can do things like
-        # 
-        #  true
-        # 
-        #  platform == :ios
-        # 
-        #  [:ios, :mac].include? platform
-        # 
-
-        platform == :ios
+        [:ios, :mac].include? platform
       end
     end
   end

--- a/lib/fastlane/actions/slather.rb
+++ b/lib/fastlane/actions/slather.rb
@@ -7,83 +7,25 @@ module Fastlane
     class SlatherAction < Action
       def self.run(params)
         command = "slather coverage "
-
-        if params[:input_format]
-          command += " --input-format #{params[:input_format]}"
-        end
-
-        if params[:build_directory]
-          command += " --build-directory #{params[:build_directory]}"
-        end
-
-        if params[:scheme]
-          command += " --scheme #{params[:scheme]}"
-        end
-
-        if params[:buildkite]
-          command += " --buildkite"
-        end
-
-        if params[:jenkins]
-          command += " --jenkins"
-        end
-
-        if params[:travis]
-          command += " --travis"
-        end
-
-        if params[:circleci]
-          command += " --circleci"
-        end
-
-        if params[:coveralls]
-          command += " --coveralls"
-        end
-
-        if params[:simple_output]
-          command += " --simple-output"
-        end
-
-        if params[:gutter_json]
-          command += " --gutter-json"
-        end
-
-        if params[:cobertura_xml]
-          command += " --cobertura-xml"
-        end
-
-        if params[:html]
-          command += " --html"
-        end
-
-        if params[:show]
-          command += " --show"
-        end
-
-        if params[:source_directory]
-          command += " --source-directory #{params[:source_directory]}"
-        end
-
-        if params[:output_directory]
-          command += " --output-directory #{params[:output_directory]}"
-        end
-
-        if params[:ignore]
-          command += " --ignore #{params[:ignore]}"
-        end
-
-        if params[:proj]
-          command += " #{params[:proj]}"
-        end
-
+        command += " --build-directory #{params[:build_directory]}"
+        command += " --input-format #{params[:input_format]}" if params[:input_format]
+        command += " --scheme #{params[:scheme]}" if params[:scheme]
+        command += " --buildkite" if params[:buildkite]
+        command += " --jenkins" if params[:jenkins]
+        command += " --travis" if params[:travis]
+        command += " --circleci" if params[:circleci]
+        command += " --coveralls" if params[:coveralls]
+        command += " --simple-output" if params[:simple_output]
+        command += " --gutter-json" if params[:gutter_json]
+        command += " --cobertura-xml" if params[:cobertura_xml]
+        command += " --html" if params[:html]
+        command += " --show" if params[:show]
+        command += " --source-directory #{params[:source_directory]}" if params[:source_directory]
+        command += " --output-directory #{params[:output_directory]}" if params[:output_directory]
+        command += " --ignore #{params[:ignore]}" if params[:ignore]
+        command += " #{params[:proj]}"
         sh command
-
-        # sh "shellcommand ./path"
-
-        # Actions.lane_context[SharedValues::SLATHER_CUSTOM_VALUE] = "my_val"
       end
-
-
 
       #####################################################
       # @!group Documentation
@@ -94,10 +36,10 @@ module Fastlane
       end
 
       def self.details
-        # Optional:
-        # this is your change to provide a more detailed description of this action
-        "Slather works with multiple code coverage formats including Xcode7 code coverage.\n" +
-        "Slather is available at https://github.com/venmo/slather"
+        return <<-eos
+Slather works with multiple code coverage formats including Xcode7 code coverage.
+Slather is available at https://github.com/venmo/slather
+        eos
       end
 
       def self.available_options
@@ -106,13 +48,13 @@ module Fastlane
                                        env_name: "FL_SLATHER_BUILD_DIRECTORY", # The name of the environment variable
                                        description: "The location of the build output", # a short description of this parameter
                                        verify_block: proc do |value|
-                                          raise "No Build Directory specified, pass using `build_directory: 'location/of/your/build/output'`".red unless (value and not value.empty?)
+                                         raise "No Build Directory specified, pass using `build_directory: 'location/of/your/build/output'`".red unless value and !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :proj,
                                        env_name: "FL_SLATHER_PROJ", # The name of the environment variable
                                        description: "The project file that slather looks at", # a short description of this parameter
                                        verify_block: proc do |value|
-                                         raise "No project file specified, pass using `proj: 'Project.xcodeproj'`".red unless (value and not value.empty?)
+                                         raise "No project file specified, pass using `proj: 'Project.xcodeproj'`".red unless value and !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :scheme,
                                        env_name: "FL_SLATHER_SCHEME", # The name of the environment variable
@@ -183,7 +125,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :ignore,
                                        env_name: "FL_SLATHER_IGNORE",
                                        description: "Tell slather to ignore files matching a path",
-                                       optional: true),
+                                       optional: true)
         ]
       end
 

--- a/spec/actions_specs/slather_spec.rb
+++ b/spec/actions_specs/slather_spec.rb
@@ -1,0 +1,51 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Slather Integration" do
+      it "works with all parameters" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          slather({
+            build_directory: 'foo',
+            input_format: 'bah',
+            scheme: 'Foo',
+            buildkite: true,
+            jenkins: true,
+            travis: true,
+            circleci: true,
+            coveralls: true,
+            simple_output: true,
+            gutter_json: true,
+            cobertura_xml: true,
+            html: true,
+            show: true,
+            source_directory: 'baz',
+            output_directory: '123',
+            ignore: 'nothing',
+            proj: 'foo.xcodeproj'
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("slather coverage  --build-directory foo --input-format bah --scheme Foo --buildkite --jenkins --travis --circleci --coveralls --simple-output --gutter-json --cobertura-xml --html --show --source-directory baz --output-directory 123 --ignore nothing foo.xcodeproj")
+      end
+
+      it "requires build_directory" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            slather({
+              proj: 'something.xcodeproj'
+            })
+          end").runner.execute(:test)
+        end.to raise_error
+      end
+
+      it "requires proj" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            slather({
+              build_directory: 'foo/bar'
+            })
+          end").runner.execute(:test)
+        end.to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
This ads an action to allow for slather to be called from within fastlane.

A couple of questions I do have that would make the addition a bit more complete / robust.
1. What's the best way to test this? At a basic level it just constructs a command line argument.
2. As slather exists as a rubygem, should it be added as a dependency in the gemspec or would it be up to the people using the action to make sure that is part of a Gemfile?

```
+-----------------------------------------------------------------------------------+
|                                      slather                                      |
+-----------------------------------------------------------------------------------+
| Use slather to generate a code coverage report                                    |
|                                                                                   |
| Slather works with multiple code coverage formats including Xcode7 code coverage. |
| Slather is available at https://github.com/venmo/slather                          |
|                                                                                   |
| Created by @mattdelves                                                            |
+-----------------------------------------------------------------------------------+

+------------------+--------------------------------------------------------------------+----------------------------------+
|                                                         slather                                                          |
+------------------+--------------------------------------------------------------------+----------------------------------+
| Key              | Description                                                        | Env Var                          |
+------------------+--------------------------------------------------------------------+----------------------------------+
| build_directory  | The location of the build output                                   | FL_SLATHER_BUILD_DIRECTORY       |
| proj             | The project file that slather looks at                             | FL_SLATHER_PROJ                  |
| scheme           | Scheme to use when calling slather                                 | FL_SLATHER_SCHEME                |
| input_format     | The input format that slather should look for                      | FL_SLATHER_INPUT_FORMAT          |
| buildkite        | Tell slather that it is running on Buildkite                       | FL_SLATHER_BUILDKITE_ENABLED     |
| jenkins          | Tell slather that it is running on Jenkins                         | FL_SLATHER_JENKINS_ENABLED       |
| travis           | Tell slather that it is running on TravisCI                        | FL_SLATHER_TRAVIS_ENABLED        |
| circleci         | Tell slather that it is running on CircleCI                        | FL_SLATHER_CIRCLECI_ENABLED      |
| coveralls        | Tell slather that it should post data to Coveralls                 | FL_SLATHER_COVERALLS_ENABLED     |
| simple_output    | Tell slather that it should output results to the terminal         | FL_SLATHER_SIMPLE_OUTPUT_ENABLED |
| gutter_json      | Tell slather that it should output results as Gutter JSON format   | FL_SLATHER_GUTTER_JSON_ENABLED   |
| cobertura_xml    | Tell slather that it should output results as Cobertura XML format | FL_SLATHER_COBERTURA_XML_ENABLED |
| html             | Tell slather that it should output results as static HTML pages    | FL_SLATHER_HTML_ENABLED          |
| show             | Tell slather that it should oupen static html pages automatically  | FL_SLATHER_SHOW_ENABLED          |
| source_directory | Tell slather the location of your source files                     | FL_SLATHER_SOURCE_DIRECTORY      |
| output_directory | Tell slather the location of for your output files                 | FL_SLATHER_OUTPUT_DIRECTORY      |
| ignore           | Tell slather to ignore files matching a path                       | FL_SLATHER_IGNORE                |
+------------------+--------------------------------------------------------------------+----------------------------------+
```
