### PR TITLE
Restore the lost raise when test_all parts fail

### DIFF
--- a/rakelib/test_all.rake
+++ b/rakelib/test_all.rake
@@ -121,5 +121,6 @@ task :test_all do
   else
     box "Exceptions 💣"
     puts "\n" + exceptions.map(&:red).join("\n")
+    raise "All tests did not complete successfully".red
   end
 end


### PR DESCRIPTION
There used to be a `raise` here before we refactored this code to present better messaging. Without the `raise`, the rake task will pass even if the tests fail, which is a clear #youhadonejob violation.
