### PR TITLE
Add required rest-client dependeny

### DIFF
--- a/lib/fastlane/actions/mailgun.rb
+++ b/lib/fastlane/actions/mailgun.rb
@@ -10,6 +10,7 @@ module Fastlane
 
       def self.run(options)
         Actions.verify_gem!('rest-client')
+        require 'rest-client'
         handle_params_transition(options)
         mailgunit(options)
       end


### PR DESCRIPTION
Without this dependency mailgun action gives the following error

```
uninitialized constant Fastlane::Actions::MailgunAction::RestClient
```

This pull request fixes this issue https://github.com/fastlane/fastlane/issues/1042
