### PR TITLE
Update mailgun.rb to fix missing values

### DIFF
--- a/lib/fastlane/actions/mailgun.rb
+++ b/lib/fastlane/actions/mailgun.rb
@@ -103,8 +103,8 @@ module Fastlane
           message: options[:message],
           app_link: options[:app_link]
         }
-        hash[:success] = options[:success] if options[:success]
-        hash[:ci_build_link] = options[:success] if options[:ci_build_link]
+        hash[:success] = options[:success]
+        hash[:ci_build_link] = options[:ci_build_link]
         Fastlane::ErbTemplateHelper.render(
           Fastlane::ErbTemplateHelper.load("mailgun_html_template"),
           hash


### PR DESCRIPTION
Fixed bug: HTML template of mailgun doesn't have CI Build link if build has failed.
Fixed bug: CI Build link is pointing to the result of the build, and not the build link.
