### PR TITLE
Adding Sentry action for uploading dSYM files

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -894,6 +894,20 @@ lane :refresh_dsyms do
   clean_build_artifacts           # Delete the local dSYM files
 end
 ```
+### [upload_symbols_to_sentry](https://getsentry.com)
+
+This action allows you to upload symbolication files to Sentry.
+
+```ruby
+upload_sybols_to_sentry(
+  api_key: '...',
+  org_slug: '...',
+  project_slug: '...',
+  dsym_path: './App.dSYM.zip'
+)
+```
+
+The following environment variables may be used in place of parameters: `SENTRY_API_KEY`, `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG`, and `SENTRY_DSYM_PATH`.
 
 
 ### AWS S3 Distribution

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
@@ -1,0 +1,119 @@
+module Fastlane
+  module Actions
+    class UploadSymbolsToSentryAction < Action
+      def self.run(params)
+        require 'rest-client'
+
+        # Params - API
+        host = params[:api_host]
+        api_key = params[:api_key]
+        org = params[:org_slug]
+        project = params[:project_slug]
+
+        # Params - dSYM
+        dsym_path = params[:dsym_path]
+        dsym_paths = params[:dsym_paths] || []
+
+        # Url to post dSYMs to
+        url = "#{host}/projects/#{org}/#{project}/files/dsyms/"
+        resource = RestClient::Resource.new( url, api_key, '' )
+
+        UI.message "Will upload dSYM(s) to #{url}"
+
+        # Upload dsym(s)
+        dsym_paths += [dsym_path]
+        uploaded_paths = dsym_paths.compact.map do |dsym|
+          upload_dsym(resource, dsym)
+        end
+
+        # Return uplaoded dSYM paths
+        uploaded_paths
+      end
+
+      def self.upload_dsym(resource, dsym)
+        UI.message "Uploading... #{dsym}"
+        resource.post(file: File.new(dsym, 'rb')) unless Helper.test?
+        UI.success 'dSYM successfully uploaded to Sentry!'
+
+        dsym
+      rescue
+        UI.user_error! 'Error while trying to upload dSYM to Sentry'
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Upload dSYM symbolication files to Sentry"
+      end
+
+      def self.details
+        [
+          "This action allows you to upload symbolication files to Sentry.",
+          "It's extra useful if you use it to download the latest dSYM files from Apple when you",
+          "use Bitcode"
+        ].join(" ")
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :api_host,
+                                       env_name: "SENTRY_HOST",
+                                       description: "API host url for Sentry",
+                                       is_string: true,
+                                       default_value: "https://app.getsentry.com/api/0",
+                                       optional: true
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :api_key,
+                                       env_name: "SENTRY_API_KEY",
+                                       description: "API Key for Sentry",
+                                       verify_block: proc do |value|
+                                         raise "No API token for SentryAction given, pass using `api_key: 'key'`".red unless value and !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :org_slug,
+                                       env_name: "SENTRY_ORG_SLUG",
+                                       description: "Organization slug for Sentry project",
+                                       verify_block: proc do |value|
+                                         raise "No organization slug for SentryAction given, pass using `org_slug: 'org'`".red unless value and !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :project_slug,
+                                       env_name: "SENTRY_PROJECT_SLUG",
+                                       description: "Prgoject slug for Sentry",
+                                       verify_block: proc do |value|
+                                         raise "No project slug for SentryAction given, pass using `project_slug: 'project'`".red unless value and !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :dsym_path,
+                                       env_name: "SENTRY_DSYM_PATH",
+                                       description: "Path to your symbols file. For iOS and Mac provide path to app.dSYM.zip",
+                                       default_value: Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH],
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         # validation is done in the action
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :dsym_paths,
+                                       env_name: "SENTRY_DSYM_PATHS",
+                                       description: "Path to an array of your symbols file. For iOS and Mac provide path to app.dSYM.zip",
+                                       default_value: Actions.lane_context[SharedValues::DSYM_PATHS],
+                                       is_string: false,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         # validation is done in the action
+                                       end)
+        ]
+      end
+
+      def self.return_value
+        "The uploaded dSYM path(s)"
+      end
+
+      def self.authors
+        ["joshdholtz"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/upload_symbols_to_sentry_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_sentry_spec.rb
@@ -1,0 +1,36 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "sentry" do
+      it "returns uploaded dSYM path" do
+        dsym_path_1 = './fastlane/spec/fixtures/dSYM/Themoji.dSYM.zip'
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          upload_symbols_to_sentry(
+            api_key: 'something123',
+            org_slug: 'some_org',
+            project_slug: 'some_project',
+            dsym_path: '#{dsym_path_1}')
+        end").runner.execute(:test)
+
+        expect(result).to include(dsym_path_1)
+      end
+
+      it "returns uploaded dSYM paths" do
+        dsym_path_1 = './fastlane/spec/fixtures/dSYM/Themoji.dSYM.zip'
+        dsym_path_2 = './fastlane/spec/fixtures/dSYM/This_doesnt_exist_but_doesnt_need_to.dSYM.zip'
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          upload_symbols_to_sentry(
+            api_key: 'something123',
+            org_slug: 'some_org',
+            project_slug: 'some_project',
+            dsym_path: '#{dsym_path_1}',
+            dsym_paths: ['#{dsym_path_2}'])
+        end").runner.execute(:test)
+
+        expect(result).to include(dsym_path_1)
+        expect(result).to include(dsym_path_2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
New action, `sentry`, for uploading dSYM files to [Sentry](https://getsentry.com)'s API. Takes either (or both) a single dSYM file path or an array of file paths

Defaults use...
- `Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH]` from Xcode output (`gym`, `ipa`, etc.)
- `Actions.lane_context[SharedValues::DSYM_PATHS]` from ITC (`download_dsyms`)
