### PR TITLE
add last_git_commit action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1167,6 +1167,15 @@ import_from_git(
 )
 ```
 
+### last_git_commit
+
+Get information about the last git commit, returns the author and the git message.
+
+```ruby
+last_commit = last_git_commit
+crashlytics(notes: last_commit[:message])
+```
+
 ## Using mercurial
 
 ### hg_ensure_clean_status

--- a/lib/fastlane/actions/last_git_commit.rb
+++ b/lib/fastlane/actions/last_git_commit.rb
@@ -1,0 +1,32 @@
+module Fastlane
+  module Actions
+    class LastGitCommitAction < Action
+      def self.run(params)
+        message = sh "git log -1 --pretty=%B"
+        author = sh "git log -1 --pretty=%an"
+
+        {author: author, message: message}
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Return last git commit message and author"
+      end
+
+      def self.return_value
+        "Returns the following dict: {author: \"Author\", message: \"commit message\"}"
+      end
+
+      def self.author
+        "ngutman"
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/last_git_commit.rb
+++ b/lib/fastlane/actions/last_git_commit.rb
@@ -25,7 +25,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        true
       end
     end
   end


### PR DESCRIPTION
Return information about the last git commit, we use it to create a custom message when releasing a Crashlytics build.

Might be useful to other people
