### PR TITLE
Fix for fastlane init crashing for account with no ITC access

### DIFF
--- a/lib/fastlane/setup/setup_ios.rb
+++ b/lib/fastlane/setup/setup_ios.rb
@@ -131,8 +131,12 @@ module Fastlane
       self.portal_ref = Spaceship::App.find(self.app_identifier)
 
       Spaceship::Tunes.login(@apple_id, nil)
-      self.itc_team = Spaceship::Tunes.select_team
-      self.itc_ref = Spaceship::Application.find(self.app_identifier)
+      begin
+        self.itc_team = Spaceship::Tunes.select_team
+        self.itc_ref = Spaceship::Application.find(self.app_identifier)
+      rescue Spaceship::Client::UnexpectedResponse
+        UI.message "Unable to access iTunes Connect"
+      end
     end
 
     def create_app_if_necessary


### PR DESCRIPTION
This error was occurring because my apple id did not have access to iTunes Connect. While logging in succeeded, trying to get teams or applications return a 401 status causing fastlane init to fail.
