### PR TITLE
improve pod push action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1352,13 +1352,13 @@ Push a Podspec to Trunk or a private repository
 
 ```ruby
 # If no path is supplied then Trunk will attempt to find the first Podspec in the current directory.
-pod_push_trunk
+pod_trunk
 
 # Alternatively, supply the Podspec file path
-pod_push_trunk(path: 'TSMessages.podspec')
+pod_trunk(path: 'TSMessages.podspec')
 
 # You may also push to a private repo instead of Trunk
-pod_push_trunk(path: 'TSMessages.podspec', :repo: 'MyRepo')
+pod_trunk(path: 'TSMessages.podspec', :repo: 'MyRepo')
 ```
 
 ### prompt

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1358,7 +1358,7 @@ pod_trunk
 pod_trunk(path: 'TSMessages.podspec')
 
 # You may also push to a private repo instead of Trunk
-pod_trunk(path: 'TSMessages.podspec', :repo: 'MyRepo')
+pod_trunk(path: 'TSMessages.podspec', repo: 'MyRepo')
 ```
 
 ### prompt

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1356,6 +1356,9 @@ pod_push_trunk
 
 # Alternatively, supply the Podspec file path
 pod_push_trunk(path: 'TSMessages.podspec')
+
+# You may also push to a private repo instead of Trunk
+pod_push_trunk(path: 'TSMessages.podspec', :repo: 'MyRepo')
 ```
 
 ### prompt

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1346,9 +1346,9 @@ This will find the first podspec in the folder. You can also pass in the specifi
 spec = read_podspec(path: "./XcodeServerSDK.podspec")
 ```
 
-### pod_push_trunk
+### pod_push
 
-Push a Podspec to trunk
+Push a Podspec to Trunk or a private repository
 
 ```ruby
 # If no path is supplied then Trunk will attempt to find the first Podspec in the current directory.

--- a/lib/fastlane/actions/pod_push.rb
+++ b/lib/fastlane/actions/pod_push.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Actions
-    class PodPushTrunkAction < Action
+    class PodPushAction < Action
       def self.run(params)
         if params[:repo]
           repo = params[:repo]

--- a/lib/fastlane/actions/pod_push.rb
+++ b/lib/fastlane/actions/pod_push.rb
@@ -39,7 +39,6 @@ module Fastlane
                                          raise "Couldn't find file at path '#{value}'".red unless File.exist?(value)
                                          raise "File must be a `.podspec`".red unless value.end_with?(".podspec")
                                        end),
-
           FastlaneCore::ConfigItem.new(key: :repo,
                                        description: "The repo you want to push. Pushes to Trunk by default",
                                        optional: true)

--- a/lib/fastlane/actions/pod_push_trunk.rb
+++ b/lib/fastlane/actions/pod_push_trunk.rb
@@ -2,7 +2,13 @@ module Fastlane
   module Actions
     class PodPushTrunkAction < Action
       def self.run(params)
-        command = 'pod trunk push'
+        if params[:repo]
+          repo = params[:repo]
+          command = "pod repo push #{repo}"
+        else
+          command = 'pod trunk push'
+        end
+
         if params[:path]
           command << " '#{params[:path]}'"
         end
@@ -17,7 +23,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Push a Podspec to Trunk"
+        "Push a Podspec to Trunk or a private repository"
       end
 
       def self.details
@@ -32,7 +38,11 @@ module Fastlane
                                        verify_block: proc do |value|
                                          raise "Couldn't find file at path '#{value}'".red unless File.exist?(value)
                                          raise "File must be a `.podspec`".red unless value.end_with?(".podspec")
-                                       end)
+                                       end),
+
+          FastlaneCore::ConfigItem.new(key: :repo,
+                                       description: "The repo you want to push. Pushes to Trunk by default",
+                                       optional: true)
         ]
       end
 

--- a/spec/actions_specs/pod_push_spec.rb
+++ b/spec/actions_specs/pod_push_spec.rb
@@ -1,25 +1,25 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    describe "Pod Push Trunk" do
-      it "generates the correct pod push command" do
+    describe "Pod Push action" do
+      it "generates the correct pod push command with no parameters" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          pod_push_trunk
+          pod_push
         end").runner.execute(:test)
 
         expect(result).to eq("pod trunk push")
       end
 
-      it "generates the correct pod push command with an argument" do
+      it "generates the correct pod push command with a path parameter" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          pod_push_trunk(path: './fastlane/spec/fixtures/podspecs/test.podspec')
+          pod_push(path: './fastlane/spec/fixtures/podspecs/test.podspec')
         end").runner.execute(:test)
 
         expect(result).to eq("pod trunk push './fastlane/spec/fixtures/podspecs/test.podspec'")
       end
 
-      it "generates the correct pod push command with a repo argument" do
+      it "generates the correct pod push command with a repo parameter" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          pod_push_trunk(path: './fastlane/spec/fixtures/podspecs/test.podspec', repo: 'MyRepo')
+          pod_push(path: './fastlane/spec/fixtures/podspecs/test.podspec', repo: 'MyRepo')
         end").runner.execute(:test)
 
         expect(result).to eq("pod repo push MyRepo './fastlane/spec/fixtures/podspecs/test.podspec'")

--- a/spec/actions_specs/pod_push_trunk_spec.rb
+++ b/spec/actions_specs/pod_push_trunk_spec.rb
@@ -16,6 +16,14 @@ describe Fastlane do
 
         expect(result).to eq("pod trunk push './fastlane/spec/fixtures/podspecs/test.podspec'")
       end
+
+      it "generates the correct pod push command with a repo argument" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_push_trunk(path: './fastlane/spec/fixtures/podspecs/test.podspec', repo: 'MyRepo')
+        end").runner.execute(:test)
+
+        expect(result).to eq("pod repo push MyRepo './fastlane/spec/fixtures/podspecs/test.podspec'")
+      end
     end
   end
 end


### PR DESCRIPTION
**Please read before merging!**

The first commit adds the ability to push to a private repository instead of Trunk, as discussed in https://github.com/KrauseFx/fastlane/pull/663.

The second, _potentially breaking commit_, renames the action from `pod_push_trunk` to `pod_push`. I feel this is better semantics, as it more accurately describes the action.

The third commit is because I'm an idiot and forgot to update the documentation fully :sob: 

Have a think if you're happy for the action to be renamed, if not, then cherry pick the first commit :+1: 
