### PR TITLE
Check for highest_installed_gems in update_action

### DIFF
--- a/fastlane/lib/fastlane/actions/update_fastlane.rb
+++ b/fastlane/lib/fastlane/actions/update_fastlane.rb
@@ -55,6 +55,15 @@ module Fastlane
           return
         end
 
+        if updater.respond_to? :highest_installed_gems
+          UI.important "The update_fastlane action requires rubygems version 2.1.0 or greater."
+          UI.important "Please update your version of ruby gems before proceeding."
+          UI.command "gem install rubygems-update"
+          UI.command "update_rubygems"
+          UI.command "gem update --system"
+          return
+        end
+
         highest_versions = updater.highest_installed_gems.keep_if { |key| tools_to_update.include? key }
         update_needed = updater.which_to_update(highest_versions, tools_to_update)
 


### PR DESCRIPTION
The `highest_installed_gems` was introduced in version `2.1.0` of `rubygems` so if you are using a version older than that an exception will be raised when running the `update_fastlane` action. This checks to make sure you can call that method and logs a warning instead of crashing.
