### PR TITLE
`carthage build` command

### DIFF
--- a/lib/fastlane/actions/carthage.rb
+++ b/lib/fastlane/actions/carthage.rb
@@ -4,12 +4,7 @@ module Fastlane
       def self.run(params)
         cmd = ["carthage"]
 
-        if params[:update]
-          cmd << "update"
-        else
-          cmd << "bootstrap"
-        end
-
+        cmd << params[:command]
         cmd << "--use-ssh" if params[:use_ssh]
         cmd << "--use-submodules" if params[:use_submodules]
         cmd << "--no-use-binaries" if params[:use_binaries] == false
@@ -26,16 +21,13 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :update,
-                                       env_name: "FL_CARTHAGE_UPDATE",
-                                       description: "Update the the project's dependencies",
-                                       is_string: false,
-                                       optional: true,
-                                       default_value: false,
+          FastlaneCore::ConfigItem.new(key: :command,
+                                       env_name: "FL_CARTHAGE_COMMAND",
+                                       description: "Carthage command (one of `build`, `bootstrap`, `update`)",
+                                       default_value: 'bootstrap',
                                        verify_block: proc do |value|
-                                         raise "Please pass a valid value for update. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                         raise "Please pass a valid command. Use one of the following: build, bootstrap, update" unless %w(build bootstrap update).include? value
                                        end),
-
           FastlaneCore::ConfigItem.new(key: :use_ssh,
                                        env_name: "FL_CARTHAGE_USE_SSH",
                                        description: "Use SSH for downloading GitHub repositories",
@@ -91,7 +83,7 @@ module Fastlane
       end
 
       def self.authors
-        ["bassrock", "petester42", "jschmid", "JaviSoto"]
+        ["bassrock", "petester42", "jschmid", "JaviSoto", "uny"]
       end
     end
   end

--- a/spec/actions_specs/carthage_spec.rb
+++ b/spec/actions_specs/carthage_spec.rb
@@ -1,6 +1,16 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Carthage Integration" do
+      it "raises an error if command is invalid" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              command: 'thisistest'
+            )
+          end").runner.execute(:test)
+        end.to raise_error("Please pass a valid command. Use one of the following: build, bootstrap, update")
+      end
+
       it "raises an error if use_ssh is invalid" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
@@ -69,9 +79,25 @@ describe Fastlane do
         expect(result).to eq("carthage bootstrap")
       end
 
-      it "update if set to true" do
+      it "sets the command to build" do
         result = Fastlane::FastFile.new.parse("lane :test do
-            carthage(update: true)
+            carthage(command: 'build')
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage build")
+      end
+
+      it "sets the command to bootstrap" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(command: 'bootstrap')
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap")
+      end
+
+      it "sets the command to update" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(command: 'update')
           end").runner.execute(:test)
 
         expect(result).to eq("carthage update")


### PR DESCRIPTION
Focus the changes for the `command` option from this PR https://github.com/fastlane/fastlane/pull/1376.

We need `carthage build` to use the sources committed in `Carthage/Checkouts`.
Then, `command` option is needed for easy understanding.
