### PR TITLE
Fix git changelog action when tag names need shell escaping

### DIFF
--- a/lib/fastlane/helper/git_helper.rb
+++ b/lib/fastlane/helper/git_helper.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     def self.git_log_between(pretty_format, from, to)
-      Actions.sh("git log --pretty=\"#{pretty_format}\" #{from}...#{to}", log: false).chomp
+      Actions.sh("git log --pretty=\"#{pretty_format}\" #{from.shellescape}...#{to.shellescape}", log: false).chomp
     rescue
       nil
     end

--- a/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane do
           changelog_from_git_commits
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" git describe --tags --abbrev=0...HEAD")
+        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ --abbrev\\=0...HEAD")
       end
 
       it "Uses the provided pretty format to collect log messages" do
@@ -14,7 +14,7 @@ describe Fastlane do
           changelog_from_git_commits(pretty: '%s%n%b')
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%s%n%b\" git describe --tags --abbrev=0...HEAD")
+        expect(result).to eq("git log --pretty=\"%s%n%b\" git\\ describe\\ --tags\\ --abbrev\\=0...HEAD")
       end
 
       it "Does not match lightweight tags when searching for the last one if so requested" do
@@ -22,7 +22,7 @@ describe Fastlane do
           changelog_from_git_commits(match_lightweight_tag: false)
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" git describe --abbrev=0...HEAD")
+        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --abbrev\\=0...HEAD")
       end
 
       it "Collects logs in the specified revision range if specified" do
@@ -31,6 +31,14 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result).to eq("git log --pretty=\"%B\" abcd...1234")
+      end
+
+      it "handles tag names with characters that need shell escaping" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          changelog_from_git_commits(between: ['v1.8.0(30)', 'HEAD'])
+        end").runner.execute(:test)
+
+        expect(result).to eq("git log --pretty=\"%B\" v1.8.0\\(30\\)...HEAD")
       end
 
       it "Does not accept a string value for between" do


### PR DESCRIPTION
Tag names like `v1.8.0(30)` were causing trouble for the shell command because some characters need escaping (In this case, the parens).
