### PR TITLE
Add no-build option to Carthage

### DIFF
--- a/lib/fastlane/actions/carthage.rb
+++ b/lib/fastlane/actions/carthage.rb
@@ -7,6 +7,7 @@ module Fastlane
         cmd << "--use-ssh" if params[:use_ssh]
         cmd << "--use-submodules" if params[:use_submodules]
         cmd << "--no-use-binaries" if params[:use_binaries] == false
+        cmd << "--no-build" if params[:no_build] == true
         cmd << "--platform #{params[:platform]}" if params[:platform]
 
         Actions.sh(cmd.join(' '))
@@ -42,6 +43,14 @@ module Fastlane
                                        verify_block: proc do |value|
                                          raise "Please pass a valid value for use_binaries. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
                                        end),
+          FastlaneCore::ConfigItem.new(key: :no_build,
+                                       env_name: "FL_CARTHAGE_NO_BUILD",
+                                       description: "When bootstrapping Carthage do not build",
+                                       is_string: false,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         raise "Please pass a valid value for no_build. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                       end),          
           FastlaneCore::ConfigItem.new(key: :platform,
                                        env_name: "FL_CARTHAGE_PLATFORM",
                                        description: "Define which platform to build for",

--- a/spec/actions_specs/carthage_spec.rb
+++ b/spec/actions_specs/carthage_spec.rb
@@ -31,6 +31,16 @@ describe Fastlane do
         end.to raise_error("Please pass a valid value for use_binaries. Use one of the following: true, false")
       end
 
+      it "raises an error if no_build is invalid" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_build: 'thisistest'
+            )
+          end").runner.execute(:test)
+        end.to raise_error("Please pass a valid value for no_build. Use one of the following: true, false")
+      end
+
       it "raises an error if platform is invalid" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
@@ -103,6 +113,26 @@ describe Fastlane do
         result = Fastlane::FastFile.new.parse("lane :test do
             carthage(
               use_binaries: true
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap")
+      end
+
+      it "adds no-build flag to command if no_build is set to true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_build: true
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap --no-build")
+      end
+
+      it "does not add a no-build flag to command if no_build is set to false" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_build: false
             )
           end").runner.execute(:test)
 


### PR DESCRIPTION
Adds the ability to prevent Carthage from building. i.e.

```
carthage(
  use_ssh: false,         # Use SSH for downloading GitHub repositories.
  use_submodules: false,  # Add dependencies as Git submodules.
  use_binaries: true,     # Check out dependency repositories even when prebuilt
  no_build: true,         # Do not build the dependency repositories
  platform: "all"         # Define which platform to build for
)
```

In some situations (i.e. third party frameworks and Bitcode) you sometimes find you must prevent Carthage from building the frameworks, such that you can bring them into your Xcode project by hand. Note "Adding frameworks to unit tests or a framework" on Carthage's README.
