### PR TITLE
Fix git_pull by using `git fetch --tags` to fetch tags

### DIFF
--- a/lib/fastlane/actions/git_pull.rb
+++ b/lib/fastlane/actions/git_pull.rb
@@ -2,14 +2,15 @@ module Fastlane
   module Actions
     class GitPullAction < Action
       def self.run(params)
-        command = [
-          'git',
-          'pull',
-          '--tags'
-        ]
+        commands = []
 
-        Actions.sh(command.join(' '))
-        Helper.log.info 'Sucesfully pulled from remote.'
+        unless params[:only_tags]
+          commands += ["git pull &&"]
+        end
+
+        commands += ["git fetch --tags"]
+
+        Actions.sh(commands.join(' '))
       end
 
       def self.description
@@ -18,11 +19,19 @@ module Fastlane
 
       def self.available_options
         [
+          FastlaneCore::ConfigItem.new(key: :only_tags,
+                                       description: "Simply pull the tags, and not bring new commits to the current branch from the remote",
+                                       is_string: false,
+                                       optional: true,
+                                       default_value: false,
+                                       verify_block: proc do |value|
+                                         raise "Please pass a valid value for only_tags. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                       end)
         ]
       end
 
-      def self.author
-        "KrauseFx"
+      def self.authors
+        ["KrauseFx", "JaviSoto"]
       end
 
       def self.is_supported?(platform)

--- a/spec/actions_specs/git_pull_spec.rb
+++ b/spec/actions_specs/git_pull_spec.rb
@@ -1,0 +1,23 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Git Pull Action" do
+      it "runs git pull and git fetch with tags by default" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            git_pull
+          end").runner.execute(:test)
+
+        expect(result).to eq("git pull && git fetch --tags")
+      end
+
+      it "only runs git fetch --tags if only_tags" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            git_pull(
+              only_tags: true
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("git fetch --tags")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- `git pull --tags` doesn't work on newer version of git. It shows this error:

``` sh
/usr/local/lib/ruby/gems/2.2.0/gems/fastlane_core-0.36.5/lib/fastlane_core/ui/interface.rb:120:in `crash!': [!] Exit status of command 'git pull --tags' was 1 instead of 0. (FastlaneCore::Interface::FastlaneCrash)
It doesn't make sense to pull all tags; you probably meant:
  git fetch --tags
```
- This change doesn't change the existing behavior: by default it does `git pull` AND `git fetch --tags`
- Added new option so that one can simply update the tags, to avoid unintended merges happening
- Added tests for `git_pull`
