### PR TITLE
Added xcargs option to xcodebuild action

### DIFF
--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -268,6 +268,9 @@ module Fastlane
           elsif k == :keychain && v.to_s.length > 0
             # If keychain is specified, append as OTHER_CODE_SIGN_FLAGS
             "OTHER_CODE_SIGN_FLAGS=\"--keychain #{v}\""
+          elsif k == :xcargs && v.to_s.length > 0
+            # Add more xcodebuild arguments
+            "#{v}"
           end
         end.compact.sort
       end
@@ -299,6 +302,7 @@ module Fastlane
           ['workspace', 'The workspace to use'],
           ['scheme', 'The scheme to build'],
           ['build_settings', 'Hash of additional build information'],
+          ['xcargs', 'Pass additional xcodebuild options'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
@@ -340,6 +344,7 @@ module Fastlane
           ['workspace', 'The workspace to use'],
           ['scheme', 'The scheme to build'],
           ['build_settings', 'Hash of additional build information'],
+          ['xcargs', 'Pass additional xcodebuild options'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
@@ -374,6 +379,7 @@ module Fastlane
           ['workspace', 'The workspace to use'],
           ['scheme', 'The scheme to build'],
           ['build_settings', 'Hash of additional build information'],
+          ['xcargs', 'Pass additional xcodebuild options'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
@@ -408,6 +414,7 @@ module Fastlane
           ['workspace', 'The workspace to use'],
           ['scheme', 'The scheme to build'],
           ['build_settings', 'Hash of additional build information'],
+          ['xcargs', 'Pass additional xcodebuild options'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
@@ -438,6 +445,7 @@ module Fastlane
           ['workspace', 'The workspace to use'],
           ['scheme', 'The scheme to build'],
           ['build_settings', 'Hash of additional build information'],
+          ['xcargs', 'Pass additional xcodebuild options'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
@@ -470,6 +478,7 @@ module Fastlane
           ['workspace', 'The workspace to use'],
           ['scheme', 'The scheme to build'],
           ['build_settings', 'Hash of additional build information'],
+          ['xcargs', 'Pass additional xcodebuild options'],
           ['destination', 'The simulator to use, e.g. "name=iPhone 5s,OS=8.1"'],
           ['destination_timeout', 'The timeout for connecting to the simulator, in seconds'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],

--- a/spec/actions_specs/xcodebuild_spec.rb
+++ b/spec/actions_specs/xcodebuild_spec.rb
@@ -43,7 +43,8 @@ describe Fastlane do
             xcconfig: 'my.xcconfig',
             buildlog_path: 'mypath',
             raw_buildlog: false,
-            xcpretty_output: 'test'
+            xcpretty_output: 'test',
+            xcargs: '-newArgument YES'
           )
         end").runner.execute(:test)
 
@@ -64,6 +65,7 @@ describe Fastlane do
           + "-exportProvisioningProfile \"MyApp Distribution\" " \
           + "-exportSigningIdentity \"Distribution: MyCompany, LLC\" " \
           + "-exportWithOriginalSigningIdentity " \
+          + "-newArgument YES " \
           + "-project \"MyApp.xcodeproj\" " \
           + "-resultBundlePath \"/result/bundle/path\" " \
           + "-scheme \"MyApp\" " \


### PR DESCRIPTION
This MR adds the possibility to add unsupported `xcodebuild` arguments by the `xcodebuild` action and friends actions.

``` ruby
xcodebuild(
  build: true,
  workspace: 'MyApp.xcworkspace',
  configuration: 'Debug',
  xcargs: '-newArgument YES and_other_command_line_options'
)
```
