### PR TITLE
Updated xcodeproj dependency

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'krausefx-shenzhen', '>= 0.14.7' # to upload to Hockey and Crashlytics and build the app
   spec.add_dependency 'slack-notifier', '~> 1.3' # Slack notifications
-  spec.add_dependency 'xcodeproj', '>= 0.20', '< 1.0.0' # Needed for commit_version_bump action
+  spec.add_dependency 'xcodeproj', '>= 0.20', '< 2.0.0' # Needed for commit_version_bump action
   spec.add_dependency 'xcpretty', '>= 0.2.1' # prettify xcodebuild output
   spec.add_dependency 'terminal-notifier', '~> 1.6.2' # Mac OS X notifications
   spec.add_dependency 'terminal-table', '~> 1.4.5' # Actions documentation


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/1361
According to @orta there were no breaking changes in xcodeproj 1.0, it was just a version bump. This way we support both below 1.0 and above 1.0 :+1:
