### PR TITLE
WWDR certificate install keychain search

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -48,7 +48,8 @@ module FastlaneCore
 
     def self.wwdr_certificate_installed?
       certificate_name = "Apple Worldwide Developer Relations Certification Authority"
-      response = Helper.backticks("security find-certificate -c '#{certificate_name}'", print: $verbose)
+      keychain = wwdr_keychain
+      response = Helper.backticks("security find-certificate -c '#{certificate_name}' #{keychain}", print: $verbose)
       return response.include?("attributes:")
     end
 
@@ -56,9 +57,26 @@ module FastlaneCore
       Dir.chdir('/tmp') do
         url = 'https://developer.apple.com/certificationauthority/AppleWWDRCA.cer'
         filename = File.basename(url)
-        `curl -O #{url} && security import #{filename} -k login.keychain`
+        keychain = wwdr_keychain
+        keychain.prepend("-k ") unless keychain.empty?
+        `curl -O #{url} && security import #{filename} #{keychain}`
         UI.user_error!("Could not install WWDR certificate") unless $?.success?
       end
+    end
+
+    def self.wwdr_keychain
+      priority = [
+        "security list-keychains -d user",
+        "security default-keychain -d user"
+      ]
+      priority.each do |command|
+        keychains = Helper.backticks(command, print: $verbose).split("\n")
+        unless keychains.empty?
+          # Select first keychain name from returned keychains list
+          return keychains[0].strip.tr('"', '').split(File::SEPARATOR)[-1]
+        end
+      end
+      return ""
     end
 
     def self.sha1_fingerprint(path)


### PR DESCRIPTION
Original pull request: https://github.com/fastlane/fastlane_core/pull/116

Add logic to select correct user keychain based on security list output.

On a regular setup this will match login.keychain, but also allows systems that run with custom keychains (CI build systems for example that have no login) to not crash on this step.

Fixes https://github.com/fastlane/fastlane/issues/2852
Expands on code introduced in https://github.com/fastlane/fastlane_core/pull/35
