### PR TITLE
Strip trailing whitespace in README.md generation

### DIFF
--- a/fastlane/lib/fastlane/documentation/docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/docs_generator.rb
@@ -32,8 +32,8 @@ module Fastlane
         output << ""
       end
 
-      output << "This README.md is auto-generated and will be re-generated every time to run [fastlane](https://fastlane.tools).  "
-      output << "More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools).  "
+      output << "This README.md is auto-generated and will be re-generated every time to run [fastlane](https://fastlane.tools)."
+      output << "More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools)."
       output << "The documentation of fastlane can be found on [GitHub](https://github.com/fastlane/fastlane/tree/master/fastlane)."
 
       File.write(output_path, output.join("\n"))


### PR DESCRIPTION
This was a mild irritation when reviewing git diffs
