### PR TITLE
iphone simulator timeout fix

### DIFF
--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -17,7 +17,7 @@ module Fastlane
         clean: "clean",
         install: "install",
         installsrc: "installsrc",
-        test: "test",
+        test: "build test",
 
         # parameters
         alltargets: "-alltargets",

--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -17,7 +17,7 @@ module Fastlane
         clean: "clean",
         install: "install",
         installsrc: "installsrc",
-        test: "build test",
+        test: "test",
 
         # parameters
         alltargets: "-alltargets",
@@ -408,6 +408,7 @@ module Fastlane
     class XctestAction < Action
       def self.run(params)
         params_hash = params || {}
+        params_hash[:build] = true
         params_hash[:test] = true
         XcodebuildAction.run(params_hash)
       end

--- a/spec/actions_specs/xcodebuild_spec.rb
+++ b/spec/actions_specs/xcodebuild_spec.rb
@@ -299,7 +299,7 @@ describe Fastlane do
     end
 
     describe "xctest" do
-      it "is equivalent to 'xcodebuild test'" do
+      it "is equivalent to 'xcodebuild build test'" do
         result = Fastlane::FastFile.new.parse("lane :test do
           xctest(
             destination: 'name=iPhone 5s,OS=8.1',
@@ -316,6 +316,7 @@ describe Fastlane do
           + "-destination-timeout \"240\" " \
           + "-scheme \"MyApp\" " \
           + "-workspace \"MyApp.xcworkspace\" " \
+          + "build " \
           + "test " \
           + "| xcpretty --color --test"
         )
@@ -340,6 +341,7 @@ describe Fastlane do
           + "-destination \"name=iPhone 5s,OS=8.1\" " \
           + "-scheme \"MyApp\" " \
           + "-workspace \"MyApp.xcworkspace\" " \
+          + "build " \
           + "test " \
           + "| xcpretty --color " \
           + "--report junit " \
@@ -367,6 +369,7 @@ describe Fastlane do
           + "-destination \"name=iPhone 5s,OS=8.1\" " \
           + "-scheme \"MyApp\" " \
           + "-workspace \"MyApp.xcworkspace\" " \
+          + "build " \
           + "test " \
           + "| xcpretty --color " \
           + "--report html " \
@@ -394,6 +397,7 @@ describe Fastlane do
           + "-destination \"name=iPhone 5s,OS=8.1\" " \
           + "-scheme \"MyApp\" " \
           + "-workspace \"MyApp.xcworkspace\" " \
+          + "build " \
           + "test " \
           + "| xcpretty --color " \
           + "--report html " \
@@ -427,6 +431,7 @@ describe Fastlane do
           + "-destination \"name=iPhone 5s,OS=8.1\" " \
           + "-scheme \"MyApp\" " \
           + "-workspace \"MyApp.xcworkspace\" " \
+          + "build " \
           + "test " \
           + "| xcpretty --color " \
           + "--report html " \
@@ -461,6 +466,7 @@ describe Fastlane do
           + "-destination \"name=iPhone 5s,OS=8.1\" " \
           + "-scheme \"MyApp\" " \
           + "-workspace \"MyApp.xcworkspace\" " \
+          + "build " \
           + "test " \
           + "| xcpretty --color " \
           + "--report html " \


### PR DESCRIPTION
Fixes a bug in Xcode when the iPhone simulator times our after 120 seconds.

`xcodebuild[54591:624937]  iPhoneSimulator: Timed out waiting 120 seconds for simulator to boot, current state is 1.`

Changing `xcodebuild test` to `xcodebuild build test` fixes the issue. In that case the build time is not calculated into the boot time.

Related radar link: https://openradar.appspot.com/22413115
Repository to reproduce: https://github.com/bitrise-io/simulator-launch-timeout-includes-build-time
