### PR TITLE
Support multiple ignore paths for slather action

### DIFF
--- a/lib/fastlane/actions/slather.rb
+++ b/lib/fastlane/actions/slather.rb
@@ -17,9 +17,9 @@ module Fastlane
         command = ""
         command += "bundle exec " if params[:use_bundle_exec]
         command += "slather coverage "
-        command += " --build-directory #{params[:build_directory]}" if params[:build_directory]
+        command += " --build-directory #{params[:build_directory].shellescape}" if params[:build_directory]
         command += " --input-format #{params[:input_format]}" if params[:input_format]
-        command += " --scheme #{params[:scheme]}" if params[:scheme]
+        command += " --scheme #{params[:scheme].shellescape}" if params[:scheme]
         command += " --buildkite" if params[:buildkite]
         command += " --jenkins" if params[:jenkins]
         command += " --travis" if params[:travis]
@@ -30,10 +30,14 @@ module Fastlane
         command += " --cobertura-xml" if params[:cobertura_xml]
         command += " --html" if params[:html]
         command += " --show" if params[:show]
-        command += " --source-directory #{params[:source_directory]}" if params[:source_directory]
-        command += " --output-directory #{params[:output_directory]}" if params[:output_directory]
-        command += " --ignore #{params[:ignore]}" if params[:ignore]
-        command += " #{params[:proj]}"
+        command += " --source-directory #{params[:source_directory].shellescape}" if params[:source_directory]
+        command += " --output-directory #{params[:output_directory].shellescape}" if params[:output_directory]
+        if params[:ignore].kind_of?(String)
+          command += " --ignore #{params[:ignore].shellescape}"
+        elsif params[:ignore].kind_of?(Array)
+          command += " #{params[:ignore].map { |path| "--ignore #{path.shellescape}" }.join(' ')}"
+        end
+        command += " #{params[:proj].shellescape}"
         sh command
       end
 
@@ -135,7 +139,8 @@ Slather is available at https://github.com/venmo/slather
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :ignore,
                                        env_name: "FL_SLATHER_IGNORE",
-                                       description: "Tell slather to ignore files matching a path",
+                                       description: "Tell slather to ignore files matching a path or any path from an array of paths",
+                                       is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :use_bundle_exec,
                                       env_name: "FL_SLATHER_USE_BUNDLE_EXEC",

--- a/spec/actions_specs/slather_spec.rb
+++ b/spec/actions_specs/slather_spec.rb
@@ -74,6 +74,33 @@ describe Fastlane do
           expect(result).to eq("slather coverage foo.xcodeproj")
         end
       end
+
+      it "works with spaces in paths" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          slather({
+            build_directory: 'build dir',
+            input_format: 'bah',
+            scheme: 'Foo App',
+            source_directory: 'source dir',
+            output_directory: 'output dir',
+            ignore: 'nothing to ignore',
+            proj: 'foo bar.xcodeproj'
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("slather coverage  --build-directory build\\ dir --input-format bah --scheme Foo\\ App --source-directory source\\ dir --output-directory output\\ dir --ignore nothing\\ to\\ ignore foo\\ bar.xcodeproj")
+      end
+
+      it "works with multiple ignore patterns" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          slather({
+            ignore: ['Pods/*', '../**/*/Xcode*'],
+            proj: 'foo.xcodeproj'
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("slather coverage  --ignore Pods/\\* --ignore ../\\*\\*/\\*/Xcode\\* foo.xcodeproj")
+      end
     end
   end
 end


### PR DESCRIPTION
With these changes it's possible to specify multiple ignore paths as an array as well as keep backwards compatibility and use just a string.

``` ruby
    slather(
        proj: "project",
        scheme: "scheme",
        input_format: "profdata",
        ignore: ["Pods/*", "../**/*/Xcode*"],
       # ignore: "Pods/*", # also works
        simple_output: true
    )
```

This change also adds quotes when composing shell command, so it's becomes `--ignore "../**/*/Xcode*"` instead of `--ignore ../**/*/Xcode*`, which causes some troubles.

What do you think @mattdelves ?
