### PR TITLE
Replace raise with UI.crash calls

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -31,12 +31,12 @@ module Deliver
                                      description: "Path to your ipa file",
                                      default_value: Dir["*.ipa"].first,
                                      verify_block: proc do |value|
-                                       raise "Could not find ipa file at path '#{value}'".red unless File.exist?(value)
-                                       raise "'#{value}' doesn't seem to be an ipa file".red unless value.end_with?(".ipa")
+                                       UI.crash!("Could not find ipa file at path '#{value}'") unless File.exist?(value)
+                                       UI.crash!("'#{value}' doesn't seem to be an ipa file") unless value.end_with?(".ipa")
                                      end,
                                      conflicting_options: [:pkg],
                                      conflict_block: proc do |value|
-                                       raise "You can't use 'ipa' and '#{value.key}' options in one run.".red
+                                       UI.crash!("You can't use 'ipa' and '#{value.key}' options in one run.")
                                      end),
         FastlaneCore::ConfigItem.new(key: :pkg,
                                      short_option: "-c",
@@ -45,12 +45,12 @@ module Deliver
                                      description: "Path to your pkg file",
                                      default_value: Dir["*.pkg"].first,
                                      verify_block: proc do |value|
-                                       raise "Could not find pkg file at path '#{value}'".red unless File.exist?(value)
-                                       raise "'#{value}' doesn't seem to be a pkg file".red unless value.end_with?(".pkg")
+                                       UI.crash!("Could not find pkg file at path '#{value}'") unless File.exist?(value)
+                                       UI.crash!("'#{value}' doesn't seem to be a pkg file") unless value.end_with?(".pkg")
                                      end,
                                      conflicting_options: [:ipa],
                                      conflict_block: proc do |value|
-                                       raise "You can't use 'pkg' and '#{value.key}' options in one run.".red
+                                       UI.crash!("You can't use 'pkg' and '#{value.key}' options in one run.")
                                      end),
         FastlaneCore::ConfigItem.new(key: :metadata_path,
                                      short_option: '-m',
@@ -100,7 +100,7 @@ module Deliver
                                      optional: true,
                                      conflicting_options: [:ipa, :pkg],
                                      conflict_block: proc do |value|
-                                       raise "You can't use 'build_number' and '#{value.key}' options in one run.".red
+                                       UI.crash!("You can't use 'build_number' and '#{value.key}' options in one run.")
                                      end),
         FastlaneCore::ConfigItem.new(key: :app_rating_config_path,
                                      short_option: "-g",
@@ -108,8 +108,8 @@ module Deliver
                                      is_string: true,
                                      optional: true,
                                      verify_block: proc do |value|
-                                       raise "Could not find config file at path '#{value}'".red unless File.exist?(value)
-                                       raise "'#{value}' doesn't seem to be a JSON file".red unless value.end_with?(".json")
+                                       UI.crash!("Could not find config file at path '#{value}'") unless File.exist?(value)
+                                       UI.crash!("'#{value}' doesn't seem to be a JSON file") unless value.end_with?(".json")
                                      end),
         FastlaneCore::ConfigItem.new(key: :submission_information,
                                      short_option: "-b",
@@ -143,16 +143,16 @@ module Deliver
                                      optional: true,
                                      short_option: "-l",
                                      verify_block: proc do |value|
-                                       raise "Could not find png file at path '#{value}'".red unless File.exist?(value)
-                                       raise "'#{value}' doesn't seem to be a png file".red unless value.end_with?(".png")
+                                       UI.crash!("Could not find png file at path '#{value}'") unless File.exist?(value)
+                                       UI.crash!("'#{value}' doesn't seem to be a png file") unless value.end_with?(".png")
                                      end),
         FastlaneCore::ConfigItem.new(key: :apple_watch_app_icon,
                                      description: "Metadata: The path to the Apple Watch app icon",
                                      optional: true,
                                      short_option: "-q",
                                      verify_block: proc do |value|
-                                       raise "Could not find png file at path '#{value}'".red unless File.exist?(value)
-                                       raise "'#{value}' doesn't seem to be a png file".red unless value.end_with?(".png")
+                                       UI.crash!("Could not find png file at path '#{value}'") unless File.exist?(value)
+                                       UI.crash!("'#{value}' doesn't seem to be a png file") unless value.end_with?(".png")
                                      end),
         FastlaneCore::ConfigItem.new(key: :copyright,
                                      description: "Metadata: The copyright notice",

--- a/fastlane/lib/assets/custom_action_template.rb
+++ b/fastlane/lib/assets/custom_action_template.rb
@@ -43,8 +43,8 @@ module Fastlane
                                        env_name: "FL_[[NAME_UP]]_API_TOKEN", # The name of the environment variable
                                        description: "API Token for [[NAME_CLASS]]", # a short description of this parameter
                                        verify_block: proc do |value|
-                                          raise "No API token for [[NAME_CLASS]] given, pass using `api_token: 'token'`".red unless (value and not value.empty?)
-                                          # raise "Couldn't find file at path '#{value}'".red unless File.exist?(value)
+                                          UI.crash!("No API token for [[NAME_CLASS]] given, pass using `api_token: 'token'`") unless (value and not value.empty?)
+                                          # UI.crash!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :development,
                                        env_name: "FL_[[NAME_UP]]_DEVELOPMENT",

--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -53,7 +53,7 @@ module Fastlane
       #
       #  [:ios, :mac].include?(platform)
       #
-      raise "Implementing `is_supported?` for all actions is mandatory. Please update #{self}".red
+      UI.crash!("Implementing `is_supported?` for all actions is mandatory. Please update #{self}")
     end
 
     # Is printed out in the Steps: output in the terminal

--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -25,7 +25,7 @@ module Fastlane
     #   This might be nil, in which case the step is not printed out to the terminal
     def self.execute_action(step_name)
       start = Time.now # before the raise block, since `start` is required in the ensure block
-      raise 'No block given'.red unless block_given?
+      UI.crash!('No block given') unless block_given?
 
       error = nil
       exc = nil

--- a/fastlane/lib/fastlane/actions/appaloosa.rb
+++ b/fastlane/lib/fastlane/actions/appaloosa.rb
@@ -180,7 +180,7 @@ module Fastlane
                                        description: 'Binary path. Optional for ipa if you use the `ipa` or `xcodebuild` action',
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        verify_block: proc do |value|
-                                         raise "Couldn't find ipa || apk file at path '#{value}'".red unless File.exist?(value)
+                                         UI.crash!("Couldn't find ipa || apk file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_token,
                                        env_name: 'FL_APPALOOSA_API_TOKEN',

--- a/fastlane/lib/fastlane/actions/appetize.rb
+++ b/fastlane/lib/fastlane/actions/appetize.rb
@@ -34,7 +34,7 @@ module Fastlane
         req.body = JSON.generate(params)
         response = https.request(req)
 
-        raise 'Error when trying to upload ipa to Appetize.io'.red unless parse_response(response)
+        UI.crash!('Error when trying to upload ipa to Appetize.io') unless parse_response(response)
         UI.message("App URL: #{Actions.lane_context[SharedValues::APPETIZE_APP_URL]}")
         UI.message("Manage URL: #{Actions.lane_context[SharedValues::APPETIZE_MANAGE_URL]}")
         UI.message("App Private Key: #{Actions.lane_context[SharedValues::APPETIZE_PRIVATE_KEY]}")
@@ -83,14 +83,14 @@ module Fastlane
                                       description: "Appetize.io API Token",
                                       is_string: true,
                                       verify_block: proc do |value|
-                                        raise "No API Token for Appetize.io given, pass using `api_token: 'token'`".red unless value.to_s.length > 0
+                                        UI.crash!("No API Token for Appetize.io given, pass using `api_token: 'token'`") unless value.to_s.length > 0
                                       end),
          FastlaneCore::ConfigItem.new(key: :url,
                                       env_name: "APPETIZE_URL",
                                       description: "Target url of the zipped build",
                                       is_string: true,
                                       verify_block: proc do |value|
-                                        raise "No URL of your zipped build".red unless value.to_s.length > 0
+                                        UI.crash!("No URL of your zipped build") unless value.to_s.length > 0
                                       end),
          FastlaneCore::ConfigItem.new(key: :private_key,
                                       env_name: "APPETIZE_PRIVATEKEY",

--- a/fastlane/lib/fastlane/actions/appium.rb
+++ b/fastlane/lib/fastlane/actions/appium.rb
@@ -29,7 +29,7 @@ module Fastlane
         rspec_args << params[:spec_path]
         status = RSpec::Core::Runner.run(rspec_args).to_i
         if status != 0
-          raise "Failed to run Appium spec. status code: #{status}".red
+          UI.crash!("Failed to run Appium spec. status code: #{status}")
         end
       ensure
         Actions.sh "kill #{appium_pid}" if appium_pid
@@ -54,7 +54,7 @@ module Fastlane
         end
 
         unless File.exist?(appium_path)
-          raise 'You have to install Appium using `npm install -g appium`'.red
+          UI.crash!('You have to install Appium using `npm install -g appium`')
         end
 
         if appium_path.end_with?('.app')
@@ -70,7 +70,7 @@ module Fastlane
           break if `lsof -i:#{params[:port]}`.to_s.length != 0
 
           if count * 5 > INVOKE_TIMEOUT
-            raise 'Invoke Appium server timed out'.red
+            UI.crash!('Invoke Appium server timed out')
           end
           sleep 5
         end

--- a/fastlane/lib/fastlane/actions/appledoc.rb
+++ b/fastlane/lib/fastlane/actions/appledoc.rb
@@ -55,7 +55,7 @@ module Fastlane
       def self.run(params)
         unless Helper.test?
           UI.message("Install using `brew install homebrew/boneyard/appledoc`")
-          raise "appledoc not installed".red if `which appledoc`.length == 0
+          UI.crash!("appledoc not installed") if `which appledoc`.length == 0
         end
 
         params_hash = params.values

--- a/fastlane/lib/fastlane/actions/backup_xcarchive.rb
+++ b/fastlane/lib/fastlane/actions/backup_xcarchive.rb
@@ -66,14 +66,14 @@ module Fastlane
                                        optional: false,
                                        env_name: 'BACKUP_XCARCHIVE_ARCHIVE',
                                        verify_block: proc do |value|
-                                         raise "Couldn't find xcarchive file at path '#{value}'".red if !Helper.test? && !File.exist?(value)
+                                         UI.crash!("Couldn't find xcarchive file at path '#{value}'") if !Helper.test? && !File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :destination,
                                        description: 'Where your archive will be placed',
                                        optional: false,
                                        env_name: 'BACKUP_XCARCHIVE_DESTINATION',
                                        verify_block: proc do |value|
-                                         raise "Couldn't find the destination folder at '#{value}'".red if !Helper.test? && !File.directory?(value) && !File.exist?(value)
+                                         UI.crash!("Couldn't find the destination folder at '#{value}'") if !Helper.test? && !File.directory?(value) && !File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :zip,
                                        description: 'Enable compression of the archive. Default value `true`',

--- a/fastlane/lib/fastlane/actions/badge.rb
+++ b/fastlane/lib/fastlane/actions/badge.rb
@@ -43,14 +43,14 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "dark is only a flag and should always be true".red unless value == true
+                                         UI.crash!("dark is only a flag and should always be true") unless value == true
                                        end),
           FastlaneCore::ConfigItem.new(key: :custom,
                                        env_name: "FL_BADGE_CUSTOM",
                                        description: "Add your custom overlay/badge image",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "custom should be a valid file path".red unless value and File.exist?(value)
+                                         UI.crash!("custom should be a valid file path") unless value and File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :no_badge,
                                        env_name: "FL_BADGE_NO_BADGE",
@@ -58,7 +58,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "no_badge is only a flag and should always be true".red unless value == true
+                                         UI.crash!("no_badge is only a flag and should always be true") unless value == true
                                        end),
           FastlaneCore::ConfigItem.new(key: :shield,
                                        env_name: "FL_BADGE_SHIELD",
@@ -71,7 +71,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "alpha is only a flag and should always be true".red unless value == true
+                                         UI.crash!("alpha is only a flag and should always be true") unless value == true
                                        end),
           FastlaneCore::ConfigItem.new(key: :path,
                                        env_name: "FL_BADGE_PATH",
@@ -80,7 +80,7 @@ module Fastlane
                                        is_string: true,
                                        default_value: '.',
                                        verify_block: proc do |value|
-                                         raise "path needs to be a valid directory".red if Dir[value].empty?
+                                         UI.crash!("path needs to be a valid directory") if Dir[value].empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :shield_io_timeout,
                                        env_name: "FL_BADGE_SHIELD_IO_TIMEOUT",
@@ -88,7 +88,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "shield_io_timeout needs to be an integer > 0".red if value.to_i < 1
+                                         UI.crash!("shield_io_timeout needs to be an integer > 0") if value.to_i < 1
                                        end),
           FastlaneCore::ConfigItem.new(key: :glob,
                                        env_name: "FL_BADGE_GLOB",
@@ -101,7 +101,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "alpha_channel is only a flag and should always be true".red unless value == true
+                                         UI.crash!("alpha_channel is only a flag and should always be true") unless value == true
                                        end),
           FastlaneCore::ConfigItem.new(key: :shield_gravity,
                                        env_name: "FL_BADGE_SHIELD_GRAVITY",
@@ -114,7 +114,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "shield_no_resize is only a flag and should always be true".red unless value == true
+                                         UI.crash!("shield_no_resize is only a flag and should always be true") unless value == true
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -57,9 +57,9 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise ":between must be of type array".red unless value.kind_of?(Array)
-                                         raise ":between must not contain nil values".red if value.any?(&:nil?)
-                                         raise ":between must be an array of size 2".red unless (value || []).size == 2
+                                         UI.crash!(":between must be of type array") unless value.kind_of?(Array)
+                                         UI.crash!(":between must not contain nil values") if value.any?(&:nil?)
+                                         UI.crash!(":between must be an array of size 2") unless (value || []).size == 2
                                        end),
           FastlaneCore::ConfigItem.new(key: :pretty,
                                        env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_PRETTY',
@@ -92,7 +92,7 @@ module Fastlane
                                        default_value: 'include_merges',
                                        verify_block: proc do |value|
                                          matches_option = GIT_MERGE_COMMIT_FILTERING_OPTIONS.any? { |opt| opt.to_s == value }
-                                         raise "Valid values for :merge_commit_filtering are #{GIT_MERGE_COMMIT_FILTERING_OPTIONS.map {|o| "'#{o}'" }.join(', ')}".red unless matches_option
+                                         UI.crash!("Valid values for :merge_commit_filtering are #{GIT_MERGE_COMMIT_FILTERING_OPTIONS.map {|o| "'#{o}'" }.join(', ')}") unless matches_option
                                        end
                                       )
         ]

--- a/fastlane/lib/fastlane/actions/chatwork.rb
+++ b/fastlane/lib/fastlane/actions/chatwork.rb
@@ -27,7 +27,7 @@ module Fastlane
         else
           require 'json'
           json = JSON.parse(response.body)
-          raise "HTTP Error: #{response.code} #{json['errors']}".red
+          UI.crash!("HTTP Error: #{response.code} #{json['errors']}")
         end
       end
 
@@ -43,7 +43,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          unless value.to_s.length > 0
                                            UI.error("Please add 'ENV[\"CHATWORK_API_TOKEN\"] = \"your token\"' to your Fastfile's `before_all` section.")
-                                           raise 'No CHATWORK_API_TOKEN given.'.red
+                                           UI.crash!('No CHATWORK_API_TOKEN given.')
                                          end
                                        end),
           FastlaneCore::ConfigItem.new(key: :message,

--- a/fastlane/lib/fastlane/actions/clean_cocoapods_cache.rb
+++ b/fastlane/lib/fastlane/actions/clean_cocoapods_cache.rb
@@ -24,7 +24,7 @@ module Fastlane
                                        optional: true,
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "You must specify pod name which should be removed from cache".red if value.to_s.empty?
+                                         UI.crash!("You must specify pod name which should be removed from cache") if value.to_s.empty?
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -74,7 +74,7 @@ module Fastlane
                                        optional: true,
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "Could not find Podfile".red unless File.exist?(value) || Helper.test?
+                                         UI.crash!("Could not find Podfile") unless File.exist?(value) || Helper.test?
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -23,12 +23,12 @@ module Fastlane
           xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))].reject { |path| %r{Pods\/.*.xcodeproj} =~ path }
 
           # no projects found: error
-          raise 'Could not find a .xcodeproj in the current repository\'s working directory.'.red if xcodeproj_paths.count == 0
+          UI.crash!('Could not find a .xcodeproj in the current repository\'s working directory.') if xcodeproj_paths.count == 0
 
           # too many projects found: error
           if xcodeproj_paths.count > 1
             relative_projects = xcodeproj_paths.map { |e| Pathname.new(e).relative_path_from(repo_pathname).to_s }.join("\n")
-            raise "Found multiple .xcodeproj projects in the current repository's working directory. Please specify your app's main project: \n#{relative_projects}".red
+            UI.crash!("Found multiple .xcodeproj projects in the current repository's working directory. Please specify your app's main project: \n#{relative_projects}")
           end
 
           # one project found: great
@@ -65,7 +65,7 @@ module Fastlane
         git_dirty_files = Actions.sh('git diff --name-only HEAD').split("\n") + Actions.sh('git ls-files --other --exclude-standard').split("\n")
 
         # little user hint
-        raise 'No file changes picked up. Make sure you run the `increment_build_number` action first.'.red if git_dirty_files.empty?
+        UI.crash!('No file changes picked up. Make sure you run the `increment_build_number` action first.') if git_dirty_files.empty?
 
         # check if the files changed are the ones we expected to change (these should be only the files that have version info in them)
         changed_files_as_expected = (Set.new(git_dirty_files.map(&:downcase)).subset? Set.new(expected_changed_files.map(&:downcase)))
@@ -79,7 +79,7 @@ module Fastlane
               "working directory while your lane is running. You can also use the :force option to bypass this ",
               "check, and always commit a version bump regardless of the state of the working directory."
             ].join("\n")
-            raise error.red
+            UI.crash!(error)
           end
         end
 
@@ -125,8 +125,8 @@ module Fastlane
                                        description: "The path to your project file (Not the workspace). If you have only one, this is optional",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                                         raise "Could not find Xcode project".red unless File.exist?(value)
+                                         UI.crash!"Please pass the path to the project, not the workspace" if value.end_with? ".xcworkspace"
+                                         UI.crash!("Could not find Xcode project") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :force,
                                        env_name: "FL_FORCE_COMMIT",

--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -24,7 +24,7 @@ module Fastlane
         elsif params[:apk_path]
           command = Helper::CrashlyticsHelper.generate_android_command(params)
         else
-          raise "You have to either pass an ipa or an apk file to the Crashlytics action".red
+          UI.crash!("You have to either pass an ipa or an apk file to the Crashlytics action")
         end
 
         UI.success('Uploading the build to Crashlytics Beta. Time for some ☕️.')
@@ -49,7 +49,7 @@ module Fastlane
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] || Dir["*.ipa"].last,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find ipa file at path '#{value}'".red unless File.exist?(value)
+                                         UI.crash!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
                                        end),
           # Android Specific
           FastlaneCore::ConfigItem.new(key: :apk_path,
@@ -58,7 +58,7 @@ module Fastlane
                                        default_value: Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH] || Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-Release.apk")].last,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find apk file at path '#{value}'".red unless File.exist?(value)
+                                         UI.crash!("Couldn't find apk file at path '#{value}'") unless File.exist?(value)
                                        end),
           # General
           FastlaneCore::ConfigItem.new(key: :crashlytics_path,
@@ -67,26 +67,26 @@ module Fastlane
                                        default_value: Dir["./Pods/iOS/Crashlytics/Crashlytics.framework"].last || Dir["./**/Crashlytics.framework"].last,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find crashlytics at path '#{File.expand_path(value)}'`".red unless File.exist?(File.expand_path(value))
+                                         UI.crash!("Couldn't find crashlytics at path '#{File.expand_path(value)}'`") unless File.exist?(File.expand_path(value))
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_token,
                                        env_name: "CRASHLYTICS_API_TOKEN",
                                        description: "Crashlytics Beta API Token",
                                        verify_block: proc do |value|
-                                         raise "No API token for Crashlytics given, pass using `api_token: 'token'`".red unless value && !value.empty?
+                                         UI.crash!("No API token for Crashlytics given, pass using `api_token: 'token'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :build_secret,
                                        env_name: "CRASHLYTICS_BUILD_SECRET",
                                        description: "Crashlytics Build Secret",
                                        verify_block: proc do |value|
-                                         raise "No build secret for Crashlytics given, pass using `build_secret: 'secret'`".red unless value && !value.empty?
+                                         UI.crash!("No build secret for Crashlytics given, pass using `build_secret: 'secret'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :notes_path,
                                        env_name: "CRASHLYTICS_NOTES_PATH",
                                        description: "Path to the release notes",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Path '#{value}' not found".red unless File.exist?(value)
+                                         UI.crash!("Path '#{value}' not found") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :notes,
                                        env_name: "CRASHLYTICS_NOTES",

--- a/fastlane/lib/fastlane/actions/default_platform.rb
+++ b/fastlane/lib/fastlane/actions/default_platform.rb
@@ -6,7 +6,7 @@ module Fastlane
 
     class DefaultPlatformAction < Action
       def self.run(params)
-        raise "You forgot to pass the default platform".red if params.first.nil?
+        UI.crash!("You forgot to pass the default platform") if params.first.nil?
 
         platform = params.first.to_sym
 

--- a/fastlane/lib/fastlane/actions/deploygate.rb
+++ b/fastlane/lib/fastlane/actions/deploygate.rb
@@ -36,7 +36,7 @@ module Fastlane
           UI.message("DeployGate URL: #{Actions.lane_context[SharedValues::DEPLOYGATE_URL]}")
           UI.success("Build successfully uploaded to DeployGate as revision \##{Actions.lane_context[SharedValues::DEPLOYGATE_REVISION]}!")
         else
-          raise 'Error when trying to upload ipa to DeployGate'.red
+          UI.crash!('Error when trying to upload ipa to DeployGate')
         end
       end
 
@@ -87,20 +87,20 @@ module Fastlane
                                        env_name: "DEPLOYGATE_API_TOKEN",
                                        description: "Deploygate API Token",
                                        verify_block: proc do |value|
-                                         raise "No API Token for DeployGate given, pass using `api_token: 'token'`".red unless value.to_s.length > 0
+                                         UI.crash!("No API Token for DeployGate given, pass using `api_token: 'token'`") unless value.to_s.length > 0
                                        end),
           FastlaneCore::ConfigItem.new(key: :user,
                                        env_name: "DEPLOYGATE_USER",
                                        description: "Target username or organization name",
                                        verify_block: proc do |value|
-                                         raise "No User for app given, pass using `user: 'user'`".red unless value.to_s.length > 0
+                                         UI.crash!("No User for app given, pass using `user: 'user'`") unless value.to_s.length > 0
                                        end),
           FastlaneCore::ConfigItem.new(key: :ipa,
                                        env_name: "DEPLOYGATE_IPA_PATH",
                                        description: "Path to your IPA file. Optional if you use the `gym` or `xcodebuild` action",
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        verify_block: proc do |value|
-                                         raise "Couldn't find ipa file at path '#{value}'".red unless File.exist?(value)
+                                         UI.crash!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :message,
                                        env_name: "DEPLOYGATE_MESSAGE",

--- a/fastlane/lib/fastlane/actions/dotgpg_environment.rb
+++ b/fastlane/lib/fastlane/actions/dotgpg_environment.rb
@@ -28,7 +28,7 @@ module Fastlane
                                        default_value: Dir["dotgpg/*.gpg"].last,
                                        optional: false,
                                        verify_block: proc do |value|
-                                         raise "Dotgpg file '#{File.expand_path(value)}' not found".red unless File.exist?(value)
+                                         UI.crash!("Dotgpg file '#{File.expand_path(value)}' not found") unless File.exist?(value)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/dsym_zip.rb
+++ b/fastlane/lib/fastlane/actions/dsym_zip.rb
@@ -46,7 +46,7 @@ module Fastlane
                                        optional: true,
                                        env_name: 'DSYM_ZIP_XCARCHIVE_PATH',
                                        verify_block: proc do |value|
-                                         raise "Couldn't find xcarchive file at path '#{value}'".red if !Helper.test? && !File.exist?(value)
+                                         UI.crash!("Couldn't find xcarchive file at path '#{value}'") if !Helper.test? && !File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :dsym_path,
                                        description: 'Path for generated dsym. Optional, default is your apps root directory',

--- a/fastlane/lib/fastlane/actions/ensure_git_branch.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_branch.rb
@@ -11,7 +11,7 @@ module Fastlane
         if Actions.git_branch =~ branch_expr
           UI.success("Git branch match `#{branch}`, all good! 💪")
         else
-          raise "Git is not on a branch matching `#{branch}`. Current branch is `#{Actions.git_branch}`! Please ensure the repo is checked out to the correct branch.".red
+          UI.crash!("Git is not on a branch matching `#{branch}`. Current branch is `#{Actions.git_branch}`! Please ensure the repo is checked out to the correct branch.")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -13,7 +13,7 @@ module Fastlane
           UI.success('Git status is clean, all good! 💪')
           Actions.lane_context[SharedValues::GIT_REPO_WAS_CLEAN_ON_START] = true
         else
-          raise 'Git repository is dirty! Please ensure the repo is in a clean state by commiting/stashing/discarding all changes first.'.red
+          UI.crash!('Git repository is dirty! Please ensure the repo is in a clean state by commiting/stashing/discarding all changes first.')
         end
       end
 

--- a/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
+++ b/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
@@ -63,7 +63,7 @@ module Fastlane
                                        description: "The directory containing all the source files",
                                        default_value: ".",
                                        verify_block: proc do |value|
-                                         raise "Couldn't find the folder at '#{File.absolute_path(value)}'".red unless File.directory?(value)
+                                         UI.crash!("Couldn't find the folder at '#{File.absolute_path(value)}'") unless File.directory?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :extension,
                                        env_name: "FL_ENSURE_NO_DEBUG_CODE_EXTENSION",

--- a/fastlane/lib/fastlane/actions/fastlane_version.rb
+++ b/fastlane/lib/fastlane/actions/fastlane_version.rb
@@ -9,10 +9,10 @@ module Fastlane
         value = (params || []).first
         defined_version = Gem::Version.new(value) if value
 
-        raise "Please pass minimum fastlane version as parameter to fastlane_version".red unless defined_version
+        UI.crash!("Please pass minimum fastlane version as parameter to fastlane_version") unless defined_version
 
         if Gem::Version.new(Fastlane::VERSION) < defined_version
-          raise "The Fastfile requires a fastlane version of >= #{defined_version}. You are on #{Fastlane::VERSION}. Please update using `sudo gem update fastlane`.".red
+          UI.crash!("The Fastfile requires a fastlane version of >= #{defined_version}. You are on #{Fastlane::VERSION}. Please update using `sudo gem update fastlane`.")
         end
 
         UI.message("fastlane version valid")

--- a/fastlane/lib/fastlane/actions/frameit.rb
+++ b/fastlane/lib/fastlane/actions/frameit.rb
@@ -49,7 +49,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          available = ['iPhone_6_Plus', 'iPhone_5s', 'iPhone_4', 'iPad_mini', 'Mac']
                                          unless available.include? value
-                                           raise "Invalid device type '#{value}'. Available values: #{available}".red
+                                           UI.crash!("Invalid device type '#{value}'. Available values: #{available}")
                                          end
                                        end)
         ]

--- a/fastlane/lib/fastlane/actions/gcovr.rb
+++ b/fastlane/lib/fastlane/actions/gcovr.rb
@@ -53,7 +53,7 @@ module Fastlane
 
       def self.run(params)
         unless Helper.test?
-          raise "gcovr not installed".red if `which gcovr`.length == 0
+          UI.crash!("gcovr not installed") if `which gcovr`.length == 0
         end
 
         # The args we will build with

--- a/fastlane/lib/fastlane/actions/get_build_number.rb
+++ b/fastlane/lib/fastlane/actions/get_build_number.rb
@@ -58,8 +58,8 @@ module Fastlane
                              description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
                              optional: true,
                              verify_block: proc do |value|
-                               raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                               raise "Could not find Xcode project".red if !File.exist?(value) and !Helper.is_test?
+                               UI.crash!"Please pass the path to the project, not the workspace" if value.end_with? ".xcworkspace"
+                               UI.crash!("Could not find Xcode project") if !File.exist?(value) and !Helper.is_test?
                              end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/get_github_release.rb
+++ b/fastlane/lib/fastlane/actions/get_github_release.rb
@@ -110,8 +110,8 @@ module Fastlane
                                        env_name: "FL_GET_GITHUB_RELEASE_URL",
                                        description: "The path to your repo, e.g. 'KrauseFx/fastlane'",
                                        verify_block: proc do |value|
-                                         raise "Please only pass the path, e.g. 'KrauseFx/fastlane'".red if value.include? "github.com"
-                                         raise "Please only pass the path, e.g. 'KrauseFx/fastlane'".red if value.split('/').count != 2
+                                         UI.crash!"Please only pass the path, e.g. 'KrauseFx/fastlane'" if value.include? "github.com"
+                                         UI.crash!("Please only pass the path, e.g. 'KrauseFx/fastlane'") if value.split('/').count != 2
                                        end),
           FastlaneCore::ConfigItem.new(key: :server_url,
                                        env_name: "FL_GITHUB_RELEASE_SERVER_URL",
@@ -119,7 +119,7 @@ module Fastlane
                                        default_value: "https://api.github.com",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please include the protocol in the server url, e.g. https://your.github.server".red unless value.include? "//"
+                                         UI.crash!"Please include the protocol in the server url, e.g. https://your.github.server" unless value.include? "//"
                                        end),
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: "FL_GET_GITHUB_RELEASE_VERSION",

--- a/fastlane/lib/fastlane/actions/get_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/get_info_plist_value.rb
@@ -37,7 +37,7 @@ module Fastlane
                                        description: "Path to plist file you want to read",
                                        optional: false,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find plist file at path '#{value}'".red unless File.exist?(value)
+                                         UI.crash!("Couldn't find plist file at path '#{value}'") unless File.exist?(value)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -59,8 +59,8 @@ module Fastlane
                              description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
                              optional: true,
                              verify_block: proc do |value|
-                               raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                               raise "Could not find Xcode project at path '#{File.expand_path(value)}'".red if !File.exist?(value) and !Helper.is_test?
+                               UI.crash!"Please pass the path to the project, not the workspace" if value.end_with? ".xcworkspace"
+                               UI.crash!("Could not find Xcode project at path '#{File.expand_path(value)}'") if !File.exist?(value) and !Helper.is_test?
                              end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -32,10 +32,10 @@ module Fastlane
                                        is_string: false,
                                        verify_block: proc do |value|
                                          if value.kind_of?(String)
-                                           raise "Couldn't find file at path '#{value}'".red unless File.exist?(value)
+                                           UI.crash!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                          else
                                            value.each do |x|
-                                             raise "Couldn't find file at path '#{x}'".red unless File.exist?(x)
+                                             UI.crash!("Couldn't find file at path '#{x}'") unless File.exist?(x)
                                            end
                                          end
                                        end)

--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -32,10 +32,10 @@ module Fastlane
                                        is_string: false,
                                        verify_block: proc do |value|
                                          if value.kind_of?(String)
-                                           raise "Couldn't find file at path '#{value}'".red unless File.exist?(value)
+                                           UI.crash!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                          else
                                            value.each do |x|
-                                             raise "Couldn't find file at path '#{x}'".red unless File.exist?(x)
+                                             UI.crash!("Couldn't find file at path '#{x}'") unless File.exist?(x)
                                            end
                                          end
                                        end),

--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -30,7 +30,7 @@ module Fastlane
                       end
 
         # Ensure we ended up with a valid path to gradle
-        raise "Couldn't find gradlew at path '#{File.expand_path(gradle_path)}'".red unless File.exist?(gradle_path)
+        UI.crash!("Couldn't find gradlew at path '#{File.expand_path(gradle_path)}'") unless File.exist?(gradle_path)
 
         # Construct our flags
         flags = []

--- a/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
@@ -29,12 +29,12 @@ module Fastlane
           xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))].reject { |path| %r{Pods\/.*.xcodeproj} =~ path }
 
           # no projects found: error
-          raise 'Could not find a .xcodeproj in the current repository\'s working directory.'.red if xcodeproj_paths.count == 0
+          UI.crash!('Could not find a .xcodeproj in the current repository\'s working directory.') if xcodeproj_paths.count == 0
 
           # too many projects found: error
           if xcodeproj_paths.count > 1
             relative_projects = xcodeproj_paths.map { |e| Pathname.new(e).relative_path_from(repo_pathname).to_s }.join("\n")
-            raise "Found multiple .xcodeproj projects in the current repository's working directory. Please specify your app's main project: \n#{relative_projects}".red
+            UI.crash!("Found multiple .xcodeproj projects in the current repository's working directory. Please specify your app's main project: \n#{relative_projects}")
           end
 
           # one project found: great
@@ -76,7 +76,7 @@ module Fastlane
         end
 
         # little user hint
-        raise 'No file changes picked up. Make sure you run the `increment_build_number` action first.'.red if hg_dirty_files.empty?
+        UI.crash!('No file changes picked up. Make sure you run the `increment_build_number` action first.') if hg_dirty_files.empty?
 
         # check if the files changed are the ones we expected to change (these should be only the files that have version info in them)
         dirty_set = Set.new(hg_dirty_files.map(&:downcase))
@@ -91,7 +91,7 @@ module Fastlane
                    "stage in your lane, and don't touch the working directory while your lane is running. You can also use the :force option to ",
                    "bypass this check, and always commit a version bump regardless of the state of the working directory."
                   ].join("\n")
-            raise str.red
+            UI.crash!(str)
           end
         end
 
@@ -123,8 +123,8 @@ module Fastlane
                                        description: "The path to your project file (Not the workspace). If you have only one, this is optional",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                                         raise "Could not find Xcode project".red unless File.exist?(value)
+                                         UI.crash!"Please pass the path to the project, not the workspace" if value.end_with? ".xcworkspace"
+                                         UI.crash!("Could not find Xcode project") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :force,
                                        env_name: "FL_FORCE_COMMIT",

--- a/fastlane/lib/fastlane/actions/hg_ensure_clean_status.rb
+++ b/fastlane/lib/fastlane/actions/hg_ensure_clean_status.rb
@@ -12,7 +12,7 @@ module Fastlane
           UI.success('Mercurial status is clean, all good! 😎')
           Actions.lane_context[SharedValues::HG_REPO_WAS_CLEAN_ON_START] = true
         else
-          raise 'Mercurial repository is dirty! Please ensure the repo is in a clean state by commiting/stashing/discarding all changes first.'.red
+          UI.crash!('Mercurial repository is dirty! Please ensure the repo is in a clean state by commiting/stashing/discarding all changes first.')
         end
       end
 

--- a/fastlane/lib/fastlane/actions/hipchat.rb
+++ b/fastlane/lib/fastlane/actions/hipchat.rb
@@ -31,7 +31,7 @@ module Fastlane
         if api_version.to_i == 1
           ########## running on V1 ##########
           if user?(channel)
-            raise 'HipChat private message not working with API V1 please use API V2 instead'.red
+            UI.crash!('HipChat private message not working with API V1 please use API V2 instead')
           else
             uri = URI.parse("https://#{api_host}/v1/rooms/message")
             response = Net::HTTP.post_form(uri, { 'from' => from,
@@ -78,11 +78,11 @@ module Fastlane
         when 200, 204
           true
         when 404
-          raise "Channel `#{channel}` not found".red
+          UI.crash!("Channel `#{channel}` not found")
         when 401
-          raise "Access denied for channel `#{channel}`".red
+          UI.crash!("Access denied for channel `#{channel}`")
         else
-          raise "Unexpected #{response.code} for `#{channel}` with response: #{response.body}".red
+          UI.crash!("Unexpected #{response.code} for `#{channel}` with response: #{response.body}")
         end
       end
 
@@ -105,7 +105,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          unless value.to_s.length > 0
                                            UI.error("Please add 'ENV[\"HIPCHAT_API_TOKEN\"] = \"your token\"' to your Fastfile's `before_all` section.")
-                                           raise 'No HIPCHAT_API_TOKEN given.'.red
+                                           UI.crash!('No HIPCHAT_API_TOKEN given.')
                                          end
                                        end),
           FastlaneCore::ConfigItem.new(key: :custom_color,
@@ -125,7 +125,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          if value.nil? || ![1, 2].include?(value.to_i)
                                            UI.error("Please add 'ENV[\"HIPCHAT_API_VERSION\"] = \"1 or 2\"' to your Fastfile's `before_all` section.")
-                                           raise 'No HIPCHAT_API_VERSION given.'.red
+                                           UI.crash!('No HIPCHAT_API_VERSION given.')
                                          end
                                        end),
           FastlaneCore::ConfigItem.new(key: :notify_room,
@@ -147,7 +147,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          unless ["html", "text"].include?(value.to_s)
                                            UI.error("Please specify the message format as either 'html' or 'text'.")
-                                           raise 'Unrecognized message_format.'.red
+                                           UI.crash!('Unrecognized message_format.')
                                          end
                                        end),
           FastlaneCore::ConfigItem.new(key: :include_html_header,

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -32,7 +32,7 @@ module Fastlane
           end
         end
 
-        raise "Symbols on path '#{File.expand_path(dsym_filename)}' not found".red if dsym_filename && !File.exist?(dsym_filename)
+        UI.crash!("Symbols on path '#{File.expand_path(dsym_filename)}' not found") if dsym_filename && !File.exist?(dsym_filename)
 
         UI.success('Starting with ipa upload to HockeyApp... this could take some time.')
 
@@ -61,7 +61,7 @@ module Fastlane
           if response.body.to_s.include?("App could not be created")
             raise "Hockey has an issue processing this app. Please confirm that an app in Hockey matches this IPA's bundle ID or that you are using the correct API upload token. If error persists, please provide the :public_identifier option from the HockeyApp website. More information https://github.com/fastlane/fastlane/issues/400"
           else
-            raise "Error when trying to upload ipa to HockeyApp: #{response.body}".red
+            UI.crash!("Error when trying to upload ipa to HockeyApp: #{response.body}")
           end
         end
       end
@@ -76,7 +76,7 @@ module Fastlane
                                        env_name: "FL_HOCKEY_API_TOKEN",
                                        description: "API Token for Hockey Access",
                                        verify_block: proc do |value|
-                                         raise "No API token for Hockey given, pass using `api_token: 'token'`".red unless value and !value.empty?
+                                         UI.crash!("No API token for Hockey given, pass using `api_token: 'token'`") unless value and !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :ipa,
                                        env_name: "FL_HOCKEY_IPA",
@@ -84,7 +84,7 @@ module Fastlane
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find ipa file at path '#{value}'".red unless File.exist?(value)
+                                         UI.crash!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :dsym,
                                        env_name: "FL_HOCKEY_DSYM",

--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -61,8 +61,8 @@ module Fastlane
                                        description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                                         raise "Could not find Xcode project".red if !File.exist?(value) and !Helper.is_test?
+                                         UI.crash!"Please pass the path to the project, not the workspace" if value.end_with? ".xcworkspace"
+                                         UI.crash!("Could not find Xcode project") if !File.exist?(value) and !Helper.is_test?
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -104,8 +104,8 @@ module Fastlane
                                        env_name: "FL_VERSION_NUMBER_PROJECT",
                                        description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                                         raise "Could not find Xcode project".red unless File.exist?(value)
+                                         UI.crash!"Please pass the path to the project, not the workspace" if value.end_with? ".xcworkspace"
+                                         UI.crash!("Could not find Xcode project") unless File.exist?(value)
                                        end,
                                        optional: true)
         ]

--- a/fastlane/lib/fastlane/actions/install_on_device.rb
+++ b/fastlane/lib/fastlane/actions/install_on_device.rb
@@ -5,7 +5,7 @@ module Fastlane
     class InstallOnDeviceAction < Action
       def self.run(params)
         unless Helper.test?
-          raise "ios-deploy not installed, see https://github.com/phonegap/ios-deploy for instructions".red if `which ios-deploy`.length == 0
+          UI.crash!("ios-deploy not installed, see https://github.com/phonegap/ios-deploy for instructions") if `which ios-deploy`.length == 0
         end
         taxi_cmd = [
           "ios-deploy",

--- a/fastlane/lib/fastlane/actions/install_xcode_plugin.rb
+++ b/fastlane/lib/fastlane/actions/install_xcode_plugin.rb
@@ -28,8 +28,8 @@ module Fastlane
                                        env_name: "FL_XCODE_PLUGIN_URL",
                                        description: "URL for Xcode plugin ZIP file",
                                        verify_block: proc do |value|
-                                         raise "No URL for InstallXcodePluginAction given, pass using `url: 'url'`".red if value.to_s.length == 0
-                                         raise "URL doesn't use HTTPS".red unless value.start_with?("https://")
+                                         UI.crash!("No URL for InstallXcodePluginAction given, pass using `url: 'url'`") if value.to_s.length == 0
+                                         UI.crash!("URL doesn't use HTTPS") unless value.start_with?("https://")
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/installr.rb
+++ b/fastlane/lib/fastlane/actions/installr.rb
@@ -17,7 +17,7 @@ module Fastlane
           Actions.lane_context[SharedValues::INSTALLR_BUILD_INFORMATION] = response.body
           UI.success('Build successfully uploaded to Installr!')
         else
-          raise "Error when trying to upload build file to Installr: #{response.body}".red
+          UI.crash!("Error when trying to upload build file to Installr: #{response.body}")
         end
       end
 
@@ -69,14 +69,14 @@ module Fastlane
                                      env_name: "INSTALLR_API_TOKEN",
                                      description: "API Token for Installr Access",
                                      verify_block: proc do |value|
-                                       raise "No API token for Installr given, pass using `api_token: 'token'`".red unless value and !value.empty?
+                                       UI.crash!("No API token for Installr given, pass using `api_token: 'token'`") unless value and !value.empty?
                                      end),
           FastlaneCore::ConfigItem.new(key: :ipa,
                                      env_name: "INSTALLR_IPA_PATH",
                                      description: "Path to your IPA file. Optional if you use the `gym` or `xcodebuild` action",
                                      default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                      verify_block: proc do |value|
-                                       raise "Couldn't find build file at path '#{value}'".red unless File.exist?(value)
+                                       UI.crash!("Couldn't find build file at path '#{value}'") unless File.exist?(value)
                                      end),
           FastlaneCore::ConfigItem.new(key: :notes,
                                      env_name: "INSTALLR_NOTES",

--- a/fastlane/lib/fastlane/actions/ipa.rb
+++ b/fastlane/lib/fastlane/actions/ipa.rb
@@ -89,7 +89,7 @@ module Fastlane
           end
 
           # Raise a custom exception, as the the normal one is useless for the user
-          raise "A build error occured, this is usually related to code signing. Take a look at the error above".red
+          UI.crash!("A build error occured, this is usually related to code signing. Take a look at the error above")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/lcov.rb
+++ b/fastlane/lib/fastlane/actions/lcov.rb
@@ -8,7 +8,7 @@ module Fastlane
 
       def self.run(options)
         unless Helper.test?
-          raise 'lcov not installed, please install using `brew install lcov`'.red if `which lcov`.length == 0
+          UI.crash!('lcov not installed, please install using `brew install lcov`') if `which lcov`.length == 0
         end
         gen_cov(options)
       end

--- a/fastlane/lib/fastlane/actions/nexus_upload.rb
+++ b/fastlane/lib/fastlane/actions/nexus_upload.rb
@@ -74,7 +74,7 @@ module Fastlane
                                        optional: false,
                                        verify_block: proc do |value|
                                          file_path = File.expand_path(value)
-                                         raise "Couldn't find file at path '#{file_path}'".red unless File.exist?(file_path)
+                                         UI.crash!("Couldn't find file at path '#{file_path}'") unless File.exist?(file_path)
                                        end),
           FastlaneCore::ConfigItem.new(key: :repo_id,
                                        env_name: "FL_NEXUS_REPO_ID",

--- a/fastlane/lib/fastlane/actions/oclint.rb
+++ b/fastlane/lib/fastlane/actions/oclint.rb
@@ -9,11 +9,11 @@ module Fastlane
       def self.run(params)
         oclint_path = params[:oclint_path]
         if `which #{oclint_path}`.to_s.empty? and !Helper.test?
-          raise "You have to install oclint or provide path to oclint binary. Fore more details: ".red + "http://docs.oclint.org/en/stable/intro/installation.html".yellow
+          UI.crash!("You have to install oclint or provide path to oclint binary. Fore more details: " + "http://docs.oclint.org/en/stable/intro/installation.html".yellow)
         end
 
         compile_commands = params[:compile_commands]
-        raise "Could not find json compilation database at path '#{compile_commands}'".red unless File.exist?(compile_commands)
+        UI.crash!("Could not find json compilation database at path '#{compile_commands}'") unless File.exist?(compile_commands)
 
         if params[:select_reqex]
           UI.important("'select_reqex' paramter is deprecated. Please use 'select_regex' instead.")

--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -51,7 +51,7 @@ module Fastlane
         when 200, 204
           puts "Succesfully created new OneSignal app".green
         else
-          raise "Unexpected #{response.code} with response: #{response.body}".red
+          UI.crash!("Unexpected #{response.code} with response: #{response.body}")
         end
       end
 
@@ -71,7 +71,7 @@ module Fastlane
                                       verify_block: proc do |value|
                                         unless value.to_s.length > 0
                                           UI.error("Please add 'ENV[\"ONE_SIGNAL_AUTH_KEY\"] = \"your token\"' to your Fastfile's `before_all` section.")
-                                          raise 'No ONE_SIGNAL_AUTH_KEY given.'.red
+                                          UI.crash!('No ONE_SIGNAL_AUTH_KEY given.')
                                         end
                                       end),
 
@@ -81,7 +81,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          unless value.to_s.length > 0
                                            UI.error("Please add 'ENV[\"ONE_SIGNAL_APP_NAME\"] = \"Your app name\"' to your Fastfile's `before_all` section.")
-                                           raise 'No ONE_SIGNAL_APP_NAME given.'.red
+                                           UI.crash!('No ONE_SIGNAL_APP_NAME given.')
                                          end
                                        end),
 

--- a/fastlane/lib/fastlane/actions/pod_push.rb
+++ b/fastlane/lib/fastlane/actions/pod_push.rb
@@ -45,8 +45,8 @@ module Fastlane
                                        description: "The Podspec you want to push",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find file at path '#{value}'".red unless File.exist?(value)
-                                         raise "File must be a `.podspec`".red unless value.end_with?(".podspec")
+                                         UI.crash!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+                                         UI.crash!("File must be a `.podspec`") unless value.end_with?(".podspec")
                                        end),
           FastlaneCore::ConfigItem.new(key: :repo,
                                        description: "The repo you want to push. Pushes to Trunk by default",
@@ -60,7 +60,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "Sources must be an array.".red unless value.kind_of?(Array)
+                                         UI.crash!("Sources must be an array.") unless value.kind_of?(Array)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/podio_item.rb
+++ b/fastlane/lib/fastlane/actions/podio_item.rb
@@ -39,41 +39,41 @@ module Fastlane
                                        description: 'Client ID for Podio API (see https://developers.podio.com/api-key)',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "No Client ID for Podio given, pass using `client_id: 'id'`".red unless value && !value.empty?
+                                         UI.crash!("No Client ID for Podio given, pass using `client_id: 'id'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :client_secret,
                                        env_name: 'PODIO_ITEM_CLIENT_SECRET',
                                        description: 'Client secret for Podio API (see https://developers.podio.com/api-key)',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "No Client Secret for Podio given, pass using `client_secret: 'secret'`".red unless value && !value.empty?
+                                         UI.crash!("No Client Secret for Podio given, pass using `client_secret: 'secret'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :app_id,
                                        env_name: 'PODIO_ITEM_APP_ID',
                                        description: 'App ID of the app you intend to authenticate with (see https://developers.podio.com/authentication/app_auth)',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "No App ID for Podio given, pass using `app_id: 'id'`".red unless value && !value.empty?
+                                         UI.crash!("No App ID for Podio given, pass using `app_id: 'id'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :app_token,
                                        env_name: 'PODIO_ITEM_APP_TOKEN',
                                        description: 'App token of the app you intend to authenticate with (see https://developers.podio.com/authentication/app_auth)',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "No App token for Podio given, pass using `app_token: 'token'`".red unless value && !value.empty?
+                                         UI.crash!("No App token for Podio given, pass using `app_token: 'token'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :identifying_field,
                                        env_name: 'PODIO_ITEM_IDENTIFYING_FIELD',
                                        description: 'String specifying the field key used for identification of an item',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "No Identifying field given, pass using `identifying_field: 'field name'`".red unless value && !value.empty?
+                                         UI.crash!("No Identifying field given, pass using `identifying_field: 'field name'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :identifying_value,
                                        description: 'String uniquely specifying an item within the app',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "No Identifying value given, pass using `identifying_value: 'unique value'`".red unless value && !value.empty?
+                                         UI.crash!("No Identifying value given, pass using `identifying_value: 'unique value'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :other_fields,
                                        description: 'Dictionary of your app fields. Podio supports several field types, see https://developers.podio.com/doc/items',

--- a/fastlane/lib/fastlane/actions/read_podspec.rb
+++ b/fastlane/lib/fastlane/actions/read_podspec.rb
@@ -42,7 +42,7 @@ module Fastlane
                                        description: "Path to the podspec to be read",
                                        default_value: Dir['*.podspec*'].first,
                                        verify_block: proc do |value|
-                                         raise "File #{value} not found".red unless File.exist?(value)
+                                         UI.crash!("File #{value} not found") unless File.exist?(value)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -22,14 +22,14 @@ module Fastlane
 
         if devices
           device_objs = devices.map do |k, v|
-            raise "Passed invalid UDID: #{v} for device: #{k}".red unless UDID_REGEXP =~ v
+            UI.crash!("Passed invalid UDID: #{v} for device: #{k}") unless UDID_REGEXP =~ v
             Spaceship::Device.create!(name: k, udid: v)
           end
         elsif devices_file
           require 'csv'
 
           devices_file = CSV.read(File.expand_path(File.join(devices_file)), col_sep: "\t")
-          raise 'Please provide a file according to the Apple Sample UDID file (https://devimages.apple.com.edgekey.net/downloads/devices/Multiple-Upload-Samples.zip)'.red unless devices_file.first == ['Device ID', 'Device Name']
+          UI.crash!('Please provide a file according to the Apple Sample UDID file (https://devimages.apple.com.edgekey.net/downloads/devices/Multiple-Upload-Samples.zip)') unless devices_file.first == ['Device ID', 'Device Name']
 
           UI.message("Fetching list of currently registered devices...")
           existing_devices = Spaceship::Device.all
@@ -37,13 +37,13 @@ module Fastlane
           device_objs = devices_file.drop(1).map do |device|
             next if existing_devices.map(&:udid).include?(device[0])
 
-            raise 'Invalid device line, please provide a file according to the Apple Sample UDID file (https://devimages.apple.com.edgekey.net/downloads/devices/Multiple-Upload-Samples.zip)'.red unless device.count == 2
-            raise "Passed invalid UDID: #{device[0]} for device: #{device[1]}".red unless UDID_REGEXP =~ device[0]
+            UI.crash!('Invalid device line, please provide a file according to the Apple Sample UDID file (https://devimages.apple.com.edgekey.net/downloads/devices/Multiple-Upload-Samples.zip)') unless device.count == 2
+            UI.crash!("Passed invalid UDID: #{device[0]} for device: #{device[1]}") unless UDID_REGEXP =~ device[0]
 
             Spaceship::Device.create!(name: device[1], udid: device[0])
           end
         else
-          raise 'You must pass either a valid `devices` or `devices_file`. Please check the readme.'.red
+          UI.crash!('You must pass either a valid `devices` or `devices_file`. Please check the readme.')
         end
 
         UI.success("Successfully registered new devices.")
@@ -69,7 +69,7 @@ module Fastlane
                                        description: "Provide a path to the devices to register",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Could not find file '#{value}'".red unless File.exist?(value)
+                                         UI.crash!("Could not find file '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :team_id,
                                        env_name: "FASTLANE_TEAM_ID",

--- a/fastlane/lib/fastlane/actions/reset_git_repo.rb
+++ b/fastlane/lib/fastlane/actions/reset_git_repo.rb
@@ -36,7 +36,7 @@ module Fastlane
             UI.success("Git cleaned up #{paths.count} files.")
           end
         else
-          raise 'This is a destructive and potentially dangerous action. To protect from data loss, please add the `ensure_git_status_clean` action to the beginning of your lane, or if you\'re absolutely sure of what you\'re doing then call this action with the :force option.'.red
+          UI.crash!('This is a destructive and potentially dangerous action. To protect from data loss, please add the `ensure_git_status_clean` action to the beginning of your lane, or if you\'re absolutely sure of what you\'re doing then call this action with the :force option.')
         end
       end
 

--- a/fastlane/lib/fastlane/actions/resign.rb
+++ b/fastlane/lib/fastlane/actions/resign.rb
@@ -9,7 +9,7 @@ module Fastlane
         if Sigh::Resign.resign(params[:ipa], params[:signing_identity], params[:provisioning_profile], params[:entitlements], params[:version])
           UI.success('Successfully re-signed .ipa 🔏.')
         else
-          raise 'Failed to re-sign .ipa'.red
+          UI.crash!('Failed to re-sign .ipa')
         end
       end
 
@@ -38,7 +38,7 @@ module Fastlane
                                        description: "Path to the ipa file to resign. Optional if you use the `gym` or `xcodebuild` action",
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        verify_block: proc do |value|
-                                         raise "Couldn't find ipa file at path '#{value}'".red unless File.exist?(value)
+                                         UI.crash!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :signing_identity,
                                        env_name: "FL_RESIGN_SIGNING_IDENTITY",
@@ -60,7 +60,7 @@ module Fastlane
                                                  else [value]
                                                  end
                                          files.each do |file|
-                                           raise "Couldn't find provisiong profile at path '#{file}'".red unless File.exist?(file)
+                                           UI.crash!("Couldn't find provisiong profile at path '#{file}'") unless File.exist?(file)
                                          end
                                        end),
           FastlaneCore::ConfigItem.new(key: :version,

--- a/fastlane/lib/fastlane/actions/s3.rb
+++ b/fastlane/lib/fastlane/actions/s3.rb
@@ -54,10 +54,10 @@ module Fastlane
         dsym_file = params[:dsym]
         s3_path = params[:path]
 
-        raise "No S3 access key given, pass using `access_key: 'key'`".red unless s3_access_key.to_s.length > 0
-        raise "No S3 secret access key given, pass using `secret_access_key: 'secret key'`".red unless s3_secret_access_key.to_s.length > 0
-        raise "No S3 bucket given, pass using `bucket: 'bucket'`".red unless s3_bucket.to_s.length > 0
-        raise "No IPA file path given, pass using `ipa: 'ipa path'`".red unless ipa_file.to_s.length > 0
+        UI.crash!("No S3 access key given, pass using `access_key: 'key'`") unless s3_access_key.to_s.length > 0
+        UI.crash!("No S3 secret access key given, pass using `secret_access_key: 'secret key'`") unless s3_secret_access_key.to_s.length > 0
+        UI.crash!("No S3 bucket given, pass using `bucket: 'bucket'`") unless s3_bucket.to_s.length > 0
+        UI.crash!("No IPA file path given, pass using `ipa: 'ipa path'`") unless ipa_file.to_s.length > 0
 
         plist_template_path = params[:plist_template_path]
         html_template_path = params[:html_template_path]

--- a/fastlane/lib/fastlane/actions/set_github_release.rb
+++ b/fastlane/lib/fastlane/actions/set_github_release.rb
@@ -52,7 +52,7 @@ module Fastlane
             get_response = self.call_releases_endpoint("get", server_url, repo_name, "/releases/#{release_id}", api_token, nil)
             if get_response[:status] != 200
               UI.error("GitHub responded with #{response[:status]}:#{response[:body]}")
-              raise "Failed to fetch the newly created release, but it *has been created* successfully.".red
+              UI.crash!("Failed to fetch the newly created release, but it *has been created* successfully.")
             end
 
             get_body = JSON.parse(get_response.body)
@@ -67,10 +67,10 @@ module Fastlane
           UI.error("Release on tag #{params[:tag_name]} already exists!")
         when 404
           UI.error(response.body)
-          raise "Repository #{params[:repository_name]} cannot be found, please double check its name and that you provided a valid API token (if it's a private repository).".red
+          UI.crash!("Repository #{params[:repository_name]} cannot be found, please double check its name and that you provided a valid API token (if it's a private repository).")
         when 401
           UI.error(response.body)
-          raise "You are not authorized to access #{params[:repository_name]}, please make sure you provided a valid API token.".red
+          UI.crash!("You are not authorized to access #{params[:repository_name]}, please make sure you provided a valid API token.")
         else
           if response[:status] != 200
             UI.error("GitHub responded with #{response[:status]}:#{response[:body]}")
@@ -175,8 +175,8 @@ module Fastlane
                                        env_name: "FL_SET_GITHUB_RELEASE_REPOSITORY_NAME",
                                        description: "The path to your repo, e.g. 'fastlane/fastlane'",
                                        verify_block: proc do |value|
-                                         raise "Please only pass the path, e.g. 'fastlane/fastlane'".red if value.include? "github.com"
-                                         raise "Please only pass the path, e.g. 'fastlane/fastlane'".red if value.split('/').count != 2
+                                         UI.crash!"Please only pass the path, e.g. 'fastlane/fastlane'" if value.include? "github.com"
+                                         UI.crash!("Please only pass the path, e.g. 'fastlane/fastlane'") if value.split('/').count != 2
                                        end),
           FastlaneCore::ConfigItem.new(key: :server_url,
                                        env_name: "FL_GITHUB_RELEASE_SERVER_URL",
@@ -184,7 +184,7 @@ module Fastlane
                                        default_value: "https://api.github.com",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please include the protocol in the server url, e.g. https://your.github.server/api/v3".red unless value.include? "//"
+                                         UI.crash!"Please include the protocol in the server url, e.g. https://your.github.server/api/v3" unless value.include? "//"
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_token,
                                        env_name: "FL_GITHUB_RELEASE_API_TOKEN",

--- a/fastlane/lib/fastlane/actions/set_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/set_info_plist_value.rb
@@ -40,7 +40,7 @@ module Fastlane
                                        description: "Path to plist file you want to update",
                                        optional: false,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find plist file at path '#{value}'".red unless File.exist?(value)
+                                         UI.crash!("Couldn't find plist file at path '#{value}'") unless File.exist?(value)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -47,7 +47,7 @@ module Fastlane
           UI.success('Successfully sent Slack notification')
         else
           UI.verbose(result)
-          raise 'Error pushing Slack message, maybe the integration has no permission to post on this channel? Try removing the channel parameter in your Fastfile.'.red
+          UI.crash!('Error pushing Slack message, maybe the integration has no permission to post on this channel? Try removing the channel parameter in your Fastfile.')
         end
       end
 

--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -89,7 +89,7 @@ Slather is available at https://github.com/venmo/slather
                                        env_name: "FL_SLATHER_PROJ", # The name of the environment variable
                                        description: "The project file that slather looks at", # a short description of this parameter
                                        verify_block: proc do |value|
-                                         raise "No project file specified, pass using `proj: 'Project.xcodeproj'`".red unless value and !value.empty?
+                                         UI.crash!("No project file specified, pass using `proj: 'Project.xcodeproj'`") unless value and !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :scheme,
                                        env_name: "FL_SLATHER_SCHEME", # The name of the environment variable

--- a/fastlane/lib/fastlane/actions/sonar.rb
+++ b/fastlane/lib/fastlane/actions/sonar.rb
@@ -30,7 +30,7 @@ module Fastlane
       end
 
       def self.verify_sonar_runner_binary
-        raise "You have to install sonar-runner using `brew install sonar-runner`".red unless `which sonar-runner`.to_s.length > 0
+        UI.crash!("You have to install sonar-runner using `brew install sonar-runner`") unless `which sonar-runner`.to_s.length > 0
       end
 
       #####################################################
@@ -52,7 +52,7 @@ module Fastlane
                                         description: "The path to your sonar project configuration file; defaults to `sonar-project.properties`", # default is enforced by sonar-runner binary
                                         optional: true,
                                         verify_block: proc do |value|
-                                          raise "Couldn't find file at path '#{value}'".red unless value.nil? or File.exist?(value)
+                                          UI.crash!("Couldn't find file at path '#{value}'") unless value.nil? or File.exist?(value)
                                         end),
           FastlaneCore::ConfigItem.new(key: :project_key,
                                        env_name: "FL_SONAR_RUNNER_PROJECT_KEY",

--- a/fastlane/lib/fastlane/actions/splunkmint.rb
+++ b/fastlane/lib/fastlane/actions/splunkmint.rb
@@ -22,7 +22,7 @@ module Fastlane
 
       def self.fail_on_error(result)
         if result.include?("error")
-          raise "Server error, failed to upload the dSYM file".red
+          UI.crash!("Server error, failed to upload the dSYM file")
         end
       end
 
@@ -45,11 +45,11 @@ module Fastlane
 
         if file_path
           expanded_file_path = File.expand_path(file_path)
-          raise "Couldn't find file at path '#{expanded_file_path}'".red unless File.exist?(expanded_file_path)
+          UI.crash!("Couldn't find file at path '#{expanded_file_path}'") unless File.exist?(expanded_file_path)
 
           return expanded_file_path
         else
-          raise "Couldn't find any dSYM file".red
+          UI.crash!("Couldn't find any dSYM file")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -3,12 +3,12 @@ module Fastlane
     class SwiftlintAction < Action
       def self.run(params)
         if `which swiftlint`.to_s.length == 0 and !Helper.test?
-          raise "You have to install swiftlint using `brew install swiftlint`".red
+          UI.crash!("You have to install swiftlint using `brew install swiftlint`")
         end
 
         version = Gem::Version.new(Helper.test? ? '0.0.0' : `swiftlint version`.chomp)
         if params[:mode] == :autocorrect and version < Gem::Version.new('0.5.0') and !Helper.test?
-          raise "Your version of swiftlint (#{version}) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`".red
+          UI.crash!("Your version of swiftlint (#{version}) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
         end
 
         command = "swiftlint #{params[:mode]}"
@@ -17,7 +17,7 @@ module Fastlane
 
         if params[:files]
           if version < Gem::Version.new('0.5.1') and !Helper.test?
-            raise "Your version of swiftlint (#{version}) does not support list of files as input.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`".red
+            UI.crash!("Your version of swiftlint (#{version}) does not support list of files as input.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
           end
 
           files = params[:files].map.with_index(0) { |f, i| "SCRIPT_INPUT_FILE_#{i}=#{f.shellescape}" }.join(" ")

--- a/fastlane/lib/fastlane/actions/team_id.rb
+++ b/fastlane/lib/fastlane/actions/team_id.rb
@@ -7,7 +7,7 @@ module Fastlane
       def self.run(params)
         params = nil unless params.kind_of? Array
         team = (params || []).first
-        raise "Please pass your Team ID (e.g. team_id 'Q2CBPK58CA')".red unless team.to_s.length > 0
+        UI.crash!("Please pass your Team ID (e.g. team_id 'Q2CBPK58CA')") unless team.to_s.length > 0
 
         UI.message("Setting Team ID to '#{team}' for all build steps")
 

--- a/fastlane/lib/fastlane/actions/team_name.rb
+++ b/fastlane/lib/fastlane/actions/team_name.rb
@@ -7,7 +7,7 @@ module Fastlane
       def self.run(params)
         params = nil unless params.kind_of? Array
         team = (params || []).first
-        raise "Please pass your Team Name (e.g. team_name 'Felix Krause')".red unless team.to_s.length > 0
+        UI.crash!("Please pass your Team Name (e.g. team_name 'Felix Krause')") unless team.to_s.length > 0
 
         UI.message("Setting Team Name to '#{team}' for all build steps")
 

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -22,7 +22,7 @@ module Fastlane
           UI.success("Build URL: #{Actions.lane_context[SharedValues::TESTFAIRY_BUILD_URL]}")
           UI.success("Build successfully uploaded to TestFairy.")
         else
-          raise 'Error when trying to upload ipa to TestFairy'.red
+          UI.crash!('Error when trying to upload ipa to TestFairy')
         end
       end
 
@@ -55,14 +55,14 @@ module Fastlane
                                        env_name: "FL_TESTFAIRY_API_KEY", # The name of the environment variable
                                        description: "API Key for TestFairy", # a short description of this parameter
                                        verify_block: proc do |value|
-                                         raise "No API key for TestFairy given, pass using `api_key: 'key'`".red unless value.to_s.length > 0
+                                         UI.crash!("No API key for TestFairy given, pass using `api_key: 'key'`") unless value.to_s.length > 0
                                        end),
           FastlaneCore::ConfigItem.new(key: :ipa,
                                        env_name: 'TESTFAIRY_IPA_PATH',
                                        description: 'Path to your IPA file. Optional if you use the `gym` or `xcodebuild` action',
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        verify_block: proc do |value|
-                                         raise "Couldn't find ipa file at path '#{value}'".red unless File.exist?(value)
+                                         UI.crash!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :comment,
                                        env_name: "FL_TESTFAIRY_COMMENT",

--- a/fastlane/lib/fastlane/actions/testmunk.rb
+++ b/fastlane/lib/fastlane/actions/testmunk.rb
@@ -28,7 +28,7 @@ module Fastlane
         if response
           UI.success('Your tests are being executed right now. Please wait for the mail with results and decide if you want to continue.')
         else
-          raise 'Something went wrong while uploading your app to Testmunk'.red
+          UI.crash!('Something went wrong while uploading your app to Testmunk')
         end
       end
 

--- a/fastlane/lib/fastlane/actions/tryouts.rb
+++ b/fastlane/lib/fastlane/actions/tryouts.rb
@@ -19,7 +19,7 @@ module Fastlane
           UI.success('Build successfully uploaded to Tryouts!')
           UI.message("Release download url: #{response.body['download_url']}") if response.body["download_url"]
         else
-          raise "Error when trying to upload build file to Tryouts: #{response.body}".red
+          UI.crash!("Error when trying to upload build file to Tryouts: #{response.body}")
         end
       end
 
@@ -68,20 +68,20 @@ module Fastlane
                                      env_name: "TRYOUTS_APP_ID",
                                      description: "Tryouts application hash",
                                      verify_block: proc do |value|
-                                       raise "No application identifier for Tryouts given, pass using `app_id: 'application id'`".red unless value and !value.empty?
+                                       UI.crash!("No application identifier for Tryouts given, pass using `app_id: 'application id'`") unless value and !value.empty?
                                      end),
           FastlaneCore::ConfigItem.new(key: :api_token,
                                      env_name: "TRYOUTS_API_TOKEN",
                                      description: "API Token for Tryouts Access",
                                      verify_block: proc do |value|
-                                       raise "No API token for Tryouts given, pass using `api_token: 'token'`".red unless value and !value.empty?
+                                       UI.crash!("No API token for Tryouts given, pass using `api_token: 'token'`") unless value and !value.empty?
                                      end),
           FastlaneCore::ConfigItem.new(key: :build_file,
                                      env_name: "TRYOUTS_BUILD_FILE",
                                      description: "Path to your IPA or APK file. Optional if you use the `gym` or `xcodebuild` action",
                                      default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                      verify_block: proc do |value|
-                                       raise "Couldn't find build file at path '#{value}'".red unless File.exist?(value)
+                                       UI.crash!("Couldn't find build file at path '#{value}'") unless File.exist?(value)
                                      end),
           FastlaneCore::ConfigItem.new(key: :notes,
                                      env_name: "TRYOUTS_NOTES",
@@ -92,7 +92,7 @@ module Fastlane
                                      env_name: "TRYOUTS_NOTES_PATH",
                                      description: "Release notes text file path. Overrides the :notes paramether",
                                      verify_block: proc do |value|
-                                       raise "Couldn't find notes file at path '#{value}'".red unless File.exist?(value)
+                                       UI.crash!("Couldn't find notes file at path '#{value}'") unless File.exist?(value)
                                      end,
                                      optional: true),
           FastlaneCore::ConfigItem.new(key: :notify,
@@ -105,7 +105,7 @@ module Fastlane
                                      description: "2 to make your release public. Release will be distributed to available testers. 1 to make your release private. Release won't be distributed to testers. This also prevents release from showing up for SDK update",
                                      verify_block: proc do |value|
                                        available_options = ["1", "2"]
-                                       raise "'#{value}' is not a valid 'status' value. Available options are #{available_options.join(', ')}".red unless available_options.include?(value.to_s)
+                                       UI.crash!("'#{value}' is not a valid 'status' value. Available options are #{available_options.join(', ')}") unless available_options.include?(value.to_s)
                                      end,
                                      is_string: false,
                                      default_value: 2)

--- a/fastlane/lib/fastlane/actions/typetalk.rb
+++ b/fastlane/lib/fastlane/actions/typetalk.rb
@@ -11,7 +11,7 @@ module Fastlane
         }.merge(params || {})
 
         [:message, :topic_id, :typetalk_token].each do |key|
-          raise "No #{key} given.".red unless options[key]
+          UI.crash!("No #{key} given.") unless options[key]
         end
 
         emoticon = (options[:success] ? ':smile:' : ':rage:')
@@ -47,7 +47,7 @@ module Fastlane
         when 200, 204
           true
         else
-          raise "Could not sent Typetalk notification".red
+          UI.crash!("Could not sent Typetalk notification")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/unlock_keychain.rb
+++ b/fastlane/lib/fastlane/actions/unlock_keychain.rb
@@ -63,7 +63,7 @@ module Fastlane
           end
         end
 
-        raise "Could not find the keychain file in: #{possible_locations}".red
+        UI.crash!("Could not find the keychain file in: #{possible_locations}")
       end
 
       #####################################################

--- a/fastlane/lib/fastlane/actions/update_app_group_identifiers.rb
+++ b/fastlane/lib/fastlane/actions/update_app_group_identifiers.rb
@@ -12,15 +12,15 @@ module Fastlane
         UI.message("New App Group Identifiers: #{params[:app_group_identifiers]}")
 
         entitlements_file = params[:entitlements_file]
-        raise "Could not find entitlements file at path '#{entitlements_file}'".red unless File.exist?(entitlements_file)
+        UI.crash!("Could not find entitlements file at path '#{entitlements_file}'") unless File.exist?(entitlements_file)
 
         # parse entitlements
         result = Plist.parse_xml(entitlements_file)
-        raise "Entitlements file at '#{entitlements_file}' cannot be parsed.".red unless result
+        UI.crash!("Entitlements file at '#{entitlements_file}' cannot be parsed.") unless result
 
         # get app group field
         app_group_field = result['com.apple.security.application-groups']
-        raise 'No existing App group field specified. Please specify an App Group in the entitlements file.'.red unless app_group_field
+        UI.crash!('No existing App group field specified. Please specify an App Group in the entitlements file.') unless app_group_field
 
         # set new app group identifiers
         UI.message("Old App Group Identifiers: #{app_group_field}")
@@ -43,15 +43,15 @@ module Fastlane
                                        env_name: "FL_UPDATE_APP_GROUP_IDENTIFIER_ENTITLEMENTS_FILE_PATH", # The name of the environment variable
                                        description: "The path to the entitlement file which contains the app group identifiers", # a short description of this parameter
                                        verify_block: proc do |value|
-                                         raise "Please pass a path to an entitlements file. ".red unless value.include? ".entitlements"
-                                         raise "Could not find entitlements file".red if !File.exist?(value) and !Helper.is_test?
+                                         UI.crash!"Please pass a path to an entitlements file. " unless value.include? ".entitlements"
+                                         UI.crash!("Could not find entitlements file") if !File.exist?(value) and !Helper.is_test?
                                        end),
           FastlaneCore::ConfigItem.new(key: :app_group_identifiers,
                                        env_name: "FL_UPDATE_APP_GROUP_IDENTIFIER_APP_GROUP_IDENTIFIERS",
                                        description: "An Array of unique identifiers for the app groups. Eg. ['group.com.test.testapp']",
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "The parameter app_group_identifiers need to be an Array.".red unless value.kind_of? Array
+                                         UI.crash!("The parameter app_group_identifiers need to be an Array.") unless value.kind_of? Array
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/update_app_identifier.rb
+++ b/fastlane/lib/fastlane/actions/update_app_identifier.rb
@@ -10,7 +10,7 @@ module Fastlane
 
         # Read existing plist file
         info_plist_path = File.join(params[:xcodeproj], '..', params[:plist_path])
-        raise "Couldn't find info plist file at path '#{params[:plist_path]}'".red unless File.exist?(info_plist_path)
+        UI.crash!("Couldn't find info plist file at path '#{params[:plist_path]}'") unless File.exist?(info_plist_path)
         plist = Plist.parse_xml(info_plist_path)
 
         # Check if current app identifier product bundle identifier
@@ -21,10 +21,10 @@ module Fastlane
 
           # Fetch the build configuration objects
           configs = project.objects.select { |obj| obj.isa == 'XCBuildConfiguration' && !obj.build_settings[identifier_key].nil? }
-          raise "Info plist uses $(#{identifier_key}), but xcodeproj does not".red unless configs.count > 0
+          UI.crash!("Info plist uses $(#{identifier_key}), but xcodeproj does not") unless configs.count > 0
 
           configs = configs.select { |obj| obj.build_settings[info_plist_key] == params[:plist_path] }
-          raise "Xcodeproj doesn't have configuration with info plist #{params[:plist_path]}.".red unless configs.count > 0
+          UI.crash!("Xcodeproj doesn't have configuration with info plist #{params[:plist_path]}.") unless configs.count > 0
 
           # For each of the build configurations, set app identifier
           configs.each do |c|
@@ -66,14 +66,14 @@ module Fastlane
                                        description: "Path to your Xcode project",
                                        default_value: Dir['*.xcodeproj'].first,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red unless value.end_with?(".xcodeproj")
-                                         raise "Could not find Xcode project".red unless File.exist?(value)
+                                         UI.crash!("Please pass the path to the project, not the workspace") unless value.end_with?(".xcodeproj")
+                                         UI.crash!("Could not find Xcode project") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :plist_path,
                                        env_name: "FL_UPDATE_APP_IDENTIFIER_PLIST_PATH",
                                        description: "Path to info plist, relative to your Xcode project",
                                        verify_block: proc do |value|
-                                         raise "Invalid plist file".red unless value[-6..-1].casecmp(".plist").zero?
+                                         UI.crash!("Invalid plist file") unless value[-6..-1].casecmp(".plist").zero?
                                        end),
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        env_name: 'FL_UPDATE_APP_IDENTIFIER',

--- a/fastlane/lib/fastlane/actions/update_info_plist.rb
+++ b/fastlane/lib/fastlane/actions/update_info_plist.rb
@@ -19,7 +19,7 @@ module Fastlane
 
           # Read existing plist file
           info_plist_path = File.join(folder, "..", params[:plist_path])
-          raise "Couldn't find info plist file at path '#{params[:plist_path]}'".red unless File.exist?(info_plist_path)
+          UI.crash!("Couldn't find info plist file at path '#{params[:plist_path]}'") unless File.exist?(info_plist_path)
           plist = Plist.parse_xml(info_plist_path)
 
           # Update plist values
@@ -59,14 +59,14 @@ module Fastlane
                                        description: "Path to your Xcode project",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                                         raise "Could not find Xcode project".red unless File.exist?(value)
+                                         UI.crash!"Please pass the path to the project, not the workspace" if value.end_with? ".xcworkspace"
+                                         UI.crash!("Could not find Xcode project") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :plist_path,
                                        env_name: "FL_UPDATE_PLIST_PATH",
                                        description: "Path to info plist",
                                        verify_block: proc do |value|
-                                         raise "Invalid plist file".red unless value[-6..-1].casecmp(".plist").zero?
+                                         UI.crash!("Invalid plist file") unless value[-6..-1].casecmp(".plist").zero?
                                        end),
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        env_name: 'FL_UPDATE_PLIST_APP_IDENTIFIER',

--- a/fastlane/lib/fastlane/actions/update_project_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/update_project_code_signing.rb
@@ -11,7 +11,7 @@ module Fastlane
 
         path = params[:path]
         path = File.join(path, "project.pbxproj")
-        raise "Could not find path to project config '#{path}'. Pass the path to your project (not workspace)!".red unless File.exist?(path)
+        UI.crash!("Could not find path to project config '#{path}'. Pass the path to your project (not workspace)!") unless File.exist?(path)
 
         UI.message("Updating provisioning profile UDID (#{params[:udid]}) for the given project '#{path}'")
 
@@ -35,7 +35,7 @@ module Fastlane
                                        env_name: "FL_PROJECT_SIGNING_PROJECT_PATH",
                                        description: "Path to your Xcode project",
                                        verify_block: proc do |value|
-                                         raise "Path is invalid".red unless File.exist?(value)
+                                         UI.crash!("Path is invalid") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :udid,
                                        env_name: "FL_PROJECT_SIGNING_UDID",

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -15,7 +15,7 @@ module Fastlane
 
         # validate folder
         project_file_path = File.join(folder, "project.pbxproj")
-        raise "Could not find path to project config '#{project_file_path}'. Pass the path to your project (not workspace)!".red unless File.exist?(project_file_path)
+        UI.crash!("Could not find path to project config '#{project_file_path}'. Pass the path to your project (not workspace)!") unless File.exist?(project_file_path)
 
         # download certificate
         unless File.exist?(params[:certificate])
@@ -94,14 +94,14 @@ module Fastlane
                                        description: "Path to your Xcode project",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Path to xcode project is invalid".red unless File.exist?(value)
+                                         UI.crash!("Path to xcode project is invalid") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :profile,
                                        env_name: "FL_PROJECT_PROVISIONING_PROFILE_FILE",
                                        description: "Path to provisioning profile (.mobileprovision)",
                                        default_value: Actions.lane_context[SharedValues::SIGH_PROFILE_PATH],
                                        verify_block: proc do |value|
-                                         raise "Path to provisioning profile is invalid".red unless File.exist?(value)
+                                         UI.crash!("Path to provisioning profile is invalid") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :target_filter,
                                        env_name: "FL_PROJECT_PROVISIONING_PROFILE_TARGET_FILTER",

--- a/fastlane/lib/fastlane/actions/update_project_team.rb
+++ b/fastlane/lib/fastlane/actions/update_project_team.rb
@@ -7,7 +7,7 @@ module Fastlane
       def self.run(params)
         path = params[:path]
         path = File.join(path, "project.pbxproj")
-        raise "Could not find path to project config '#{path}'. Pass the path to your project (not workspace)!".red unless File.exist?(path)
+        UI.crash!("Could not find path to project config '#{path}'. Pass the path to your project (not workspace)!") unless File.exist?(path)
 
         UI.message("Updating development team (#{params[:teamid]}) for the given project '#{path}'")
 
@@ -31,7 +31,7 @@ module Fastlane
                                        env_name: "FL_PROJECT_SIGNING_PROJECT_PATH",
                                        description: "Path to your Xcode project",
                                        verify_block: proc do |value|
-                                         raise "Path is invalid".red unless File.exist?(value)
+                                         UI.crash!("Path is invalid") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :teamid,
                                        env_name: "FL_PROJECT_TEAM_ID",

--- a/fastlane/lib/fastlane/actions/update_url_schemes.rb
+++ b/fastlane/lib/fastlane/actions/update_url_schemes.rb
@@ -25,7 +25,7 @@ module Fastlane
             is_string: true,
             optional: false,
             verify_block: proc do |path|
-              raise "Could not find plist at path '#{path}'".red unless File.exist?(path)
+              UI.crash!("Could not find plist at path '#{path}'") unless File.exist?(path)
             end
           ),
 

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
@@ -69,19 +69,19 @@ module Fastlane
                                        env_name: "SENTRY_API_KEY",
                                        description: "API Key for Sentry",
                                        verify_block: proc do |value|
-                                         raise "No API token for SentryAction given, pass using `api_key: 'key'`".red unless value and !value.empty?
+                                         UI.crash!("No API token for SentryAction given, pass using `api_key: 'key'`") unless value and !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :org_slug,
                                        env_name: "SENTRY_ORG_SLUG",
                                        description: "Organization slug for Sentry project",
                                        verify_block: proc do |value|
-                                         raise "No organization slug for SentryAction given, pass using `org_slug: 'org'`".red unless value and !value.empty?
+                                         UI.crash!("No organization slug for SentryAction given, pass using `org_slug: 'org'`") unless value and !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :project_slug,
                                        env_name: "SENTRY_PROJECT_SLUG",
                                        description: "Prgoject slug for Sentry",
                                        verify_block: proc do |value|
-                                         raise "No project slug for SentryAction given, pass using `project_slug: 'project'`".red unless value and !value.empty?
+                                         UI.crash!("No project slug for SentryAction given, pass using `project_slug: 'project'`") unless value and !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :dsym_path,
                                        env_name: "SENTRY_DSYM_PATH",

--- a/fastlane/lib/fastlane/actions/verify_build.rb
+++ b/fastlane/lib/fastlane/actions/verify_build.rb
@@ -27,7 +27,7 @@ module Fastlane
         ipa_path = File.expand_path(ipa_path)
 
         `unzip '#{ipa_path}' -d #{dir}`
-        raise "Unable to unzip ipa".red unless $? == 0
+        UI.crash!("Unable to unzip ipa") unless $? == 0
 
         app_path = File.expand_path("#{dir}/Payload/*.app")
 
@@ -36,7 +36,7 @@ module Fastlane
 
       def self.gather_cert_info(app_path)
         cert_info = `codesign -vv -d #{app_path} 2>&1`
-        raise "Unable to verify code signing".red unless $? == 0
+        UI.crash!("Unable to verify code signing") unless $? == 0
 
         values = {}
 
@@ -59,7 +59,7 @@ module Fastlane
 
       def self.update_with_profile_info(app_path, values)
         profile = `cat #{app_path}/embedded.mobileprovision | security cms -D`
-        raise "Unable to extract profile".red unless $? == 0
+        UI.crash!("Unable to extract profile") unless $? == 0
 
         plist = Plist.parse_xml(profile)
 
@@ -103,22 +103,22 @@ module Fastlane
 
       def self.evaulate(params, values)
         if params[:provisioning_type]
-          raise "Mismatched provisioning_type. Required: '#{params[:provisioning_type]}''; Found: '#{values['provisioning_type']}'".red unless params[:provisioning_type] == values['provisioning_type']
+          UI.crash!("Mismatched provisioning_type. Required: '#{params[:provisioning_type]}''; Found: '#{values['provisioning_type']}'") unless params[:provisioning_type] == values['provisioning_type']
         end
         if params[:provisioning_uuid]
-          raise "Mismatched provisioning_uuid. Required: '#{params[:provisioning_uuid]}'; Found: '#{values['provisioning_uuid']}'".red unless params[:provisioning_uuid] == values['provisioning_uuid']
+          UI.crash!("Mismatched provisioning_uuid. Required: '#{params[:provisioning_uuid]}'; Found: '#{values['provisioning_uuid']}'") unless params[:provisioning_uuid] == values['provisioning_uuid']
         end
         if params[:team_identifier]
-          raise "Mismatched team_identifier. Required: '#{params[:team_identifier]}'; Found: '#{values['team_identifier']}'".red unless params[:team_identifier] == values['team_identifier']
+          UI.crash!("Mismatched team_identifier. Required: '#{params[:team_identifier]}'; Found: '#{values['team_identifier']}'") unless params[:team_identifier] == values['team_identifier']
         end
         if params[:team_name]
-          raise "Mismatched team_name. Required: '#{params[:team_name]}'; Found: 'values['team_name']'".red unless params[:team_name] == values['team_name']
+          UI.crash!("Mismatched team_name. Required: '#{params[:team_name]}'; Found: 'values['team_name']'") unless params[:team_name] == values['team_name']
         end
         if params[:app_name]
-          raise "Mismatched app_name. Required: '#{params[:app_name]}'; Found: '#{values['app_name']}'".red unless params[:app_name] == values['app_name']
+          UI.crash!("Mismatched app_name. Required: '#{params[:app_name]}'; Found: '#{values['app_name']}'") unless params[:app_name] == values['app_name']
         end
         if params[:bundle_identifier]
-          raise "Mismatched bundle_identifier. Required: '#{params[:bundle_identifier]}'; Found: '#{values['bundle_identifier']}'".red unless params[:bundle_identifier] == values['bundle_identifier']
+          UI.crash!("Mismatched bundle_identifier. Required: '#{params[:bundle_identifier]}'; Found: '#{values['bundle_identifier']}'") unless params[:bundle_identifier] == values['bundle_identifier']
         end
 
         UI.success "Build is verified, have a 🍪."

--- a/fastlane/lib/fastlane/actions/verify_xcode.rb
+++ b/fastlane/lib/fastlane/actions/verify_xcode.rb
@@ -90,7 +90,7 @@ module Fastlane
                                        description: "The path to the Xcode installation to test",
                                        default_value: File.expand_path('../../', FastlaneCore::Helper.xcode_path),
                                        verify_block: proc do |value|
-                                         raise "Couldn't find Xcode at path '#{value}'".red unless File.exist?(value)
+                                         UI.crash!("Couldn't find Xcode at path '#{value}'") unless File.exist?(value)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/version_bump_podspec.rb
+++ b/fastlane/lib/fastlane/actions/version_bump_podspec.rb
@@ -8,7 +8,7 @@ module Fastlane
       def self.run(params)
         podspec_path = params[:path]
 
-        raise "Could not find podspec file at path #{podspec_path}".red unless File.exist? podspec_path
+        UI.crash!("Could not find podspec file at path #{podspec_path}") unless File.exist? podspec_path
 
         version_podspec_file = Helper::PodspecHelper.new(podspec_path)
 
@@ -45,7 +45,7 @@ module Fastlane
                                        description: "You must specify the path to the podspec file to update",
                                        default_value: Dir["*.podspec"].last,
                                        verify_block: proc do |value|
-                                         raise "Please pass a path to the `version_bump_podspec` action".red if value.length == 0
+                                         UI.crash!("Please pass a path to the `version_bump_podspec` action") if value.length == 0
                                        end),
           FastlaneCore::ConfigItem.new(key: :bump_type,
                                        env_name: "FL_VERSION_BUMP_PODSPEC_BUMP_TYPE",

--- a/fastlane/lib/fastlane/actions/version_get_podspec.rb
+++ b/fastlane/lib/fastlane/actions/version_get_podspec.rb
@@ -4,7 +4,7 @@ module Fastlane
       def self.run(params)
         podspec_path = params[:path]
 
-        raise "Could not find podspec file at path '#{podspec_path}'".red unless File.exist? podspec_path
+        UI.crash!("Could not find podspec file at path '#{podspec_path}'") unless File.exist? podspec_path
 
         version_podspec_file = Helper::PodspecHelper.new(podspec_path)
 
@@ -27,7 +27,7 @@ module Fastlane
                                        is_string: true,
                                        default_value: Dir["*.podspec"].last,
                                        verify_block: proc do |value|
-                                         raise "Please pass a path to the `version_get_podspec` action".red if value.length == 0
+                                         UI.crash!("Please pass a path to the `version_get_podspec` action") if value.length == 0
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/xcode_select.rb
+++ b/fastlane/lib/fastlane/actions/xcode_select.rb
@@ -23,10 +23,10 @@ module Fastlane
         xcode_path = (params || []).first
 
         # Verify that a param was passed in
-        raise "Path to Xcode application required (e.x. \"/Applications/Xcode.app\")".red unless xcode_path.to_s.length > 0
+        UI.crash!("Path to Xcode application required (e.x. \"/Applications/Xcode.app\")") unless xcode_path.to_s.length > 0
 
         # Verify that a path to a directory was passed in
-        raise "Path '#{xcode_path}' doesn't exist".red unless Dir.exist?(xcode_path)
+        UI.crash!("Path '#{xcode_path}' doesn't exist") unless Dir.exist?(xcode_path)
 
         UI.message("Setting Xcode version to #{xcode_path} for all build steps")
 

--- a/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
+++ b/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
@@ -37,7 +37,7 @@ module Fastlane
 
         # match the bot name with a found bot, otherwise fail
         found_bots = bots.select { |bot| bot['name'] == bot_name }
-        raise "Failed to find a Bot with name #{bot_name} on server #{host}, only available Bots: #{bot_names}".red if found_bots.count == 0
+        UI.crash!("Failed to find a Bot with name #{bot_name} on server #{host}, only available Bots: #{bot_names}") if found_bots.count == 0
 
         bot = found_bots[0]
 
@@ -45,12 +45,12 @@ module Fastlane
 
         # we have our bot, get finished integrations, sorted from newest to oldest
         integrations = xcs.fetch_integrations(bot['_id']).select { |i| i['currentStep'] == 'completed' }
-        raise "Failed to find any completed integration for Bot \"#{bot_name}\"".red if (integrations || []).count == 0
+        UI.crash!("Failed to find any completed integration for Bot \"#{bot_name}\"") if (integrations || []).count == 0
 
         # if no integration number is specified, pick the newest one (this is sorted from newest to oldest)
         if integration_number_override
           integration = integrations.find { |i| i['number'] == integration_number_override }
-          raise "Specified integration number #{integration_number_override} does not exist.".red unless integration
+          UI.crash!("Specified integration number #{integration_number_override} does not exist.") unless integration
         else
           integration = integrations.first
         end
@@ -117,14 +117,14 @@ module Fastlane
 
         def fetch_all_bots
           response = get_endpoint('/bots')
-          raise "You are unauthorized to access data on #{@host}, please check that you're passing in a correct username and password.".red if response.status == 401
-          raise "Failed to fetch Bots from Xcode Server at #{@host}, response: #{response.status}: #{response.body}.".red if response.status != 200
+          UI.crash!("You are unauthorized to access data on #{@host}, please check that you're passing in a correct username and password.") if response.status == 401
+          UI.crash!("Failed to fetch Bots from Xcode Server at #{@host}, response: #{response.status}: #{response.body}.") if response.status != 200
           JSON.parse(response.body)['results']
         end
 
         def fetch_integrations(bot_id)
           response = get_endpoint("/bots/#{bot_id}/integrations?last=10")
-          raise "Failed to fetch Integrations for Bot #{bot_id} from Xcode Server at #{@host}, response: #{response.status}: #{response.body}".red if response.status != 200
+          UI.crash!("Failed to fetch Integrations for Bot #{bot_id} from Xcode Server at #{@host}, response: #{response.status}: #{response.body}") if response.status != 200
           JSON.parse(response.body)['results']
         end
 
@@ -145,8 +145,8 @@ module Fastlane
             response = self.get_endpoint("/integrations/#{integration_id}/assets", streamer)
             f.close
 
-            raise "Integration doesn't have any assets (it probably never ran).".red if response.status == 500
-            raise "Failed to fetch Assets zip for Integration #{integration_id} from Xcode Server at #{@host}, response: #{response.status}: #{response.body}".red if response.status != 200
+            UI.crash!("Integration doesn't have any assets (it probably never ran).") if response.status == 500
+            UI.crash!("Failed to fetch Assets zip for Integration #{integration_id} from Xcode Server at #{@host}, response: #{response.status}: #{response.body}") if response.status != 200
 
             # unzip it, it's a .tar.gz file
             out_folder = File.join(dir, "out_#{rand(1000000)}")
@@ -161,7 +161,7 @@ module Fastlane
             # rename the folder in out_folder to asset_foldername
             found_folder = Dir.entries(out_folder).select { |item| item != '.' && item != '..' }[0]
 
-            raise "Internal error, couldn't find unzipped folder".red if found_folder.nil?
+            UI.crash!("Internal error, couldn't find unzipped folder") if found_folder.nil?
 
             unzipped_folder_temp_name = File.join(out_folder, found_folder)
             unzipped_folder = File.join(out_folder, asset_foldername)

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -57,7 +57,7 @@ module Fastlane
 
       def self.run(params)
         unless Helper.test?
-          raise "xcodebuild not installed".red if `which xcodebuild`.length == 0
+          UI.crash!("xcodebuild not installed") if `which xcodebuild`.length == 0
         end
 
         # The args we will build with
@@ -155,7 +155,7 @@ module Fastlane
         # Formatting style
         if params && params[:output_style]
           output_style = params[:output_style]
-          raise "Invalid output_style #{output_style}".red unless [:standard, :basic].include?(output_style)
+          UI.crash!("Invalid output_style #{output_style}") unless [:standard, :basic].include?(output_style)
         else
           output_style = :standard
         end

--- a/fastlane/lib/fastlane/actions/xctool.rb
+++ b/fastlane/lib/fastlane/actions/xctool.rb
@@ -4,7 +4,7 @@ module Fastlane
       def self.run(params)
         UI.important("Have you seen the new 'scan' tool to run tests? https://github.com/fastlane/fastlane/tree/master/scan")
         unless Helper.test?
-          raise 'xctool not installed, please install using `brew install xctool`'.red if `which xctool`.length == 0
+          UI.crash!('xctool not installed, please install using `brew install xctool`') if `which xctool`.length == 0
         end
 
         params = [] if params.kind_of? FastlaneCore::Configuration

--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -153,7 +153,7 @@ module Fastlane
 
           elsif current.kind_of? Array
             # Legacy actions that don't use the new config manager
-            raise "Invalid number of elements in this row: #{current}. Must be 2 or 3".red unless [2, 3].include? current.count
+            UI.crash!("Invalid number of elements in this row: #{current}. Must be 2 or 3") unless [2, 3].include? current.count
             rows << current
             rows.last[0] = rows.last.first.yellow # color it yellow :)
             rows.last << nil while fill_all and rows.last.count < 3 # to have a nice border in the table

--- a/fastlane/lib/fastlane/erb_template_helper.rb
+++ b/fastlane/lib/fastlane/erb_template_helper.rb
@@ -8,7 +8,7 @@ module Fastlane
 
     def self.load_from_path(template_filepath)
       unless File.exist?(template_filepath)
-        raise "Could not find Template at path '#{template_filepath}'".red
+        UI.crash!("Could not find Template at path '#{template_filepath}'")
       end
       File.read(template_filepath)
     end

--- a/fastlane/lib/fastlane/helper/gradle_helper.rb
+++ b/fastlane/lib/fastlane/helper/gradle_helper.rb
@@ -24,7 +24,7 @@ module Fastlane
 
       # Run a certain action
       def trigger(task: nil, flags: nil, serial: nil)
-        # raise "Could not find gradle task '#{task}' in the list of available tasks".red unless task_available?(task)
+        # UI.crash!("Could not find gradle task '#{task}' in the list of available tasks") unless task_available?(task)
 
         android_serial = (serial != "") ? "ANDROID_SERIAL=#{serial}" : nil
         command = [android_serial, gradle_path, task, flags].reject(&:nil?).join(" ")

--- a/fastlane/lib/fastlane/helper/podspec_helper.rb
+++ b/fastlane/lib/fastlane/helper/podspec_helper.rb
@@ -12,7 +12,7 @@ module Fastlane
         @version_regex = /^(?<begin>[^#]*#{version_var_name}\s*=\s*['"])(?<value>(?<major>[0-9]+)(\.(?<minor>[0-9]+))?(\.(?<patch>[0-9]+))?)(?<end>['"])/i
 
         return unless (path || '').length > 0
-        raise "Could not find podspec file at path '#{path}'".red unless File.exist?(path)
+        UI.crash!("Could not find podspec file at path '#{path}'") unless File.exist?(path)
 
         @path = File.expand_path(path)
         podspec_content = File.read(path)
@@ -23,7 +23,7 @@ module Fastlane
       def parse(podspec_content)
         @podspec_content = podspec_content
         @version_match = @version_regex.match(@podspec_content)
-        raise "Could not find version in podspec content '#{@podspec_content}'".red if @version_match.nil?
+        UI.crash!("Could not find version in podspec content '#{@podspec_content}'") if @version_match.nil?
         @version_value = @version_match[:value]
       end
 

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -27,7 +27,7 @@ module Fastlane
 
       lane_obj = lanes.fetch(current_platform, {}).fetch(current_lane, nil)
 
-      raise "Could not find lane '#{full_lane_name}'. Available lanes: #{available_lanes.join(', ')}".red unless lane_obj
+      UI.crash!("Could not find lane '#{full_lane_name}'. Available lanes: #{available_lanes.join(', ')}") unless lane_obj
       raise "You can't call the private lane '#{lane}' directly" if lane_obj.is_private
 
       ENV["FASTLANE_LANE_NAME"] = current_lane.to_s
@@ -97,7 +97,7 @@ module Fastlane
         original_full = full_lane_name
         original_lane = current_lane
 
-        raise "Parameters for a lane must always be a hash".red unless (parameters.first || {}).kind_of? Hash
+        UI.crash!("Parameters for a lane must always be a hash") unless (parameters.first || {}).kind_of? Hash
 
         pretty = [new_lane]
         pretty = [current_platform, new_lane] if current_platform
@@ -137,7 +137,7 @@ module Fastlane
               # This action does not use the new action format
               # Just passing the arguments to this method
             else
-              raise "You have to call the integration like `#{method_sym}(key: \"value\")`. Run `fastlane action #{method_sym}` for all available keys. Please check out the current documentation on GitHub.".red
+              UI.crash!("You have to call the integration like `#{method_sym}(key: \"value\")`. Run `fastlane action #{method_sym}` for all available keys. Please check out the current documentation on GitHub.")
             end
 
             class_ref.run(arguments)
@@ -156,7 +156,7 @@ module Fastlane
           platform = Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
 
           unless class_ref.is_supported?(platform)
-            raise "Action '#{name}' doesn't support required operating system '#{platform}'.".red
+            UI.crash!("Action '#{name}' doesn't support required operating system '#{platform}'.")
           end
         end
       end
@@ -179,7 +179,7 @@ module Fastlane
       lanes[lane.platform] ||= {}
 
       if !override and lanes[lane.platform][lane.name]
-        raise "Lane '#{lane.name}' was defined multiple times!".red
+        UI.crash!("Lane '#{lane.name}' was defined multiple times!")
       end
 
       lanes[lane.platform][lane.name] = lane

--- a/fastlane/lib/fastlane/supported_platforms.rb
+++ b/fastlane/lib/fastlane/supported_platforms.rb
@@ -11,7 +11,7 @@ module Fastlane
     # this will throw an exception if the passed platform is not supported
     def self.verify!(platform)
       unless all.include? platform.to_s.to_sym
-        raise "Platform '#{platform}' is not supported. Must be either #{self.all}".red
+        UI.crash!("Platform '#{platform}' is not supported. Must be either #{self.all}")
       end
     end
   end

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -2,7 +2,7 @@ module FastlaneCore
   # This class checks if a specific certificate is installed on the current mac
   class CertChecker
     def self.installed?(path)
-      raise "Could not find file '#{path}'".red unless File.exist?(path)
+      UI.crash!("Could not find file '#{path}'") unless File.exist?(path)
 
       ids = installed_identies
       finger_print = sha1_fingerprint(path)

--- a/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
@@ -70,10 +70,10 @@ module FastlaneCore
     def validate_short_switch(used_switches, short_switch)
       return if short_switch.nil?
 
-      raise "Short option #{short_switch} already taken for key #{option.key}".red if used_switches.include?(short_switch)
-      raise "-v is already used for the version (key #{option.key})".red if short_switch == "-v"
-      raise "-h is already used for the help screen (key #{option.key})".red if short_switch == "-h"
-      raise "-t is already used for the trace screen (key #{option.key})".red if short_switch == "-t"
+      UI.crash!("Short option #{short_switch} already taken for key #{option.key}") if used_switches.include?(short_switch)
+      UI.crash!"-v is already used for the version (key #{option.key})" if short_switch == "-v"
+      UI.crash!"-h is already used for the help screen (key #{option.key})" if short_switch == "-h"
+      UI.crash!"-t is already used for the trace screen (key #{option.key})" if short_switch == "-t"
 
       used_switches << short_switch
     end

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -10,7 +10,7 @@ module FastlaneCore
     # @param default_value the value which is used if there was no given values and no environment values
     # @param verify_block an optional block which is called when a new value is set.
     #   Check value is valid. This could be type checks or if a folder/file exists
-    #   You have to raise a specific exception if something goes wrong. Append .red after the string
+    #   You have to UI.crash!(a specific exception) if something goes wrong. Append  after the string
     # @param is_string *DEPRECATED: Use `type` instead* (Boolean) is that parameter a string? Defaults to true. If it's true, the type string will be verified.
     # @param type (Class) the data type of this config item. Takes precedence over `is_string`
     # @param optional (Boolean) is false by default. If set to true, also string values will not be asked to the user
@@ -24,7 +24,7 @@ module FastlaneCore
         raise "short_option must be a String of length 1" unless short_option.kind_of? String and short_option.delete('-').length == 1
       end
       if description
-        raise "Do not let descriptions end with a '.', since it's used for user inputs as well".red if description[-1] == '.'
+        UI.crash!("Do not let descriptions end with a '.', since it's used for user inputs as well") if description[-1] == '.'
       end
 
       if type.to_s.length > 0 and short_option.to_s.length == 0

--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -25,7 +25,7 @@ module FastlaneCore
         # rubocop:enable Lint/Eval
       rescue SyntaxError => ex
         line = ex.to_s.match(/\(eval\):(\d+)/)[1]
-        raise "Syntax error in your configuration file '#{path}' on line #{line}: #{ex}".red
+        UI.crash!("Syntax error in your configuration file '#{path}' on line #{line}: #{ex}")
       end
     end
 

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -135,7 +135,7 @@ module FastlaneCore
         result = File.join(self.xcode_path, path)
         return result if File.exist?(result)
       end
-      raise "Could not find transporter at #{self.xcode_path}. Please make sure you set the correct path to your Xcode installation.".red
+      UI.crash!("Could not find transporter at #{self.xcode_path}. Please make sure you set the correct path to your Xcode installation.")
     end
 
     def self.fastlane_enabled?

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -174,7 +174,7 @@ module FastlaneCore
           Helper.log.fatal "Transporter transfer failed.".red
           Helper.log.warn(@warnings.join("\n").yellow)
           Helper.log.error(@errors.join("\n").red)
-          raise "Return status of iTunes Transporter was #{$1}: #{@errors.join('\n')}".red
+          UI.crash!("Return status of iTunes Transporter was #{$1}: #{@errors.join('\n')}")
         else
           Helper.log.info "iTunes Transporter successfully finished its job".green
         end

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -5,7 +5,7 @@ module FastlaneCore
       # Project discovery
       def detect_projects(config)
         if config[:workspace].to_s.length > 0 and config[:project].to_s.length > 0
-          raise "You can only pass either a workspace or a project path, not both".red
+          UI.crash!("You can only pass either a workspace or a project path, not both")
         end
 
         return if config[:project].to_s.length > 0
@@ -72,7 +72,7 @@ module FastlaneCore
       self.is_workspace = (options[:workspace].to_s.length > 0)
 
       if !path or !File.directory?(path)
-        raise "Could not find project at path '#{path}'".red
+        UI.crash!("Could not find project at path '#{path}'")
       end
     end
 
@@ -123,7 +123,7 @@ module FastlaneCore
         elsif Helper.is_ci?
           Helper.log.error "Multiple schemes found but you haven't specified one.".red
           Helper.log.error "Since this is a CI, please pass one using the `scheme` option".red
-          raise "Multiple schemes found".red
+          UI.crash!("Multiple schemes found")
         else
           puts "Select Scheme: "
           options[:scheme] = choose(*schemes)
@@ -132,7 +132,7 @@ module FastlaneCore
         Helper.log.error "Couldn't find any schemes in this project, make sure that the scheme is shared if you are using a workspace".red
         Helper.log.error "Open Xcode, click on `Manage Schemes` and check the `Shared` box for the schemes you want to use".red
 
-        raise "No Schemes found".red
+        UI.crash!("No Schemes found")
       end
     end
     # rubocop:enable Metrics/AbcSize
@@ -271,7 +271,7 @@ module FastlaneCore
           " You can override the timeout value with the environment variable FASTLANE_XCODE_LIST_TIMEOUT".red
       end
 
-      raise "Error parsing xcode file using `#{command}`".red if @raw.length == 0
+      UI.crash!("Error parsing xcode file using `#{command}`") if @raw.length == 0
 
       return @raw
     end

--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -58,7 +58,7 @@ module FastlaneCore
           # copy to Xcode provisioning profile directory
           FileUtils.copy(path, destination)
           unless File.exist?(destination)
-            raise "Failed installation of provisioning profile at location: '#{destination}'".red
+            UI.crash!("Failed installation of provisioning profile at location: '#{destination}'")
           end
         end
 

--- a/fastlane_core/lib/fastlane_core/simulator.rb
+++ b/fastlane_core/lib/fastlane_core/simulator.rb
@@ -20,7 +20,7 @@ module FastlaneCore
 
         unless output.include?("== Devices ==")
           Helper.log.error "xcrun simctl CLI broken, run `xcrun simctl list devices` and make sure it works".red
-          raise "xcrun simctl not working.".red
+          UI.crash!("xcrun simctl not working.")
         end
 
         output.split(/\n/).each do |line|
@@ -71,7 +71,7 @@ module FastlaneCore
       #   rescue => ex
       #     Helper.log.error ex
       #     Helper.log.error "xcrun simctl CLI broken, run `xcrun simctl list devices` and make sure it works".red
-      #     raise "xcrun simctl not working.".red
+      #     UI.crash!("xcrun simctl not working.")
       #   end
 
       #   data["devices"].each do |os_version, l|

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -38,7 +38,7 @@ module Commander
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         error_message = "\n[!] #{e}".red
         if $verbose # with stack trace
-          raise e, "[!] #{e.message}".red, e.backtrace
+          UI.crash!(e, "[!] #{e.message}", e.backtrace)
         else
           abort error_message # without stack trace
         end
@@ -46,7 +46,7 @@ module Commander
         FastlaneCore::CrashReporting.handle_crash(e)
         # From https://stackoverflow.com/a/4789702/445598
         # We do this to make the actual error message red and therefore more visible
-        raise e, "[!] #{e.message}".red, e.backtrace
+        UI.crash!(e, "[!] #{e.message}", e.backtrace)
       end
     end
   end

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -136,7 +136,7 @@ module FastlaneCore
     # @!group Helpers
     #####################################################
     def not_implemented(method_name)
-      raise "Current UI '#{self}' doesn't support method '#{method_name}'".red
+      UI.crash!("Current UI '#{self}' doesn't support method '#{method_name}'")
     end
 
     def to_s

--- a/rakelib/test_all.rake
+++ b/rakelib/test_all.rake
@@ -39,8 +39,8 @@ def format_failure(failure, gem_name, count)
 end
 
 def bundle_install
-  cache_path = File.expand_path("/tmp/vendor/bundle")
-  sh "bundle check --path='#{cache_path}' || bundle install --path='#{cache_path}' --jobs=4 --retry=3"
+  #cache_path = File.expand_path("/tmp/vendor/bundle")
+  #sh "bundle check --path='#{cache_path}' || bundle install --path='#{cache_path}' --jobs=4 --retry=3"
 end
 
 def get_line_from_file(line_number, file)


### PR DESCRIPTION
I replaced all 

```
raise "something".red 
```

with

```
UI.crash!("something")
```

there are more raise "" calls that I haven't converted.

I can also convert them automatically if you think it is required. (at least the one under actions ?)
And I can do the same with other modules.
