### PR TITLE
Updated crashlytics upload action to support multiple dSYM paths

### DIFF
--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -2,16 +2,23 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "upload_symbols_to_crashlytics" do
       it "generates a valid command" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          upload_symbols_to_crashlytics(
-            dsym_path: './fastlane/spec/fixtures/dSYM/Themoji.dSYM.zip',
-            api_token: 'something123',
-            binary_path: './fastlane/spec/fixtures/screenshots/screenshot1.png')
-        end").runner.execute(:test)
+        binary_path = './spec/fixtures/screenshots/screenshot1.png'
+        dsym_path = './spec/fixtures/dSYM/Themoji.dSYM.zip'
 
-        expect(result).to include("screenshot1.png")
-        expect(result).to include("-a something123 -p ios")
-        expect(result).to include("dSYM/Themoji.dSYM.zip")
+        command = []
+        command << File.expand_path(binary_path)
+        command << "-a something123"
+        command << "-p ios"
+        command << File.expand_path(dsym_path)
+
+        expect(Fastlane::Actions).to receive(:sh).with(command.join(" "))
+
+        Fastlane::FastFile.new.parse("lane :test do
+          upload_symbols_to_crashlytics(
+            dsym_path: 'fastlane/#{dsym_path}',
+            api_token: 'something123',
+            binary_path: 'fastlane/#{binary_path}')
+        end").runner.execute(:test)
       end
     end
   end


### PR DESCRIPTION
This will allow us to use the dSYM files from the `Actions.lane_context[SharedValues::DSYM_PATHS` variable which is generated by `download_dsyms`
