### PR TITLE
Pilot: allow create and remove by app with technical role

### DIFF
--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -55,5 +55,18 @@ module Pilot
       result ||= ask("Please enter the app's bundle identifier: ")
       return result
     end
+
+    # Perform the app_id lookup based solely on the passed parameters
+    # nil if app_id is not configured.
+    def find_app_id_no_prompt
+      return @apple_id if @apple_id
+      app_filter = (config[:apple_id] || config[:app_identifier])
+      if app_filter
+        @app = Spaceship::Application.find(app_filter)
+        raise "Couldn't find app with '#{app_filter}'" unless @app
+        @apple_id = @app.apple_id
+        return @apple_id
+      end
+    end
   end
 end

--- a/spaceship/lib/spaceship/tunes/tester.rb
+++ b/spaceship/lib/spaceship/tunes/tester.rb
@@ -87,14 +87,16 @@ module Spaceship
         # @param email (String) (required): The email of the new tester
         # @param first_name (String) (optional): The first name of the new tester
         # @param last_name (String) (optional): The last name of the new tester
+        # @param app_id (String) (optional): The numeric apple id of the application.
         # @example
-        #   Spaceship::Tunes::Tester.external.create!(email: "tester@mathiascarignani.com", first_name: "Cary", last_name:"Bennett")
+        #   Spaceship::Tunes::Tester.external.create!(email: "tester@mathiascarignani.com", first_name: "Cary", last_name:"Bennett", app_id:"12345467")
         # @return (Tester): The newly created tester
-        def create!(email: nil, first_name: nil, last_name: nil)
+        def create!(email: nil, first_name: nil, last_name: nil, app_id: nil)
           data = client.create_tester!(tester: self,
                                         email: email,
                                    first_name: first_name,
-                                    last_name: last_name)
+                                    last_name: last_name,
+                                       app_id: app_id)
           self.factory(data)
         end
 
@@ -105,7 +107,11 @@ module Spaceship
         # @return (Array) Returns all beta testers available for this account filtered by app
         # @param app_id (String) (required): The app id to filter the testers
         def all_by_app(app_id)
-          client.testers_by_app(self, app_id).map { |tester| self.factory(tester) }
+          if app_id
+            client.testers_by_app(self, app_id).map { |tester| self.factory(tester) }
+          else
+            all
+          end
         end
 
         # @return (Spaceship::Tunes::Tester) Returns the tester matching the parameter
@@ -113,8 +119,12 @@ module Spaceship
         # @param app_id (String) (required): The app id to filter the testers
         # @param identifier (String) (required): Value used to filter the tester, case insensitive
         def find_by_app(app_id, identifier)
-          all_by_app(app_id).find do |tester|
-            (tester.tester_id.to_s.casecmp(identifier.to_s).zero? or tester.email.to_s.casecmp(identifier.to_s).zero?)
+          if app_id
+            all_by_app(app_id).detect do |tester|
+              (tester.tester_id.to_s.casecmp(identifier.to_s).zero? or tester.email.to_s.casecmp(identifier.to_s).zero?)
+            end
+          else
+            find(identifier)
           end
         end
 
@@ -149,6 +159,7 @@ module Spaceship
             index: "ra/users/pre/ext",
             index_by_app: "ra/user/externalTesters/#{app_id}/",
             create: "ra/users/pre/create",
+            create_by_app: "ra/user/externalTesters/#{app_id}/",
             delete: "ra/users/pre/ext/delete",
             update_by_app: "ra/user/externalTesters/#{app_id}/"
           }

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -758,13 +758,24 @@ module Spaceship
     end
 
     def testers_by_app(tester, app_id)
-      url = tester.url(app_id)[:index_by_app]
-      r = request(:get, url)
-      parse_response(r, 'data')['users']
+      if app_id
+        url = tester.url(app_id)[:index_by_app]
+        r = request(:get, url)
+        parse_response(r, 'data')['users']
+      else
+        testers(tester)
+      end
     end
 
-    def create_tester!(tester: nil, email: nil, first_name: nil, last_name: nil)
-      url = tester.url[:create]
+    def create_tester!(tester: nil, email: nil, first_name: nil, last_name: nil, app_id: nil)
+      if app_id
+        url = tester.url(app_id)[:create_by_app]
+        arr_key = 'users'
+      else
+        url = tester.url[:create]
+        arr_key = 'testers'
+      end
+
       raise "Action not provided for this tester type." unless url
 
       tester_data = {
@@ -782,7 +793,7 @@ module Spaceship
             }
           }
 
-      data = { testers: [tester_data] }
+      data = Hash[arr_key, [tester_data]]
 
       r = request(:post) do |req|
         req.url url
@@ -790,8 +801,8 @@ module Spaceship
         req.headers['Content-Type'] = 'application/json'
       end
 
-      data = parse_response(r, 'data')['testers']
-      handle_itc_response(data) || data[0]
+      data = parse_response(r, 'data')[arr_key]
+      handle_itc_response(data) || data.detect { |element| element['emailAddress']['value'] == email }
     end
 
     def delete_tester!(tester)


### PR DESCRIPTION
Allow create and remove functions to operate properly when app_id is present and you are using a technical role account rather than admin.
#1895
