### PR TITLE
Slack action customizations

### DIFF
--- a/lib/fastlane/actions/slack.rb
+++ b/lib/fastlane/actions/slack.rb
@@ -27,11 +27,8 @@ module Fastlane
 
         notifier = Slack::Notifier.new(options[:slack_url])
 
-        if options[:username].to_s.length > 0
-          notifier.username = options[:username]
-        else
-          notifier.username = 'fastlane'
-        end
+        notifier.username = options[:use_webhook_configured_username_and_icon] ? nil : options[:username]
+        icon_url = options[:use_webhook_configured_username_and_icon] ? nil : options[:icon_url]
 
         if options[:channel].to_s.length > 0
           notifier.channel = options[:channel]
@@ -42,15 +39,9 @@ module Fastlane
 
         return [notifier, slack_attachment] if Helper.is_test? # tests will verify the slack attachments and other properties
 
-        if options[:icon_url].to_s.length > 0
-          result = notifier.ping '',
-                                 icon_url: options[:icon_url],
-                                 attachments: [slack_attachment]
-        else
-          result = notifier.ping '',
-                                 icon_url: 'https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png',
-                                 attachments: [slack_attachment]
-        end
+        result = notifier.ping '',
+                               icon_url: icon_url,
+                               attachments: [slack_attachment]
 
         if result.code.to_i == 200
           Helper.log.info 'Successfully sent Slack notification'.green
@@ -66,14 +57,6 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :username,
-                                       env_name: "FL_SLACK_USERNAME",
-                                       description: "The username that should be displayed on Slack",
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :icon_url,
-                                       env_name: "FL_SLACK_ICON_URL",
-                                       description: "The URL of the icon that should be displayed on Slack",
-                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :message,
                                        env_name: "FL_SLACK_MESSAGE",
                                        description: "The message that should be displayed on Slack. This supports the standard Slack markup language",
@@ -82,12 +65,30 @@ module Fastlane
                                        env_name: "FL_SLACK_CHANNEL",
                                        description: "#channel or @username",
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :use_webhook_configured_username_and_icon,
+                                       env_name: "FL_SLACK_USE_WEBHOOK_CONFIGURED_USERNAME_AND_ICON",
+                                       description: "Use webook's default username and icon settings? (true/false)",
+                                       default_value: false,
+                                       is_string: false,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :slack_url,
                                        env_name: "SLACK_URL",
                                        description: "Create an Incoming WebHook for your Slack group",
                                        verify_block: proc do |value|
                                          raise "Invalid URL, must start with https://" unless value.start_with? "https://"
                                        end),
+          FastlaneCore::ConfigItem.new(key: :username,
+                                       env_name: "FL_SLACK_USERNAME",
+                                       description: "Overrides the webook's username property if use_webhook_configured_username_and_icon is false",
+                                       default_value: "fastlane",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :icon_url,
+                                       env_name: "FL_SLACK_ICON_URL",
+                                       description: "Overrides the webook's image property if use_webhook_configured_username_and_icon is false",
+                                       default_value: "https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png",
+                                       is_string: true,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :payload,
                                        env_name: "FL_SLACK_PAYLOAD",
                                        description: "Add additional information to this post. payload must be a hash containg any key with any value",


### PR DESCRIPTION
1) use_webhook_configured_username_and_icon: default value is false
2) username: default value is fastlane
3) icon_url: default value is
https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png

The current implementation always overrides the username and icon_url
settings.

If use_webhook_configured_username_and_icon is set to true, then the
action will fall back to the values set in the webook's settings in
Slack. Otherwise a username and/or icon_url can be passed in to use in
place of the default values.
