### PR TITLE
Add an apple compliant git version

### DIFF
--- a/lib/fastlane/actions/set_build_number_repository.rb
+++ b/lib/fastlane/actions/set_build_number_repository.rb
@@ -75,10 +75,10 @@ module Fastlane
           command = 'git svn info | grep Revision | egrep -o "[0-9]+"'
         elsif is_git?
           Helper.log.info "Detected repo: git"
-          tagPrefix = params[:use_git_counts_matching_tag]
-          if tagPrefix
-            major = git_tags_matching(tagPrefix).count
-            minor = git_commit_count_between(git_diverging_commit_matching(tagPrefix))
+          tag_prefix = params[:use_git_counts_matching_tag]
+          if tag_prefix
+            major = git_tags_matching(tag_prefix).count
+            minor = git_commit_count_between(git_diverging_commit_matching(tag_prefix))
             patch = git_abbrev_last_commit.to_i(16)
             build_number = "#{major}.#{minor}.#{patch}"
           else

--- a/lib/fastlane/actions/set_build_number_repository.rb
+++ b/lib/fastlane/actions/set_build_number_repository.rb
@@ -36,18 +36,26 @@ module Fastlane
         return false
       end
 
-      def self.git_tag_count
-        tags = Actions.sh('git log --simplify-by-decoration --decorate --pretty=oneline HEAD | grep "tag:"').shellsplit
-        tags.count
-      rescue
-        0
+      def self.git_initial_commit
+        Actions.sh('git rev-list --max-parents=0 --abbrev-commit HEAD').chomp
       end
 
-      def self.git_commit_count_reference_point
-        Actions.sh('git describe --tags --abbrev=0 $(git rev-list --tags --max-count=1 HEAD)').chomp
-      rescue
-        # No tags, return first sha
-        Actions.sh('git rev-list --max-parents=0 --abbrev-commit HEAD').chomp
+      def self.git_tags_matching(matching)
+        tags = Actions.sh('git show-ref --tags').split("\n")
+        tags = tags.map { |tag| tag.split(" ") }
+        if matching
+          tags = tags.select { |shaTag| shaTag[1].start_with? "refs/tags/#{matching}" }
+        end
+        tags.map { |shaTag| shaTag[0] }
+      end
+
+      def self.git_diverging_commit_matching(matching)
+        list = git_tags_matching(matching)
+        if list.empty?
+          git_initial_commit
+        else
+          list.last.split(" ").first
+        end
       end
 
       def self.git_commit_count_between(commitA, commitB = "HEAD")
@@ -67,9 +75,10 @@ module Fastlane
           command = 'git svn info | grep Revision | egrep -o "[0-9]+"'
         elsif is_git?
           Helper.log.info "Detected repo: git"
-          if params[:use_git_counts_from_tag]
-            major = git_tag_count
-            minor = git_commit_count_between(git_commit_count_reference_point)
+          tagPrefix = params[:use_git_counts_matching_tag]
+          if tagPrefix
+            major = git_tags_matching(tagPrefix).count
+            minor = git_commit_count_between(git_diverging_commit_matching(tagPrefix))
             patch = git_abbrev_last_commit.to_i(16)
             build_number = "#{major}.#{minor}.#{patch}"
           else
@@ -108,12 +117,12 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        default_value: false),
-          FastlaneCore::ConfigItem.new(key: :use_git_counts_from_tag,
-                                       env_name: "USE_GIT_COUNTS_FROM_TAG",
-                                       description: "Use the number of tags as the major version, number of commits since last tag as minor version, and a numeric SHA as the patch version",
+          FastlaneCore::ConfigItem.new(key: :use_git_counts_matching_tag,
+                                       env_name: "USE_GIT_COUNTS_MATCHING_TAG",
+                                       description: "Use the number of matching tags as the major version, number of commits since last matching tag as minor version, and a numeric SHA as the patch version",
                                        optional: true,
-                                       is_string: false,
-                                       default_value: false)
+                                       is_string: true,
+                                       default_value: nil)
         ]
       end
 

--- a/lib/fastlane/actions/set_build_number_repository.rb
+++ b/lib/fastlane/actions/set_build_number_repository.rb
@@ -36,6 +36,28 @@ module Fastlane
         return false
       end
 
+      def self.git_tag_count
+        tags = Actions.sh('git log --simplify-by-decoration --decorate --pretty=oneline HEAD | grep "tag:"').shellsplit
+        tags.count
+      rescue
+        0
+      end
+
+      def self.git_commit_count_reference_point
+        Actions.sh('git describe --tags --abbrev=0 $(git rev-list --tags --max-count=1 HEAD)').chomp
+      rescue
+        # No tags, return first sha
+        Actions.sh('git rev-list --max-parents=0 --abbrev-commit HEAD').chomp
+      end
+
+      def self.git_commit_count_between(commitA, commitB="HEAD")
+        Actions.sh("git rev-list #{commitA}..#{commitB} --count").chomp
+      end
+
+      def self.git_abbrev_last_commit
+        Actions.sh('git rev-list --max-count=1 --abbrev=0 --abbrev-commit HEAD').chomp
+      end
+
       def self.run(params)
         if is_svn?
           Helper.log.info "Detected repo: svn"
@@ -45,7 +67,14 @@ module Fastlane
           command = 'git svn info | grep Revision | egrep -o "[0-9]+"'
         elsif is_git?
           Helper.log.info "Detected repo: git"
-          command = 'git rev-parse --short HEAD'
+          if params[:use_git_counts_from_tag]
+            major = git_tag_count
+            minor = git_commit_count_between(git_commit_count_reference_point)
+            patch = git_abbrev_last_commit.to_i(16)
+            build_number = "#{major}.#{minor}.#{patch}"
+          else
+            command = 'git rev-parse --short HEAD'
+          end
         elsif is_hg?
           Helper.log.info "Detected repo: hg"
           if params[:use_hg_revision_number]
@@ -56,8 +85,9 @@ module Fastlane
         else
           raise "No repository detected"
         end
-
-        build_number = Actions.sh command
+        if build_number == nil
+          build_number = Actions.sh command
+        end
 
         Fastlane::Actions::IncrementBuildNumberAction.run(build_number: build_number)
       end
@@ -75,6 +105,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :use_hg_revision_number,
                                        env_name: "USE_HG_REVISION_NUMBER",
                                        description: "Use hg revision number instead of hash (ignored for non-hg repos)",
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :use_git_counts_from_tag,
+                                       env_name: "USE_GIT_COUNTS_FROM_TAG",
+                                       description: "Use the number of tags as the major version, number of commits since last tag as minor version, and a numeric SHA as the patch version",
                                        optional: true,
                                        is_string: false,
                                        default_value: false)

--- a/lib/fastlane/actions/set_build_number_repository.rb
+++ b/lib/fastlane/actions/set_build_number_repository.rb
@@ -50,7 +50,7 @@ module Fastlane
         Actions.sh('git rev-list --max-parents=0 --abbrev-commit HEAD').chomp
       end
 
-      def self.git_commit_count_between(commitA, commitB="HEAD")
+      def self.git_commit_count_between(commitA, commitB = "HEAD")
         Actions.sh("git rev-list #{commitA}..#{commitB} --count").chomp
       end
 
@@ -85,7 +85,7 @@ module Fastlane
         else
           raise "No repository detected"
         end
-        if build_number == nil
+        if build_number.nil?
           build_number = Actions.sh command
         end
 


### PR DESCRIPTION
The action `set_build_number_repository` action generates an invalid `CFBundleVersion`. 

https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364

I added an option `use_git_counts_matching_tag` to generate safe build numbers from the git history.  This option specifies a tag prefix, and will generate a version string as follows:

Major Number: The number of tags in the commit history that start with `use_git_counts_matching_tag`
Minor Number: The number of commits since the last matching tag
Patch Number: The git sha as an integer

This will generate a build number that sorts correctly in hocky app (and others) and should be accepted in Test Flight which requires each build to have a bigger build number.

For example, if `use_git_counts_matching_tag=sprint` was specified, and the sprint demo build was tagged with `sprint-<sprint number>` at the end of the sprint, After 10 commits in sprint 2, the build number would be 2.10.git-sha-as-integer. 

I believe this is as good as we can get given the non-linear nature of git. If two branches were built with the same number of commits since the last tag, the build numbers would still be unique by the patch version, even though the major and minor numbers would be the same.
