### PR TITLE
Add new action to upload to Appetize.io

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -733,6 +733,18 @@ nexus_upload(
 )
 ```
 
+### [Appetize.io](https://appetize.io/)
+
+Upload your zipped app to Appetize.io
+
+```ruby
+appetize(
+    api_token: 'yourapitoken',
+    url: 'https://example.com/your/zipped/app.zip',
+    private_key: 'yourprivatekey'
+)
+```
+
 ## Modifying Project
 
 ### [increment_build_number](https://developer.apple.com/library/ios/qa/qa1827/_index.html)

--- a/lib/fastlane/actions/appetize.rb
+++ b/lib/fastlane/actions/appetize.rb
@@ -23,7 +23,7 @@ module Fastlane
         https = Net::HTTP.new(uri.host, uri.port)
         https.use_ssl = true
 
-        req = Net::HTTP::Post.new(uri.request_uri, initheader={'Content-Type' => 'application/json'})
+        req = Net::HTTP::Post.new(uri.request_uri, initheader: {'Content-Type' => 'application/json'})
         params = {
             token: options[:api_token],
             url: options[:url],
@@ -43,34 +43,32 @@ module Fastlane
       end
 
       def self.parse_response(response)
-        begin
-          body = JSON.parse(response.body)
-          app_url = body['appURL']
-          manage_url = body['manageURL']
-          private_key = body['privateKey']
-          public_key = body['publicKey']
-          Actions.lane_context[SharedValues::APPETIZE_PRIVATE_KEY] = private_key
-          Actions.lane_context[SharedValues::APPETIZE_PUBLIC_KEY] = public_key
-          Actions.lane_context[SharedValues::APPETIZE_APP_URL] = app_url
-          Actions.lane_context[SharedValues::APPETIZE_MANAGE_URL] = manage_url
-          true
-        rescue
-          Helper.log.fatal "Error uploading to Appetize.io: #{response.body}".red
-          help_message(response)
-          false
-        end
+        body = JSON.parse(response.body)
+        app_url = body['appURL']
+        manage_url = body['manageURL']
+        private_key = body['privateKey']
+        public_key = body['publicKey']
+        Actions.lane_context[SharedValues::APPETIZE_PRIVATE_KEY] = private_key
+        Actions.lane_context[SharedValues::APPETIZE_PUBLIC_KEY] = public_key
+        Actions.lane_context[SharedValues::APPETIZE_APP_URL] = app_url
+        Actions.lane_context[SharedValues::APPETIZE_MANAGE_URL] = manage_url
+        true
+      rescue
+        Helper.log.fatal "Error uploading to Appetize.io: #{response.body}".red
+        help_message(response)
+        false
       end
       private_class_method :parse_response
 
       def self.help_message(response)
         message =
             case response.body
-              when 'Invalid token'
-                'Invalid API Token specified.'
-              when 'Error downloading zip file'
-                'URL should be wrong'
-              when 'No app with specified privateKey found'
-                'Invalid privateKey specified'
+            when 'Invalid token'
+              'Invalid API Token specified.'
+            when 'Error downloading zip file'
+              'URL should be wrong'
+            when 'No app with specified privateKey found'
+              'Invalid privateKey specified'
             end
         Helper.log.error message.red if message
       end
@@ -81,34 +79,32 @@ module Fastlane
       end
 
       def self.available_options
-        [
-            FastlaneCore::ConfigItem.new(key: :api_token,
-                                         env_name: "APPETIZE_API_TOKEN",
-                                         description: "Appetize.io API Token",
-                                         is_string: true,
-                                         verify_block: proc do |value|
-                                           raise "No API Token for Appetize.io given, pass using `api_token: 'token'`".red unless value.to_s.length > 0
-                                         end),
-            FastlaneCore::ConfigItem.new(key: :url,
-                                         env_name: "APPETIZE_URL",
-                                         description: "Target url of the zipped build",
-                                         is_string: true,
-                                         verify_block: proc do |value|
-                                           raise "No URL of your zipped build".red unless value.to_s.length > 0
-                                         end),
-            FastlaneCore::ConfigItem.new(key: :private_key,
-                                         env_name: "APPETIZE_PRIVATEKEY",
-                                         description: "privateKey which specify each applications",
-                                         optional: true)
+        [FastlaneCore::ConfigItem.new(key: :api_token,
+                                      env_name: "APPETIZE_API_TOKEN",
+                                      description: "Appetize.io API Token",
+                                      is_string: true,
+                                      verify_block: proc do |value|
+                                        raise "No API Token for Appetize.io given, pass using `api_token: 'token'`".red unless value.to_s.length > 0
+                                      end),
+         FastlaneCore::ConfigItem.new(key: :url,
+                                      env_name: "APPETIZE_URL",
+                                      description: "Target url of the zipped build",
+                                      is_string: true,
+                                      verify_block: proc do |value|
+                                        raise "No URL of your zipped build".red unless value.to_s.length > 0
+                                      end),
+         FastlaneCore::ConfigItem.new(key: :private_key,
+                                      env_name: "APPETIZE_PRIVATEKEY",
+                                      description: "privateKey which specify each applications",
+                                      optional: true)
         ]
       end
 
       def self.output
-        [
-            ['APPETIZE_PRIVATE_KEY', 'a string that is used to prove "ownership" of your app - save this so that you may subsequently update the app'],
-            ['APPETIZE_PUBLIC_KEY', 'a public identiifer for your app'],
-            ['APPETIZE_APP_URL', 'a page to test and share your app'],
-            ['APPETIZE_MANAGE_URL', 'a page to manage your app'],
+        [['APPETIZE_PRIVATE_KEY', 'a string that is used to prove "ownership" of your app - save this so that you may subsequently update the app'],
+         ['APPETIZE_PUBLIC_KEY', 'a public identiifer for your app'],
+         ['APPETIZE_APP_URL', 'a page to test and share your app'],
+         ['APPETIZE_MANAGE_URL', 'a page to manage your app']
         ]
       end
 

--- a/lib/fastlane/actions/appetize.rb
+++ b/lib/fastlane/actions/appetize.rb
@@ -32,7 +32,7 @@ module Fastlane
         params.merge!(privateKey: options[:private_key]) unless options[:private_key].nil?
         req.body = JSON.generate(params)
         response = https.request(req)
-        if parse_response response
+        if parse_response(response)
           Helper.log.info "App URL: #{Actions.lane_context[SharedValues::APPETIZE_APP_URL]}"
           Helper.log.info "Manage URL: #{Actions.lane_context[SharedValues::APPETIZE_MANAGE_URL]}"
           Helper.log.info "App Private Key: #{Actions.lane_context[SharedValues::APPETIZE_PRIVATE_KEY]}"
@@ -53,7 +53,7 @@ module Fastlane
           Actions.lane_context[SharedValues::APPETIZE_PUBLIC_KEY] = public_key
           Actions.lane_context[SharedValues::APPETIZE_APP_URL] = app_url
           Actions.lane_context[SharedValues::APPETIZE_MANAGE_URL] = manage_url
-          return true
+          true
         rescue
           Helper.log.fatal "Error uploading to Appetize.io: #{response.body}".red
           help_message(response)

--- a/lib/fastlane/actions/appetize.rb
+++ b/lib/fastlane/actions/appetize.rb
@@ -1,0 +1,120 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      APPETIZE_PRIVATE_KEY = :APPETIZE_PRIVATE_KEY
+      APPETIZE_PUBLIC_KEY = :APPETIZE_PUBLIC_KEY
+      APPETIZE_APP_URL = :APPETIZE_APP_URL
+      APPETIZE_MANAGE_URL = :APPETIZE_MANAGE_URL
+    end
+
+    class AppetizeAction < Action
+      APPETIZE_URL_BASE = 'https://api.appetize.io/v1/app/update'
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+
+      def self.run(options)
+        require 'net/http'
+        require 'uri'
+        require 'json'
+
+        uri = URI.parse(APPETIZE_URL_BASE)
+        https = Net::HTTP.new(uri.host, uri.port)
+        https.use_ssl = true
+
+        req = Net::HTTP::Post.new(uri.request_uri, initheader={'Content-Type' => 'application/json'})
+        params = {
+            token: options[:api_token],
+            url: options[:url],
+            platform: 'ios'
+        }
+        params.merge!(privateKey: options[:private_key]) unless options[:private_key].nil?
+        req.body = JSON.generate(params)
+        response = https.request(req)
+        if parse_response response
+          Helper.log.info "App URL: #{Actions.lane_context[SharedValues::APPETIZE_APP_URL]}"
+          Helper.log.info "Manage URL: #{Actions.lane_context[SharedValues::APPETIZE_MANAGE_URL]}"
+          Helper.log.info "App Private Key: #{Actions.lane_context[SharedValues::APPETIZE_PRIVATE_KEY]}"
+          Helper.log.info "Build successfully uploaded to Appetize.io".green
+        else
+          raise 'Error when trying to upload ipa to Appetize.io'.red
+        end
+      end
+
+      def self.parse_response(response)
+        begin
+          body = JSON.parse(response.body)
+          app_url = body['appURL']
+          manage_url = body['manageURL']
+          private_key = body['privateKey']
+          public_key = body['publicKey']
+          Actions.lane_context[SharedValues::APPETIZE_PRIVATE_KEY] = private_key
+          Actions.lane_context[SharedValues::APPETIZE_PUBLIC_KEY] = public_key
+          Actions.lane_context[SharedValues::APPETIZE_APP_URL] = app_url
+          Actions.lane_context[SharedValues::APPETIZE_MANAGE_URL] = manage_url
+          return true
+        rescue
+          Helper.log.fatal "Error uploading to Appetize.io: #{response.body}".red
+          help_message(response)
+          false
+        end
+      end
+      private_class_method :parse_response
+
+      def self.help_message(response)
+        message =
+            case response.body
+              when 'Invalid token'
+                'Invalid API Token specified.'
+              when 'Error downloading zip file'
+                'URL should be wrong'
+              when 'No app with specified privateKey found'
+                'Invalid privateKey specified'
+            end
+        Helper.log.error message.red if message
+      end
+      private_class_method :help_message
+
+      def self.description
+        "Create or Update apps on Appetize.io"
+      end
+
+      def self.available_options
+        [
+            FastlaneCore::ConfigItem.new(key: :api_token,
+                                         env_name: "APPETIZE_API_TOKEN",
+                                         description: "Appetize.io API Token",
+                                         is_string: true,
+                                         verify_block: proc do |value|
+                                           raise "No API Token for Appetize.io given, pass using `api_token: 'token'`".red unless value.to_s.length > 0
+                                         end),
+            FastlaneCore::ConfigItem.new(key: :url,
+                                         env_name: "APPETIZE_URL",
+                                         description: "Target url of the zipped build",
+                                         is_string: true,
+                                         verify_block: proc do |value|
+                                           raise "No URL of your zipped build".red unless value.to_s.length > 0
+                                         end),
+            FastlaneCore::ConfigItem.new(key: :private_key,
+                                         env_name: "APPETIZE_PRIVATEKEY",
+                                         description: "privateKey which specify each applications",
+                                         optional: true)
+        ]
+      end
+
+      def self.output
+        [
+            ['APPETIZE_PRIVATE_KEY', 'a string that is used to prove "ownership" of your app - save this so that you may subsequently update the app'],
+            ['APPETIZE_PUBLIC_KEY', 'a public identiifer for your app'],
+            ['APPETIZE_APP_URL', 'a page to test and share your app'],
+            ['APPETIZE_MANAGE_URL', 'a page to manage your app'],
+        ]
+      end
+
+      def self.author
+        "giginet"
+      end
+    end
+  end
+end

--- a/spec/actions_specs/appetize_spec.rb
+++ b/spec/actions_specs/appetize_spec.rb
@@ -1,6 +1,6 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    let(:response_string) {
+    let(:response_string) do
       <<-"EOS"
       {
         "privateKey" : "private_Djksfj",
@@ -9,17 +9,17 @@ describe Fastlane do
         "manageURL"  : "https://appetize.io/manage/private_Djksfj"
       }
       EOS
-    }
+    end
     let(:api_token) { 'mysecrettoken' }
     let(:url) { 'https://example.com/app.zip' }
     let(:http) { double('http') }
     let(:request) { double('request') }
     let(:response) { double('response') }
-    let(:params) {
+    let(:params) do
       {token: api_token,
        url: url,
        platform: 'ios'}
-    }
+    end
     before do
       allow(Net::HTTP).to receive(:new).and_return(http)
       allow(Net::HTTP::Post).to receive(:new).and_return(request)
@@ -40,7 +40,7 @@ describe Fastlane do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             appetize({
-              'api_token': '#{api_token}'
+              api_token: '#{api_token}'
             })
           end").runner.execute(:test)
         end.to raise_error
@@ -49,7 +49,7 @@ describe Fastlane do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             appetize({
-              'url': '#{url}'
+              url: '#{url}'
             })
           end").runner.execute(:test)
         end.to raise_error
@@ -58,8 +58,8 @@ describe Fastlane do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             appetize({
-              'api_token': '#{api_token}',
-              'url': '#{url}'
+              api_token: '#{api_token}',
+              url: '#{url}'
             })
           end").runner.execute(:test)
         end.not_to raise_error

--- a/spec/actions_specs/appetize_spec.rb
+++ b/spec/actions_specs/appetize_spec.rb
@@ -1,0 +1,74 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    let(:response_string) {
+      <<-"EOS"
+      {
+        "privateKey" : "private_Djksfj",
+        "publicKey"  : "sKdfjL",
+        "appURL"  : "https://appetize.io/app/sKdfjL",
+        "manageURL"  : "https://appetize.io/manage/private_Djksfj"
+      }
+      EOS
+    }
+    let(:api_token) { 'mysecrettoken' }
+    let(:url) { 'https://example.com/app.zip' }
+    let(:http) { double('http') }
+    let(:request) { double('request') }
+    let(:response) { double('response') }
+    let(:params) {
+      {token: api_token,
+       url: url,
+       platform: 'ios'}
+    }
+    before do
+      allow(Net::HTTP).to receive(:new).and_return(http)
+      allow(Net::HTTP::Post).to receive(:new).and_return(request)
+      allow(http).to receive(:use_ssl=).with(true)
+      allow(http).to receive(:request).with(request).and_return(response)
+      allow(request).to receive(:body=).with(kind_of(String)).and_return(response)
+      allow(response).to receive(:body).and_return(response_string)
+    end
+    describe "Appetize Integration" do
+      it "raises an error if no parameters were given" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            appetize()
+          end").runner.execute(:test)
+        end.to raise_error
+      end
+      it "raises an error if no url was given" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            appetize({
+              'api_token': '#{api_token}'
+            })
+          end").runner.execute(:test)
+        end.to raise_error
+      end
+      it "raises an error if no API token was given" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            appetize({
+              'url': '#{url}'
+            })
+          end").runner.execute(:test)
+        end.to raise_error
+      end
+      it "works with valid parameter" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            appetize({
+              'api_token': '#{api_token}',
+              'url': '#{url}'
+            })
+          end").runner.execute(:test)
+        end.not_to raise_error
+        expect(http).not_to receive(:request).with(JSON.generate(params))
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APPETIZE_PRIVATE_KEY]).to eql('private_Djksfj')
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APPETIZE_PUBLIC_KEY]).to eql('sKdfjL')
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APPETIZE_APP_URL]).to eql('https://appetize.io/app/sKdfjL')
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APPETIZE_MANAGE_URL]).to eql('https://appetize.io/manage/private_Djksfj')
+      end
+    end
+  end
+end


### PR DESCRIPTION
I added new action to upload the app to [Appetize.io](https://appetize.io/).

Appetize.io is the service which enables to run your app on the browser.

``` ruby
appetize(
    api_token: 'yourapitoken',
    url: 'https://example.com/your/zipped/app.zip',
    private_key: 'yourprivatekey'
)
```

See [this document](https://appetize.io/api) for more detail.

Please review it :bow: 
