### PR TITLE
Saving archive path after gym action.

### DIFF
--- a/lib/fastlane/actions/gym.rb
+++ b/lib/fastlane/actions/gym.rb
@@ -24,6 +24,7 @@ module Fastlane
 
           Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] = absolute_ipa_path
           Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH] = absolute_dsym_path if File.exist?(absolute_dsym_path)
+          Actions.lane_context[SharedValues::XCODEBUILD_ARCHIVE] = Gym::BuildCommandGenerator.archive_path
           ENV[SharedValues::IPA_OUTPUT_PATH.to_s] = absolute_ipa_path # for deliver
           ENV[SharedValues::DSYM_OUTPUT_PATH.to_s] = absolute_dsym_path if File.exist?(absolute_dsym_path)
 

--- a/lib/fastlane/runner.rb
+++ b/lib/fastlane/runner.rb
@@ -18,7 +18,6 @@ module Fastlane
     # @param lane_name The name of the lane to execute
     # @param platform The name of the platform to execute
     # @param parameters [Hash] The parameters passed from the command line to the lane
-    # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/AbcSize
     def execute(lane, platform = nil, parameters = nil)
       raise "No lane given" unless lane


### PR DESCRIPTION
Saving archive path after Gym action in the lane context. Archive path can be later used by `backup_xcarchive` action.
