### PR TITLE
Add the Display Name option to sigh resign

### DIFF
--- a/fastlane/lib/fastlane/actions/resign.rb
+++ b/fastlane/lib/fastlane/actions/resign.rb
@@ -6,7 +6,7 @@ module Fastlane
         require 'sigh'
 
         # try to resign the ipa
-        if Sigh::Resign.resign(params[:ipa], params[:signing_identity], params[:provisioning_profile], params[:entitlements], params[:version])
+        if Sigh::Resign.resign(params[:ipa], params[:signing_identity], params[:provisioning_profile], params[:entitlements], params[:version], params[:display_name])
           UI.success('Successfully re-signed .ipa 🔏.')
         else
           raise 'Failed to re-sign .ipa'.red
@@ -66,6 +66,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: "FL_RESIGN_VERSION",
                                        description: "Version number to force resigned ipa to use",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :display_name,
+                                       env_name: "FL_DISPLAY_NAME",
+                                       description: "Display name to force resigned ipa to use",
                                        is_string: true,
                                        optional: true)
         ]

--- a/sigh/bin/sigh
+++ b/sigh/bin/sigh
@@ -66,6 +66,7 @@ class SighApplication
                'Can be provided multiple times if the application contains nested applications and app extensions, which need their own provisioning profile.'\
                'The path may be prefixed with a identifier in order to determine which provisioning profile should be used on which app.',
                &multiple_values_option_proc(c, "provisioning_profile", &proc { |value| value.split('=', 2) })
+      c.option '-d', '--display_name STRING', String, 'Display name to use'
 
       c.action do |args, options|
         Sigh::Resign.new.run(options, args)

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -6,16 +6,16 @@ module Sigh
     def run(options, args)
       # get the command line inputs and parse those into the vars we need...
 
-      ipa, signing_identity, provisioning_profiles, entitlements, version = get_inputs(options, args)
+      ipa, signing_identity, provisioning_profiles, entitlements, version, display_name = get_inputs(options, args)
       # ... then invoke our programmatic interface with these vars
-      resign(ipa, signing_identity, provisioning_profiles, entitlements, version)
+      resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name)
     end
 
-    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements, version)
-      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements, version)
+    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name)
+      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name)
     end
 
-    def resign(ipa, signing_identity, provisioning_profiles, entitlements, version)
+    def resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name)
       resign_path = find_resign_path
       signing_identity = find_signing_identity(signing_identity)
 
@@ -28,6 +28,7 @@ module Sigh
       entitlements = "-e #{entitlements}" if entitlements
       provisioning_options = provisioning_profiles.map { |fst, snd| "-p #{[fst, snd].compact.map(&:shellescape).join('=')}" }.join(' ')
       version = "-n #{version}" if version
+      display_name = "-d #{display_name.shellescape}" if display_name
 
       command = [
         resign_path.shellescape,
@@ -36,6 +37,7 @@ module Sigh
         provisioning_options, # we are aleady shellescaping this above, when we create the provisioning_options from the provisioning_profiles
         entitlements,
         version,
+        display_name,
         ipa.shellescape
       ].join(' ')
 
@@ -57,8 +59,9 @@ module Sigh
       provisioning_profiles = options.provisioning_profile || find_provisioning_profile || ask('Path to provisioning file: ')
       entitlements = options.entitlements || find_entitlements
       version = options.version_number || nil
+      display_name = options.display_name || nil
 
-      return ipa, signing_identity, provisioning_profiles, entitlements, version
+      return ipa, signing_identity, provisioning_profiles, entitlements, version, display_name
     end
 
     def find_resign_path


### PR DESCRIPTION
resign.sh already accepts parameter -d that defines new Display Name for the app. I exposed a way to pass Display Name from sigh resign into resign.sh. 
