### PR TITLE
`carthage build` command

### DIFF
--- a/lib/fastlane/actions/carthage.rb
+++ b/lib/fastlane/actions/carthage.rb
@@ -4,12 +4,7 @@ module Fastlane
       def self.run(params)
         cmd = ['carthage']
 
-        if params[:command]
-          cmd << params[:command]
-        else
-          cmd << 'bootstrap'
-        end
-
+        cmd << params[:command]
         cmd << "--configuration #{params[:configuration]}" if params[:configuration]
         cmd << "--platform #{params[:platform]}"           if params[:platform]
         cmd << '--verbose'                                 if params[:verbose]
@@ -32,7 +27,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :command,
                                        env_name: "FL_CARTHAGE_COMMAND",
                                        description: "Carthage command (one of `build`, `bootstrap`, `update`)",
-                                       optional: true,
+                                       default_value: 'bootstrap',
                                        verify_block: proc do |value|
                                          raise "Please pass a valid command. Use one of the following: build, bootstrap, update" unless %w(build bootstrap update).include? value
                                        end),

--- a/lib/fastlane/actions/carthage.rb
+++ b/lib/fastlane/actions/carthage.rb
@@ -10,6 +10,7 @@ module Fastlane
           cmd << 'bootstrap'
         end
 
+        cmd << "--configuration #{params[:configuration]}" if params[:configuration]
         cmd << "--platform #{params[:platform]}"           if params[:platform]
         cmd << '--verbose'                                 if params[:verbose]
         cmd << '--no-skip-current'                         if params[:no_skip_current]
@@ -34,6 +35,13 @@ module Fastlane
                                        optional: true,
                                        verify_block: proc do |value|
                                          raise "Please pass a valid command. Use one of the following: build, bootstrap, update" unless %w(build bootstrap update).include? value
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :configuration,
+                                       env_name: "FL_CARTHAGE_CONFIGURATION",
+                                       description: "The Xcode configuration to build",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         raise "Please pass a valid configuration. Use non-empty string" if value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :platform,
                                        env_name: "FL_CARTHAGE_PLATFORM",

--- a/lib/fastlane/actions/carthage.rb
+++ b/lib/fastlane/actions/carthage.rb
@@ -2,20 +2,22 @@ module Fastlane
   module Actions
     class CarthageAction < Action
       def self.run(params)
-        cmd = ["carthage"]
+        cmd = ['carthage']
 
-        if params[:update]
-          cmd << "update"
+        if params[:command]
+          cmd << params[:command]
         else
-          cmd << "bootstrap"
+          cmd << 'bootstrap'
         end
 
-        cmd << "--use-ssh" if params[:use_ssh]
-        cmd << "--use-submodules" if params[:use_submodules]
-        cmd << "--no-use-binaries" if params[:use_binaries] == false
-        cmd << "--no-build" if params[:no_build] == true
-        cmd << "--verbose" if params[:verbose] == true
-        cmd << "--platform #{params[:platform]}" if params[:platform]
+        cmd << "--platform #{params[:platform]}"           if params[:platform]
+        cmd << '--verbose'                                 if params[:verbose]
+        cmd << '--no-skip-current'                         if params[:no_skip_current]
+        cmd << '--no-checkout'                             if params[:no_checkout]
+        cmd << '--no-build'                                if params[:no_build]
+        cmd << '--use-ssh'                                 if params[:use_ssh]
+        cmd << '--use-submodules'                          if params[:use_submodules]
+        cmd << '--no-use-binaries'                         if params[:no_use_binaries]
 
         Actions.sh(cmd.join(' '))
       end
@@ -26,16 +28,52 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :update,
-                                       env_name: "FL_CARTHAGE_UPDATE",
-                                       description: "Update the the project's dependencies",
+          FastlaneCore::ConfigItem.new(key: :command,
+                                       env_name: "FL_CARTHAGE_COMMAND",
+                                       description: "Carthage command (one of `build`, `bootstrap`, `update`)",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         raise "Please pass a valid command. Use one of the following: build, bootstrap, update" unless %w(build bootstrap update).include? value
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :platform,
+                                       env_name: "FL_CARTHAGE_PLATFORM",
+                                       description: "Define which platform to build for",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         raise "Please pass a valid platform. Use one of the following: all, iOS, Mac, watchOS" unless ["all", "iOS", "Mac", "watchOS"].include? value
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :verbose,
+                                       env_name: "FL_CARTHAGE_VERBOSE",
+                                       description: "Print xcodebuild output inline",
                                        is_string: false,
                                        optional: true,
-                                       default_value: false,
                                        verify_block: proc do |value|
-                                         raise "Please pass a valid value for update. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                         raise "Please pass a valid value for verbose. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
                                        end),
-
+          FastlaneCore::ConfigItem.new(key: :no_skip_current,
+                                       env_name: "FL_CARTHAGE_NO_SKIP_CURRENT",
+                                       description: "Don't skip building the Carthage project (in addition to its dependencies)",
+                                       is_string: false,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         raise "Please pass a valid value for no_skip_current. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :no_checkout,
+                                       env_name: "FL_CARTHAGE_NO_CHECKOUT",
+                                       description: "Skip the checking out of dependencies after updating",
+                                       is_string: false,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         raise "Please pass a valid value for no_checkout. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :no_build,
+                                       env_name: "FL_CARTHAGE_NO_BUILD",
+                                       description: "When bootstrapping Carthage do not build",
+                                       is_string: false,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         raise "Please pass a valid value for no_build. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                       end),
           FastlaneCore::ConfigItem.new(key: :use_ssh,
                                        env_name: "FL_CARTHAGE_USE_SSH",
                                        description: "Use SSH for downloading GitHub repositories",
@@ -52,36 +90,13 @@ module Fastlane
                                        verify_block: proc do |value|
                                          raise "Please pass a valid value for use_submodules. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
                                        end),
-          FastlaneCore::ConfigItem.new(key: :use_binaries,
-                                       env_name: "FL_CARTHAGE_USE_BINARIES",
+          FastlaneCore::ConfigItem.new(key: :no_use_binaries,
+                                       env_name: "FL_CARTHAGE_NO_USE_BINARIES",
                                        description: "Check out dependency repositories even when prebuilt frameworks exist",
                                        is_string: false,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass a valid value for use_binaries. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :no_build,
-                                       env_name: "FL_CARTHAGE_NO_BUILD",
-                                       description: "When bootstrapping Carthage do not build",
-                                       is_string: false,
-                                       optional: true,
-                                       verify_block: proc do |value|
-                                         raise "Please pass a valid value for no_build. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :verbose,
-                                       env_name: "FL_CARTHAGE_VERBOSE",
-                                       description: "Print xcodebuild output inline",
-                                       is_string: false,
-                                       optional: true,
-                                       verify_block: proc do |value|
-                                         raise "Please pass a valid value for verbose. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :platform,
-                                       env_name: "FL_CARTHAGE_PLATFORM",
-                                       description: "Define which platform to build for",
-                                       optional: true,
-                                       verify_block: proc do |value|
-                                         raise "Please pass a valid platform. Use one of the following: all, iOS, Mac, watchOS" unless ["all", "iOS", "Mac", "watchOS"].include? value
+                                         raise "Please pass a valid value for no_use_binaries. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
                                        end)
         ]
       end
@@ -91,7 +106,7 @@ module Fastlane
       end
 
       def self.authors
-        ["bassrock", "petester42", "jschmid", "JaviSoto"]
+        ["bassrock", "petester42", "jschmid", "JaviSoto", "uny"]
       end
     end
   end

--- a/spec/actions_specs/carthage_spec.rb
+++ b/spec/actions_specs/carthage_spec.rb
@@ -1,6 +1,66 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Carthage Integration" do
+      it "raises an error if command is invalid" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              command: 'thisistest'
+            )
+          end").runner.execute(:test)
+        end.to raise_error("Please pass a valid command. Use one of the following: build, bootstrap, update")
+      end
+
+      it "raises an error if platform is invalid" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              platform: 'thisistest'
+            )
+          end").runner.execute(:test)
+        end.to raise_error("Please pass a valid platform. Use one of the following: all, iOS, Mac, watchOS")
+      end
+
+      it "raises an error if verbose is invalid" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              verbose: 'thisistest'
+            )
+          end").runner.execute(:test)
+        end.to raise_error("Please pass a valid value for verbose. Use one of the following: true, false")
+      end
+
+      it "raises an error if no_skip_current is invalid" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_skip_current: 'thisistest'
+            )
+          end").runner.execute(:test)
+        end.to raise_error("Please pass a valid value for no_skip_current. Use one of the following: true, false")
+      end
+
+      it "raises an error if no_checkout is invalid" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_checkout: 'thisistest'
+            )
+          end").runner.execute(:test)
+        end.to raise_error("Please pass a valid value for no_checkout. Use one of the following: true, false")
+      end
+
+      it "raises an error if no_build is invalid" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_build: 'thisistest'
+            )
+          end").runner.execute(:test)
+        end.to raise_error("Please pass a valid value for no_build. Use one of the following: true, false")
+      end
+
       it "raises an error if use_ssh is invalid" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
@@ -21,44 +81,14 @@ describe Fastlane do
         end.to raise_error("Please pass a valid value for use_submodules. Use one of the following: true, false")
       end
 
-      it "raises an error if use_binaries is invalid" do
+      it "raises an error if no_use_binaries is invalid" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             carthage(
-              use_binaries: 'thisistest'
+              no_use_binaries: 'thisistest'
             )
           end").runner.execute(:test)
-        end.to raise_error("Please pass a valid value for use_binaries. Use one of the following: true, false")
-      end
-
-      it "raises an error if no_build is invalid" do
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
-            carthage(
-              no_build: 'thisistest'
-            )
-          end").runner.execute(:test)
-        end.to raise_error("Please pass a valid value for no_build. Use one of the following: true, false")
-      end
-
-      it "raises an error if verbose is invalid" do
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
-            carthage(
-              verbose: 'thisistest'
-            )
-          end").runner.execute(:test)
-        end.to raise_error("Please pass a valid value for verbose. Use one of the following: true, false")
-      end
-
-      it "raises an error if platform is invalid" do
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
-            carthage(
-              platform: 'thisistest'
-            )
-          end").runner.execute(:test)
-        end.to raise_error("Please pass a valid platform. Use one of the following: all, iOS, Mac, watchOS")
+        end.to raise_error("Please pass a valid value for no_use_binaries. Use one of the following: true, false")
       end
 
       it "default use case is boostrap" do
@@ -69,12 +99,138 @@ describe Fastlane do
         expect(result).to eq("carthage bootstrap")
       end
 
-      it "update if set to true" do
+      it "sets the command to build" do
         result = Fastlane::FastFile.new.parse("lane :test do
-            carthage(update: true)
+            carthage(command: 'build')
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage build")
+      end
+
+      it "sets the command to bootstrap" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(command: 'bootstrap')
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap")
+      end
+
+      it "sets the command to update" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(command: 'update')
           end").runner.execute(:test)
 
         expect(result).to eq("carthage update")
+      end
+
+      it "sets the platform to iOS" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              platform: 'iOS'
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap --platform iOS")
+      end
+
+      it "sets the platform to Mac" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              platform: 'Mac'
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap --platform Mac")
+      end
+
+      it "sets the platform to watchOS" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              platform: 'watchOS'
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap --platform watchOS")
+      end
+
+      it "adds verbose flag to command if verbose is set to true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              verbose: true
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap --verbose")
+      end
+
+      it "does not add a verbose flag to command if verbose is set to false" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              verbose: false
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap")
+      end
+
+      it "adds no-skip-current flag to command if no_skip_current is set to true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_skip_current: true
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap --no-skip-current")
+      end
+
+      it "doesn't add a no-skip-current flag to command if no_skip_current is set to true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_skip_current: false
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap")
+      end
+
+      it "adds no-checkout flag to command if no_checkout is set to true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_checkout: true
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap --no-checkout")
+      end
+
+      it "doesn't add a no-checkout flag to command if no_checkout is set to true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_checkout: false
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap")
+      end
+
+      it "adds no-build flag to command if no_build is set to true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_build: true
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap --no-build")
+      end
+
+      it "does not add a no-build flag to command if no_build is set to false" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_build: false
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap")
       end
 
       it "adds use-ssh flag to command if use_ssh is set to true" do
@@ -117,94 +273,24 @@ describe Fastlane do
         expect(result).to eq("carthage bootstrap")
       end
 
-      it "adds no-use-binaries flag to command if use_binaries is set to false" do
+      it "adds no-use-binaries flag to command if no_use_binaries is set to false" do
         result = Fastlane::FastFile.new.parse("lane :test do
             carthage(
-              use_binaries: false
+              no_use_binaries: true
             )
           end").runner.execute(:test)
 
         expect(result).to eq("carthage bootstrap --no-use-binaries")
       end
 
-      it "doesn't add a no-use-binaries flag to command if use_binaries is set to true" do
+      it "doesn't add a no-use-binaries flag to command if no_use_binaries is set to true" do
         result = Fastlane::FastFile.new.parse("lane :test do
             carthage(
-              use_binaries: true
+              no_use_binaries: false
             )
           end").runner.execute(:test)
 
         expect(result).to eq("carthage bootstrap")
-      end
-
-      it "adds no-build flag to command if no_build is set to true" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-            carthage(
-              no_build: true
-            )
-          end").runner.execute(:test)
-
-        expect(result).to eq("carthage bootstrap --no-build")
-      end
-
-      it "does not add a no-build flag to command if no_build is set to false" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-            carthage(
-              no_build: false
-            )
-          end").runner.execute(:test)
-
-        expect(result).to eq("carthage bootstrap")
-      end
-
-      it "adds verbose flag to command if verbose is set to true" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-            carthage(
-              verbose: true
-            )
-          end").runner.execute(:test)
-
-        expect(result).to eq("carthage bootstrap --verbose")
-      end
-
-      it "does not add a verbose flag to command if verbose is set to false" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-            carthage(
-              verbose: false
-            )
-          end").runner.execute(:test)
-
-        expect(result).to eq("carthage bootstrap")
-      end
-
-      it "sets the platform to iOS" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-            carthage(
-              platform: 'iOS'
-            )
-          end").runner.execute(:test)
-
-        expect(result).to eq("carthage bootstrap --platform iOS")
-      end
-
-      it "sets the platform to Mac" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-            carthage(
-              platform: 'Mac'
-            )
-          end").runner.execute(:test)
-
-        expect(result).to eq("carthage bootstrap --platform Mac")
-      end
-
-      it "sets the platform to watchOS" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-            carthage(
-              platform: 'watchOS'
-            )
-          end").runner.execute(:test)
-
-        expect(result).to eq("carthage bootstrap --platform watchOS")
       end
 
       it "works with no parameters" do
@@ -219,10 +305,15 @@ describe Fastlane do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             carthage(
+              command: 'bootstrap',
+              platform: 'iOS',
+              verbose: true,
+              no_skip_current: true,
+              no_checkout: false,
+              no_build: false,
               use_ssh: true,
               use_submodules: true,
-              use_binaries: false,
-              platform: 'iOS'
+              no_use_binaries: true,
             )
           end").runner.execute(:test)
         end.not_to raise_error

--- a/spec/actions_specs/carthage_spec.rb
+++ b/spec/actions_specs/carthage_spec.rb
@@ -11,6 +11,16 @@ describe Fastlane do
         end.to raise_error("Please pass a valid command. Use one of the following: build, bootstrap, update")
       end
 
+      it "raises an error if configuration is invalid" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              configuration: ''
+            )
+          end").runner.execute(:test)
+        end.to raise_error("Please pass a valid configuration. Use non-empty string")
+      end
+
       it "raises an error if platform is invalid" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
@@ -121,6 +131,16 @@ describe Fastlane do
           end").runner.execute(:test)
 
         expect(result).to eq("carthage update")
+      end
+
+      it "sets the configuration to Debug" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              configuration: 'Debug'
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap --configuration Debug")
       end
 
       it "sets the platform to iOS" do


### PR DESCRIPTION
For the issue https://github.com/fastlane/fastlane/issues/1375.

Also I added some options for carthage such as https://github.com/fastlane/fastlane/issues/813.
1. add `command` option to support `carthage build`
2. add options `configuration`, `no_skip_current` and `no_checkout`.
3. change `use_binaries` into `no_use_binaries` to follow the `carthage` itself options.
4. sort `cmd <<`, `FastlaneCore::ConfigItem.new`, and rspec as the same order.
