### PR TITLE
Improved 'unlock_keychain' to support replacing keychains

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -265,6 +265,26 @@ unlock_keychain(
 )
 ```
 
+By default the keychain is added to the existing. To replace them with the selected keychain you may use `:replace`.
+
+```ruby
+unlock_keychain(
+  path: "/path/to/KeychainName.keychain",
+  password: "mysecret",
+  add_to_search_list: :replace # To only add a keychain use `true` or `:add`.
+)
+```
+
+In addition, the keychain can be selected as a default keychain.
+
+```ruby
+unlock_keychain(
+  path: "/path/to/KeychainName.keychain",
+  password: "mysecret",
+  set_default: true
+)
+```
+
 If the keychain file is located in the standard location `~/Library/Keychains`, then it is sufficient to provide the keychain file name, or file name with its suffix.
 
 ```ruby

--- a/lib/fastlane/actions/unlock_keychain.rb
+++ b/lib/fastlane/actions/unlock_keychain.rb
@@ -4,20 +4,28 @@ module Fastlane
       def self.run(params)
         keychain_path = self.expand_keychain_path(params[:path])
         add_to_search_list = params[:add_to_search_list]
+        set_default = params[:set_default]
+        commands = []
 
         if keychain_path.empty?
           raise "Could not find the keychain file: #{keychain_path}".red
         end
 
         # add to search list if not already added
-        if add_to_search_list
-          add_keychain_to_search_list(keychain_path)
+        if add_to_search_list == true || add_to_search_list == :add
+          commands << add_keychain_to_search_list(keychain_path)
+        elsif add_to_search_list == :replace
+          commands << replace_keychain_in_search_list(keychain_path)
+        end
+
+        # set default keychain
+        if set_default
+          commands << default_keychain(keychain_path)
         end
 
         escaped_path = keychain_path.shellescape
         escaped_password = params[:password].shellescape
 
-        commands = []
         # unlock given keychain and disable lock and timeout
         commands << Fastlane::Actions.sh("security unlock-keychain -p #{escaped_password} #{escaped_path}", log: false)
         commands << Fastlane::Actions.sh("security set-keychain-settings #{escaped_path}", log: false)
@@ -31,10 +39,19 @@ module Fastlane
         unless keychains.include?(keychain_path)
           keychains << keychain_path
 
-          commands = []
-          commands << Fastlane::Actions.sh("security list-keychains -s #{keychains.shelljoin}", log: false)
-          commands
+          Fastlane::Actions.sh("security list-keychains -s #{keychains.shelljoin}", log: false)
         end
+      end
+
+      def self.replace_keychain_in_search_list(keychain_path)
+        Actions.lane_context[Actions::SharedValues::ORIGINAL_DEFAULT_KEYCHAIN] = Fastlane::Actions.sh("security default-keychain", log: false).strip
+        escaped_path = keychain_path.shellescape
+        Fastlane::Actions.sh("security list-keychains -s #{escaped_path}", log: false)
+      end
+
+      def self.default_keychain(keychain_path)
+        escaped_path = keychain_path.shellescape
+        Fastlane::Actions.sh("security default-keychain -s #{escaped_path}", log: false)
       end
 
       def self.expand_keychain_path(keychain_path)
@@ -62,7 +79,8 @@ module Fastlane
       end
 
       def self.details
-        "Unlocks the give keychain file and adds it to the keychain search list"
+        "Unlocks the give keychain file and adds it to the keychain search list\n" \
+        "Keychains can be replaced with `add_to_search_list: :replace`"
       end
 
       def self.available_options
@@ -79,7 +97,12 @@ module Fastlane
                                        env_name: "FL_UNLOCK_KEYCHAIN_ADD_TO_SEARCH_LIST",
                                        description: "Add to keychain search list",
                                        is_string: false,
-                                       default_value: true)
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :set_default,
+                                       env_name: "FL_UNLOCK_KEYCHAIN_SET_DEFAULT",
+                                       description: "Set as default keychain",
+                                       is_string: false,
+                                       default_value: false)
 
         ]
       end

--- a/spec/actions_specs/unlock_keychain_spec.rb
+++ b/spec/actions_specs/unlock_keychain_spec.rb
@@ -7,13 +7,67 @@ describe Fastlane do
         result = Fastlane::FastFile.new.parse("lane :test do
           unlock_keychain ({
             path: '#{keychain_path}',
+            password: 'testpassword'
+          })
+        end").runner.execute(:test)
+
+        expect(result.size).to eq(3)
+        expect(result[0]).to start_with("security list-keychains -s")
+        expect(result[0]).to end_with(keychain_path)
+        expect(result[1]).to eq("security unlock-keychain -p testpassword #{keychain_path}")
+        expect(result[2]).to eq("security set-keychain-settings #{keychain_path}")
+      end
+
+      it "doesn't add keychain to search list" do
+        keychain_path = Tempfile.new('foo').path
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          unlock_keychain ({
+            path: '#{keychain_path}',
             password: 'testpassword',
+            add_to_search_list: false,
           })
         end").runner.execute(:test)
 
         expect(result.size).to eq(2)
         expect(result[0]).to eq("security unlock-keychain -p testpassword #{keychain_path}")
         expect(result[1]).to eq("security set-keychain-settings #{keychain_path}")
+      end
+
+      it "replace keychain in search list" do
+        keychain_path = Tempfile.new('foo').path
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          unlock_keychain ({
+            path: '#{keychain_path}',
+            password: 'testpassword',
+            add_to_search_list: :replace,
+          })
+        end").runner.execute(:test)
+
+        expect(result.size).to eq(3)
+        expect(result[0]).to eq("security list-keychains -s #{keychain_path}")
+        expect(result[1]).to eq("security unlock-keychain -p testpassword #{keychain_path}")
+        expect(result[2]).to eq("security set-keychain-settings #{keychain_path}")
+      end
+
+      it "set default keychain" do
+        keychain_path = Tempfile.new('foo').path
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          unlock_keychain ({
+            path: '#{keychain_path}',
+            password: 'testpassword',
+            set_default: true,
+          })
+        end").runner.execute(:test)
+
+        expect(result.size).to eq(4)
+        expect(result[0]).to start_with("security list-keychains -s")
+        expect(result[0]).to end_with(keychain_path)
+        expect(result[1]).to eq("security default-keychain -s #{keychain_path}")
+        expect(result[2]).to eq("security unlock-keychain -p testpassword #{keychain_path}")
+        expect(result[3]).to eq("security set-keychain-settings #{keychain_path}")
       end
     end
   end


### PR DESCRIPTION
Hi,

In some situations, mostly on Jenkins nodes, it is useful to have only one active keychain. This update adds support for replacing keychains (instead of adding to the list) using `add_to_search_list: :replace` and setting the keychain as default using `set_default: true`.
