### PR TITLE
Add mac platform to SetBuildNumberRepositoryAction

### DIFF
--- a/lib/fastlane/actions/set_build_number_repository.rb
+++ b/lib/fastlane/actions/set_build_number_repository.rb
@@ -5,7 +5,7 @@ module Fastlane
 
     class SetBuildNumberRepositoryAction < Action
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include? platform
       end
 
       def self.is_svn?


### PR DESCRIPTION
Pretty simple fix, it shouldn't of been restricted from mac. Discovered by @tcurdt !
