### PR TITLE
* latest_testflight_build_number crash

### DIFF
--- a/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -30,7 +30,12 @@ module Fastlane
         Helper.log.info "Fetching the latest build number for version #{version_number}"
 
         train = app.build_trains[version_number]
-        build_number = train.builds.map(&:build_version).map(&:to_i).sort.last
+        begin
+          build_number = train.builds.map(&:build_version).map(&:to_i).sort.last
+        rescue
+          raise "could not find a build on iTC - and 'initial_build_number' option is not set" unless params[:initial_build_number]
+          build_number = params[:initial_build_number]
+        end
 
         Helper.log.info "Latest upload is build number: #{build_number}"
         Actions.lane_context[SharedValues::LATEST_TESTFLIGHT_BUILD_NUMBER] = build_number
@@ -66,7 +71,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: "LATEST_VERSION",
                                        description: "The version number whose latest build number we want",
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :initial_build_number,
+                                       env_name: "INTITIAL_BUILD_NUMBER",
+                                       description: "sets the build number to given value if no build is in current train",
+                                       optional: true,
+                                       is_string: false)
+
         ]
       end
 


### PR DESCRIPTION
we are using `increment_build_number` in combination with `latest_testflight_build_number`
Crashes if there is a new version train with no build.
fixes: sets latest_build to :initial_build_number if set

crash log:

```
[10:16:49]: Fetching the latest build number for version 2.4
[10:16:50]: Variable Dump:
[10:16:50]: {:PLATFORM_NAME=>nil, :LANE_NAME=>"dd"}
[10:16:50]: undefined method `builds' for nil:NilClass

```

workaround without this PR:

``` ruby
begin
    last_tf = latest_testflight_build_number
  rescue
    puts "No Active Build using build nr. 0"
    last_tf = 0
  end
  increment_build_number(build_number: last_tf + 1)
```

@KrauseFx 
