### PR TITLE
Added support for `:export_options_plist` as a hash for xcodebuild action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -355,6 +355,31 @@ xcodebuild(
 To keep your Fastfile lightweight, there are also alias actions available for
 the most common `xcodebuild` operations: `xcarchive`, `xcbuild`, `xcclean`, `xctest` & `xcexport`.
 
+To export the IPA files using `xcodebuild` you can provide `:export_options_plist` as a path to plist file or as a hash of values. To get the list of available keys and values please read help page: `xcodebuild --help`:
+
+```ruby
+xcexport(
+  archive_path: "...",
+  export_options_plist: "/path/to/export_options.plist"
+)
+
+# or
+xcexport(
+  archive_path: "...",
+  export_options_plist: {
+    method: "ad-hoc",
+    thinning: "<thin-for-all-variants>",
+    manifest: {
+      appURL: "https://example.com/path/MyApp Name.ipa",
+      displayImageURL: "https://example.com/display image.png",
+      fullSizeImageURL: "https://example.com/fullSize image.png",
+    }
+  }
+)
+```
+
+When using `:export_options_plist` as hash, the `:teamID` is read from `Appfile`. `:appURL`, `:displayImageURL`, `:fullSizeImageURL`, `:assetPackManifestURL` and `:onDemandResourcesAssetPacksBaseURL` are URI escaped to prevent Xcode errors.
+
 Environment variables may be added to a .env file in place of some parameters:
 
 ```

--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -132,6 +132,7 @@ module Fastlane
           end
 
           # Maps parameter hash to CLI args
+          params = export_options_to_plist(params)
           if hash_args = hash_to_args(params)
             xcodebuild_args += hash_args
           end
@@ -264,6 +265,27 @@ module Fastlane
         end
 
         output_result
+      end
+
+      def self.export_options_to_plist(hash)
+        # Extract export options parameters from input options
+        if hash.has_key?(:export_options_plist) && hash[:export_options_plist].is_a?(Hash)
+          export_options = hash[:export_options_plist]
+
+          # Normalize some values
+          export_options[:teamID] = CredentialsManager::AppfileConfig.try_fetch_value(:team_id) if !export_options[:teamID] && CredentialsManager::AppfileConfig.try_fetch_value(:team_id)
+          export_options[:onDemandResourcesAssetPacksBaseURL] = URI.escape(export_options[:onDemandResourcesAssetPacksBaseURL]) if export_options[:onDemandResourcesAssetPacksBaseURL]
+          export_options[:manifest][:appURL] = URI.escape(export_options[:manifest][:appURL]) if export_options[:manifest][:appURL]
+          export_options[:manifest][:displayImageURL] = URI.escape(export_options[:manifest][:displayImageURL]) if export_options[:manifest][:displayImageURL]
+          export_options[:manifest][:fullSizeImageURL] = URI.escape(export_options[:manifest][:fullSizeImageURL]) if export_options[:manifest][:fullSizeImageURL]
+          export_options[:manifest][:assetPackManifestURL] = URI.escape(export_options[:manifest][:assetPackManifestURL]) if export_options[:manifest][:assetPackManifestURL]
+
+          # Saves options to plist
+          path = "#{Tempfile.new('exportOptions').path}.plist"
+          File.write(path, export_options.to_plist)
+          hash[:export_options_plist] = path
+        end
+        hash
       end
 
       def self.hash_to_args(hash)

--- a/spec/actions_specs/xcodebuild_spec.rb
+++ b/spec/actions_specs/xcodebuild_spec.rb
@@ -108,6 +108,37 @@ describe Fastlane do
         expect(result).to include('PROVISIONING_PROFILE="JoshIsCoolProfile"')
       end
 
+      it "works with export_options_plist as hash" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+        xcodebuild(
+          archive_path: './build-dir/MyApp.xcarchive',
+          export_archive: true,
+          export_options_plist: {
+            method: \"ad-hoc\",
+            thinning: \"<thin-for-all-variants>\",
+            teamID: \"1234567890\",
+            manifest: {
+              appURL: \"https://example.com/path/MyApp Name.ipa\",
+              displayImageURL: \"https://example.com/display image.png\",
+              fullSizeImageURL: \"https://example.com/fullSize image.png\",
+            },
+          }
+        )
+      end").runner.execute(:test)
+
+        expect(result).to start_with(
+          "set -o pipefail && " \
+          + "xcodebuild " \
+          + "-archivePath \"./build-dir/MyApp.xcarchive\" " \
+          + "-exportArchive " \
+        )
+        expect(result).to match(/-exportOptionsPlist \".*\.plist\"/)
+        expect(result).to end_with(
+          "-exportPath \"./build-dir/MyApp\" " \
+          + "| tee '#{build_log_path}' | xcpretty --color --simple"
+        )
+      end
+
       it "when archiving, should cache the archive path for a later export step" do
         Fastlane::FastFile.new.parse("lane :test do
         xcodebuild(


### PR DESCRIPTION
Added support for specifying `:export_options_plist` as a hash for `xcodebuild` action. Current behaviour, where `:export_options_plist` defines path to the plist file still works. Now users will have choice. They can creates multiple plist files, or defines export options directly in the Fastfile.
