### PR TITLE
Nested resigning

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -217,6 +217,19 @@ resign(
 )
 ```
 
+You may provide multiple provisioning profiles if the application contains nested applications or app extensions, which need their own provisioning profile. You can do so by passing an array of provisiong profile strings or a hash that associates provisioning profile values to bundle identifier keys.
+
+```ruby
+resign(
+  ipa: 'path/to/ipa', # can omit if using the `ipa` action
+  signing_identity: 'iPhone Distribution: Luka Mirosevic (0123456789)',
+  provisioning_profile: {
+  	'com.example.awesome-app' => 'path/to/profile',
+  	'com.example.awesome-app.app-extension' => 'path/to/app-extension/profile'
+  }
+)
+```
+
 ### `create_keychain`
 
 Create a new keychain, which can then be used to import certificates.

--- a/lib/fastlane/actions/resign.rb
+++ b/lib/fastlane/actions/resign.rb
@@ -49,7 +49,11 @@ module Fastlane
                                        default_value: Actions.lane_context[SharedValues::SIGH_PROFILE_PATH],
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         files = value.kind_of?(Enumerable) ? value.map { |fst, snd| snd || fst } : [value]
+                                         files = case value
+                                         when Hash; value.values
+                                         when Enumerable; value
+                                         else [value]
+                                         end
                                          files.each do |file|
                                            raise "Couldn't find provisiong profile at path '#{file}'".red unless File.exist?(file)
                                          end

--- a/lib/fastlane/actions/resign.rb
+++ b/lib/fastlane/actions/resign.rb
@@ -17,6 +17,20 @@ module Fastlane
         "Codesign an existing ipa file"
       end
 
+      def self.details
+        [
+          "You may provide multiple provisioning profiles if the application contains",
+          "nested applications or app extensions, which need their own provisioning",
+          "profile. You can do so by passing an array of provisiong profile strings or a",
+          "hash that associates provisioning profile values to bundle identifier keys.",
+          "",
+          "resign ipa: 'path', signing_identity: 'identity', provisioning_profile: {",
+          "  'com.example.awesome-app' => 'App.mobileprovision',",
+          "  'com.example.awesome-app.app-extension' => 'Extension.mobileprovision'",
+          "}"
+        ].join("\n")
+      end
+
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :ipa,
@@ -33,8 +47,12 @@ module Fastlane
                                        env_name: "FL_RESIGN_PROVISIONING_PROFILE",
                                        description: "Path to your provisioning_profile. Optional if you use `sigh`",
                                        default_value: Actions.lane_context[SharedValues::SIGH_PROFILE_PATH],
+                                       is_string: false,
                                        verify_block: proc do |value|
-                                         raise "No provisioning_profile file given or found, pass using `provisioning_profile: 'path/app.mobileprovision'`".red unless File.exist?(value)
+                                         files = value.kind_of?(Enumerable) ? value.map { |fst, snd| snd || fst } : [value]
+                                         files.each do |file|
+                                           raise "Couldn't find provisiong profile at path '#{file}'".red unless File.exist?(file)
+                                         end
                                        end)
         ]
       end

--- a/lib/fastlane/actions/resign.rb
+++ b/lib/fastlane/actions/resign.rb
@@ -24,10 +24,10 @@ module Fastlane
           "profile. You can do so by passing an array of provisiong profile strings or a",
           "hash that associates provisioning profile values to bundle identifier keys.",
           "",
-          "resign ipa: 'path', signing_identity: 'identity', provisioning_profile: {",
-          "  'com.example.awesome-app' => 'App.mobileprovision',",
-          "  'com.example.awesome-app.app-extension' => 'Extension.mobileprovision'",
-          "}"
+          "resign(ipa: \"path\", signing_identity: \"identity\", provisioning_profile: {",
+          "  \"com.example.awesome-app\" => \"App.mobileprovision\",",
+          "  \"com.example.awesome-app.app-extension\" => \"Extension.mobileprovision\"",
+          "})"
         ].join("\n")
       end
 

--- a/lib/fastlane/actions/resign.rb
+++ b/lib/fastlane/actions/resign.rb
@@ -50,10 +50,10 @@ module Fastlane
                                        is_string: false,
                                        verify_block: proc do |value|
                                          files = case value
-                                         when Hash; value.values
-                                         when Enumerable; value
-                                         else [value]
-                                         end
+                                                 when Hash then value.values
+                                                 when Enumerable then value
+                                                 else [value]
+                                                 end
                                          files.each do |file|
                                            raise "Couldn't find provisiong profile at path '#{file}'".red unless File.exist?(file)
                                          end


### PR DESCRIPTION
Sigh now supports passing multiple provisioning profiles to the resign action (fastlane/sigh#174).
