### PR TITLE
Added unlock_keychain action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -230,6 +230,27 @@ create_keychain(
 )
 ```
 
+### `unlock_keychain`
+
+Unlock existing keychain and add it to the keychain search list.
+
+```ruby
+unlock_keychain(
+  path: "/path/to/KeychainName.keychain",
+  password: "mysecret"
+)
+```
+
+If the keychain file is located in the standard location `~/Library/Keychains`, then it is sufficient to provide the keychain file name, or file name with suffix.
+
+```ruby
+unlock_keychain(
+  path: "KeychainName",
+  password: "mysecret"
+)
+```
+
+
 ### `delete_keychain`
 
 Delete a keychain, can be used after creating one with `create_keychain`.

--- a/lib/fastlane/actions/unlock_keychain.rb
+++ b/lib/fastlane/actions/unlock_keychain.rb
@@ -44,15 +44,13 @@ module Fastlane
         possible_locations << "~/Library/Keychains/#{@keychain_path}"
         possible_locations << "~/Library/Keychains/#{@keychain_path}.keychain"
 
-        for location in possible_locations
+        possible_locations.each do |location|
           expaded_location = File.expand_path(location)
           if File.exist?(expaded_location)
             @keychain_path = expaded_location
             return true
           end
         end
-
-        return false
       end
 
       #####################################################
@@ -70,8 +68,8 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :path,
-                                       env_name: "FL_UNLOCK_KEYCHAIN_PATH", # The name of the environment variable
-                                       description: "Path to the Keychain file", # a short description of this parameter
+                                       env_name: "FL_UNLOCK_KEYCHAIN_PATH",
+                                       description: "Path to the Keychain file",
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :password,
                                        env_name: "FL_UNLOCK_KEYCHAIN_PASSWORD",
@@ -80,8 +78,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :add_to_search_list,
                                        env_name: "FL_UNLOCK_KEYCHAIN_ADD_TO_SEARCH_LIST",
                                        description: "Add to keychain search list",
-                                       is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: true) # the default value if the user didn't provide one
+                                       is_string: false,
+                                       default_value: true)
 
         ]
       end

--- a/lib/fastlane/actions/unlock_keychain.rb
+++ b/lib/fastlane/actions/unlock_keychain.rb
@@ -1,0 +1,98 @@
+module Fastlane
+  module Actions
+    class UnlockKeychainAction < Action
+      def self.run(params)
+        @keychain_path = params[:path]
+        add_to_search_list = params[:add_to_search_list]
+
+        if !keychainfile_exists?
+          raise "Could not find the keychain file: #{@keychain_path}".red
+        end
+
+        # add to search list if not already added
+        if add_to_search_list
+          add_keychain_to_search_list
+        end
+
+        escaped_path = @keychain_path.shellescape
+        escaped_password = params[:password].shellescape
+
+        commands = []
+        # unlock given keychain and disable lock and timeout
+        commands << Fastlane::Actions.sh("security unlock-keychain -p #{escaped_password} #{escaped_path}", log: false)
+        commands << Fastlane::Actions.sh("security set-keychain-settings #{escaped_path}", log: false)
+        commands
+      end
+
+      def self.add_keychain_to_search_list
+        escaped_path = @keychain_path.shellescape
+
+        result = Fastlane::Actions.sh("security list-keychains", log: false)
+
+        # add the keychain to the keychains list
+        # the basic strategy is to open the keychain file it with Keychain Access
+        if !result.include?(@keychain_path)
+          commands = []
+          commands << Fastlane::Actions.sh("open #{escaped_path}")
+          commands
+        end
+      end
+
+      def self.keychainfile_exists?
+        possible_locations = []
+        possible_locations << @keychain_path
+        possible_locations << "~/Library/Keychains/#{@keychain_path}"
+        possible_locations << "~/Library/Keychains/#{@keychain_path}.keychain"
+
+        for location in possible_locations
+          expaded_location = File.expand_path(location)
+          if File.exist?(expaded_location)
+            @keychain_path = expaded_location
+            return true
+          end
+        end
+
+        return false
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Unlock a keychain"
+      end
+
+      def self.details
+        "Unlocks the give keychain file and it adds it to the keychain search list."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: "FL_UNLOCK_KEYCHAIN_PATH", # The name of the environment variable
+                                       description: "Path to the Keychain file", # a short description of this parameter
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :password,
+                                       env_name: "FL_UNLOCK_KEYCHAIN_PASSWORD",
+                                       description: "Keychain password",
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :add_to_search_list,
+                                       env_name: "FL_UNLOCK_KEYCHAIN_ADD_TO_SEARCH_LIST",
+                                       description: "Add to keychain search list",
+                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       default_value: true) # the default value if the user didn't provide one
+
+        ]
+      end
+
+      def self.authors
+        ["xfreebird"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/spec/actions_specs/create_keychain_spec.rb
+++ b/spec/actions_specs/create_keychain_spec.rb
@@ -1,124 +1,20 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    describe "Create keychain Integration" do
+    describe "Unlock keychain Integration" do
 
-      it "works with name and password" do
+      it "works with path and password and existing keychain" do
+        expanded_path = File.expand_path("~/Library/Keychains/login.keychain")
+
         result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            name: 'test.keychain',
+          unlock_keychain ({
+            path: '#{expanded_path}',
             password: 'testpassword',
           })
         end").runner.execute(:test)
 
         expect(result.size).to eq 2
-        expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
-
-        expect(result[1]).to start_with 'security set-keychain-settings'
-        expect(result[1]).to include '-t 300'
-        expect(result[1]).to_not include '-l'
-        expect(result[1]).to_not include '-u'
-        expect(result[1]).to include '~/Library/Keychains/test.keychain'
-      end
-
-      it "works with name and password that contain spaces or `\"`" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            name: 'test.keychain',
-            password: '\"test password\"',
-          })
-        end").runner.execute(:test)
-
-        expect(result.size).to eq 2
-        expect(result[0]).to eq %(security create-keychain -p \\\"test\\ password\\\" test.keychain)
-      end
-
-      it "works with keychain-settings and name and password" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
-            timeout: 600,
-            lock_when_sleeps: true,
-            lock_after_timeout: true,
-          })
-        end").runner.execute(:test)
-
-        expect(result.size).to eq 2
-        expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
-
-        expect(result[1]).to start_with 'security set-keychain-settings'
-        expect(result[1]).to include '-t 600'
-        expect(result[1]).to include '-l'
-        expect(result[1]).to include '-u'
-        expect(result[1]).to include '~/Library/Keychains/test.keychain'
-      end
-
-      it "works with default_keychain and name and password" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
-            default_keychain: true,
-          })
-        end").runner.execute(:test)
-
-        expect(result.size).to eq 3
-        expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
-
-        expect(result[1]).to eq 'security default-keychain -s test.keychain'
-
-        expect(result[2]).to start_with 'security set-keychain-settings'
-        expect(result[2]).to include '-t 300'
-        expect(result[2]).to_not include '-l'
-        expect(result[2]).to_not include '-u'
-        expect(result[2]).to include '~/Library/Keychains/test.keychain'
-      end
-
-      it "works with unlock and name and password" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
-            unlock: true,
-          })
-        end").runner.execute(:test)
-
-        expect(result.size).to eq 3
-        expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
-
-        expect(result[1]).to eq 'security unlock-keychain -p testpassword test.keychain'
-
-        expect(result[2]).to start_with 'security set-keychain-settings'
-        expect(result[2]).to include '-t 300'
-        expect(result[2]).to_not include '-l'
-        expect(result[2]).to_not include '-u'
-        expect(result[2]).to include '~/Library/Keychains/test.keychain'
-      end
-
-      it "works with all params" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
-            default_keychain: true,
-            unlock: true,
-            timeout: 600,
-            lock_when_sleeps: true,
-            lock_after_timeout: true,
-          })
-        end").runner.execute(:test)
-
-        expect(result.size).to eq 4
-        expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
-
-        expect(result[1]).to eq 'security default-keychain -s test.keychain'
-        expect(result[2]).to eq 'security unlock-keychain -p testpassword test.keychain'
-
-        expect(result[3]).to start_with 'security set-keychain-settings'
-        expect(result[3]).to include '-t 600'
-        expect(result[3]).to include '-l'
-        expect(result[3]).to include '-u'
-        expect(result[3]).to include '~/Library/Keychains/test.keychain'
+        expect(result[0]).to eq "security unlock-keychain -p testpassword #{expanded_path}"
+        expect(result[1]).to eq "security set-keychain-settings #{expanded_path}"
       end
     end
   end

--- a/spec/actions_specs/unlock_keychain_spec.rb
+++ b/spec/actions_specs/unlock_keychain_spec.rb
@@ -1,0 +1,97 @@
+module Fastlane
+  module Actions
+    class UnlockKeychainAction < Action
+      def self.run(params)
+        keychain_path = self.expand_keychain_path(params[:path])
+        add_to_search_list = params[:add_to_search_list]
+
+        if keychain_path.empty?
+          raise "Could not find the keychain file: #{keychain_path}".red
+        end
+
+        # add to search list if not already added
+        if add_to_search_list
+          add_keychain_to_search_list(keychain_path)
+        end
+
+        escaped_path = keychain_path.shellescape
+        escaped_password = params[:password].shellescape
+
+        commands = []
+        # unlock given keychain and disable lock and timeout
+        commands << Fastlane::Actions.sh("security unlock-keychain -p #{escaped_password} #{escaped_path}", log: false)
+        commands << Fastlane::Actions.sh("security set-keychain-settings #{escaped_path}", log: false)
+        commands
+      end
+
+      def self.add_keychain_to_search_list(keychain_path)
+        escaped_path = keychain_path.shellescape
+
+        result = Fastlane::Actions.sh("security list-keychains", log: false)
+
+        # add the keychain to the keychains list
+        # the basic strategy is to open the keychain file with Keychain Access
+        unless result.include?(keychain_path)
+          commands = []
+          commands << Fastlane::Actions.sh("open #{escaped_path}")
+          commands
+        end
+      end
+
+      def self.expand_keychain_path(keychain_path)
+        possible_locations = []
+        possible_locations << keychain_path
+        possible_locations << "~/Library/Keychains/#{keychain_path}"
+        possible_locations << "~/Library/Keychains/#{keychain_path}.keychain"
+
+        possible_locations.each do |location|
+          expanded_location = File.expand_path(location)
+          if File.exist?(expanded_location)
+            return expanded_location
+          end
+        end
+
+        return ""
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Unlock a keychain"
+      end
+
+      def self.details
+        "Unlocks the give keychain file and adds it to the keychain search list."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: "FL_UNLOCK_KEYCHAIN_PATH",
+                                       description: "Path to the Keychain file",
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :password,
+                                       env_name: "FL_UNLOCK_KEYCHAIN_PASSWORD",
+                                       description: "Keychain password",
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :add_to_search_list,
+                                       env_name: "FL_UNLOCK_KEYCHAIN_ADD_TO_SEARCH_LIST",
+                                       description: "Add to keychain search list",
+                                       is_string: false,
+                                       default_value: true)
+
+        ]
+      end
+
+      def self.authors
+        ["xfreebird"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/spec/actions_specs/unlock_keychain_spec.rb
+++ b/spec/actions_specs/unlock_keychain_spec.rb
@@ -1,96 +1,20 @@
-module Fastlane
-  module Actions
-    class UnlockKeychainAction < Action
-      def self.run(params)
-        keychain_path = self.expand_keychain_path(params[:path])
-        add_to_search_list = params[:add_to_search_list]
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Unlock keychain Integration" do
 
-        if keychain_path.empty?
-          raise "Could not find the keychain file: #{keychain_path}".red
-        end
+      it "works with path and password and existing keychain" do
+        expanded_path = File.expand_path("~/Library/Keychains/login.keychain")
 
-        # add to search list if not already added
-        if add_to_search_list
-          add_keychain_to_search_list(keychain_path)
-        end
+        result = Fastlane::FastFile.new.parse("lane :test do
+          unlock_keychain ({
+            path: '#{expanded_path}',
+            password: 'testpassword',
+          })
+        end").runner.execute(:test)
 
-        escaped_path = keychain_path.shellescape
-        escaped_password = params[:password].shellescape
-
-        commands = []
-        # unlock given keychain and disable lock and timeout
-        commands << Fastlane::Actions.sh("security unlock-keychain -p #{escaped_password} #{escaped_path}", log: false)
-        commands << Fastlane::Actions.sh("security set-keychain-settings #{escaped_path}", log: false)
-        commands
-      end
-
-      def self.add_keychain_to_search_list(keychain_path)
-        escaped_path = keychain_path.shellescape
-
-        result = Fastlane::Actions.sh("security list-keychains", log: false)
-
-        # add the keychain to the keychains list
-        # the basic strategy is to open the keychain file with Keychain Access
-        unless result.include?(keychain_path)
-          commands = []
-          commands << Fastlane::Actions.sh("open #{escaped_path}")
-          commands
-        end
-      end
-
-      def self.expand_keychain_path(keychain_path)
-        possible_locations = []
-        possible_locations << keychain_path
-        possible_locations << "~/Library/Keychains/#{keychain_path}"
-        possible_locations << "~/Library/Keychains/#{keychain_path}.keychain"
-
-        possible_locations.each do |location|
-          expanded_location = File.expand_path(location)
-          if File.exist?(expanded_location)
-            return expanded_location
-          end
-        end
-
-        return ""
-      end
-
-      #####################################################
-      # @!group Documentation
-      #####################################################
-
-      def self.description
-        "Unlock a keychain"
-      end
-
-      def self.details
-        "Unlocks the give keychain file and adds it to the keychain search list."
-      end
-
-      def self.available_options
-        [
-          FastlaneCore::ConfigItem.new(key: :path,
-                                       env_name: "FL_UNLOCK_KEYCHAIN_PATH",
-                                       description: "Path to the Keychain file",
-                                       optional: false),
-          FastlaneCore::ConfigItem.new(key: :password,
-                                       env_name: "FL_UNLOCK_KEYCHAIN_PASSWORD",
-                                       description: "Keychain password",
-                                       optional: false),
-          FastlaneCore::ConfigItem.new(key: :add_to_search_list,
-                                       env_name: "FL_UNLOCK_KEYCHAIN_ADD_TO_SEARCH_LIST",
-                                       description: "Add to keychain search list",
-                                       is_string: false,
-                                       default_value: true)
-
-        ]
-      end
-
-      def self.authors
-        ["xfreebird"]
-      end
-
-      def self.is_supported?(platform)
-        platform == :ios
+        expect(result.size).to eq 2
+        expect(result[0]).to eq "security unlock-keychain -p testpassword #{expanded_path}"
+        expect(result[1]).to eq "security set-keychain-settings #{expanded_path}"
       end
     end
   end

--- a/spec/actions_specs/unlock_keychain_spec.rb
+++ b/spec/actions_specs/unlock_keychain_spec.rb
@@ -3,18 +3,18 @@ describe Fastlane do
     describe "Unlock keychain Integration" do
 
       it "works with path and password and existing keychain" do
-        expanded_path = File.expand_path("~/Library/Keychains/login.keychain")
+        keychain_path = Tempfile.new('foo').path
 
         result = Fastlane::FastFile.new.parse("lane :test do
           unlock_keychain ({
-            path: '#{expanded_path}',
+            path: '#{keychain_path}',
             password: 'testpassword',
           })
         end").runner.execute(:test)
 
         expect(result.size).to eq 2
-        expect(result[0]).to eq "security unlock-keychain -p testpassword #{expanded_path}"
-        expect(result[1]).to eq "security set-keychain-settings #{expanded_path}"
+        expect(result[0]).to eq "security unlock-keychain -p testpassword #{keychain_path}"
+        expect(result[1]).to eq "security set-keychain-settings #{keychain_path}"
       end
     end
   end


### PR DESCRIPTION
Added a new action unlock_keychain. It allows the user to unlock a given keychain, also it adds it to the keychain search list.

 This is useful because it doesn't require to set a specific keychain as the default one, which might make issues when some program tries to access specific items from former keychains while being locked.
