### PR TITLE
Allow gradle to run on ios platform

### DIFF
--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -147,7 +147,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :android
+        platform == :android || platform == :ios
       end
     end
   end


### PR DESCRIPTION
Allowing gradle action to run on ios platform to support scenarios where one code base (e.g. React Native) produces binaries for multiple platforms.

https://github.com/fastlane/fastlane/issues/1414
