### PR TITLE
Fixed small typo in custom action template

### DIFF
--- a/lib/assets/custom_action_template.rb
+++ b/lib/assets/custom_action_template.rb
@@ -30,7 +30,7 @@ module Fastlane
 
       def self.details
         # Optional:
-        # this is your change to provide a more detailed description of this action
+        # this is your chance to provide a more detailed description of this action
         "You can use this action to do cool things..."
       end
 


### PR DESCRIPTION
I ran `fastlane new_action`and spotted a typo in the generated file so I fixed the typo in the template file.
