### PR TITLE
Added `setup_jenkins` action.

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1807,6 +1807,14 @@ sonar(
 ```
 It can process unit test results if formatted as junit report as shown in [xctest](#xctest) action. It can also integrate coverage reports in Cobertura format, which can be transformed into by [slather](#slather) action.
 
+### setup_jenkins
+
+This action helps with Jenkins integration. Creates own derived data for each job. All build results like IPA files and archives will be stored in the `./output` directory. The action also works with [Keychains and Provisioning Profiles Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Keychains+and+Provisioning+Profiles+Plugin), selected keychain will be automatically unlocked and the selected code signing identity will be used. By default this action will work only if the Fastlane was executed on a CI system.
+
+```ruby
+setup_jenkins
+```
+
 ## Misc
 
 ### twitter

--- a/docs/Jenkins.md
+++ b/docs/Jenkins.md
@@ -32,6 +32,7 @@ I recommend the following plugins:
 - **[HTML Publisher Plugin](https://wiki.jenkins-ci.org/display/JENKINS/HTML+Publisher+Plugin):** Can be used to show the generated screenshots right inside Jenkins.
 - **[AnsiColor Plugin](https://wiki.jenkins-ci.org/display/JENKINS/AnsiColor+Plugin):** Used to show the coloured output of the fastlane tools. Don’t forget to enable `Color ANSI Console Output` in the `Build Environment` or your project.
 - **[Rebuild Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Rebuild+Plugin):** This plugin will save you a lot of time.
+- **[Keychains and Provisioning Profiles Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Keychains+and+Provisioning+Profiles+Plugin):** Manages keychains across Jenkins instalatins.
 
 ## Build Step
 
@@ -42,6 +43,12 @@ fastlane appstore
 ```
 
 Replace `appstore` with the lane you want to use.
+
+### setup_jenkins
+
+You can use `setup_jenkins` action which integrates well with the [Keychains and Provisioning Profiles Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Keychains+and+Provisioning+Profiles+Plugin). Selected keychain will automatically unlocked and the selected code signing identity will be used. Also all build results, like IPA files, archives, dSYMs and result bundles will be stored in the `./output` folder in the job workspace. In additions `setup_jenkins` will create separate derived data folder for each job (in the `./derivedData`).
+
+Under the hood `setup_jenkins` configures other actions like: `gym`, `scan`, `xcodebuild`, `backup_xcarchive` and `clear_derived_data`.
 
 ## Test Results and Screenshots
 

--- a/lib/fastlane/actions/setup_jenkins.rb
+++ b/lib/fastlane/actions/setup_jenkins.rb
@@ -1,0 +1,172 @@
+module Fastlane
+  module Actions
+    class SetupJenkinsAction < Action
+      USED_ENV_NAMES = [
+        "BACKUP_XCARCHIVE_DESTINATION",
+        "DERIVED_DATA_PATH",
+        "GYM_BUILD_PATH",
+        "GYM_CODE_SIGNING_IDENTITY",
+        "GYM_DERIVED_DATA_PATH",
+        "GYM_OUTPUT_DIRECTORY",
+        "GYM_RESULT_BUNDLE",
+        "SCAN_DERIVED_DATA_PATH",
+        "SCAN_OUTPUT_DIRECTORY",
+        "SCAN_RESULT_BUNDLE",
+        "XCODE_DERIVED_DATA_PATH"
+      ].freeze
+
+      def self.run(params)
+        # Stop if not executed by CI
+        if !Helper.is_ci? && !params[:force]
+          UI.important "Not executed by Continuous Integration system."
+          return
+        end
+
+        # Print table
+        FastlaneCore::PrintTable.print_values(
+          config: params,
+          title: "Summary for Setup Jenkins Action"
+        )
+
+        # Keychain
+        if params[:unlock_keychain] && params[:keychain_path]
+          keychain_path = File.expand_path(params[:keychain_path])
+          UI.message "Unlocking keychain: \"#{keychain_path}\"."
+          Actions::UnlockKeychainAction.run(
+            path: keychain_path,
+            password: params[:keychain_password],
+            add_to_search_list: params[:add_keychain_to_search_list],
+            set_default: params[:set_default_keychain]
+          )
+        end
+
+        # Code signing identity
+        if params[:set_code_signing_identity] && params[:code_signing_identity]
+          code_signing_identity = params[:code_signing_identity]
+          UI.message "Set code signing identity: \"#{code_signing_identity}\"."
+          ENV['GYM_CODE_SIGNING_IDENTITY'] = code_signing_identity
+        end
+
+        # Set output directory
+        if params[:output_directory]
+          output_directory_path = File.expand_path(params[:output_directory])
+          UI.message "Set output directory path to: \"#{output_directory_path}\"."
+          ENV['GYM_BUILD_PATH'] = output_directory_path
+          ENV['GYM_OUTPUT_DIRECTORY'] = output_directory_path
+          ENV['SCAN_OUTPUT_DIRECTORY'] = output_directory_path
+          ENV['BACKUP_XCARCHIVE_DESTINATION'] = output_directory_path
+        end
+
+        # Set derived data
+        if params[:derived_data_path]
+          derived_data_path = File.expand_path(params[:derived_data_path])
+          UI.message "Set derived data path to: \"#{derived_data_path}\"."
+          ENV['DERIVED_DATA_PATH'] = derived_data_path # Used by clear_derived_data.
+          ENV['XCODE_DERIVED_DATA_PATH'] = derived_data_path
+          ENV['GYM_DERIVED_DATA_PATH'] = derived_data_path
+          ENV['SCAN_DERIVED_DATA_PATH'] = derived_data_path
+        end
+
+        # Set result bundle
+        if params[:result_bundle]
+          UI.message "Set result bundle."
+          ENV['GYM_RESULT_BUNDLE'] = "YES"
+          ENV['SCAN_RESULT_BUNDLE'] = "YES"
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Setup xcodebuild, gym and scan for easier Jenkins integration"
+      end
+
+      def self.details
+        [
+          "- Adds and unlocks keychains from Jenkins 'Keychains and Provisioning Profiles Plugin'",
+          "- Sets code signing identity from Jenkins 'Keychains and Provisioning Profiles Plugin'",
+          "- Sets output directory to './output' (gym, scan and backup_xcarchive).",
+          "- Sets derived data path to './derivedData' (xcodebuild, gym, scan and clear_derived_data).",
+          "- Produce result bundle (gym and scan)."
+        ].join("\n")
+      end
+
+      def self.available_options
+        [
+          # General
+          FastlaneCore::ConfigItem.new(key: :force,
+                                       env_name: "FL_SETUP_JENKINS_FORCE",
+                                       description: "Force setup, even if not executed by Jenkins",
+                                       is_string: false,
+                                       default_value: false),
+
+          # Keychain
+          FastlaneCore::ConfigItem.new(key: :unlock_keychain,
+                                       env_name: "FL_SETUP_JENKINS_UNLOCK_KEYCHAIN",
+                                       description: "Unlocks keychain",
+                                       is_string: false,
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :add_keychain_to_search_list,
+                                       env_name: "FL_SETUP_JENKINS_ADD_KEYCHAIN_TO_SEARCH_LIST",
+                                       description: "Add to keychain search list",
+                                       is_string: false,
+                                       default_value: :replace),
+          FastlaneCore::ConfigItem.new(key: :set_default_keychain,
+                                       env_name: "FL_SETUP_JENKINS_SET_DEFAULT_KEYCHAIN",
+                                       description: "Set keychain as default",
+                                       is_string: false,
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :keychain_path,
+                                       env_name: "KEYCHAIN_PATH",
+                                       description: "Path to keychain",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :keychain_password,
+                                       env_name: "KEYCHAIN_PASSWORD",
+                                       description: "Keychain password",
+                                       is_string: true,
+                                       default_value: ""),
+
+          # Code signing identity
+          FastlaneCore::ConfigItem.new(key: :set_code_signing_identity,
+                                       env_name: "FL_SETUP_JENKINS_SET_CODE_SIGNING_IDENTITY",
+                                       description: "Set code signing identity from CODE_SIGNING_IDENTITY environment",
+                                       is_string: false,
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :code_signing_identity,
+                                       env_name: "CODE_SIGNING_IDENTITY",
+                                       description: "Code signing identity",
+                                       is_string: true,
+                                       optional: true),
+
+          # Xcode parameters
+          FastlaneCore::ConfigItem.new(key: :output_directory,
+                                       env_name: "FL_SETUP_JENKINS_OUTPUT_DIRECTORY",
+                                       description: "The directory in which the ipa file should be stored in",
+                                       is_string: true,
+                                       default_value: "./output"),
+          FastlaneCore::ConfigItem.new(key: :derived_data_path,
+                                       env_name: "FL_SETUP_JENKINS_DERIVED_DATA_PATH",
+                                       description: "The directory where build products and other derived data will go",
+                                       is_string: true,
+                                       default_value: "./derivedData"),
+          FastlaneCore::ConfigItem.new(key: :result_bundle,
+                                       env_name: "FL_SETUP_JENKINS_RESULT_BUNDLE",
+                                       description: "Produce the result bundle describing what occurred will be placed",
+                                       is_string: false,
+                                       default_value: true)
+        ]
+      end
+
+      def self.authors
+        ["bartoszj"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/xcodebuild.rb
+++ b/lib/fastlane/actions/xcodebuild.rb
@@ -70,6 +70,9 @@ module Fastlane
         project       = ENV["XCODE_PROJECT"]
         buildlog_path = ENV["XCODE_BUILDLOG_PATH"]
 
+        # Set derived data path.
+        params[:derivedDataPath] ||= ENV["XCODE_DERIVED_DATA_PATH"]
+
         # Append slash to build path, if needed
         if build_path && !build_path.end_with?("/")
           build_path += "/"

--- a/spec/actions_specs/setup_jenkins_spec.rb
+++ b/spec/actions_specs/setup_jenkins_spec.rb
@@ -1,0 +1,193 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Setup Jenkins Integration" do
+      before :each do
+        # Clean all used environemnt variables
+        Fastlane::Actions::SetupJenkinsAction::USED_ENV_NAMES + Fastlane::Actions::SetupJenkinsAction.available_options.map(&:env_name).each do |key|
+          ENV.delete(key)
+        end
+      end
+
+      it "doesn't work outside CI" do
+        stub_const('ENV', {})
+
+        expect(UI).to receive(:important).with("Not executed by Continuous Integration system.")
+
+        Fastlane::FastFile.new.parse("lane :test do
+          setup_jenkins
+        end").runner.execute(:test)
+
+        expect(ENV['BACKUP_XCARCHIVE_DESTINATION']).to be_nil
+        expect(ENV['DERIVED_DATA_PATH']).to be_nil
+        expect(ENV['GYM_BUILD_PATH']).to be_nil
+        expect(ENV['GYM_CODE_SIGNING_IDENTITY']).to be_nil
+        expect(ENV['GYM_DERIVED_DATA_PATH']).to be_nil
+        expect(ENV['GYM_OUTPUT_DIRECTORY']).to be_nil
+        expect(ENV['GYM_RESULT_BUNDLE']).to be_nil
+        expect(ENV['SCAN_DERIVED_DATA_PATH']).to be_nil
+        expect(ENV['SCAN_OUTPUT_DIRECTORY']).to be_nil
+        expect(ENV['SCAN_RESULT_BUNDLE']).to be_nil
+        expect(ENV['XCODE_DERIVED_DATA_PATH']).to be_nil
+      end
+
+      it "works when forced" do
+        stub_const('ENV', {})
+
+        Fastlane::FastFile.new.parse("lane :test do
+          setup_jenkins(
+            force: true
+          )
+        end").runner.execute(:test)
+
+        pwd = Dir.pwd
+        output = File.expand_path(File.join(pwd, "../output"))
+        derived_data = File.expand_path(File.join(pwd, "../derivedData"))
+        expect(ENV['BACKUP_XCARCHIVE_DESTINATION']).to eq(output)
+        expect(ENV['DERIVED_DATA_PATH']).to eq(derived_data)
+        expect(ENV['GYM_BUILD_PATH']).to eq(output)
+        expect(ENV['GYM_CODE_SIGNING_IDENTITY']).to be_nil
+        expect(ENV['GYM_DERIVED_DATA_PATH']).to eq(derived_data)
+        expect(ENV['GYM_OUTPUT_DIRECTORY']).to eq(output)
+        expect(ENV['GYM_RESULT_BUNDLE']).to eq("YES")
+        expect(ENV['SCAN_DERIVED_DATA_PATH']).to eq(derived_data)
+        expect(ENV['SCAN_OUTPUT_DIRECTORY']).to eq(output)
+        expect(ENV['SCAN_RESULT_BUNDLE']).to eq("YES")
+        expect(ENV['XCODE_DERIVED_DATA_PATH']).to eq(derived_data)
+      end
+
+      it "works inside CI" do
+        stub_const('ENV', { 'TRAVIS' => true })
+
+        Fastlane::FastFile.new.parse("lane :test do
+          setup_jenkins
+        end").runner.execute(:test)
+
+        pwd = Dir.pwd
+        output = File.expand_path(File.join(pwd, "../output"))
+        derived_data = File.expand_path(File.join(pwd, "../derivedData"))
+        expect(ENV['BACKUP_XCARCHIVE_DESTINATION']).to eq(output)
+        expect(ENV['DERIVED_DATA_PATH']).to eq(derived_data)
+        expect(ENV['GYM_BUILD_PATH']).to eq(output)
+        expect(ENV['GYM_CODE_SIGNING_IDENTITY']).to be_nil
+        expect(ENV['GYM_DERIVED_DATA_PATH']).to eq(derived_data)
+        expect(ENV['GYM_OUTPUT_DIRECTORY']).to eq(output)
+        expect(ENV['GYM_RESULT_BUNDLE']).to eq("YES")
+        expect(ENV['SCAN_DERIVED_DATA_PATH']).to eq(derived_data)
+        expect(ENV['SCAN_OUTPUT_DIRECTORY']).to eq(output)
+        expect(ENV['SCAN_RESULT_BUNDLE']).to eq("YES")
+        expect(ENV['XCODE_DERIVED_DATA_PATH']).to eq(derived_data)
+      end
+
+      describe "under CI" do
+        before :each do
+          stub_const('ENV', { 'TRAVIS' => true })
+        end
+
+        it "don't unlock keychain" do
+          expect(UI).to receive(:message).with(/Set output directory path to:/)
+          expect(UI).to receive(:message).with(/Set derived data path to:/)
+          expect(UI).to receive(:message).with("Set result bundle.")
+
+          Fastlane::FastFile.new.parse("lane :test do
+            setup_jenkins
+          end").runner.execute(:test)
+        end
+
+        it 'unlock keychain' do
+          keychain_path = Tempfile.new('foo').path
+          ENV['KEYCHAIN_PATH'] = keychain_path
+
+          expect(UI).to receive(:message).with("Unlocking keychain: \"#{keychain_path}\".")
+          expect(UI).to receive(:message).with(/Set output directory path to:/)
+          expect(UI).to receive(:message).with(/Set derived data path to:/)
+          expect(UI).to receive(:message).with("Set result bundle.")
+
+          Fastlane::FastFile.new.parse("lane :test do
+            setup_jenkins
+          end").runner.execute(:test)
+        end
+
+        it 'disable keychain unlock' do
+          keychain_path = Tempfile.new('foo').path
+          ENV['KEYCHAIN_PATH'] = keychain_path
+
+          expect(UI).to receive(:message).with(/Set output directory path to:/)
+          expect(UI).to receive(:message).with(/Set derived data path to:/)
+          expect(UI).to receive(:message).with("Set result bundle.")
+
+          Fastlane::FastFile.new.parse("lane :test do
+            setup_jenkins(
+              unlock_keychain: false
+            )
+          end").runner.execute(:test)
+        end
+
+        it 'set code signing identity' do
+          ENV['CODE_SIGNING_IDENTITY'] = "Code signing"
+
+          Fastlane::FastFile.new.parse("lane :test do
+            setup_jenkins
+          end").runner.execute(:test)
+
+          expect(ENV['GYM_CODE_SIGNING_IDENTITY']).to eq("Code signing")
+        end
+
+        it 'disable setting code signing identity' do
+          ENV['CODE_SIGNING_IDENTITY'] = "Code signing"
+
+          Fastlane::FastFile.new.parse("lane :test do
+            setup_jenkins(
+              set_code_signing_identity: false
+            )
+          end").runner.execute(:test)
+
+          expect(ENV['GYM_CODE_SIGNING_IDENTITY']).to be_nil
+        end
+
+        it 'set output directory' do
+          Fastlane::FastFile.new.parse("lane :test do
+            setup_jenkins(
+              output_directory: '/tmp/output/directory'
+            )
+          end").runner.execute(:test)
+
+          expect(ENV['BACKUP_XCARCHIVE_DESTINATION']).to eq("/tmp/output/directory")
+          expect(ENV['GYM_BUILD_PATH']).to eq("/tmp/output/directory")
+          expect(ENV['GYM_OUTPUT_DIRECTORY']).to eq("/tmp/output/directory")
+          expect(ENV['SCAN_OUTPUT_DIRECTORY']).to eq("/tmp/output/directory")
+        end
+
+        it 'set derived data' do
+          Fastlane::FastFile.new.parse("lane :test do
+            setup_jenkins(
+              derived_data_path: '/tmp/derived_data'
+            )
+          end").runner.execute(:test)
+
+          expect(ENV['DERIVED_DATA_PATH']).to eq("/tmp/derived_data")
+          expect(ENV['GYM_DERIVED_DATA_PATH']).to eq("/tmp/derived_data")
+          expect(ENV['SCAN_DERIVED_DATA_PATH']).to eq("/tmp/derived_data")
+          expect(ENV['XCODE_DERIVED_DATA_PATH']).to eq("/tmp/derived_data")
+        end
+
+        it 'disable result bundle path' do
+          Fastlane::FastFile.new.parse("lane :test do
+            setup_jenkins(
+              result_bundle: false
+            )
+          end").runner.execute(:test)
+
+          expect(ENV['GYM_RESULT_BUNDLE']).to be_nil
+          expect(ENV['SCAN_RESULT_BUNDLE']).to be_nil
+        end
+      end
+
+      after :all do
+        # Clean all used environemnt variables
+        Fastlane::Actions::SetupJenkinsAction::USED_ENV_NAMES + Fastlane::Actions::SetupJenkinsAction.available_options.map(&:env_name).each do |key|
+          ENV.delete(key)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

I've created one small action, which I believe will help with Jenkins job setup. Basically this action setups other actions like `gym`, `scan` or `xcodebuild` to create build products in the job workspace. So all results like IPA files or dSYMs will be easily accessible and can be archived to artifact from Jenkins. In addition, each job will have its own derived data folder, so two different jobs will not share cached data like `ModuleCache`. Also, jobs could clean derived data folder, by using `clear_derived_data`, without touching derived data folder of other jobs.

This action works with the [Keychains and Provisioning Profiles Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Keychains+and+Provisioning+Profiles+Plugin). The selected keychain will be automatically unlocked and the selected code signing identity will be used.

`setup_jenkins` action will work only under Continuous Integration environment, so users can create one acton which will work as usual on their macs, but under CI the output folder and derived data will be different.
