### PR TITLE
Update repo for deliver and gym to be fastlane-old

### DIFF
--- a/fastlane/fastlane/Fastfile
+++ b/fastlane/fastlane/Fastfile
@@ -152,7 +152,11 @@ end
 
 desc "e.g. fastlane/deliver"
 private_lane :github_url do |options|
-  ["fastlane", options[:tool]].join("/")
+  org = "fastlane"
+  if ["deliver", "gym"].include?(options[:tool])
+    org = "fastlane-old"
+  end
+  [org, options[:tool]].join("/")
 end
 
 desc "Get the version number of the last release"


### PR DESCRIPTION
Temporary fix to change repo name of deliver and gym to be fastlane-old so that we can still push github releases there.
