### PR TITLE
Fix link to xctool documentation

### DIFF
--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -78,7 +78,7 @@ For example, try running the following (depending on what you plan on using):
 - [snapshot](https://github.com/KrauseFx/snapshot)
 - [sigh](https://github.com/KrauseFx/sigh)
 - [frameit](https://github.com/KrauseFx/frameit)
-- [xctool](https://github.com/facebook/xctool) (which you should [configure correctly](https://github.com/krausefx/fastlane#xctool))
+- [xctool](https://github.com/facebook/xctool) (which you should [configure correctly](https://github.com/fastlane/fastlane/blob/master/docs/Actions.md#xctool))
 
 All those tools have detailed instructions on how to set them up. It's easier to set them up now, than later.
 


### PR DESCRIPTION
I guess that the `xctool` section in the actions documentation is the right one to point to.
