### PR TITLE
New read_podspec Action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1195,3 +1195,19 @@ else
   say "Hi Human!"
 end
 ```
+
+### read_podspec
+
+Loads the specified (or the first found) podspec in the folder as JSON, so that you can inspect its `version`, `files` etc. This can be useful when basing your release process on the version string only stored in one place - in the podspec. As one of the first steps you'd read the podspec and its version and the rest of the workflow can use that version string (when e.g. creating a new git tag or a GitHub Release).
+
+```ruby
+spec = read_podspec
+version = spec['version']
+puts "Using Version #{version}"
+```
+
+This will find the first podspec in the folder. You can also pass in the specific podspec path.
+
+```ruby
+spec = read_podspec(path: "./XcodeServerSDK.podspec")
+```

--- a/lib/fastlane/actions/read_podspec.rb
+++ b/lib/fastlane/actions/read_podspec.rb
@@ -6,7 +6,7 @@ module Fastlane
 
     class ReadPodspecAction < Action
       def self.run(params)
-        path = params[:path] || Dir['*.podspec*'].first
+        path = params[:path]
 
         # will fail if cocoapods is not installed
         require 'cocoapods-core'
@@ -38,10 +38,10 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :path,
                                        env_name: "FL_READ_PODSPEC_PATH",
-                                       description: "(Optional) Path to the podspec to be read",
-                                       optional: true,
+                                       description: "Path to the podspec to be read",
+                                       default_value: Dir['*.podspec*'].first,
                                        verify_block: proc do |value|
-                                         raise "File #{value} not found".red unless File.exist?(spec_path)
+                                         raise "File #{value} not found".red unless File.exist?(value)
                                        end)
         ]
       end

--- a/lib/fastlane/actions/read_podspec.rb
+++ b/lib/fastlane/actions/read_podspec.rb
@@ -1,0 +1,64 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      READ_PODSPEC_JSON = :READ_PODSPEC_JSON
+    end
+
+    class ReadPodspecAction < Action
+      def self.run(params)
+        path = params[:path] || Dir['*.podspec*'].first
+
+        # will fail if cocoapods is not installed
+        require 'cocoapods-core'
+        spec = Pod::Spec.from_file(path).to_hash
+
+        Helper.log.info "Reading podspec from file #{path}".green
+
+        Actions.lane_context[SharedValues::READ_PODSPEC_JSON] = spec
+        return spec
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Loads a CocoaPods spec as JSON"
+      end
+
+      def self.details
+        [
+          "This can be used for only specifying a version string in your podspec",
+          "- and during your release process you'd read it from the podspec by running",
+          "`version = read_podspec['version']` at the beginning of your lane"
+        ].join("\n")
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: "FL_READ_PODSPEC_PATH",
+                                       description: "(Optional) Path to the podspec to be read",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         raise "File #{value} not found".red unless File.exist?(spec_path)
+                                       end)
+        ]
+      end
+
+      def self.output
+        [
+          ['READ_PODSPEC_JSON', 'Podspec JSON payload']
+        ]
+      end
+
+      def self.authors
+        ["czechboy0"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added a new action for loading CocoaPods podspecs in a lane. This is useful for only keeping the library's version number in the podspec and everything else loads it from there.

``` ruby
version = read_podspec['version']
```
