### PR TITLE
Fixed `backup_xcarchive` destination path handling

### DIFF
--- a/lib/fastlane/actions/backup_xcarchive.rb
+++ b/lib/fastlane/actions/backup_xcarchive.rb
@@ -28,19 +28,20 @@ module Fastlane
 
         # Save archive to destination
         if zipped
-          Helper.log.info "Compressing #{xcarchive}"
+          Dir.mktmpdir("backup_xcarchive") do |dir|
+            Helper.log.info "Compressing #{xcarchive}"
+            xcarchive_folder = File.expand_path(File.dirname(xcarchive))
+            xcarchive_file = File.basename(xcarchive)
+            zip_file = File.join(dir, "#{xcarchive_file}.zip")
 
-          xcarchive_folder = File.expand_path(File.dirname(xcarchive))
-          xcarchive_file = File.basename(xcarchive)
-          zip_file = File.expand_path(File.join("#{xcarchive_file}.zip"))
+            # Create zip
+            Actions.sh(%(cd "#{xcarchive_folder}" && zip -r -X "#{zip_file}" "#{xcarchive_file}" > /dev/null))
 
-          # Create zip
-          Actions.sh(%(cd "#{xcarchive_folder}" && zip -r -X "#{zip_file}" "#{xcarchive_file}" > /dev/null))
+            # Moved to its final destination
+            FileUtils.mv(zip_file, full_destination)
 
-          # Moved to its final destination
-          FileUtils.mv(zip_file, full_destination)
-
-          Actions.lane_context[SharedValues::BACKUP_XCARCHIVE_FILE] = "#{full_destination}/#{File.basename(zip_file)}"
+            Actions.lane_context[SharedValues::BACKUP_XCARCHIVE_FILE] = "#{full_destination}/#{File.basename(zip_file)}"
+          end
         else
           # Copy xcarchive file
           FileUtils.cp_r(xcarchive, full_destination)

--- a/spec/actions_specs/backup_xcarchive_spec.rb
+++ b/spec/actions_specs/backup_xcarchive_spec.rb
@@ -1,12 +1,13 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Backup xcarchive Integration" do
-      let (:source_path) { "/tmp/fastlane/tests/fastlane" }
-      let (:destination_path) { "#{source_path}/dest" }
-      let (:xcarchive_file) { "fake.xcarchive" }
-      let (:zip_file) { "fake.xcarchive.zip" }
-      let (:source_xcarchive_path) { "#{source_path}/#{xcarchive_file}" }
-      let (:file_content) { Time.now.to_s }
+      let(:tmp_path) { "/tmp/fastlane/tests" }
+      let(:source_path) { "#{tmp_path}/fastlane" }
+      let(:destination_path) { "#{source_path}/dest" }
+      let(:xcarchive_file) { "fake.xcarchive" }
+      let(:zip_file) { "fake.xcarchive.zip" }
+      let(:source_xcarchive_path) { "#{source_path}/#{xcarchive_file}" }
+      let(:file_content) { Time.now.to_s }
 
       context "plain backup" do
         before :each do
@@ -39,7 +40,8 @@ describe Fastlane do
           FileUtils.mkdir_p(source_path)
           FileUtils.mkdir_p(destination_path)
           File.write(File.join(source_path, xcarchive_file), file_content)
-          File.write(File.join("../", zip_file), file_content)
+          File.write(File.join(tmp_path, zip_file), file_content)
+          expect(Dir).to receive(:mktmpdir).with("backup_xcarchive").and_yield(tmp_path)
         end
 
         it "make and copy zip to destination" do


### PR DESCRIPTION
Fixed #1247 issue.

The solution for the issue #1247 is to create zip file in some temporary folder and then move the file to the destination.
