### PR TITLE
Fixing formatting issues on the Actions Docs

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -788,6 +788,7 @@ update_info_plist(
   plist_path: "path/to/Info.plist",
   display_name: "MyApp-Beta"
 )
+```
 
 ## Developer Portal
 


### PR DESCRIPTION
The section Developer Portal was inside a code block. That pull request fixes it.
