### PR TITLE
Apply File.expand_path to all apk paths

### DIFF
--- a/lib/fastlane/actions/gradle.rb
+++ b/lib/fastlane/actions/gradle.rb
@@ -62,6 +62,7 @@ module Fastlane
 
         # Our apk is now built, but there might actually be multiple ones that were built if a flavor was not specified in a multi-flavor project (e.g. `assembleRelease`), however we're not interested in unaligned apk's...
         new_apks = Dir[apk_search_path].reject { |path| path =~ /^.*-unaligned.apk$/i}
+        new_apks = new_apks.map { |path| File.expand_path(path)}
 
         # We expose all of these new apk's
         Actions.lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] = new_apks


### PR DESCRIPTION
Make GRADLE_ALL_APK_OUTPUT_PATHS have absolute path names like GRADLE_ALL_APK_OUTPUT_PATH 
