### PR TITLE
Remove unused require 'pty'

### DIFF
--- a/lib/fastlane/actions/actions_helper.rb
+++ b/lib/fastlane/actions/actions_helper.rb
@@ -1,5 +1,3 @@
-require 'pty'
-
 module Fastlane
   module Actions
     module SharedValues


### PR DESCRIPTION
[This commit](https://github.com/fastlane/fastlane/commit/150d61693f7ebdc5f486306d69b18164d0b5517e) removes the use of `pty` but not the dependency. 
