### PR TITLE
Add xcpretty_output option to use --simple or --test for xcpretty

### DIFF
--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -203,9 +203,9 @@ module Fastlane
 
         # Stdout format
         if testing && !archiving
-          xcpretty_args.push "--test"
+          xcpretty_args << (params[:xcpretty_output] ? "--#{params[:xcpretty_output]}" : "--test")
         else
-          xcpretty_args.push "--simple"
+          xcpretty_args << (params[:xcpretty_output] ? "--#{params[:xcpretty_output]}" : "--simple")
         end
 
         xcpretty_args = xcpretty_args.join(" ")
@@ -301,7 +301,8 @@ module Fastlane
           ['build_settings', 'Hash of additional build information'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
-          ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false']
+          ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
+          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\'']
         ]
       end
 
@@ -341,7 +342,8 @@ module Fastlane
           ['build_settings', 'Hash of additional build information'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
-          ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false']
+          ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
+          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\'']
         ]
       end
     end
@@ -374,7 +376,8 @@ module Fastlane
           ['build_settings', 'Hash of additional build information'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
-          ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false']
+          ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
+          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\'']
         ]
       end
     end
@@ -407,7 +410,8 @@ module Fastlane
           ['build_settings', 'Hash of additional build information'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
-          ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false']
+          ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
+          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\'']
         ]
       end
     end
@@ -436,7 +440,8 @@ module Fastlane
           ['build_settings', 'Hash of additional build information'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
-          ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false']
+          ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
+          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\'']
         ]
       end
 
@@ -469,7 +474,8 @@ module Fastlane
           ['destination_timeout', 'The timeout for connecting to the simulator, in seconds'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
-          ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false']
+          ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
+          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\'']
         ]
       end
 

--- a/spec/actions_specs/xcodebuild_spec.rb
+++ b/spec/actions_specs/xcodebuild_spec.rb
@@ -42,7 +42,8 @@ describe Fastlane do
             workspace: 'MyApp.xcworkspace',
             xcconfig: 'my.xcconfig',
             buildlog_path: 'mypath',
-            raw_buildlog: false
+            raw_buildlog: false,
+            xcpretty_output: 'test'
           )
         end").runner.execute(:test)
 
@@ -79,7 +80,7 @@ describe Fastlane do
           + "install " \
           + "installsrc " \
           + "test " \
-          + "| tee 'mypath/xcodebuild.log' | xcpretty --color --simple"
+          + "| tee 'mypath/xcodebuild.log' | xcpretty --color --test"
         )
       end
 
@@ -90,7 +91,7 @@ describe Fastlane do
             'name=iPhone 5s,OS=8.1',
             'name=iPhone 4,OS=7.1',
           ],
-          destination_timeout: 240,
+          destination_timeout: 240
         )
       end").runner.execute(:test)
 


### PR DESCRIPTION
Added a xcpretty_output option for XCBuild to allow an end user to choose between rspec style dots, or the simple style with more information. Uses xcpretty's --test and --simple options
