### PR TITLE
Gradle upgrades

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -89,6 +89,44 @@ Use `gym --help` to get all available options.
 
 The alternative to `gym` is [`ipa`](#ipa) which uses [shenzhen](https://github.com/nomad/shenzhen) under the hood.
 
+### gradle
+
+You can use the `gradle` action to integrate your gradle tasks into `fastlane`.
+
+Simple usage:
+```ruby
+gradle(
+  task: 'assemble',
+  flavor: 'WorldDomination',
+  build_type: 'Release'
+)
+```
+
+In case of an `assemble` task, the signed apk path is accessible in: `Actions.lane_context[Actions::SharedValues::GRADLE_APK_OUTPUT_PATH]`
+
+
+You can pass [gradle properties](https://docs.gradle.org/current/userguide/build_environment.html):
+```ruby
+gradle(
+  # ...
+
+  properties: {
+    'versionCode' => 100,
+    'versionName' => '1.0.0',
+    # ...
+  }
+)
+```
+
+To pass any other CLI flags to gradle use:
+```ruby
+gradle(
+  # ...
+
+  flags: "--exitcode --xml file.xml"
+)
+```
+
 ### verify_xcode
 
 Verifies that the Xcode installation is properly signed by Apple. This is relevant after recent [attacks targeting Xcode](http://researchcenter.paloaltonetworks.com/2015/09/novel-malware-xcodeghost-modifies-xcode-infects-apple-ios-apps-and-hits-app-store/).

--- a/lib/fastlane/actions/gradle.rb
+++ b/lib/fastlane/actions/gradle.rb
@@ -1,36 +1,77 @@
+require 'pathname'
+require 'shellwords'
+
 module Fastlane
   module Actions
     module SharedValues
-      GRADLE_APK_OUTPUT_PATH = :APK_OUTPUT_PATH
+      GRADLE_APK_OUTPUT_PATH = :GRADLE_APK_OUTPUT_PATH
+      GRADLE_ALL_APK_OUTPUT_PATHS = :GRADLE_ALL_APK_OUTPUT_PATHS
       GRADLE_FLAVOR = :GRADLE_FLAVOR
+      GRADLE_BUILD_TYPE = :GRADLE_BUILD_TYPE
     end
 
     class GradleAction < Action
       def self.run(params)
         task = params[:task]
+        flavor = params[:flavor]
+        build_type = params[:build_type]
 
-        gradle = Helper::GradleHelper.new(gradle_path: params[:gradle_path])
+        gradle_task = [task, flavor, build_type].join
 
-        result = gradle.trigger(task: task, flags: params[:flags], serial: params[:serial])
+        project_dir = params[:project_dir]
 
-        return result unless task.start_with?("assemble")
+        gradle_path_param = params[:gradle_path] || './gradlew'
 
-        # We built our app. Store the path to the apk
-        flavor = task.match(/assemble(\w*)/)
-        if flavor and flavor[1]
-          flavor = flavor[1].downcase # Release => release
-          apk_path = Dir[File.join("app", "build", "outputs", "apk", "*-#{flavor}.apk")].last
-          if apk_path
-            Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH] = File.expand_path(apk_path)
-          else
-            Helper.log.info "Couldn't find signed apk file at path '#{apk_path}'...".red
-            if flavor == 'release'
-              Helper.log.info "Make sure to enable code signing in your gradle task: ".red
-              Helper.log.info "https://stackoverflow.com/questions/18328730/how-to-create-a-release-signed-apk-file-using-gradle".red
-            end
-          end
-          Actions.lane_context[SharedValues::GRADLE_FLAVOR] = flavor
+        # Get the path to gradle, if it's an absolute path we take it as is, if it's relative we assume it's relative to the project_dir
+        gradle_path = if Pathname.new(gradle_path_param).absolute?
+                        File.expand_path(gradle_path_param)
+                      else
+                        File.expand_path(File.join(project_dir, gradle_path_param))
+                      end
+
+        # Ensure we ended up with a valid path to gradle
+        raise "Couldn't find gradlew at path '#{File.expand_path(gradle_path)}'".red unless File.exist?(gradle_path)
+
+        # Construct our flags
+        flags = []
+        flags << "-p #{project_dir.shellescape}"
+        flags << params[:properties].map { |k, v| "-P#{k}=#{v}" }.join(' ') unless params[:properties].nil?
+        flags << params[:flags] unless params[:flags].nil?
+
+        # Run the actual gradle task
+        gradle = Helper::GradleHelper.new(gradle_path: gradle_path)
+
+        # If these were set as properties, then we expose them back out as they might be useful to others
+        Actions.lane_context[SharedValues::GRADLE_BUILD_TYPE] = build_type if build_type
+        Actions.lane_context[SharedValues::GRADLE_FLAVOR] = flavor if flavor
+
+        # Are we assembling, and therefore expecting apk's?
+        is_assembling = task.start_with?('assemble')
+
+        # We need to first clean up any old apk's that might still be lying around because otherwise there is no way of knowing which were the newly generated apk's
+        if is_assembling
+          apk_search_path = File.join(project_dir, '*', 'build', 'outputs', 'apk', '*-*.apk')
+          Dir[apk_search_path].each(&File.method(:delete))
         end
+
+        # We run the actual gradle task
+        result = gradle.trigger(task: gradle_task, serial: params[:serial], flags: flags.join(' '))
+
+        # If we didn't build, then we return now, as it makes no sense to search for apk's in a non-`assemble` scenario
+        return result unless is_assembling
+
+        # Our apk is now built, but there might actually be multiple ones that were built if a flavor was not specified in a multi-flavor project (e.g. `assembleRelease`), however we're not interested in unaligned apk's...
+        new_apks = Dir[apk_search_path].reject { |path| path =~ /^.*-unaligned.apk$/i}
+
+        # We expose all of these new apk's
+        Actions.lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] = new_apks
+
+        # We also take the most recent apk to return as SharedValues::GRADLE_APK_OUTPUT_PATH, this is the one that will be relevant for most projects that just build a single build variant (flavor + build type combo). In multi build variants this value is undefined
+        last_apk_path = new_apks.sort_by(&File.method(:mtime)).last
+        Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH] = File.expand_path(last_apk_path) if last_apk_path
+
+        # Give a helpful message in case there were no new apk's. Remember we're only running this code when assembling, in which case we certainly expect there to be an apk
+        Helper.log.info 'Couldn\'t find any new signed apk files...'.red if new_apks.empty?
 
         return result
       end
@@ -40,54 +81,75 @@ module Fastlane
       #####################################################
 
       def self.description
-        "All gradle related actions, including building and testing your Android app"
+        'All gradle related actions, including building and testing your Android app'
       end
 
       def self.details
         [
-          "Run `./gradlew tasks` to get a list of all available gradle tasks for your project"
+          'Run `./gradlew tasks` to get a list of all available gradle tasks for your project'
         ].join("\n")
       end
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :serial,
-                                       env_name: "FL_ANDROID_SERIAL",
-                                       description: "Android serial, wich device should be used for this command",
-                                       is_string: true,
-                                       default_value: ""),
           FastlaneCore::ConfigItem.new(key: :task,
-                                       env_name: "FL_GRADLE_TASK",
-                                       description: "The gradle task you want to execute",
+                                       env_name: 'FL_GRADLE_TASK',
+                                       description: 'The gradle task you want to execute, e.g. `assemble` or `test`. For tasks such as `assembleMyFlavorRelease` you should use gradle(task: \'assemble\', flavor: \'Myflavor\', build_type: \'Release\')',
+                                       optional: false,
                                        is_string: true),
-          FastlaneCore::ConfigItem.new(key: :flags,
-                                       env_name: "FL_GRADLE_FLAGS",
-                                       description: "All parameter flags you want to pass to the gradle command, e.g. `--exitcode --xml file.xml`",
+          FastlaneCore::ConfigItem.new(key: :flavor,
+                                       env_name: 'FL_GRADLE_FLAVOR',
+                                       description: 'The flavor that you want the task for, e.g. `MyFlavor`. If you are running the `assemble` task in a multi-flavor project, and you rely on Actions.lane_context[Actions.SharedValues::GRADLE_APK_OUTPUT_PATH] then you must specify a flavor here or else this value will be undefined',
                                        optional: true,
                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :build_type,
+                                       env_name: 'FL_GRADLE_BUILD_TYPE',
+                                       description: 'The build type that you want the task for, e.g. `Release`. Useful for some tasks such as `assemble`',
+                                       optional: true,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :flags,
+                                       env_name: 'FL_GRADLE_FLAGS',
+                                       description: 'All parameter flags you want to pass to the gradle command, e.g. `--exitcode --xml file.xml`',
+                                       optional: true,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :project_dir,
+                                       env_name: 'FL_GRADLE_PROJECT_DIR',
+                                       description: 'The root directory of the gradle project. Defaults to `.`',
+                                       default_value: '.',
+                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :gradle_path,
-                                       env_name: "FL_GRADLE_PATH",
-                                       description: "The path to your `gradlew`",
+                                       env_name: 'FL_GRADLE_PATH',
+                                       description: 'The path to your `gradlew`. If you specify a relative path, it is assumed to be relative to the `project_dir`',
+                                       optional: true,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :properties,
+                                       env_name: 'FL_GRADLE_PROPERTIES',
+                                       description: 'Gradle properties to be exposed to the gradle script',
+                                       optional: true,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :serial,
+                                       env_name: 'FL_ANDROID_SERIAL',
+                                       description: 'Android serial, wich device should be used for this command',
                                        is_string: true,
-                                       default_value: Dir["./gradlew"].last, # Using Dir to be nil when the file doesn't exist (import for validation)
-                                       verify_block: proc do |value|
-                                         raise "Couldn't find gradlew at path '#{File.expand_path(value)}'".red unless File.exist?(value)
-                                       end)
+                                       default_value: '')
         ]
       end
 
       def self.output
         [
-          ['GRADLE_APK_OUTPUT_PATH', 'The path to the newly generated apk file']
+          ['GRADLE_APK_OUTPUT_PATH', 'The path to the newly generated apk file. Undefined in a multi-variant assemble scenario'],
+          ['GRADLE_ALL_APK_OUTPUT_PATHS', 'When running a multi-variant `assemble`, the array of signed apk\'s that were generated'],
+          ['GRADLE_FLAVOR', 'The flavor, e.g. `MyFlavor`'],
+          ['GRADLE_BUILD_TYPE', 'The build type, e.g. `Release`']
         ]
       end
 
       def self.return_value
-        "The output of running the gradle task"
+        'The output of running the gradle task'
       end
 
       def self.authors
-        ["KrauseFx"]
+        ['KrauseFx', 'lmirosevic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/helper/gradle_helper.rb
+++ b/lib/fastlane/helper/gradle_helper.rb
@@ -23,10 +23,11 @@ module Fastlane
       end
 
       # Run a certain action
-      def trigger(task: nil, flags: nil, serial:nil)
+      def trigger(task: nil, flags: nil, serial: nil)
         # raise "Could not find gradle task '#{task}' in the list of available tasks".red unless task_available?(task)
-        android_serial = serial != "" ? "ANDROID_SERIAL=#{serial}" : nil
-        command = [android_serial, gradle_path, task, flags].join(" ")
+
+        android_serial = (serial != "") ? "ANDROID_SERIAL=#{serial}" : nil
+        command = [android_serial, gradle_path, task, flags].reject(&:nil?).join(" ")
         Action.sh(command)
       end
 

--- a/spec/actions_specs/gradle_spec.rb
+++ b/spec/actions_specs/gradle_spec.rb
@@ -2,11 +2,51 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "gradle" do
       it "generates a valid command" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          gradle(task: 'test', gradle_path: './fastlane/README.md')
-        end").runner.execute(:test)
+        result = Fastlane::FastFile.new.parse("lane :build do
+          gradle(task: 'assemble', flavor: 'WorldDomination', build_type: 'Release', properties: { 'versionCode' => 200}, gradle_path: './fastlane/README.md')
+        end").runner.execute(:build)
 
-        expect(result).to eq(" ./fastlane/README.md test ")
+        expect(result).to eq("#{File.expand_path('README.md')} assembleWorldDominationRelease -p . -PversionCode=200")
+      end
+
+      it "correctly uses the serial" do
+        result = Fastlane::FastFile.new.parse("lane :build do
+          gradle(task: 'assemble', flavor: 'WorldDomination', build_type: 'Release', properties: { 'versionCode' => 200}, serial: 'abc123', gradle_path: './fastlane/README.md')
+        end").runner.execute(:build)
+
+        expect(result).to eq("ANDROID_SERIAL=abc123 #{File.expand_path('README.md')} assembleWorldDominationRelease -p . -PversionCode=200")
+      end
+
+      it "supports multiple flavors" do
+        result = Fastlane::FastFile.new.parse("lane :build do
+          gradle(task: 'assemble', build_type: 'Release', gradle_path: './fastlane/README.md')
+        end").runner.execute(:build)
+
+        expect(result).to eq("#{File.expand_path('README.md')} assembleRelease -p .")
+      end
+
+      it "supports multiple build types" do
+        result = Fastlane::FastFile.new.parse("lane :build do
+          gradle(task: 'assemble', flavor: 'WorldDomination', gradle_path: './fastlane/README.md')
+        end").runner.execute(:build)
+
+        expect(result).to eq("#{File.expand_path('README.md')} assembleWorldDomination -p .")
+      end
+
+      it "supports multiple flavors and build types" do
+        result = Fastlane::FastFile.new.parse("lane :build do
+          gradle(task: 'assemble', gradle_path: './fastlane/README.md')
+        end").runner.execute(:build)
+
+        expect(result).to eq("#{File.expand_path('README.md')} assemble -p .")
+      end
+
+      it "supports the backwards compatible syntax" do
+        result = Fastlane::FastFile.new.parse("lane :build do
+          gradle(task: 'assembleWorldDominationRelease', gradle_path: './fastlane/README.md')
+        end").runner.execute(:build)
+
+        expect(result).to eq("#{File.expand_path('README.md')} assembleWorldDominationRelease -p .")
       end
     end
   end


### PR DESCRIPTION
Improves the `gradle` action in a few ways:
- Adds support for passing "gradle properties". To support use cases like [this](http://robertomurray.co.uk/blog/2013/gradle-android-inject-version-code-from-command-line-parameter/). Also provides an elegant solution for #878
- Adds support for having your Android project in a directory other than `.`. Fixes #749 
- Fixes issues around the apk file not being properly detected. Fixes #750. Renders #827 obsolete.
- Some small consistency improvements
- Completed class documentation for missing output values.
- Added GRADLE_BUILD_TYPE output value.
- Added documentation for `gradle` to `Actions.md`

The calling convention has changed a little. Previously one would use it like this:

``` ruby
gradle(
  task: 'assembleWorldDominationRelease'
)
```

New syntax (additionally with the new options):

``` ruby
gradle(
  task: 'assemble',
  flavor: 'WorldDomination',
  build_type: 'Release'
)
```

This was necessary in order to reliably resolve issues with the apk file detection. However, the new implementation is backwards compatible, so the previous convention will continue to work as previously, albeit without the apk detection (however that never worked anyways).

Advanced example:

``` ruby
gradle(
  # New way to define tasks
  task: 'assemble',
  flavor: 'WorldDomination',
  build_type: 'Release',

  # Custom directories
  project_dir: './some/folder',

  # Gradle properties
  properties: {
    'versionCode' => 200,
    'versionName' => 1.0.0
  }
)
```
