### PR TITLE
[WIP] Let deliver sync screenshots!

### DIFF
--- a/deliver/deliver.gemspec
+++ b/deliver/deliver.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   # fastlane dependencies
   spec.add_dependency 'fastlane_core', '>= 0.41.2', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'credentials_manager', '>= 0.12.0', '< 1.0.0'
-  spec.add_dependency 'spaceship', '>= 0.24.1', '< 1.0.0' # Communication with iTunes Connect
+  spec.add_dependency 'spaceship', '>= 0.25.0', '< 1.0.0' # Communication with iTunes Connect
 
   # third party dependencies
   spec.add_dependency 'fastimage', '~> 1.6' # fetch the image sizes from the screenshots

--- a/deliver/lib/deliver/upload_assets.rb
+++ b/deliver/lib/deliver/upload_assets.rb
@@ -6,17 +6,28 @@ module Deliver
       v = app.edit_version
       UI.user_error!("Could not find a version to edit for app '#{app.name}'") unless v
 
+      # check if we need to call save! and waste time
+      save_needed = false
+
       if options[:app_icon]
-        UI.message("Uploading app icon...")
-        v.upload_large_icon!(options[:app_icon])
+        if v.upload_large_icon!(options[:app_icon])
+          UI.message("Uploading app icon...")
+          save_needed = true
+        else
+          UI.message("App icon not changed. Skipping upload")
+        end
       end
 
       if options[:apple_watch_app_icon]
-        UI.message("Uploading apple watchapp icon...")
-        v.upload_watch_icon!(options[:apple_watch_app_icon])
+        if v.upload_watch_icon!(options[:apple_watch_app_icon])
+          UI.message("Uploading apple watchapp icon...")
+          save_needed = true
+        else
+          UI.message("Watchapp icon not changed. Skipping upload")
+        end
       end
 
-      v.save!
+      v.save! if save_needed
     end
   end
 end

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -1,6 +1,29 @@
 module Deliver
+  # used to maintain 2 set of MD5s one for local one for remotes
+  class ScreenshotMD5s
+    def initialize
+      @checksums = {}
+    end
+
+    # index is implicitly computed
+    def add_md5(language, device_type, md5)
+      @checksums[language] ||= {}
+      @checksums[language][device_type] ||= []
+      @checksums[language][device_type] << md5
+    end
+
+    def matches_md5?(language, device_type, md5, index)
+      @checksums[language] &&
+      @checksums[language][device_type] &&
+      @checksums[language][device_type].include?(md5) &&
+      @checksums[language][device_type].index(md5) + 1 == index
+    end
+  end
+
   # upload screenshots to iTunes Connect
   class UploadScreenshots
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
     def upload(options, screenshots)
       return if options[:skip_screenshots]
 
@@ -9,16 +32,44 @@ module Deliver
       v = app.edit_version
       UI.user_error!("Could not find a version to edit for app '#{app.name}'") unless v
 
-      UI.message("Starting with the upload of screenshots...")
+      @checksums_local = ScreenshotMD5s.new
+      @checksums_remote = ScreenshotMD5s.new
 
-      # First, clear all previously uploaded screenshots, but only where we have new ones
-      # screenshots.each do |screenshot|
-      #   to_remove = v.screenshots[screenshot.language].find_all do |current|
-      #     current.device_type == screenshot.device_type
-      #   end
-      #   to_remove.each { |t| t.reset! }
-      # end
-      # This part is not working yet...
+      screenshots.each do |screenshot|
+        md5 = Spaceship::Utilities.md5digest(screenshot.path)
+        @checksums_local.add_md5(screenshot.language, screenshot.device_type, md5)
+      end
+
+      # If we have nothing to delete, there's no point in calling save!
+      nothing_to_delete = true
+
+      v.screenshots.each do |lang, screenshots_for_lang|
+        screenshots_for_lang.each do |current|
+          original_file_name = current.original_file_name
+          matched = original_file_name.match(/ftl_([0-9a-f]{32})_(.*)/)
+
+          if matched
+            md5 = matched[1]
+            original_file_name = matched[2]
+          end
+          # store remote checksum. We will need it later to determine if we have to upload screenshot
+          @checksums_remote.add_md5(current.language, current.device_type, md5)
+          # Remove from ITC non existing locally screenshots
+          # Or screenshots that have wrong order (compare indexes)
+          # Or screenshots that we haven't uploaded through spaceship
+          next if md5 && @checksums_local.matches_md5?(current.language, current.device_type, md5, current.sort_order)
+
+          UI.message("Deleting screenshot: #{original_file_name}, order: #{current.sort_order} for language: #{current.language}")
+          nothing_to_delete = false
+          v.upload_screenshot!(nil, current.sort_order, current.language, current.device_type)
+        end
+      end
+
+      if screenshots.empty?
+        UI.message("Nothing to upload...")
+      else
+        UI.message("Starting with the upload of screenshots...")
+      end
 
       # Now, fill in the new ones
       indized = {} # per language and device type
@@ -26,6 +77,10 @@ module Deliver
       screenshots_per_language = screenshots.group_by(&:language)
       screenshots_per_language.each do |language, screenshots_for_language|
         UI.message("Uploading #{screenshots_for_language.length} screenshots for language #{language}")
+
+        # If we don't have anything to upload, there's no point in calling save!
+        nothing_to_upload = true
+
         screenshots_for_language.each do |screenshot|
           indized[screenshot.language] ||= {}
           indized[screenshot.language][screenshot.device_type] ||= 0
@@ -38,19 +93,42 @@ module Deliver
             next
           end
 
-          UI.message("Uploading '#{screenshot.path}'...")
-          v.upload_screenshot!(screenshot.path,
-                               index,
-                               screenshot.language,
-                               screenshot.device_type)
+          md5 = Spaceship::Utilities.md5digest(screenshot.path)
+
+          device_type = screenshot.device_type
+
+          if @checksums_remote.matches_md5?(screenshot.language, device_type, md5, index)
+            UI.message("Screenshot #{screenshot.path} already uploaded. Skipping")
+          else
+            nothing_to_upload = false
+            UI.message("Uploading '#{screenshot.path}'...")
+            v.upload_screenshot!(screenshot.path,
+                                 index,
+                                 screenshot.language,
+                                 screenshot.device_type)
+          end
         end
         # ideally we should only save once, but itunes server can't cope it seems
         # so we save per language. See issue #349
+        if nothing_to_upload
+          UI.message("Nothing changed. Skipping save")
+        else
+          UI.message("Saving changes")
+          v.save!
+        end
+      end
+
+      UI.message("Nothing to delete...") if nothing_to_delete
+      # we need extra save! in case if we only deleting screenshots - nothing to upload
+      # we are skipping save if nothing to upload and nothing to delete
+      if screenshots.empty? && !nothing_to_delete
         UI.message("Saving changes")
         v.save!
       end
-      UI.success("Successfully uploaded screenshots to iTunes Connect")
+      UI.success("Screenshot sync (upload/delete) finished.")
     end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
 
     def collect_screenshots(options)
       return [] if options[:skip_screenshots]

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -46,11 +46,11 @@ module Deliver
       v.screenshots.each do |lang, screenshots_for_lang|
         screenshots_for_lang.each do |current|
           original_file_name = current.original_file_name
-          matched = original_file_name.match(/ftl_([0-9a-f]{32})_(.*)/)
+          matched = Spaceship::UploadFile.deconstruct_upload_filename(original_file_name)
 
           if matched
-            md5 = matched[1]
-            original_file_name = matched[2]
+            md5 = matched[:md5]
+            original_file_name = matched[:original_file_name]
           end
           # store remote checksum. We will need it later to determine if we have to upload screenshot
           @checksums_remote.add_md5(current.language, current.device_type, md5)

--- a/deliver/spec/stubs/upload_stubbing.rb
+++ b/deliver/spec/stubs/upload_stubbing.rb
@@ -1,0 +1,55 @@
+# Our fake application
+class FakeApp
+  def edit_version
+    @ev ||= EditVersion.new
+  end
+end
+
+# Screenshot class shared between ITC Sceenshot and Deliver Screenshot
+class Screenshot
+
+  def initialize(args)
+    self.path = args[:file_path]
+    self.device_type = "iphone4"
+    self.language = args[:language]
+    self.screen_size = 'iOS-4-in'
+    self.original_file_name = args[:original_file_name]
+    self.sort_order = args[:sort_order]
+  end
+  attr_accessor :sort_order, :original_file_name, :path, :language, :device_type, :screen_size
+end
+
+# Fake EditEversion with necessary methods stubbed
+class EditVersion
+
+  def screenshots
+    @ret ||= init_screenshots
+  end
+
+  # we don't have to really upload. It's enoguth to know if we are uploading or deleting
+  def upload_screenshot!(path, order, lang, device)
+    if path
+      puts "Uploading '#{path}' for device #{device}"
+    else
+      puts "Deleting #{order} for device #{device}"
+    end
+  end
+
+  def save!
+  end
+
+  private
+
+  def init_screenshots
+    @ret = {}
+    @ret['en-US'] ||= []
+    root = '/tmp/screenshots/'
+    (1..4).each do |i|
+      file_path = File.join(root, "scr_#{i}.jpg")
+      md5 = Spaceship::Utilities.md5digest(file_path)
+      file = Screenshot.new({file_path: file_path, language: 'en-US', original_file_name: "ftl_#{md5}_scr_#{i}.jpg", sort_order: i})
+      @ret['en-US'] << file
+    end
+    @ret
+  end
+end

--- a/deliver/spec/upload_screenshots_spec.rb
+++ b/deliver/spec/upload_screenshots_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+require 'fakefs/spec_helpers'
+require 'stubs/upload_stubbing'
+
+describe Deliver::UploadScreenshots do
+  include FakeFS::SpecHelpers
+
+  before :each do
+    @root = '/tmp/screenshots/'
+    FileUtils.mkdir_p(@root)
+
+    (1..5).each do |i|
+      file_path = File.join(@root, "scr_#{i}.jpg")
+      File.open(file_path, 'w') { |file| file.write(i.to_s) }
+    end
+  end
+
+  def mock_local_upload(sequence)
+    @order = 0
+    to_upload = sequence.map do |i|
+      file_path = File.join(@root, "scr_#{i}.jpg")
+      md5 = Spaceship::Utilities.md5digest(file_path)
+      file = Screenshot.new({file_path: file_path, language: 'en-US', original_file_name: "ftl_#{md5}_scr_#{i}.jpg", sort_order: @order})
+      @order += 1
+      file
+    end
+    to_upload
+  end
+
+  let(:options) { { app: FakeApp.new } }
+  let(:deliver) { Deliver::UploadScreenshots.new }
+
+  context "Deleting screenshots from ITC" do
+    it "should delete screenshot from ITC when order had been changed" do
+      # 1st and 2nd changed places. Expecting deletion of both
+      expect do
+        deliver.upload(options, mock_local_upload([2, 1, 3, 4]))
+      end.to output(/Deleting 1 for device iphone4\nDeleting 2 for device iphone4/).to_stdout
+    end
+
+    it "should delete screenshot from ITC when file had been changed" do
+      # 1st changed. Expecting deletion of first
+      expect do
+        deliver.upload(options, mock_local_upload([5, 2, 3, 4]))
+      end.to output(/Deleting 1 for device iphone4/).to_stdout
+    end
+
+    it "should delete screenshot from ITC when there's no md5 in filename" do
+      # add screenshot without md5 - simulate screenshot not uploaded by spaceship
+      file_path = File.join(@root, "scr_5.jpg")
+      file = Screenshot.new({file_path: file_path, language: 'en-US', original_file_name: "scr_5.jpg", sort_order: 5})
+      options[:app].edit_version.screenshots['en-US'] << file
+
+      # 5th don't have md5 in file name. Expecting deletion
+      to_upload = mock_local_upload([1, 2, 3, 4, 5])
+
+      expect do
+        deliver.upload(options, to_upload)
+      end.to output(/Deleting 5 for device iphone4/).to_stdout
+    end
+
+    it "should delete all screenshots and upload noting if no screenshots local" do
+      to_upload = []
+      expected_stdout = "Deleting 1 for device iphone4\n" \
+        "Deleting 2 for device iphone4\n" \
+        "Deleting 3 for device iphone4\n" \
+        "Deleting 4 for device iphone4\n"
+      expect do
+        deliver.upload(options, to_upload)
+      end.to output(expected_stdout).to_stdout
+    end
+  end
+
+  context "Uploading screenshots to ITC" do
+    it "should re-upload first 2 screenshots when changed order of 1st and 2nd" do
+      # 1st and 2nd changed places. Expecting re-upload of both
+      expected_stdout = "Deleting 1 for device iphone4\n" \
+        "Deleting 2 for device iphone4\n" \
+        "Uploading '/tmp/screenshots/scr_2.jpg' for device iphone4\n" \
+        "Uploading '/tmp/screenshots/scr_1.jpg' for device iphone4\n"
+      expect do
+        deliver.upload(options, mock_local_upload([2, 1, 3, 4]))
+      end.to output(expected_stdout).to_stdout
+    end
+
+    it "should re-upload first screenshot when 1st changed" do
+      # 1st changed. Expecting re-upload of first
+      expected_stdout = "Deleting 1 for device iphone4\n" \
+        "Uploading '/tmp/screenshots/scr_5.jpg' for device iphone4\n"
+      expect do
+        deliver.upload(options, mock_local_upload([5, 2, 3, 4]))
+      end.to output(expected_stdout).to_stdout
+    end
+
+    it "should skip screenshot upload when screenshot is already uploaded on ITC with the same order" do
+      # nothing's changed upload_screenshot! won't be called at all
+      expect do
+        deliver.upload(options, mock_local_upload([1, 2, 3, 4]))
+      end.to output('').to_stdout
+    end
+  end
+end

--- a/spaceship/lib/spaceship/du/upload_file.rb
+++ b/spaceship/lib/spaceship/du/upload_file.rb
@@ -20,7 +20,7 @@ module Spaceship
         content_type = Utilities.content_type(path)
         self.new(
           file_path: path,
-          file_name: 'ftl_' + content_md5 + '_' + File.basename(path),
+          file_name: construct_upload_filename(content_md5, path),
           file_size: File.size(path),
           content_type: content_type,
           bytes: File.read(path)
@@ -36,6 +36,25 @@ module Spaceship
         `sips -s format bmp '#{path}' &> /dev/null ` # &> /dev/null since there is warning because of the extension
         `sips -s format png '#{path}'`
         return path
+      end
+
+      # Construct proper filename for upload file, containing md5 hash of the file's content and it's original filename
+      # @param md5 (String) md5 of files content
+      # @param path (String) path to a file
+      # @return (String)
+      def construct_upload_filename(md5, path)
+        'ftl_' + md5 + '_' + File.basename(path)
+      end
+
+      # Checks if original file name contains md5 of file's content, and returns hash containing md5 and original file name
+      # @param file_name (String)
+      # @return (Hash)
+      def deconstruct_upload_filename(file_name)
+        match = file_name.match(/ftl_([0-9a-f]{32})_(.*)/)
+        unless match
+          return nil
+        end
+        { md5: match[1], original_file_name: match[2] }
       end
     end
 

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -301,10 +301,24 @@ module Spaceship
           @large_app_icon.reset!
           return
         end
-        upload_image = UploadFile.from_path icon_path
-        image_data = client.upload_large_icon(self, upload_image)
 
-        @large_app_icon.reset!({ asset_token: image_data['token'], original_file_name: upload_image.file_name })
+        # compare md5's to see if we have to re-upload file
+        local_md5 = Utilities.md5digest(icon_path)
+        matched = UploadFile.deconstruct_upload_filename(@large_app_icon.original_file_name)
+
+        if matched
+          remote_md5 = matched[:md5]
+        end
+
+        # return fasle if upload skipped
+        if !(remote_md5 && local_md5 == remote_md5)
+          upload_image = UploadFile.from_path icon_path
+          image_data = client.upload_large_icon(self, upload_image)
+
+          @large_app_icon.reset!({ asset_token: image_data['token'], original_file_name: upload_image.file_name })
+        else
+          false
+        end
       end
 
       # Uploads or removes the watch icon
@@ -314,10 +328,24 @@ module Spaceship
           @watch_app_icon.reset!
           return
         end
-        upload_image = UploadFile.from_path icon_path
-        image_data = client.upload_watch_icon(self, upload_image)
 
-        @watch_app_icon.reset!({ asset_token: image_data["token"], original_file_name: upload_image.file_name })
+        # compare md5's to see if we have to re-upload file
+        local_md5 = Utilities.md5digest(icon_path)
+        matched = UploadFile.deconstruct_upload_filename(@watch_app_icon.original_file_name)
+
+        if matched
+          remote_md5 = matched[:md5]
+        end
+
+        # return fasle if upload skipped
+        if !(remote_md5 && local_md5 == remote_md5)
+          upload_image = UploadFile.from_path icon_path
+          image_data = client.upload_watch_icon(self, upload_image)
+
+          @watch_app_icon.reset!({ asset_token: image_data["token"], original_file_name: upload_image.file_name })
+        else
+          false
+        end
       end
 
       # Uploads or removes the transit app file

--- a/spaceship/spec/tunes/app_version_spec.rb
+++ b/spaceship/spec/tunes/app_version_spec.rb
@@ -233,13 +233,21 @@ describe Spaceship::AppVersion, all: true do
         json = JSON.parse(du_read_fixture_file("upload_image_success.json"))
         allow(client.du_client).to receive(:upload_large_icon).and_return(json)
         allow(client.du_client).to receive(:upload_watch_icon).and_return(json)
+        allow(Spaceship::Utilities).to receive(:md5digest).and_return("FAKEMD5")
       end
 
-      it "modifies the large app data after update" do
+      it "modifies the large app data after update if file changed" do
+        allow(Spaceship::UploadFile).to receive(:deconstruct_upload_filename).and_return({ md5: 'FAKEMD55', original_file_name: '' })
         version.upload_large_icon!("path_to_jpg")
         expect(version.large_app_icon.url).to eq(nil)
         expect(version.large_app_icon.original_file_name).to eq("ftl_FAKEMD5_icon1024.jpg")
         expect(version.large_app_icon.asset_token).to eq("Purple7/v4/65/04/4d/65044dae-15b0-a5e0-d021-5aa4162a03a3/pr_source.jpg")
+      end
+
+      it "skips modification of the large app data if file not changed" do
+        allow(Spaceship::UploadFile).to receive(:deconstruct_upload_filename).and_return({ md5: 'FAKEMD5', original_file_name: '' })
+
+        expect(version.upload_large_icon!("path_to_jpg")).to eq(false)
       end
 
       it "deletes the large app data" do
@@ -249,11 +257,18 @@ describe Spaceship::AppVersion, all: true do
         expect(version.large_app_icon.asset_token).to eq(nil)
       end
 
-      it "modifies the watch app data after update" do
+      it "modifies the watch app data after update if file changed" do
+        allow(Spaceship::UploadFile).to receive(:deconstruct_upload_filename).and_return({ md5: 'FAKEMD55', original_file_name: '' })
         version.upload_watch_icon!("path_to_jpg")
         expect(version.watch_app_icon.url).to eq(nil)
         expect(version.watch_app_icon.original_file_name).to eq("ftl_FAKEMD5_icon1024.jpg")
         expect(version.watch_app_icon.asset_token).to eq("Purple7/v4/65/04/4d/65044dae-15b0-a5e0-d021-5aa4162a03a3/pr_source.jpg")
+      end
+
+      it "skips modification of the watch app data if file not changed" do
+        allow(Spaceship::UploadFile).to receive(:deconstruct_upload_filename).and_return({ md5: 'FAKEMD5', original_file_name: '' })
+
+        expect(version.upload_watch_icon!("path_to_jpg")).to eq(false)
       end
 
       it "deletes the watch app data" do


### PR DESCRIPTION
deliver: sync local screenshots and icons with ITC server (#1510)
  We use MD5 to keep track of the screenshots
  We delete and re-upload files that had been changed
  We skip re-upload of files that match md5 and order
  We delete screenshots if none present locally (this is what preview HTML says anyway).
  We don't save if no changes made

From daniszewskik
Assisted by lacostej

This should address #1510, #1516, #1549, #597, #550, #500 and other issues (Thanks Krzys!)

Not really sure why but git lost authorship when I split the commit into 2.  :( Sorry about that Krzys.

First part of the patch is sent as #3765 

**Statuses**:
- deliver init has a bug after we merged the little spaceship change #4177. We will fix it here.
- build triggered by this PR because spaceship requires a change
- I would like feedback on this change, as it contains more than I wanted:
  - I wanted it to contain the construct and deconstruct methods (https://github.com/lacostej/fastlane/commit/837dbb0dd62bf6597aa13cb8817c906ac7bc96f2#diff-b75794ded3de5cb0b68bff995d8ee7f9R20), and let deliver handle the decision of sending or not, but it ended containing that function as well (https://github.com/lacostej/fastlane/commit/837dbb0dd62bf6597aa13cb8817c906ac7bc96f2#diff-797ec61e5715816da95944f6ce08fac6R301). Before we scrap that second part, I let it for discussion! In case it has some benefits I do not see here. So the main question is: **do we want spaceship to contain the logic for deciding the sending or not (meaning every potential client will automatically get the caching) or not ? Or should this feature only be in deliver ?** The current PR has the logic in spaceship, an earlier one had it in deliver.
