### PR TITLE
Add created keychain to search list in create_keychain action

### DIFF
--- a/lib/fastlane/actions/create_keychain.rb
+++ b/lib/fastlane/actions/create_keychain.rb
@@ -33,7 +33,6 @@ module Fastlane
           keychains = []
           keychains += Fastlane::Actions.sh("security list-keychains -d user", log: false).shellsplit unless Helper.test?
           keychains << File.expand_path(params[:name], "~/Library/Keychains")
-          keychains.uniq!
           commands << Fastlane::Actions.sh("security list-keychains -s #{keychains.shelljoin}", log: false)
         end
 

--- a/lib/fastlane/actions/create_keychain.rb
+++ b/lib/fastlane/actions/create_keychain.rb
@@ -28,6 +28,15 @@ module Fastlane
         command << " ~/Library/Keychains/#{escaped_name}"
 
         commands << Fastlane::Actions.sh(command, log: false)
+
+        if params[:add_to_search_list]
+          keychains = []
+          keychains << Fastlane::Actions.sh("security list-keychains -d user", log: false).shellsplit unless Helper.test?
+          keychains << File.expand_path(params[:name], "~/Library/Keychains")
+          keychains.uniq!
+          commands << Fastlane::Actions.sh("security list-keychains -s #{keychains.shelljoin}", log: false)
+        end
+
         commands
       end
 
@@ -64,7 +73,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :lock_after_timeout,
                                        description: 'Lock keychain after timeout interval',
                                        is_string: false,
-                                       default_value: false)
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :add_to_search_list,
+                                       description: 'Add keychain to search list',
+                                       is_string: false,
+                                       default_value: true)
         ]
       end
 

--- a/lib/fastlane/actions/create_keychain.rb
+++ b/lib/fastlane/actions/create_keychain.rb
@@ -30,8 +30,7 @@ module Fastlane
         commands << Fastlane::Actions.sh(command, log: false)
 
         if params[:add_to_search_list]
-          keychains = `security list-keychains -d user`.shellsplit
-          raise "Retrieving the keychain search list failed with exit status #{$?.exitstatus} instead of 0" unless $?.exitstatus.zero?
+          keychains = Action.sh("security list-keychains -d user").shellsplit
           keychains << File.expand_path(params[:name], "~/Library/Keychains")
           commands << Fastlane::Actions.sh("security list-keychains -s #{keychains.shelljoin}", log: false)
         end

--- a/lib/fastlane/actions/create_keychain.rb
+++ b/lib/fastlane/actions/create_keychain.rb
@@ -31,7 +31,7 @@ module Fastlane
 
         if params[:add_to_search_list]
           keychains = []
-          keychains << Fastlane::Actions.sh("security list-keychains -d user", log: false).shellsplit unless Helper.test?
+          keychains += Fastlane::Actions.sh("security list-keychains -d user", log: false).shellsplit unless Helper.test?
           keychains << File.expand_path(params[:name], "~/Library/Keychains")
           keychains.uniq!
           commands << Fastlane::Actions.sh("security list-keychains -s #{keychains.shelljoin}", log: false)

--- a/lib/fastlane/actions/create_keychain.rb
+++ b/lib/fastlane/actions/create_keychain.rb
@@ -30,8 +30,8 @@ module Fastlane
         commands << Fastlane::Actions.sh(command, log: false)
 
         if params[:add_to_search_list]
-          keychains = []
-          keychains += Fastlane::Actions.sh("security list-keychains -d user", log: false).shellsplit unless Helper.test?
+          keychains = `security list-keychains -d user`.shellsplit
+          raise "Retrieving the keychain search list failed with exit status #{$?.exitstatus} instead of 0" unless $?.exitstatus.zero?
           keychains << File.expand_path(params[:name], "~/Library/Keychains")
           commands << Fastlane::Actions.sh("security list-keychains -s #{keychains.shelljoin}", log: false)
         end

--- a/spec/actions_specs/create_keychain_spec.rb
+++ b/spec/actions_specs/create_keychain_spec.rb
@@ -17,7 +17,8 @@ describe Fastlane do
         expect(result[1]).to_not include '-l'
         expect(result[1]).to_not include '-u'
         expect(result[1]).to include '~/Library/Keychains/test.keychain'
-        expect(result[2]).to eq "security list-keychains -s #{File.expand_path('~/Library/Keychains/test.keychain')}"
+        expect(result[2]).to start_with "security list-keychains -s"
+        expect(result[2]).to end_with "#{File.expand_path('~/Library/Keychains/test.keychain')}"
       end
 
       it "works with name and password that contain spaces or `\"`" do

--- a/spec/actions_specs/create_keychain_spec.rb
+++ b/spec/actions_specs/create_keychain_spec.rb
@@ -9,7 +9,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq 2
+        expect(result.size).to eq 3
         expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
 
         expect(result[1]).to start_with 'security set-keychain-settings'
@@ -17,6 +17,7 @@ describe Fastlane do
         expect(result[1]).to_not include '-l'
         expect(result[1]).to_not include '-u'
         expect(result[1]).to include '~/Library/Keychains/test.keychain'
+        expect(result[2]).to eq "security list-keychains -s #{File.expand_path('~/Library/Keychains/test.keychain')}"
       end
 
       it "works with name and password that contain spaces or `\"`" do
@@ -27,7 +28,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq 2
+        expect(result.size).to eq 3
         expect(result[0]).to eq %(security create-keychain -p \\\"test\\ password\\\" test.keychain)
       end
 
@@ -42,7 +43,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq 2
+        expect(result.size).to eq 3
         expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
 
         expect(result[1]).to start_with 'security set-keychain-settings'
@@ -61,7 +62,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq 3
+        expect(result.size).to eq 4
         expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
 
         expect(result[1]).to eq 'security default-keychain -s test.keychain'
@@ -82,7 +83,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result.size).to eq 3
+        expect(result.size).to eq 4
         expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
 
         expect(result[1]).to eq 'security unlock-keychain -p testpassword test.keychain'
@@ -104,6 +105,7 @@ describe Fastlane do
             timeout: 600,
             lock_when_sleeps: true,
             lock_after_timeout: true,
+            add_to_search_list: false,
           })
         end").runner.execute(:test)
 


### PR DESCRIPTION
New keychains need to be added to the search list if you want `codesign` to find the identities they contain. I don't know any reason not to add the new keychain to the search list, so I think this should be done by default.
