### PR TITLE
Ignore all files in the screenshots folder.

### DIFF
--- a/docs/Gitignore.md
+++ b/docs/Gitignore.md
@@ -10,8 +10,7 @@ fastlane/report.xml
 fastlane/Preview.html
 
 # snapshot generated screenshots
-fastlane/screenshots/**/*.png
-fastlane/screenshots/screenshots.html
+fastlane/screenshots
 
 # scan temporary files
 fastlane/test_output


### PR DESCRIPTION
Apple supports both PNG and JPEG files for screenshots. The current recommendation only ignores PNG files. All files in the screenshots folder should be ignored. This change matches the recommendation on [gitignore.io](https://www.gitignore.io/api/swift).
