### PR TITLE
Add new action to run SonarQube analysis

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -23,6 +23,7 @@ import './path/to/other/Fastfile'
 - [Using git](#using-git)
 - [Using mercurial](#using-mercurial)
 - [Notifications](#notifications)
+- [Other](#other)
 - [Misc](#misc)
 
 ## Building
@@ -1418,6 +1419,20 @@ before_all do
   ...
 end
 ```
+
+### sonar
+
+This action will execute `sonar-runner` to run SonarQube analysis on your source code. 
+
+```ruby
+sonar(
+  project_key: "name.gretzki.awesomeApp",
+  project_version: "1.0",
+  project_name: "iOS - AwesomeApp",
+  sources_path: File.expand_path("../AwesomeApp")
+)
+```
+It can process unit test results if formatted as junit report as shown in [xctest](#xctest) action. It can also integrate coverage reports in Cobertura format, which can be transformed into by [slather](#slather) action.
 
 ## Misc
 

--- a/lib/fastlane/actions/sonar.rb
+++ b/lib/fastlane/actions/sonar.rb
@@ -27,7 +27,7 @@ module Fastlane
       end
 
       def self.verify_sonar_runner_binary
-        raise "You have to install sonar-runner using `brew install sonar-runner`".red unless `which sonar-runner`.to_s.length > 0 or !Helper.test?
+        raise "You have to install sonar-runner using `brew install sonar-runner`".red unless `which sonar-runner`.to_s.length > 0
       end
 
       #####################################################

--- a/lib/fastlane/actions/sonar.rb
+++ b/lib/fastlane/actions/sonar.rb
@@ -1,0 +1,86 @@
+module Fastlane
+  module Actions
+    class SonarAction < Action
+      def self.run(params)
+        verify_sonar_runner_binary
+
+        command_prefix = [
+          'cd',
+          File.expand_path('.').shellescape,
+          '&&'
+        ].join(' ')
+
+        sonar_runner_args = []
+        sonar_runner_args << "-Dproject.settings=\"#{params[:project_configuration_path]}\"" if params[:project_configuration_path]
+        sonar_runner_args << "-Dsonar.projectKey=\"#{params[:project_key]}\"" if params[:project_key]
+        sonar_runner_args << "-Dsonar.projectName=\"#{params[:project_name]}\"" if params[:project_name]
+        sonar_runner_args << "-Dsonar.projectVersion=\"#{params[:project_version]}\"" if params[:project_version]
+        sonar_runner_args << "-Dsonar.sources=\"#{params[:sources_path]}\"" if params[:sources_path]
+
+        command = [
+          command_prefix,
+          'sonar-runner',
+          sonar_runner_args,
+        ].join(' ')
+
+        Action.sh command
+      end
+
+      def self.verify_sonar_runner_binary
+        raise "You have to install sonar-runner using `brew install sonar-runner`".red unless `which sonar-runner`.to_s.length > 0 or !Helper.test?
+      end
+
+      #####################################################
+      # @!group Documentation
+      ##################################################### 
+
+      def self.description
+        "Invokes sonar-runner to programmatically run SonarQube analysis"
+      end
+
+      def self.details
+        "See http://docs.sonarqube.org/display/SONAR/Analyzing+with+SonarQube+Scanner for details."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :project_configuration_path,
+                                        env_name: "FL_SONAR_RUNNER_PROPERTIES_PATH",
+                                        description: "The path to your sonar project configuration file; defaults to `sonar-project.properties`", #default is enforced by sonar-runner binary
+                                        optional: true,
+                                        verify_block: proc do |value|
+                                          raise "Couldn't find file at path '#{value}'".red unless value.nil? or File.exist?(value)
+                                        end),
+          FastlaneCore::ConfigItem.new(key: :project_key,
+                                       env_name: "FL_SONAR_RUNNER_PROJECT_KEY",
+                                       description: "The key sonar uses to identify the project, e.g. `name.gretzki.awesomeApp`. Must either be specified here or inside the sonar project configuration file",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :project_name,
+                                       env_name: "FL_SONAR_RUNNER_PROJECT_NAME",
+                                       description: "The name of the project that gets displayed on the sonar report page. Must either be specified here or inside the sonar project configuration file",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :project_version,
+                                       env_name: "FL_SONAR_RUNNER_PROJECT_VERSION",
+                                       description: "The project's version that gets displayed on the sonar report page. Must either be specified here or inside the sonar project configuration file",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :sources_path,
+                                       env_name: "FL_SONAR_RUNNER_SOURCES_PATH",
+                                       description: "Comma-separated paths to directories containing source files. Must either be specified here or inside the sonar project configuration file",
+                                       optional: true)
+        ]
+      end
+
+      def self.return_value
+        "The exit code of the sonar-runner binary"
+      end
+
+      def self.authors
+        ["c_gretzki"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/sonar.rb
+++ b/lib/fastlane/actions/sonar.rb
@@ -20,7 +20,7 @@ module Fastlane
         command = [
           command_prefix,
           'sonar-runner',
-          sonar_runner_args,
+          sonar_runner_args
         ].join(' ')
 
         Action.sh command
@@ -32,7 +32,7 @@ module Fastlane
 
       #####################################################
       # @!group Documentation
-      ##################################################### 
+      #####################################################
 
       def self.description
         "Invokes sonar-runner to programmatically run SonarQube analysis"
@@ -46,7 +46,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :project_configuration_path,
                                         env_name: "FL_SONAR_RUNNER_PROPERTIES_PATH",
-                                        description: "The path to your sonar project configuration file; defaults to `sonar-project.properties`", #default is enforced by sonar-runner binary
+                                        description: "The path to your sonar project configuration file; defaults to `sonar-project.properties`", # default is enforced by sonar-runner binary
                                         optional: true,
                                         verify_block: proc do |value|
                                           raise "Couldn't find file at path '#{value}'".red unless value.nil? or File.exist?(value)


### PR DESCRIPTION
Added new action to run SonarQube analysis with sonar-runner.

It's only a thin wrapper around sonar-runner binary, but I find it neat to have the checks and documentation integrated as separate fastlane action.

To be used inside Fastfile like this:

```
sonar(
  project_key: "name.gretzki.awesomeApp",
  project_version: "1.0",
  project_name: "iOS - AwesomeApp",
  sources_path: File.expand_path("../AwesomeApp")
)
```

Thanks,
Chris :smiley:
