### PR TITLE
Fix up `notify`: add useful parameters

### DIFF
--- a/lib/fastlane/actions/notify.rb
+++ b/lib/fastlane/actions/notify.rb
@@ -4,8 +4,15 @@ module Fastlane
       def self.run(params)
         require 'terminal-notifier'
 
-        text = params.join(' ')
-        TerminalNotifier.notify(text, title: 'fastlane')
+        message  = params[:message]
+        title    = params[:title] || 'fastlane'
+        subtitle = params[:subtitle] if params[:subtitle]
+
+        if subtitle
+          TerminalNotifier.notify(message, title: title, subtitle: subtitle)
+        else
+          TerminalNotifier.notify(message, title: title)
+        end
       end
 
       def self.description
@@ -13,7 +20,21 @@ module Fastlane
       end
 
       def self.author
-        "champo"
+        "champo, cbowns"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :message,
+                                       description: "The message to display in the notification",
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :title,
+                                       description: "The title to display in the notification",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :subtitle,
+                                       description: "A subtitle to display in the notification",
+                                       optional: true),
+        ]
       end
 
       def self.is_supported?(platform)


### PR DESCRIPTION
Added optional and required parameters for message, title, and subtitle.

`notify` also just didn't work for me at all before. Now it does.

(I'm very open to stylistic recommendations for this, I'm not familiar with how to handle ruby optional arguments.)
