### PR TITLE
Fixed `erb` placeholders default value.

### DIFF
--- a/lib/fastlane/actions/erb.rb
+++ b/lib/fastlane/actions/erb.rb
@@ -34,16 +34,15 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :destination,
                                        short_option: "-D",
                                        env_name: "FL_ERB_DST",
-                                       description: "destination file",
+                                       description: "Destination file",
                                        optional: true,
                                        is_string: true
                                       ),
           FastlaneCore::ConfigItem.new(key: :placeholders,
                                        short_option: "-p",
-                                       env_name: "FL_ERB_LOG",
-                                       description: "Log Commands",
-                                       optional: true,
-                                       default_value: true,
+                                       env_name: "FL_ERB_PLACEHOLDERS",
+                                       description: "Placeholders given as a hash",
+                                       default_value: {},
                                        is_string: false,
                                        type: Hash
                                       )

--- a/spec/actions_specs/erb_spec.rb
+++ b/spec/actions_specs/erb_spec.rb
@@ -1,0 +1,58 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "ERB template" do
+      let(:template) { File.expand_path("./spec/fixtures/templates/dummy_html_template.erb") }
+      let(:destination) { "/tmp/fastlane/template.html" }
+
+      it "generate template without placeholders" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          erb(
+            template: '#{template}'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("<h1></h1>\n")
+      end
+
+      it "generate template with placeholders" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          erb(
+            template: '#{template}',
+            placeholders: {
+              template_name: 'ERB template name'
+            }
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("<h1>ERB template name</h1>\n")
+      end
+
+      context "save to file" do
+        before do
+          FileUtils.mkdir_p(File.dirname(destination))
+        end
+
+        it "generate template and save to file" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            erb(
+              template: '#{template}',
+              destination: '#{destination}',
+              placeholders: {
+                template_name: 'ERB template name with save'
+              }
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("<h1>ERB template name with save</h1>\n")
+          expect(
+            File.read(destination)
+          ).to eq("<h1>ERB template name with save</h1>\n")
+        end
+
+        after do
+          File.delete(destination)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `erb` action has a default value for `:placeholders` parameters. But if the action was executed with default value it crashes:

```
/Users/bjanda/.rbenv/versions/2.1.8/lib/ruby/2.1.0/ostruct.rb:90:in `initialize': [!] undefined method `each_pair' for true:TrueClass (NoMethodError)
    from /Users/bjanda/.rbenv/versions/2.1.8/lib/ruby/gems/2.1.0/gems/fastlane-1.59.0/lib/fastlane/actions/erb.rb:6:in `new'
    from /Users/bjanda/.rbenv/versions/2.1.8/lib/ruby/gems/2.1.0/gems/fastlane-1.59.0/lib/fastlane/actions/erb.rb:6:in `run'
...
```

Problem is with default value set to `true`, but it should be set to empty hash.

Also I've added some unit tests and changed `FL_ERB_LOG` to `FL_ERB_PLACEHOLDERS` because I don't know how the placeholders are related to the "log". I think now it should be more friendly to the users.
