### PR TITLE
Only specify /tmp/vendor gem --path on CI

### DIFF
--- a/rakelib/test_all.rake
+++ b/rakelib/test_all.rake
@@ -39,8 +39,12 @@ def format_failure(failure, gem_name, count)
 end
 
 def bundle_install
-  cache_path = File.expand_path("/tmp/vendor/bundle")
-  sh "bundle check --path='#{cache_path}' || bundle install --path='#{cache_path}' --jobs=4 --retry=3"
+  if ENV['CI']
+    cache_path = File.expand_path("/tmp/vendor/bundle")
+    path = " --path='#{cache_path}'"
+  end
+
+  sh "bundle check#{path} || bundle install#{path} --jobs=4 --retry=3"
 end
 
 def get_line_from_file(line_number, file)


### PR DESCRIPTION
Allowing `rake test_all` to change the gem install `--path` to `/tmp/vendor` on local development machines was breaking people's Ruby/gem management (RVM, rbenv, etc.)

This path change is only important on CI for caching purposes, so we will limit this parameter use accordingly.
