### PR TITLE
Introduce UI.deprecated and ConfigItem.deprecated

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,9 @@ UI.user_error!("You don't have a project in the current directory")
 
 ###### an actual crash when something unexpected happened
 UI.crash!("Network timeout")
+
+###### a deprecation message
+UI.deprecated("The '--key' parameter is deprecated")
 ```
 
 The output will look like this

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -42,10 +42,11 @@ module Fastlane
       nil
     end
 
+    # @deprecated Use <tt>git_author_email</tt> instead
     # Get the author email of the last git commit
     # <b>DEPRECATED:</b> Use <tt>git_author_email</tt> instead.
     def self.git_author
-      UI.important('`git_author` is deprecated. Please use `git_author_email` instead.')
+      UI.deprecated('`git_author` is deprecated. Please use `git_author_email` instead.')
       git_author_email
     end
 

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -1,6 +1,6 @@
 module FastlaneCore
   class ConfigItem
-    attr_accessor :key, :env_name, :description, :short_option, :default_value, :verify_block, :optional, :conflicting_options, :conflict_block
+    attr_accessor :key, :env_name, :description, :short_option, :default_value, :verify_block, :optional, :conflicting_options, :conflict_block, :deprecated
 
     # Creates a new option
     # @param key (Symbol) the key which is used as command paramters or key in the fastlane tools
@@ -16,7 +16,8 @@ module FastlaneCore
     # @param optional (Boolean) is false by default. If set to true, also string values will not be asked to the user
     # @param conflicting_options ([]) array of conflicting option keys(@param key). This allows to resolve conflicts intelligently
     # @param conflict_block an optional block which is called when options conflict happens
-    def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, type: nil, optional: false, conflicting_options: nil, conflict_block: nil)
+    # @param deprecated (String) Set if the option is deprecated. A deprecated option should be optional and is made optional if the parameter isn't set, and fails otherwise
+    def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, type: nil, optional: nil, conflicting_options: nil, conflict_block: nil, deprecated: nil)
       UI.user_error!("key must be a symbol") unless key.kind_of? Symbol
       UI.user_error!("env_name must be a String") unless (env_name || '').kind_of? String
 
@@ -36,6 +37,14 @@ module FastlaneCore
           UI.user_error!("Conflicting option key must be a symbol") unless conflicting_option_key.kind_of? Symbol
         end
       end
+      if deprecated
+        # deprecated options are automatically optional
+        optional = true if optional.nil?
+        UI.crash!("Deprecated option must be optional") unless optional
+        # deprecated options are marked deprecated in their description
+        description = "[DEPRECATED!] #{deprecated} - #{description}"
+      end
+      optional = false if optional.nil?
 
       @key = key
       @env_name = env_name
@@ -48,6 +57,7 @@ module FastlaneCore
       @optional = optional
       @conflicting_options = conflicting_options
       @conflict_block = conflict_block
+      @deprecated = deprecated
     end
 
     # This will raise an exception if the value is not valid

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -57,6 +57,7 @@ module FastlaneCore
 
         option = option_for_key(key)
         if option
+          UI.deprecated("Using deprecated option: '--#{key}' (#{option.deprecated})") if option.deprecated
           option.verify!(value) # Call the verify block for it too
         else
           UI.user_error!("Could not find option '#{key}' in the list of available options: #{@available_options.collect(&:key).join(', ')}")

--- a/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
+++ b/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
@@ -45,6 +45,10 @@ module FastlaneCore
       log.info(message.to_s)
     end
 
+    def deprecated(message)
+      log.error(message.to_s.bold.blue)
+    end
+
     def command(message)
       log.info("$ #{message}".cyan.underline)
     end

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -38,6 +38,13 @@ module FastlaneCore
       not_implemented(__method__)
     end
 
+    # Level Deprecated: Show that a particular function is deprecated
+    #
+    #   By default those messages shown in strong blue
+    def deprecated(_message)
+      not_implemented(__method__)
+    end
+
     # Level Command: Print out a terminal command that is being
     #   executed.
     #

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -34,329 +34,392 @@ describe FastlaneCore do
         end.to raise_error "Do not let descriptions end with a '.', since it's used for user inputs as well"
       end
 
-      it "raises an error if a a key was used twice" do
-        expect do
-          FastlaneCore::Configuration.create([FastlaneCore::ConfigItem.new(
-            key: :cert_name,
-       env_name: "asdf"),
-                                              FastlaneCore::ConfigItem.new(
-                                                key: :cert_name,
-                                           env_name: "asdf")], {})
-        end.to raise_error "Multiple entries for configuration key 'cert_name' found!"
+      describe "config conflicts" do
+        it "raises an error if a a key was used twice" do
+          expect do
+            FastlaneCore::Configuration.create([FastlaneCore::ConfigItem.new(
+              key: :cert_name,
+         env_name: "asdf"),
+                                                FastlaneCore::ConfigItem.new(
+                                                  key: :cert_name,
+                                             env_name: "asdf")], {})
+          end.to raise_error "Multiple entries for configuration key 'cert_name' found!"
+        end
+
+        it "raises an error if a a short_option was used twice" do
+          conflicting_options = [
+            FastlaneCore::ConfigItem.new(key: :foo,
+                                         short_option: "-f",
+                                         description: "foo"),
+            FastlaneCore::ConfigItem.new(key: :bar,
+                                         short_option: "-f",
+                                         description: "bar")
+          ]
+
+          expect do
+            FastlaneCore::Configuration.create(conflicting_options, {})
+          end.to raise_error "Multiple entries for short_option '-f' found!"
+        end
+
+        it "raises an error for unresolved conflict between options" do
+          conflicting_options = [
+            FastlaneCore::ConfigItem.new(key: :foo,
+                                         short_option: "-f",
+                                         conflicting_options: [:bar, :oof]),
+            FastlaneCore::ConfigItem.new(key: :bar,
+                                         short_option: "-b"),
+            FastlaneCore::ConfigItem.new(key: :oof,
+                                         short_option: "-o")
+          ]
+
+          values = {
+              foo: "",
+              bar: ""
+          }
+
+          expect do
+            FastlaneCore::Configuration.create(conflicting_options, values)
+          end.to raise_error "Unresolved conflict between options: 'foo' and 'bar'"
+        end
+
+        it "calls custom conflict handler when conflict happens between two options" do
+          conflicting_options = [
+            FastlaneCore::ConfigItem.new(key: :foo,
+                                         short_option: "-f",
+                                         conflicting_options: [:bar, :oof],
+                                         conflict_block: proc do |value|
+                                           UI.user_error!("You can't use option '#{value.short_option}' along with '-f'")
+                                         end),
+            FastlaneCore::ConfigItem.new(key: :bar,
+                                         short_option: "-b"),
+            FastlaneCore::ConfigItem.new(key: :oof,
+                                         short_option: "-o",
+                                         conflict_block: proc do |value|
+                                           UI.user_error!("You can't use option '#{value.short_option}' along with '-o'")
+                                         end)
+          ]
+
+          values = {
+              foo: "",
+              bar: ""
+          }
+
+          expect do
+            FastlaneCore::Configuration.create(conflicting_options, values)
+          end.to raise_error "You can't use option '-b' along with '-f'"
+        end
+
+        it "raises an error for unresolved conflict between options" do
+          conflicting_options = [
+            FastlaneCore::ConfigItem.new(key: :foo,
+                                         short_option: "-f",
+                                         conflicting_options: [:bar, :oof]),
+            FastlaneCore::ConfigItem.new(key: :bar,
+                                         short_option: "-b"),
+            FastlaneCore::ConfigItem.new(key: :oof,
+                                         short_option: "-o")
+          ]
+
+          values = {
+              foo: "",
+              bar: ""
+          }
+
+          expect do
+            FastlaneCore::Configuration.create(conflicting_options, values)
+          end.to raise_error "Unresolved conflict between options: 'foo' and 'bar'"
+        end
+
+        it "calls custom conflict handler when conflict happens between two options" do
+          conflicting_options = [
+            FastlaneCore::ConfigItem.new(key: :foo,
+                                         short_option: "-f",
+                                         conflicting_options: [:bar, :oof],
+                                         conflict_block: proc do |value|
+                                           UI.user_error!("You can't use option '#{value.short_option}' along with '-f'")
+                                         end),
+            FastlaneCore::ConfigItem.new(key: :bar,
+                                         short_option: "-b"),
+            FastlaneCore::ConfigItem.new(key: :oof,
+                                         short_option: "-o",
+                                         conflict_block: proc do |value|
+                                           UI.user_error!("You can't use option '#{value.short_option}' along with '-o'")
+                                         end)
+          ]
+
+          values = {
+              foo: "",
+              bar: ""
+          }
+
+          expect do
+            FastlaneCore::Configuration.create(conflicting_options, values)
+          end.to raise_error "You can't use option '-b' along with '-f'"
+        end
+
+        it "raises an error for unresolved conflict between options" do
+          conflicting_options = [
+            FastlaneCore::ConfigItem.new(key: :foo,
+                                         short_option: "-f",
+                                         conflicting_options: [:bar, :oof]),
+            FastlaneCore::ConfigItem.new(key: :bar,
+                                         short_option: "-b"),
+            FastlaneCore::ConfigItem.new(key: :oof,
+                                         short_option: "-o")
+          ]
+
+          values = {
+              foo: "",
+              bar: ""
+          }
+
+          expect do
+            FastlaneCore::Configuration.create(conflicting_options, values)
+          end.to raise_error "Unresolved conflict between options: 'foo' and 'bar'"
+        end
+
+        it "calls custom conflict handler when conflict happens between two options" do
+          conflicting_options = [
+            FastlaneCore::ConfigItem.new(key: :foo,
+                                         short_option: "-f",
+                                         conflicting_options: [:bar, :oof],
+                                         conflict_block: proc do |value|
+                                           UI.user_error!("You can't use option '#{value.short_option}' along with '-f'")
+                                         end),
+            FastlaneCore::ConfigItem.new(key: :bar,
+                                         short_option: "-b"),
+            FastlaneCore::ConfigItem.new(key: :oof,
+                                         short_option: "-o",
+                                         conflict_block: proc do |value|
+                                           UI.user_error!("You can't use option '#{value.short_option}' along with '-o'")
+                                         end)
+          ]
+
+          values = {
+              foo: "",
+              bar: ""
+          }
+
+          expect do
+            FastlaneCore::Configuration.create(conflicting_options, values)
+          end.to raise_error "You can't use option '-b' along with '-f'"
+        end
       end
 
-      it "raises an error if a a short_option was used twice" do
-        conflicting_options = [
-          FastlaneCore::ConfigItem.new(key: :foo,
-                                       short_option: "-f",
-                                       description: "foo"),
-          FastlaneCore::ConfigItem.new(key: :bar,
-                                       short_option: "-f",
-                                       description: "bar")
-        ]
+      describe "data_type" do
+        it "sets the data type correctly if `is_string` is not set but type is specified" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo',
+                                                     type: Array)
 
-        expect do
-          FastlaneCore::Configuration.create(conflicting_options, {})
-        end.to raise_error "Multiple entries for short_option '-f' found!"
+          expect(config_item.data_type).to eq(Array)
+        end
+
+        it "sets the data type correctly if `is_string` is set but the type is specified" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo',
+                                                     is_string: true,
+                                                     type: Array)
+
+          expect(config_item.data_type).to eq(Array)
+        end
+
+        it "sets the data type correctly if `is_string` is set but the type is not specified" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo',
+                                                     is_string: true)
+
+          expect(config_item.data_type).to eq(String)
+        end
       end
 
-      it "raises an error for unresolved conflict between options" do
-        conflicting_options = [
-          FastlaneCore::ConfigItem.new(key: :foo,
-                                       short_option: "-f",
-                                       conflicting_options: [:bar, :oof]),
-          FastlaneCore::ConfigItem.new(key: :bar,
-                                       short_option: "-b"),
-          FastlaneCore::ConfigItem.new(key: :oof,
-                                       short_option: "-o")
-        ]
+      describe "arrays" do
+        it "returns Array default values correctly" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo',
+                                                     type: Array,
+                                                     optional: true,
+                                                     default_value: ['5', '4', '3', '2', '1'])
+          config = FastlaneCore::Configuration.create([config_item], {})
 
-        values = {
-            foo: "",
-            bar: ""
-        }
+          expect(config[:foo]).to eq(['5', '4', '3', '2', '1'])
+        end
 
-        expect do
-          FastlaneCore::Configuration.create(conflicting_options, values)
-        end.to raise_error "Unresolved conflict between options: 'foo' and 'bar'"
+        it "returns Array input values correctly" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo',
+                                                     type: Array)
+          config = FastlaneCore::Configuration.create([config_item], { foo: ['5', '4', '3', '2', '1'] })
+
+          expect(config[:foo]).to eq(['5', '4', '3', '2', '1'])
+        end
+
+        it "returns Array environment variable values correctly" do
+          ENV["FOO"] = '5,4,3,2,1'
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo',
+                                                     env_name: 'FOO',
+                                                     type: Array)
+          config = FastlaneCore::Configuration.create([config_item], {})
+
+          expect(config[:foo]).to eq(['5', '4', '3', '2', '1'])
+          ENV.delete("FOO")
+        end
       end
 
-      it "calls custom conflict handler when conflict happens between two options" do
-        conflicting_options = [
-          FastlaneCore::ConfigItem.new(key: :foo,
-                                       short_option: "-f",
-                                       conflicting_options: [:bar, :oof],
-                                       conflict_block: proc do |value|
-                                         UI.user_error!("You can't use option '#{value.short_option}' along with '-f'")
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :bar,
-                                       short_option: "-b"),
-          FastlaneCore::ConfigItem.new(key: :oof,
-                                       short_option: "-o",
-                                       conflict_block: proc do |value|
-                                         UI.user_error!("You can't use option '#{value.short_option}' along with '-o'")
-                                       end)
-        ]
+      describe "auto_convert_value" do
+        it "auto converts string values to Integers" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo',
+                                                     type: Integer)
 
-        values = {
-            foo: "",
-            bar: ""
-        }
+          value = config_item.auto_convert_value('987')
 
-        expect do
-          FastlaneCore::Configuration.create(conflicting_options, values)
-        end.to raise_error "You can't use option '-b' along with '-f'"
+          expect(value).to eq(987)
+        end
+
+        it "auto converts string values to Floats" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo',
+                                                     type: Float)
+
+          value = config_item.auto_convert_value('9.91')
+
+          expect(value).to eq(9.91)
+        end
+
+        it "auto converts booleans as strings to booleans" do
+          c = [
+            FastlaneCore::ConfigItem.new(key: :true_value),
+            FastlaneCore::ConfigItem.new(key: :true_value2),
+            FastlaneCore::ConfigItem.new(key: :false_value),
+            FastlaneCore::ConfigItem.new(key: :false_value2)
+          ]
+          config = FastlaneCore::Configuration.create(c, {
+            true_value: "true",
+            true_value2: "YES",
+            false_value: "false",
+            false_value2: "NO"
+          })
+
+          expect(config[:true_value]).to eq(true)
+          expect(config[:true_value2]).to eq(true)
+          expect(config[:false_value]).to eq(false)
+          expect(config[:false_value2]).to eq(false)
+        end
       end
 
-      it "raises an error for unresolved conflict between options" do
-        conflicting_options = [
-          FastlaneCore::ConfigItem.new(key: :foo,
-                                       short_option: "-f",
-                                       conflicting_options: [:bar, :oof]),
-          FastlaneCore::ConfigItem.new(key: :bar,
-                                       short_option: "-b"),
-          FastlaneCore::ConfigItem.new(key: :oof,
-                                       short_option: "-o")
-        ]
+      describe "validation" do
+        it "raises an exception if the data type is not as expected" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo',
+                                                     type: Float)
 
-        values = {
-            foo: "",
-            bar: ""
-        }
+          expect do
+            config_item.valid?('ABC')
+          end.to raise_error
+        end
 
-        expect do
-          FastlaneCore::Configuration.create(conflicting_options, values)
-        end.to raise_error "Unresolved conflict between options: 'foo' and 'bar'"
+        it "verifies the default value as well" do
+          c = FastlaneCore::ConfigItem.new(key: :output,
+                                    env_name: "SIGH_OUTPUT_PATH",
+                                 description: "Directory in which the profile should be stored",
+                               default_value: "notExistent",
+                                verify_block: proc do |value|
+                                  UI.user_error!("Could not find output directory '#{value}'")
+                                end)
+          expect do
+            @config = FastlaneCore::Configuration.create([c], {})
+          end.to raise_error "Invalid default value for output, doesn't match verify_block"
+        end
       end
 
-      it "calls custom conflict handler when conflict happens between two options" do
-        conflicting_options = [
-          FastlaneCore::ConfigItem.new(key: :foo,
-                                       short_option: "-f",
-                                       conflicting_options: [:bar, :oof],
-                                       conflict_block: proc do |value|
-                                         UI.user_error!("You can't use option '#{value.short_option}' along with '-f'")
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :bar,
-                                       short_option: "-b"),
-          FastlaneCore::ConfigItem.new(key: :oof,
-                                       short_option: "-o",
-                                       conflict_block: proc do |value|
-                                         UI.user_error!("You can't use option '#{value.short_option}' along with '-o'")
-                                       end)
-        ]
+      describe "deprecation", focus: true do
+        it "deprecated changes the description" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     description: 'foo',
+                                                     deprecated: 'replaced by bar')
+          expect(config_item.description).to eq("[DEPRECATED!] replaced by bar - foo")
+        end
 
-        values = {
-            foo: "",
-            bar: ""
-        }
+        it "deprecated makes it optional" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     description: 'foo',
+                                                     deprecated: 'replaced by bar')
+          expect(config_item.optional).to eq(true)
+        end
 
-        expect do
-          FastlaneCore::Configuration.create(conflicting_options, values)
-        end.to raise_error "You can't use option '-b' along with '-f'"
+        it "raises an exception if a deprecated option is not optional" do
+          expect do
+            config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                       description: 'foo',
+                                                       optional: false,
+                                                       deprecated: 'replaced by bar')
+          end.to raise_error
+        end
+
+        it "doesn't display a deprecation message when loading a config if a deprecated option doesn't have a value" do
+          c = FastlaneCore::ConfigItem.new(key: :foo,
+                                           description: 'foo',
+                                           deprecated: 'replaced by bar')
+          values = {
+            foo: "something"
+          }
+          expect(FastlaneCore::UI).to receive(:deprecated).with("Using deprecated option: '--foo' (replaced by bar)")
+          config = FastlaneCore::Configuration.create([c], values)
+        end
+
+        it "displays a deprecation message when loading a config if a deprecated option has a value" do
+          c = FastlaneCore::ConfigItem.new(key: :foo,
+                                           description: 'foo',
+                                           deprecated: 'replaced by bar')
+
+          expect(FastlaneCore::UI).not_to receive(:deprecated)
+          config = FastlaneCore::Configuration.create([c], {})
+        end
       end
 
-      it "raises an error for unresolved conflict between options" do
-        conflicting_options = [
-          FastlaneCore::ConfigItem.new(key: :foo,
-                                       short_option: "-f",
-                                       conflicting_options: [:bar, :oof]),
-          FastlaneCore::ConfigItem.new(key: :bar,
-                                       short_option: "-b"),
-          FastlaneCore::ConfigItem.new(key: :oof,
-                                       short_option: "-o")
-        ]
+      describe "misc features" do
+        it "makes it non optional by default" do
+          c = FastlaneCore::ConfigItem.new(key: :test,
+                                 default_value: '123')
+          expect(c.optional).to eq(false)
+        end
 
-        values = {
-            foo: "",
-            bar: ""
-        }
+        it "supports options without 'env_name'" do
+          c = FastlaneCore::ConfigItem.new(key: :test,
+                                 default_value: '123')
+          config = FastlaneCore::Configuration.create([c], {})
+          expect(config.values[:test]).to eq('123')
+        end
 
-        expect do
-          FastlaneCore::Configuration.create(conflicting_options, values)
-        end.to raise_error "Unresolved conflict between options: 'foo' and 'bar'"
-      end
+        it "takes the values frmo the environment if available" do
+          c = FastlaneCore::ConfigItem.new(key: :test,
+                                      env_name: "FL_TEST")
+          config = FastlaneCore::Configuration.create([c], {})
+          ENV["FL_TEST"] = "123value"
+          expect(config.values[:test]).to eq('123value')
+          ENV.delete("FL_TEST")
+        end
 
-      it "calls custom conflict handler when conflict happens between two options" do
-        conflicting_options = [
-          FastlaneCore::ConfigItem.new(key: :foo,
-                                       short_option: "-f",
-                                       conflicting_options: [:bar, :oof],
-                                       conflict_block: proc do |value|
-                                         UI.user_error!("You can't use option '#{value.short_option}' along with '-f'")
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :bar,
-                                       short_option: "-b"),
-          FastlaneCore::ConfigItem.new(key: :oof,
-                                       short_option: "-o",
-                                       conflict_block: proc do |value|
-                                         UI.user_error!("You can't use option '#{value.short_option}' along with '-o'")
-                                       end)
-        ]
-
-        values = {
-            foo: "",
-            bar: ""
-        }
-
-        expect do
-          FastlaneCore::Configuration.create(conflicting_options, values)
-        end.to raise_error "You can't use option '-b' along with '-f'"
-      end
-
-      it "sets the data type correctly if `is_string` is not set but type is specified" do
-        config_item = FastlaneCore::ConfigItem.new(key: :foo,
-                                                   short_option: '-f',
-                                                   description: 'foo',
-                                                   type: Array)
-
-        expect(config_item.data_type).to eq(Array)
-      end
-
-      it "sets the data type correctly if `is_string` is set but the type is specified" do
-        config_item = FastlaneCore::ConfigItem.new(key: :foo,
-                                                   short_option: '-f',
-                                                   description: 'foo',
-                                                   is_string: true,
-                                                   type: Array)
-
-        expect(config_item.data_type).to eq(Array)
-      end
-
-      it "sets the data type correctly if `is_string` is set but the type is not specified" do
-        config_item = FastlaneCore::ConfigItem.new(key: :foo,
-                                                   short_option: '-f',
-                                                   description: 'foo',
-                                                   is_string: true)
-
-        expect(config_item.data_type).to eq(String)
-      end
-
-      it "returns Array default values correctly" do
-        config_item = FastlaneCore::ConfigItem.new(key: :foo,
-                                                   short_option: '-f',
-                                                   description: 'foo',
-                                                   type: Array,
-                                                   optional: true,
-                                                   default_value: ['5', '4', '3', '2', '1'])
-        config = FastlaneCore::Configuration.create([config_item], {})
-
-        expect(config[:foo]).to eq(['5', '4', '3', '2', '1'])
-      end
-
-      it "returns Array input values correctly" do
-        config_item = FastlaneCore::ConfigItem.new(key: :foo,
-                                                   short_option: '-f',
-                                                   description: 'foo',
-                                                   type: Array)
-        config = FastlaneCore::Configuration.create([config_item], { foo: ['5', '4', '3', '2', '1'] })
-
-        expect(config[:foo]).to eq(['5', '4', '3', '2', '1'])
-      end
-
-      it "returns Array environment variable values correctly" do
-        ENV["FOO"] = '5,4,3,2,1'
-        config_item = FastlaneCore::ConfigItem.new(key: :foo,
-                                                   short_option: '-f',
-                                                   description: 'foo',
-                                                   env_name: 'FOO',
-                                                   type: Array)
-        config = FastlaneCore::Configuration.create([config_item], {})
-
-        expect(config[:foo]).to eq(['5', '4', '3', '2', '1'])
-        ENV.delete("FOO")
-      end
-
-      it "auto converts string values to Integers" do
-        config_item = FastlaneCore::ConfigItem.new(key: :foo,
-                                                   short_option: '-f',
-                                                   description: 'foo',
-                                                   type: Integer)
-
-        value = config_item.auto_convert_value('987')
-
-        expect(value).to eq(987)
-      end
-
-      it "auto converts string values to Floats" do
-        config_item = FastlaneCore::ConfigItem.new(key: :foo,
-                                                   short_option: '-f',
-                                                   description: 'foo',
-                                                   type: Float)
-
-        value = config_item.auto_convert_value('9.91')
-
-        expect(value).to eq(9.91)
-      end
-
-      it "raises an exception if the data type is not as expected" do
-        config_item = FastlaneCore::ConfigItem.new(key: :foo,
-                                                   short_option: '-f',
-                                                   description: 'foo',
-                                                   type: Float)
-
-        expect do
-          config_item.valid?('ABC')
-        end.to raise_error
-      end
-
-      it "verifies the default value as well" do
-        c = FastlaneCore::ConfigItem.new(key: :output,
-                                  env_name: "SIGH_OUTPUT_PATH",
-                               description: "Directory in which the profile should be stored",
-                             default_value: "notExistent",
-                              verify_block: proc do |value|
-                                UI.user_error!("Could not find output directory '#{value}'")
-                              end)
-        expect do
-          @config = FastlaneCore::Configuration.create([c], {})
-        end.to raise_error "Invalid default value for output, doesn't match verify_block"
-      end
-
-      it "supports options without 'env_name'" do
-        c = FastlaneCore::ConfigItem.new(key: :test,
-                               default_value: '123')
-        config = FastlaneCore::Configuration.create([c], {})
-        expect(config.values[:test]).to eq('123')
-      end
-
-      it "takes the values frmo the environment if available" do
-        c = FastlaneCore::ConfigItem.new(key: :test,
-                                    env_name: "FL_TEST")
-        config = FastlaneCore::Configuration.create([c], {})
-        ENV["FL_TEST"] = "123value"
-        expect(config.values[:test]).to eq('123value')
-        ENV.delete("FL_TEST")
-      end
-
-      it "supports modifying the value after taken from the environment" do
-        c = FastlaneCore::ConfigItem.new(key: :test,
-                                    env_name: "FL_TEST")
-        config = FastlaneCore::Configuration.create([c], {})
-        ENV["FL_TEST"] = "123value"
-        config.values[:test].gsub!("123", "456")
-        expect(config.values[:test]).to eq('456value')
-        ENV.delete("FL_TEST")
-      end
-
-      it "auto converts booleans as strings to booleans" do
-        c = [
-          FastlaneCore::ConfigItem.new(key: :true_value),
-          FastlaneCore::ConfigItem.new(key: :true_value2),
-          FastlaneCore::ConfigItem.new(key: :false_value),
-          FastlaneCore::ConfigItem.new(key: :false_value2)
-        ]
-        config = FastlaneCore::Configuration.create(c, {
-          true_value: "true",
-          true_value2: "YES",
-          false_value: "false",
-          false_value2: "NO"
-        })
-
-        expect(config[:true_value]).to eq(true)
-        expect(config[:true_value2]).to eq(true)
-        expect(config[:false_value]).to eq(false)
-        expect(config[:false_value2]).to eq(false)
+        it "supports modifying the value after taken from the environment" do
+          c = FastlaneCore::ConfigItem.new(key: :test,
+                                      env_name: "FL_TEST")
+          config = FastlaneCore::Configuration.create([c], {})
+          ENV["FL_TEST"] = "123value"
+          config.values[:test].gsub!("123", "456")
+          expect(config.values[:test]).to eq('456value')
+          ENV.delete("FL_TEST")
+        end
       end
 
       describe "Automatically removes the --verbose flag" do

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -37,18 +37,17 @@ module Supply
                                      env_name: "SUPPLY_KEY",
                                      short_option: "-k",
                                      conflicting_options: [:json_key],
-                                     optional: true, # deprecated
+                                     deprecated: 'Use --json_key instead',
                                      description: "The p12 File used to authenticate with Google",
                                      default_value: Dir["*.p12"].first || CredentialsManager::AppfileConfig.try_fetch_value(:keyfile),
                                      verify_block: proc do |value|
-                                       UI.important("DEPRECATED --key OPTION. Use --json_key instead")
                                        UI.user_error! "Could not find p12 file at path '#{File.expand_path(value)}'" unless File.exist?(File.expand_path(value))
                                      end),
         FastlaneCore::ConfigItem.new(key: :issuer,
                                      env_name: "SUPPLY_ISSUER",
                                      short_option: "-i",
                                      conflicting_options: [:json_key],
-                                     optional: true, # deprecated
+                                     deprecated: 'Use --json_key instead',
                                      description: "The issuer of the p12 file (email address of the service account)",
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:issuer),
                                      verify_block: proc do |value|


### PR DESCRIPTION
I experimented with automatically fetching the stack using `caller`,
but I am not 100% comfortable with it yet and would prefer
discussing the overall idea before spending more time into it.

![image](https://cloud.githubusercontent.com/assets/24282/13721208/06efaa16-e81f-11e5-9d28-0b03256c78e4.png)

The main reason for not trying to introduce method extracting was:
- meta programming and caller interaction. Not really sure about the consequences
- I could see cases where it wouldn't work properly, so it would require a way to disable it, making the API too complex from my PoV

Obviously another colour might be preferable ;) :rainbow: 

I can also retrofit the previous messages in #3686

```
 git grep "Helper.log" | grep deprecated
lib/fastlane/actions/oclint.rb:          Helper.log.warn "'select_reqex' paramter is deprecated. Please use 'select_regex' instead.".yellow
lib/fastlane/actions/oclint.rb:          Helper.log.warn "It's recommended to use 'thresholds' instead of deprecated 'rc' parameter".yellow
lib/fastlane/helper/git_helper.rb:      Helper.log.warn '`last_git_commit` is deprecated. Please use `last_git_commit_message` instead.'.red
```

And here it is with config_item:

![image](https://cloud.githubusercontent.com/assets/24282/13728356/14be58ca-e916-11e5-9b8f-d6a82a0a7270.png)

One thing I think could be improved:
- the name of the `deprecated` field in config_item sounds like a bool not a String
