### PR TITLE
Import from git, sparse checkout

### DIFF
--- a/lib/fastlane/actions/import_from_git.rb
+++ b/lib/fastlane/actions/import_from_git.rb
@@ -37,7 +37,7 @@ module Fastlane
       end
 
       def self.authors
-        ["fabiomassimo", "KrauseFx"]
+        ["fabiomassimo", "KrauseFx", "Liquidsoul"]
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -219,7 +219,7 @@ module Fastlane
 
         # setup sparse-checkout file
         sparse_checkout_file_path = File.join(clone_folder, '.git/info/sparse-checkout')
-        
+
         if File.exist? sparse_checkout_file_path
           # delete existing sparse-checkout file
           Actions.sh("rm -f #{sparse_checkout_file_path}")
@@ -231,7 +231,7 @@ module Fastlane
 
         sparse_checkout_file = File.new(sparse_checkout_file_path, 'w')
         sparse_checkout_file.write([path, actions_folder].join("\n"))
-        sparse_checkout_file.close()
+        sparse_checkout_file.close
 
         # Fetch latest updates from remote
         Actions.sh("cd '#{clone_folder}' && git fetch --all")

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -203,7 +203,7 @@ module Fastlane
                         git remote add origin #{url} && \
                         git config core.sparsecheckout true"
 
-        if not File.directory? clone_folder
+        if !File.directory? clone_folder
           Helper.log.info "Repo not yet created, initializing it..."
           Actions.sh(init_command)
         else


### PR DESCRIPTION
Hi @KrauseFx !

Here is an implementation of sparse-checkout that should solve #539.
Tell me what you think about it!

By the way, I have tested the feature using a spec I pushed in my branch [import_from_git/spec](https://github.com/Liquidsoul/fastlane/tree/import_from_git/spec). However, [as I've told you before](https://github.com/KrauseFx/fastlane/pull/513), this cannot be integrated yet because `sh` commands are not run during tests. I've overridden this in [this commit](https://github.com/Liquidsoul/fastlane/commit/515bbe18169e0104524f4f5a444b084ece1e6f9e) to bypass this. It would be nice if we could find a way to allow the creation of this kind of tests :smiley: 

Hope this'll help! :rocket: 
