### PR TITLE
Improve rubocop config for spec files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@
 
 inherit_from: .rubocop_general.yml
 
-# e.g. 
+# e.g.
 # def self.is_supported?(platform)
 # we may never use `platform`
 Lint/UnusedMethodArgument:
@@ -12,6 +12,11 @@ Lint/UnusedMethodArgument:
 
 # the let(:key) { ... }
 Lint/ParenthesesAsGroupedExpression:
+  Exclude:
+    - 'spec/**/*'
+
+# the let(:key) { ... }
+Style/RedundantParentheses:
   Exclude:
     - 'spec/**/*'
 

--- a/.rubocop_general.yml
+++ b/.rubocop_general.yml
@@ -45,6 +45,11 @@ Lint/ParenthesesAsGroupedExpression:
   Exclude:
     - 'spec/**/*'
 
+# the let(:key) { ... } should be allowed in tests
+Style/RedundantParentheses:
+  Exclude:
+    - 'spec/**/*'
+
 # options.rb might be large, we know that
 Metrics/MethodLength:
   Max: 60


### PR DESCRIPTION
Current rule is not the one actually checked by rubocop
Disable redundant parentheses warning

This impacts files in `spec` directory and reduces number of warnings by 38.

Before:

```
spec/setup_spec.rb:13:11: C: Style/RedundantParentheses: Don't use parentheses around a literal.
      let (:workspace) { File.expand_path("/tmp/setup_workspace/") }
          ^^^^^^^^^^^^

272 files inspected, 140 offenses detected
```

After:

```
272 files inspected, 102 offenses detected
```
