### PR TITLE
Remove tester from a specific app

### DIFF
--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -56,8 +56,21 @@ module Pilot
       tester ||= Spaceship::Tunes::Tester::Internal.find(config[:email])
 
       if tester
-        tester.delete!
-        Helper.log.info "Successfully removed tester #{tester.email}".green
+        app_filter = (config[:apple_id] || config[:app_identifier])
+        if app_filter
+          begin
+            app = Spaceship::Application.find(app_filter)
+            raise "Couldn't find app with '#{app_filter}'" unless app
+            tester.remove_from_app!(app.apple_id)
+            Helper.log.info "Successfully removed tester #{tester.email} from app #{app_filter}".green
+          rescue => ex
+            Helper.log.error "Could not remove #{tester.email} from app: #{ex}".red
+            raise ex
+          end
+        else
+          tester.delete!
+          Helper.log.info "Successfully removed tester #{tester.email}".green
+        end
       else
         Helper.log.error "Tester not found: #{config[:email]}".red
       end


### PR DESCRIPTION
Previously attempting to remove a tester from one app would actually delete the tester altogether and thus remove from all apps.
