### PR TITLE
setup-jenkins - don't set GYM_BUILD_PATH

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/setup_jenkins.rb
@@ -4,7 +4,6 @@ module Fastlane
       USED_ENV_NAMES = [
         "BACKUP_XCARCHIVE_DESTINATION",
         "DERIVED_DATA_PATH",
-        "GYM_BUILD_PATH",
         "GYM_CODE_SIGNING_IDENTITY",
         "GYM_DERIVED_DATA_PATH",
         "GYM_OUTPUT_DIRECTORY",
@@ -51,7 +50,6 @@ module Fastlane
         if params[:output_directory]
           output_directory_path = File.expand_path(params[:output_directory])
           UI.message "Set output directory path to: \"#{output_directory_path}\"."
-          ENV['GYM_BUILD_PATH'] = output_directory_path
           ENV['GYM_OUTPUT_DIRECTORY'] = output_directory_path
           ENV['SCAN_OUTPUT_DIRECTORY'] = output_directory_path
           ENV['BACKUP_XCARCHIVE_DESTINATION'] = output_directory_path

--- a/fastlane/spec/actions_specs/setup_jenkins_spec.rb
+++ b/fastlane/spec/actions_specs/setup_jenkins_spec.rb
@@ -19,7 +19,6 @@ describe Fastlane do
 
         expect(ENV['BACKUP_XCARCHIVE_DESTINATION']).to be_nil
         expect(ENV['DERIVED_DATA_PATH']).to be_nil
-        expect(ENV['GYM_BUILD_PATH']).to be_nil
         expect(ENV['GYM_CODE_SIGNING_IDENTITY']).to be_nil
         expect(ENV['GYM_DERIVED_DATA_PATH']).to be_nil
         expect(ENV['GYM_OUTPUT_DIRECTORY']).to be_nil
@@ -44,7 +43,6 @@ describe Fastlane do
         derived_data = File.expand_path(File.join(pwd, "../derivedData"))
         expect(ENV['BACKUP_XCARCHIVE_DESTINATION']).to eq(output)
         expect(ENV['DERIVED_DATA_PATH']).to eq(derived_data)
-        expect(ENV['GYM_BUILD_PATH']).to eq(output)
         expect(ENV['GYM_CODE_SIGNING_IDENTITY']).to be_nil
         expect(ENV['GYM_DERIVED_DATA_PATH']).to eq(derived_data)
         expect(ENV['GYM_OUTPUT_DIRECTORY']).to eq(output)
@@ -67,7 +65,6 @@ describe Fastlane do
         derived_data = File.expand_path(File.join(pwd, "../derivedData"))
         expect(ENV['BACKUP_XCARCHIVE_DESTINATION']).to eq(output)
         expect(ENV['DERIVED_DATA_PATH']).to eq(derived_data)
-        expect(ENV['GYM_BUILD_PATH']).to eq(output)
         expect(ENV['GYM_CODE_SIGNING_IDENTITY']).to be_nil
         expect(ENV['GYM_DERIVED_DATA_PATH']).to eq(derived_data)
         expect(ENV['GYM_OUTPUT_DIRECTORY']).to eq(output)
@@ -152,7 +149,6 @@ describe Fastlane do
           end").runner.execute(:test)
 
           expect(ENV['BACKUP_XCARCHIVE_DESTINATION']).to eq("/tmp/output/directory")
-          expect(ENV['GYM_BUILD_PATH']).to eq("/tmp/output/directory")
           expect(ENV['GYM_OUTPUT_DIRECTORY']).to eq("/tmp/output/directory")
           expect(ENV['SCAN_OUTPUT_DIRECTORY']).to eq("/tmp/output/directory")
         end


### PR DESCRIPTION
When GYM_BUILD_PATH and GYM_OUTPUT_DIRECTORY are identical, an error can
happen when gym moves the ipa to the output directory.

FileUtils.mv throws the following exception:

fileutils.rb:1569:in `block in fu_each_src_dest': same file: /output/myProject.ipa and /output/myProject.ipa (ArgumentError)

This is due to the following line in gym:

https://github.com/fastlane/gym/blob/4f7cb499c26c3e7d237da182ba70eb5aa42b0f28/lib/gym/runner.rb#L143
