### PR TITLE
Add the ability to only show merge commits

### DIFF
--- a/lib/fastlane/helper/git_helper.rb
+++ b/lib/fastlane/helper/git_helper.rb
@@ -1,9 +1,10 @@
 module Fastlane
   module Actions
-    def self.git_log_between(pretty_format, from, to, include_merges)
+    def self.git_log_between(pretty_format, from, to, include_merges, only_merges)
       command = 'git log'
       command << " --pretty=\"#{pretty_format}\" #{from.shellescape}...#{to.shellescape}"
       command << " --no-merges" unless include_merges
+      command << " --merges" if only_merges
       Actions.sh(command, log: false).chomp
     rescue
       nil

--- a/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -72,6 +72,30 @@ describe Fastlane do
 
         expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD --no-merges")
       end
+
+      it "Only include merge commits if merge_commit_filtering is only_include_merges" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          changelog_from_git_commits(merge_commit_filtering: 'only_include_merges')
+        end").runner.execute(:test)
+
+        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD --merges")
+      end
+
+      it "Include merge commits if merge_commit_filtering is include_merges" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          changelog_from_git_commits(merge_commit_filtering: 'include_merges')
+        end").runner.execute(:test)
+
+        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD")
+      end
+
+      it "Does not include merge commits if merge_commit_filtering is exclude_merges" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          changelog_from_git_commits(merge_commit_filtering: 'exclude_merges')
+        end").runner.execute(:test)
+
+        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD --no-merges")
+      end
     end
   end
 end


### PR DESCRIPTION
If you use a pull request workflow its useful to create a changelog with only merge commits.
