### PR TITLE
* allow_warnings during pod push

### DIFF
--- a/lib/fastlane/actions/pod_push.rb
+++ b/lib/fastlane/actions/pod_push.rb
@@ -17,6 +17,9 @@ module Fastlane
           sources = params[:sources].join(",")
           command << " --sources='#{sources}'"
         end
+        if params[:allow_warnings]
+          command << " --allow-warnings"
+        end
 
         result = Actions.sh("#{command}")
         Helper.log.info "Successfully pushed Podspec ⬆️ ".green
@@ -47,6 +50,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :repo,
                                        description: "The repo you want to push. Pushes to Trunk by default",
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :allow_warnings,
+                                       description: "Allow warnings during pod push",
+                                       optional: true,
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :sources,
                                        description: "The sources of repos you want the pod spec to lint with, separated by commas",
                                        optional: true,


### PR DESCRIPTION
adds option to allow warnings during pod push.

for example when using ssh repo's (internal) pod push complains about 

```
- WARN  | source: Git SSH URLs will NOT work for people behind firewalls configured to only allow HTTP, therefore HTTPS is preferred.
```
