### PR TITLE
Add `output_file` and `reporter` option to `swiftlint` action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -542,6 +542,16 @@ oclint(
 )  
 ```
 
+### [SwiftLint](https://github.com/realm/SwiftLint)
+Run SwiftLint for your project.
+
+```
+swiftlint(
+  output_file: 'swiftlint.result.json', # The path of the output file (optional)
+  config_file: '.swiftlint-ci.yml'      # The path of the configuration file (optional)
+)
+```
+
 ### `ensure_no_debug_code`
 
 You don't want any debug code to slip into production. You can use the `ensure_no_debug_code` action to make sure no debug code is in your code base before deploying it:

--- a/lib/fastlane/actions/swiftlint.rb
+++ b/lib/fastlane/actions/swiftlint.rb
@@ -5,7 +5,11 @@ module Fastlane
         if `which swiftlint`.to_s.length == 0 and !Helper.test?
           raise "You have to install swiftlint using `brew install swiftlint`".red
         end
-        Actions.sh("swiftlint")
+
+        command = 'swiftlint lint'
+        command << " --config #{params[:config_file]}" if params[:config_file]
+        command << " > #{params[:output_file]}" if params[:output_file]
+        Actions.sh(command)
       end
 
       #####################################################
@@ -21,6 +25,12 @@ module Fastlane
 
       def self.available_options
         [
+          FastlaneCore::ConfigItem.new(key: :output_file,
+                                       description: 'Path to output SwiftLint result',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :config_file,
+                                       description: 'Custom configuration file of SwiftLint',
+                                       optional: true)
         ]
       end
 

--- a/spec/actions_specs/swiftlint_spec.rb
+++ b/spec/actions_specs/swiftlint_spec.rb
@@ -1,12 +1,54 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "SwiftLint" do
-      it "default use case" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          swiftlint
-        end").runner.execute(:test)
+      let (:output_file) { "swiftlint.result.json" }
+      let (:config_file) { ".swiftlint-ci.yml" }
 
-        expect(result).to eq("swiftlint")
+      context "default use case" do
+        it "default use case" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint")
+        end
+      end
+
+      context "when specify output_file options" do
+        it "adds redirect file to command" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              output_file: '#{output_file}'
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint > #{output_file}")
+        end
+      end
+
+      context "when specify config_file options" do
+        it "adds config option" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              config_file: '#{config_file}'
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint --config #{config_file}")
+        end
+      end
+
+      context "when specify output_file and config_file options" do
+        it "adds config option and redirect file" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              output_file: '#{output_file}',
+              config_file: '#{config_file}'
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint --config #{config_file} > #{output_file}")
+        end
       end
     end
   end


### PR DESCRIPTION
I hope to receive SwiftLint result that is formatted JSON.
Sample is here https://github.com/noboru-i/kyouen-ios/blob/bcbca4f21be08d56242e23a44f04986496515bd3/fastlane/Fastfile#L80

SwiftLint can switch reporter by using `.swiftlint.yml`.
So I make backup and replace `reporter` when executing `swiftlint`.

Sorry for less test code.
I don't know how to test that ".swiftlint.yml" is correct when executing `swiftlint`.
