### PR TITLE
Raise friendly error when listing testers for invalid app

### DIFF
--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -70,6 +70,7 @@ module Pilot
       app_filter = (config[:apple_id] || config[:app_identifier])
       if app_filter
         app = Spaceship::Application.find(app_filter)
+        raise "Couldn't find app with '#{app_filter}'" unless app
         int_testers = Spaceship::Tunes::Tester::Internal.all_by_app(app.apple_id)
         ext_testers = Spaceship::Tunes::Tester::External.all_by_app(app.apple_id)
       else


### PR DESCRIPTION
Similar pattern as used elsewhere in the same file.

Previously would raise:

```
/usr/local/lib/ruby/gems/2.1.0/gems/pilot-1.4.1/lib/pilot/tester_manager.rb:86:in `list_testers': [!] undefined method `apple_id' for nil:NilClass (NoMethodError)
```
