### PR TITLE
fixes register_devices action bug

### DIFF
--- a/lib/fastlane/actions/register_devices.rb
+++ b/lib/fastlane/actions/register_devices.rb
@@ -17,7 +17,7 @@ module Fastlane
 
         credentials = CredentialsManager::AccountManager.new(user: params[:username])
         Spaceship.login(credentials.user, credentials.password)
-        ENV["FASTLANE_TEAM_ID"] = platform[:team_id]
+        ENV["FASTLANE_TEAM_ID"] = params[:team_id] unless params.nil?
         Spaceship.select_team
 
         if devices


### PR DESCRIPTION
team_id is retrieved from params and not from platform

I had this error using the register_devices action:
"NameError: undefined local variable or method `platform' for Fastlane::Actions::RegisterDevicesAction:Class"

I think the problem is that the parameter is being retrieved with platform instead of params.

I didn't found the tests for this action and had no way to test it
