### PR TITLE
*add rsync action

### DIFF
--- a/lib/fastlane/actions/rsync.rb
+++ b/lib/fastlane/actions/rsync.rb
@@ -1,0 +1,65 @@
+
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+    class RsyncAction < Action
+
+      def self.run(params)
+        rsync_cmd = ["rsync"]
+        rsync_cmd << params[:extra]
+        rsync_cmd << params[:source]
+        rsync_cmd << params[:destination]
+        Actions.sh(rsync_cmd.join(" "))
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Rsync files from :source to :destination"
+      end
+
+      def self.details
+        "A wrapper around rsync, rsync is a tool that lets you synchronize files, including permissions and so on for a more detailed information about rsync please see rsync(1) manpage."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :extra,
+                                       short_option: "-X",
+                                       env_name: "FL_RSYNC_EXTRA", # The name of the environment variable
+                                       description: "Port", # a short description of this parameter
+                                       optional: true,
+                                       default_value: "-av",
+                                       is_string: true
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :source,
+                                       short_option: "-S",
+                                       env_name: "FL_RSYNC_SRC", # The name of the environment variable
+                                       description: "source file/folder", # a short description of this parameter
+                                       optional: false,
+                                       is_string: true
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :destination,
+                                       short_option: "-D",
+                                       env_name: "FL_RSYNC_DST", # The name of the environment variable
+                                       description: "destination file/folder", # a short description of this parameter
+                                       optional: false,
+                                       is_string: true
+                                      )
+        ]
+      end
+
+      def self.authors
+        ["hjanuschka"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/spec/actions_specs/rsync_spec.rb
+++ b/spec/actions_specs/rsync_spec.rb
@@ -1,0 +1,12 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "rsync" do
+      it "generates a valid command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          rsync(source: '/tmp/1.txt', destination: '/tmp/2.txt')
+        end").runner.execute(:test)
+        expect(result).to eq("rsync -av /tmp/1.txt /tmp/2.txt")
+      end
+    end
+  end
+end


### PR DESCRIPTION
a little wrapper around rsync  - to not have to use `sh`

``` ruby
rsync(
          source: "root@dev.januschka.com:/tmp/1.txt",
          destination: "/tmp/new_f"
    )
```
