### PR TITLE
New action to recreate / regenerate Xcode project schemes

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -404,6 +404,16 @@ splunkmint(
 
 If you use `gym` the `dsym` parameter is optional.
 
+### recreate_schemes
+
+Recreate not shared Xcode project schemes.
+
+```ruby
+recreate_schemes(
+	project: './path/to/MyApp.xcodeproj'
+)
+```
+
 ## Testing
 
 ### xctest

--- a/lib/fastlane/actions/recreate_schemes.rb
+++ b/lib/fastlane/actions/recreate_schemes.rb
@@ -1,0 +1,37 @@
+module Fastlane
+  module Actions
+    class RecreateSchemesAction < Action
+      def self.run(params)
+        require 'xcodeproj'
+
+        Helper.log.info "Recreate schemes for project: #{params[:project]}"
+
+        project = Xcodeproj::Project.open(params[:project])
+        project.recreate_user_schemes
+        #project.save
+      end
+
+      def self.description
+        "Recreate not shared Xcode project schemes."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :project,
+            env_name: "XCODE_PROJECT",
+            description: "The project to use"
+          )
+        ]
+      end
+
+      def self.authors
+        "jerolimov"
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include? platform
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/recreate_schemes.rb
+++ b/lib/fastlane/actions/recreate_schemes.rb
@@ -8,7 +8,6 @@ module Fastlane
 
         project = Xcodeproj::Project.open(params[:project])
         project.recreate_user_schemes
-        #project.save
       end
 
       def self.description

--- a/lib/fastlane/actions/recreate_schemes.rb
+++ b/lib/fastlane/actions/recreate_schemes.rb
@@ -11,7 +11,7 @@ module Fastlane
       end
 
       def self.description
-        "Recreate not shared Xcode project schemes."
+        "Recreate not shared Xcode project schemes"
       end
 
       def self.available_options
@@ -19,7 +19,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :project,
             env_name: "XCODE_PROJECT",
-            description: "The project to use"
+            description: "The Xcode project"
           )
         ]
       end


### PR DESCRIPTION
This solves an issue when no scheme is commited into the SCM or the Xcode project is generated (in Apache Cordova for example). This could be fixed for example with this `recreate_schemes` action within  the `before_all` block.

After generating (add) a Apache Cordova Xcode project with `cordova platform add ios` for example the project contains no scheme by default. Also other project maybe exclude the user schemes in the `.gitignore`. After open the project with Xcode everything works as expected. But for me I had strange issues with `gym` & co. to build the project automatically without Xcode (local and on a CI/CD server).

The main issue was that `xcodebuild -list -project path/to/MyApp.xcodeproj` doesn't exit when it doesn't find a scheme. m( The command hangs after this:

```
    Information about project "MyApp":
        Targets:
            MyApp

        Build Configurations:
            Debug
            Release

        If no build configuration is specified and -scheme is not passed then "Release" is used.
[XCODEBUILD NEVER STOPS...]
```

Code was inspired from http://stackoverflow.com/a/20941812
