### PR TITLE
Added owner_id to hockey parameters

### DIFF
--- a/lib/fastlane/actions/hockey.rb
+++ b/lib/fastlane/actions/hockey.rb
@@ -141,7 +141,11 @@ module Fastlane
                                       env_name: "FL_HOCKEY_UPLOAD_DSYM_ONLY",
                                       description: "Flag to upload only the dSYM file to hockey app",
                                       is_string: false,
-                                      default_value: false)
+                                      default_value: false),
+          FastlaneCore::ConfigItem.new(key: :owner_id,
+                                      env_name: "FL_HOCKEY_OWNER_ID",
+                                      description: "ID for the owner of the app",
+                                      optional: true)
         ]
       end
 

--- a/spec/actions_specs/hockey_spec.rb
+++ b/spec/actions_specs/hockey_spec.rb
@@ -57,6 +57,7 @@ describe Fastlane do
         expect(values[:release_type]).to eq(0.to_s)
         expect(values[:tags]).to eq(nil)
         expect(values[:teams]).to eq(nil)
+        expect(values[:owner_id]).to eq(nil)
         expect(values[:mandatory]).to eq(0.to_s)
         expect(values[:notes_type]).to eq(1.to_s)
         expect(values[:upload_dsym_only]).to eq(false)
@@ -144,6 +145,18 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(values[:tags]).to eq('123,123')
+      end
+
+      it "can change owners" do
+        values = Fastlane::FastFile.new.parse("lane :test do
+          hockey({
+            api_token: 'xxx',
+            ipa: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+            owner_id: '123'
+          })
+        end").runner.execute(:test)
+
+        expect(values[:owner_id]).to eq('123')
       end
     end
   end


### PR DESCRIPTION
Added an optional owner_id parameter to the hockey action.

This is following PR: https://github.com/fastlane/shenzhen/pull/5

This will allow users to assign ownership of an app upon upload.
