### PR TITLE
Added option to exclude merge commits from changelog_from_git_commits action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1141,6 +1141,7 @@ changelog_from_git_commits(
   between: ['7b092b3', 'HEAD'], # Optional, lets you specify a revision/tag range between which to collect commit info
   pretty: '- (%ae) %s', # Optional, lets you provide a custom format to apply to each commit when generating the changelog text
   match_lightweight_tag: false # Optional, lets you ignore lightweight (non-annotated) tags when searching for the last tag
+  include_merges: true # Optional, lets you filter out merge commits
 )
 ```
 

--- a/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -16,7 +16,7 @@ module Fastlane
 
         Helper.log.info "Collecting Git commits between #{from} and #{to}".green
 
-        changelog = Actions.git_log_between(params[:pretty], from, to)
+        changelog = Actions.git_log_between(params[:pretty], from, to, params[:include_merges])
         changelog = changelog.gsub("\n\n", "\n") if changelog # as there are duplicate newlines
         Actions.lane_context[SharedValues::FL_CHANGELOG] = changelog
 
@@ -59,6 +59,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :match_lightweight_tag,
                                        env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_MATCH_LIGHTWEIGHT_TAG',
                                        description: 'Whether or not to match a lightweight tag when searching for the last one',
+                                       optional: true,
+                                       default_value: true,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :include_merges,
+                                       env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_INCLUDE_MERGES',
+                                       description: 'Whether or not to include any commits that are merges',
                                        optional: true,
                                        default_value: true,
                                        is_string: false)

--- a/lib/fastlane/helper/git_helper.rb
+++ b/lib/fastlane/helper/git_helper.rb
@@ -1,7 +1,10 @@
 module Fastlane
   module Actions
-    def self.git_log_between(pretty_format, from, to)
-      Actions.sh("git log --pretty=\"#{pretty_format}\" #{from.shellescape}...#{to.shellescape}", log: false).chomp
+    def self.git_log_between(pretty_format, from, to, include_merges)
+      command = 'git log'
+      command << " --pretty=\"#{pretty_format}\" #{from.shellescape}...#{to.shellescape}"
+      command << " --no-merges" unless include_merges
+      Actions.sh(command, log: false).chomp
     rescue
       nil
     end

--- a/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -56,6 +56,14 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error(":between must be an array of size 2".red)
       end
+
+      it "Does not include merge commits in the list of commits" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          changelog_from_git_commits(include_merges: false)
+        end").runner.execute(:test)
+
+        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ --abbrev\\=0...HEAD --no-merges")
+      end
     end
   end
 end


### PR DESCRIPTION
This provides a mechanism to filter out the merge commits in your git log. Useful when sending out a log of commits as a release notes and you don't want the unnecessary merge commits in that text. By default, it includes the merges (as the original action functioned).
