### PR TITLE
Updates pod_push action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1798,6 +1798,9 @@ pod_push(path: 'TSMessages.podspec')
 
 # You may also push to a private repo instead of Trunk
 pod_push(path: 'TSMessages.podspec', repo: 'MyRepo')
+
+# If the podspec has a dependency on another private pod, then you will have to supply the sources you want the podspec to lint with for pod_push to succeed. Read more here - https://github.com/CocoaPods/CocoaPods/issues/2543.
+pod_push(path: 'TMessages.podspec', repo: 'MyRepo', sources: ['https://github.com/MyGithubPage/Specs', 'https://github.com/CocoaPods/Specs'])
 ```
 
 ### clean_cocoapods_cache

--- a/lib/fastlane/actions/pod_push.rb
+++ b/lib/fastlane/actions/pod_push.rb
@@ -13,6 +13,11 @@ module Fastlane
           command << " '#{params[:path]}'"
         end
 
+        if params[:sources]
+          sources = params[:sources].join(",")
+          command << " --sources='#{sources}'"
+        end
+
         result = Actions.sh("#{command}")
         Helper.log.info "Successfully pushed Podspec ⬆️ ".green
         return result
@@ -41,7 +46,14 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :repo,
                                        description: "The repo you want to push. Pushes to Trunk by default",
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :sources,
+                                       description: "The sources of repos you want the pod spec to lint with, separated by commas",
+                                       optional: true,
+                                       is_string: false,
+                                       verify_block: proc do |value|
+                                         raise "Sources must be an array.".red unless value.kind_of?(Array)
+                                       end)
         ]
       end
 


### PR DESCRIPTION
Solves #1112 
- Added a parameter to the action called `sources`. `sources` is an
  array and holds string value of the repos that the pod will be linted
  with.
- For a podspec with dependency to a private pod, sources should be
  provided in the command. They should be comma seperated.
- For further read https://github.com/CocoaPods/CocoaPods/issues/2543.
