### PR TITLE
Fix broken links in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ One of the best ways we can keep fastlane an approachable, stable, and dependabl
 
 ## Contributing New Actions
 
-Writing a custom action is an easy way to extend the capabilities of fastlane. Actions that make good candidates for inclusion in the fastlane codebase are **flexible** and apply to **many projects, teams, and development setups**. Before working to contribute your custom action to fastlane, consider whether it is likely to solve a problem that many developers have. If not, it can still provide value for your fastlane environment! Check out the documentation for creating [local action extensions](https://github.com/fastlane/fastlane/blob/master/docs/README.md#extensions).
+Writing a custom action is an easy way to extend the capabilities of fastlane. Actions that make good candidates for inclusion in the fastlane codebase are **flexible** and apply to **many projects, teams, and development setups**. Before working to contribute your custom action to fastlane, consider whether it is likely to solve a problem that many developers have. If not, it can still provide value for your fastlane environment! Check out the documentation for creating [local action extensions](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/README.md#extensions).
 
 # Above All, Thanks for Your Contributions
 

--- a/deliver/Deliverfile.md
+++ b/deliver/Deliverfile.md
@@ -89,7 +89,7 @@ app_review_information(
 ```
 
 ##### submission_information 
-Must be a hash. This is used as the last step for the deployment process, where you define if you use third party content or use encryption. [A list of available options](https://github.com/fastlane/spaceship/blob/master/lib/spaceship/tunes/app_submission.rb#L18-L69).
+Must be a hash. This is used as the last step for the deployment process, where you define if you use third party content or use encryption. [A list of available options](https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/tunes/app_submission.rb#L18-L69).
 
 ```ruby
 submission_information({
@@ -108,9 +108,9 @@ automatic_release false
 ```
 
 ##### app_rating_config_path
-You can set the app age ratings using `deliver`. You'll have to create and store a `JSON` configuration file. Copy the [template](https://github.com/fastlane/deliver/blob/master/assets/example_rating_config.json) to your project folder and pass the path to the `JSON` file using the `app_rating_config_path` option. 
+You can set the app age ratings using `deliver`. You'll have to create and store a `JSON` configuration file. Copy the [template](https://github.com/fastlane/fastlane/blob/master/deliver/assets/example_rating_config.json) to your project folder and pass the path to the `JSON` file using the `app_rating_config_path` option. 
 
-The keys/values on the top allow values from 0-2, and the items on the bottom allow only 0 or 1. More information in the [Reference.md](https://github.com/fastlane/deliver/blob/master/Reference.md).
+The keys/values on the top allow values from 0-2, and the items on the bottom allow only 0 or 1. More information in the [Reference.md](https://github.com/fastlane/fastlane/blob/master/deliver/Reference.md).
 
 
 
@@ -177,7 +177,7 @@ copyright "#{Time.now.year} Felix Krause"
 ##### primary_category
 The english name of the category you want to set (e.g. `Business`, `Books`)
 
-See [Reference.md](https://github.com/fastlane/deliver/blob/master/Reference.md) for a list of available categories
+See [Reference.md](https://github.com/fastlane/fastlane/blob/master/deliver/Reference.md) for a list of available categories
 
 ##### secondary_category
 The english name of the secondary category you want to set

--- a/deliver/MigrationGuide.md
+++ b/deliver/MigrationGuide.md
@@ -6,7 +6,7 @@ Originally `deliver` was designed to be "The Continuous Delivery tool for iOS". 
 
 ### What do I have to do to get my setup working again?
 
-In general, check out the latest documentation for the [Deliverfile](https://github.com/fastlane/deliver/blob/master/Deliverfile.md).
+In general, check out the latest documentation for the [Deliverfile](https://github.com/fastlane/fastlane/blob/master/deliver/Deliverfile.md).
 
 With 1.0 the app will not be submitted to Review by default. You can use the `deliver --submit_for_review` to submit after the upload.
 
@@ -43,8 +43,8 @@ From     | To              | Note
 `title`  | `name` | requires `name({ "en-US" => "App name" })`
 `changelog` | `release_notes`
 `keywords` |   | requires a simple string instead of arrays
-`ratings_config_path` | `app_rating_config_path` | [New Format](https://github.com/fastlane/deliver/blob/master/Deliverfile.md#app_rating_config_path)
-`submit_further_information` | `submission_information` | [New Format](https://github.com/fastlane/deliver/blob/master/Deliverfile.md#submission_information)
+`ratings_config_path` | `app_rating_config_path` | [New Format](https://github.com/fastlane/fastlane/blob/master/deliver/Deliverfile.md#app_rating_config_path)
+`submit_further_information` | `submission_information` | [New Format](https://github.com/fastlane/fastlane/blob/master/deliver/Deliverfile.md#submission_information)
 
 **The following commands have been removed:**
 
@@ -57,9 +57,9 @@ Removed                   | Use instead
 
 Changed                   | &nbsp;
 --------------------------|------------------------
-Language Codes | [Reference.md](https://github.com/fastlane/deliver/blob/master/Reference.md)
-Age Rating | [Reference.md](https://github.com/fastlane/deliver/blob/master/Reference.md)
-App Categories | [Reference.md](https://github.com/fastlane/deliver/blob/master/Reference.md)
+Language Codes | [Reference.md](https://github.com/fastlane/fastlane/blob/master/deliver/Reference.md)
+Age Rating | [Reference.md](https://github.com/fastlane/fastlane/blob/master/deliver/Reference.md)
+App Categories | [Reference.md](https://github.com/fastlane/fastlane/blob/master/deliver/Reference.md)
 
 ### What's different now? :recycle: 
 

--- a/fastlane/docs/Advanced.md
+++ b/fastlane/docs/Advanced.md
@@ -238,7 +238,7 @@ actions_path '../custom_actions_folder/'
 
 ## The Appfile
 
-The documentation was moved to [Appfile.md](https://github.com/fastlane/fastlane/blob/master/docs/Appfile.md).
+The documentation was moved to [Appfile.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Appfile.md).
 
 ## Skip update check when launching `fastlane`
 
@@ -263,4 +263,4 @@ password has been deleted.
 
 ## Gitignore
 
-The documentation was moved to [Gitignore.md](https://github.com/fastlane/fastlane/blob/master/docs/Gitignore.md).
+The documentation was moved to [Gitignore.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md).

--- a/fastlane/docs/FAQs.md
+++ b/fastlane/docs/FAQs.md
@@ -25,7 +25,7 @@ rvm osx-ssl-certs update all
 
 This is usually caused when running Jenkins as its own user. While this is possible, you'll have to take care of creating a temporary Keychain, filling it and then using it when building your application. 
 
-For more information about the recommended setup with Jenkins open the [Jenkins Guide](https://github.com/fastlane/fastlane/blob/master/docs/Jenkins.md).
+For more information about the recommended setup with Jenkins open the [Jenkins Guide](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Jenkins.md).
 
 ### Code signing issues
 

--- a/fastlane/docs/Guide.md
+++ b/fastlane/docs/Guide.md
@@ -48,7 +48,7 @@ When running the setup commands, please read the instructions shown in the termi
 
     fastlane init
 
-This will prompt you for your _Apple ID_ in order run [`produce`](https://github.com/fastlane/fastlane/tree/master/produce) which will create your app on iTunes Connect and the Apple Developer Center, and enable [`sigh`](https://github.com/KrauseFx/sigh) and [`deliver`](https://github.com/KrauseFx/deliver).
+This will prompt you for your _Apple ID_ in order run [`produce`](https://github.com/fastlane/fastlane/tree/master/produce) which will create your app on iTunes Connect and the Apple Developer Center, and enable [`sigh`](https://github.com/fastlane/fastlane/tree/master/sigh) and [`deliver`](https://github.com/fastlane/fastlane/tree/master/deliver).
 
 That's it, you should have received a success message.
 
@@ -59,7 +59,7 @@ What did this setup do?
 - Created `fastlane/Appfile`, which stores your *Apple ID* and *Bundle Identifier*.
 - Created `fastlane/Fastfile`, which stores your deployment pipelines.
 
-The setup automatically detects, which tools you're using (e.g. [`deliver`](https://github.com/fastlane/fastlane/tree/master/deliver), [CocoaPods](http://cocoapods.org/)).
+The setup automatically detects, which tools you're using (e.g. [`deliver`](https://github.com/fastlane/fastlane/tree/master/deliver), [CocoaPods](https://cocoapods.org/)).
 
 ### Individual Tools
 
@@ -144,7 +144,7 @@ This will execute your existing build script. Everything inside the `"` will be 
 
 ### Create your own actions (build steps)
 
-If you want a fancy command (like `snapshot` has), you can build your own extension very easily using [fastlane new_action](https://github.com/fastlane/fastlane/blob/master/docs/README.md#extensions).
+If you want a fancy command (like `snapshot` has), you can build your own extension very easily using [fastlane new_action](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/README.md#extensions).
 
 # Example projects
 

--- a/fastlane/docs/README.md
+++ b/fastlane/docs/README.md
@@ -3,7 +3,7 @@
 - [fastlane guide](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Guide.md) to get started. 
 - [Actions.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Actions.md) for all the built-in integrations
 - [Bamboo.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Bamboo.md) for Bamboo specific help
-- [Code signing guide](https://github.com/fastlane/fastlane/fastlane/blob/master/docs/CodeSigning.md) to show you how to do code signing right.
+- [Code signing guide](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/CodeSigning.md) to show you how to do code signing right.
 - [FAQs](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/FAQs.md) for frequently asked questions
 - [Advanced.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Advanced.md) for more advanced settings and tips.
 - [Jenkins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Jenkins.md) for Jenkins specific help


### PR DESCRIPTION
This pull request fixes broken links in Markdown files

This is looking like part 1 of 2, not sure I want to have it in a giant pull

Reviewed 
- [x] cert/ManualSteps.md
- [x] CODE_OF_CONDUCT.md
- [x] deliver/Reference.md
- [x] fastlane/docs/Android.md
- [x] fastlane/docs/Appfile.md
- [x] fastlane/docs/Bamboo.md
- [x] fastlane/docs/CodeSigning.md
- [x] fastlane/docs/Gitignore.md
- [x] fastlane/docs/Jenkins.md
- [x] fastlane/docs/Platforms.md
- [x] fastlane/ISSUE_TEMPLATE.md
- [x] fastlane/lib/fastlane/actions/README.md
- [x] fastlane/lib/fastlane/helper/README.md
- [x] gym/fastlane/README.md
- [x] gym/lib/gym/generators/README.md
- [x] gym/lib/gym/xcodebuild_fixes/README.md
- [x] ISSUE_TEMPLATE.md
- [x] match/lib/assets/READMETemplate.md
- [x] snapshot/lib/snapshot/fixes/README.md
- [x] snapshot/MigrationGuide.md

Fixed
- [x] CONTRIBUTING.md
- [x] deliver/Deliverfile.md
- [x] deliver/MigrationGuide.md
- [x] fastlane/docs/Advanced.md
- [x] fastlane/docs/FAQs.md
- [x] fastlane/docs/Guide.md
- [x] fastlane/docs/README.md
