### PR TITLE
import_from_git to a unique location

### DIFF
--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -206,7 +206,7 @@ module Fastlane
         # Checkout the repo
         repo_name = url.split("/").last
 
-        clone_folder = File.join("/tmp", "fl_clones_#{Time.now.to_i}", repo_name)
+        clone_folder = File.join("/tmp", "fl_clones_#{Time.now.to_f}", repo_name)
 
         branch_option = ""
         branch_option = "--branch #{branch}" if branch != 'HEAD'

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -206,18 +206,12 @@ module Fastlane
         # Checkout the repo
         repo_name = url.split("/").last
 
-        clone_folder = File.join("/tmp", "fl_clones", repo_name)
+        clone_folder = File.join("/tmp", "fl_clones_#{Time.now.to_i}", repo_name)
 
         branch_option = ""
         branch_option = "--branch #{branch}" if branch != 'HEAD'
 
         clone_command = "git clone '#{url}' '#{clone_folder}' --depth 1 -n #{branch_option}"
-
-        if Dir.exist? clone_folder
-          # We want to re-clone if the folder already exists
-          Helper.log.info "Deleting existing git repo..."
-          Actions.sh("rm -rf '#{clone_folder}'")
-        end
 
         Helper.log.info "Cloning remote git repo..."
         Actions.sh(clone_command)


### PR DESCRIPTION
import_from_git to a unique location to avoid path collisions when cloning the same url from several fastlane instances at the same time.  #608

The failing unit tests are inherited from the original branch, and are not related to this PR.
