### PR TITLE
Validate CocoaPods Keys action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1399,6 +1399,16 @@ else
 end
 ```
 
+### verify_pods_keys
+
+Runs a check against all keys specified in your Podfile to make sure they're more than a single character long. This is to ensure you don't deploy with stubbed keys.
+
+```ruby
+verify_pods_keys
+```
+
+Will raise an error if any key is empty or a single character.
+
 ### read_podspec
 
 Loads the specified (or the first found) podspec in the folder as JSON, so that you can inspect its `version`, `files` etc. This can be useful when basing your release process on the version string only stored in one place - in the podspec. As one of the first steps you'd read the podspec and its version and the rest of the workflow can use that version string (when e.g. creating a new git tag or a GitHub Release).

--- a/lib/fastlane/actions/verify_pods_keys.rb
+++ b/lib/fastlane/actions/verify_pods_keys.rb
@@ -1,0 +1,53 @@
+module Fastlane
+  module Actions
+    class VerifyPodKeysAction < Action
+      def self.run(params)
+        Helper.log.info "Validating CocoaPods Keys"
+
+        options = plugin_options
+        target = options["target"] || ""
+
+        options["keys"].each do |key|
+          Helper.log.info " - #{key}"
+          validate(key, target)
+        end
+      end
+
+      def self.plugin_options
+        require 'cocoapods-core'
+        podfile = Pod::Podfile.from_file "Podfile"
+        podfile.plugins["cocoapods-keys"]
+      end
+
+      def self.validate(key, target)
+        if value(key, target).length < 2
+          message = "Did not pass validation for key #{key}. " \
+            "Run `[bundle exec] pod keys get #{key} #{target}` to see what it is. " \
+            "It's likely this is running with empty/OSS keys."
+          raise message
+        end
+      end
+
+      def self.value(key, target)
+        value = `pod keys get #{key} #{target}`
+        value.split("]").last.strip
+      end
+
+      def self.author
+        "ashfurrow"
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Verifies all keys referenced from the Podfile are non-empty"
+      end
+
+      def self.is_supported?(platform)
+        return true
+      end
+    end
+  end
+end

--- a/spec/actions_specs/verify_pod_keys_spec.rb
+++ b/spec/actions_specs/verify_pod_keys_spec.rb
@@ -1,0 +1,45 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "CocoaPods Keys Verification" do
+      let(:key) { "Key" }
+      let(:target) { "Target" }
+
+      before(:each) do
+        options = { "target" => :target, "keys" => [:key] }
+        allow(Fastlane::Actions::VerifyPodKeysAction).to receive(:plugin_options).and_return(options)
+      end
+
+      describe "valid values" do
+        value = "Value"
+
+        before(:each) do
+          allow(Fastlane::Actions::VerifyPodKeysAction).to receive(:value).with(:key, :target).and_return(value)
+        end
+
+        it "raises no exception" do
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              verify_pod_keys
+            end").runner.execute(:test)
+          end.to_not raise_error
+        end
+      end
+
+      describe "invalid values" do
+        value = ""
+
+        before(:each) do
+          allow(Fastlane::Actions::VerifyPodKeysAction).to receive(:value).with(:key, :target).and_return(value)
+        end
+
+        it "raises an exception" do
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              verify_pod_keys
+            end").runner.execute(:test)
+          end.to raise_error("Did not pass validation for key key. Run `[bundle exec] pod keys get key target` to see what it is. It's likely this is running with empty/OSS keys.")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Continued from our discuss at https://github.com/artsy/eidolon/pull/541/files#r42803717

Tests _pass_, but I am using a partial mock to stub out accessing the Podfile, and also invoking a CocoaPods shell command. Happy to be pointed in the right direction to avoid those, if that's a good idea. 
