### PR TITLE
Make workspace exception criteria more correct

### DIFF
--- a/lib/fastlane/actions/commit_version_bump.rb
+++ b/lib/fastlane/actions/commit_version_bump.rb
@@ -124,7 +124,7 @@ module Fastlane
                                        description: "The path to your project file (Not the workspace). If you have only one, this is optional",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.include? "workspace"
+                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
                                          raise "Could not find Xcode project".red unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :force,

--- a/lib/fastlane/actions/get_build_number.rb
+++ b/lib/fastlane/actions/get_build_number.rb
@@ -58,7 +58,7 @@ module Fastlane
                              description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
                              optional: true,
                              verify_block: proc do |value|
-                               raise "Please pass the path to the project, not the workspace".red if value.include? "workspace"
+                               raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
                                raise "Could not find Xcode project".red if !File.exist?(value) and !Helper.is_test?
                              end)
         ]

--- a/lib/fastlane/actions/get_version_number.rb
+++ b/lib/fastlane/actions/get_version_number.rb
@@ -59,7 +59,7 @@ module Fastlane
                              description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
                              optional: true,
                              verify_block: proc do |value|
-                               raise "Please pass the path to the project, not the workspace".red if value.include? "workspace"
+                               raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
                                raise "Could not find Xcode project at path '#{File.expand_path(value)}'".red if !File.exist?(value) and !Helper.is_test?
                              end)
         ]

--- a/lib/fastlane/actions/hg_commit_version_bump.rb
+++ b/lib/fastlane/actions/hg_commit_version_bump.rb
@@ -123,7 +123,7 @@ module Fastlane
                                        description: "The path to your project file (Not the workspace). If you have only one, this is optional",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.include? "workspace"
+                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
                                          raise "Could not find Xcode project".red unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :force,

--- a/lib/fastlane/actions/increment_build_number.rb
+++ b/lib/fastlane/actions/increment_build_number.rb
@@ -61,7 +61,7 @@ module Fastlane
                                        description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.include? "workspace"
+                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
                                          raise "Could not find Xcode project".red if !File.exist?(value) and !Helper.is_test?
                                        end)
         ]

--- a/lib/fastlane/actions/increment_version_number.rb
+++ b/lib/fastlane/actions/increment_version_number.rb
@@ -104,7 +104,7 @@ module Fastlane
                                        env_name: "FL_VERSION_NUMBER_PROJECT",
                                        description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.include? "workspace"
+                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
                                          raise "Could not find Xcode project".red unless File.exist?(value)
                                        end,
                                        optional: true)

--- a/lib/fastlane/actions/update_info_plist.rb
+++ b/lib/fastlane/actions/update_info_plist.rb
@@ -54,7 +54,7 @@ module Fastlane
                                        description: "Path to your Xcode project",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.include? "workspace"
+                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
                                          raise "Could not find Xcode project".red unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :plist_path,


### PR DESCRIPTION
Fixes #895  

Makes the exception criteria for workspace exceptions more accurate by verifying that ".xcworkspace" is present rather than just "workspace".
