### PR TITLE
Minor edit to replace ambiguous variable name.

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -809,7 +809,7 @@ See how [Wikpedia](https://github.com/fastlane/examples/blob/master/Wikipedia/Fa
 You can also only receive the build number without modifying it
 
 ```ruby
-version = get_build_number(xcodeproj: "Project.xcodeproj")
+build_number = get_build_number(xcodeproj: "Project.xcodeproj")
 ```
 
 ### [increment_version_number](https://developer.apple.com/library/ios/qa/qa1827/_index.html)


### PR DESCRIPTION
At a glance, this line

``` ruby
version = get_build_number(xcodeproj: "Project.xcodeproj")
```

suggested that the action `get_build_number` could return the project's version number. This change makes it clear what the action does for those that like to skim read (such as myself).
