### PR TITLE
* add scp command

### DIFF
--- a/lib/fastlane/actions/scp.rb
+++ b/lib/fastlane/actions/scp.rb
@@ -1,0 +1,103 @@
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+    class ScpAction < Action
+
+      def self.run(params)
+        Actions.verify_gem!('net-scp')
+        require "net/scp"
+        ret = nil
+        Net::SCP.start(params[:host], params[:username], {port: params[:port].to_i, password: params[:password]}) do |scp|
+          if params[:upload]
+            scp.upload! params[:upload][:src], params[:upload][:dst], recursive: true
+            Helper.log.info ['[SCP COMMAND]', "Successfully Uploaded", params[:upload][:src], params[:upload][:dst]].join(': ')
+          end
+          if params[:download]
+
+            t_ret = scp.download! params[:download][:src], params[:download][:dst], recursive: true
+            Helper.log.info ['[SCP COMMAND]', "Successfully Downloaded", params[:upload][:src], params[:upload][:dst]].join(': ')
+            unless params[:download][:dst]
+              ret = t_ret
+            end
+          end
+        end
+        ret
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Transfer files via SCP"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :username,
+                                       short_option: "-u",
+                                       env_name: "FL_SSH_USERNAME",
+                                       description: "Username",
+                                       is_string: true
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :password,
+                                       short_option: "-p",
+                                       env_name: "FL_SSH_PASSWORD",
+                                       description: "Password",
+                                       optional: true,
+                                       is_string: true
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :host,
+                                       short_option: "-H",
+                                       env_name: "FL_SSH_HOST",
+                                       description: "Hostname",
+                                       is_string: true
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :port,
+                                       short_option: "-P",
+                                       env_name: "FL_SSH_PORT",
+                                       description: "Port",
+                                       optional: true,
+                                       default_value: "22",
+                                       is_string: true
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :upload,
+                                       short_option: "-U",
+                                       env_name: "FL_SCP_UPLOAD",
+                                       description: "Upload",
+                                       optional: true,
+                                       is_string: false,
+                                       type: Hash
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :download,
+                                       short_option: "-D",
+                                       env_name: "FL_SCP_DOWNLOAD",
+                                       description: "Download",
+                                       optional: true,
+                                       is_string: false,
+                                       type: Hash
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :log,
+                                       short_option: "-l",
+                                       env_name: "FL_SSH_LOG",
+                                       description: "Log Commands",
+                                       optional: true,
+                                       default_value: true,
+                                       is_string: false
+                                      )
+
+        ]
+      end
+
+      def self.authors
+        ["hjanuschka"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
adds an action to scp files from and to remote-hosts

use-case: i am trying to port some of my deployment scripts, and there i needed to fetch & pull files from remote.

samples:
## Uploads-String to a file

``` ruby
scp(
        host: "dev.januschka.com",
        username: "root",
        upload: {
            :src => StringIO.new("SRC"),
            :dst => "/tmp/1.txt"
        }
    )
```
## upload a file

``` ruby
scp(
        host: "dev.januschka.com",
        username: "root",
        upload: {
            :src => "/tmp/1.txt",
            :dst => "/tmp/1.txt"
        }
    )   
```
## download a file

``` ruby
scp(
        host: "dev.januschka.com",
        username: "root",
        download: {
            :src => "/tmp/1.txt",
            :dst => "/tmp/2.txt"
        }
    )   
```
## download a file but not to disk just to a var

``` ruby
file_out = scp(
        host: "dev.januschka.com",
        username: "root",
        download: {
            :src => "/tmp/1.txt"            
        }
    )   
puts "#{file_out.inspect}"  
```
## download a folder

``` ruby
scp(
        host: "dev.januschka.com",
        username: "root",
        download: {
          :src => "/root/dir1",
            :dst => "/tmp/new_dir"      
        }
)
```
## upload a folder

``` ruby
scp(
        host: "dev.januschka.com",
        username: "root",
        upload: {
          :src => "/root/dir1",
            :dst => "/tmp/new_dir"      
        }
)
```
