### PR TITLE
Crash shell commands without message when `log=false`

### DIFF
--- a/lib/fastlane/helper/sh_helper.rb
+++ b/lib/fastlane/helper/sh_helper.rb
@@ -35,8 +35,12 @@ module Fastlane
 
         if exit_status != 0
           # this will also append the output to the exception
-          message = "Exit status of command '#{command}' was #{exit_status} instead of 0."
-          message += "\n#{result}" if log
+          if log
+            message = "Exit status of command '#{command}' was #{exit_status} instead of 0."
+            message += "\n#{result}"
+          else
+            message = "Shell command exited with exit status #{exit_status} instead of 0."
+          end
           UI.crash!(message)
         end
       end

--- a/spec/unused_options_spec.rb
+++ b/spec/unused_options_spec.rb
@@ -1,14 +1,14 @@
 describe Fastlane do
   describe Fastlane::Action do
     describe "No unused options" do
-      let (:al_exceptions) { %w(pilot appstore cert deliver gym match pem produce scan sigh snapshot supply testflight mailgun testfairy ipa import_from_git hockey deploygate crashlytics artifactory appledoc) }
+      let (:all_exceptions) { %w(pilot appstore cert deliver gym match pem produce scan sigh snapshot supply testflight mailgun testfairy ipa import_from_git hockey deploygate crashlytics artifactory appledoc) }
 
       Fastlane::ActionsList.all_actions do |action, name|
         next unless action.available_options.kind_of?(Array)
         next unless action.available_options.last.kind_of?(FastlaneCore::ConfigItem)
 
-        it "No unsed parameters in '#{name}'" do
-          next if al_exceptions.include?(name)
+        it "No unused parameters in '#{name}'" do
+          next if all_exceptions.include?(name)
           content = File.read(File.join("lib", "fastlane", "actions", name + ".rb"))
           action.available_options.each do |option|
             unless content.include?("[:#{option.key}]")


### PR DESCRIPTION
This change prevents logging of passwords passed in shell commands ~~to CI~~.

Passwords and filenames passed to shell commands had previously been appearing unredacted in our ~~CI~~ logs when the shell commands failed, eg.

``` sh
Exit status of command 'security import <certificate_name> -k <keychain_path> -P <password> -T /usr/bin/security' was 1 instead of 0.
```

Devs: @emmaviolet, @ecaselles
