### PR TITLE
Add pod_push_trunk action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1348,6 +1348,18 @@ This will find the first podspec in the folder. You can also pass in the specifi
 spec = read_podspec(path: "./XcodeServerSDK.podspec")
 ```
 
+### pod_push_trunk
+
+Push a Podspec to trunk
+
+```ruby
+# If no path is supplied then Trunk will attempt to find the first Podspec in the current directory.
+pod_push_trunk
+
+# Alternatively, supply the Podspec file path
+pod_push_trunk(path: 'TSMessages.podspec')
+```
+
 ### prompt
 
 You can use `prompt` to ask the user for a value or to just let the user confirm the next step.

--- a/lib/fastlane/actions/pod_push_trunk.rb
+++ b/lib/fastlane/actions/pod_push_trunk.rb
@@ -8,7 +8,7 @@ module Fastlane
         end
 
         result = Actions.sh("#{command}")
-        Helper.log.info "Successfully pushed Podspec".green
+        Helper.log.info "Successfully pushed Podspec ⬆️ ".green
         return result
       end
 
@@ -31,6 +31,7 @@ module Fastlane
                                        optional: true,
                                        verify_block: proc do |value|
                                          raise "Couldn't find file at path '#{value}'".red unless File.exist?(value)
+                                         raise "File must be a `.podspec`".red unless value.end_with?(".podspec")
                                        end)
         ]
       end

--- a/lib/fastlane/actions/pod_push_trunk.rb
+++ b/lib/fastlane/actions/pod_push_trunk.rb
@@ -1,0 +1,54 @@
+module Fastlane
+  module Actions
+    class PodPushTrunkAction < Action
+      def self.run(params)
+        command = 'pod trunk push'
+        if params[:path]
+          command << " '#{params[:path]}'"
+        end
+
+        result = Actions.sh("#{command}")
+        Helper.log.info "Successfully pushed Podspec".green
+        return result
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Push a Podspec to Trunk"
+      end
+
+      def self.details
+        ""
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       description: "The Podspec you want to push",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         raise "Couldn't find file at path '#{value}'".red unless File.exist?(value)
+                                       end)
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.authors
+        ["squarefrog"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/spec/actions_specs/pod_push_trunk_spec.rb
+++ b/spec/actions_specs/pod_push_trunk_spec.rb
@@ -11,10 +11,10 @@ describe Fastlane do
 
       it "generates the correct pod push command with an argument" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          pod_push_trunk(path: './fastlane/README.md')
+          pod_push_trunk(path: './fastlane/spec/fixtures/podspecs/test.podspec')
         end").runner.execute(:test)
 
-        expect(result).to eq("pod trunk push './fastlane/README.md'")
+        expect(result).to eq("pod trunk push './fastlane/spec/fixtures/podspecs/test.podspec'")
       end
     end
   end

--- a/spec/actions_specs/pod_push_trunk_spec.rb
+++ b/spec/actions_specs/pod_push_trunk_spec.rb
@@ -1,0 +1,21 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Pod Push Trunk" do
+      it "generates the correct pod push command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_push_trunk
+        end").runner.execute(:test)
+
+        expect(result).to eq("pod trunk push")
+      end
+
+      it "generates the correct pod push command with an argument" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_push_trunk(path: './fastlane/README.md')
+        end").runner.execute(:test)
+
+        expect(result).to eq("pod trunk push './fastlane/README.md'")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This action allows you to push a Podspec to trunk.

Supplying a `path` argument passes the path to `pod trunk`

For example:

``` ruby
# runs pod trunk push
pod_push_trunk

#runs pod trunk push 'Example/Example.podspec'
pod_push_trunk(path: 'Example/Example.podspec')
```
# 

I'm not entirely happy with the `available_options` and spec here. I feel it would make more sense to check if the path:
1. Matches `/.podspec$/`
2. File exists

As a result the current spec for pushing with an argument looks for an irrelevant file. I'd appreciate some help fixing this spec if possible!
