### PR TITLE
Added sound parameter to OS X notification action

### DIFF
--- a/lib/fastlane/actions/notification.rb
+++ b/lib/fastlane/actions/notification.rb
@@ -4,10 +4,19 @@ module Fastlane
       def self.run(params)
         require 'terminal-notifier'
 
-        if params[:subtitle]
+        if params[:subtitle] && params[:sound]
           TerminalNotifier.notify(params[:message],
                                   title: params[:title],
-                               subtitle: params[:subtitle])
+                                  subtitle: params[:subtitle],
+                                  sound: params[:sound])
+        elsif params[:subtitle]
+          TerminalNotifier.notify(params[:message],
+                                  title: params[:title],
+                                  subtitle: params[:subtitle])
+        elsif params[:sound]
+          TerminalNotifier.notify(params[:message],
+                                  title: params[:title],
+                                  sound: params[:sound])
         else
           # It should look nice without a subtitle too
           TerminalNotifier.notify(params[:message],
@@ -20,7 +29,7 @@ module Fastlane
       end
 
       def self.author
-        ["champo", "cbowns", "KrauseFx"]
+        ["champo", "cbowns", "KrauseFx", "amarcadet"]
       end
 
       def self.available_options
@@ -33,7 +42,10 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :message,
                                        description: "The message to display in the notification",
-                                       optional: false)
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :sound,
+                                       description: "The name of a sound to play when the notification appears (names are listed in Sound Preferences)",
+                                       optional: true),
         ]
       end
 

--- a/lib/fastlane/actions/notification.rb
+++ b/lib/fastlane/actions/notification.rb
@@ -45,7 +45,7 @@ module Fastlane
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :sound,
                                        description: "The name of a sound to play when the notification appears (names are listed in Sound Preferences)",
-                                       optional: true),
+                                       optional: true)
         ]
       end
 


### PR DESCRIPTION
I thought it would be nice to play a sound with the OS X notification action.
Since I am new to ruby it might not be the smartest way to do it or I might have done something wrong, feel free to tell me if I must update anything.

I didn't found any specs for this action, so there is no tests with my PR.

Hope you like it :smiley: 
