### PR TITLE
GitHub Release Creation Action can now Upload Assets

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -567,7 +567,7 @@ If you put `deploygate` after `ipa` action, you don't have to specify IPA file p
 
 More information about the available options can be found in the [DeployGate Push API document](https://deploygate.com/docs/api).
 
-### [Xcode Server get assets](https://www.apple.com/uk/support/osxserver/xcodeserver/)
+### [Xcode Server](https://www.apple.com/uk/support/osxserver/xcodeserver/)
 
 This action retrieves integration assets (`.xcarchive`, logs etc) from your Xcode Server instance over HTTPS.
 
@@ -591,6 +591,22 @@ set_changelog(app_identifier: "com.krausefx.app", version: "1.0", changelog: "Al
 ```
 
 You can store the changelog in `./fastlane/changelog.txt` and it will automatically get loaded from there. This integration is useful if you support e.g. 10 languages and want to use the same "What's new"-text for all languages.
+
+### [GitHub Releases](https://github.com)
+
+This action creates a new release for your repository on GitHub and can also upload specified assets like `.ipa`s and `.app`s, binary files, changelogs etc. 
+
+```ruby
+github_release = set_github_release(
+  repository_name: "krausefx/fastlane",
+  api_token: ENV['GITHUB_TOKEN']
+  name: "Super New actions",
+  tag_name: "v1.22.0",
+  description: File.read("changelog"),
+  commitish: "master",
+  upload_assets: ["example_integration.ipa", "./pkg/built.gem"]
+)
+```
 
 ## Modifying Project
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pbxplorer', '~> 1.0.0' # Manipulate xcproject files for provisioning profiles
   spec.add_dependency 'rest-client', '~> 1.8.0' # Needed for mailgun action
   spec.add_dependency 'plist', '~> 3.1.0' # Needed for set_build_number_repository and get_info_plist_value actions
+  spec.add_dependency 'addressable', '~> 2.3.8' # Support for URI templates
 
   spec.add_dependency 'fastlane_core', '>= 0.15.0', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'credentials_manager', '>= 0.7.4', '< 1.0.0' # Password Manager

--- a/lib/fastlane/actions/set_github_release.rb
+++ b/lib/fastlane/actions/set_github_release.rb
@@ -153,7 +153,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "This will create a new release on GitHub from given metadata and upload assets for it"
+        "This will create a new release on GitHub and upload assets for it"
       end
 
       def self.details

--- a/lib/fastlane/actions/set_github_release.rb
+++ b/lib/fastlane/actions/set_github_release.rb
@@ -1,3 +1,5 @@
+# rubocop:disable Metrics/AbcSize
+
 module Fastlane
   module Actions
     module SharedValues
@@ -79,12 +81,11 @@ module Fastlane
       end
 
       def self.upload(asset_path, upload_url_template, api_token)
-
         # if it's a directory, zip it first in a temp directory, because we can only upload binary files
         absolute_path = File.absolute_path(asset_path)
 
         # check that the asset even exists
-        raise "Asset #{absolute_path} doesn't exist" unless File.exists?(absolute_path)
+        raise "Asset #{absolute_path} doesn't exist" unless File.exist?(absolute_path)
 
         name = File.basename(absolute_path)
         response = nil
@@ -160,8 +161,7 @@ module Fastlane
         (get one from https://github.com/settings/tokens/new), the repository name
         and tag name. If the tag doesn't exist, one will be created on the commit or branch passed-in as
         commitish. Out parameters provide the release's id, which can be used for later editing and the
-        release html link to GitHub."
-        "You can also specify a list of assets to be uploaded to the release with the upload_assets parameter."
+        release html link to GitHub. You can also specify a list of assets to be uploaded to the release with the upload_assets parameter."
       end
 
       def self.available_options
@@ -216,8 +216,8 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "upload_assets must be an Array of paths to assets" unless value.is_a? Array
-                                       end),
+                                         raise "upload_assets must be an Array of paths to assets" unless value.kind_of? Array
+                                       end)
         ]
       end
 

--- a/lib/fastlane/actions/set_github_release.rb
+++ b/lib/fastlane/actions/set_github_release.rb
@@ -9,6 +9,7 @@ module Fastlane
     class SetGithubReleaseAction < Action
       def self.run(params)
         Helper.log.info "Creating release of #{params[:repository_name]} on tag \"#{params[:tag_name]}\" with name \"#{params[:name]}\".".yellow
+        Helper.log.info "Will also upload assets #{params[:upload_assets]}.".yellow if params[:upload_assets]
 
         require 'json'
         body = {
@@ -20,14 +21,11 @@ module Fastlane
           'prerelease' => params[:is_prerelease]
         }.to_json
 
-        require 'excon'
-        require 'base64'
-        headers = { 'User-Agent' => 'fastlane-set_github_release' }
-        headers['Authorization'] = "Basic #{Base64.strict_encode64(params[:api_token])}" if params[:api_token]
-        response = Excon.post("https://api.github.com/repos/#{params[:repository_name]}/releases",
-                              headers: headers,
-                              body: body
-                             )
+        repo_name = params[:repository_name]
+        api_token = params[:api_token]
+
+        # create the release
+        response = call_releases_endpoint("post", repo_name, "/releases", api_token, body)
 
         case response[:status]
         when 201
@@ -39,7 +37,27 @@ module Fastlane
           Actions.lane_context[SharedValues::SET_GITHUB_RELEASE_HTML_LINK] = html_url
           Actions.lane_context[SharedValues::SET_GITHUB_RELEASE_RELEASE_ID] = release_id
           Actions.lane_context[SharedValues::SET_GITHUB_RELEASE_JSON] = body
-          return body
+
+          assets = params[:upload_assets]
+          if assets && assets.count > 0
+
+            # upload assets
+            self.upload_assets(assets, body['upload_url'], api_token)
+
+            # fetch the release again, so that it contains the uploaded assets
+            get_response = self.call_releases_endpoint("get", repo_name, "/releases/#{release_id}", api_token, nil)
+            if get_response[:status] != 200
+              Helper.log.error "GitHub responded with #{response[:status]}:#{response[:body]}".red
+              raise "Failed to fetch the newly created release, but it *has been created* successfully.".red
+            end
+
+            get_body = JSON.parse(get_response.body)
+            Actions.lane_context[SharedValues::SET_GITHUB_RELEASE_JSON] = get_body
+            Helper.log.info "Successfully uploaded assets #{assets} to release \"#{html_url}\"".green
+            return get_body
+          else
+            return body
+          end
         when 422
           Helper.log.error "Release on tag #{params[:tag_name]} already exists!".red
         when 404
@@ -54,12 +72,87 @@ module Fastlane
         return nil
       end
 
+      def self.upload_assets(assets, upload_url_template, api_token)
+        assets.each do |asset|
+          self.upload(asset, upload_url_template, api_token)
+        end
+      end
+
+      def self.upload(asset_path, upload_url_template, api_token)
+
+        # if it's a directory, zip it first in a temp directory, because we can only upload binary files
+        absolute_path = File.absolute_path(asset_path)
+
+        # check that the asset even exists
+        raise "Asset #{absolute_path} doesn't exist" unless File.exists?(absolute_path)
+
+        name = File.basename(absolute_path)
+        response = nil
+        if File.directory?(absolute_path)
+          Dir.mktmpdir do |dir|
+            tmpzip = File.join(dir, File.basename(absolute_path) + '.zip')
+            name = File.basename(tmpzip)
+            sh "cd \"#{File.dirname(absolute_path)}\"; zip -r \"#{tmpzip}\" \"#{File.basename(absolute_path)}\" 2>&1 >/dev/null"
+            response = self.upload_file(tmpzip, upload_url_template, api_token)
+          end
+        else
+          response = self.upload_file(absolute_path, upload_url_template, api_token)
+        end
+        return response
+      end
+
+      def self.upload_file(file, url_template, api_token)
+        require 'addressable/template'
+        name = File.basename(file)
+        expanded_url = Addressable::Template.new(url_template).expand(name: name).to_s
+        headers = self.headers(api_token)
+        headers['Content-Type'] = 'application/zip' # how do we detect other types e.g. other binary files? file extensions?
+
+        Helper.log.info "Uploading #{name}".yellow
+        response = self.call_endpoint(expanded_url, "post", headers, File.read(file))
+
+        # inspect the response
+        case response.status
+        when 201
+          # all good in the hood
+          Helper.log.info "Successfully uploaded #{name}.".green
+        else
+          Helper.log.error "GitHub responded with #{response[:status]}:#{response[:body]}".red
+          raise "Failed to upload asset #{name} to GitHub."
+        end
+      end
+
+      def self.call_endpoint(url, method, headers, body)
+        require 'excon'
+        case method
+        when "post"
+          response = Excon.post(url, headers: headers, body: body)
+        when "get"
+          response = Excon.get(url, headers: headers, body: body)
+        else
+          raise "Unsupported method #{method}"
+        end
+        return response
+      end
+
+      def self.call_releases_endpoint(method, repo, endpoint, api_token, body)
+        url = "https://api.github.com/repos/#{repo}#{endpoint}"
+        self.call_endpoint(url, method, self.headers(api_token), body)
+      end
+
+      def self.headers(api_token)
+        require 'base64'
+        headers = { 'User-Agent' => 'fastlane-set_github_release' }
+        headers['Authorization'] = "Basic #{Base64.strict_encode64(api_token)}" if api_token
+        headers
+      end
+
       #####################################################
       # @!group Documentation
       #####################################################
 
       def self.description
-        "This will create a new release on GitHub from given metadata"
+        "This will create a new release on GitHub from given metadata and upload assets for it"
       end
 
       def self.details
@@ -68,6 +161,7 @@ module Fastlane
         and tag name. If the tag doesn't exist, one will be created on the commit or branch passed-in as
         commitish. Out parameters provide the release's id, which can be used for later editing and the
         release html link to GitHub."
+        "You can also specify a list of assets to be uploaded to the release with the upload_assets parameter."
       end
 
       def self.available_options
@@ -115,7 +209,15 @@ module Fastlane
                                        description: "Whether the release should be marked as prerelease",
                                        optional: true,
                                        default_value: false,
-                                       is_string: false)
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :upload_assets,
+                                       env_name: "FL_SET_GITHUB_RELEASE_UPLOAD_ASSETS",
+                                       description: "Path to assets to be uploaded with the release",
+                                       optional: true,
+                                       is_string: false,
+                                       verify_block: proc do |value|
+                                         raise "upload_assets must be an Array of paths to assets" unless value.is_a? Array
+                                       end),
         ]
       end
 


### PR DESCRIPTION
Finally added the ability to attach assets to GitHub releases from the `set_github_release` action and refactored the action a bit in the process. Even if you specify a directory, the action automatically zips it first. Should be useful when you want to attach built assets that you don't want stored in git.
