### PR TITLE
Small README generator fix for footer

### DIFF
--- a/lib/fastlane/documentation/docs_generator.rb
+++ b/lib/fastlane/documentation/docs_generator.rb
@@ -32,9 +32,9 @@ module Fastlane
         output << ""
       end
 
-      output << "This README.md is auto-generated and will be re-generated every time to run [fastlane](https://fastlane.tools)"
-      output << "More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools)."
-      output << "The documentation of fastlane can be found on [GitHub](https://github.com/fastlane/fastlane)"
+      output << "This README.md is auto-generated and will be re-generated every time to run [fastlane](https://fastlane.tools).  "
+      output << "More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools).  "
+      output << "The documentation of fastlane can be found on [GitHub](https://github.com/fastlane/fastlane)."
 
       File.write(output_path, output.join("\n"))
       UI.success "Successfully generated documentation to path '#{File.expand_path(output_path)}'" if $verbose


### PR DESCRIPTION
The footer appeared as a single line without full stops separating the sentences on some less flavoured Markdown generators (like Bitbucket's repository browser).
So I fixed by adding a couple of missing `.` and also added double spaces to the end of the lines so that line breaks are inserted.

![](https://dl.dropboxusercontent.com/s/m5p927s27gcmngr/Screen%20Shot%202016-01-29%20at%2014.17.14.png?dl=0)
