### PR TITLE
Adding match_pattern param to changelog_from_git_commits

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1126,6 +1126,7 @@ changelog_from_git_commits
 changelog_from_git_commits(
   between: ['7b092b3', 'HEAD'], # Optional, lets you specify a revision/tag range between which to collect commit info
   pretty: '- (%ae) %s', # Optional, lets you provide a custom format to apply to each commit when generating the changelog text
+  match_pattern: nil, # Optional, lets you search for a tag name that matches a glov(7) pattern
   match_lightweight_tag: false # Optional, lets you ignore lightweight (non-annotated) tags when searching for the last tag
 )
 ```

--- a/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -9,7 +9,7 @@ module Fastlane
         if params[:between]
           from, to = params[:between]
         else
-          from = Actions.last_git_tag_name(params[:match_lightweight_tag])
+          from = Actions.last_git_tag_name(params[:match_lightweight_tag], params[:match_pattern])
           Helper.log.debug "Found the last Git tag: #{from}"
           to = 'HEAD'
         end
@@ -56,6 +56,12 @@ module Fastlane
                                        optional: true,
                                        default_value: '%B',
                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :match_pattern,
+                                       env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_MATCH_PATTERN',
+                                       description: 'Whether or not to match a glob(7) pattern in tag name',
+                                       optional: true,
+                                       default_value: nil,
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :match_lightweight_tag,
                                        env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_MATCH_LIGHTWEIGHT_TAG',
                                        description: 'Whether or not to match a lightweight tag when searching for the last one',

--- a/lib/fastlane/helper/git_helper.rb
+++ b/lib/fastlane/helper/git_helper.rb
@@ -6,10 +6,11 @@ module Fastlane
       nil
     end
 
-    def self.last_git_tag_name(match_lightweight = true)
+    def self.last_git_tag_name(match_lightweight = true, match_pattern = nil)
       command = ['git describe']
       command << '--tags' if match_lightweight
       command << '--abbrev=0'
+      command << "--match #{match_pattern}" if match_pattern
       Actions.sh(command.join(' '), log: false).chomp
     rescue
       nil

--- a/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -56,6 +56,22 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error(":between must be an array of size 2".red)
       end
+
+      it "Uses pattern matching for tag name if requested" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          changelog_from_git_commits(match_pattern: '*1.8*')
+        end").runner.execute(:test)
+
+        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ --abbrev\\=0\\ --match\\ \\*1.8\\*...HEAD")
+      end
+
+      it "Does not use pattern matching for tag name if so requested" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          changelog_from_git_commits()
+        end").runner.execute(:test)
+
+        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ --abbrev\\=0...HEAD")
+      end
     end
   end
 end


### PR DESCRIPTION
Adds the option to fetch changelog from git commits with _from_ tag name that matches a given [glob(7)](http://man7.org/linux/man-pages/man7/glob.7.html) pattern.
For example if you're tags have a naming convention like:
- `builds/production/v1.6` - latest for **production** environment, and latest in repo/branch
- `builds/dev/v1.5` - latest for **dev** environment, but _not_ latest in repo/branch

So, if you call `changelog_from_git_commits(match_pattern: 'builds/dev/*')`, then it will skip `builds/production/v1.6` although it is the latest, and take `builds/dev/v1.5` for _from_ tag name.
