### PR TITLE
Allow only to upload dSYM to HockeyApp

### DIFF
--- a/lib/fastlane/actions/hockey.rb
+++ b/lib/fastlane/actions/hockey.rb
@@ -42,7 +42,7 @@ module Fastlane
 
         ipa_filename = options[:ipa]
         ipa_filename = nil if options[:upload_dsym_only]
-        
+
         response = client.upload_build(ipa_filename, values)
         case response.status
         when 200...300

--- a/lib/fastlane/actions/hockey.rb
+++ b/lib/fastlane/actions/hockey.rb
@@ -40,7 +40,10 @@ module Fastlane
 
         return values if Helper.test?
 
-        response = client.upload_build(options[:ipa], values)
+        ipa_filename = options[:ipa]
+        ipa_filename = nil if options[:upload_dsym_only]
+        
+        response = client.upload_build(ipa_filename, values)
         case response.status
         when 200...300
           url = response.body['public_url']
@@ -133,7 +136,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :build_server_url,
                                       env_name: "FL_HOCKEY_BUILD_SERVER_URL",
                                       description: "The URL of the build job on your build server",
-                                      optional: true)
+                                      optional: true),
+          FastlaneCore::ConfigItem.new(key: :upload_dsym_only,
+                                      env_name: "FL_HOCKEY_UPLOAD_DSYM_ONLY",
+                                      description: "Flag to upload only the dSYM file to hockey app",
+                                      is_string: false,
+                                      optional: true,
+                                      default_value: false)
         ]
       end
 

--- a/spec/actions_specs/hockey_spec.rb
+++ b/spec/actions_specs/hockey_spec.rb
@@ -59,6 +59,7 @@ describe Fastlane do
         expect(values[:teams]).to eq(nil)
         expect(values[:mandatory]).to eq(0.to_s)
         expect(values[:notes_type]).to eq(1.to_s)
+        expect(values[:upload_dsym_only]).to eq(false)
       end
 
       it "has the correct default notes_type value" do


### PR DESCRIPTION
PR for issue #613

With the simple option 'upload_dsym_only' set to 'true',
users can make the hockey action only upload the dSYM file.

The option is defaulted to 'false'.
