### PR TITLE
Add a strict option to swiftlint action

### DIFF
--- a/lib/fastlane/actions/swiftlint.rb
+++ b/lib/fastlane/actions/swiftlint.rb
@@ -7,6 +7,7 @@ module Fastlane
         end
 
         command = 'swiftlint lint'
+        command << " --strict" if params[:strict]
         command << " --config #{params[:config_file]}" if params[:config_file]
         command << " > #{params[:output_file]}" if params[:output_file]
         Actions.sh(command)
@@ -30,6 +31,11 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :config_file,
                                        description: 'Custom configuration file of SwiftLint',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :strict,
+                                       description: 'Fail on warnings? (true/false)',
+                                       default_value: false,
+                                       is_string: false,
                                        optional: true)
         ]
       end

--- a/spec/actions_specs/swiftlint_spec.rb
+++ b/spec/actions_specs/swiftlint_spec.rb
@@ -14,6 +14,18 @@ describe Fastlane do
         end
       end
 
+      context "when specify strict options" do
+        it "adds strict option" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              strict: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint --strict")
+        end
+      end
+
       context "when specify output_file options" do
         it "adds redirect file to command" do
           result = Fastlane::FastFile.new.parse("lane :test do
@@ -38,16 +50,17 @@ describe Fastlane do
         end
       end
 
-      context "when specify output_file and config_file options" do
-        it "adds config option and redirect file" do
+      context "when specify output_file, config_file and strict options" do
+        it "adds config option, strict option and redirect file" do
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(
+              strict: true,
               output_file: '#{output_file}',
               config_file: '#{config_file}'
             )
           end").runner.execute(:test)
 
-          expect(result).to eq("swiftlint lint --config #{config_file} > #{output_file}")
+          expect(result).to eq("swiftlint lint --strict --config #{config_file} > #{output_file}")
         end
       end
     end


### PR DESCRIPTION
This adds a strict option to the swiftlint action which is passed to the swiftlint executable resulting in an exit code of 1 if swiftlint returns any warnings or errors. This is useful if you want your CI to fail if swiftlint omits any warnings.
