### PR TITLE
Show what app identifier Pilot is using

### DIFF
--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -53,6 +53,7 @@ module Pilot
       result = config[:app_identifier]
       result ||= FastlaneCore::IpaFileAnalyser.fetch_app_identifier(config[:ipa])
       result ||= ask("Please enter the app's bundle identifier: ")
+      Helper.log.debug "App identifier (#{result})"
       return result
     end
   end


### PR DESCRIPTION
Sometimes Pilot guesses wrong. This should help pin that down.

This is what I ended up doing to figure out why my app identifier wasn't being used as I expected from the specified IPA or deliverfile. (turns out pilot makes it's own guess)
