### PR TITLE
Added a flag to support a single sampling of iTunes Connect status

### DIFF
--- a/watchbuild/lib/watchbuild/options.rb
+++ b/watchbuild/lib/watchbuild/options.rb
@@ -17,7 +17,11 @@ module WatchBuild
                                      short_option: "-u",
                                      env_name: "FASTLANE_USER",
                                      description: "Your Apple ID Username",
-                                     default_value: user)
+                                     default_value: user),
+        FastlaneCore::ConfigItem.new(key: :sample_only_once,
+                                     description: "Only check for the build once, instead of waiting for it to process",
+                                     is_string: false,
+                                     default_value: false)
       ]
     end
   end

--- a/watchbuild/lib/watchbuild/runner.rb
+++ b/watchbuild/lib/watchbuild/runner.rb
@@ -44,13 +44,22 @@ module WatchBuild
           Helper.log.error ex
           Helper.log.info "Something failed... trying again to recover"
         end
-        sleep 30
+        if WatchBuild.config[:sample_only_once] == false
+          sleep 30
+        else
+          break
+        end
       end
       nil
     end
 
     def notification(build, minutes)
       require 'terminal-notifier'
+
+      if build.nil?
+        Helper.log.info "Application build is still processing"
+        return
+      end
 
       url = "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/#{@app.apple_id}/activity/ios/builds/#{build.train_version}/#{build.build_version}/details"
       TerminalNotifier.notify("Build finished processing",


### PR DESCRIPTION
In order to avoid hanging of the script, the pull request allow u to use `--sample_only_once` flag and `watchbuild` will sample iTunes Connect only once.
The previous behaviour (without the new flag) stay cool as it was :-}
