### PR TITLE
Fix importing Fastfile for all tools

### DIFF
--- a/credentials_manager/fastlane/Fastfile
+++ b/credentials_manager/fastlane/Fastfile
@@ -1,2 +1,2 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")

--- a/deliver/fastlane/Fastfile
+++ b/deliver/fastlane/Fastfile
@@ -1,2 +1,2 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")

--- a/fastlane_core/fastlane/Fastfile
+++ b/fastlane_core/fastlane/Fastfile
@@ -1,2 +1,2 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")

--- a/frameit/fastlane/Fastfile
+++ b/frameit/fastlane/Fastfile
@@ -1,2 +1,2 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")

--- a/gym/fastlane/Fastfile
+++ b/gym/fastlane/Fastfile
@@ -1,2 +1,2 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")

--- a/match/fastlane/Fastfile
+++ b/match/fastlane/Fastfile
@@ -1,2 +1,2 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")

--- a/pem/fastlane/Fastfile
+++ b/pem/fastlane/Fastfile
@@ -1,5 +1,5 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")
 
 override_lane :module_ref do |options|
   PEM

--- a/pilot/fastlane/Fastfile
+++ b/pilot/fastlane/Fastfile
@@ -1,2 +1,2 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")

--- a/produce/fastlane/Fastfile
+++ b/produce/fastlane/Fastfile
@@ -1,2 +1,2 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")

--- a/scan/fastlane/Fastfile
+++ b/scan/fastlane/Fastfile
@@ -1,2 +1,2 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")

--- a/screengrab/fastlane/Fastfile
+++ b/screengrab/fastlane/Fastfile
@@ -1,5 +1,5 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")
 
 lane :deploy_aar do
   ensure_git_branch

--- a/sigh/fastlane/Fastfile
+++ b/sigh/fastlane/Fastfile
@@ -1,2 +1,2 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")

--- a/snapshot/fastlane/Fastfile
+++ b/snapshot/fastlane/Fastfile
@@ -1,2 +1,2 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")

--- a/supply/fastlane/Fastfile
+++ b/supply/fastlane/Fastfile
@@ -1,2 +1,2 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")

--- a/watchbuild/fastlane/Fastfile
+++ b/watchbuild/fastlane/Fastfile
@@ -1,5 +1,5 @@
 # Fetch and use the latest Fastfile from the fastlane main repository
-import_from_git(url: "https://github.com/fastlane/fastlane/")
+import("../../fastlane/fastlane/Fastfile")
 
 override_lane :module_ref do |options|
   WatchBuild


### PR DESCRIPTION
All tools previously imported the fastlane Fastfile from git. Since we're in a monorepo now, we can just import the file directly :tada: 
