### PR TITLE
Using temporary folder to generate IPA file

### DIFF
--- a/gym/lib/gym/generators/package_command_generator_legacy.rb
+++ b/gym/lib/gym/generators/package_command_generator_legacy.rb
@@ -40,6 +40,11 @@ module Gym
         [""]
       end
 
+      # Place where the IPA file will be created, so it can be safely moved to the destination folder
+      def temporary_output_path
+        Gym.cache[:temporary_output_path] ||= Dir.mktmpdir('gym_output')
+      end
+
       def appfile_path
         path = Dir.glob("#{BuildCommandGenerator.archive_path}/Products/Applications/*.app").first
         path ||= Dir[BuildCommandGenerator.archive_path + "/**/*.app"].last
@@ -49,7 +54,7 @@ module Gym
 
       # We export it to the temporary folder and move it over to the actual output once it's finished and valid
       def ipa_path
-        File.join(BuildCommandGenerator.build_path, "#{Gym.config[:output_name]}.ipa")
+        File.join(temporary_output_path, "#{Gym.config[:output_name]}.ipa")
       end
 
       # The path the the dsym file for this app. Might be nil

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -37,7 +37,7 @@ module Gym
 
       # We export the ipa into this directory, as we can't specify the ipa file directly
       def temporary_output_path
-        Gym.cache[:temporary_output_path] ||= "#{Tempfile.new('gym').path}.gym_output"
+        Gym.cache[:temporary_output_path] ||= Dir.mktmpdir('gym_output')
       end
 
       def ipa_path
@@ -68,7 +68,7 @@ module Gym
 
       # The path the config file we use to sign our app
       def config_path
-        Gym.cache[:config_path] ||= "#{Tempfile.new('gym').path}_config.plist"
+        Gym.cache[:config_path] ||= "#{Tempfile.new('gym_config').path}.plist"
         return Gym.cache[:config_path]
       end
 

--- a/gym/spec/package_command_generator_legacy_spec.rb
+++ b/gym/spec/package_command_generator_legacy_spec.rb
@@ -58,5 +58,14 @@ describe Gym do
                              ""
                            ])
     end
+
+    it "uses a temporary folder to store the resulting ipa file" do
+      options = { project: "./examples/standard/Example.xcodeproj" }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      result = Gym::PackageCommandGeneratorLegacy.generate
+      expect(Gym::PackageCommandGeneratorLegacy.temporary_output_path).to match(%r{#{Dir.tmpdir}/gym_output.+})
+      expect(Gym::PackageCommandGeneratorLegacy.ipa_path).to match(%r{#{Dir.tmpdir}/gym_output.+/ExampleProductName.ipa})
+    end
   end
 end

--- a/gym/spec/package_command_generator_xcode7_spec.rb
+++ b/gym/spec/package_command_generator_xcode7_spec.rb
@@ -143,11 +143,11 @@ describe Gym do
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 
       result = Gym::PackageCommandGeneratorXcode7.generate
-      expect(Gym::PackageCommandGeneratorXcode7.temporary_output_path).to match(%r{#{Dir.tmpdir}/gym.+\.gym_output})
-      expect(Gym::PackageCommandGeneratorXcode7.manifest_path).to match(%r{#{Dir.tmpdir}/gym.+\.gym_output/manifest.plist})
-      expect(Gym::PackageCommandGeneratorXcode7.app_thinning_path).to match(%r{#{Dir.tmpdir}/gym.+\.gym_output/app-thinning.plist})
-      expect(Gym::PackageCommandGeneratorXcode7.app_thinning_size_report_path).to match(%r{#{Dir.tmpdir}/gym.+\.gym_output/App Thinning Size Report.txt})
-      expect(Gym::PackageCommandGeneratorXcode7.apps_path).to match(%r{#{Dir.tmpdir}/gym.+\.gym_output/Apps})
+      expect(Gym::PackageCommandGeneratorXcode7.temporary_output_path).to match(%r{#{Dir.tmpdir}/gym_output.+})
+      expect(Gym::PackageCommandGeneratorXcode7.manifest_path).to match(%r{#{Dir.tmpdir}/gym_output.+/manifest.plist})
+      expect(Gym::PackageCommandGeneratorXcode7.app_thinning_path).to match(%r{#{Dir.tmpdir}/gym_output.+/app-thinning.plist})
+      expect(Gym::PackageCommandGeneratorXcode7.app_thinning_size_report_path).to match(%r{#{Dir.tmpdir}/gym_output.+/App Thinning Size Report.txt})
+      expect(Gym::PackageCommandGeneratorXcode7.apps_path).to match(%r{#{Dir.tmpdir}/gym_output.+/Apps})
     end
   end
 end


### PR DESCRIPTION
When using `gym` in the legacy mode and the `--build_path` and the `--output_directory` options are pointing to the same folder an error occurs. `gym` tries to move IPA file to the same place:

```
FileUtils.mv throws the following exception:

fileutils.rb:1569:in `block in fu_each_src_dest': same file: /output/myProject.ipa and /output/myProject.ipa (ArgumentError)
```

The solution is to generate IPA file in the temporary directory and then move it to the destination folder. This behaviour was already used when the Xcode 7 API was used, so this PR is only adjusting the "legacy mode".

This PR fix another issue, #1663, but in different way. 
