### PR TITLE
Provide ipa_url and plist_url to s3 templates when available

### DIFF
--- a/lib/assets/s3_html_template.erb
+++ b/lib/assets/s3_html_template.erb
@@ -54,7 +54,7 @@
 
     <div class="oneRow">
       <span class="download" id="ios">
-        <a href="itms-services://?action=download-manifest&url=itms-services://?action=download-manifest&url=<%= url %>" id="text" class="btn btn-lg btn-default" onclick="document.getElementById('finished').id = '';">
+        <a href="itms-services://?action=download-manifest&url=itms-services://?action=download-manifest&url=<%= plist_url %>" id="text" class="btn btn-lg btn-default" onclick="document.getElementById('finished').id = '';">
           Install <%= title %> <%= bundle_version %>
         </a>
       </span>
@@ -62,7 +62,7 @@
       <!-- <span class="download" id="android">
       </span> -->
     </div>
-    
+
     <h3 id="desktop">Please open this page on your iPhone!</h3>
 
     <p id="finished">
@@ -70,7 +70,7 @@
     </p>
 
     <p id="footnote">
-      This is a beta version and is not meant to share with the public. 
+      This is a beta version and is not meant to share with the public.
     </p>
     <img src="https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane_medium.png" id="fastlaneLogo" />
   </body>

--- a/lib/assets/s3_plist_template.erb
+++ b/lib/assets/s3_plist_template.erb
@@ -11,7 +11,7 @@
           <key>kind</key>
           <string>software-package</string>
           <key>url</key>
-          <string><%= url %></string>
+          <string><%= ipa_url %></string>
         </dict>
       </array>
       <key>metadata</key>

--- a/lib/assets/s3_version_template.erb
+++ b/lib/assets/s3_version_template.erb
@@ -1,4 +1,4 @@
-{ 
+{
     "latestVersion": "<%= full_version %>",
-    "updateUrl": "itms-services://?action=download-manifest&url=<%= url %>"
+    "updateUrl": "itms-services://?action=download-manifest&url=<%= plist_url %>"
 }

--- a/lib/fastlane/actions/s3.rb
+++ b/lib/fastlane/actions/s3.rb
@@ -135,6 +135,7 @@ module Fastlane
         end
         plist_render = eth.render(plist_template, {
           url: ipa_url,
+          ipa_url: ipa_url,
           build_num: build_num,
           bundle_id: bundle_id,
           bundle_version: bundle_version,
@@ -149,6 +150,8 @@ module Fastlane
         end
         html_render = eth.render(html_template, {
           url: plist_url,
+          plist_url: plist_url,
+          ipa_url: ipa_url,
           build_num: build_num,
           bundle_id: bundle_id,
           bundle_version: bundle_version,
@@ -163,6 +166,8 @@ module Fastlane
         end
         version_render = eth.render(version_template, {
           url: plist_url,
+          plist_url: plist_url,
+          ipa_url: ipa_url,
           build_num: build_num,
           bundle_version: bundle_version,
           full_version: full_version


### PR DESCRIPTION
I need both the ipa url and the plist url for the html s3 template (to provide an iPad friendly link as well as a link download to desktop), so I've added them and modified the templates to use the new template variables.

~~This breaks backwards compatibility with the templates, but I thought that having "url" represent two different urls in different files would be more confusing.~~
