### PR TITLE
frameit layout improvements

### DIFF
--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -87,6 +87,10 @@ module Frameit
           if key == 'padding'
             UI.user_error! "padding must be type integer or pair of integers of format 'AxB' or a percentage" unless value.kind_of?(Integer) || value.split('x').length == 2 || (value.end_with?('%') && value.to_f > 0)
           end
+
+          if key == 'font_scale_factor'
+            UI.user_error! "font_scale_factor must be numeric" unless value.kind_of?(Numeric)
+          end
         end
       end
     end

--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -85,7 +85,7 @@ module Frameit
           end
 
           if key == 'padding'
-            UI.user_error! "padding must be type integer or pair of integers of format 'AxB'" unless value.kind_of?(Integer) || value.split('x').length == 2
+            UI.user_error! "padding must be type integer or pair of integers of format 'AxB' or a percentage" unless value.kind_of?(Integer) || value.split('x').length == 2 || (value.end_with?('%') && value.to_f > 0)
           end
         end
       end

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -114,7 +114,7 @@ module Frameit
     # Horizontal adding around the frames
     def horizontal_frame_padding
       padding = fetch_config['padding']
-      unless padding.kind_of?(Integer)
+      if padding.kind_of?(String) && padding.split('x').length == 2
         padding = padding.split('x')[0].to_i
       end
       return scale_padding(padding)
@@ -123,13 +123,16 @@ module Frameit
     # Vertical adding around the frames
     def vertical_frame_padding
       padding = fetch_config['padding']
-      unless padding.kind_of?(Integer)
+      if padding.kind_of?(String) && padding.split('x').length == 2
         padding = padding.split('x')[1].to_i
       end
       return scale_padding(padding)
     end
 
     def scale_padding(padding)
+      if padding.end_with?('%')
+        padding = ([image.width, image.height].min * padding.to_f * 0.01).ceil
+      end
       multi = 1.0
       multi = 1.7 if self.screenshot.triple_density?
       return padding * multi

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -87,19 +87,23 @@ module Frameit
     def complex_framing
       background = generate_background
 
+      self.top_space_above_device = vertical_frame_padding
+
+      if fetch_config['title']
+        background = put_title_into_background(background)
+      end
+
       if self.frame # we have no frame on le mac
         resize_frame!
         @image = put_into_frame
 
         # Decrease the size of the framed screenshot to fit into the defined padding + background
         frame_width = background.width - horizontal_frame_padding * 2
+        frame_height = background.height - top_space_above_device - vertical_frame_padding
         image.resize "#{frame_width}x"
-      end
-
-      self.top_space_above_device = vertical_frame_padding
-
-      if fetch_config['title']
-        background = put_title_into_background(background)
+        if image.height > frame_height
+          image.resize "x#{frame_height.to_i}"
+        end
       end
 
       @image = put_device_into_background(background)
@@ -156,13 +160,13 @@ module Frameit
     def resize_frame!
       multiplicator = (screenshot.size[0].to_f / offset['width'].to_f) # by how much do we have to change this?
       new_frame_width = multiplicator * frame.width # the new width for the frame
-      frame.resize "#{new_frame_width.round}x" # resize it to the calculated witdth
+      frame.resize "#{new_frame_width.round}x" # resize it to the calculated width
       modify_offset(multiplicator) # modify the offset to properly insert the screenshot into the frame later
     end
 
     # Add the title above the device
     def put_title_into_background(background)
-      title_images = build_title_images(image.width, image.height)
+      title_images = build_title_images(image.width - 2 * horizontal_frame_padding, image.height - 2 * vertical_frame_padding)
 
       keyword = title_images[:keyword]
       title = title_images[:title]
@@ -174,7 +178,7 @@ module Frameit
 
       # Resize the 2 labels if necessary
       smaller = 1.0 # default
-      ratio = (sum_width + keyword_padding * 2) / image.width.to_f
+      ratio = (sum_width + (keyword_padding + horizontal_frame_padding) * 2) / image.width.to_f
       if ratio > 1.0
         # too large - resizing now
         smaller = (1.0 / ratio)
@@ -187,10 +191,10 @@ module Frameit
       end
 
       vertical_padding = vertical_frame_padding
-      top_space = vertical_padding
+      top_space = vertical_padding + (actual_font_size - title.height) / 2
       left_space = (background.width / 2.0 - sum_width / 2.0).round
 
-      self.top_space_above_device += title.height + vertical_padding
+      self.top_space_above_device += actual_font_size + vertical_padding
 
       # First, put the keyword on top of the screenshot, if we have one
       if keyword

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -218,7 +218,8 @@ module Frameit
     end
 
     def actual_font_size
-      [@image.width / 10.0].max.round
+      font_scale_factor = fetch_config['font_scale_factor'] || 0.1
+      [@image.width * font_scale_factor].max.round
     end
 
     # The space between the keyword and the title


### PR DESCRIPTION
this solves multiple layout issues:
- vertically "jumping" device frame depending on title height
- limit title font size to achieve the same font size for all shots of a particular device
- consider the horizontal padding for the title
- added padding as a percentage (useful for vastly varying device sizes such as iPad Pro and iPhone 4")
