### PR TITLE
Add new update url schemes action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -856,6 +856,16 @@ update_info_plist(
 )
 ```
 
+## update_url_schemes
+
+This action allows you to update the URL schemes of the app before building it.
+For example, you can use this to set a different url scheme for the alpha
+or beta version of the app.
+
+```ruby
+update_url_schemes path: 'path/to/Info.plist', url_schemes: ['myawesomeapp']
+```
+
 ## Developer Portal
 
 ### [sigh](https://github.com/KrauseFx/sigh)

--- a/lib/fastlane/actions/update_url_schemes.rb
+++ b/lib/fastlane/actions/update_url_schemes.rb
@@ -1,0 +1,69 @@
+require 'plist'
+
+module Fastlane
+  module Actions
+    class UpdateUrlSchemesAction < Action
+      def self.run(params)
+        path = params[:path]
+        url_schemes = params[:url_schemes]
+
+        hash = Plist.parse_xml(path)
+        hash['CFBundleURLTypes'].first['CFBundleURLSchemes'] = url_schemes
+        File.write(path, hash.to_plist)
+      end
+
+      def self.description
+        'Updates the URL schemes in the given Info.plist'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :path,
+            env_name: 'FL_UPDATE_URL_SCHEMES_PATH',
+            description: 'The Plist file\'s path',
+            is_string: true,
+            verify_block: verify_path_block
+          ),
+
+          FastlaneCore::ConfigItem.new(
+            key: :url_schemes,
+            env_name: "FL_UPDATE_URL_SCHEMES_URL_SCHEMES",
+            description: 'The new URL schemes',
+            is_string: false,
+            verify_block: verify_url_schemes_block
+          )
+        ]
+      end
+
+      def self.output
+        []
+      end
+
+      def self.authors
+        ['kmikael']
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include? platform
+      end
+
+      def self.verify_path_block
+        lambda do |path|
+          raise "Could not find plist at path '#{path}'".red unless File.exist?(path)
+        end
+      end
+
+      def self.verify_url_schemes_block
+        lambda do |url_schemes|
+          string = "The URL schemes must be an array of strings, got '#{url_schemes}'.".red
+          raise string unless url_schemes.kind_of?(Array)
+
+          url_schemes.each do |url_scheme|
+            raise string unless url_scheme.kind_of?(String)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This action allows you to update the URL schemes of the app before building it. For example, you can use this to set a different url scheme for the alpha or beta version of the app.
