### PR TITLE
Add new action to run UI test by Appium

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -569,6 +569,22 @@ ensure_no_debug_code(text: "NSLog",
                 extension: "m")
 ```
 
+### [Appium](http://appium.io/)
+
+Run UI testing by `Appium::Driver` with RSpec.
+
+```ruby
+appium(
+  app_path:  "appium/apps/TargetApp.app",
+  spec_path: "appium/spec",
+  platform:  "iOS",
+  caps: {
+    versionNumber: "9.1",
+    deviceName:    "iPhone 6"
+  }
+)
+```
+
 ## Deploying
 
 ### [pilot](https://github.com/fastlane/pilot)
@@ -947,7 +963,7 @@ For example, you can use this to set a different url scheme for the alpha
 or beta version of the app.
 
 ```ruby
-update_url_schemes(path: "path/to/Info.plist", 
+update_url_schemes(path: "path/to/Info.plist",
             url_schemes: ["com.myapp"])
 ```
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -58,4 +58,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 1.19.0'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rubocop', '~> 0.29'
+  spec.add_development_dependency 'appium_lib', '~> 4.1.0'
 end

--- a/lib/fastlane/actions/appium.rb
+++ b/lib/fastlane/actions/appium.rb
@@ -1,0 +1,175 @@
+module Fastlane
+  module Actions
+    class AppiumAction < Action
+      INVOKE_TIMEOUT = 30
+      APPIUM_PATH_HOMEBREW = '/usr/local/bin/appium'
+      APPIUM_APP_PATH = '/Applications/Appium.app'
+      APPIUM_APP_BUNDLE_PATH = 'Contents/Resources/node_modules/.bin/appium'
+
+      def self.run(params)
+        Actions.verify_gem!('rspec')
+        Actions.verify_gem!('appium_lib')
+
+        require 'rspec'
+        require 'appium_lib'
+
+        FastlaneCore::PrintTable.print_values(
+          config: params,
+          title: "Summary for Appium Action"
+        )
+
+        if params[:invoke_appium_server]
+          appium_pid = invoke_appium_server(params)
+          wait_for_appium_server(params)
+        end
+
+        configure_rspec(params)
+
+        rspec_args = []
+        rspec_args << params[:spec_path]
+        status = RSpec::Core::Runner.run(rspec_args).to_i
+        if status != 0
+          raise "Failed to run Appium spec. status code: #{status}".red
+        end
+      ensure
+        Actions.sh "kill #{appium_pid}" if appium_pid
+      end
+
+      def self.invoke_appium_server(params)
+        appium = detect_appium(params)
+        fork do
+          Process.exec("#{appium} -a #{params[:host]} -p #{params[:port]}")
+        end
+      end
+
+      def self.detect_appium(params)
+        appium_path = params[:appium_path] || `which appium`.to_s.strip
+
+        if appium_path.empty?
+          if File.exist?(APPIUM_PATH_HOMEBREW)
+            appium_path = APPIUM_PATH_HOMEBREW
+          elsif File.exist?(APPIUM_APP_PATH)
+            appium_path = APPIUM_APP_PATH
+          end
+        end
+
+        unless File.exist?(appium_path)
+          raise 'You have to install Appium using `npm install -g appium`'.red
+        end
+
+        if appium_path.end_with?('.app')
+          appium_path = "#{appium_path}/#{APPIUM_APP_BUNDLE_PATH}"
+        end
+
+        Helper.log.info("Appium executable detected: #{appium_path}")
+        appium_path
+      end
+
+      def self.wait_for_appium_server(params)
+        loop.with_index do |_, count|
+          break if `lsof -i:#{params[:port]}`.to_s.length != 0
+
+          if count * 5 > INVOKE_TIMEOUT
+            raise 'Invoke Appium server timed out'.red
+          end
+          sleep 5
+        end
+      end
+
+      def self.configure_rspec(params)
+        RSpec.configure do |c|
+          c.before(:each) do
+            caps = params[:caps] || {}
+            caps[:platformName] ||= params[:platform]
+            caps[:autoAcceptAlerts] ||= true
+            caps[:app] = params[:app_path]
+
+            @driver = Appium::Driver.new(
+              caps: caps,
+              server_url: params[:host],
+              port: params[:port]
+            ).start_driver
+            Appium.promote_appium_methods(RSpec::Core::ExampleGroup)
+          end
+
+          c.after(:each) do
+            @driver.quit unless @driver.nil?
+          end
+        end
+      end
+
+      def self.description
+        'Run UI test by Appium with RSpec'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :platform,
+            env_name: 'FL_APPIUM_PLATFORM',
+            description: 'Appium platform name',
+            is_string: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :spec_path,
+            env_name: 'FL_APPIUM_SPEC_PATH',
+            description: 'Path to Appium spec directory',
+            is_string: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :app_path,
+            env_name: 'FL_APPIUM_APP_FILE_PATH',
+            description: 'Path to Appium target app file',
+            is_string: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :invoke_appium_server,
+            env_name: 'FL_APPIUM_INVOKE_APPIUM_SERVER',
+            description: 'Use local Appium server with invoke automatically',
+            is_string: false,
+            default_value: true,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :host,
+            env_name: 'FL_APPIUM_HOST',
+            description: 'Hostname of Appium server',
+            is_string: true,
+            default_value: '0.0.0.0',
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :port,
+            env_name: 'FL_APPIUM_PORT',
+            description: 'HTTP port of Appium server',
+            is_string: false,
+            default_value: 4723,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :appium_path,
+            env_name: 'FL_APPIUM_EXECUTABLE_PATH',
+            description: 'Path to Appium executable',
+            is_string: true,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :caps,
+            env_name: 'FL_APPIUM_CAPS',
+            description: 'Hash of caps for Appium::Driver',
+            is_string: false,
+            optional: true
+          )
+        ]
+      end
+
+      def self.author
+        'yonekawa'
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/spec/actions_specs/appium_spec.rb
+++ b/spec/actions_specs/appium_spec.rb
@@ -1,0 +1,147 @@
+require 'appium_lib'
+
+describe Fastlane do
+  describe Fastlane::FastFile do
+    before :each do
+      allow_any_instance_of(Appium::Driver).to receive(:start_driver)
+    end
+
+    context 'no parameters were given' do
+      it 'should raises an error' do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            appium()
+          end").runner.execute(:test)
+        end.to raise_error
+      end
+    end
+
+    context 'no platform were given' do
+      it 'should raises an error' do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            appium({
+              app_path: 'appium/app/Target.app',
+              spec_path: 'appium/spec'
+            })
+          end").runner.execute(:test)
+        end.to raise_error
+      end
+    end
+
+    context 'no app_path were given' do
+      it 'should raises an error' do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            appium({
+              platform: 'iOS',
+              spec_path: 'appium/spec'
+            })
+          end").runner.execute(:test)
+        end.to raise_error
+      end
+    end
+
+    context 'no spec_path were given' do
+      it 'should raises an error' do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            appium({
+              platform: 'iOS',
+              app_path: 'appium/app/Target.app',
+            })
+          end").runner.execute(:test)
+        end.to raise_error
+      end
+    end
+
+    context 'with valid parameters' do
+      before do
+        allow(Fastlane::Actions::AppiumAction).to receive(:invoke_appium_server)
+        allow(Fastlane::Actions::AppiumAction).to receive(:wait_for_appium_server)
+      end
+
+      before :each do
+        allow(RSpec::Core::Runner).to receive(:run).and_return(status_code)
+      end
+
+      context 'when spec failed' do
+        let(:status_code) { 1 }
+
+        it 'should raises an error' do
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              appium({
+                platform: 'iOS',
+                app_path: 'appium/app/Target.app',
+                spec_path: 'appium/spec'
+              })
+            end").runner.execute(:test)
+          end.to raise_error("Failed to run Appium spec. status code: #{status_code}".red)
+        end
+      end
+
+      context 'when spec succeeded' do
+        let(:status_code) { 0 }
+
+        it 'should not raises an error' do
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              appium({
+                platform: 'iOS',
+                app_path: 'appium/app/Target.app',
+                spec_path: 'appium/spec'
+              })
+            end").runner.execute(:test)
+          end.not_to raise_error
+        end
+      end
+    end
+
+    context 'with invoke_appium_server' do
+      context 'is false' do
+        before :each do
+          allow(RSpec::Core::Runner).to receive(:run).and_return(0)
+        end
+
+        it 'should not invoke and wait appium server' do
+          expect(Fastlane::Actions::AppiumAction).not_to receive(:invoke_appium_server)
+          expect(Fastlane::Actions::AppiumAction).not_to receive(:wait_for_appium_server)
+
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              appium({
+                platform: 'iOS',
+                app_path: 'appium/app/Target.app',
+                spec_path: 'appium/spec',
+                invoke_appium_server: false
+              })
+            end").runner.execute(:test)
+          end.not_to raise_error
+        end
+      end
+
+      context 'is true' do
+        before :each do
+          allow(RSpec::Core::Runner).to receive(:run).and_return(0)
+        end
+
+        it 'should invoke and wait appium server' do
+          expect(Fastlane::Actions::AppiumAction).to receive(:invoke_appium_server)
+          expect(Fastlane::Actions::AppiumAction).to receive(:wait_for_appium_server)
+
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              appium({
+                platform: 'iOS',
+                app_path: 'appium/app/Target.app',
+                spec_path: 'appium/spec',
+                invoke_appium_server: true
+              })
+            end").runner.execute(:test)
+          end.not_to raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added new action to run UI test by [Appium](http://appium.io/) with RSpec.

``` rb
appium(
  app_path:  'appium/apps/TargetApp.app',
  spec_path: 'appium/spec',
  platform:  'iOS',
  caps: {
    versionNumber: '9.1',
    deviceName:    'iPhone 6'
  }
)
```

This is spec example.

``` rb
describe 'Examples' do
  it 'should display success' do
    find_element(:name, 'Show').click
    expect(find_element(:name, 'Success').displayed?).to be_truthy
  end
end
```

See [this document](http://appium.io/getting-started.html?lang=en) for more detail.
Please review it :smiley: 
