### PR TITLE
Enhance ensure_no_debug_code action

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -746,6 +746,12 @@ ensure_no_debug_code(text: "(^#define DEBUG|NSLog)",
                 extension: "m")
 ```
 
+```ruby
+ensure_no_debug_code(text: "<<<<<<",
+                     path: "./lib",
+               extensions: ["m", "swift"])
+```
+
 ### [Appium](http://appium.io/)
 
 Run UI testing by `Appium::Driver` with RSpec.

--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -740,6 +740,12 @@ ensure_no_debug_code(text: "NSLog",
                 extension: "m")
 ```
 
+```ruby
+ensure_no_debug_code(text: "(^#define DEBUG|NSLog)",
+                     path: "./lib",
+                extension: "m")
+```
+
 ### [Appium](http://appium.io/)
 
 Run UI testing by `Appium::Driver` with RSpec.

--- a/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
+++ b/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class EnsureNoDebugCodeAction < Action
       def self.run(params)
-        command = "grep -R '#{params[:text]}' '#{File.absolute_path(params[:path])}'"
+        command = "grep -RE '#{params[:text]}' '#{File.absolute_path(params[:path])}'"
         return command if Helper.is_test?
 
         Helper.log.info command.yellow

--- a/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
+++ b/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
@@ -3,6 +3,22 @@ module Fastlane
     class EnsureNoDebugCodeAction < Action
       def self.run(params)
         command = "grep -RE '#{params[:text]}' '#{File.absolute_path(params[:path])}'"
+
+        extensions = []
+        extensions << params[:extension] unless params[:extension].nil?
+
+        if params[:extensions]
+          params[:extensions].each do |extension|
+            extension.delete!('.') if extension.include? "."
+            extensions << extension
+          end
+        end
+
+        if extensions.count > 1
+          command << " --include=\\*.{#{extensions.join(',')}}"
+        elsif extensions.count > 0
+          command << " --include=\\*.#{extensions.join(',')}"
+        end
         return command if Helper.is_test?
 
         Helper.log.info command.yellow
@@ -14,14 +30,7 @@ module Fastlane
 
         found = []
         results.split("\n").each do |current_raw|
-          current = current_raw.strip
-          if params[:extension]
-            if current.include? ".#{params[:extension]}:"
-              found << current
-            end
-          else
-            found << current
-          end
+          found << current_raw.strip
         end
 
         raise "Found debug code '#{params[:text]}': \n\n#{found.join("\n")}" if found.count > 0
@@ -62,7 +71,12 @@ module Fastlane
                                        optional: true,
                                        verify_block: proc do |value|
                                          value.delete!('.') if value.include? "."
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :extensions,
+                                       env_name: "FL_ENSURE_NO_DEBUG_CODE_EXTENSIONS",
+                                       description: "An array of file extensions that should be searched for",
+                                       optional: true,
+                                       is_string: false)
         ]
       end
 

--- a/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
@@ -1,9 +1,44 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "ensure_no_debug_code" do
-      it "doesn't raise an exception if nothing was found" do
+      it "handles extension and extensions parameters correctly" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_no_debug_code(text: 'pry', path: '.', extension: 'rb', extensions: ['m', 'h'])
+        end").runner.execute(:test)
+        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('../')}' --include=\\*.{rb,m,h}")
+      end
+
+      it "handles the extension parameter correctly" do
         result = Fastlane::FastFile.new.parse("lane :test do
           ensure_no_debug_code(text: 'pry', path: '.', extension: 'rb')
+        end").runner.execute(:test)
+        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('../')}' --include=\\*.rb")
+      end
+
+      it "handles the extensions parameter with multiple elements correctly" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_no_debug_code(text: 'pry', path: '.', extensions: ['m', 'h'])
+        end").runner.execute(:test)
+        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('../')}' --include=\\*.{m,h}")
+      end
+
+      it "handles the extensions parameter with a single element correctly" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_no_debug_code(text: 'pry', path: '.', extensions: ['m'])
+        end").runner.execute(:test)
+        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('../')}' --include=\\*.m")
+      end
+
+      it "handles the extensions parameter with no elements correctly" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_no_debug_code(text: 'pry', path: '.', extensions: [])
+        end").runner.execute(:test)
+        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('../')}'")
+      end
+
+      it "handles no extension or extensions parameters" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_no_debug_code(text: 'pry', path: '.')
         end").runner.execute(:test)
         expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('../')}'")
       end

--- a/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
@@ -5,7 +5,7 @@ describe Fastlane do
         result = Fastlane::FastFile.new.parse("lane :test do
           ensure_no_debug_code(text: 'pry', path: '.', extension: 'rb')
         end").runner.execute(:test)
-        expect(result).to eq("grep -R 'pry' '#{File.absolute_path('../')}'")
+        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('../')}'")
       end
     end
   end


### PR DESCRIPTION
#### Support extended regular expression flag in grep command
- Adds the ability to support multiple matches for one call to ensure_no_debug_code
- Reduces the number of times ensure_no_debug_code needs to be called
#### Support list of extensions in ensure_no_debug_code action
- Adds the ability to match against multiple file types in one grep command
- Reduces the number of times ensure_no_debug_code needs to be called
