### PR TITLE
The "xcode version" parameter in ensure_xcode_version is non optional

### DIFF
--- a/lib/fastlane/actions/ensure_xcode_version.rb
+++ b/lib/fastlane/actions/ensure_xcode_version.rb
@@ -41,7 +41,7 @@ module Fastlane
                                        env_name: "FL_ENSURE_XCODE_VERSION",
                                        description: "Xcode version to verify that is selected",
                                        is_string: true,
-                                       default_value: false)
+                                       optional: false)
         ]
       end
 


### PR DESCRIPTION
Use that option instead of the erroneous "default_value"
