### PR TITLE
Adding dotgpg environment action

### DIFF
--- a/lib/fastlane/actions/dotgpg_environment.rb
+++ b/lib/fastlane/actions/dotgpg_environment.rb
@@ -1,0 +1,46 @@
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+    class DotgpgEnvironmentAction < Action
+      def self.run(options)
+        require 'dotgpg/environment'
+        
+        if options[:dotgpg_file]
+          dotgpg_file = options[:dotgpg_file]
+        end
+
+        raise "Dotgpg file '#{File.expand_path(dotgpg_file)}' not found".red if dotgpg_file && !File.exist?(dotgpg_file)
+
+        Helper.log.info "Reading secrets from #{dotgpg_file}"
+        Dotgpg::Environment.new(dotgpg_file).apply
+      end
+
+      def self.description
+        "Reads in production secrets set in a dotgpg file and puts them in ENV. More information at https://github.com/ConradIrwin/dotgpg"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :dotgpg_file,
+                                       env_name: "DOTGPG_FILE",
+                                       description: "Path to your DSYM file",
+                                       default_value: "dotgpg/secrets.gpg",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                          # validation is done in the action
+                                       end)
+        ]
+      end
+
+      def self.authors
+        ["simonlevy5"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include? platform
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/dotgpg_environment.rb
+++ b/lib/fastlane/actions/dotgpg_environment.rb
@@ -26,8 +26,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :dotgpg_file,
                                        env_name: "DOTGPG_FILE",
                                        description: "Path to your DSYM file",
-                                       default_value: "dotgpg/secrets.gpg",
-                                       optional: true,
+                                       default_value: Dir["dotgpg/*.gpg"].last,
+                                       optional: false,
                                        verify_block: proc do |value|
                                          # validation is done in the action
                                        end)
@@ -39,7 +39,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include? platform
+        true
       end
     end
   end

--- a/lib/fastlane/actions/dotgpg_environment.rb
+++ b/lib/fastlane/actions/dotgpg_environment.rb
@@ -18,7 +18,11 @@ module Fastlane
       end
 
       def self.description
-        "Reads in production secrets set in a dotgpg file and puts them in ENV. More information at https://github.com/ConradIrwin/dotgpg"
+        "Reads in production secrets set in a dotgpg file and puts them in ENV."
+      end
+
+      def self.details
+        "More information about dotgpg can be found at https://github.com/ConradIrwin/dotgpg"
       end
 
       def self.available_options

--- a/lib/fastlane/actions/dotgpg_environment.rb
+++ b/lib/fastlane/actions/dotgpg_environment.rb
@@ -6,7 +6,7 @@ module Fastlane
     class DotgpgEnvironmentAction < Action
       def self.run(options)
         require 'dotgpg/environment'
-        
+
         if options[:dotgpg_file]
           dotgpg_file = options[:dotgpg_file]
         end
@@ -29,7 +29,7 @@ module Fastlane
                                        default_value: "dotgpg/secrets.gpg",
                                        optional: true,
                                        verify_block: proc do |value|
-                                          # validation is done in the action
+                                         # validation is done in the action
                                        end)
         ]
       end


### PR DESCRIPTION
Action to support loading dotgpg encrypted variables into the ruby ENV.
This has two gem dependencies: ‘dotgpg’ and ‘dotgpg-environment’
