### PR TITLE
CLOC (Line Count Tool) Action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -823,7 +823,7 @@ You can add some options:
 ```ruby
 appaloosa(
   binary: '/path/to/binary.ipa', # path tor your IPA or APK
-  store_id: 'your_store_id', # you'll be asked for your email if you are not already registered 
+  store_id: 'your_store_id', # you'll be asked for your email if you are not already registered
   api_token: 'your_api_key', # only if already registered
   group_ids: '112, 232, 387', # User group_ids visibility, if it's not specified we 'll publish the app for all users in your store'
   # screenshots: after snapshot step:
@@ -1134,7 +1134,7 @@ This action turns your git commit history into formatted changelog text.
 
 ```ruby
 # Collects commits since your last tag and returns a concatenation of their subjects and bodies
-changelog_from_git_commits 
+changelog_from_git_commits
 
 # Advanced options
 changelog_from_git_commits(
@@ -1353,7 +1353,7 @@ puts commit[:author]
 
 ### create_pull_request
 
-Create a new pull request. 
+Create a new pull request.
 
 ```ruby
 create_pull_request(
@@ -1542,7 +1542,7 @@ testmunk
 ```
 
 ### [Podio](http://podio.com)
-Creates an item within your Podio app. In case an item with the given identifying value already exists within your Podio app, it updates that item. To find out how to get your authentication credentials see [Podio API documentation](https://developers.podio.com). To find out how to get your identifying field (external ID) and general info about Podio item see [tutorials](https://developers.podio.com/examples/items). 
+Creates an item within your Podio app. In case an item with the given identifying value already exists within your Podio app, it updates that item. To find out how to get your authentication credentials see [Podio API documentation](https://developers.podio.com). To find out how to get your identifying field (external ID) and general info about Podio item see [tutorials](https://developers.podio.com/examples/items).
 
 ```ruby
 ENV["PODIO_ITEM_IDENTIFYING_FIELD"] = "String specifying the field key used for identification of an item"
@@ -1588,7 +1588,7 @@ end
 
 ### sonar
 
-This action will execute `sonar-runner` to run SonarQube analysis on your source code. 
+This action will execute `sonar-runner` to run SonarQube analysis on your source code.
 
 ```ruby
 sonar(
@@ -1692,6 +1692,15 @@ This can be used to store some generated URL or value for easy copy & paste (e.g
 
 ```ruby
 clipboard(value: lane_context[SharedValues::HOCKEY_DOWNLOAD_LINK])
+```
+
+### [CLOC](https://github.com/AlDanial/cloc)
+
+You can generate a Line Count (that is readable by Jenkins - see the [SLOCCount Plugin](https://wiki.jenkins-ci.org/display/JENKINS/SLOCCount+Plugin) for more details).  This action is a wrapper around the cloc tool:
+
+```ruby
+# Result will be an XML report file: reports/cloc.xml
+cloc(exclude_dir: 'ThirdParty,Resources', output_directory: 'reports', source_directory: 'MyCoolApp')
 ```
 
 ### is_ci?

--- a/lib/fastlane/actions/cloc.rb
+++ b/lib/fastlane/actions/cloc.rb
@@ -1,0 +1,72 @@
+module Fastlane
+  module Actions
+    class ClocAction < Action
+      def self.run(params)
+        cloc_binary = params[:binary_path]
+        exclude_dirs = params[:exclude_dir].nil? ? '' : "--exclude-dir=#{params[:exclude_dir]}"
+        xml_format = params[:xml]
+        out_dir = params[:output_directory]
+        output_file = xml_format ? "#{out_dir}/cloc.xml" : "#{out_dir}/cloc.txt"
+        source_directory = params[:source_directory]
+
+        command = [
+          cloc_binary,
+          exclude_dirs,
+          '--by-file',
+          xml_format ? '--xml ' : '',
+          "--out=#{output_file}",
+          source_directory
+        ].join(' ').strip
+
+        Actions.sh command
+      end
+
+      def self.description
+        "Generates a Code Count that can be read by Jenkins (xml format)"
+      end
+
+      def self.details
+        "This action will run cloc to generate a SLOC report that the Jenkins SLOCCount plugin can read.  See https://wiki.jenkins-ci.org/display/JENKINS/SLOCCount+Plugin for more information."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :binary_path,
+                                       env_name: "FL_CLOC_BINARY_PATH",
+                                       description: "Where the cloc binary lives on your system (full path including 'cloc')",
+                                       optional: true,
+                                       is_string: true,
+                                       default_value: '/usr/local/bin/cloc'),
+          FastlaneCore::ConfigItem.new(key: :exclude_dir,
+                                       env_name: "FL_CLOC_EXCLUDE_DIR",
+                                       description: "Comma separated list of directories to exclude", # a short description of this parameter
+                                       optional: true,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :output_directory,
+                                       env_name: "FL_CLOC_OUTPUT_DIRECTORY",
+                                       description: "Where to put the generated report file",
+                                       is_string: true,
+                                       default_value: "build"),
+          FastlaneCore::ConfigItem.new(key: :source_directory,
+                                      env_name: "FL_CLOC_SOURCE_DIRECTORY",
+                                      description: "Where to look for the source code (relative to the project root folder)",
+                                      is_string: true,
+                                      default_value: ""),
+          FastlaneCore::ConfigItem.new(key: :xml,
+                                      env_name: "FL_CLOC_XML",
+                                      description: "Should we generate an XML File (if false, it will generate a plain text file)?",
+                                      is_string: false,
+                                      default_value: true)
+        ]
+      end
+
+      def self.authors
+        ["intere"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+    end
+  end
+end

--- a/spec/actions_specs/cloc_spec.rb
+++ b/spec/actions_specs/cloc_spec.rb
@@ -1,0 +1,45 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "CLOC Integration" do
+      it "does run cloc using only default options" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            cloc
+          end").runner.execute(:test)
+
+        expect(result).to eq("/usr/local/bin/cloc  --by-file --xml  --out=build/cloc.xml")
+      end
+
+      it 'does set the exclude directories' do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            cloc(exclude_dir: 'test1,test2,build')
+          end").runner.execute(:test)
+
+        expect(result).to eq("/usr/local/bin/cloc --exclude-dir=test1,test2,build --by-file --xml  --out=build/cloc.xml")
+      end
+
+      it 'does set the output directory' do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            cloc(output_directory: '/tmp')
+          end").runner.execute(:test)
+
+        expect(result).to eq("/usr/local/bin/cloc  --by-file --xml  --out=/tmp/cloc.xml")
+      end
+
+      it 'does set the source directory' do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            cloc(source_directory: 'MyCoolApp')
+          end").runner.execute(:test)
+
+        expect(result).to eq("/usr/local/bin/cloc  --by-file --xml  --out=build/cloc.xml MyCoolApp")
+      end
+
+      it 'does switch to plain text when xml is toggled off' do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            cloc(xml: false)
+          end").runner.execute(:test)
+
+        expect(result).to eq("/usr/local/bin/cloc  --by-file  --out=build/cloc.txt")
+      end
+    end
+  end
+end


### PR DESCRIPTION
As part of our CI build process, we perform line counts. CLOC is a tool that will create line count reports in a format that Jenkins supports. This action allows you to generate them (with various configurations) and put them where you please.
