### PR TITLE
Added `copy_artifacts` action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -345,6 +345,25 @@ More usage examples (assumes the above .env setup is being used):
 
 See how [Wikipedia](https://github.com/fastlane/examples/blob/master/Wikipedia/Fastfile) uses the `xctest` action to test their app.
 
+### copy_artifacts
+This action copies artifacs to a target directory. It's useful if you have a CI that will pick up these artifacts and attach them to the build. Useful e.g. for storing your `.ipa`s, `.dSYM.zip`s, `.mobileprovision`s, `.cert`s
+
+Make sure your target_path is gitignored, and if you use `reset_git_repo`, make sure the artifacts are added to the exclude list
+
+Example in conjunction with reset_git_repo
+```ruby
+# Move our artifacts to a safe location so TeamCity can pick them up
+copy_artifacts(
+  target_path: 'artifacts',
+  artifacts: ['*.cer', '*.mobileprovision', '*.ipa', '*.dSYM.zip']
+)
+
+# Reset the git repo to a clean state, but leave our artifacts in place
+reset_git_repo(
+  exclude: 'artifacts'
+)
+```
+
 ### clean_build_artifacts
 This action deletes the files that get created in your repo as a result of running the `ipa` and `sigh` commands. It doesn't delete the `fastlane/report.xml` though, this is probably more suited for the .gitignore.
 

--- a/lib/fastlane/actions/copy_artifacts.rb
+++ b/lib/fastlane/actions/copy_artifacts.rb
@@ -1,0 +1,70 @@
+module Fastlane
+  module Actions
+    class CopyArtifactsAction < Action
+      def self.run(params)
+        # we want to make sure that our target folder exist already
+        target_folder_command = 'mkdir -p ' + params[:target_path]
+        Actions.sh(target_folder_command)
+
+        # construct the main command that will do the copying/moving for us
+        base_command = params[:keep_original] ? 'cp' : 'mv'
+        options = []
+        options << '-f'
+        options << '-r' if params[:keep_original] # we only want the -r flag for the cp command, which we get when the user asks to keep the original
+        options << params[:artifacts].map { |e| e.tr(' ', '\ ') }
+        options << params[:target_path]
+
+        command = ([base_command] + options).join(' ')
+
+        # if we don't want to fail on missing files, then we need to swallow the error from our command, by ORing with the nil command, guaranteeing a 0 status code
+        command += ' || :' unless params[:fail_on_missing]
+
+        # call our command
+        Actions.sh(command)
+        
+        Helper.log.info 'Build artifacts sucesfully copied!'.green
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Small action to save your build artifacts. Useful when you use reset_git_repo"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :keep_original,
+                                       description: "Set this to true if you want copy, rather than move, semantics",
+                                       is_string: false,
+                                       optional: true,
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :target_path,
+                                       description: "The directory in which you want your artifacts placed",
+                                       is_string: false,
+                                       optional: false,
+                                       default_value: 'artifacts'),
+          FastlaneCore::ConfigItem.new(key: :artifacts,
+                                       description: "An array of file patterns of the files/folders you want to preserve",
+                                       is_string: false,
+                                       optional: false,
+                                       default_value: []),
+          FastlaneCore::ConfigItem.new(key: :fail_on_missing,
+                                       description: "Fail when a source file isn't found",
+                                       is_string: false,
+                                       optional: true,
+                                       default_value: false)
+        ]
+      end
+
+      def self.authors
+        ["lmirosevic"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/copy_artifacts.rb
+++ b/lib/fastlane/actions/copy_artifacts.rb
@@ -21,7 +21,7 @@ module Fastlane
 
         # call our command
         Actions.sh(command)
-        
+
         Helper.log.info 'Build artifacts sucesfully copied!'.green
       end
 


### PR DESCRIPTION
This action copies artifacs to a target directory. It's useful if you have a CI that will pick up these artifacts and attach them to the build. Useful e.g. for storing your `.ipa`s, `.dSYM.zip`s, `.mobileprovision`s, `.cert`s

Example in conjunction with reset_git_repo

``` ruby
# Move our artifacts to a safe location so TeamCity can pick them up
copy_artifacts(
  target_path: 'artifacts',
  artifacts: ['*.cer', '*.mobileprovision', '*.ipa', '*.dSYM.zip']
)

# Reset the git repo to a clean state, but leave our artifacts in place
reset_git_repo(
  exclude: 'artifacts'
)
```
