### PR TITLE
Specify region in upload_plist_and_html_to_s3

### DIFF
--- a/lib/fastlane/actions/s3.rb
+++ b/lib/fastlane/actions/s3.rb
@@ -208,7 +208,7 @@ module Fastlane
             secret_access_key: s3_secret_access_key
           )
         end
-        
+
         bucket = s3_client.buckets[s3_bucket]
 
         plist_obj = bucket.objects.create(plist_file_name, plist_render.to_s, acl: :public_read)


### PR DESCRIPTION
I am using AWS S3 region:ap-southeast-1 and having this issue. Since upload_plist_and_html_to_s3 does not specify region which lead to this eror
`The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.`

this will resolve issue:#623
