### PR TITLE
Change 'IPA' to 'build' when describing Crashlytics Beta uploads

### DIFF
--- a/lib/fastlane/actions/crashlytics.rb
+++ b/lib/fastlane/actions/crashlytics.rb
@@ -27,7 +27,7 @@ module Fastlane
           raise "You have to either pass an ipa or an apk file to the Crashlytics action".red
         end
 
-        Helper.log.info 'Uploading the IPA to Crashlytics Beta. Time for some ☕️.'.green
+        Helper.log.info 'Uploading the build to Crashlytics Beta. Time for some ☕️.'.green
         Helper.log.debug command.join(" ") if $verbose
         Actions.sh command.join(" ")
 


### PR DESCRIPTION
Some Beta builds are actually APKs! :smile:

This changes the output to simply refer to the "build" when uploading, matching the success statement when complete. If preferred, we can call it the IPA or APK specifically in each case.

```
[21:39:24]: -------------------------
[21:39:24]: --- Step: crashlytics ---
[21:39:24]: -------------------------
[21:39:24]: Downloading Crashlytics Support Library - this might take a minute...
[21:39:33]: [SHELL COMMAND]: unzip '/Users/mfurtak/Library/CrashlyticsAndroid/crashlytics-devtools.zip' -d '/Users/mfurtak/Library/CrashlyticsAndroid'
[21:39:33]: [SHELL]: Archive:  /Users/mfurtak/Library/CrashlyticsAndroid/crashlytics-devtools.zip
[21:39:33]: [SHELL]: inflating: /Users/mfurtak/Library/CrashlyticsAndroid/crashlytics_build.xml
[21:39:33]: [SHELL]: inflating: /Users/mfurtak/Library/CrashlyticsAndroid/crashlytics_build_base.xml
[21:39:33]: [SHELL]: inflating: /Users/mfurtak/Library/CrashlyticsAndroid/crashlytics-devtools.jar
[21:39:33]: Succesfully downloaded Crashlytics Support Library to '/Users/mfurtak/Library/CrashlyticsAndroid/crashlytics-devtools.jar'
[21:39:33]: Uploading the IPA to Crashlytics Beta. Time for some ☕️.

...

[21:39:38]: Build successfully uploaded to Crashlytics Beta 🌷
```
