### PR TITLE
Fix missing rest-client dependency

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -61,4 +61,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rubocop', '~> 0.35.1'
   spec.add_development_dependency 'appium_lib', '~> 4.1.0'
+  spec.add_development_dependency 'rest-client', '~> 1.6.7'
 end


### PR DESCRIPTION
When `coveralls` went to 0.8.11 it removed its dependency on `rest-client`. We depend on `rest-client` to run the `mailgun` specs, but we hadn't declared that development dependency directly. This fixes those failing tests by making the dependency explicit.
