### PR TITLE
Set more specific rubocop version

### DIFF
--- a/.rubocop_general.yml
+++ b/.rubocop_general.yml
@@ -11,13 +11,6 @@ Lint/UselessAssignment:
   Exclude:
     - 'spec/**/*'
 
-Style/IndentArray:
-  EnforcedStyle: consistent
-  SupportedStyles:
-    - special_inside_parentheses
-    - consistent
-    - align_brackets
-
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 Style/IndentHash:

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -57,6 +57,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard', '~> 0.8.7.4'
   spec.add_development_dependency 'webmock', '~> 1.19.0'
   spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency 'rubocop', '~> 0.29'
+  spec.add_development_dependency 'rubocop', '~> 0.35.1'
   spec.add_development_dependency 'appium_lib', '~> 4.1.0'
 end

--- a/lib/fastlane/actions/hipchat.rb
+++ b/lib/fastlane/actions/hipchat.rb
@@ -42,7 +42,7 @@ module Fastlane
           end
         else
           ########## running on V2 ##########
-          if user?(channel) # rubocop:disable Style/IfInsideElse
+          if user?(channel)
             params = { 'message' => message, 'message_format' => message_format }
             json_headers = { 'Content-Type' => 'application/json',
                              'Accept' => 'application/json', 'Authorization' => "Bearer #{api_token}" }


### PR DESCRIPTION
An alternative to https://github.com/fastlane/fastlane/pull/1136 and some other PRs.
Instead of fixing new warnings picked up by rubocop `0.36.0` fix it's version to `0.35.1`.

Though after this change rubocop won't recognize a couple of new settings:

```
Warning: unrecognized parameter Style/IndentArray:EnforcedStyle found in /Users/maksymgrebenets/Projects/oss/fastlane/.rubocop_general.yml
Warning: unrecognized parameter Style/IndentArray:EnforcedStyle found in /Users/maksymgrebenets/Projects/oss/fastlane/.rubocop.yml
```

Is it something that should disabled or should be kept for future move to `0.36.0`?
