### PR TITLE
keep "@" for users in hipchat.rb

### DIFF
--- a/lib/fastlane/actions/hipchat.rb
+++ b/lib/fastlane/actions/hipchat.rb
@@ -43,7 +43,6 @@ module Fastlane
         else
           ########## running on V2 ##########
           if user?(channel)
-            channel.slice!(0)
             params = { 'message' => message, 'message_format' => message_format }
             json_headers = { 'Content-Type' => 'application/json',
                              'Accept' => 'application/json', 'Authorization' => "Bearer #{api_token}" }


### PR DESCRIPTION
For some reason i can't send a private message if "@" is removed because the api can't find the user. Maybe the api have changed?
