### PR TITLE
* add erb action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1746,6 +1746,33 @@ It can process unit test results if formatted as junit report as shown in [xctes
 
 ## Misc
 
+### erb
+
+Parses a given ERB template file (passes `placeholders` as a binding), and saves the rendered output to destination.
+if no destination is given, it returns the rendered output as a string.
+
+  * sample erb template:
+
+```ruby
+Variable1 <%= var1 %>
+Variable2 <%= var2 %>
+<% for item in var3 %>
+        <%= item %>
+<% end %>
+```
+
+ ```ruby
+erb(
+  template: "1.erb",
+  destination: "/tmp/rendered.out",
+  placeholders: {
+    :var1 => 123,
+    :var2 => "string",
+    :var3 => ["element1", "element2"]
+  }
+)
+```
+
 ### appledoc
 
 Generate Apple-like source code documentation from specially formatted source code comments.

--- a/lib/fastlane/actions/erb.rb
+++ b/lib/fastlane/actions/erb.rb
@@ -1,0 +1,64 @@
+module Fastlane
+  module Actions
+    class ErbAction < Action
+      def self.run(params)
+        template = File.read(params[:template])
+        result =   ERB.new(template).result(OpenStruct.new(params[:placeholders]).instance_eval { binding })
+        File.open(params[:destination], 'w') { |file| file.write(result) } if params[:destination]
+        Helper.log.info "Successfully parsed template: '#{params[:template]}' and rendered output to: #{params[:destination]}" if params[:destination]
+        result
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Allows to Generate output files based on ERB templates"
+      end
+
+      def self.details
+        "Renders an ERB template with `placeholders` given as a hash via parameter, if no :destination is set, returns rendered template as string"
+      end
+
+      def self.available_options
+        [
+
+          FastlaneCore::ConfigItem.new(key: :template,
+                                       short_option: "-T",
+                                       env_name: "FL_ERB_SRC",
+                                       description: "ERB Template File",
+                                       optional: false,
+                                       is_string: true
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :destination,
+                                       short_option: "-D",
+                                       env_name: "FL_ERB_DST",
+                                       description: "destination file",
+                                       optional: true,
+                                       is_string: true
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :placeholders,
+                                       short_option: "-p",
+                                       env_name: "FL_ERB_LOG",
+                                       description: "Log Commands",
+                                       optional: true,
+                                       default_value: true,
+                                       is_string: false,
+                                       type: Hash
+                                      )
+
+        ]
+      end
+
+      def self.authors
+        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+        ["hjanuschka"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
adds an action `erb` - lets you do templating - i needed this for automated configuration-file generation.

file: 1.erb

```
O <%= var1 %> O
O <%= var2 %> O
<% for item in var3 %>
        <%= item %>
<% end %>
```

``` ruby
    erb(
          template: "1.erb",
          destination: "/tmp/rendered.out",
          placeholders: {
              :var1 => 1,
              :var2 => "123123",
              :var3 => ["asdf", "asdf"]
          }
      )
```

result:

```

O 1 O
O 123123 O
        asdf
        asdf
```
