### PR TITLE
Add Style/IndentArray rule and format code

### DIFF
--- a/.rubocop_general.yml
+++ b/.rubocop_general.yml
@@ -11,6 +11,13 @@ Lint/UselessAssignment:
   Exclude:
     - 'spec/**/*'
 
+Style/IndentArray:
+  EnforcedStyle: consistent
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_brackets
+
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 Style/IndentHash:

--- a/spec/actions_specs/crashlytics_spec.rb
+++ b/spec/actions_specs/crashlytics_spec.rb
@@ -55,13 +55,14 @@ describe Fastlane do
               })
             end").runner.execute(:test)
 
-            expect(command).to eq([@crashlytics_bundle,
-                                   "wadus",
-                                   "secret",
-                                   "-ipaPath './fastlane/spec/fixtures/fastfiles/Fastfile1'",
-                                   "-notifications YES",
-                                   "-debug NO"
-                                  ])
+            expect(command).to eq([
+              @crashlytics_bundle,
+              "wadus",
+              "secret",
+              "-ipaPath './fastlane/spec/fixtures/fastfiles/Fastfile1'",
+              "-notifications YES",
+              "-debug NO"
+            ])
           end
 
           it "works automatically stores the notes in a file if given" do
@@ -220,7 +221,8 @@ describe Fastlane do
               "-notesPath './fastlane/spec/fixtures/fastfiles/Fastfile1'",
               "-groupAliases 'groups,123'",
               "-notifications NO",
-              "-debug NO"])
+              "-debug NO"
+            ])
           end
         end
 


### PR DESCRIPTION
Wit this new Cop I was able to get same results from auto formatting tools (like beautify plugin) and from Hound. Before adding this config, running beautify locally would produce results that hound would not like.
