### PR TITLE
Corrected three action descriptions

### DIFF
--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -290,7 +290,7 @@ module Fastlane
       end
 
       def self.description
-        "Builds the project using `xcodebuild`"
+        "Archives the project using `xcodebuild`"
       end
 
       def self.author
@@ -351,7 +351,7 @@ module Fastlane
       end
 
       def self.description
-        "Builds the project using `xcodebuild`"
+        "Cleans the project using `xcodebuild`"
       end
 
       def self.author
@@ -382,7 +382,7 @@ module Fastlane
       end
 
       def self.description
-        "Builds the project using `xcodebuild`"
+        "Exports the project using `xcodebuild`"
       end
 
       def self.author


### PR DESCRIPTION
The description of the three xcodebuild actions should be more specific.
![screen shot 2015-08-31 at 3 31 09 pm](https://cloud.githubusercontent.com/assets/3658887/9579811/83cab6e2-4ff5-11e5-8909-2fd484e4fabf.png)
