### PR TITLE
Update last_git_commit action

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -1553,7 +1553,7 @@ import_from_git(
 
 ### last_git_commit
 
-Get information about the last git commit, returns the author and the git message.
+Get information about the last git commit, returns the commit hash, the abbreviated commit hash, the author and the git message.
 
 ```ruby
 commit = last_git_commit

--- a/lib/fastlane/actions/last_git_commit.rb
+++ b/lib/fastlane/actions/last_git_commit.rb
@@ -10,11 +10,11 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Return last git commit message and author"
+        "Return last git commit hash, abbreviated commit hash, commit message and author"
       end
 
       def self.return_value
-        "Returns the following dict: {author: \"Author\", message: \"commit message\"}"
+        "Returns the following dict: {commit_hash: \"commit hash\", abbreviated_commit_hash: \"abbreviated commit hash\" author: \"Author\", message: \"commit message\"}"
       end
 
       def self.author

--- a/lib/fastlane/helper/git_helper.rb
+++ b/lib/fastlane/helper/git_helper.rb
@@ -28,7 +28,9 @@ module Fastlane
 
       {
           author: last_git_commit_formatted_with('%an'),
-          message: last_git_commit_formatted_with('%B')
+          message: last_git_commit_formatted_with('%B'),
+          commit_hash: last_git_commit_formatted_with('%H'),
+          abbreviated_commit_hash: last_git_commit_formatted_with('%h')
       }
     end
 


### PR DESCRIPTION
Update the last_git_commit action to return this new information:
- commit_hash
- abbreviated_commit_hash
