### PR TITLE
Skip `git clean` in reset_git_repo

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1078,6 +1078,7 @@ push_git_tags
 
 ### reset_git_repo
 This action will reset your git repo to a clean state, discarding any uncommitted and untracked changes. Useful in case you need to revert the repo back to a clean state, e.g. after the fastlane run.
+Untracked files like `.env` will also be deleted, unless `:skip_clean` is true.
 
 It's a pretty drastic action so it comes with a sort of safety latch. It will only proceed with the reset if either of these conditions are met:
 
@@ -1089,6 +1090,7 @@ Also useful for putting in your `error` block, to bring things back to a pristin
 ```ruby
 reset_git_repo
 reset_git_repo :force # If you don't care about warnings and are absolutely sure that you want to discard all changes. This will reset the repo even if you have valuable uncommitted changes, so use with care!
+reset_git_repo :skip_clean # If you want 'git clean' to be skipped, thus NOT deleting untracked files like '.env'. Optional, defaults to false.
 
 # You can also specify a list of files that should be resetted.
 reset_git_repo(

--- a/lib/fastlane/actions/reset_git_repo.rb
+++ b/lib/fastlane/actions/reset_git_repo.rb
@@ -10,7 +10,7 @@ module Fastlane
 
           if (paths || []).count == 0
             Actions.sh('git reset --hard HEAD')
-            Actions.sh('git clean -qfdx')
+            Actions.sh('git clean -qfdx') unless params[:skip_clean]
             Helper.log.info 'Git repo was reset and cleaned back to a pristine state.'.green
           else
             paths.each do |path|
@@ -31,6 +31,7 @@ module Fastlane
       def self.details
         [
           "This action will reset your git repo to a clean state, discarding any uncommitted and untracked changes. Useful in case you need to revert the repo back to a clean state, e.g. after the fastlane run.",
+          "Untracked files like `.env` will also be deleted, unless `:skip_clean` is true.",
           "It's a pretty drastic action so it comes with a sort of safety latch. It will only proceed with the reset if either of these conditions are met:",
           "You have called the ensure_git_status_clean action prior to calling this action. This ensures that your repo started off in a clean state, so the only things that will get destroyed by this action are files that are created as a byproduct of the fastlane run."
         ].join(' ')
@@ -49,6 +50,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :force,
                                        env_name: "FL_RESET_GIT_FORCE",
                                        description: "Skip verifying of previously clean state of repo. Only recommended in combination with `files` option",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :skip_clean,
+                                       env_name: "FL_RESET_GIT_SKIP_CLEAN",
+                                       description: "Skip 'git clean' to avoid removing untracked files like `.env`. Optional, defaults to false",
+                                       optional: true,
                                        is_string: false,
                                        default_value: false)
         ]


### PR DESCRIPTION
As mentioned in https://github.com/fastlane/fastlane/issues/811

If you have a file like `.env` (e.g. for credentials) in your repository, then it will be deleted when you call `reset_git_repo` upon error, as it's usually untracked.
I'm suggesting to add a `skip_clean` option to this action to skip the `git clean` step in it.
