### PR TITLE
Add installation instructions for OS X 10.11 El Capitain

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,13 @@ fastlane appstore
 
 I recommend following the [fastlane guide](https://github.com/KrauseFx/fastlane/blob/master/docs/Guide.md) to get started.
 
+Up to OS X 10.10 Yosemite:
+
     sudo gem install fastlane --verbose
+
+OS X 10.11 El Capitain:
+
+    sudo gem install faslane -n/usr/local/bin --verbose
 
 Make sure, you have the latest version of the Xcode command line tools installed:
 


### PR DESCRIPTION
Hey Felix,

Installing fastlane the usual way on OS X 10.11 will fail with a permission error. [`/usr/bin` is now off-limits](http://stackoverflow.com/questions/31972968/cant-install-gems-on-macos-x-el-capitan#32253142) thanks to the new "System Integrity Protection". The workaround is to install gems in `/usr/local/bin`.

J-
