### PR TITLE
Fix import_from_git action race condition

### DIFF
--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -216,12 +216,14 @@ module Fastlane
       raise "Please pass a path to the `import_from_git` action".red if url.to_s.length == 0
 
       Actions.execute_action('import_from_git') do
+        require 'tmpdir'
+
         collector.did_launch_action(:import_from_git)
 
         # Checkout the repo
         repo_name = url.split("/").last
 
-        tmp_path = File.join("/tmp", "fl_clones_#{Time.now.to_f}")
+        tmp_path = Dir.mktmpdir("fl_clone")
         clone_folder = File.join(tmp_path, repo_name)
 
         branch_option = ""

--- a/lib/fastlane/fast_file.rb
+++ b/lib/fastlane/fast_file.rb
@@ -221,7 +221,7 @@ module Fastlane
         # Checkout the repo
         repo_name = url.split("/").last
 
-        tmp_path = File.join("/tmp", "fl_clones_#{Time.now.to_i}")
+        tmp_path = File.join("/tmp", "fl_clones_#{Time.now.to_f}")
         clone_folder = File.join(tmp_path, repo_name)
 
         branch_option = ""


### PR DESCRIPTION
Recently I've been having issues with the `import_from_git` action, Jenkins jobs would trigger at the same second, hence using the same path for git clone.

So I end up with such errors:

```
/Users/mobile_daily/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/fastlane-1.37.0/lib/fastlane/helper/sh_helper.rb:37:in `sh_no_action': Exit status of command 'git clone 'https://github.com/xfreebird/fastlane-utils' '/tmp/fl_clones_1447146993/fastlane-utils' --depth 1 -n ' was 128 instead of 0.  (RuntimeError)
fatal: could not create work tree dir '/tmp/fl_clones_1447146993/fastlane-utils': File exists
    from /Users/mobile_daily/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/fastlane-1.37.0/lib/fastlane/helper/sh_helper.rb:8:in `sh'
```

This fixes that.
