### PR TITLE
Added `get_build_number_repository` action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1078,15 +1078,25 @@ You can also only receive the version number without modifying it
 version = get_version_number(xcodeproj: "Project.xcodeproj")
 ```
 
+### get_build_number_repository
+```ruby
+get_build_number_repository
+```
+
+This action will get the **build number** according to what the SCM HEAD reports.
+Currently supported SCMs are svn (uses root revision), git-svn (uses svn revision) and git (uses short hash) and mercurial (uses short hash or revision number).
+
+There is an option, `:use_hg_revision_number`, which allows to use mercurial revision number instead of hash.
+
 ### set_build_number_repository
 ```ruby
 set_build_number_repository
 ```
 
 This action will set the **build number** according to what the SCM HEAD reports.
-Currently supported SCMs are svn (uses root revision), git-svn (uses svn revision) and git (uses short hash).
+Currently supported SCMs are svn (uses root revision), git-svn (uses svn revision) and git (uses short hash) and mercurial (uses short hash or revision number).
 
-There are no options currently available for this action.
+There is an option, `:use_hg_revision_number`, which allows to use mercurial revision number instead of hash.
 
 ### update_project_team
 This action allows you to modify the developer team. This may be useful if you want to use a different team for alpha, beta or distribution.

--- a/lib/fastlane/actions/get_build_number_repository.rb
+++ b/lib/fastlane/actions/get_build_number_repository.rb
@@ -1,0 +1,102 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      BUILD_NUMBER_REPOSITORY = :BUILD_NUMBER_REPOSITORY
+    end
+
+    class GetBuildNumberRepositoryAction < Action
+      def self.is_svn?
+        Actions.sh 'svn info'
+        return true
+      rescue
+        return false
+      end
+
+      def self.is_git?
+        Actions.sh 'git rev-parse HEAD'
+        return true
+      rescue
+        return false
+      end
+
+      def self.is_git_svn?
+        Actions.sh 'git svn info'
+        return true
+      rescue
+        return false
+      end
+
+      def self.is_hg?
+        Actions.sh 'hg status'
+        return true
+      rescue
+        return false
+      end
+
+      def self.command(use_hg_revision_number)
+        if is_svn?
+          UI.message "Detected repo: svn"
+          return 'svn info | grep Revision | egrep -o "[0-9]+"'
+        elsif is_git_svn?
+          UI.message "Detected repo: git-svn"
+          return 'git svn info | grep Revision | egrep -o "[0-9]+"'
+        elsif is_git?
+          UI.message "Detected repo: git"
+          return 'git rev-parse --short HEAD'
+        elsif is_hg?
+          UI.message "Detected repo: hg"
+          if use_hg_revision_number
+            return 'hg parent --template {rev}'
+          else
+            return 'hg parent --template "{node|short}"'
+          end
+        else
+          raise "No repository detected"
+        end
+      end
+
+      def self.run(params)
+        build_number = Action.sh command(params[:use_hg_revision_number])
+        Actions.lane_context[SharedValues::BUILD_NUMBER_REPOSITORY] = build_number
+        build_number
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Get the build number from the current repository"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :use_hg_revision_number,
+                                       env_name: "USE_HG_REVISION_NUMBER",
+                                       description: "Use hg revision number instead of hash (ignored for non-hg repos)",
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false)
+        ]
+      end
+
+      def self.output
+        [
+          ['BUILD_NUMBER_REPOSITORY', 'The build number from the current repository']
+        ]
+      end
+
+      def self.return_value
+        "The build number from the current repository"
+      end
+
+      def self.authors
+        ["bartoszj", "pbrooks", "armadsen"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include? platform
+      end
+    end
+  end
+end

--- a/lib/fastlane/actions/set_build_number_repository.rb
+++ b/lib/fastlane/actions/set_build_number_repository.rb
@@ -8,56 +8,10 @@ module Fastlane
         [:ios, :mac].include? platform
       end
 
-      def self.is_svn?
-        Actions.sh 'svn info'
-        return true
-      rescue
-        return false
-      end
-
-      def self.is_git?
-        Actions.sh 'git rev-parse HEAD'
-        return true
-      rescue
-        return false
-      end
-
-      def self.is_git_svn?
-        Actions.sh 'git svn info'
-        return true
-      rescue
-        return false
-      end
-
-      def self.is_hg?
-        Actions.sh 'hg status'
-        return true
-      rescue
-        return false
-      end
-
       def self.run(params)
-        if is_svn?
-          Helper.log.info "Detected repo: svn"
-          command = 'svn info | grep Revision | egrep -o "[0-9]+"'
-        elsif is_git_svn?
-          Helper.log.info "Detected repo: git-svn"
-          command = 'git svn info | grep Revision | egrep -o "[0-9]+"'
-        elsif is_git?
-          Helper.log.info "Detected repo: git"
-          command = 'git rev-parse --short HEAD'
-        elsif is_hg?
-          Helper.log.info "Detected repo: hg"
-          if params[:use_hg_revision_number]
-            command = 'hg parent --template {rev}'
-          else
-            command = 'hg parent --template "{node|short}"'
-          end
-        else
-          raise "No repository detected"
-        end
-
-        build_number = Actions.sh command
+        build_number = Fastlane::Actions::GetBuildNumberRepositoryAction.run(
+          use_hg_revision_number: params[:use_hg_revision_number]
+        )
 
         Fastlane::Actions::IncrementBuildNumberAction.run(build_number: build_number)
       end

--- a/spec/actions_specs/get_build_number_repository_spec.rb
+++ b/spec/actions_specs/get_build_number_repository_spec.rb
@@ -1,0 +1,86 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    context "SVN repository" do
+      before do
+        expect(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_svn?).and_return(true)
+        allow(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_git_svn?).and_return(false)
+        allow(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_git?).and_return(false)
+        allow(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_hg?).and_return(false)
+      end
+
+      it "get SVN build number" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            get_build_number_repository
+        end").runner.execute(:test)
+
+        expect(result).to eq('svn info | grep Revision | egrep -o "[0-9]+"')
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER_REPOSITORY]).to eq('svn info | grep Revision | egrep -o "[0-9]+"')
+      end
+    end
+
+    context "GIT-SVN repository" do
+      before do
+        allow(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_svn?).and_return(false)
+        expect(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_git_svn?).and_return(true)
+        allow(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_git?).and_return(false)
+        allow(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_hg?).and_return(false)
+      end
+
+      it "get GIT-SVN build number" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            get_build_number_repository
+        end").runner.execute(:test)
+
+        expect(result).to eq('git svn info | grep Revision | egrep -o "[0-9]+"')
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER_REPOSITORY]).to eq('git svn info | grep Revision | egrep -o "[0-9]+"')
+      end
+    end
+
+    context "GIT repository" do
+      before do
+        allow(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_svn?).and_return(false)
+        allow(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_git_svn?).and_return(false)
+        expect(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_git?).and_return(true)
+        allow(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_hg?).and_return(false)
+      end
+
+      it "get GIT build number" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            get_build_number_repository
+        end").runner.execute(:test)
+
+        expect(result).to eq('git rev-parse --short HEAD')
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER_REPOSITORY]).to eq('git rev-parse --short HEAD')
+      end
+    end
+
+    context "Mercurial repository" do
+      before do
+        allow(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_svn?).and_return(false)
+        allow(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_git_svn?).and_return(false)
+        allow(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_git?).and_return(false)
+        expect(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:is_hg?).and_return(true)
+      end
+
+      it "get HG build number" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            get_build_number_repository
+        end").runner.execute(:test)
+
+        expect(result).to eq('hg parent --template "{node|short}"')
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER_REPOSITORY]).to eq('hg parent --template "{node|short}"')
+      end
+
+      it "get HG revision number" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          get_build_number_repository(
+            use_hg_revision_number: true
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq('hg parent --template {rev}')
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER_REPOSITORY]).to eq('hg parent --template {rev}')
+      end
+    end
+  end
+end

--- a/spec/actions_specs/set_build_number_repository_spec.rb
+++ b/spec/actions_specs/set_build_number_repository_spec.rb
@@ -1,0 +1,27 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    context "set build number repository" do
+      before do
+        expect(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:run).and_return("asd123")
+      end
+
+      it "set build number" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            set_build_number_repository
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool new-version -all asd123/)
+      end
+
+      it "set build number" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            set_build_number_repository(
+              use_hg_revision_number: true
+            )
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool new-version -all asd123/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

I've added `get_build_number_repository` action which is based on the `set_build_number_repository`. The later one reads revision number and sets it as the build numer to the Xcode project. But in some cases user needs only the revision number, without changing settings in the project. This is why I've added a new action.
