### PR TITLE
add jazzy option

### DIFF
--- a/lib/fastlane/actions/jazzy.rb
+++ b/lib/fastlane/actions/jazzy.rb
@@ -3,7 +3,9 @@ module Fastlane
     class JazzyAction < Action
       def self.run(params)
         Actions.verify_gem!('jazzy')
-        Actions.sh("jazzy")
+        command = "jazzy"
+        command << " --config #{params[:config]}" if params[:config]
+        Actions.sh(command)
       end
 
       #####################################################
@@ -19,6 +21,13 @@ module Fastlane
 
       def self.available_options
         [
+          FastlaneCore::ConfigItem.new(
+            key: :config,
+            env_name: 'FL_JAZZY_CONFIG',
+            description: 'Path to jazzy config file',
+            is_string: true,
+            optional: true
+          )
         ]
       end
 

--- a/spec/actions_specs/jazzy_spec.rb
+++ b/spec/actions_specs/jazzy_spec.rb
@@ -8,6 +8,16 @@ describe Fastlane do
 
         expect(result).to eq("jazzy")
       end
+
+      it "add config option" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          jazzy(
+            config: '.jazzy.yaml'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("jazzy --config .jazzy.yaml")
+      end
     end
   end
 end


### PR DESCRIPTION
I use [jazzy](https://github.com/realm/jazzy) with config file. (e.g. `.jazzy.yml`)
I want jazzy in fastlane with config file.

Of course, jazzy has more options and I could apply all of them.
Tentatively I added only `--config` option because we can apply all options with config file.
