### PR TITLE
* add adb and adb_devices action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1817,6 +1817,30 @@ setup_jenkins
 
 ## Misc
 
+### adb
+
+Lets you execute adb commands.
+
+```ruby
+adb(
+  command: "shell ls",
+)
+```
+
+### adb_devices
+
+Returns an array of all currently connected android devices.
+e.g.: run an adb command on all connected devices.
+
+```
+adb_devices.each  do | device |
+  model = adb(command: "shell getprop ro.product.model",
+              serial: device.serial
+             ).strip
+  puts "Model #{model} is connected"
+end
+```
+
 ### twitter
 
 Post a tweet on twitter. Requires you to setup an app on twitter.com and obtain consumer and access_token.

--- a/lib/fastlane/actions/adb.rb
+++ b/lib/fastlane/actions/adb.rb
@@ -1,0 +1,65 @@
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+    class AdbAction < Action
+      def self.run(params)
+        adb = Helper::AdbHelper.new(adb_path: params[:adb_path])
+        result = adb.trigger(command: params[:command], serial: params[:serial])
+        return result
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Run ADB Actions"
+      end
+
+      def self.details
+        [
+          "see adb --help for more details"
+        ].join("\n")
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :serial,
+                                       env_name: "FL_ANDROID_SERIAL",
+                                       description: "Android serial, which device should be used for this command",
+                                       is_string: true,
+                                       default_value: ""),
+          FastlaneCore::ConfigItem.new(key: :command,
+                                       env_name: "FL_ADB_COMMAND",
+                                       description: "All commands you want to pass to the adb command, e.g. `kill-server`",
+                                       optional: true,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :adb_path,
+                                       env_name: "FL_ADB_PATH",
+                                       optional: true,
+                                       description: "The path to your `adb` binary",
+                                       is_string: true,
+                                       default_value: "adb"
+                                      )
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+        "The output of the adb command"
+      end
+
+      def self.authors
+        ["hjanuschka"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/adb_devices.rb
+++ b/lib/fastlane/actions/adb_devices.rb
@@ -1,0 +1,55 @@
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+    class AdbDevicesAction < Action
+      def self.run(params)
+        adb = Helper::AdbHelper.new(adb_path: params[:adb_path])
+        result = adb.load_all_devices
+        return result
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Get an Array of Connected android device serials"
+      end
+
+      def self.details
+        [
+          "fetches device list via adb"
+        ].join("\n")
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :adb_path,
+                                       env_name: "FL_ADB_PATH",
+                                       description: "The path to your `adb` binary",
+                                       is_string: true,
+                                       optional: true,
+                                       default_value: "adb"
+                                      )
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+        "Array of devices"
+      end
+
+      def self.authors
+        ["hjanuschka"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/gradle.rb
+++ b/lib/fastlane/actions/gradle.rb
@@ -11,7 +11,7 @@ module Fastlane
 
         gradle = Helper::GradleHelper.new(gradle_path: params[:gradle_path])
 
-        result = gradle.trigger(task: task, flags: params[:flags])
+        result = gradle.trigger(task: task, flags: params[:flags], serial: params[:serial])
 
         return result unless task.start_with?("assemble")
 
@@ -51,6 +51,11 @@ module Fastlane
 
       def self.available_options
         [
+          FastlaneCore::ConfigItem.new(key: :serial,
+                                       env_name: "FL_ANDROID_SERIAL",
+                                       description: "Android serial, wich device should be used for this command",
+                                       is_string: true,
+                                       default_value: ""),
           FastlaneCore::ConfigItem.new(key: :task,
                                        env_name: "FL_GRADLE_TASK",
                                        description: "The gradle task you want to execute",

--- a/lib/fastlane/helper/adb_helper.rb
+++ b/lib/fastlane/helper/adb_helper.rb
@@ -1,0 +1,48 @@
+module Fastlane
+  module Helper
+    class AdbDevice
+      attr_accessor :serial
+
+      def initialize(serial: nil)
+        self.serial = serial
+      end
+    end
+
+    class AdbHelper
+      # Path to the adb binary
+      attr_accessor :adb_path
+
+      # All available devices
+      attr_accessor :devices
+
+      def initialize(adb_path: nil)
+        self.adb_path = adb_path
+      end
+
+      # Run a certain action
+      def trigger(command: nil, serial: nil)
+        android_serial = serial != "" ? "ANDROID_SERIAL=#{serial}" : nil
+        command = [android_serial, adb_path, command].join(" ")
+        Action.sh(command)
+      end
+
+      def device_avalaible?(serial)
+        load_all_devices
+        return devices.map(&:serial).include?(serial)
+      end
+
+      def load_all_devices
+        self.devices = []
+
+        command = [adb_path, "devices"].join(" ")
+        output = Actions.sh(command, log: false)
+        output.split("\n").each do |line|
+          if (result = line.match(/(.*)\tdevice$/))
+            self.devices << AdbDevice.new(serial: result[1])
+          end
+        end
+        self.devices
+      end
+    end
+  end
+end

--- a/lib/fastlane/helper/gradle_helper.rb
+++ b/lib/fastlane/helper/gradle_helper.rb
@@ -23,10 +23,10 @@ module Fastlane
       end
 
       # Run a certain action
-      def trigger(task: nil, flags: nil)
+      def trigger(task: nil, flags: nil, serial:nil)
         # raise "Could not find gradle task '#{task}' in the list of available tasks".red unless task_available?(task)
-
-        command = [gradle_path, task, flags].join(" ")
+        android_serial = serial != "" ? "ANDROID_SERIAL=#{serial}" : nil
+        command = [android_serial, gradle_path, task, flags].join(" ")
         Action.sh(command)
       end
 

--- a/spec/actions_specs/adb_devices_spec.rb
+++ b/spec/actions_specs/adb_devices_spec.rb
@@ -1,12 +1,12 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    describe "gradle" do
+    describe "adb_devices" do
       it "generates a valid command" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          gradle(task: 'test', gradle_path: './fastlane/README.md')
+          adb_devices(adb_path: './fastlane/README.md')
         end").runner.execute(:test)
 
-        expect(result).to eq(" ./fastlane/README.md test ")
+        expect(result).to match_array([])
       end
     end
   end

--- a/spec/actions_specs/adb_spec.rb
+++ b/spec/actions_specs/adb_spec.rb
@@ -1,12 +1,12 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    describe "gradle" do
+    describe "adb" do
       it "generates a valid command" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          gradle(task: 'test', gradle_path: './fastlane/README.md')
+          adb(command: 'test', adb_path: './fastlane/README.md')
         end").runner.execute(:test)
 
-        expect(result).to eq(" ./fastlane/README.md test ")
+        expect(result).to eq(" ./fastlane/README.md test")
       end
     end
   end


### PR DESCRIPTION
this adds the following actions
- `adb`
  - allows to run a any adb command, specified via `flags:`
- `adb_devices`
  - returns an array of connected android devices/emulators
- `gradle``
  - adds serial option parameter to specify wich device to run on

i needed the actions to port some of my android-CI scripts to fastlane :boom: 

for example to get the model name of all connected devices  - and run androidConnectedTest on all devices.

``` ruby
lane :android_demo do
        adb({adb_path: "/Users/hja/Library/Android/sdk/platform-tools/adb", flags: "kill-server"})
        adb({adb_path: "/Users/hja/Library/Android/sdk/platform-tools/adb", flags: "start-server"})
        devs = adb_devices({adb_path: "/Users/hja/Library/Android/sdk/platform-tools/adb"});

        devs.each do | device |
                model = adb({adb_path: "/Users/hja/Library/Android/sdk/platform-tools/adb", flags: "shell getprop ro.product.model", serial: device.serial})
                puts "Device - #{device.serial} - Model: #{model}"
                gradle({
                    task: "connectedDebugAndroidTest",
                    serial: device.serial
                })
        end
        gradle({task: "no-serial-task"});
end
```

i tried to stick to the coding conventions, but please be nice to me  - it is my first ruby expierence :o !!

truncated sample output:

``` bash
[21:10:29]: Successfully loaded custom action '/Users/hja/fastlane/fastlane/actions/rubocop.rb'.
[21:10:29]: Driving the lane 'android_demo' 🚀
[21:10:29]: -----------------
[21:10:29]: --- Step: adb ---
[21:10:29]: -----------------
[21:10:29]: [SHELL COMMAND]:  /Users/hja/Library/Android/sdk/platform-tools/adb kill-server
[21:10:29]: -----------------
[21:10:29]: --- Step: adb ---
[21:10:29]: -----------------
[21:10:29]: [SHELL COMMAND]:  /Users/hja/Library/Android/sdk/platform-tools/adb start-server
[21:10:32]: -------------------------
[21:10:32]: --- Step: adb_devices ---
[21:10:32]: -------------------------
[21:10:32]: -----------------
[21:10:32]: --- Step: adb ---
[21:10:32]: -----------------
[21:10:32]: [SHELL COMMAND]: ANDROID_SERIAL=emulator-5554 /Users/hja/Library/Android/sdk/platform-tools/adb shell getprop ro.product.model
[21:10:32]: [SHELL]: Android SDK built for x86
[21:10:32]: Device - emulator-5554 - Model: Android SDK built for x86
[21:10:32]: --------------------
[21:10:32]: --- Step: gradle ---
[21:10:32]: --------------------
[21:10:54]: -----------------
[21:10:54]: --- Step: adb ---
[21:10:54]: -----------------
[21:10:54]: [SHELL COMMAND]: ANDROID_SERIAL=SH35CW906378 /Users/hja/Library/Android/sdk/platform-tools/adb shell getprop ro.product.model
[21:10:54]: [SHELL]: One
[21:10:54]: Device - SH35CW906378 - Model: One
[21:10:54]: --------------------
[21:10:54]: --- Step: gradle ---
[21:10:54]: --------------------
[21:10:58]: [SHELL COMMAND]: ANDROID_SERIAL=SH35CW906378 /Users/hja/Desktop/android-project/gradlew tasks 
[21:11:01]: --------------------
[21:11:01]: --- Step: gradle ---
[21:11:01]: --------------------
[21:11:05]: [SHELL COMMAND]:  /Users/hja/Desktop/android-project/gradlew tasks 

+------+-----------------+-------------+
|           fastlane summary           |
+------+-----------------+-------------+
| Step | Action          | Time (in s) |
+------+-----------------+-------------+
| 1    | update_fastlane | 0           |
| 2    | adb             | 0           |
| 3    | adb             | 3           |
| 4    | adb_devices     | 0           |
| 5    | adb             | 0           |
| 6    | gradle          | 21          |
| 7    | adb             | 0           |
| 8    | gradle          | 6           |
| 9    | gradle          | 6           |
+------+-----------------+-------------+

[21:11:07]: fastlane.tools finished successfully 🎉
```
