### PR TITLE
Add the ability to fetch promocodes

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -457,6 +457,18 @@ module Spaceship
         client.release!(self.application.apple_id, self.version_id)
       end
 
+      #####################################################
+      # @!group Promo codes
+      #####################################################
+      def generate_promocodes!(quantity)
+        data = client.generate_app_version_promocodes!(
+          app_id: self.application.apple_id,
+          version_id: self.version_id,
+          quantity: quantity
+        )
+        Tunes::AppVersionGeneratedPromocodes.factory(data)
+      end
+
       # These methods takes care of properly parsing values that
       # are not returned in the right format, e.g. boolean as string
       def release_on_approval

--- a/spaceship/lib/spaceship/tunes/app_version_generated_promocodes.rb
+++ b/spaceship/lib/spaceship/tunes/app_version_generated_promocodes.rb
@@ -1,0 +1,35 @@
+module Spaceship
+  module Tunes
+    # Represents the information about the generation of promocodes
+    class AppVersionGeneratedPromocodes < TunesBase
+      # @return
+      attr_reader :effective_date
+      attr_reader :expiration_date
+      attr_reader :username
+      # the AppVersionPromocodes this relates to
+      attr_reader :version
+      # Array of String
+      attr_reader :codes
+
+      attr_mapping({
+        'effectiveDate' => :effective_date,
+        'expirationDate' => :expiration_date,
+        'username' => :username
+      })
+
+      class << self
+        # Create a new object based on a hash.
+        # This is used to create a new object based on the server response.
+        def factory(attrs)
+          obj = self.new(attrs)
+          return obj
+        end
+      end
+
+      def setup
+        @version = Tunes::AppVersionPromocodes.factory(raw_data['version'])
+        @codes = raw_data['codes']
+      end
+    end
+  end
+end

--- a/spaceship/lib/spaceship/tunes/app_version_promocodes.rb
+++ b/spaceship/lib/spaceship/tunes/app_version_promocodes.rb
@@ -1,0 +1,34 @@
+module Spaceship
+  module Tunes
+    # Represents the information about remaining number of promo codes for an app version
+    class AppVersionPromocodes < TunesBase
+      # @return
+      attr_reader :app_id
+      attr_reader :app_name
+      attr_reader :version
+      attr_reader :platform
+      attr_reader :number_of_codes
+      attr_reader :maximum_number_of_codes
+      attr_reader :contract_file_name
+
+      attr_mapping({
+        'id' => :app_id,
+        'appName' => :app_name,
+        'version' => :version,
+        'platform' => :platform,
+        'numberOfCodes' => :number_of_codes,
+        'maximumNumberOfCodes' => :maximum_number_of_codes,
+        'contractFileName' => :contract_file_name
+      })
+
+      class << self
+        # Create a new object based on a hash.
+        # This is used to create a new object based on the server response.
+        def factory(attrs)
+          obj = self.new(attrs)
+          return obj
+        end
+      end
+    end
+  end
+end

--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -376,6 +376,23 @@ module Spaceship
         tester.remove_from_app!(self.apple_id)
       end
 
+      #####################################################
+      # @!group Promo codes
+      #####################################################
+      def promocodes
+        data = client.app_promocodes(app_id: self.apple_id)
+        data.map do |attrs|
+          Tunes::AppVersionPromocodes.factory(attrs)
+        end
+      end
+
+      def promocodes_history
+        data = client.app_promocodes_history(app_id: self.apple_id)
+        data.map do |attrs|
+          Tunes::AppVersionGeneratedPromocodes.factory(attrs)
+        end
+      end
+
       # private to module
       def ensure_not_a_bundle
         # we only support applications

--- a/spaceship/lib/spaceship/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/tunes/tunes.rb
@@ -24,6 +24,9 @@ require 'spaceship/tunes/tester'
 require 'spaceship/tunes/app_details'
 require 'spaceship/tunes/pricing_tier'
 
+require 'spaceship/tunes/app_version_promocodes'
+require 'spaceship/tunes/app_version_generated_promocodes'
+
 # File Uploads
 require 'spaceship/du/utilities'
 require 'spaceship/du/upload_file'

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -864,6 +864,33 @@ module Spaceship
       parse_response(r, 'data')
     end
 
+    #####################################################
+    # @!group Promo codes
+    #####################################################
+    def app_promocodes(app_id: nil)
+      r = request(:get, "ra/apps/#{app_id}/promocodes/versions")
+      parse_response(r, 'data')['versions']
+    end
+
+    def generate_app_version_promocodes!(app_id: nil, version_id: nil, quantity: nil)
+      data = {
+        numberOfCodes: { value: quantity },
+        agreedToContract: { value: true }
+      }
+      url = "ra/apps/#{app_id}/promocodes/versions/#{version_id}"
+      r = request(:post) do |req|
+        req.url url
+        req.body = data.to_json
+        req.headers['Content-Type'] = 'application/json'
+      end
+      parse_response(r, 'data')
+    end
+
+    def app_promocodes_history(app_id: nil)
+      r = request(:get, "ra/apps/#{app_id}/promocodes/history")
+      parse_response(r, 'data')['requests']
+    end
+
     private
 
     def with_tunes_retry(tries = 5, &_block)

--- a/spaceship/spec/tunes/app_version_spec.rb
+++ b/spaceship/spec/tunes/app_version_spec.rb
@@ -589,4 +589,28 @@ describe Spaceship::AppVersion, all: true do
       # end
     end
   end
+
+  describe "Modifying the app live version" do
+    let(:version) { Spaceship::Application.all.first.live_version }
+
+    describe "Generate promo codes", focus: true do
+      it "fetches remaining promocodes" do
+        promocodes = version.generate_promocodes!(1)
+
+        expect(promocodes.effective_date).to eq(1457864552300)
+        expect(promocodes.expiration_date).to eq(1460283752300)
+        expect(promocodes.username).to eq('joe@wewanttoknow.com')
+
+        expect(promocodes.codes.count).to eq(1)
+        expect(promocodes.codes[0]).to eq('6J49JFRPTXXXX')
+        expect(promocodes.version.app_id).to eq(816549081)
+        expect(promocodes.version.app_name).to eq('DragonBox Numbers')
+        expect(promocodes.version.version).to eq('1.5.0')
+        expect(promocodes.version.platform).to eq('ios')
+        expect(promocodes.version.number_of_codes).to eq(3)
+        expect(promocodes.version.maximum_number_of_codes).to eq(100)
+        expect(promocodes.version.contract_file_name).to eq('promoCodes/ios/spqr5/PromoCodeHolderTermsDisplay_en_us.html')
+      end
+    end
+  end
 end

--- a/spaceship/spec/tunes/application_spec.rb
+++ b/spaceship/spec/tunes/application_spec.rb
@@ -178,7 +178,7 @@ describe Spaceship::Application do
         end
       end
 
-      describe "BUNDLES", focus: true do
+      describe "BUNDLES" do
         let (:bundle) { Spaceship::Application.find(928_444_013) }
         it "can find a bundle" do
           expect(bundle.raw_data['type']).to eq("iOS App Bundle")
@@ -207,7 +207,7 @@ describe Spaceship::Application do
       end
     end
 
-    describe "Version history", focus: true do
+    describe "Version history" do
       it "Parses history" do
         app = Spaceship::Application.all.first
         history = app.versions_history
@@ -234,6 +234,43 @@ describe Spaceship::Application do
         expect(v.items[3].user_name).to eq("Apple")
         expect(v.items[3].user_email).to eq(nil)
         expect(v.items[3].date).to eq(1_450_461_891_000)
+      end
+    end
+
+    describe "Promo codes" do
+      let(:app) { Spaceship::Application.all.first }
+
+      it "fetches remaining promocodes" do
+        promocodes = app.promocodes
+        expect(promocodes.count).to eq(1)
+        expect(promocodes[0].app_id).to eq(816549081)
+        expect(promocodes[0].app_name).to eq('DragonBox Numbers')
+        expect(promocodes[0].version).to eq('1.5.0')
+        expect(promocodes[0].platform).to eq('ios')
+        expect(promocodes[0].number_of_codes).to eq(2)
+        expect(promocodes[0].maximum_number_of_codes).to eq(100)
+        expect(promocodes[0].contract_file_name).to eq('promoCodes/ios/spqr5/PromoCodeHolderTermsDisplay_en_us.html')
+      end
+
+      it "fetches promocodes history", focus: true do
+        promocodes = app.promocodes_history
+        expect(promocodes.count).to eq(7)
+
+        promocodes = promocodes[4]
+
+        expect(promocodes.effective_date).to eq(1457864552000)
+        expect(promocodes.expiration_date).to eq(1460283752000)
+        expect(promocodes.username).to eq('joe@wewanttoknow.com')
+
+        expect(promocodes.codes.count).to eq(1)
+        expect(promocodes.codes[0]).to eq('6J49JFRP----')
+        expect(promocodes.version.app_id).to eq(816549081)
+        expect(promocodes.version.app_name).to eq('DragonBox Numbers')
+        expect(promocodes.version.version).to eq('1.5.0')
+        expect(promocodes.version.platform).to eq('ios')
+        expect(promocodes.version.number_of_codes).to eq(7)
+        expect(promocodes.version.maximum_number_of_codes).to eq(100)
+        expect(promocodes.version.contract_file_name).to eq('promoCodes/ios/spqr5/PromoCodeHolderTermsDisplay_en_us.html')
       end
     end
   end

--- a/spaceship/spec/tunes/fixtures/promocodes.json
+++ b/spaceship/spec/tunes/fixtures/promocodes.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "versions": [{
+      "id": 816549081,
+      "appName": "DragonBox Numbers",
+      "version": "1.5.0",
+      "platform": "ios",
+      "numberOfCodes": 2,
+      "maximumNumberOfCodes": 100,
+      "contractFileName": "promoCodes/ios/spqr5/PromoCodeHolderTermsDisplay_en_us.html"
+    }]
+  },
+  "messages": {
+    "warn": null,
+    "error": null,
+    "info": null
+  },
+  "statusCode": "SUCCESS"
+}

--- a/spaceship/spec/tunes/fixtures/promocodes_generated.json
+++ b/spaceship/spec/tunes/fixtures/promocodes_generated.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "effectiveDate": 1457864552300,
+    "expirationDate": 1460283752300,
+    "username": "joe@wewanttoknow.com",
+    "version": {
+      "id": 816549081,
+      "appName": "DragonBox Numbers",
+      "version": "1.5.0",
+      "platform": "ios",
+      "numberOfCodes": 3,
+      "maximumNumberOfCodes": 100,
+      "contractFileName": "promoCodes/ios/spqr5/PromoCodeHolderTermsDisplay_en_us.html"
+    },
+    "codes": ["6J49JFRPTXXXX"]
+  },
+  "messages": {
+    "warn": null,
+    "error": null,
+    "info": null
+  },
+  "statusCode": "SUCCESS"
+}

--- a/spaceship/spec/tunes/fixtures/promocodes_history.json
+++ b/spaceship/spec/tunes/fixtures/promocodes_history.json
@@ -1,0 +1,109 @@
+{
+  "data": {
+    "requests": [{
+      "effectiveDate": 1457900260000,
+      "expirationDate": 1460319460000,
+      "username": "joe@wewanttoknow.com",
+      "version": {
+        "id": 816549081,
+        "appName": "DragonBox Numbers",
+        "version": "1.5.0",
+        "platform": "ios",
+        "numberOfCodes": 7,
+        "maximumNumberOfCodes": 100,
+        "contractFileName": "promoCodes/ios/spqr5/PromoCodeHolderTermsDisplay_en_us.html"
+      },
+      "codes": ["HM9Y9L49----"]
+    }, {
+      "effectiveDate": 1457900138000,
+      "expirationDate": 1460319338000,
+      "username": "joe@wewanttoknow.com",
+      "version": {
+        "id": 816549081,
+        "appName": "DragonBox Numbers",
+        "version": "1.5.0",
+        "platform": "ios",
+        "numberOfCodes": 7,
+        "maximumNumberOfCodes": 100,
+        "contractFileName": "promoCodes/ios/spqr5/PromoCodeHolderTermsDisplay_en_us.html"
+      },
+      "codes": ["3RXKMT34----"]
+    }, {
+      "effectiveDate": 1457872654000,
+      "expirationDate": 1460291854000,
+      "username": "joe@wewanttoknow.com",
+      "version": {
+        "id": 816549081,
+        "appName": "DragonBox Numbers",
+        "version": "1.5.0",
+        "platform": "ios",
+        "numberOfCodes": 7,
+        "maximumNumberOfCodes": 100,
+        "contractFileName": "promoCodes/ios/spqr5/PromoCodeHolderTermsDisplay_en_us.html"
+      },
+      "codes": ["TX6LL69M----"]
+    }, {
+      "effectiveDate": 1457871731000,
+      "expirationDate": 1460290931000,
+      "username": "joe@wewanttoknow.com",
+      "version": {
+        "id": 816549081,
+        "appName": "DragonBox Numbers",
+        "version": "1.5.0",
+        "platform": "ios",
+        "numberOfCodes": 7,
+        "maximumNumberOfCodes": 100,
+        "contractFileName": "promoCodes/ios/spqr5/PromoCodeHolderTermsDisplay_en_us.html"
+      },
+      "codes": ["74FTKEAM----"]
+    }, {
+      "effectiveDate": 1457864552000,
+      "expirationDate": 1460283752000,
+      "username": "joe@wewanttoknow.com",
+      "version": {
+        "id": 816549081,
+        "appName": "DragonBox Numbers",
+        "version": "1.5.0",
+        "platform": "ios",
+        "numberOfCodes": 7,
+        "maximumNumberOfCodes": 100,
+        "contractFileName": "promoCodes/ios/spqr5/PromoCodeHolderTermsDisplay_en_us.html"
+      },
+      "codes": ["6J49JFRP----"]
+    }, {
+      "effectiveDate": 1457703322000,
+      "expirationDate": 1460118922000,
+      "username": "c.steen@wewanttoknow.com",
+      "version": {
+        "id": 816549081,
+        "appName": "DragonBox Numbers",
+        "version": "1.5.0",
+        "platform": "ios",
+        "numberOfCodes": 7,
+        "maximumNumberOfCodes": 100,
+        "contractFileName": "promoCodes/ios/spqr5/PromoCodeHolderTermsDisplay_en_us.html"
+      },
+      "codes": ["7P4Y3NAL----"]
+    }, {
+      "effectiveDate": 1457459346000,
+      "expirationDate": 1459874946000,
+      "username": "joe@wewanttoknow.com",
+      "version": {
+        "id": 816549081,
+        "appName": "DragonBox Numbers",
+        "version": "1.5.0",
+        "platform": "ios",
+        "numberOfCodes": 7,
+        "maximumNumberOfCodes": 100,
+        "contractFileName": "promoCodes/ios/spqr5/PromoCodeHolderTermsDisplay_en_us.html"
+      },
+      "codes": ["RN3R77TW----"]
+    }]
+  },
+  "messages": {
+    "warn": null,
+    "error": null,
+    "info": null
+  },
+  "statusCode": "SUCCESS"
+}

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -226,6 +226,24 @@ def itc_stub_release_to_store
               headers: { "Content-Type" => "application/json" })
 end
 
+def itc_stub_promocodes
+  stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/promocodes/versions").
+    to_return(status: 200, body: itc_read_fixture_file("promocodes.json"),
+              headers: { "Content-Type" => "application/json" })
+end
+
+def itc_stub_generate_promocodes
+  stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/promocodes/versions/812106519").
+    to_return(status: 200, body: itc_read_fixture_file("promocodes_generated.json"),
+              headers: { "Content-Type" => "application/json" })
+end
+
+def itc_stub_promocodes_history
+  stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/promocodes/history").
+    to_return(status: 200, body: itc_read_fixture_file("promocodes_history.json"),
+              headers: { "Content-Type" => "application/json" })
+end
+
 WebMock.disable_net_connect!
 
 RSpec.configure do |config|
@@ -241,5 +259,8 @@ RSpec.configure do |config|
     itc_stub_candiate_builds
     itc_stub_pricing_tiers
     itc_stub_release_to_store
+    itc_stub_promocodes
+    itc_stub_generate_promocodes
+    itc_stub_promocodes_history
   end
 end


### PR DESCRIPTION
I'll see if I can revive the `codes` CLI tool later on. 

**update**: here it goes https://github.com/fastlane/codes/pull/29

Note the fun part:

```
generated.expiration_date
 => 1460291854022 
Time.at(generated.expiration_date/1000)
 => 2016-04-10 14:37:34 +0200 
```

Millisecond precision :)
