### PR TITLE
cocoapods podfile option

### DIFF
--- a/lib/fastlane/actions/cocoapods.rb
+++ b/lib/fastlane/actions/cocoapods.rb
@@ -4,6 +4,8 @@ module Fastlane
       def self.run(params)
         cmd = []
 
+        cmd << ["cd '#{File.dirname(params[:podfile])}' &&"] unless params[:podfile].nil?
+
         cmd << ['bundle exec'] if File.exist?('Gemfile') && params[:use_bundle_exec]
         cmd << ['pod install']
 
@@ -57,7 +59,15 @@ module Fastlane
                                        env_name: "FL_COCOAPODS_USE_BUNDLE_EXEC",
                                        description: "Use bundle exec when there is a Gemfile presented",
                                        is_string: false,
-                                       default_value: true)
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :podfile,
+                                       env_name: "FL_COCOAPODS_PODFILE",
+                                       description: "Explicitly specify the path to the Cocoapods' Podfile",
+                                       optional: true,
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                         raise "Could not find Podfile".red unless File.exist?(value) || Helper.test?
+                                       end)
         ]
       end
 

--- a/lib/fastlane/actions/cocoapods.rb
+++ b/lib/fastlane/actions/cocoapods.rb
@@ -4,7 +4,14 @@ module Fastlane
       def self.run(params)
         cmd = []
 
-        cmd << ["cd '#{File.dirname(params[:podfile])}' &&"] unless params[:podfile].nil?
+        unless params[:podfile].nil?
+          if params[:podfile].end_with?('Podfile')
+            podfile_folder = File.dirname(params[:podfile])
+          else
+            podfile_folder = params[:podfile]
+          end
+          cmd << ["cd '#{podfile_folder}' &&"]
+        end
 
         cmd << ['bundle exec'] if File.exist?('Gemfile') && params[:use_bundle_exec]
         cmd << ['pod install']
@@ -62,7 +69,7 @@ module Fastlane
                                        default_value: true),
           FastlaneCore::ConfigItem.new(key: :podfile,
                                        env_name: "FL_COCOAPODS_PODFILE",
-                                       description: "Explicitly specify the path to the Cocoapods' Podfile",
+                                       description: "Explicitly specify the path to the Cocoapods' Podfile. You can either set it to the Podfile's path or to the folder containing the Podfile file",
                                        optional: true,
                                        is_string: true,
                                        verify_block: proc do |value|

--- a/lib/fastlane/actions/cocoapods.rb
+++ b/lib/fastlane/actions/cocoapods.rb
@@ -66,7 +66,7 @@ module Fastlane
       end
 
       def self.authors
-        ["KrauseFx", "tadpol", "birmacher"]
+        ["KrauseFx", "tadpol", "birmacher", "Liquidsoul"]
       end
     end
   end

--- a/spec/actions_specs/cocoapods_spec.rb
+++ b/spec/actions_specs/cocoapods_spec.rb
@@ -78,6 +78,16 @@ describe Fastlane do
 
         expect(result).to eq("cd 'Project' && pod install")
       end
+
+      it "changes directory if podfile is set to a directory" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          cocoapods(
+            podfile: 'Project'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("cd 'Project' && pod install")
+      end
     end
   end
 end

--- a/spec/actions_specs/cocoapods_spec.rb
+++ b/spec/actions_specs/cocoapods_spec.rb
@@ -68,6 +68,16 @@ describe Fastlane do
 
         expect(result).to eq("pod install --no-ansi")
       end
+
+      it "changes directory if podfile is set to the Podfile path" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          cocoapods(
+            podfile: 'Project/Podfile'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("cd 'Project' && pod install")
+      end
     end
   end
 end


### PR DESCRIPTION
This is an implementation of issue #565.
It adds a `podfile` option to the `cocoapods` action which allows to specify the location of the `Podfile` to execute.
