### PR TITLE
Add Fastlane cocoapods action 'version' parameter to specify a specific cocoapods version

### DIFF
--- a/lib/fastlane/actions/cocoapods.rb
+++ b/lib/fastlane/actions/cocoapods.rb
@@ -15,7 +15,11 @@ module Fastlane
         end
 
         cmd << ['bundle exec'] if File.exist?('Gemfile') && params[:use_bundle_exec]
-        cmd << ['pod install']
+        cmd << ['pod']
+
+        cmd << '_' + params[:version] + '_' if params[:version]
+
+        cmd << ['install']
 
         cmd << '--no-clean' unless params[:clean]
         cmd << '--no-integrate' unless params[:integrate]
@@ -75,6 +79,14 @@ module Fastlane
                                        is_string: true,
                                        verify_block: proc do |value|
                                          raise "Could not find Podfile".red unless File.exist?(value) || Helper.test?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       env_name: "FL_COCOAPODS_VERSION",
+                                       description: "Explicitly specify the Cocoapods version to run (must be installed)",
+                                       optional: true,
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                         raise "Invalid cocoapods version".red unless value.split(".").count == 3
                                        end)
         ]
       end


### PR DESCRIPTION
Cocoapods provides the ability to specify a version by adding it before the command and surrounded by _ (underscore) characters, for example:

`pod _0.38.2_ install`

This is useful for legacy code bases which may not have been updated to support newer versions of Cocoapods. For example, Cocoapods v0.39.0 implemented some changes to the way header files must be imported.
