### PR TITLE
Added support for passing empty values to lane parameters.

### DIFF
--- a/lib/fastlane/command_line_handler.rb
+++ b/lib/fastlane/command_line_handler.rb
@@ -9,7 +9,7 @@ module Fastlane
       args.each do |current|
         if current.include? ":" # that's a key/value which we want to pass to the lane
           key, value = current.split(":")
-          raise "Please pass values like this: key:value" unless key.length > 0 and value.length > 0
+          raise "Please pass values like this: key:value" unless key.length > 0
           value = convert_value(value)
           Helper.log.debug "Using #{key}: #{value}".green
           lane_parameters[key.to_sym] = value


### PR DESCRIPTION
In my lane I want to pass empty value (as parameter) to the lane:

```
fastlane lane_name key1:
```

Unfortunately I'm receiving this error:

```
error: undefined method `length' for nil:NilClass. Use --trace to view backtrace
```

Problems is in file `lib/fastlane/command_line_handler.rb:11`:

```
key, value = current.split(":")
```

After splitting `value` is a NilClass and not a string. Secondly next line will throw exception if the `value` length is 0. Personally I think that only `key` type and length should be checked and we should allow passing empty values.
