### PR TITLE
Add new action for cocoapods cache cleanup.

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1447,6 +1447,18 @@ pod_trunk(path: 'TSMessages.podspec')
 pod_trunk(path: 'TSMessages.podspec', repo: 'MyRepo')
 ```
 
+### clean_cocoapods_cache
+
+Cleanup the Cocoapods cache.
+
+```ruby
+# Clean entire cocoapods cache.
+clean_cocoapods_cache
+
+# Alternatively, supply the name of pod to be removed from cache.
+clean_cocoapods_cache(name: 'CACHED POD')
+```
+
 ### prompt
 
 You can use `prompt` to ask the user for a value or to just let the user confirm the next step.

--- a/lib/fastlane/actions/clean_cocoapods_cache.rb
+++ b/lib/fastlane/actions/clean_cocoapods_cache.rb
@@ -3,7 +3,7 @@ module Fastlane
     class CleanCocoapodsCacheAction < Action
       def self.run(params)
         Actions.verify_gem!('cocoapods')
-        
+
         cmd = ['pod cache clean']
 
         cmd << "#{params[:name]}" if params[:name]
@@ -11,7 +11,7 @@ module Fastlane
       end
 
       def self.description
-        "Remove the cache for pods"
+        'Remove the cache for pods'
       end
 
       def self.available_options
@@ -22,7 +22,7 @@ module Fastlane
                                        optional: true,
                                        is_string: true,
                                        verify_block: proc do |value|
-                                          raise "You must specify pod name which should be removed from cache".red unless (value and not value.empty?)
+                                         raise "You must specify pod name which should be removed from cache".red unless value and !value.empty?
                                        end)
         ]
       end

--- a/lib/fastlane/actions/clean_cocoapods_cache.rb
+++ b/lib/fastlane/actions/clean_cocoapods_cache.rb
@@ -8,6 +8,8 @@ module Fastlane
 
         cmd << "#{params[:name]}" if params[:name]
         cmd << '--all'
+
+        Actions.sh(cmd.join(' '))
       end
 
       def self.description

--- a/lib/fastlane/actions/clean_cocoapods_cache.rb
+++ b/lib/fastlane/actions/clean_cocoapods_cache.rb
@@ -24,7 +24,7 @@ module Fastlane
                                        optional: true,
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "You must specify pod name which should be removed from cache".red unless value and !value.empty?
+                                         raise "You must specify pod name which should be removed from cache".red if value.to_s.empty?
                                        end)
         ]
       end

--- a/lib/fastlane/actions/clean_cocoapods_cache.rb
+++ b/lib/fastlane/actions/clean_cocoapods_cache.rb
@@ -1,0 +1,39 @@
+module Fastlane
+  module Actions
+    class CleanCocoapodsCacheAction < Action
+      def self.run(params)
+        Actions.verify_gem!('cocoapods')
+        
+        cmd = ['pod cache clean']
+
+        cmd << "#{params[:name]}" if params[:name]
+        cmd << '--all'
+      end
+
+      def self.description
+        "Remove the cache for pods"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :name,
+                                       env_name: "FL_CLEAN_COCOAPODS_CACHE_DEVELOPMENT",
+                                       description: "Pod name to be removed from cache",
+                                       optional: true,
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                          raise "You must specify pod name which should be removed from cache".red unless (value and not value.empty?)
+                                       end)
+        ]
+      end
+
+      def self.authors
+        ["alexmx"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include? platform
+      end
+    end
+  end
+end

--- a/spec/actions_specs/clean_cocoapods_cache_spec.rb
+++ b/spec/actions_specs/clean_cocoapods_cache_spec.rb
@@ -20,13 +20,13 @@ describe Fastlane do
       end
 
       it "raise an exception if name is empty" do
-        expect { 
+        expect do
           Fastlane::FastFile.new.parse("lane :test do
             clean_cocoapods_cache(
               name: ''
             )
-            end").runner.execute(:test) 
-          }.to raise_error(RuntimeError)
+            end").runner.execute(:test)
+        end.to raise_error(RuntimeError)
       end
     end
   end

--- a/spec/actions_specs/clean_cocoapods_cache_spec.rb
+++ b/spec/actions_specs/clean_cocoapods_cache_spec.rb
@@ -1,0 +1,33 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Clean Cocoapods Cache Integration" do
+      it "default use case" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          clean_cocoapods_cache
+        end").runner.execute(:test)
+
+        expect(result).to eq("pod cache clean --all")
+      end
+
+      it "adds pod name to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          clean_cocoapods_cache(
+            name: 'Name'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("pod cache clean Name --all")
+      end
+
+      it "raise an exception if name is empty" do
+        expect { 
+          Fastlane::FastFile.new.parse("lane :test do
+            clean_cocoapods_cache(
+              name: ''
+            )
+            end").runner.execute(:test) 
+          }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
It would be cool to have an action which will reset the Cocoapods cache.

Clean entire cache:

``` bash
pod cache clean --all
```

Or a specific pod:

``` bash
pod cache clean [NAME] --all
```

Action will look this way:

``` bash
before_all do
    clean_cocoapods_cache
end
```

Or

``` bash
before_all do
    clean_cocoapods_cache(name: 'MY CACHED POD')
end
```
