### PR TITLE
Adds remove_non_framed_screenshots action

### DIFF
--- a/lib/fastlane/actions/remove_non_framed_screenshots.rb
+++ b/lib/fastlane/actions/remove_non_framed_screenshots.rb
@@ -1,0 +1,47 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      REMOVE_NON_FRAMED_SCREENSHOTS_CUSTOM_VALUE = :REMOVE_NON_FRAMED_SCREENSHOTS_CUSTOM_VALUE
+    end
+
+    class RemoveNonFramedScreenshotsAction < Action
+      def self.run(params)
+        Actions.sh("find #{params[:screenshotsFolder]} -type f -name \"*.png\" | grep -v framed | grep -v #{params[:backgroundImage]} | xargs rm")
+      end
+
+      def self.description
+        "Removes non-framed screenshots"
+      end
+
+      def self.details
+        "There seems to be a bug in Deliver that uploads both framed and non-framed
+        screenshots. This is a dirty fix until it gets resolved."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :screenshotsFolder,
+                                       env_name: "FL_SCREENSHOTS_PATH",
+                                       description: "Path to screenshots folder",
+                                       is_string: true,
+                                       default_value: "fastlane/screenshots/",
+                                       optional: true), 
+          FastlaneCore::ConfigItem.new(key: :backgroundImage,
+                                       env_name: "FL_BACKGROUND_IMAGE_NAME",
+                                       description: "Name of background image",
+                                       is_string: true,
+                                       default_value: "background.png",
+                                       optional: true)
+        ]
+      end
+
+      def self.authors
+        ["JagCesar"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/remove_non_framed_screenshots.rb
+++ b/lib/fastlane/actions/remove_non_framed_screenshots.rb
@@ -25,7 +25,7 @@ module Fastlane
                                        description: "Path to screenshots folder",
                                        is_string: true,
                                        default_value: "fastlane/screenshots/",
-                                       optional: true), 
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :backgroundImage,
                                        env_name: "FL_BACKGROUND_IMAGE_NAME",
                                        description: "Name of background image",


### PR DESCRIPTION
This action is a dirty fix to get deliver working, https://github.com/fastlane/deliver/issues/403

It looks for `*.png` images in the default screenshot folder and removes the png-images that don't have `framed` in the filename or are named `background.png`. The screenshots path and `background.png` can both be set using optional arguments.
