### PR TITLE
Updated hipchat action to support custom colors

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1547,7 +1547,7 @@ mailgun(
 ```
 
 ### [HipChat](http://www.hipchat.com/)
-Send a message to **room** (by default) or a direct message to **@username** with success (green) or failure (red) status.
+Send a message to **room** (by default) or a direct message to **@username** with success (green) or failure (red) status. A custom color can also be set.
 
 ```ruby
   ENV["HIPCHAT_API_TOKEN"] = "Your API token"
@@ -1557,8 +1557,9 @@ Send a message to **room** (by default) or a direct message to **@username** wit
     message: "App successfully released!",
     message_format: "html", # or "text", defaults to "html"
     channel: "Room or @username",
-    from: "sender name", defaults to "fastlane"
-    success: true
+    from: "sender name", #defaults to "fastlane"
+    success: true,
+    custom_color: 'random' #overrides success param if set
   )
 ```
 

--- a/lib/fastlane/actions/hipchat.rb
+++ b/lib/fastlane/actions/hipchat.rb
@@ -15,7 +15,11 @@ module Fastlane
         message_format = options[:message_format]
 
         channel = options[:channel]
-        color = (options[:success] ? 'green' : 'red')
+        if ['yellow', 'red', 'green', 'purple', 'gray', 'random'].include?(options[:custom_color]) == true
+          color = options[:custom_color]
+        else
+          color = (options[:success] ? 'green' : 'red')
+        end
 
         from = options[:from]
 
@@ -106,6 +110,11 @@ module Fastlane
                                            raise 'No HIPCHAT_API_TOKEN given.'.red
                                          end
                                        end),
+          FastlaneCore::ConfigItem.new(key: :custom_color,
+                                       env_name: "FL_HIPCHAT_CUSTOM_COLOR",
+                                       description: "Specify a custom color, this overrides the success boolean. Can be one of 'yellow', 'red', 'green', 'purple', 'gray', or 'random'",
+                                       optional: true,
+                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :success,
                                        env_name: "FL_HIPCHAT_SUCCESS",
                                        description: "Was this build successful? (true/false)",


### PR DESCRIPTION
As discussed in #1158, have updated hipchat action to support custom colors.

Hope we can merge this in, would be great to not have to reimplement the hipchat action for each project.
