### PR TITLE
Add `tag_match_pattern` param to `changelog_from_git_commits`

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1267,6 +1267,7 @@ changelog_from_git_commits
 changelog_from_git_commits(
   between: ['7b092b3', 'HEAD'], # Optional, lets you specify a revision/tag range between which to collect commit info
   pretty: '- (%ae) %s', # Optional, lets you provide a custom format to apply to each commit when generating the changelog text
+  tag_match_pattern: nil, # Optional, lets you search for a tag name that matches a glob(7) pattern
   match_lightweight_tag: false # Optional, lets you ignore lightweight (non-annotated) tags when searching for the last tag
   include_merges: true # Optional, lets you filter out merge commits
 )

--- a/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -9,7 +9,7 @@ module Fastlane
         if params[:between]
           from, to = params[:between]
         else
-          from = Actions.last_git_tag_name(params[:match_lightweight_tag])
+          from = Actions.last_git_tag_name(params[:match_lightweight_tag], params[:tag_match_pattern])
           Helper.log.debug "Found the last Git tag: #{from}"
           to = 'HEAD'
         end
@@ -67,6 +67,10 @@ module Fastlane
                                        optional: true,
                                        default_value: '%B',
                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :tag_match_pattern,
+                                       env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_TAG_MATCH_PATTERN',
+                                       description: 'A glob(7) pattern to match against when finding the last git tag',
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :match_lightweight_tag,
                                        env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_MATCH_LIGHTWEIGHT_TAG',
                                        description: 'Whether or not to match a lightweight tag when searching for the last one',

--- a/lib/fastlane/helper/git_helper.rb
+++ b/lib/fastlane/helper/git_helper.rb
@@ -12,10 +12,12 @@ module Fastlane
       nil
     end
 
-    def self.last_git_tag_name(match_lightweight = true)
+    def self.last_git_tag_name(match_lightweight = true, tag_match_pattern = nil)
+      tag_pattern_param = tag_match_pattern ? "=#{tag_match_pattern.shellescape}" : ''
+
       command = ['git describe']
       command << '--tags' if match_lightweight
-      command << '`git rev-list --tags --max-count=1`'
+      command << "`git rev-list --tags#{tag_pattern_param} --max-count=1`"
       Actions.sh(command.join(' '), log: false).chomp
     rescue
       nil

--- a/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -107,6 +107,22 @@ describe Fastlane do
 
         expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD --no-merges")
       end
+
+      it "Uses pattern matching for tag name if requested" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          changelog_from_git_commits(tag_match_pattern: '*1.8*')
+        end").runner.execute(:test)
+
+        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\=\\\\\\*1.8\\\\\\*\\ --max-count\\=1\\`...HEAD")
+      end
+
+      it "Does not use pattern matching for tag name if so requested" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          changelog_from_git_commits()
+        end").runner.execute(:test)
+
+        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD")
+      end
     end
   end
 end


### PR DESCRIPTION
This allows using a glob(7) pattern for matching the git tag, back to which the changelog will be generated.

This is based on #1105, massaged to clean up the git commits a bit.

@7mllm7 If this looks good to you, we can get it merged!
