### PR TITLE
Access control to resources for multiple instances of fastlane running on the same machine

### DIFF
--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -183,6 +183,19 @@ module Fastlane
       end
     end
 
+    # Lock execution of block across multiple fastlane instances
+    def lock_exec(lockname = "global", &block)
+      Helper::LockerHelper.lock_exec(lockname) { yield }
+    end
+
+    def lock_simulator(&block)
+      lock_exec("simulator") { yield }
+    end
+
+    def lock_pods(&block)
+      lock_exec("cocoapods") { yield }
+    end
+
     def desc(string)
       desc_collection << string
     end

--- a/lib/fastlane/helper/lock_helper.rb
+++ b/lib/fastlane/helper/lock_helper.rb
@@ -1,0 +1,105 @@
+module Fastlane
+  module Helper
+    # Helps to make sure that only one instance of action(s)
+    # is(are) executed on the same machine at the same time
+    class LockerHelper
+
+      attr_accessor :waited_time
+      attr_accessor :lock_name
+      attr_accessor :lock_file_name
+
+      # wait 30 seconds between checks
+      def self.lock_recheck_sleep_time
+        30
+      end
+
+      def self.max_wait_time
+        60 * 2 * (2 * LockerHelper.lock_recheck_sleep_time)
+      end
+
+      def self.current_pid
+        Process.pid
+      end
+
+      def locking_pid
+        # get the current locking process pid from the lock file
+        Integer(File.read(lock_file_name))
+      end
+
+      def create_lock
+        File.open(lock_file_name, "w") do |f|
+          f.write(LockerHelper.current_pid)
+          f.close
+        end
+      end
+
+      def remove_lock
+        File.delete(lock_file_name)
+      end
+
+      def wait_retry
+        unless Helper.is_test?
+          sleep LockerHelper.lock_recheck_sleep_time
+        end
+
+        @waited_time += LockerHelper.lock_recheck_sleep_time
+      end
+
+      def proceed_condition
+        !File.exist?(lock_file_name) || @waited_time >= LockerHelper.max_wait_time
+      end
+
+      def check_locking_process_existance
+        Process.getpgid(locking_pid)
+      end
+
+      def self.lock_file_path(lock_name)
+        "/tmp/fastlane_#{lock_name}.lock"
+      end
+
+      def self.lock_exec(name, &block)
+        locker = LockerHelper.new
+        locker.waited_time = 0
+        locker.lock_file_name = LockerHelper.lock_file_path(name)
+
+        Helper.log.info "[LOCKER] Locking execution context '#{locker.lock_name}' -> '#{locker.lock_file_name}' ..."
+
+        loop do
+          # exit the loop if:
+          # - lock_file does not exist
+          # or - waited more than 2h, that process must be hung somewhere
+          break if locker.proceed_condition
+
+          # check whether the locking process still exists
+          # break the loop if it doesn't exits or we waited too much time
+          begin
+            locker.check_locking_process_existance
+          rescue Errno::ESRCH
+            locker.remove_lock
+            break
+          end
+
+          tries = 1 + locker.waited_time / LockerHelper.lock_recheck_sleep_time
+          Helper.log.info "[LOCKER] Waiting #{LockerHelper.lock_recheck_sleep_time} seconds for execution context '#{locker.lock_name}' to unlock. Try ##{tries}."
+
+          # wait a little bit, then try again
+          locker.wait_retry
+        end
+
+        # create the lock file with the current process pid
+        locker.create_lock
+
+        Helper.log.info "[LOCKER] Locked execution context '#{locker.lock_name}' -> '#{locker.lock_file_name}'."
+
+        # execute the block
+        block.call
+
+        # remove the lock file
+        locker.remove_lock
+        Helper.log.info "[LOCKER] Unlocked execution context '#{locker.lock_name}' -> '#{locker.lock_file_name}'."
+
+        locker
+      end
+    end
+  end
+end

--- a/spec/fast_file_spec.rb
+++ b/spec/fast_file_spec.rb
@@ -334,5 +334,57 @@ describe Fastlane do
         end.to raise_exception "Lane 'test' was defined multiple times!".red
       end
     end
+
+    describe "lock_exec should run as expected" do
+      before do
+        @ff = Fastlane::FastFile.new
+
+        @global_lock_file = '/tmp/fastlane_global.lock'
+        @simulator_lock_file = '/tmp/fastlane_simulator.lock'
+        @cocoapods_lock_file = '/tmp/fastlane_cocoapods.lock'
+
+        if File.exist?(@global_lock_file)
+          File.delete(@global_lock_file)
+        end
+
+        if File.exist?(@simulator_lock_file)
+          File.delete(@simulator_lock_file)
+        end
+
+        if File.exist?(@cocoapods_lock_file)
+          File.delete(@cocoapods_lock_file)
+        end
+      end
+
+      it "lock_exec default lock is created" do
+        expect do
+          @ff.lock_exec do
+            if File.exist?(@global_lock_file)
+              raise 'lock_exec lock file was created'.green
+            end
+          end
+        end.to raise_exception "lock_exec lock file was created".green
+      end
+
+      it "lock_simulator default lock is created" do
+        expect do
+          @ff.lock_simulator do
+            if File.exist?(@simulator_lock_file)
+              raise 'lock_simulator lock file was created'.green
+            end
+          end
+        end.to raise_exception "lock_simulator lock file was created".green
+      end
+
+      it "lock_cocoapods default lock is created" do
+        expect do
+          @ff.lock_pods do
+            if File.exist?(@cocoapods_lock_file)
+              raise 'lock_cocoapods lock file was created'.green
+            end
+          end
+        end.to raise_exception "lock_cocoapods lock file was created".green
+      end
+    end
   end
 end

--- a/spec/lock_helper_spec.rb
+++ b/spec/lock_helper_spec.rb
@@ -1,0 +1,116 @@
+describe Fastlane do
+  describe Fastlane::Helper::LockerHelper do
+    describe "LockerHelper tests" do
+      before do
+        @lh = Fastlane::Helper::LockerHelper.new
+        @lh.lock_file_name = "/tmp/fastlane_test.lock"
+
+        if File.exist?(@lh.lock_file_name)
+          File.delete(@lh.lock_file_name)
+        end
+      end
+
+      it "verifies that the recheck sleep time is 30s" do
+        expect(Fastlane::Helper::LockerHelper.lock_recheck_sleep_time).to eq(30)
+      end
+
+      it "validates max_wait_time" do
+        expect(Fastlane::Helper::LockerHelper.max_wait_time).to eq(60 * 2 * (2 * Fastlane::Helper::LockerHelper.lock_recheck_sleep_time))
+      end
+
+      it "validates current_pid" do
+        expect(Fastlane::Helper::LockerHelper.current_pid).to eq(Process.pid)
+      end
+
+      it "validates locking_pid" do
+        File.open(@lh.lock_file_name, "w") do |f|
+          f.write(12)
+          f.close
+        end
+
+        expect(@lh.locking_pid).to eq(12)
+      end
+
+      it "validates create_lock" do
+        @lh.create_lock
+
+        expect(Integer(File.read(@lh.lock_file_name))).to eq(Process.pid)
+      end
+
+      it "validates proceed_condition lock file does not exist and waited time is less than max" do
+        @lh.waited_time = 0
+
+        expect(@lh.proceed_condition).to eq(true)
+      end
+
+      it "validates proceed_condition lock file exist and waited time is less than max" do
+        @lh.create_lock
+        @lh.waited_time = 0
+
+        expect(@lh.proceed_condition).to eq(false)
+      end
+
+      it "validates that the locking process existance is detected correctly, locking process exist" do
+        @lh.create_lock
+        @lh.check_locking_process_existance
+      end
+
+      it "validates that the locking process existance is detected correctly, locking process does not exist" do
+        File.open(@lh.lock_file_name, "w") do |f|
+          f.write(59800)
+          f.close
+        end
+
+        expect do
+          @lh.check_locking_process_existance
+        end.to raise_error(/No such process/)
+      end
+
+      it "validates lock file path is generated as expected" do
+        expect(Fastlane::Helper::LockerHelper.lock_file_path("test")).to eq(@lh.lock_file_name)
+      end
+
+      it "validates lock_exec works properly when no locking exists" do
+        my_test_value = 20
+        locker = Fastlane::Helper::LockerHelper.lock_exec("test") do
+          my_test_value = 30
+          expect(File.exist?(@lh.lock_file_name)).to eq(true)
+        end
+
+        expect(locker.waited_time == 0).to eq(true)
+        expect(my_test_value).to eq(30)
+        expect(File.exist?(@lh.lock_file_name)).to eq(false)
+      end
+
+      it "validates lock_exec works properly when some locking exists, locking process exists, and waited max time" do
+        File.open(@lh.lock_file_name, "w") do |f|
+          f.write(Process.pid)
+          f.close
+        end
+
+        my_test_value = 20
+        locker = Fastlane::Helper::LockerHelper.lock_exec("test") { my_test_value = 30 }
+
+        expect(locker.waited_time > 0).to eq(true)
+        expect(my_test_value).to eq(30)
+        expect(File.exist?(@lh.lock_file_name)).to eq(false)
+      end
+
+      it "validates lock_exec works properly when some locking exists, locking process does not exists, and waited max time" do
+        File.open(@lh.lock_file_name, "w") do |f|
+          f.write(59800)
+          f.close
+        end
+
+        my_test_value = 20
+        locker = Fastlane::Helper::LockerHelper.lock_exec("test") do
+          my_test_value = 30
+        end
+
+        expect(locker.waited_time == 0).to eq(true)
+        expect(my_test_value).to eq(30)
+        expect(File.exist?(@lh.lock_file_name)).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Introduction

This solution is for environments where on a CI box multiple projects are built at the same time with `fastlane`.
## Use cases

When running multiple instances of `fastlane` on the same machine (e.g. CI box),
due to limitation of the `iOS Simulator` (e.g. only one instance of the simulator can be used)
the tests might crash in both instances of the `fastlane` because they were trying to run tests at the same time in the `iOS Simulator`

A similar case is for `Cocoapods`, if two instances of `fastlane` try to run `pod install` for the same `pods`, the `Cocoapods` cache will become corrupted.

There might be other usages when it is desired only one process of `fastlane` to access a certain resource.

I've been using this solution for two months already (imported from git https://github.com/xfreebird/fastlane-utils), it works great and is stable.

It adds three new options to `fastlane` for atomising access to a certain resource on the build machine.

``` ruby

lock_exec {
    # atomic execution of the block on the build machine
    # using lockname global
   action1
   action2
}

lock_exec(lockname: "mylock") {
    # atomic execution of the block on the build machine
    # using lockname mylock
   action1
   action2
}

lock_pods {
    # atomic execution of the block on the build machine
    # using lockname cocoapods
   action1
   action2
}

lock_simulator {
    # atomic execution of the block on the build machine
    # using lockname simulatior
   action1
   action2
}
```
## Usage

``` ruby
default_platform :ios

platform :ios do

  lane :beta do

    lock_pods { 
      cocoapods
    }

    increment_build_number
    sigh

    lock_simulator { 
      xctest
    }

   deliver
   slack
  end

end
```

Resolves issue #524 .
