### PR TITLE
Updating last_git_tag to use

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1164,6 +1164,19 @@ Simple action to get the latest git tag
 last_git_tag
 ```
 
+If you are using this action on a **shallow clone**, *the default with some CI systems like Bamboo*, you need to ensure that you have also have pulled all the git tags appropriately.  Assuming your git repo has the correct remote set you can issue `sh("git fetch --tags")`
+
+```ruby
+  #Only fetch tags if a remote is set
+  remote_count = sh("git remote show | wc -l")
+  if remote_count > 0.to_s
+    sh("git fetch --tags")
+    last_git_tag
+  end
+```
+
+
+
 ### git_branch
 
 Quickly get the name of the branch you're currently in

--- a/lib/fastlane/helper/git_helper.rb
+++ b/lib/fastlane/helper/git_helper.rb
@@ -12,7 +12,7 @@ module Fastlane
     def self.last_git_tag_name(match_lightweight = true)
       command = ['git describe']
       command << '--tags' if match_lightweight
-      command << '--abbrev=0'
+      command << '`git rev-list --tags --max-count=1`'
       Actions.sh(command.join(' '), log: false).chomp
     rescue
       nil

--- a/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane do
           changelog_from_git_commits
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ --abbrev\\=0...HEAD")
+        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD")
       end
 
       it "Uses the provided pretty format to collect log messages" do
@@ -14,7 +14,7 @@ describe Fastlane do
           changelog_from_git_commits(pretty: '%s%n%b')
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%s%n%b\" git\\ describe\\ --tags\\ --abbrev\\=0...HEAD")
+        expect(result).to eq("git log --pretty=\"%s%n%b\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD")
       end
 
       it "Does not match lightweight tags when searching for the last one if so requested" do
@@ -22,7 +22,7 @@ describe Fastlane do
           changelog_from_git_commits(match_lightweight_tag: false)
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --abbrev\\=0...HEAD")
+        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD")
       end
 
       it "Collects logs in the specified revision range if specified" do
@@ -62,7 +62,7 @@ describe Fastlane do
           changelog_from_git_commits(include_merges: false)
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ --abbrev\\=0...HEAD --no-merges")
+        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD --no-merges")
       end
     end
   end

--- a/spec/actions_specs/last_git_tag_spec.rb
+++ b/spec/actions_specs/last_git_tag_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane do
           last_git_tag
         end").runner.execute(:test)
 
-        expect(result).to eq("git describe --tags --abbrev=0")
+        expect(result).to eq("git describe --tags `git rev-list --tags --max-count=1`")
       end
     end
   end


### PR DESCRIPTION
In reference to my issue #1039 I thought this "might" help things.

Updating the last tag comment to use 

```
git describe --tags `git rev-list --tags --max-count=1`
```
