### PR TITLE
Fix possible nil dereference in `changelog_from_git_commits`

### DIFF
--- a/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -16,7 +16,8 @@ module Fastlane
 
         Helper.log.info "Collecting Git commits between #{from} and #{to}".green
 
-        changelog = Actions.git_log_between(params[:pretty], from, to).gsub("\n\n", "\n") # as there are duplicate newlines
+        changelog = Actions.git_log_between(params[:pretty], from, to)
+        changelog = changelog.gsub("\n\n", "\n") if changelog # as there are duplicate newlines
         Actions.lane_context[SharedValues::FL_CHANGELOG] = changelog
 
         changelog
@@ -41,7 +42,7 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :between,
-                                       env_name: 'FL_GIT_COLLECT_MESSAGES_BETWEEN',
+                                       env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_BETWEEN',
                                        description: 'Array containing two Git revision values between which to collect messages',
                                        optional: true,
                                        is_string: false,
@@ -50,13 +51,13 @@ module Fastlane
                                          raise ":between must be an array of size 2".red unless (value || []).size == 2
                                        end),
           FastlaneCore::ConfigItem.new(key: :pretty,
-                                       env_name: 'FL_GIT_COLLECT_MESSAGES_PRETTY',
+                                       env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_PRETTY',
                                        description: 'The format applied to each commit while generating the collected value',
                                        optional: true,
                                        default_value: '%B',
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :match_lightweight_tag,
-                                       env_name: 'FL_GIT_COLLECT_MESSAGES_MATCH_LIGHTWEIGHT_TAG',
+                                       env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_MATCH_LIGHTWEIGHT_TAG',
                                        description: 'Whether or not to match a lightweight tag when searching for the last one',
                                        optional: true,
                                        default_value: true,

--- a/lib/fastlane/helper/git_helper.rb
+++ b/lib/fastlane/helper/git_helper.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     def self.git_log_between(pretty_format, from, to)
-      Actions.sh("git log --pretty=#{pretty_format} #{from}...#{to}", log: false).chomp
+      Actions.sh("git log --pretty=\"#{pretty_format}\" #{from}...#{to}", log: false).chomp
     rescue
       nil
     end

--- a/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane do
           changelog_from_git_commits
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=%B git describe --tags --abbrev=0...HEAD")
+        expect(result).to eq("git log --pretty=\"%B\" git describe --tags --abbrev=0...HEAD")
       end
 
       it "Uses the provided pretty format to collect log messages" do
@@ -14,7 +14,7 @@ describe Fastlane do
           changelog_from_git_commits(pretty: '%s%n%b')
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=%s%n%b git describe --tags --abbrev=0...HEAD")
+        expect(result).to eq("git log --pretty=\"%s%n%b\" git describe --tags --abbrev=0...HEAD")
       end
 
       it "Does not match lightweight tags when searching for the last one if so requested" do
@@ -22,7 +22,7 @@ describe Fastlane do
           changelog_from_git_commits(match_lightweight_tag: false)
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=%B git describe --abbrev=0...HEAD")
+        expect(result).to eq("git log --pretty=\"%B\" git describe --abbrev=0...HEAD")
       end
 
       it "Collects logs in the specified revision range if specified" do
@@ -30,7 +30,7 @@ describe Fastlane do
           changelog_from_git_commits(between: ['abcd', '1234'])
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=%B abcd...1234")
+        expect(result).to eq("git log --pretty=\"%B\" abcd...1234")
       end
 
       it "Does not accept a string value for between" do


### PR DESCRIPTION
- Rename `changelog_from_git_commits` env vars to match final action name
- Wrap the provided `pretty` format in quotes to make the shell-out command happier
