### PR TITLE
Stop sorting xcodebuild params so that clean can come before build

### DIFF
--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -273,7 +273,7 @@ module Fastlane
             # Add more xcodebuild arguments
             "#{v}"
           end
-        end.compact.sort
+        end.compact
       end
 
       def self.detect_workspace


### PR DESCRIPTION
Fixes the user's problem from #1096, although in a somewhat hacky way. I'd love suggestions for a better way to solve/control this. @KrauseFx @samrobbins 
