### PR TITLE
Add detection of productFlavor when building APK

### DIFF
--- a/lib/fastlane/actions/gradle.rb
+++ b/lib/fastlane/actions/gradle.rb
@@ -18,13 +18,13 @@ module Fastlane
         # We built our app. Store the path to the apk
         flavor = task.match(/assemble(\w*)/)
         if flavor and flavor[1]
-          flavor = flavor[1].downcase # Release => release
+          flavor = flavor[1].gsub(/([a-z])([A-Z])/,'\1-\2').downcase # ProductflavorBuildtype => productflavor-buildtype
           apk_path = Dir[File.join("app", "build", "outputs", "apk", "*-#{flavor}.apk")].last
           if apk_path
             Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH] = File.expand_path(apk_path)
           else
             Helper.log.info "Couldn't find signed apk file at path '#{apk_path}'...".red
-            if flavor == 'release'
+            if flavor =~ /release$/ # Test a regex because of productflavor possible presence
               Helper.log.info "Make sure to enable code signing in your gradle task: ".red
               Helper.log.info "https://stackoverflow.com/questions/18328730/how-to-create-a-release-signed-apk-file-using-gradle".red
             end

--- a/lib/fastlane/actions/gradle.rb
+++ b/lib/fastlane/actions/gradle.rb
@@ -18,7 +18,7 @@ module Fastlane
         # We built our app. Store the path to the apk
         flavor = task.match(/assemble(\w*)/)
         if flavor and flavor[1]
-          flavor = flavor[1].gsub(/([a-z])([A-Z])/,'\1-\2').downcase # ProductflavorBuildtype => productflavor-buildtype
+          flavor = flavor[1].gsub(/([a-z])([A-Z])/, '\1-\2').downcase # ProductflavorBuildtype => productflavor-buildtype
           apk_path = Dir[File.join("app", "build", "outputs", "apk", "*-#{flavor}.apk")].last
           if apk_path
             Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH] = File.expand_path(apk_path)


### PR DESCRIPTION
When we use the gradle action to build apk with a productFlavor the task name is:

"assembleProductflavorDev" or "assembleProductflavorRelesase".

The resulting APK filename is app-productflavor-dev.apk.
