### PR TITLE
Handle --email command-line argument in pilot add/remove/find

### DIFF
--- a/pilot/lib/pilot/commands_generator.rb
+++ b/pilot/lib/pilot/commands_generator.rb
@@ -27,6 +27,7 @@ module Pilot
     def handle_multiple(action, args, options)
       mgr = Pilot::TesterManager.new
       config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
+      args.push(config[:email]) if config[:email] && args.empty?
       args.push(ask("Email address of the tester: ".yellow)) if args.empty?
       failures = []
       args.each do |address|


### PR DESCRIPTION
Without this change, the following command line didn't work:
`pilot add -f "Fast" -l "Lane" --email "email@email.com"`

According to the help, `--email` or `-e` should be supported:
`-e, --email STRING   The tester's email (PILOT_TESTER_EMAIL)`

This is functionally equivalent to:
`pilot add -f "Fast" -l "Lane" "email@email.com"`

In addition, the documented environment variable `PILOT_TESTER_EMAIL` is also supported.
`PILOT_TESTER_EMAIL="email@email.com" pilot add -f Fast -l Lane`
