### PR TITLE
Add icon overlay action.

### DIFF
--- a/lib/fastlane/actions/add_icon_overlay.rb
+++ b/lib/fastlane/actions/add_icon_overlay.rb
@@ -9,7 +9,7 @@ module Fastlane
         appiconset = params[:appiconset_path]
 
         if overlay_type == 'image'
-          self.addImageOverlay(appiconset, params)
+          self.add_image_overlay(appiconset, params)
         elsif overlay_type == 'banner'
           self.add_banner_overlay(appiconset, params)
         else
@@ -21,7 +21,7 @@ module Fastlane
         Dir.glob(File.join(appiconset, '*.png')) do |icon|
           img = MiniMagick::Image.new(icon)
           MiniMagick::Tool::Convert.new do |c|
-            height = img[:height]*params[:text_overlay_height].to_f
+            height = img[:height] * params[:text_overlay_height].to_f
             c.background(params[:text_background_color])
             c.fill(params[:text_foreground_color])
             c.gravity('center')
@@ -65,7 +65,7 @@ module Fastlane
         end
       end
 
-      def self.addImageOverlay(appiconset, params)
+      def self.add_image_overlay(appiconset, params)
         overlay_image = MiniMagick::Image.new(params[:overlay_image_path])
 
         Dir.glob(File.join(appiconset, '*.png')) do |icon|
@@ -101,13 +101,13 @@ module Fastlane
                                        description: "Path for .appiconset containing the icons",
                                        is_string: true,
                                        default_value: '**/AppIcon.appiconset'
-                                       ),
+                                      ),
           FastlaneCore::ConfigItem.new(key: :overlay_image_path,
                                        env_name: "FL_ADD_ICON_OVERLAY_OVERLAY_IMAGE_PATH",
                                        description: "Path for the image that will be overlaid on the icons",
                                        is_string: true,
                                        optional: true,
-                                       verify_block: Proc.new do |value|
+                                       verify_block: proc do |value|
                                        raise "No overlay image path for AddIconOverlayAction given, pass using `overlay_image_path: 'image_path.png'`".red unless value and not value.empty?
                                        end
                                       ),
@@ -116,7 +116,7 @@ module Fastlane
                                        description: "Flag specifying if an image, text or banner will be overlayed over the icon",
                                        is_string: true,
                                        default_value: 'text',
-                                       verify_block: Proc.new do |value|
+                                       verify_block: proc do |value|
                                          raise "Invalid overlay type provided. Expected 'text' or 'image' and '#{value}' was provided" unless value == "text" or value == "image" or value == "banner"
                                        end
                                       ),
@@ -140,7 +140,7 @@ module Fastlane
                                        optional: true,
                                        default_value: 0.3,
                                        is_string: false,
-                                       verify_block: Proc.new do |value|
+                                       verify_block: proc do |value|
                                          raise "Invalid height percentage provided. Must be a float value between 0.0 & 1.0" unless value and value.to_f > 0 and value.to_f <= 1.0
                                        end
                                       ),
@@ -165,7 +165,7 @@ module Fastlane
                                        is_string: true,
                                        optional: true,
                                        default_value: "Helvetica"
-                                       )
+                                      )
         ]
       end
 

--- a/lib/fastlane/actions/add_icon_overlay.rb
+++ b/lib/fastlane/actions/add_icon_overlay.rb
@@ -1,0 +1,181 @@
+module Fastlane
+  module Actions
+
+    class AddIconOverlayAction < Action
+      def self.run(params)
+        Helper.log.info "Image to overlay on icons: #{params[:overlay_image_path]}" unless not params[:overlay_type] == 'image'
+        require 'mini_magick'
+
+        overlay_type = params[:overlay_type]
+        appiconset = params[:appiconset_path]
+
+        if overlay_type == 'image'
+          self.addImageOverlay(appiconset, params)
+        elsif overlay_type == 'banner'
+          self.addBannerOverlay(appiconset, params)
+        else
+          self.addTextOverlay(appiconset, params)
+        end
+      end
+
+      def self.addTextOverlay(appiconset, params)
+        Dir.glob(File.join(appiconset, '*.png')) do |icon|
+          img = MiniMagick::Image.new(icon)
+          MiniMagick::Tool::Convert.new do |c|
+            height = img[:height]*params[:text_overlay_height].to_f
+            c.background(params[:text_background_color])
+            c.fill(params[:text_foreground_color])
+            c.gravity('center')
+            c.size("#{img[:width]}x#{height}")
+            c.font(params[:text_overlay_font])
+            c << "caption:#{params[:text_overlay]}"
+            c << icon
+            c.swap.+
+            c.gravity(params[:text_overlay_position])
+            c.composite(icon)
+          end
+        end
+      end
+
+      def self.addBannerOverlay(appiconset, params)
+        Dir.glob(File.join(appiconset, '*.png')) do |icon|
+          original_icon = MiniMagick::Image.new(icon)
+          width = original_icon.width
+          height = original_icon.height
+          rect_height = height * params[:text_overlay_height].to_f
+          rect_width = width * 1.6
+          x = width * 0.65 # correct positioning for topright banner
+          y = -0.7 * rect_height # correct positioning for topright banner
+          text_size = width / 8
+          padding = text_size / 2
+
+          result = original_icon.combine_options do |c|
+            c.fill(params[:text_background_color])
+            c.draw "push graphic-context translate #{x}, #{y} rotate 45 rectangle #{0}, #{0}, #{0 + rect_width}, #{0 + rect_height} pop graphic-context"
+          end
+
+          result = result.combine_options do |c|
+            c.fill(params[:text_foreground_color]) # set the text fill colour
+            c.gravity 'Northeast' # anchor the text to the top right
+            c.font(params[:text_overlay_font])
+            c.draw "rotate 45 text #{text_size + padding},#{text_size + padding} '#{params[:text_overlay]}'" # draw text
+            c.pointsize "#{text_size}" # set font size
+          end
+
+          result.write icon
+        end
+      end
+
+      def self.addImageOverlay(appiconset, params)
+        overlay_image = MiniMagick::Image.new(params[:overlay_image_path])
+
+        Dir.glob(File.join(appiconset, '*.png')) do |icon|
+          original_icon = MiniMagick::Image.new(icon)
+
+          result = original_icon.composite(overlay_image) do |c|
+            c.compose "Over"
+            c.resize "#{original_icon.width}x#{original_icon.height}"
+            c.quality 100
+          end
+          result.write icon
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Overlays an image or text over all icons."
+      end
+
+      def self.details
+        "Overlays an image or text over all icons, using ImageMagick and replacing the old icons.
+        Text overlay based off @merowing's script http://merowing.info/2013/03/overlaying-application-version-on-top-of-your-icon/
+        Banner overlay based off of @squarefrog's comment https://github.com/KrauseFx/fastlane/issues/481#issuecomment-147368555"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :appiconset_path,
+                                       env_name: "FL_ADD_ICON_OVERLAY_APPICONSET_PATH",
+                                       description: "Path for .appiconset containing the icons",
+                                       is_string: true,
+                                       default_value: '**/AppIcon.appiconset'
+                                       ),
+          FastlaneCore::ConfigItem.new(key: :overlay_image_path,
+                                       env_name: "FL_ADD_ICON_OVERLAY_OVERLAY_IMAGE_PATH",
+                                       description: "Path for the image that will be overlaid on the icons",
+                                       is_string: true,
+                                       optional: true,
+                                       verify_block: Proc.new do |value|
+                                       raise "No overlay image path for AddIconOverlayAction given, pass using `overlay_image_path: 'image_path.png'`".red unless (value and not value.empty?)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :overlay_type,
+                                       env_name: "FL_ADD_ICON_OVERLAY_OVERLAY_TYPE",
+                                       description: "Flag specifying if an image, text or banner will be overlayed over the icon",
+                                       is_string: true,
+                                       default_value: 'text',
+                                       verify_block: Proc.new do |value|
+                                         raise "Invalid overlay type provided. Expected 'text' or 'image' and '#{value}' was provided" unless (value == "text" or value == "image" or value == "banner")
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :text_background_color,
+                                       env_name: "FL_ADD_ICON_OVERLAY_TEXT_BACKGROUND_COLOR",
+                                       description: "Background color for the text overlay. If a hex value is provided must contain the '#' character",
+                                       is_string: true,
+                                       default_value: "#C2C2C3",
+                                       optional: true
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :text_foreground_color,
+                                       env_name: "FL_ADD_ICON_OVERLAY_TEXT_FOREGROUND_COLOR",
+                                       description: "Foreground color for the text overlay (Text color). If a hex value is provided must contain the '#' character",
+                                       is_string: true,
+                                       default_value: "white",
+                                       optional: true
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :text_overlay_height,
+                                       env_name: "FL_ADD_ICON_OVERLAY_OVERLAY_HEIGHT",
+                                       description: "Height of the overlay in respect to the overall height of the icon (e.g. 0.5 for 50%)",
+                                       optional: true,
+                                       default_value: 0.3,
+                                       is_string: false,
+                                       verify_block: Proc.new do |value|
+                                         raise "Invalid height percentage provided. Must be a float value between 0.0 & 1.0" unless value and value.to_f > 0 and value.to_f <= 1.0
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :text_overlay,
+                                       description: "The text to be overlayed over the icon. Can contain '\\t' and '\\n' when 'overlay_type' is 'text', not on 'banner'",
+                                       is_string: true,
+                                       optional: true
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :text_overlay_position,
+                                       env_name: "FL_ADD_ICON_OVERLAY_TEXT_OVERLAY_POSITION",
+                                       description: "Where on the icon the text will be overlayed (south & north). Only available for 'overlay_type' 'text'",
+                                       is_string: true,
+                                       optional: true,
+                                       default_value: "south",
+                                       verify_block: Proc.new do |value|
+                                         raise "Invalid text overlay position. Expected 'north' or 'south' and '#{value}' provided" unless value and (value == "north" || value == "south")
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :text_overlay_font,
+                                       env_name: "FL_ADD_OVERLAY_ICON_FONT",
+                                       description: "Name of the font to be used on the text overlay. Must be in font list `convert -list font or full path to font",
+                                       is_string: true,
+                                       optional: true,
+                                       default_value: "Helvetica"
+                                       )
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.authors
+        ["esttorhe", "marcelofabri"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/add_icon_overlay.rb
+++ b/lib/fastlane/actions/add_icon_overlay.rb
@@ -1,9 +1,8 @@
 module Fastlane
   module Actions
-
     class AddIconOverlayAction < Action
       def self.run(params)
-        Helper.log.info "Image to overlay on icons: #{params[:overlay_image_path]}" unless not params[:overlay_type] == 'image'
+        Helper.log.info "Image to overlay on icons: #{params[:overlay_image_path]}" if params[:overlay_type] == 'image'
         require 'mini_magick'
 
         overlay_type = params[:overlay_type]
@@ -12,13 +11,13 @@ module Fastlane
         if overlay_type == 'image'
           self.addImageOverlay(appiconset, params)
         elsif overlay_type == 'banner'
-          self.addBannerOverlay(appiconset, params)
+          self.add_banner_overlay(appiconset, params)
         else
-          self.addTextOverlay(appiconset, params)
+          self.add_text_overlay(appiconset, params)
         end
       end
 
-      def self.addTextOverlay(appiconset, params)
+      def self.add_text_overlay(appiconset, params)
         Dir.glob(File.join(appiconset, '*.png')) do |icon|
           img = MiniMagick::Image.new(icon)
           MiniMagick::Tool::Convert.new do |c|
@@ -37,7 +36,7 @@ module Fastlane
         end
       end
 
-      def self.addBannerOverlay(appiconset, params)
+      def self.add_banner_overlay(appiconset, params)
         Dir.glob(File.join(appiconset, '*.png')) do |icon|
           original_icon = MiniMagick::Image.new(icon)
           width = original_icon.width
@@ -109,16 +108,18 @@ module Fastlane
                                        is_string: true,
                                        optional: true,
                                        verify_block: Proc.new do |value|
-                                       raise "No overlay image path for AddIconOverlayAction given, pass using `overlay_image_path: 'image_path.png'`".red unless (value and not value.empty?)
-                                       end),
+                                       raise "No overlay image path for AddIconOverlayAction given, pass using `overlay_image_path: 'image_path.png'`".red unless value and not value.empty?
+                                       end
+                                      ),
           FastlaneCore::ConfigItem.new(key: :overlay_type,
                                        env_name: "FL_ADD_ICON_OVERLAY_OVERLAY_TYPE",
                                        description: "Flag specifying if an image, text or banner will be overlayed over the icon",
                                        is_string: true,
                                        default_value: 'text',
                                        verify_block: Proc.new do |value|
-                                         raise "Invalid overlay type provided. Expected 'text' or 'image' and '#{value}' was provided" unless (value == "text" or value == "image" or value == "banner")
-                                       end),
+                                         raise "Invalid overlay type provided. Expected 'text' or 'image' and '#{value}' was provided" unless value == "text" or value == "image" or value == "banner"
+                                       end
+                                      ),
           FastlaneCore::ConfigItem.new(key: :text_background_color,
                                        env_name: "FL_ADD_ICON_OVERLAY_TEXT_BACKGROUND_COLOR",
                                        description: "Background color for the text overlay. If a hex value is provided must contain the '#' character",
@@ -141,7 +142,8 @@ module Fastlane
                                        is_string: false,
                                        verify_block: Proc.new do |value|
                                          raise "Invalid height percentage provided. Must be a float value between 0.0 & 1.0" unless value and value.to_f > 0 and value.to_f <= 1.0
-                                       end),
+                                       end
+                                      ),
           FastlaneCore::ConfigItem.new(key: :text_overlay,
                                        description: "The text to be overlayed over the icon. Can contain '\\t' and '\\n' when 'overlay_type' is 'text', not on 'banner'",
                                        is_string: true,
@@ -153,9 +155,10 @@ module Fastlane
                                        is_string: true,
                                        optional: true,
                                        default_value: "south",
-                                       verify_block: Proc.new do |value|
+                                       verify_block: proc do |value|
                                          raise "Invalid text overlay position. Expected 'north' or 'south' and '#{value}' provided" unless value and (value == "north" || value == "south")
-                                       end),
+                                       end
+                                      ),
           FastlaneCore::ConfigItem.new(key: :text_overlay_font,
                                        env_name: "FL_ADD_OVERLAY_ICON_FONT",
                                        description: "Name of the font to be used on the text overlay. Must be in font list `convert -list font or full path to font",


### PR DESCRIPTION
# Fix #481

Ability to add:
- image
  ![](https://camo.githubusercontent.com/818e5cdffbdf12043081d12a97bcfdf78071e7eb/68747470733a2f2f7777772e64726f70626f782e636f6d2f732f61723177636d343973376f37746c7a2f706c61796b6964732d69636f6e732e706e673f646c3d31)
- text
  ![icon-60 2x 3](https://cloud.githubusercontent.com/assets/2642850/10716676/fdb0c75e-7b05-11e5-9010-358abe9530a1.png)
  ![icon-60 2x 2](https://cloud.githubusercontent.com/assets/2642850/10716675/fdaed8a4-7b05-11e5-941f-66f97d898480.png)
- banner text
  ![icon-60 2x](https://cloud.githubusercontent.com/assets/2642850/10716677/fdb0f0bc-7b05-11e5-9cc3-e82c36261f58.png)
