### PR TITLE
Have CI cache rubocop cache info between builds

### DIFF
--- a/.rubocop-ci.yml
+++ b/.rubocop-ci.yml
@@ -1,0 +1,12 @@
+# Specialized Rubocop settings for CI that place the cache directory
+# in a known location that we can ask to be cached between builds
+#
+# We don't want to specify this for non-CI builds because the default
+# behavior is better, in that it uses a system-appropriate temp dir
+# location. '/tmp' is not an appropriate file root for all systems,
+# but on CI we can control what kind of system we are running on.
+inherit_from:
+  - .rubocop.yml
+
+AllCops:
+  CacheRootDirectory: '/tmp/rubocop'

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ dependencies:
     - bundle check --path=/tmp/vendor/bundle || bundle install --path=/tmp/vendor/bundle --jobs=4 --retry=3
   cache_directories:
     - /tmp/vendor/bundle
+    - /tmp/rubocop
 test:
   override:
     - bundle exec rake test_all

--- a/rakelib/test_all.rake
+++ b/rakelib/test_all.rake
@@ -67,6 +67,7 @@ task :test_all do
   exceptions = []
   repos_with_exceptions = []
   rspec_log_file = "rspec_logs.json"
+  rubocop_config = ENV['CI'] ? '../.rubocop-ci.yml' : '../.rubocop.yml'
 
   bundle_install
   for_each_gem do |repo|
@@ -78,7 +79,7 @@ task :test_all do
         # Since we nest bundle exec in bundle exec
         Bundler.with_clean_env do
           bundle_install
-          sh "bundle exec rubocop"
+          sh "bundle exec rubocop --config #{rubocop_config}"
           sh "bundle exec rspec --format documentation --format j --out #{rspec_log_file}"
         end
       rescue => ex


### PR DESCRIPTION
In order to be fast when nothing has changed, RuboCop [caches](https://github.com/bbatsov/rubocop#caching) inspection results on our machines. It does this intelligently, ensuring that the Ruby version, the RuboCop version, the configuration, the files being inspected, etc. are all the same before returning a cached result.

This adds `/tmp/rubocop` to the list of paths we'd like Circle CI to cache and restore for us between builds. In order to configure RuboCop to put the cache info in this location, there's a new configuration file, `.rubocop-ci.yml`. That file inherits the main RuboCop config in `.rubocop.yml`.

I didn't want to put that `/tmp/rubocop` path into the main configuration because RuboCop's default cache placement behavior is better for local development -- it respects the system's default temp directory location (`/tmp/rubocop` is not appropriate for all systems). We control what system we run on for CI, so that's fine. Sadly, there doesn't seem to be a way to pass the cache storage location as a command-line flag, otherwise I would do that. Instead, I'm specifying either the main configuration or the CI configuration in the rake script depending on `ENV['CI']`.
