### PR TITLE
Add reset_simulator action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -678,6 +678,16 @@ appium(
 )
 ```
 
+### reset_simulator
+Reset simulator by its UDID or name and optional OS version. You can also reset all simulators.
+Reset will force device to shutdown if booted, which is more reliable than `xcrun simctl erase <device>`.
+_Requires Xcode 7+._
+
+```ruby
+reset_simulator(device: "all")
+reset_simulator(device: "iPhone 6 Plus", os: "iOS 9.1")
+```
+
 ## Deploying
 
 ### [pilot](https://github.com/fastlane/pilot)

--- a/lib/fastlane/actions/reset_simulator.rb
+++ b/lib/fastlane/actions/reset_simulator.rb
@@ -1,0 +1,71 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      RESET_SIMULATOR_CUSTOM_VALUE = :RESET_SIMULATOR_CUSTOM_VALUE
+    end
+
+    class ResetSimulatorAction < Action
+      def self.run(params)
+        require 'json'
+
+        unless min_xcode7?
+          Helper.log.error "Xcode version 7 or higher is required!".red
+          return
+        end
+
+        json = JSON.parse(Actions.sh_no_action("xcrun simctl list --json devices", log: false))
+        json["devices"].each do |os, devices|
+          devices.each do |device|
+            next unless
+              params[:device] == "all" ||
+              params[:device] == device["udid"] ||
+              params[:device] == device["name"] && (params[:os].nil? || params[:os] == os)
+
+            Actions.sh("xcrun simctl shutdown #{device['udid']}") if device["state"] == "Booted"
+            Actions.sh("xcrun simctl erase #{device['udid']}")
+
+            # Unless resetting all simulators, it's time to stop
+            return unless params[:device] == "all" # rubocop:disable Lint/NonLocalExitFromIterator
+          end
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Reset (shutdown + erase) iOS simulator"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :device,
+                                       env_name: "FL_RESET_SIMULATOR_DEVICE",
+                                       description: "Simulator name, UDID or \"all\""),
+          FastlaneCore::ConfigItem.new(key: :os,
+                                       env_name: "FL_RESET_SIMULATOR_OS",
+                                       description: "Specify simulator OS, e.g. \"iOS 9.0\", \"watchOS 2.1\", etc",
+                                       optional: true)
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.authors
+        ["mgrebenets"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios].include?(platform)
+      end
+
+      def self.min_xcode7?
+        Helper.xcode_version.split(".").first.to_i >= 7
+      end
+      private_class_method :min_xcode7?
+
+    end
+  end
+end

--- a/spec/actions_specs/reset_simulator_spec.rb
+++ b/spec/actions_specs/reset_simulator_spec.rb
@@ -1,0 +1,11 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    it "raises an exception when no device name is specified" do
+      expect do
+        Fastlane::FastFile.new.parse("lane :test do
+          reset_simulator({})
+        end").runner.execute(:test)
+      end.to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This action is a wrapper around few `xcrun simctl` commands.
`xcrun simctl erase <device> | all` will fail if device is currently booted.
Additionally, if you have more than one Xcode app installed or more than one simulator runtime available, then running `xcrun simctl erase "iPad Retina"` will (for example) erase iPad Retina for iOS 8.4, while you actually want to reset iOS 9.1 device.

`reset_simulator` combines `shutdown` and `erase` actions and allows you to reset the same device you specify with `destination` option for xcodebuild, xctool, scan or other tool.
