### PR TITLE
Fixed set_github_release when no commitish is provided

### DIFF
--- a/lib/fastlane/actions/set_github_release.rb
+++ b/lib/fastlane/actions/set_github_release.rb
@@ -14,14 +14,15 @@ module Fastlane
         Helper.log.info "Will also upload assets #{params[:upload_assets]}.".yellow if params[:upload_assets]
 
         require 'json'
-        body = {
+        body_obj = {
           'tag_name' => params[:tag_name],
-          'target_commitish' => params[:commitish],
           'name' => params[:name],
           'body' => params[:description],
           'draft' => params[:is_draft],
           'prerelease' => params[:is_prerelease]
-        }.to_json
+        }
+        body_obj['target_commitish'] = params[:commitish] if params[:commitish]
+        body = body_obj.to_json
 
         repo_name = params[:repository_name]
         api_token = params[:api_token]

--- a/spec/actions_specs/set_github_release_spec.rb
+++ b/spec/actions_specs/set_github_release_spec.rb
@@ -3,7 +3,7 @@ describe Fastlane do
     describe "set_github_release" do
       it "sends and receives the right content from GitHub" do
         stub_request(:post, "https://api.github.com/repos/czechboy0/czechboy0.github.io/releases").
-        with(body: "{\"tag_name\":\"tag33\",\"target_commitish\":\"test\",\"name\":\"Awesome Release\",\"body\":\"Bunch of new things :+1:\",\"draft\":\"false\",\"prerelease\":\"false\"}",
+        with(body: "{\"tag_name\":\"tag33\",\"name\":\"Awesome Release\",\"body\":\"Bunch of new things :+1:\",\"draft\":\"false\",\"prerelease\":\"false\",\"target_commitish\":\"test\"}",
           headers: {'Authorization' => 'Basic MTIzNDVhYmNkZQ==', 'Host' => 'api.github.com:443', 'User-Agent' => 'fastlane-set_github_release'}).
         to_return(status: 201, body: File.read("./spec/fixtures/requests/github_create_release_response.json"), headers: {})
 
@@ -27,7 +27,7 @@ describe Fastlane do
 
       it "returns nil if status code != 201" do
         stub_request(:post, "https://api.github.com/repos/czechboy0/czechboy0.github.io/releases").
-        with(body: "{\"tag_name\":\"tag33\",\"target_commitish\":\"test\",\"name\":\"Awesome Release\",\"body\":\"Bunch of new things :+1:\",\"draft\":\"false\",\"prerelease\":\"false\"}",
+        with(body: "{\"tag_name\":\"tag33\",\"name\":\"Awesome Release\",\"body\":\"Bunch of new things :+1:\",\"draft\":\"false\",\"prerelease\":\"false\",\"target_commitish\":\"test\"}",
           headers: {'Authorization' => 'Basic MTIzNDVhYmNkZQ==', 'Host' => 'api.github.com:443', 'User-Agent' => 'fastlane-set_github_release'}).
         to_return(status: 422, headers: {})
 


### PR DESCRIPTION
Sorry about that, @KrauseFx. I thought I tested it back when I created it (or maybe GitHub changed behavior when an invalid commitish is provided). Anyway - it's fixed.
