### PR TITLE
Update `nexus_upload` action to accept a nexus mount_path config item

### DIFF
--- a/lib/fastlane/actions/nexus_upload.rb
+++ b/lib/fastlane/actions/nexus_upload.rb
@@ -10,11 +10,11 @@ module Fastlane
         command += upload_options(params)
         command << upload_url(params)
 
-        Fastlane::Actions.sh(command.join(' '), log: false)
+        Fastlane::Actions.sh(command.join(' '), log: params[:verbose])
       end
 
       def self.upload_url(params)
-        "#{params[:endpoint].shellescape}/nexus/service/local/artifact/maven/content"
+        "#{params[:endpoint]}#{params[:mount_path]}/service/local/artifact/maven/content".shellescape
       end
 
       def self.verbose(params)
@@ -96,6 +96,11 @@ module Fastlane
                                        env_name: "FL_NEXUS_ENDPOINT",
                                        description: "Nexus endpoint e.g. http://nexus:8081",
                                        optional: false),
+          FastlaneCore::ConfigItem.new(key: :mount_path,
+                                       env_name: "FL_NEXUS_MOUNT_PATH",
+                                       description: "Nexus mount path. Defaults to /nexus",
+                                       default_value: "/nexus",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :username,
                                        env_name: "FL_NEXUS_USERNAME",
                                        description: "Nexus username",

--- a/spec/actions_specs/nexus_upload_spec.rb
+++ b/spec/actions_specs/nexus_upload_spec.rb
@@ -7,7 +7,12 @@ describe Fastlane do
       end
 
       it "upload url is set correctly" do
-        expect(Fastlane::Actions::NexusUploadAction.upload_url(endpoint: "http://localhost:8081")).to eq "http://localhost:8081/nexus/service/local/artifact/maven/content"
+        expect(Fastlane::Actions::NexusUploadAction.upload_url(endpoint: "http://localhost:8081",
+          mount_path: "/nexus")).to eq "http://localhost:8081/nexus/service/local/artifact/maven/content"
+        expect(Fastlane::Actions::NexusUploadAction.upload_url(endpoint: "http://localhost:8081",
+          mount_path: "/custom-nexus")).to eq "http://localhost:8081/custom-nexus/service/local/artifact/maven/content"
+        expect(Fastlane::Actions::NexusUploadAction.upload_url(endpoint: "http://localhost:8081",
+          mount_path: "")).to eq "http://localhost:8081/service/local/artifact/maven/content"
       end
 
       it "ssl option is set correctly" do
@@ -95,6 +100,7 @@ describe Fastlane do
                       repo_project_name: 'myproject',
                       repo_project_version: '1.12',
                       endpoint: 'http://localhost:8081',
+                      mount_path: '/my-nexus',
                       username: 'admin',
                       password: 'admin123',
                       verbose: true)
@@ -110,7 +116,7 @@ describe Fastlane do
         expect(result).to include("-F file=@/tmp/file.ipa")
         expect(result).to include('-u admin:admin123')
         expect(result).to include('--verbose')
-        expect(result).to include('http://localhost:8081/nexus/service/local/artifact/maven/content')
+        expect(result).to include('http://localhost:8081/my-nexus/service/local/artifact/maven/content')
         expect(result).not_to include('-x')
         expect(result).not_to include('--proxy-user')
       end


### PR DESCRIPTION
Squashed and lightly adjusted from @chrisgibbs #1305
