### PR TITLE
spaceship: store md5 inside upload file name to later support deliver sync

### DIFF
--- a/spaceship/lib/spaceship/du/upload_file.rb
+++ b/spaceship/lib/spaceship/du/upload_file.rb
@@ -12,12 +12,15 @@ module Spaceship
     class << self
       def from_path(path)
         raise "Image must exists at path: #{path}" unless File.exist?(path)
+
+        # md5 from original. keeping track of md5s allows to skip previously uploaded in deliver
+        content_md5 = Spaceship::Utilities.md5digest(path)
         path = remove_alpha_channel(path) if File.extname(path).casecmp('.png').zero?
 
         content_type = Utilities.content_type(path)
         self.new(
           file_path: path,
-          file_name: File.basename(path),
+          file_name: 'ftl_' + content_md5 + '_' + File.basename(path),
           file_size: File.size(path),
           content_type: content_type,
           bytes: File.read(path)

--- a/spaceship/lib/spaceship/du/utilities.rb
+++ b/spaceship/lib/spaceship/du/utilities.rb
@@ -70,6 +70,11 @@ module Spaceship
       [res[1].to_i, res[2].to_i]
     end
 
-    module_function :content_type, :grab_video_preview, :portrait?, :resolution, :video_resolution
+    # @return (String) md5 checksum of given file
+    def md5digest(file_path)
+      Digest::MD5.hexdigest(File.read(file_path))
+    end
+
+    module_function :content_type, :grab_video_preview, :portrait?, :resolution, :video_resolution, :md5digest
   end
 end

--- a/spaceship/spec/du/du_client_spec.rb
+++ b/spaceship/spec/du/du_client_spec.rb
@@ -11,6 +11,10 @@ describe Spaceship::DUClient, :du do
 
   subject { Spaceship::DUClient.new }
 
+  before do
+    allow(Spaceship::Utilities).to receive(:md5digest).and_return("FAKEMD5")
+  end
+
   describe "#upload_large_icon and #upload_watch_icon" do
     let(:correct_jpg_image) { du_uploadimage_correct_jpg }
     let(:bad_png_image) { du_uploadimage_invalid_png }

--- a/spaceship/spec/du/du_stubbing.rb
+++ b/spaceship/spec/du/du_stubbing.rb
@@ -6,9 +6,10 @@ def du_read_fixture_file(filename)
   File.read(du_fixture_file_path(filename))
 end
 
+# those represent UploadFile structures
 def du_uploadimage_correct_screenshot
   mock_jpg = double
-  allow(mock_jpg).to receive(:file_name).and_return('screenshot1024.jpg')
+  allow(mock_jpg).to receive(:file_name).and_return('ftl_FAKEMD5_screenshot1024.jpg')
   allow(mock_jpg).to receive(:file_size).and_return(1_234_520)
   allow(mock_jpg).to receive(:content_type).and_return('image/jpeg')
   allow(mock_jpg).to receive(:bytes).and_return("the screenshot...")
@@ -17,7 +18,7 @@ end
 
 def du_uploadimage_correct_jpg
   mock_jpg = double
-  allow(mock_jpg).to receive(:file_name).and_return('icon1024.jpg')
+  allow(mock_jpg).to receive(:file_name).and_return('ftl_FAKEMD5_icon1024.jpg')
   allow(mock_jpg).to receive(:file_size).and_return(520)
   allow(mock_jpg).to receive(:content_type).and_return('image/jpeg')
   allow(mock_jpg).to receive(:bytes).and_return("binary image...")
@@ -26,7 +27,7 @@ end
 
 def du_uploadtrailer_correct_mov
   mock_jpg = double
-  allow(mock_jpg).to receive(:file_name).and_return('trailer-en-US.mov')
+  allow(mock_jpg).to receive(:file_name).and_return('ftl_FAKEMD5_trailer-en-US.mov')
   allow(mock_jpg).to receive(:file_size).and_return(123_456)
   allow(mock_jpg).to receive(:content_type).and_return('video/quicktime')
   allow(mock_jpg).to receive(:bytes).and_return("binary video...")
@@ -35,7 +36,7 @@ end
 
 def du_uploadtrailer_preview_correct_jpg
   mock_jpg = double
-  allow(mock_jpg).to receive(:file_name).and_return('trailer-en-US_preview.jpg')
+  allow(mock_jpg).to receive(:file_name).and_return('ftl_FAKEMD5_trailer-en-US_preview.jpg')
   allow(mock_jpg).to receive(:file_size).and_return(12_345)
   allow(mock_jpg).to receive(:content_type).and_return('image/jpg')
   allow(mock_jpg).to receive(:bytes).and_return("trailer preview...")
@@ -44,7 +45,7 @@ end
 
 def du_uploadimage_invalid_png
   mock_jpg = double
-  allow(mock_jpg).to receive(:file_name).and_return('icon1024.png')
+  allow(mock_jpg).to receive(:file_name).and_return('ftl_FAKEMD5_icon1024.jpg')
   allow(mock_jpg).to receive(:file_size).and_return(520)
   allow(mock_jpg).to receive(:content_type).and_return('image/png')
   allow(mock_jpg).to receive(:bytes).and_return("invalid binary image...")
@@ -84,7 +85,7 @@ def du_upload_large_image_success
     with(body: "binary image...",
            headers: { 'Accept' => 'application/json, text/plain, */*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Content-Length' => '520', 'Content-Type' => 'image/jpeg', 'Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088',
                      'X-Apple-Jingle-Correlation-Key' => 'iOS App:AdamId=898536088:Version=0.9.13', 'X-Apple-Upload-Appleid' => '898536088', 'X-Apple-Upload-Contentproviderid' => '1234567', 'X-Apple-Upload-Itctoken' => 'sso token for image',
-                     'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Apple-Upload-Validation-Rulesets' => 'MZPFT.LargeApplicationIcon', 'X-Original-Filename' => 'icon1024.jpg' }).
+                     'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Apple-Upload-Validation-Rulesets' => 'MZPFT.LargeApplicationIcon', 'X-Original-Filename' => 'ftl_FAKEMD5_icon1024.jpg' }).
     to_return(status: 201, body: du_read_fixture_file('upload_image_success.json'), headers: { 'Content-Type' => 'application/json' })
 end
 
@@ -93,7 +94,7 @@ def du_upload_watch_image_failure
     with(body: "invalid binary image...",
            headers: { 'Accept' => 'application/json, text/plain, */*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Content-Length' => '520', 'Content-Type' => 'image/png', 'Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088',
                      'X-Apple-Jingle-Correlation-Key' => 'iOS App:AdamId=898536088:Version=0.9.13', 'X-Apple-Upload-Appleid' => '898536088', 'X-Apple-Upload-Contentproviderid' => '1234567', 'X-Apple-Upload-Itctoken' => 'sso token for image',
-                     'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Apple-Upload-Validation-Rulesets' => 'MZPFT.GizmoAppIcon', 'X-Original-Filename' => 'icon1024.png' }).
+                     'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Apple-Upload-Validation-Rulesets' => 'MZPFT.GizmoAppIcon', 'X-Original-Filename' => 'ftl_FAKEMD5_icon1024.jpg' }).
     to_return(status: 400, body: du_read_fixture_file('upload_image_failed.json'), headers: { 'Content-Type' => 'application/json' })
 end
 
@@ -102,7 +103,7 @@ def du_upload_geojson_success
     with(body: du_upload_valid_geojson.bytes,
            headers: { 'Accept' => 'application/json, text/plain, */*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Content-Length' => '224', 'Content-Type' => 'application/json', 'Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088',
                      'X-Apple-Jingle-Correlation-Key' => 'iOS App:AdamId=898536088:Version=0.9.13', 'X-Apple-Upload-Appleid' => '898536088', 'X-Apple-Upload-Contentproviderid' => '1234567', 'X-Apple-Upload-Itctoken' => 'sso token for image',
-                     'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Original-Filename' => 'upload_valid.geojson' }).
+                     'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Original-Filename' => 'ftl_FAKEMD5_upload_valid.geojson' }).
     to_return(status: 201, body: du_read_upload_geojson_response_success, headers: { 'Content-Type' => 'application/json' })
 end
 
@@ -111,7 +112,7 @@ def du_upload_geojson_failure
     with(body: du_upload_invalid_geojson.bytes,
            headers: { 'Accept' => 'application/json, text/plain, */*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Content-Length' => '243', 'Content-Type' => 'application/json', 'Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088',
                      'X-Apple-Jingle-Correlation-Key' => 'iOS App:AdamId=898536088:Version=0.9.13', 'X-Apple-Upload-Appleid' => '898536088', 'X-Apple-Upload-Contentproviderid' => '1234567', 'X-Apple-Upload-Itctoken' => 'sso token for image',
-                     'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Original-Filename' => 'upload_invalid.GeoJSON' }).
+                     'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Original-Filename' => 'ftl_FAKEMD5_upload_invalid.GeoJSON' }).
     to_return(status: 400, body: du_read_upload_geojson_response_failed, headers: { 'Content-Type' => 'application/json' })
 end
 
@@ -120,7 +121,7 @@ def du_upload_screenshot_success
     with(body: "the screenshot...",
            headers: { 'Accept' => 'application/json, text/plain, */*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Content-Length' => '1234520', 'Content-Type' => 'image/jpeg', 'Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088',
                      'X-Apple-Jingle-Correlation-Key' => 'iOS App:AdamId=898536088:Version=0.9.13', 'X-Apple-Upload-Appleid' => '898536088', 'X-Apple-Upload-Contentproviderid' => '1234567', 'X-Apple-Upload-Itctoken' => 'the_sso_token_for_image',
-                     'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Apple-Upload-Validation-Rulesets' => 'MZPFT.SortedN41ScreenShot', 'X-Original-Filename' => 'screenshot1024.jpg' }).
+                     'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Apple-Upload-Validation-Rulesets' => 'MZPFT.SortedN41ScreenShot', 'X-Original-Filename' => 'ftl_FAKEMD5_screenshot1024.jpg' }).
     to_return(status: 201, body: du_read_upload_screenshot_response_success, headers: { 'Content-Type' => 'application/json' })
 end
 
@@ -129,6 +130,6 @@ end
 #      with(body: "trailer preview...",
 #           headers: {'Accept' => 'application/json, text/plain, */*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Content-Length' => '12345', 'Content-Type' => 'image/joeg', 'Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088',
 #                     'User-Agent' => 'spaceship', 'X-Apple-Jingle-Correlation-Key' => 'iOS App:AdamId=898536088:Version=0.9.13', 'X-Apple-Upload-Appleid' => '898536088', 'X-Apple-Upload-Contentproviderid' => '1234567', 'X-Apple-Upload-Itctoken' => 'the_sso_token_for_image',
-#                     'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Original-Filename' => 'trailer-en-US_preview.jpg'}).
+#                     'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Original-Filename' => 'ftl_FAKEMD5_trailer-en-US_preview.jpg'}).
 #      to_return(status: 201, body: du_read_upload_trailer_preview_response_success, headers: {'Content-Type' => 'application/json'})
 # end

--- a/spaceship/spec/tunes/app_version_spec.rb
+++ b/spaceship/spec/tunes/app_version_spec.rb
@@ -238,7 +238,7 @@ describe Spaceship::AppVersion, all: true do
       it "modifies the large app data after update" do
         version.upload_large_icon!("path_to_jpg")
         expect(version.large_app_icon.url).to eq(nil)
-        expect(version.large_app_icon.original_file_name).to eq("icon1024.jpg")
+        expect(version.large_app_icon.original_file_name).to eq("ftl_FAKEMD5_icon1024.jpg")
         expect(version.large_app_icon.asset_token).to eq("Purple7/v4/65/04/4d/65044dae-15b0-a5e0-d021-5aa4162a03a3/pr_source.jpg")
       end
 
@@ -252,7 +252,7 @@ describe Spaceship::AppVersion, all: true do
       it "modifies the watch app data after update" do
         version.upload_watch_icon!("path_to_jpg")
         expect(version.watch_app_icon.url).to eq(nil)
-        expect(version.watch_app_icon.original_file_name).to eq("icon1024.jpg")
+        expect(version.watch_app_icon.original_file_name).to eq("ftl_FAKEMD5_icon1024.jpg")
         expect(version.watch_app_icon.asset_token).to eq("Purple7/v4/65/04/4d/65044dae-15b0-a5e0-d021-5aa4162a03a3/pr_source.jpg")
       end
 
@@ -424,8 +424,10 @@ describe Spaceship::AppVersion, all: true do
       end
 
       it "modifies the geojson file data after update" do
-        version.upload_geojson!(du_fixture_file_path("upload_valid.geojson"))
-        expect(version.transit_app_file.name).to eq("upload_valid.geojson")
+        allow(Spaceship::Utilities).to receive(:md5digest).and_return("FAKEMD5")
+        file_name = "upload_valid.geojson"
+        version.upload_geojson!(du_fixture_file_path(file_name))
+        expect(version.transit_app_file.name).to eq("ftl_FAKEMD5_#{file_name}")
         expect(version.transit_app_file.url).to eq(nil)
         expect(version.transit_app_file.asset_token).to eq("Purple1/v4/45/50/9d/45509d39-6a5d-7f55-f919-0fbc7436be61/pr_source.geojson")
       end
@@ -492,6 +494,10 @@ describe Spaceship::AppVersion, all: true do
       end
 
       describe "Add, Replace, Remove screenshots" do
+        before do
+          allow(Spaceship::Utilities).to receive(:md5digest).and_return("FAKEMD5")
+        end
+
         it "can add a new screenshot to the list" do
           du_upload_screenshot_success
 


### PR DESCRIPTION
spaceship changes for #3755, split because of build setup limitations with dependencies.
