### PR TITLE
Verifies that all available options of an action are actually used

### DIFF
--- a/lib/fastlane/actions/appaloosa.rb
+++ b/lib/fastlane/actions/appaloosa.rb
@@ -241,13 +241,7 @@ module Fastlane
                                        env_name: 'FL_APPALOOSA_DEVICE',
                                        description: 'Select the device format for yours screenshots',
                                        optional: true
-                                      ),
-          FastlaneCore::ConfigItem.new(key: :development,
-                                       env_name: 'FL_APPALOOSA_DEVELOPMENT',
-                                       description: 'Create a development certificate instead of a distribution one',
-                                       is_string: false,
-                                       default_value: false,
-                                       optional: true)
+                                      )
         ]
       end
 

--- a/spec/unused_options_spec.rb
+++ b/spec/unused_options_spec.rb
@@ -1,0 +1,22 @@
+describe Fastlane do
+  describe Fastlane::Action do
+    describe "No unused options" do
+      let (:al_exceptions) { %w(pilot appstore cert deliver gym match pem produce scan sigh snapshot supply testflight mailgun testfairy ipa import_from_git hockey deploygate crashlytics artifactory appledoc) }
+
+      Fastlane::ActionsList.all_actions do |action, name|
+        next unless action.available_options.kind_of?(Array)
+        next unless action.available_options.last.kind_of?(FastlaneCore::ConfigItem)
+
+        it "No unsed parameters in '#{name}'" do
+          next if al_exceptions.include?(name)
+          content = File.read(File.join("lib", "fastlane", "actions", name + ".rb"))
+          action.available_options.each do |option|
+            unless content.include?("[:#{option.key}]")
+              raise "Action '#{name}' doesn't use the option :#{option.key}"
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The tests will fail if an action defines an option that isn't used. There is a list of tools that are not verified (especially our own gems, since it's being handled somewhere else)
