### PR TITLE
Attempt at allowing commits to span multiple modules

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
-GEMS = %w(fastlane fastlane_core deliver snapshot frameit pem sigh produce cert gym pilot credentials_manager spaceship scan supply watchbuild match screengrab)
+# the order of the gems represents the order of the dependencies in the graph
+GEMS = %w(credentials_manager spaceship fastlane_core deliver snapshot frameit pem sigh produce cert gym pilot scan supply watchbuild match screengrab fastlane)
 RAILS = %w(boarding refresher enhancer)
 
 #####################################################

--- a/fastlane/Rakefile
+++ b/fastlane/Rakefile
@@ -1,5 +1,4 @@
 require 'bundler/gem_tasks'
-require 'rubocop/rake_task'
 
 Dir.glob('tasks/**/*.rake').each(&method(:import))
 

--- a/rakelib/test_all.rake
+++ b/rakelib/test_all.rake
@@ -78,6 +78,7 @@ task :test_all do
           bundle_install
           sh "bundle exec rspec --format documentation --format j --out #{rspec_log_file}"
           sh "bundle exec rubocop"
+          sh "rake install"
         end
       rescue => ex
         puts "[[FAILURE]] with repo '#{repo}' due to\n\n#{ex}\n\n"

--- a/spaceship/Rakefile
+++ b/spaceship/Rakefile
@@ -1,5 +1,4 @@
 require "bundler/gem_tasks"
-require "rubocop/rake_task"
 
 Dir.glob('tasks/**/*.rake').each(&method(:import))
 


### PR DESCRIPTION
Modify the build system to build then install in place the dependencies in their natural order
as to avoid failing when a higher level gem depends on changes from a lower level one inside the same PR.
