### PR TITLE
Correct handling of `:` in lane parameter.

### DIFF
--- a/lib/fastlane/command_line_handler.rb
+++ b/lib/fastlane/command_line_handler.rb
@@ -8,7 +8,7 @@ module Fastlane
       platform_lane_info = [] # the part that's responsible for the lane/platform definition
       args.each do |current|
         if current.include? ":" # that's a key/value which we want to pass to the lane
-          key, value = current.split(":")
+          key, value = current.split(":", 2)
           raise "Please pass values like this: key:value" unless key.length > 0
           value = convert_value(value)
           Helper.log.debug "Using #{key}: #{value}".green


### PR DESCRIPTION
When you for example want to pass code signing identity as lane parameter you have to pass `:` to parameter value:
`fastlane lane_name code_signing_identity:"iPhone Developer: XXX YYY (12345678)"`
Unfortunately only `iPhone Developer` is passed. Problem is with the `current.split(":")` which splits value to multiple items.
I think that the easiest solution is to use a `limit` value in the `split` method.
