### PR TITLE
Build number as build setting

### DIFF
--- a/lib/fastlane/actions/gym.rb
+++ b/lib/fastlane/actions/gym.rb
@@ -17,6 +17,8 @@ module Fastlane
             values[:provisioning_profile_path] = File.expand_path(sigh_path) if sigh_path
           end
 
+          SetBuildNumberRepositoryAction.add_build_number_build_setting(values, :xcargs)
+
           values[:export_method] ||= Actions.lane_context[Actions::SharedValues::SIGH_PROFILE_TYPE]
 
           absolute_ipa_path = File.expand_path(Gym::Manager.new.work(values))

--- a/lib/fastlane/actions/set_build_number_repository.rb
+++ b/lib/fastlane/actions/set_build_number_repository.rb
@@ -1,6 +1,7 @@
 module Fastlane
   module Actions
     module SharedValues
+      BUILD_SETTING_FOR_BUILD_NUMBER = :BUILD_SETTING_FOR_BUILD_NUMBER
     end
 
     class SetBuildNumberRepositoryAction < Action
@@ -59,7 +60,25 @@ module Fastlane
 
         build_number = Actions.sh command
 
-        Fastlane::Actions::IncrementBuildNumberAction.run(build_number: build_number)
+        if params[:build_number_as_build_setting]
+          # This will pass the build number as the build setting specified to xcodebuild and gym.
+          # This will only modify the plist files if they haven't been set to this value before.
+          build_setting = params[:build_number_as_build_setting]
+          Fastlane::Actions::IncrementBuildNumberAction.run(build_number: "'\\$(#{build_setting})'")
+          Actions.lane_context[SharedValues::BUILD_SETTING_FOR_BUILD_NUMBER] = build_setting
+          Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number.chomp
+        else
+          Fastlane::Actions::IncrementBuildNumberAction.run(build_number: build_number)
+        end
+      end
+
+      def self.add_build_number_build_setting(dictionary, key)
+        build_setting_for_build_number = Actions.lane_context[SharedValues::BUILD_SETTING_FOR_BUILD_NUMBER]
+        if build_setting_for_build_number
+          build_number = Actions.lane_context[SharedValues::BUILD_NUMBER]
+          dictionary[key] ||= ""
+          dictionary[key] += " #{build_setting_for_build_number}=#{build_number}"
+        end
       end
 
       #####################################################
@@ -72,6 +91,13 @@ module Fastlane
 
       def self.available_options
         [
+          FastlaneCore::ConfigItem.new(key: :build_number_as_build_setting,
+                                       env_name: "BUILD_NUMBER_AS_BUILD_SETTING",
+                                       description: "Pass the build number into the build via a build variable instead of modifying the plist files",
+                                       optional: true,
+                                       is_string: true,
+                                       default_value: nil),
+
           FastlaneCore::ConfigItem.new(key: :use_hg_revision_number,
                                        env_name: "USE_HG_REVISION_NUMBER",
                                        description: "Use hg revision number instead of hash (ignored for non-hg repos)",

--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -316,6 +316,8 @@ module Fastlane
       def self.run(params)
         params_hash = params || {}
         params_hash[:build] = true
+
+        SetBuildNumberRepositoryAction.add_build_number_build_setting(params_hash, :build_settings)
         XcodebuildAction.run(params_hash)
       end
 


### PR DESCRIPTION
The `SetBuildNumberRepositoryAction` has always modified the plist files to store an updated version number. This then would lead to VC info being committed, and once that happened, it was instantly wrong!

This will run `IncrementBuildNumberAction` to set the CFBundleVersion to whatever is specified in `build_number_as_build_setting` which is then expanded by xcodebuild into the proper build number. So for instance:

```
set_build_number_repository(build_number_as_build_setting: "BUILD_NUMBER")
```

This resolves issue #514. 
