### PR TITLE
Fixing notify_room for V1 api

### DIFF
--- a/lib/fastlane/actions/hipchat.rb
+++ b/lib/fastlane/actions/hipchat.rb
@@ -26,6 +26,8 @@ module Fastlane
         end
 
         if api_version.to_i == 1
+          ## v1 api requires 1|0
+          notify_room = (options[:notify_room] ? 1 : 0)
           ########## running on V1 ##########
           if user?(channel)
             raise 'HipChat private message not working with API V1 please use API V2 instead'.red


### PR DESCRIPTION
The HipChat v1 API expects a `1` or `0` value for the `notify` parameter. I'm simply overwriting the variable for v1 API users.
