### PR TITLE
Add use_bundle_exec option to slather action

### DIFF
--- a/lib/fastlane/actions/slather.rb
+++ b/lib/fastlane/actions/slather.rb
@@ -6,9 +6,16 @@ module Fastlane
 
     class SlatherAction < Action
       def self.run(params)
-        Actions.verify_gem!('slather')
+        #This will fail if using Bundler. Skip the check rather than needing to
+        # require bundler
+        use_bundler = params[:use_bundle_exec]
+        if ! use_bundler
+          Actions.verify_gem!('slather')
+        end
 
-        command = "slather coverage "
+        command = ""
+        command += "bundle exec " if use_bundler
+        command += "slather coverage "
         command += " --build-directory #{params[:build_directory]}" if params[:build_directory]
         command += " --input-format #{params[:input_format]}" if params[:input_format]
         command += " --scheme #{params[:scheme]}" if params[:scheme]
@@ -128,7 +135,12 @@ Slather is available at https://github.com/venmo/slather
           FastlaneCore::ConfigItem.new(key: :ignore,
                                        env_name: "FL_SLATHER_IGNORE",
                                        description: "Tell slather to ignore files matching a path",
-                                       optional: true)
+                                       optional: true),
+         FastlaneCore::ConfigItem.new(key: :use_bundle_exec,
+                                      env_name: "FL_SLATHER_USE_BUNDLE_EXEC",
+                                      description: "Use bundle exec to execute slather. Make sure it is in the Gemfile",
+                                      is_string: false,
+                                      default_value: false),
         ]
       end
 

--- a/lib/fastlane/actions/slather.rb
+++ b/lib/fastlane/actions/slather.rb
@@ -5,16 +5,17 @@ module Fastlane
     end
 
     class SlatherAction < Action
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
-        #This will fail if using Bundler. Skip the check rather than needing to
+        # This will fail if using Bundler. Skip the check rather than needing to
         # require bundler
-        use_bundler = params[:use_bundle_exec]
-        if ! use_bundler
+        unless params[:use_bundle_exec]
           Actions.verify_gem!('slather')
         end
 
         command = ""
-        command += "bundle exec " if use_bundler
+        command += "bundle exec " if params[:use_bundle_exec]
         command += "slather coverage "
         command += " --build-directory #{params[:build_directory]}" if params[:build_directory]
         command += " --input-format #{params[:input_format]}" if params[:input_format]
@@ -136,11 +137,11 @@ Slather is available at https://github.com/venmo/slather
                                        env_name: "FL_SLATHER_IGNORE",
                                        description: "Tell slather to ignore files matching a path",
                                        optional: true),
-         FastlaneCore::ConfigItem.new(key: :use_bundle_exec,
+          FastlaneCore::ConfigItem.new(key: :use_bundle_exec,
                                       env_name: "FL_SLATHER_USE_BUNDLE_EXEC",
                                       description: "Use bundle exec to execute slather. Make sure it is in the Gemfile",
                                       is_string: false,
-                                      default_value: false),
+                                      default_value: false)
         ]
       end
 

--- a/spec/actions_specs/slather_spec.rb
+++ b/spec/actions_specs/slather_spec.rb
@@ -4,6 +4,7 @@ describe Fastlane do
       it "works with all parameters" do
         result = Fastlane::FastFile.new.parse("lane :test do
           slather({
+            use_bundle_exec: false,
             build_directory: 'foo',
             input_format: 'bah',
             scheme: 'Foo',
@@ -25,6 +26,33 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result).to eq("slather coverage  --build-directory foo --input-format bah --scheme Foo --buildkite --jenkins --travis --circleci --coveralls --simple-output --gutter-json --cobertura-xml --html --show --source-directory baz --output-directory 123 --ignore nothing foo.xcodeproj")
+      end
+
+      it "works with bundle" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          slather({
+            use_bundle_exec: true,
+            build_directory: 'foo',
+            input_format: 'bah',
+            scheme: 'Foo',
+            buildkite: true,
+            jenkins: true,
+            travis: true,
+            circleci: true,
+            coveralls: true,
+            simple_output: true,
+            gutter_json: true,
+            cobertura_xml: true,
+            html: true,
+            show: true,
+            source_directory: 'baz',
+            output_directory: '123',
+            ignore: 'nothing',
+            proj: 'foo.xcodeproj'
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec slather coverage  --build-directory foo --input-format bah --scheme Foo --buildkite --jenkins --travis --circleci --coveralls --simple-output --gutter-json --cobertura-xml --html --show --source-directory baz --output-directory 123 --ignore nothing foo.xcodeproj")
       end
 
       it "requires project to be specified" do


### PR DESCRIPTION
The gem helper was having trouble finding gems that were included via Bundle. I added a parameter `use_bundle_exec` which skips the gem lookup and runs slather using `bundle exec slather ...`. This was done in a similar fashion to the cocoa pods action. 

This is related to issue https://github.com/fastlane/fastlane/issues/871

Fixes #871 
