### PR TITLE
Add appledoc action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1327,17 +1327,18 @@ Generate Apple-like source code documentation from specially formatted source co
 
 ```ruby
 appledoc(
-      project_name: "MyProjectName",
-      project_company: "Company Name",
-      company_id: "com.company.id",
-      input: "MyProjectSources",
-      output: "/tmp/appledoc/myProjectDocs",
-      options: "--keep-intermediate-files --search-undocumented-doc",
-      warnings: "--warn-missing-output-path --warn-missing-company-id",
-      exit_threshold: 2 # Exit code threshold below which 0 is returned
-    )
+  project_name: "MyProjectName",
+  project_company: "Company Name",
+  input: "MyProjectSources",
+  ignore: [
+    'ignore/path/1',
+    'ingore/path/2'
+  ],
+  options: "--keep-intermediate-files --search-undocumented-doc",
+  warnings: "--warn-missing-output-path --warn-missing-company-id"
+)
 ```
-Use ``appledoc --help`` to see the list of all command line options.
+Use `appledoc --help` to see the list of all command line options.
 
 ### download
 

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1321,6 +1321,24 @@ end
 
 ## Misc
 
+### appledoc
+
+Generate Apple-like source code documentation from specially formatted source code comments.
+
+```ruby
+appledoc(
+      project_name: "MyProjectName",
+      project_company: "Company Name",
+      company_id: "com.company.id",
+      input: "MyProjectSources",
+      output: "/tmp/appledoc/myProjectDocs",
+      options: "--keep-intermediate-files --search-undocumented-doc",
+      warnings: "--warn-missing-output-path --warn-missing-company-id",
+      exit_threshold: 2 # Exit code threshold below which 0 is returned
+    )
+```
+Use ``appledoc --help`` to see the list of all command line options.
+
 ### download
 
 Download a file from a remote server (e.g. JSON file)

--- a/lib/fastlane/actions/appledoc.rb
+++ b/lib/fastlane/actions/appledoc.rb
@@ -349,7 +349,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :exit_threshold,
                                        env_name: "FL_APPLEDOC_OPTIONS_EXIT_THRESHOLD",
                                        description: "Exit code threshold below which 0 is returned",
-                                       is_string: true,
+                                       is_string: false,
                                        optional: true),
 
           FastlaneCore::ConfigItem.new(key: :docs_section_title,
@@ -369,13 +369,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :logformat,
                                        env_name: "FL_APPLEDOC_LOGFORMAT",
                                        description: "Log format [0-3]",
-                                       is_string: true,
+                                       is_string: false,
                                        optional: true),
 
           FastlaneCore::ConfigItem.new(key: :verbose,
                                        env_name: "FL_APPLEDOC_VERBOSE",
                                        description: "Log verbosity level [0-6,xcode]",
-                                       is_string: true,
+                                       is_string: false,
                                        optional: true)
         ]
       end

--- a/lib/fastlane/actions/appledoc.rb
+++ b/lib/fastlane/actions/appledoc.rb
@@ -1,0 +1,398 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      APPLEDOC_DOCUMENTATION_OUTPUT = :APPLEDOC_DOCUMENTATION_OUTPUT
+    end
+
+    class AppledocAction < Action
+      ARGS_MAP = {
+        input: "",
+        output: "--output",
+        templates: "--templates",
+        docset_install_path: "--docset-install-path",
+        include: "--include",
+        ignore: "--ignore",
+        exclude_output: "--exclude-output",
+        index_desc: "--index-desc",
+        project_name: "--project-name",
+        project_version: "--project-version",
+        project_company: "--project-company",
+        company_id: "--company-id",
+        create_html: "--create-html",
+        create_docset: "--create-docset",
+        install_docset: "--install-docset",
+        publish_docset: "--publish-docset",
+        html_anchors: "--html-anchors",
+        clean_output: "--clean-output",
+        docset_bundle_id: "--docset-bundle-id",
+        docset_bundle_name: "--docset-bundle-name",
+        docset_desc: "--docset-desc",
+        docset_copyright: "--docset-copyright",
+        docset_feed_name: "--docset-feed-name",
+        docset_feed_url: "--docset-feed-url",
+        docset_feed_formats: "--docset-feed-formats",
+        docset_package_url: "--docset-package-url",
+        docset_fallback_url: "--docset-fallback-url",
+        docset_publisher_id: "--docset-publisher-id",
+        docset_publisher_name: "--docset-publisher-name",
+        docset_min_xcode_version: "--docset-min-xcode-version",
+        docset_platform_family: "--docset-platform-family",
+        docset_cert_issuer: "--docset-cert-issuer",
+        docset_cert_signer: "--docset-cert-signer",
+        docset_bundle_filename: "--docset-bundle-filename",
+        docset_atom_filename: "--docset-atom-filename",
+        docset_xml_filename: "--docset-xml-filename",
+        docset_package_filename: "--docset-package-filename",
+        options: "",
+        crossref_format: "--crossref-format",
+        exit_threshold: "--exit-threshold",
+        docs_section_title: "--docs-section-title",
+        warnings: "",
+        logformat: "--logformat",
+        verbose: "--verbose"
+      }
+
+      def self.run(params)
+        unless Helper.test?
+          raise "appledoc not installed".red if `which appledoc`.length == 0
+        end
+
+        params_hash = params.values
+
+        # Check if an output path was given
+        if params_hash[:output]
+          Actions.lane_context[SharedValues::APPLEDOC_DOCUMENTATION_OUTPUT] = File.expand_path(params_hash[:output])
+          create_output_dir_if_not_exists(params_hash[:output])
+        end
+
+        # Maps parameter hash to CLI args
+        appledoc_args = params_hash_to_cli_args(params_hash)
+        Helper.log.info "Generating documentation.".green
+        cli_args = appledoc_args.join(' ')
+        command = "appledoc #{cli_args}".strip + " \"#{params_hash[:input]}\""
+        Helper.log.debug command
+        Actions.sh command
+      end
+
+      def self.params_hash_to_cli_args(params)
+        # Remove nil and false value params
+        params = params.delete_if { |_, v| v.nil? || v == false}
+
+        # Maps nice developer param names to CLI arguments
+        params.map do |k, v|
+          v ||= ""
+          args = ARGS_MAP[k]
+          if args.empty?
+            if k != :input
+              v
+            end
+          else
+            value = (v != true && v.to_s.length > 0 ? "\"#{v}\"" : "")
+            "#{args} #{value}".strip
+          end
+        end.compact
+      end
+
+      def self.create_output_dir_if_not_exists(output_path)
+        output_dir = File.dirname(output_path)
+
+        # If the output directory doesn't exist, create it
+        unless Dir.exist? output_dir
+          FileUtils.mkpath output_dir
+        end
+      end
+
+      def self.description
+        "Runs `appledoc [OPTIONS] <paths to source dirs or files>` for the project"
+      end
+
+      def self.available_options
+        [
+          # PATHS
+          FastlaneCore::ConfigItem.new(key: :input,
+                                       env_name: "FL_APPLEDOC_INPUT",
+                                       description: "Path to source files",
+                                       is_string: true),
+
+          FastlaneCore::ConfigItem.new(key: :output,
+                                       env_name: "FL_APPLEDOC_OUTPUT",
+                                       description: "Output path",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :templates,
+                                       env_name: "FL_APPLEDOC_TEMPLATES",
+                                       description: "Template files path",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_install_path,
+                                       env_name: "FL_APPLEDOC_DOCSET_INSTALL_PATH",
+                                       description: "DocSet installation path",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :include,
+                                       env_name: "FL_APPLEDOC_INCLUDE",
+                                       description: "Include static doc(s) at path",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :ignore,
+                                       env_name: "FL_APPLEDOC_IGNORE",
+                                       description: "Ignore given path",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :exclude_output,
+                                       env_name: "FL_APPLEDOC_EXCLUDE_OUTPUT",
+                                       description: "Exclude given path from output",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :index_desc,
+                                       env_name: "FL_APPLEDOC_INDEX_DESC",
+                                       description: "File including main index description",
+                                       is_string: true,
+                                       optional: true),
+
+          # PROJECT INFO
+          FastlaneCore::ConfigItem.new(key: :project_name,
+                                       env_name: "FL_APPLEDOC_PROJECT_NAME",
+                                       description: "Project name",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :project_version,
+                                       env_name: "FL_APPLEDOC_PROJECT_VERSION",
+                                       description: "Project version",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :project_company,
+                                       env_name: "FL_APPLEDOC_PROJECT_COMPANY",
+                                       description: "Project company",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :company_id,
+                                       env_name: "FL_APPLEDOC_COMPANY_ID",
+                                       description: "Company UTI (i.e. reverse DNS name)",
+                                       is_string: true,
+                                       optional: true),
+
+          # OUTPUT GENERATION
+          FastlaneCore::ConfigItem.new(key: :create_html,
+                                       env_name: "FL_APPLEDOC_CREATE_HTML",
+                                       description: "Create HTML",
+                                       is_string: false,
+                                       default_value: false),
+
+          FastlaneCore::ConfigItem.new(key: :create_docset,
+                                       env_name: "FL_APPLEDOC_CREATE_DOCSET",
+                                       description: "Create documentation set",
+                                       is_string: false,
+                                       default_value: false),
+
+          FastlaneCore::ConfigItem.new(key: :install_docset,
+                                       env_name: "FL_APPLEDOC_INSTALL_DOCSET",
+                                       description: "Install documentation set to Xcode",
+                                       is_string: false,
+                                       default_value: false),
+
+          FastlaneCore::ConfigItem.new(key: :publish_docset,
+                                       env_name: "FL_APPLEDOC_PUBLISH_DOCSET",
+                                       description: "Prepare DocSet for publishing",
+                                       is_string: false,
+                                       default_value: false),
+
+          FastlaneCore::ConfigItem.new(key: :html_anchors,
+                                       env_name: "FL_APPLEDOC_HTML_ANCHORS",
+                                       description: "The html anchor format to use in DocSet HTML",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :clean_output,
+                                       env_name: "FL_APPLEDOC_CLEAN_OUTPUT",
+                                       description: "Remove contents of output path before starting",
+                                       is_string: false,
+                                       default_value: false),
+
+          # DOCUMENTATION SET INFO
+          FastlaneCore::ConfigItem.new(key: :docset_bundle_id,
+                                       env_name: "FL_APPLEDOC_DOCSET_BUNDLE_ID",
+                                       description: "DocSet bundle identifier",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_bundle_name,
+                                       env_name: "FL_APPLEDOC_DOCSET_BUNDLE_NAME",
+                                       description: "DocSet bundle name",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_desc,
+                                       env_name: "FL_APPLEDOC_DOCSET_DESC",
+                                       description: "DocSet description",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_copyright,
+                                       env_name: "FL_APPLEDOC_DOCSET_COPYRIGHT",
+                                       description: "DocSet copyright message",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_feed_name,
+                                       env_name: "FL_APPLEDOC_DOCSET_FEED_NAME",
+                                       description: "DocSet feed name",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_feed_url,
+                                       env_name: "FL_APPLEDOC_DOCSET_FEED_URL",
+                                       description: "DocSet feed URL",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_feed_formats,
+                                       env_name: "FL_APPLEDOC_DOCSET_FEED_FORMATS",
+                                       description: "DocSet feed formats. Separated by a comma [atom,xml]",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_package_url,
+                                       env_name: "FL_APPLEDOC_DOCSET_PACKAGE_URL",
+                                       description: "DocSet package (.xar) URL",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_fallback_url,
+                                       env_name: "FL_APPLEDOC_DOCSET_FALLBACK_URL",
+                                       description: "DocSet fallback URL",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_publisher_id,
+                                       env_name: "FL_APPLEDOC_DOCSET_PUBLISHER_ID",
+                                       description: "DocSet publisher identifier",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_publisher_name,
+                                       env_name: "FL_APPLEDOC_DOCSET_PUBLISHER_NAME",
+                                       description: "DocSet publisher name",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_min_xcode_version,
+                                       env_name: "FL_APPLEDOC_DOCSET_MIN_XCODE_VERSION",
+                                       description: "DocSet min. Xcode version",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_platform_family,
+                                       env_name: "FL_APPLEDOC_DOCSET_PLATFORM_FAMILY",
+                                       description: "DocSet platform familiy",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_cert_issuer,
+                                       env_name: "FL_APPLEDOC_DOCSET_CERT_ISSUER",
+                                       description: "DocSet certificate issuer",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_cert_signer,
+                                       env_name: "FL_APPLEDOC_DOCSET_CERT_SIGNER",
+                                       description: "DocSet certificate signer",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_bundle_filename,
+                                       env_name: "FL_APPLEDOC_DOCSET_BUNDLE_FILENAME",
+                                       description: "DocSet bundle filename",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_atom_filename,
+                                       env_name: "FL_APPLEDOC_DOCSET_ATOM_FILENAME",
+                                       description: "DocSet atom feed filename",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_xml_filename,
+                                       env_name: "FL_APPLEDOC_DOCSET_XML_FILENAME",
+                                       description: "DocSet xml feed filename",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docset_package_filename,
+                                       env_name: "FL_APPLEDOC_DOCSET_PACKAGE_FILENAME",
+                                       description: "DocSet package (.xar,.tgz) filename",
+                                       is_string: true,
+                                       optional: true),
+
+          # OPTIONS
+          FastlaneCore::ConfigItem.new(key: :options,
+                                       env_name: "FL_APPLEDOC_OPTIONS",
+                                       description: "Documentation generation options",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :crossref_format,
+                                       env_name: "FL_APPLEDOC_OPTIONS_CROSSREF_FORMAT",
+                                       description: "Cross reference template regex",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :exit_threshold,
+                                       env_name: "FL_APPLEDOC_OPTIONS_EXIT_THRESHOLD",
+                                       description: "Exit code threshold below which 0 is returned",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :docs_section_title,
+                                       env_name: "FL_APPLEDOC_OPTIONS_DOCS_SECTION_TITLE",
+                                       description: "Title of the documentation section (defaults to \"Programming Guides\"",
+                                       is_string: true,
+                                       optional: true),
+
+          # WARNINGS
+          FastlaneCore::ConfigItem.new(key: :warnings,
+                                       env_name: "FL_APPLEDOC_WARNINGS",
+                                       description: "Documentation generation warnings",
+                                       is_string: true,
+                                       optional: true),
+
+          # MISCELLANEOUS
+          FastlaneCore::ConfigItem.new(key: :logformat,
+                                       env_name: "FL_APPLEDOC_LOGFORMAT",
+                                       description: "Log format [0-3]",
+                                       is_string: true,
+                                       optional: true),
+
+          FastlaneCore::ConfigItem.new(key: :verbose,
+                                       env_name: "FL_APPLEDOC_VERBOSE",
+                                       description: "Log verbosity level [0-6,xcode]",
+                                       is_string: true,
+                                       optional: true)
+        ]
+      end
+
+      def self.output
+        [
+          ['APPLEDOC_DOCUMENTATION_OUTPUT', 'Documentation set output path']
+        ]
+      end
+
+      def self.authors
+        ["alexmx"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/appledoc.rb
+++ b/lib/fastlane/actions/appledoc.rb
@@ -54,6 +54,7 @@ module Fastlane
 
       def self.run(params)
         unless Helper.test?
+          Helper.log.info "Install using `brew install homebrew/boneyard/appledoc`"
           raise "appledoc not installed".red if `which appledoc`.length == 0
         end
 
@@ -78,19 +79,30 @@ module Fastlane
         # Remove nil and false value params
         params = params.delete_if { |_, v| v.nil? || v == false}
 
-        # Maps nice developer param names to CLI arguments
-        params.map do |k, v|
-          v ||= ""
-          args = ARGS_MAP[k]
+        cli_args = []
+        params.each do |key, value|
+          args = ARGS_MAP[key]
           if args.empty?
-            if k != :input
-              v
+            if key != :input
+              cli_args << value
             end
           else
-            value = (v != true && v.to_s.length > 0 ? "\"#{v}\"" : "")
-            "#{args} #{value}".strip
+            if value.kind_of?(Array)
+              value.each do |v|
+                cli_args << cli_param(args, v)
+              end
+            else
+              cli_args << cli_param(args, value)
+            end
           end
-        end.compact
+        end
+
+        return cli_args
+      end
+
+      def self.cli_param(k, v)
+        value = (v != true && v.to_s.length > 0 ? "\"#{v}\"" : "")
+        "#{k} #{value}".strip
       end
 
       def self.create_output_dir_if_not_exists(output_path)
@@ -109,274 +121,62 @@ module Fastlane
       def self.available_options
         [
           # PATHS
-          FastlaneCore::ConfigItem.new(key: :input,
-                                       env_name: "FL_APPLEDOC_INPUT",
-                                       description: "Path to source files",
-                                       is_string: true),
-
-          FastlaneCore::ConfigItem.new(key: :output,
-                                       env_name: "FL_APPLEDOC_OUTPUT",
-                                       description: "Output path",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :templates,
-                                       env_name: "FL_APPLEDOC_TEMPLATES",
-                                       description: "Template files path",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_install_path,
-                                       env_name: "FL_APPLEDOC_DOCSET_INSTALL_PATH",
-                                       description: "DocSet installation path",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :include,
-                                       env_name: "FL_APPLEDOC_INCLUDE",
-                                       description: "Include static doc(s) at path",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :ignore,
-                                       env_name: "FL_APPLEDOC_IGNORE",
-                                       description: "Ignore given path",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :exclude_output,
-                                       env_name: "FL_APPLEDOC_EXCLUDE_OUTPUT",
-                                       description: "Exclude given path from output",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :index_desc,
-                                       env_name: "FL_APPLEDOC_INDEX_DESC",
-                                       description: "File including main index description",
-                                       is_string: true,
-                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :input, env_name: "FL_APPLEDOC_INPUT", description: "Path to source files", is_string: true),
+          FastlaneCore::ConfigItem.new(key: :output, env_name: "FL_APPLEDOC_OUTPUT", description: "Output path", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :templates, env_name: "FL_APPLEDOC_TEMPLATES", description: "Template files path", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_install_path, env_name: "FL_APPLEDOC_DOCSET_INSTALL_PATH", description: "DocSet installation path", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :include, env_name: "FL_APPLEDOC_INCLUDE", description: "Include static doc(s) at path", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :ignore, env_name: "FL_APPLEDOC_IGNORE", description: "Ignore given path", is_string: false, optional: true),
+          FastlaneCore::ConfigItem.new(key: :exclude_output, env_name: "FL_APPLEDOC_EXCLUDE_OUTPUT", description: "Exclude given path from output", is_string: false, optional: true),
+          FastlaneCore::ConfigItem.new(key: :index_desc, env_name: "FL_APPLEDOC_INDEX_DESC", description: "File including main index description", is_string: true, optional: true),
 
           # PROJECT INFO
-          FastlaneCore::ConfigItem.new(key: :project_name,
-                                       env_name: "FL_APPLEDOC_PROJECT_NAME",
-                                       description: "Project name",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :project_version,
-                                       env_name: "FL_APPLEDOC_PROJECT_VERSION",
-                                       description: "Project version",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :project_company,
-                                       env_name: "FL_APPLEDOC_PROJECT_COMPANY",
-                                       description: "Project company",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :company_id,
-                                       env_name: "FL_APPLEDOC_COMPANY_ID",
-                                       description: "Company UTI (i.e. reverse DNS name)",
-                                       is_string: true,
-                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :project_name, env_name: "FL_APPLEDOC_PROJECT_NAME", description: "Project name", is_string: true),
+          FastlaneCore::ConfigItem.new(key: :project_version, env_name: "FL_APPLEDOC_PROJECT_VERSION", description: "Project version", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :project_company, env_name: "FL_APPLEDOC_PROJECT_COMPANY", description: "Project company", is_string: true),
+          FastlaneCore::ConfigItem.new(key: :company_id, env_name: "FL_APPLEDOC_COMPANY_ID", description: "Company UTI (i.e. reverse DNS name)", is_string: true, optional: true),
 
           # OUTPUT GENERATION
-          FastlaneCore::ConfigItem.new(key: :create_html,
-                                       env_name: "FL_APPLEDOC_CREATE_HTML",
-                                       description: "Create HTML",
-                                       is_string: false,
-                                       default_value: false),
-
-          FastlaneCore::ConfigItem.new(key: :create_docset,
-                                       env_name: "FL_APPLEDOC_CREATE_DOCSET",
-                                       description: "Create documentation set",
-                                       is_string: false,
-                                       default_value: false),
-
-          FastlaneCore::ConfigItem.new(key: :install_docset,
-                                       env_name: "FL_APPLEDOC_INSTALL_DOCSET",
-                                       description: "Install documentation set to Xcode",
-                                       is_string: false,
-                                       default_value: false),
-
-          FastlaneCore::ConfigItem.new(key: :publish_docset,
-                                       env_name: "FL_APPLEDOC_PUBLISH_DOCSET",
-                                       description: "Prepare DocSet for publishing",
-                                       is_string: false,
-                                       default_value: false),
-
-          FastlaneCore::ConfigItem.new(key: :html_anchors,
-                                       env_name: "FL_APPLEDOC_HTML_ANCHORS",
-                                       description: "The html anchor format to use in DocSet HTML",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :clean_output,
-                                       env_name: "FL_APPLEDOC_CLEAN_OUTPUT",
-                                       description: "Remove contents of output path before starting",
-                                       is_string: false,
-                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :create_html, env_name: "FL_APPLEDOC_CREATE_HTML", description: "Create HTML", is_string: false, default_value: false),
+          FastlaneCore::ConfigItem.new(key: :create_docset, env_name: "FL_APPLEDOC_CREATE_DOCSET", description: "Create documentation set", is_string: false, default_value: false),
+          FastlaneCore::ConfigItem.new(key: :install_docset, env_name: "FL_APPLEDOC_INSTALL_DOCSET", description: "Install documentation set to Xcode", is_string: false, default_value: false),
+          FastlaneCore::ConfigItem.new(key: :publish_docset, env_name: "FL_APPLEDOC_PUBLISH_DOCSET", description: "Prepare DocSet for publishing", is_string: false, default_value: false),
+          FastlaneCore::ConfigItem.new(key: :html_anchors, env_name: "FL_APPLEDOC_HTML_ANCHORS", description: "The html anchor format to use in DocSet HTML", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :clean_output, env_name: "FL_APPLEDOC_CLEAN_OUTPUT", description: "Remove contents of output path before starting", is_string: false, default_value: false),
 
           # DOCUMENTATION SET INFO
-          FastlaneCore::ConfigItem.new(key: :docset_bundle_id,
-                                       env_name: "FL_APPLEDOC_DOCSET_BUNDLE_ID",
-                                       description: "DocSet bundle identifier",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_bundle_name,
-                                       env_name: "FL_APPLEDOC_DOCSET_BUNDLE_NAME",
-                                       description: "DocSet bundle name",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_desc,
-                                       env_name: "FL_APPLEDOC_DOCSET_DESC",
-                                       description: "DocSet description",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_copyright,
-                                       env_name: "FL_APPLEDOC_DOCSET_COPYRIGHT",
-                                       description: "DocSet copyright message",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_feed_name,
-                                       env_name: "FL_APPLEDOC_DOCSET_FEED_NAME",
-                                       description: "DocSet feed name",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_feed_url,
-                                       env_name: "FL_APPLEDOC_DOCSET_FEED_URL",
-                                       description: "DocSet feed URL",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_feed_formats,
-                                       env_name: "FL_APPLEDOC_DOCSET_FEED_FORMATS",
-                                       description: "DocSet feed formats. Separated by a comma [atom,xml]",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_package_url,
-                                       env_name: "FL_APPLEDOC_DOCSET_PACKAGE_URL",
-                                       description: "DocSet package (.xar) URL",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_fallback_url,
-                                       env_name: "FL_APPLEDOC_DOCSET_FALLBACK_URL",
-                                       description: "DocSet fallback URL",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_publisher_id,
-                                       env_name: "FL_APPLEDOC_DOCSET_PUBLISHER_ID",
-                                       description: "DocSet publisher identifier",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_publisher_name,
-                                       env_name: "FL_APPLEDOC_DOCSET_PUBLISHER_NAME",
-                                       description: "DocSet publisher name",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_min_xcode_version,
-                                       env_name: "FL_APPLEDOC_DOCSET_MIN_XCODE_VERSION",
-                                       description: "DocSet min. Xcode version",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_platform_family,
-                                       env_name: "FL_APPLEDOC_DOCSET_PLATFORM_FAMILY",
-                                       description: "DocSet platform familiy",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_cert_issuer,
-                                       env_name: "FL_APPLEDOC_DOCSET_CERT_ISSUER",
-                                       description: "DocSet certificate issuer",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_cert_signer,
-                                       env_name: "FL_APPLEDOC_DOCSET_CERT_SIGNER",
-                                       description: "DocSet certificate signer",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_bundle_filename,
-                                       env_name: "FL_APPLEDOC_DOCSET_BUNDLE_FILENAME",
-                                       description: "DocSet bundle filename",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_atom_filename,
-                                       env_name: "FL_APPLEDOC_DOCSET_ATOM_FILENAME",
-                                       description: "DocSet atom feed filename",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_xml_filename,
-                                       env_name: "FL_APPLEDOC_DOCSET_XML_FILENAME",
-                                       description: "DocSet xml feed filename",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docset_package_filename,
-                                       env_name: "FL_APPLEDOC_DOCSET_PACKAGE_FILENAME",
-                                       description: "DocSet package (.xar,.tgz) filename",
-                                       is_string: true,
-                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_bundle_id, env_name: "FL_APPLEDOC_DOCSET_BUNDLE_ID", description: "DocSet bundle identifier", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_bundle_name, env_name: "FL_APPLEDOC_DOCSET_BUNDLE_NAME", description: "DocSet bundle name", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_desc, env_name: "FL_APPLEDOC_DOCSET_DESC", description: "DocSet description", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_copyright, env_name: "FL_APPLEDOC_DOCSET_COPYRIGHT", description: "DocSet copyright message", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_feed_name, env_name: "FL_APPLEDOC_DOCSET_FEED_NAME", description: "DocSet feed name", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_feed_url, env_name: "FL_APPLEDOC_DOCSET_FEED_URL", description: "DocSet feed URL", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_feed_formats, env_name: "FL_APPLEDOC_DOCSET_FEED_FORMATS", description: "DocSet feed formats. Separated by a comma [atom,xml]", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_package_url, env_name: "FL_APPLEDOC_DOCSET_PACKAGE_URL", description: "DocSet package (.xar) URL", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_fallback_url, env_name: "FL_APPLEDOC_DOCSET_FALLBACK_URL", description: "DocSet fallback URL", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_publisher_id, env_name: "FL_APPLEDOC_DOCSET_PUBLISHER_ID", description: "DocSet publisher identifier", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_publisher_name, env_name: "FL_APPLEDOC_DOCSET_PUBLISHER_NAME", description: "DocSet publisher name", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_min_xcode_version, env_name: "FL_APPLEDOC_DOCSET_MIN_XCODE_VERSION", description: "DocSet min. Xcode version", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_platform_family, env_name: "FL_APPLEDOC_DOCSET_PLATFORM_FAMILY", description: "DocSet platform familiy", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_cert_issuer, env_name: "FL_APPLEDOC_DOCSET_CERT_ISSUER", description: "DocSet certificate issuer", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_cert_signer, env_name: "FL_APPLEDOC_DOCSET_CERT_SIGNER", description: "DocSet certificate signer", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_bundle_filename, env_name: "FL_APPLEDOC_DOCSET_BUNDLE_FILENAME", description: "DocSet bundle filename", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_atom_filename, env_name: "FL_APPLEDOC_DOCSET_ATOM_FILENAME", description: "DocSet atom feed filename", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_xml_filename, env_name: "FL_APPLEDOC_DOCSET_XML_FILENAME", description: "DocSet xml feed filename", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_package_filename, env_name: "FL_APPLEDOC_DOCSET_PACKAGE_FILENAME", description: "DocSet package (.xar,.tgz) filename", is_string: true, optional: true),
 
           # OPTIONS
-          FastlaneCore::ConfigItem.new(key: :options,
-                                       env_name: "FL_APPLEDOC_OPTIONS",
-                                       description: "Documentation generation options",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :crossref_format,
-                                       env_name: "FL_APPLEDOC_OPTIONS_CROSSREF_FORMAT",
-                                       description: "Cross reference template regex",
-                                       is_string: true,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :exit_threshold,
-                                       env_name: "FL_APPLEDOC_OPTIONS_EXIT_THRESHOLD",
-                                       description: "Exit code threshold below which 0 is returned",
-                                       is_string: false,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :docs_section_title,
-                                       env_name: "FL_APPLEDOC_OPTIONS_DOCS_SECTION_TITLE",
-                                       description: "Title of the documentation section (defaults to \"Programming Guides\"",
-                                       is_string: true,
-                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :options, env_name: "FL_APPLEDOC_OPTIONS", description: "Documentation generation options", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :crossref_format, env_name: "FL_APPLEDOC_OPTIONS_CROSSREF_FORMAT", description: "Cross reference template regex", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :exit_threshold, env_name: "FL_APPLEDOC_OPTIONS_EXIT_THRESHOLD", description: "Exit code threshold below which 0 is returned", is_string: false, default_value: 2, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docs_section_title, env_name: "FL_APPLEDOC_OPTIONS_DOCS_SECTION_TITLE", description: "Title of the documentation section (defaults to \"Programming Guides\"", is_string: true, optional: true),
 
           # WARNINGS
-          FastlaneCore::ConfigItem.new(key: :warnings,
-                                       env_name: "FL_APPLEDOC_WARNINGS",
-                                       description: "Documentation generation warnings",
-                                       is_string: true,
-                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :warnings, env_name: "FL_APPLEDOC_WARNINGS", description: "Documentation generation warnings", is_string: true, optional: true),
 
           # MISCELLANEOUS
-          FastlaneCore::ConfigItem.new(key: :logformat,
-                                       env_name: "FL_APPLEDOC_LOGFORMAT",
-                                       description: "Log format [0-3]",
-                                       is_string: false,
-                                       optional: true),
-
-          FastlaneCore::ConfigItem.new(key: :verbose,
-                                       env_name: "FL_APPLEDOC_VERBOSE",
-                                       description: "Log verbosity level [0-6,xcode]",
-                                       is_string: false,
-                                       optional: true)
+          FastlaneCore::ConfigItem.new(key: :logformat, env_name: "FL_APPLEDOC_LOGFORMAT", description: "Log format [0-3]", is_string: false, optional: true),
+          FastlaneCore::ConfigItem.new(key: :verbose, env_name: "FL_APPLEDOC_VERBOSE", description: "Log verbosity level [0-6,xcode]", is_string: false, optional: true)
         ]
       end
 

--- a/spec/actions_specs/appledoc_spec.rb
+++ b/spec/actions_specs/appledoc_spec.rb
@@ -1,6 +1,6 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    describe "Clean Cocoapods Cache Integration" do
+    describe "Appledoc Integration" do
       it "default use case" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(

--- a/spec/actions_specs/appledoc_spec.rb
+++ b/spec/actions_specs/appledoc_spec.rb
@@ -1,0 +1,488 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Clean Cocoapods Cache Integration" do
+      it "default use case" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc \"input/dir\"")
+      end
+
+      it "adds output param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            output: '~/Desktop'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --output \"~/Desktop\" \"input/dir\"")
+      end
+
+      it "adds templates param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            templates: 'path/to/templates'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --templates \"path/to/templates\" \"input/dir\"")
+      end
+
+      it "adds docset_install_path param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_install_path: 'docs/install/path'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-install-path \"docs/install/path\" \"input/dir\"")
+      end
+
+      it "adds include param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            include: 'path/to/include'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --include \"path/to/include\" \"input/dir\"")
+      end
+
+      it "adds ignore param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            ignore: 'ignored/path'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --ignore \"ignored/path\" \"input/dir\"")
+      end
+
+      it "adds exclude_output param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            exclude_output: 'excluded/path'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --exclude-output \"excluded/path\" \"input/dir\"")
+      end
+
+      it "adds index_desc param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            index_desc: 'index_desc/path'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --index-desc \"index_desc/path\" \"input/dir\"")
+      end
+
+      it "adds project_name param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            project_name: 'PROJECT NAME'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --project-name \"PROJECT NAME\" \"input/dir\"")
+      end
+
+      it "adds project_version param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            project_version: 'VERSION'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --project-version \"VERSION\" \"input/dir\"")
+      end
+
+      it "adds project_company param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            project_company: 'COMPANY'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --project-company \"COMPANY\" \"input/dir\"")
+      end
+
+      it "adds company_id param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            company_id: 'COMPANY ID'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --company-id \"COMPANY ID\" \"input/dir\"")
+      end
+
+      it "adds create_html param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            create_html: true
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --create-html \"input/dir\"")
+      end
+
+      it "adds create_docset param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            create_docset: true
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --create-docset \"input/dir\"")
+      end
+
+      it "adds install_docset param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            install_docset: true
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --install-docset \"input/dir\"")
+      end
+
+      it "adds publish_docset param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            publish_docset: true
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --publish-docset \"input/dir\"")
+      end
+
+      it "adds html_anchors param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            html_anchors: 'some anchors'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --html-anchors \"some anchors\" \"input/dir\"")
+      end
+
+      it "adds clean_output param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            clean_output: true
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --clean-output \"input/dir\"")
+      end
+
+      it "adds docset_bundle_id param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_bundle_id: 'com.bundle.id'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-bundle-id \"com.bundle.id\" \"input/dir\"")
+      end
+
+      it "adds docset_bundle_name param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_bundle_name: 'Bundle name'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-bundle-name \"Bundle name\" \"input/dir\"")
+      end
+
+      it "adds docset_desc param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_desc: 'DocSet description'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-desc \"DocSet description\" \"input/dir\"")
+      end
+
+      it "adds docset_copyright param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_copyright: 'DocSet copyright'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-copyright \"DocSet copyright\" \"input/dir\"")
+      end
+
+      it "adds docset_feed_name param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_feed_name: 'DocSet feed name'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-feed-name \"DocSet feed name\" \"input/dir\"")
+      end
+
+      it "adds docset_feed_url param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_feed_url: 'http://docset-feed-url.com'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-feed-url \"http://docset-feed-url.com\" \"input/dir\"")
+      end
+
+      it "adds docset_feed_formats param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_feed_formats: 'atom'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-feed-formats \"atom\" \"input/dir\"")
+      end
+
+      it "adds docset_package_url param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_package_url: 'http://docset-package-url.com'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-package-url \"http://docset-package-url.com\" \"input/dir\"")
+      end
+
+      it "adds docset_fallback_url param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_fallback_url: 'http://docset-fallback-url.com'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-fallback-url \"http://docset-fallback-url.com\" \"input/dir\"")
+      end
+
+      it "adds docset_publisher_id param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_publisher_id: 'Publisher ID'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-publisher-id \"Publisher ID\" \"input/dir\"")
+      end
+
+      it "adds docset_publisher_name param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_publisher_name: 'Publisher name'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-publisher-name \"Publisher name\" \"input/dir\"")
+      end
+
+      it "adds docset_min_xcode_version param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_min_xcode_version: '6.4'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-min-xcode-version \"6.4\" \"input/dir\"")
+      end
+
+      it "adds docset_platform_family param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_platform_family: 'ios'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-platform-family \"ios\" \"input/dir\"")
+      end
+
+      it "adds docset_cert_issuer param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_cert_issuer: 'Some issuer'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-cert-issuer \"Some issuer\" \"input/dir\"")
+      end
+
+      it "adds docset_cert_signer param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_cert_signer: 'Some signer'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-cert-signer \"Some signer\" \"input/dir\"")
+      end
+
+      it "adds docset_bundle_filename param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_bundle_filename: 'DocSet bundle filename'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-bundle-filename \"DocSet bundle filename\" \"input/dir\"")
+      end
+
+      it "adds docset_atom_filename param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_atom_filename: 'DocSet atom feed filename'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-atom-filename \"DocSet atom feed filename\" \"input/dir\"")
+      end
+
+      it "adds docset_xml_filename param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_xml_filename: 'DocSet xml feed filename'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-xml-filename \"DocSet xml feed filename\" \"input/dir\"")
+      end
+
+      it "adds docset_package_filename param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docset_package_filename: 'DocSet package filename'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docset-package-filename \"DocSet package filename\" \"input/dir\"")
+      end
+
+      it "adds options param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            options: '--use-single-star --keep-intermediate-files --search-undocumented-doc'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --use-single-star --keep-intermediate-files --search-undocumented-doc \"input/dir\"")
+      end
+
+      it "adds crossref_format param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            crossref_format: 'some regex'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --crossref-format \"some regex\" \"input/dir\"")
+      end
+
+      it "adds exit_threshold param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            exit_threshold: '2'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --exit-threshold \"2\" \"input/dir\"")
+      end
+
+      it "adds docs_section_title param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            docs_section_title: 'Section title'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --docs-section-title \"Section title\" \"input/dir\"")
+      end
+
+      it "adds warnings param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            warnings: '--warn-missing-output-path --warn-missing-company-id --warn-undocumented-object'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --warn-missing-output-path --warn-missing-company-id --warn-undocumented-object \"input/dir\"")
+      end
+
+      it "adds logformat param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            logformat: '1'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --logformat \"1\" \"input/dir\"")
+      end
+
+      it "adds verbose param to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            input: 'input/dir',
+            verbose: '1'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --verbose \"1\" \"input/dir\"")
+      end
+    end
+  end
+end

--- a/spec/actions_specs/appledoc_spec.rb
+++ b/spec/actions_specs/appledoc_spec.rb
@@ -4,484 +4,546 @@ describe Fastlane do
       it "default use case" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds output param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             output: '~/Desktop'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --output \"~/Desktop\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --output \"~/Desktop\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds templates param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             templates: 'path/to/templates'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --templates \"path/to/templates\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --templates \"path/to/templates\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_install_path param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_install_path: 'docs/install/path'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-install-path \"docs/install/path\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-install-path \"docs/install/path\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds include param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             include: 'path/to/include'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --include \"path/to/include\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --include \"path/to/include\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds ignore param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             ignore: 'ignored/path'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --ignore \"ignored/path\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --ignore \"ignored/path\" --exit-threshold \"2\" \"input/dir\"")
+      end
+
+      it "adds multiple ignore params to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
+            input: 'input/dir',
+            ignore: ['ignored/path', 'ignored/path2']
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --ignore \"ignored/path\" --ignore \"ignored/path2\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds exclude_output param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             exclude_output: 'excluded/path'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --exclude-output \"excluded/path\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exclude-output \"excluded/path\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds index_desc param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             index_desc: 'index_desc/path'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --index-desc \"index_desc/path\" \"input/dir\"")
-      end
-
-      it "adds project_name param to command" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          appledoc(
-            input: 'input/dir',
-            project_name: 'PROJECT NAME'
-          )
-        end").runner.execute(:test)
-
-        expect(result).to eq("appledoc --project-name \"PROJECT NAME\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --index-desc \"index_desc/path\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds project_version param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             project_version: 'VERSION'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-version \"VERSION\" \"input/dir\"")
-      end
-
-      it "adds project_company param to command" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          appledoc(
-            input: 'input/dir',
-            project_company: 'COMPANY'
-          )
-        end").runner.execute(:test)
-
-        expect(result).to eq("appledoc --project-company \"COMPANY\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --project-version \"VERSION\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds company_id param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             company_id: 'COMPANY ID'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --company-id \"COMPANY ID\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --company-id \"COMPANY ID\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds create_html param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             create_html: true
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --create-html \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --create-html --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds create_docset param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             create_docset: true
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --create-docset \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --create-docset --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds install_docset param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             install_docset: true
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --install-docset \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --install-docset --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds publish_docset param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             publish_docset: true
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --publish-docset \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --publish-docset --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds html_anchors param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             html_anchors: 'some anchors'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --html-anchors \"some anchors\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --html-anchors \"some anchors\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds clean_output param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             clean_output: true
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --clean-output \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --clean-output --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_bundle_id param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_bundle_id: 'com.bundle.id'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-bundle-id \"com.bundle.id\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-bundle-id \"com.bundle.id\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_bundle_name param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_bundle_name: 'Bundle name'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-bundle-name \"Bundle name\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-bundle-name \"Bundle name\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_desc param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_desc: 'DocSet description'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-desc \"DocSet description\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-desc \"DocSet description\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_copyright param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_copyright: 'DocSet copyright'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-copyright \"DocSet copyright\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-copyright \"DocSet copyright\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_feed_name param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_feed_name: 'DocSet feed name'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-feed-name \"DocSet feed name\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-feed-name \"DocSet feed name\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_feed_url param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_feed_url: 'http://docset-feed-url.com'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-feed-url \"http://docset-feed-url.com\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-feed-url \"http://docset-feed-url.com\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_feed_formats param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_feed_formats: 'atom'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-feed-formats \"atom\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-feed-formats \"atom\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_package_url param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_package_url: 'http://docset-package-url.com'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-package-url \"http://docset-package-url.com\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-package-url \"http://docset-package-url.com\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_fallback_url param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_fallback_url: 'http://docset-fallback-url.com'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-fallback-url \"http://docset-fallback-url.com\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-fallback-url \"http://docset-fallback-url.com\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_publisher_id param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_publisher_id: 'Publisher ID'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-publisher-id \"Publisher ID\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-publisher-id \"Publisher ID\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_publisher_name param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_publisher_name: 'Publisher name'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-publisher-name \"Publisher name\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-publisher-name \"Publisher name\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_min_xcode_version param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_min_xcode_version: '6.4'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-min-xcode-version \"6.4\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-min-xcode-version \"6.4\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_platform_family param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_platform_family: 'ios'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-platform-family \"ios\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-platform-family \"ios\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_cert_issuer param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_cert_issuer: 'Some issuer'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-cert-issuer \"Some issuer\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-cert-issuer \"Some issuer\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_cert_signer param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_cert_signer: 'Some signer'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-cert-signer \"Some signer\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-cert-signer \"Some signer\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_bundle_filename param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_bundle_filename: 'DocSet bundle filename'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-bundle-filename \"DocSet bundle filename\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-bundle-filename \"DocSet bundle filename\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_atom_filename param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_atom_filename: 'DocSet atom feed filename'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-atom-filename \"DocSet atom feed filename\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-atom-filename \"DocSet atom feed filename\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_xml_filename param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_xml_filename: 'DocSet xml feed filename'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-xml-filename \"DocSet xml feed filename\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-xml-filename \"DocSet xml feed filename\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docset_package_filename param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docset_package_filename: 'DocSet package filename'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docset-package-filename \"DocSet package filename\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-package-filename \"DocSet package filename\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds options param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             options: '--use-single-star --keep-intermediate-files --search-undocumented-doc'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --use-single-star --keep-intermediate-files --search-undocumented-doc \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --use-single-star --keep-intermediate-files --search-undocumented-doc --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds crossref_format param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             crossref_format: 'some regex'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --crossref-format \"some regex\" \"input/dir\"")
-      end
-
-      it "adds exit_threshold param to command" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          appledoc(
-            input: 'input/dir',
-            exit_threshold: '2'
-          )
-        end").runner.execute(:test)
-
-        expect(result).to eq("appledoc --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --crossref-format \"some regex\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds docs_section_title param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             docs_section_title: 'Section title'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --docs-section-title \"Section title\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docs-section-title \"Section title\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds warnings param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             warnings: '--warn-missing-output-path --warn-missing-company-id --warn-undocumented-object'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --warn-missing-output-path --warn-missing-company-id --warn-undocumented-object \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --warn-missing-output-path --warn-missing-company-id --warn-undocumented-object --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds logformat param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             logformat: '1'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --logformat \"1\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --logformat \"1\" --exit-threshold \"2\" \"input/dir\"")
       end
 
       it "adds verbose param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
             input: 'input/dir',
             verbose: '1'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --verbose \"1\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --verbose \"1\" --exit-threshold \"2\" \"input/dir\"")
       end
     end
   end


### PR DESCRIPTION
Generate Apple-like source code documentation from specially formatted source code comments.

``` ruby
appledoc(
      project_name: "MyProjectName",
      project_company: "Company Name",
      company_id: "com.company.id",
      input: "MyProjectSources",
      output: "/tmp/appledoc/myProjectDocs",
      options: "--keep-intermediate-files --search-undocumented-doc",
      warnings: "--warn-missing-output-path --warn-missing-company-id",
      exit_threshold: 2 # Exit code threshold below which 0 is returned
    )
```
