### PR TITLE
Fixed junit generator

### DIFF
--- a/lib/assets/report_template.xml.erb
+++ b/lib/assets/report_template.xml.erb
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="fastlane">
-  <testsuite name="run">
+<testsuites>
+  <testsuite name="fastlane.lanes">
     <% @steps.each_with_index do |step, index| %>
       <% name = [index, step[:name]].join(": ") %>
-      <testcase name=<%= name.encode(:xml => :attr) %> time="<%= step[:time] %>">
+      <testcase classname="fastlane.lanes" name=<%= name.encode(:xml => :attr) %> time="<%= step[:time] %>">
         <% if step[:error] %>
           <failure message=<%= step[:error].encode(:xml => :attr).gsub("\n", "&#10;") %> />
         <% end %>

--- a/lib/fastlane/junit_generator.rb
+++ b/lib/fastlane/junit_generator.rb
@@ -3,6 +3,7 @@ module Fastlane
     def self.generate(results)
       # JUnit file documentation: http://llg.cubic.org/docs/junit/
       # And http://nelsonwells.net/2012/09/how-jenkins-ci-parses-and-displays-junit-output/
+      # And http://windyroad.com.au/dl/Open%20Source/JUnit.xsd
 
       containing_folder = ENV['FL_REPORT_PATH'] || Fastlane::FastlaneFolder.path || Dir.pwd
       path = File.join(containing_folder, 'report.xml')


### PR DESCRIPTION
For some time Jenkins doesn't correctly parse JUnit reports generated by Fastlane. It doesn't read package name. In addition class name `run` is probably special name which forbids from displaying lanes  informations. I've adjusted JUnit generator to include class name `fastlane.lanes`, so the report can be correctly parsed and displayed by Jenkins.

Probably this pull request will fix #888 issue.
