### PR TITLE
Fix shell parameter passing to openssl to escape special characters

### DIFF
--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -1,6 +1,7 @@
 module Match
   class Encrypt
     require 'security'
+    require 'shellwords'
 
     def server_name(git_url)
       ["match", git_url].join("_")
@@ -77,9 +78,9 @@ module Match
 
       tmpfile = File.join(Dir.mktmpdir, "temporary")
       command = ["openssl aes-256-cbc"]
-      command << "-k \"#{password}\""
-      command << "-in \"#{path}\""
-      command << "-out \"#{tmpfile}\""
+      command << "-k #{password.shellescape}"
+      command << "-in #{path.shellescape}"
+      command << "-out #{tmpfile.shellescape}"
       command << "-a"
       command << "-d" unless encrypt
       command << "&> /dev/null" unless $verbose # to show show an error message is something goes wrong

--- a/match/spec/encrypt_spec.rb
+++ b/match/spec/encrypt_spec.rb
@@ -7,7 +7,7 @@ describe Match do
       File.write(@full_path, @content)
       @git_url = "https://github.com/fastlane/fastlane/tree/master/so_random"
       allow(Dir).to receive(:mktmpdir).and_return(@directory)
-      ENV["MATCH_PASSWORD"] = "my_pass"
+      ENV["MATCH_PASSWORD"] = '2"QAHg@v(Qp{=*n^'
 
       @e = Match::Encrypt.new
     end


### PR DESCRIPTION
Addresses #1986

This fixes a problem where passwords with special characters (especially quotes) would cause us to produce an improperly constructed command-line call to `openssl`.
