### PR TITLE
[Needs more testing] Generate lane docs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ Usually you'll use fastlane by triggering individual lanes:
 - `fastlane action [action_name]`: Shows a more detailed description of an action
 - `fastlane lanes`: Lists all available lanes with description
 - `fastlane list`: Lists all available lanes without description
-- `fastlane docs`: Generates a markdown based documentation of all your lanes
 - `fastlane new_action`: Create a new action (integration) for fastlane  
 
 ## Examples

--- a/bin/fastlane
+++ b/bin/fastlane
@@ -90,15 +90,9 @@ class FastlaneApplication
       c.option '-f', '--force', 'Overwrite the existing README.md in the ./fastlane folder'
 
       c.action do |args, options|
-        path = File.join(Fastlane::FastlaneFolder.path || '.', 'README.md')
-        if File.exist? path and !options.force
-          return nil unless agree('Found existing ./fastlane/README.md. Do you want to overwrite it? (y/n)', true)
-        end
-
         ff = Fastlane::FastFile.new(File.join(Fastlane::FastlaneFolder.path || '.', 'Fastfile'))
-
-        require 'fastlane/documentation/docs_generator'
-        Fastlane::DocsGenerator.run(path, ff)
+        FastlaneCore::Helper.log.info "You don't need to run `fastlane docs` manually any more, this will be done automatically for you."
+        Fastlane::DocsGenerator.run(ff)
       end
     end
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'terminal-table', '~> 1.4.5' # Actions documentation
   spec.add_dependency 'plist', '~> 3.1.0' # Needed for set_build_number_repository and get_info_plist_value actions
   spec.add_dependency 'addressable', '~> 2.3.8' # Support for URI templates
-  spec.add_dependency 'xcode-install', '~> 1.0.1' # Download new Xcode versions
+  spec.add_dependency 'xcode-install', '~> 1.2.5' # Download new Xcode versions
 
   spec.add_dependency 'fastlane_core', '>= 0.33.0', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'credentials_manager', '>= 0.14.0', '< 1.0.0' # Password Manager

--- a/lib/fastlane.rb
+++ b/lib/fastlane.rb
@@ -14,6 +14,7 @@ require 'fastlane/action_collector'
 require 'fastlane/supported_platforms'
 require 'fastlane/configuration_helper'
 require 'fastlane/command_line_handler'
+require 'fastlane/documentation/docs_generator'
 
 require 'fastlane_core'
 

--- a/lib/fastlane/documentation/docs_generator.rb
+++ b/lib/fastlane/documentation/docs_generator.rb
@@ -1,6 +1,8 @@
 module Fastlane
   class DocsGenerator
-    def self.run(output_path, ff)
+    def self.run(ff, output_path: nil)
+      output_path ||= File.join(Fastlane::FastlaneFolder.path || '.', 'README.md')
+
       output = ["fastlane documentation"]
       output << "================"
 
@@ -30,12 +32,12 @@ module Fastlane
         output << ""
       end
 
-      output << "Generate this documentation by running `fastlane docs`"
+      output << "This README.md is auto-generated and will be re-generated every time to run [fastlane](https://fastlane.tools)"
       output << "More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools)."
       output << "The documentation of fastlane can be found on [GitHub](https://github.com/fastlane/fastlane)"
 
       File.write(output_path, output.join("\n"))
-      Helper.log.info "Successfully generated documentation to path '#{File.expand_path(output_path)}'".green
+      Helper.log.info "Successfully generated documentation to path '#{File.expand_path(output_path)}'".green if $verbose
     end
 
     #####################################################
@@ -46,6 +48,7 @@ module Fastlane
       pl = pl.to_s
       return "iOS" if pl == 'ios'
       return "Mac" if pl == 'mac'
+      return "Android" if pl == 'android'
 
       return pl
     end

--- a/lib/fastlane/lane_manager.rb
+++ b/lib/fastlane/lane_manager.rb
@@ -10,6 +10,7 @@ module Fastlane
       raise 'parameters must be a hash' unless parameters.kind_of?(Hash) or parameters.nil?
 
       ff = Fastlane::FastFile.new(File.join(Fastlane::FastlaneFolder.path, 'Fastfile'))
+      Fastlane::DocsGenerator.run(ff)
 
       is_platform = false
       begin

--- a/spec/docs_generator_spec.rb
+++ b/spec/docs_generator_spec.rb
@@ -5,7 +5,7 @@ describe Fastlane do
     it "generates new markdown docs" do
       output_path = "/tmp/documentation.md"
       ff = Fastlane::FastFile.new('./spec/fixtures/fastfiles/FastfileGrouped')
-      Fastlane::DocsGenerator.run(output_path, ff)
+      Fastlane::DocsGenerator.run(ff, output_path: output_path)
 
       output = File.read(output_path)
 


### PR DESCRIPTION
When running `fastlane` the `README.md` in the `fastlane` directory will now be created by default, we take :book: seriously
