### PR TITLE
Fixed issues with spaces in filenames for git_commit action with multiple paths

### DIFF
--- a/lib/fastlane/actions/git_commit.rb
+++ b/lib/fastlane/actions/git_commit.rb
@@ -5,7 +5,7 @@ module Fastlane
         if params[:path].kind_of?(String)
           paths = "'#{params[:path]}'"
         else
-          paths = params[:path].join(" ")
+          paths = params[:path].map {|path| "'#{path}'" }.join(" ")
         end
 
         result = Actions.sh("git commit -m '#{params[:message]}' #{paths}")

--- a/spec/actions_specs/git_commit_spec.rb
+++ b/spec/actions_specs/git_commit_spec.rb
@@ -14,7 +14,7 @@ describe Fastlane do
           git_commit(path: ['./fastlane/README.md', './fastlane/LICENSE'], message: 'message')
         end").runner.execute(:test)
 
-        expect(result).to eq("git commit -m 'message' ./fastlane/README.md ./fastlane/LICENSE")
+        expect(result).to eq("git commit -m 'message' './fastlane/README.md' './fastlane/LICENSE'")
       end
     end
   end


### PR DESCRIPTION
Fixed issues with spaces in filenames for git_commit action when multiple paths are used.

Multiple paths 'spaces' issue referenced in GitHub Issue #982
