### PR TITLE
fix Crashlytics submit file path which installed via CocoaPods

### DIFF
--- a/lib/fastlane/actions/crashlytics.rb
+++ b/lib/fastlane/actions/crashlytics.rb
@@ -64,7 +64,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :crashlytics_path,
                                        env_name: "CRASHLYTICS_FRAMEWORK_PATH",
                                        description: "Path to the submit binary in the Crashlytics bundle (iOS) or `crashlytics-devtools.jar` file (Android)",
-                                       default_value: Dir["./Pods/iOS/Crashlytics/Crashlytics.framework"].last || Dir["./**/Crashlytics.framework"].last,
+                                       default_value: Dir["./Pods/iOS/Crashlytics/"].last || Dir["./**/Crashlytics.framework"].last,
                                        optional: true,
                                        verify_block: proc do |value|
                                          raise "Couldn't find crashlytics at path '#{File.expand_path(value)}'`".red unless File.exist?(File.expand_path(value))


### PR DESCRIPTION
As they documented, submit binary file was moved as below on v3.4.1.
before: Pods/Crashlytics/Crashlytics.framework/submit 
after:    Pods/Crashlytics/submit

ref: http://cocoadocs.org/docsets/Crashlytics/3.4.1/
