### PR TITLE
[FastFile] add optional path parameter to #parse method

### DIFF
--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -27,7 +27,7 @@ module Fastlane
       parse(content, @path)
     end
 
-    def get_binding
+    def parsing_binding
       binding
     end
 
@@ -46,9 +46,9 @@ module Fastlane
 
           # rubocop:disable Lint/Eval
           if path.nil?
-            eval(data, get_binding) # this is okay in this case
+            eval(data, parsing_binding) # this is okay in this case
           else
-            eval(data, get_binding, relative_path) # this is okay in this case
+            eval(data, parsing_binding, relative_path) # this is okay in this case
           end
           # rubocop:enable Lint/Eval
         rescue SyntaxError => ex

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -24,19 +24,38 @@ module Fastlane
                     'you should turn off smart quotes in your editor of choice.'.red
       end
 
-      parse(content)
+      parse(content, @path)
     end
 
-    def parse(data)
+    def get_binding
+      binding
+    end
+
+    def parse(data, path = nil)
       @runner ||= Runner.new
 
       Dir.chdir(Fastlane::FastlaneFolder.path || Dir.pwd) do # context: fastlane subfolder
+        # create nice path that we want to print in case of some problem
+        relative_path = path.nil? ? nil : Pathname.new(path).relative_path_from(Pathname.new(Dir.pwd)).to_s
+
         begin
+          # We have to use #get_binding method, because some test files defines method called `path` (for example SwitcherFastfile)
+          # and local variable has higher priority, so it causes to remove content of original Fastfile for example. With #get_binding
+          # is this always clear and safe to declare any local variables we want, because the eval function uses the instance scope
+          # instead of local.
+
           # rubocop:disable Lint/Eval
-          eval(data) # this is okay in this case
+          if path.nil?
+            eval(data, get_binding) # this is okay in this case
+          else
+            eval(data, get_binding, relative_path) # this is okay in this case
+          end
           # rubocop:enable Lint/Eval
         rescue SyntaxError => ex
-          line = ex.to_s.match(/\(eval\):(\d+)/)[1]
+          match = ex.to_s.match(/#{Regexp.escape(relative_path)}:(\d+)/) unless relative_path.nil?
+          match ||= ex.to_s.match(/\(eval\):(\d+)/)
+
+          line = match[1]
           raise "Syntax error in your Fastfile on line #{line}: #{ex}".red
         end
       end
@@ -190,7 +209,7 @@ module Fastlane
       raise "Could not find Fastfile at path '#{path}'".red unless File.exist?(path)
 
       collector.did_launch_action(:import)
-      parse(File.read(path))
+      parse(File.read(path), path)
 
       # Check if we can also import local actions which are in the same directory as the Fastfile
       actions_path = File.join(File.expand_path("..", path), 'actions')

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -36,7 +36,7 @@ module Fastlane
 
       Dir.chdir(Fastlane::FastlaneFolder.path || Dir.pwd) do # context: fastlane subfolder
         # create nice path that we want to print in case of some problem
-        relative_path = path.nil? ? nil : Pathname.new(path).relative_path_from(Pathname.new(Dir.pwd)).to_s
+        relative_path = path.nil? ? '(eval)' : Pathname.new(path).relative_path_from(Pathname.new(Dir.pwd)).to_s
 
         begin
           # We have to use #get_binding method, because some test files defines method called `path` (for example SwitcherFastfile)
@@ -45,17 +45,10 @@ module Fastlane
           # instead of local.
 
           # rubocop:disable Lint/Eval
-          if path.nil?
-            eval(data, parsing_binding) # this is okay in this case
-          else
-            eval(data, parsing_binding, relative_path) # this is okay in this case
-          end
+          eval(data, parsing_binding, relative_path) # using eval is ok for this case
           # rubocop:enable Lint/Eval
         rescue SyntaxError => ex
-          match = ex.to_s.match(/#{Regexp.escape(relative_path)}:(\d+)/) unless relative_path.nil?
-          match ||= ex.to_s.match(/\(eval\):(\d+)/)
-
-          line = match[1]
+          line = ex.to_s.match(/#{Regexp.escape(relative_path)}:(\d+)/)[1]
           raise "Syntax error in your Fastfile on line #{line}: #{ex}".red
         end
       end

--- a/spec/fast_file_spec.rb
+++ b/spec/fast_file_spec.rb
@@ -246,7 +246,7 @@ describe Fastlane do
       it "properly shows an error message when there is a syntax error in the Fastfile" do
         expect do
           ff = Fastlane::FastFile.new('./spec/fixtures/fastfiles/FastfileSytnaxError')
-        end.to raise_error("Syntax error in your Fastfile on line 17: (eval):17: syntax error, unexpected keyword_end, expecting ')'".red)
+        end.to raise_error("Syntax error in your Fastfile on line 17: spec/fixtures/fastfiles/FastfileSytnaxError:17: syntax error, unexpected keyword_end, expecting ')'".red)
       end
 
       it "raises an error if lane is not available" do

--- a/spec/fast_file_spec.rb
+++ b/spec/fast_file_spec.rb
@@ -249,6 +249,23 @@ describe Fastlane do
         end.to raise_error("Syntax error in your Fastfile on line 17: spec/fixtures/fastfiles/FastfileSytnaxError:17: syntax error, unexpected keyword_end, expecting ')'".red)
       end
 
+      it "properly shows an error message when there is a syntax error in the Fastfile from string" do
+        expect do
+          ff = Fastlane::FastFile.new.parse("lane :test do
+            cases = [:abc,
+          end")
+        end.to raise_error("Syntax error in your Fastfile on line 3: (eval):3: syntax error, unexpected keyword_end, expecting ']'
+          end
+             ^".red)
+      end
+
+      it "properly shows an error message when there is a syntax error in the imported Fastfile" do
+        ff = Fastlane::FastFile.new('./spec/fixtures/fastfiles/Fastfile')
+        expect do
+          ff.import('./FastfileSytnaxError')
+        end.to raise_error("Syntax error in your Fastfile on line 17: spec/fixtures/fastfiles/FastfileSytnaxError:17: syntax error, unexpected keyword_end, expecting ')'".red)
+      end
+
       it "raises an error if lane is not available" do
         ff = Fastlane::FastFile.new('./spec/fixtures/fastfiles/Fastfile1')
         expect do


### PR DESCRIPTION
# parse method now has optional parameter path to parsing file, this is helpful when printing backtrace to console.

I also found problem with binding, some testing FastFile uses this new variable (actually there was method with same name,
but local variable has higher priority in this case) and causes to rewrite whole file.
So I add method #get_binding to resolve this issue.
