### PR TITLE
Fixed Dangerfile if pr_body or pr_title is empty

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,6 +1,6 @@
 warn("Big PR") if lines_of_code > 500
 
-if (pr_body + pr_title).include?("WIP")
+if (pr_body.to_s + pr_title.to_s).include?("WIP")
   warn("Pull Request is Work in Progress")
 end
 


### PR DESCRIPTION
Fixes https://circleci.com/gh/fastlane/fastlane/142

```
Dangerfile:3:in `block in parse':  (Danger::DSLError)
[!] Invalid `Dangerfile` file: undefined method `+' for nil:NilClass. Updating the Danger gem might fix the issue.

 #  from Dangerfile:3
 #  -------------------------------------------
 #  
 >  if (pr_body + pr_title).include?("WIP")
 #    warn("Pull Request is Work in Progress")
 #  -------------------------------------------
    from /tmp/vendor/bundle/ruby/2.0.0/gems/danger-0.5.2/lib/danger/dangerfile.rb:86:in `eval'
    from /tmp/vendor/bundle/ruby/2.0.0/gems/danger-0.5.2/lib/danger/dangerfile.rb:86:in `block in parse'
    from /tmp/vendor/bundle/ruby/2.0.0/gems/danger-0.5.2/lib/danger/dangerfile.rb:82:in `instance_eval'
    from /tmp/vendor/bundle/ruby/2.0.0/gems/danger-0.5.2/lib/danger/dangerfile.rb:82:in `parse'
    from /tmp/vendor/bundle/ruby/2.0.0/gems/danger-0.5.2/lib/danger/commands/runner.rb:44:in `run'
    from /tmp/vendor/bundle/ruby/2.0.0/gems/claide-0.9.1/lib/claide/command.rb:312:in `run'
    from /tmp/vendor/bundle/ruby/2.0.0/gems/danger-0.5.2/bin/danger:5:in `<top (required)>'
    from /tmp/vendor/bundle/ruby/2.0.0/bin/danger:22:in `load'

```
