### PR TITLE
Create update_app_identifier action

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-os:
-  - osx
 before_install: gem update --system
 rvm:
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+os:
+  - osx
 before_install: gem update --system
 rvm:
   - 2.0.0

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -789,6 +789,18 @@ update_info_plist(
   display_name: "MyApp-Beta"
 )
 
+### update_app_identifier
+
+Update an app identifier by either setting `CFBundleIdentifier` or `PRODUCT_BUNDLE_IDENTIFIER`, depending on which is already in use.
+
+```ruby
+update_app_identifier(
+  xcodeproj: 'Example.xcodeproj', # Optional path to xcodeproj, will use the first .xcodeproj if not set
+  plist_path: 'Example/Info.plist', # Path to info plist file, relative to xcodeproj
+  app_identifier: 'com.test.example' # The App Identifier
+)
+```
+
 ## Developer Portal
 
 ### [sigh](https://github.com/KrauseFx/sigh)

--- a/lib/fastlane/actions/update_app_identifier.rb
+++ b/lib/fastlane/actions/update_app_identifier.rb
@@ -55,7 +55,7 @@ module Fastlane
       end
 
       def self.description
-        'Update an app identifier by either setting `CFBundleIdentifier` or `PRODUCT_BUNDLE_IDENTIFIER`'
+        'Update an app identifier'
       end
 
       def self.available_options

--- a/lib/fastlane/actions/update_app_identifier.rb
+++ b/lib/fastlane/actions/update_app_identifier.rb
@@ -1,0 +1,89 @@
+module Fastlane
+  module Actions
+    class UpdateAppIdentifierAction < Action
+      def self.run(params)
+        require 'plist'
+        require 'xcodeproj'
+
+        identifier_key = 'PRODUCT_BUNDLE_IDENTIFIER'
+
+        # Assign folder from parameter or search for xcodeproj file
+        folder = params[:xcodeproj] || Dir['*.xcodeproj'].first
+
+        # Read existing plist file
+        info_plist_path = File.join(folder, '..', params[:plist_path])
+        raise "Couldn't find info plist file at path '#{params[:plist_path]}'".red unless File.exist?(info_plist_path)
+        plist = Plist.parse_xml(info_plist_path)
+
+        # Check if current app identifier product bundle identifier
+        if plist['CFBundleIdentifier'] == "$(#{identifier_key})"
+          # Load .xcodeproj
+          project_path = params[:xcodeproj]
+          project = Xcodeproj::Project.open(project_path)
+
+          # Fetch the build configuration objects
+          configs = project.objects.select { |obj| obj.isa == 'XCBuildConfiguration' && !obj.build_settings[identifier_key].nil? }
+          raise "Info plist uses $(#{identifier_key}), but xcodeproj does not".red unless configs.count > 0
+
+          # For each of the build configurations, set app identifier
+          configs.each do |c|
+            c.build_settings[identifier_key] = params[:app_identifier]
+          end
+
+          # Write changes to the file
+          project.save
+
+          Helper.log.info "Updated #{params[:xcodeproj]} 💾.".green
+        else
+          # Update plist value
+          plist['CFBundleIdentifier'] = params[:app_identifier]
+
+          # Write changes to file
+          plist_string = Plist::Emit.dump(plist)
+          File.write(info_plist_path, plist_string)
+
+          Helper.log.info "Updated #{params[:plist_path]} 💾.".green
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.is_supported?(platform)
+        [:ios].include?(platform)
+      end
+
+      def self.description
+        'Update an app identifier by either setting `CFBundleIdentifier` or `PRODUCT_BUNDLE_IDENTIFIER`'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                                       env_name: "FL_UPDATE_APP_IDENTIFIER_PROJECT_PATH",
+                                       description: "Path to your Xcode project",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         raise "Please pass the path to the project, not the workspace".red if value.include? "workspace"
+                                         raise "Could not find Xcode project".red unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :plist_path,
+                                       env_name: "FL_UPDATE_APP_IDENTIFIER_PLIST_PATH",
+                                       description: "Path to info plist, relative to your Xcode project",
+                                       verify_block: proc do |value|
+                                         raise "Invalid plist file".red unless value[-6..-1].downcase == ".plist"
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :app_identifier,
+                                       env_name: 'FL_UPDATE_APP_IDENTIFIER',
+                                       description: 'The App Identifier of your app',
+                                       default_value: ENV['PRODUCE_APP_IDENTIFIER'])
+        ]
+      end
+
+      def self.authors
+        ['squarefrog', 'tobiasstrebitzer']
+      end
+    end
+  end
+end

--- a/spec/actions_specs/update_app_identifier_spec.rb
+++ b/spec/actions_specs/update_app_identifier_spec.rb
@@ -1,0 +1,91 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Update App Identifier Integration" do
+      # Variables
+      let (:test_path) { "/tmp/fastlane/tests/fastlane" }
+      let (:fixtures_path) { "./spec/fixtures/xcodeproj" }
+      let (:proj_file) { "bundle.xcodeproj" }
+      let (:identifier_key) { 'PRODUCT_BUNDLE_IDENTIFIER' }
+
+      # Action parameters
+      let (:xcodeproj) { File.join(test_path, proj_file) }
+      let (:plist_path) { "Info.plist" }
+      let (:app_identifier) { "com.test.plist" }
+
+      # Is there a better place for an helper function?
+      # Create an Info.plist file with a supplied bundle_identifier parameter
+      def create_plist_with_identifier(bundle_identifier)
+        File.write(File.join(test_path, plist_path), "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\"><plist version=\"1.0\"><dict><key>CFBundleIdentifier</key><string>#{bundle_identifier}</string></dict></plist>")
+      end
+
+      before do
+        # Create test folder
+        FileUtils.mkdir_p(test_path)
+        source = File.join(fixtures_path, proj_file)
+        destination = File.join(test_path, proj_file)
+
+        # Copy .xcodeproj fixture, as it will be modified during the test
+        FileUtils.cp_r(source, destination)
+      end
+
+      it "updates the info plist when product bundle identifier not in use" do
+        plist = create_plist_with_identifier('tools.fastlane.example')
+
+        Fastlane::FastFile.new.parse("lane :test do
+          update_app_identifier ({
+            xcodeproj: '#{xcodeproj}',
+            plist_path: '#{plist_path}',
+            app_identifier: '#{app_identifier}'
+          })
+        end").runner.execute(:test)
+
+        result = File.read(File.join(test_path, plist_path))
+        expect(result).to include("<string>#{app_identifier}</string>")
+      end
+
+      it "updates the xcode project when product bundle identifier in use" do
+        create_plist_with_identifier("$(#{identifier_key})")
+        Fastlane::FastFile.new.parse("lane :test do
+          update_app_identifier ({
+            xcodeproj: '#{xcodeproj}',
+            plist_path: '#{plist_path}',
+            app_identifier: '#{app_identifier}'
+          })
+        end").runner.execute(:test)
+
+        project = Xcodeproj::Project.open(xcodeproj)
+        configs = project.objects.select { |obj| obj.isa == 'XCBuildConfiguration' && !obj.build_settings[identifier_key].nil? }
+        configs.each do |c|
+          result = c.build_settings[identifier_key]
+          expect(result).to eq("#{app_identifier}")
+        end
+      end
+
+      it "should raise an exception when PRODUCT_BUNDLE_IDENTIFIER in info plist but not project" do
+        create_plist_with_identifier("$(#{identifier_key})")
+
+        project = Xcodeproj::Project.open(xcodeproj)
+        configs = project.objects.select { |obj| obj.isa == 'XCBuildConfiguration' && !obj.build_settings[identifier_key].nil? }
+        configs.each do |c|
+          c.build_settings.delete(identifier_key)
+        end
+        project.save
+
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+          update_app_identifier ({
+            xcodeproj: '#{xcodeproj}',
+            plist_path: '#{plist_path}',
+            app_identifier: '#{app_identifier}'
+          })
+          end").runner.execute(:test)
+        end.to raise_error("Info plist uses $(#{identifier_key}), but xcodeproj does not".red)
+      end
+
+      after do
+        # Clean up files
+        FileUtils.rm_r(test_path)
+      end
+    end
+  end
+end

--- a/spec/actions_specs/update_app_identifier_spec.rb
+++ b/spec/actions_specs/update_app_identifier_spec.rb
@@ -1,3 +1,6 @@
+require 'xcodeproj'
+include Xcodeproj
+
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Update App Identifier Integration" do

--- a/spec/fixtures/xcodeproj/bundle.xcodeproj/project.pbxproj
+++ b/spec/fixtures/xcodeproj/bundle.xcodeproj/project.pbxproj
@@ -1,0 +1,250 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXFileReference section */
+		0EB04CE71BCD87E700FE17C5 /* bundle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = bundle.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0EB04CF81BCD87E700FE17C5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0EB04CE41BCD87E700FE17C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0EB04CDE1BCD87E700FE17C5 = {
+			isa = PBXGroup;
+			children = (
+				0EB04CE91BCD87E700FE17C5 /* bundle */,
+				0EB04CE81BCD87E700FE17C5 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		0EB04CE81BCD87E700FE17C5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0EB04CE71BCD87E700FE17C5 /* bundle.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0EB04CE91BCD87E700FE17C5 /* bundle */ = {
+			isa = PBXGroup;
+			children = (
+				0EB04CF81BCD87E700FE17C5 /* Info.plist */,
+			);
+			path = bundle;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0EB04CE61BCD87E700FE17C5 /* bundle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0EB04CFB1BCD87E700FE17C5 /* Build configuration list for PBXNativeTarget "bundle" */;
+			buildPhases = (
+				0EB04CE31BCD87E700FE17C5 /* Sources */,
+				0EB04CE41BCD87E700FE17C5 /* Frameworks */,
+				0EB04CE51BCD87E700FE17C5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = bundle;
+			productName = bundle;
+			productReference = 0EB04CE71BCD87E700FE17C5 /* bundle.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0EB04CDF1BCD87E700FE17C5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0700;
+				ORGANIZATIONNAME = Fastlane;
+				TargetAttributes = {
+					0EB04CE61BCD87E700FE17C5 = {
+						CreatedOnToolsVersion = 7.0.1;
+					};
+				};
+			};
+			buildConfigurationList = 0EB04CE21BCD87E700FE17C5 /* Build configuration list for PBXProject "bundle" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 0EB04CDE1BCD87E700FE17C5;
+			productRefGroup = 0EB04CE81BCD87E700FE17C5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0EB04CE61BCD87E700FE17C5 /* bundle */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0EB04CE51BCD87E700FE17C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0EB04CE31BCD87E700FE17C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		0EB04CF91BCD87E700FE17C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0EB04CFA1BCD87E700FE17C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		0EB04CFC1BCD87E700FE17C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = bundle/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = tools.fastlane.bundle;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		0EB04CFD1BCD87E700FE17C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = bundle/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = tools.fastlane.bundle;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0EB04CE21BCD87E700FE17C5 /* Build configuration list for PBXProject "bundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0EB04CF91BCD87E700FE17C5 /* Debug */,
+				0EB04CFA1BCD87E700FE17C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0EB04CFB1BCD87E700FE17C5 /* Build configuration list for PBXNativeTarget "bundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0EB04CFC1BCD87E700FE17C5 /* Debug */,
+				0EB04CFD1BCD87E700FE17C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0EB04CDF1BCD87E700FE17C5 /* Project object */;
+}


### PR DESCRIPTION
As discussed in https://github.com/KrauseFx/fastlane/issues/684, there should be a separate action to accommodate Xcode 7's use of `PRODUCT_BUNDLE_IDENTIFIER`.
### Ready for merging

This PR modifies the Travis job to run on OS X which is a requirement for the Xcodeproj tool used by this action, and `commit_version_bump`. I'm a little surprised that `commit_version_bump` didn't already raise this issue.
