### PR TITLE
Added make_changelog_from_git action

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -963,6 +963,32 @@ set_changelog(app_identifier: "com.krausefx.app", version: "1.0", changelog: "Al
 
 You can store the changelog in `./fastlane/changelog.txt` and it will automatically get loaded from there. This integration is useful if you support e.g. 10 languages and want to use the same "What's new"-text for all languages.
 
+### make_changelog_from_git
+
+Generate a changelog using `git log`.
+
+```ruby
+make_changelog_from_git(
+  appInfoFile: 'Resources/Project-Info.plist',
+  logLimiter: '- AUTO: Patch Version Bump',
+  changelogFilePath: "fastlane/Changelog.txt"
+)
+```
+
+Using action fully:
+
+```ruby
+make_changelog_from_git(
+  appInfoFile: 'Resources/Project-Info.plist', # Optional: Path to your Xcode project info.plist file (to retrieve $bundleVersion and $buildNumber)
+  logLimiter: '- AUTO: Patch Version Bump', # Some string which will work as limiter if you want to limit number of lines to show
+  numberOfLogLines: 100, # Optional: Max number of lines to fetch
+  template: "Here's my new shiny changelog for $bundleVersion($buildNumber):\n$changelog", # Optional: $bundleVersion, $buildNumber and $changelog are supported for now
+  logFormat: "* %h %ae - %s", # Optional: You can use any other format for commit. See https://git-scm.com/docs/pretty-formats for details
+  showChangelog: true, # Optional: Shows changelog in fastlane logs
+  changelogFilePath: "fastlane/Changelog.txt" # Set path where changelog file will be written
+)
+```
+
 ### make_changelog_from_jenkins
 
 Generate a changelog using the Changes section the running Jenkins job.

--- a/fastlane/lib/fastlane/actions/make_changelog_from_git.rb
+++ b/fastlane/lib/fastlane/actions/make_changelog_from_git.rb
@@ -1,0 +1,128 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      MAKE_CHANGELOG_FROM_GIT_FILE_PATH = :MAKE_CHANGELOG_FROM_GIT_FILE_PATH
+    end
+
+    class MakeChangelogFromGitAction < Action
+      def self.run(params)
+        infoFile = params[:appInfoFile]
+
+        # Reading Bundle Version and Build Number from Info.plist file if it was provided
+        if infoFile.nil? || infoFile.empty?
+          bundleVersion = buildNumber = "[Property :appInfoFile is not specified!]"
+        else
+          bundleVersion = %x[defaults read "#{File.expand_path(infoFile).chomp('.plist')}" CFBundleShortVersionString]
+          bundleVersion = bundleVersion.gsub(/\s+/, "")
+          exit $? >> 8 if bundleVersion == ''
+
+          buildNumber = %x[defaults read "#{File.expand_path(infoFile).chomp('.plist')}" CFBundleVersion]
+          buildNumber = buildNumber.gsub(/\s+/, "")
+          exit $? >> 8 if buildNumber == ''
+        end
+
+        # Retrieving and formatting logs
+        logFormat = params[:logFormat]
+        numberOfLogLines = params[:numberOfLogLines]
+        gitLog = %x[git log --pretty=format:"#{logFormat}" -#{numberOfLogLines}]
+        logLimiter = params[:logLimiter]
+        indexOfLogLimiter = gitLog.index(logLimiter)
+        relevantGitLog = indexOfLogLimiter && indexOfLogLimiter != 0 ? gitLog.slice(0..indexOfLogLimiter - 2) : gitLog
+
+        template = params[:template]
+
+        if (infoFile.nil? || infoFile.empty?) && (template.index('$bundleVersion') || template.index('$bundleVersion'))
+          Helper.log.info "$bundleVersion or $bundleVersion is used in template, but :appInfoFile property is not set!"
+        end
+
+        template = template.sub('$bundleVersion', bundleVersion)
+        template = template.sub('$buildNumber', buildNumber)
+        template = template.sub('$changelog', relevantGitLog)
+
+        if params[:showChangelog]
+          Helper.log.info "Writing in Changelog file:"
+          Helper.log.info "#{template}"
+        end
+
+        # Writing result changelog in file
+        File.open(params[:changelogFilePath], 'w') {
+          |file| file.write(template)
+        }
+
+        Helper.log.info "Changelog file is written."
+
+        # Storing result file path in case other actions use it
+        Actions.lane_context[SharedValues::MAKE_CHANGELOG_FROM_GIT_FILE_PATH] = params[:changelogFilePath]
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Generates file with release notes gathered from git"
+      end
+
+      def self.details
+        "You can use this action to gather list of changes from git and save it to the file"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :changelogFilePath,
+                                       env_name: "FL_MAKE_CHANGELOG_FROM_GIT_FILE_PATH",
+                                       description: "File path to release notes file",
+                                       is_string: true,
+                                       default_value: "fastlane/ReleaseNotes.txt"),
+          FastlaneCore::ConfigItem.new(key: :appInfoFile,
+                                       env_name: "FL_MAKE_CHANGELOG_FROM_GIT_APP_INFO_FILE",
+                                       description: "Application info.plist file path ",
+                                       is_string: true,
+                                       default_value: ""),
+          FastlaneCore::ConfigItem.new(key: :template,
+                                       env_name: "FL_MAKE_CHANGELOG_FROM_GIT_TEMPLATE",
+                                       description: "Template for release notes. Use next variables: $bundleVersion, $buildNumber, $relevantGitLog",
+                                       is_string: true,
+                                       default_value: "What\'s new in v$bundleVersion ($buildNumber):\n$changelog\n"),
+          FastlaneCore::ConfigItem.new(key: :logFormat,
+                                       env_name: "FL_MAKE_CHANGELOG_FROM_GIT_LOG_FORMAT_STRING",
+                                       description: "GIT log pretty format. For help see: https://git-scm.com/docs/pretty-formats",
+                                       is_string: true,
+                                       default_value: "- %s (%an)"),
+          FastlaneCore::ConfigItem.new(key: :logLimiter,
+                                       env_name: "FL_MAKE_CHANGELOG_FROM_GIT_LOG_LIMITER",
+                                       description: "Commit name in log that can serve as separator for changelog",
+                                       is_string: true,
+                                       default_value: ""),
+          FastlaneCore::ConfigItem.new(key: :numberOfLogLines,
+                                       env_name: "FL_MAKE_CHANGELOG_FROM_GIT_NUMBER_OF_LOG_LINES",
+                                       description: "Number of lines from GIT you want to put into changelog file. It can be additionally limited by logLimiter property",
+                                       is_string: false,
+                                       default_value: 20),
+          FastlaneCore::ConfigItem.new(key: :showChangelog,
+                                       env_name: "FL_MAKE_CHANGELOG_FROM_GIT_SHOW_CHANGELOG",
+                                       description: "Show what will be written to changelog file in logs",
+                                       is_string: false,
+                                       default_value: false)
+        ]
+      end
+
+      def self.output
+        [
+          ['MAKE_CHANGELOG_FROM_GIT_FILE_PATH', 'Changelog file path']
+        ]
+      end
+
+      def self.return_value   
+      end
+
+      def self.authors
+        ["yuriy-tolstoguzov"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+    end
+  end
+end


### PR DESCRIPTION
🔑 Added action to create changelog file from git log. Idea is described here: #3672

Key features:
- Customizable format of commits;
- Customizable format of file with support of key word like $changelog (for git log), $buildNumber, $bundleVersion (from info.plist)
- 2 different ways to limit number of logs: by specific commit or by number of commits.

Possible improvements limitation by regex.
