### PR TITLE
Fix: #1073 git_commmit and git_add can allow to add paths with space

### DIFF
--- a/lib/fastlane/actions/git_add.rb
+++ b/lib/fastlane/actions/git_add.rb
@@ -3,9 +3,9 @@ module Fastlane
     class GitAddAction < Action
       def self.run(params)
         if params[:path].kind_of?(String)
-          paths = "'#{params[:path]}'"
+          paths = params[:path].shellescape
         else
-          paths = params[:path].join(" ")
+          paths = params[:path].map(&:shellescape).join(' ')
         end
 
         result = Actions.sh("git add #{paths}")

--- a/lib/fastlane/actions/git_commit.rb
+++ b/lib/fastlane/actions/git_commit.rb
@@ -3,9 +3,9 @@ module Fastlane
     class GitCommitAction < Action
       def self.run(params)
         if params[:path].kind_of?(String)
-          paths = "'#{params[:path]}'"
+          paths = params[:path].shellescape
         else
-          paths = params[:path].map {|path| "'#{path}'" }.join(" ")
+          paths = params[:path].map(&:shellescape).join(' ')
         end
 
         result = Actions.sh("git commit -m '#{params[:message]}' #{paths}")

--- a/spec/actions_specs/git_commit_spec.rb
+++ b/spec/actions_specs/git_commit_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane do
           git_commit(path: './fastlane/README.md', message: 'message')
         end").runner.execute(:test)
 
-        expect(result).to eq("git commit -m 'message' './fastlane/README.md'")
+        expect(result).to eq("git commit -m 'message' ./fastlane/README.md")
       end
 
       it "generates the correct git command with an array of paths" do
@@ -14,7 +14,15 @@ describe Fastlane do
           git_commit(path: ['./fastlane/README.md', './fastlane/LICENSE'], message: 'message')
         end").runner.execute(:test)
 
-        expect(result).to eq("git commit -m 'message' './fastlane/README.md' './fastlane/LICENSE'")
+        expect(result).to eq("git commit -m 'message' ./fastlane/README.md ./fastlane/LICENSE")
+      end
+
+      it "generates the correct git command with shell-escaped-paths" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          git_commit(path: ['./fastlane/README.md', './fastlane/LICENSE', './fastlane/spec/fixtures/git_commit/A FILE WITH SPACE'], message: 'message')
+        end").runner.execute(:test)
+
+        expect(result).to eq("git commit -m 'message' ./fastlane/README.md ./fastlane/LICENSE " + "./fastlane/spec/fixtures/git_commit/A FILE WITH SPACE".shellescape)
       end
     end
   end


### PR DESCRIPTION
When i tried to run `git_add` and `git_commit`, It don't allow paths with space.

```
[21:18:03]: ---------------------
[21:18:03]: --- Step: git_add ---
[21:18:03]: ---------------------
[21:18:03]: Error setting value '["./Acceptance Tests/Info.plist"]' for option 'path'
[21:18:03]: You passed invalid parameters to 'git_add'.
[21:18:03]: Check out the error below and available options by running `fastlane action git_add`
[21:18:03]: Variable Dump:
[21:18:03]: {:DEFAULT_PLATFORM=>:ios, :PLATFORM_NAME=>:ios, :LANE_NAME=>"ios git_commit"}
[21:18:03]: Couldn't find file at path './Acceptance'
```

So, i fixed it. #1073
