### PR TITLE
Fixed issue that prevented passing in `slack_url` as a parameter

### DIFF
--- a/lib/fastlane/actions/slack.rb
+++ b/lib/fastlane/actions/slack.rb
@@ -25,13 +25,7 @@ module Fastlane
         options[:message] = self.trim_message(options[:message].to_s || '')
         options[:message] = Slack::Notifier::LinkFormatter.format(options[:message])
 
-        url = ENV['SLACK_URL']
-        unless url
-          Helper.log.fatal "Please add 'ENV[\"SLACK_URL\"] = \"https://hooks.slack.com/services/...\"' to your Fastfile's `before_all` section.".red
-          raise 'No SLACK_URL given.'.red
-        end
-
-        notifier = Slack::Notifier.new(url)
+        notifier = Slack::Notifier.new(options[:slack_url])
 
         notifier.username = 'fastlane'
         if options[:channel].to_s.length > 0

--- a/spec/actions_specs/slack_spec.rb
+++ b/spec/actions_specs/slack_spec.rb
@@ -19,6 +19,7 @@ describe Fastlane do
 
         require 'fastlane/actions/slack'
         arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+          slack_url: 'http://127.0.0.1',
           message: message,
           success: false,
           channel: channel,
@@ -57,6 +58,7 @@ describe Fastlane do
 
         require 'fastlane/actions/slack'
         arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+          slack_url: 'http://127.0.0.1',
           message: message,
           success: false,
           channel: channel,

--- a/spec/actions_specs/slack_spec.rb
+++ b/spec/actions_specs/slack_spec.rb
@@ -10,15 +10,6 @@ describe Fastlane do
         expect(Fastlane::Actions::SlackAction.trim_message(long_text).length).to eq(7000)
       end
 
-      it "raises an error if no slack URL is given" do
-        ENV.delete 'SLACK_URL'
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
-            slack
-          end").runner.execute(:test)
-        end.to raise_exception('No SLACK_URL given.'.red)
-      end
-
       it "works so perfect, like Slack does" do
         channel = "#myChannel"
         message = "Custom Message"


### PR DESCRIPTION
Ran into a issue where I was trying to post to multiple slack rooms, and it failed for me.

Looking at the source, the action was specifically looking for the `SLACK_URL` env in the run method, even though its defined as an available option.

Given that, I think its fine to simply rely on `options[:slack_url]` instead of only working if the environment variable is present.
