### PR TITLE
Fixed snapshot crash when single quote appears in application name

### DIFF
--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -53,7 +53,7 @@ module Snapshot
       end
 
       def pipe
-        ["| tee '#{xcodebuild_log_path}' | xcpretty #{Snapshot.config[:xcpretty_args]}"]
+        ["| tee #{xcodebuild_log_path.shellescape} | xcpretty #{Snapshot.config[:xcpretty_args]}"]
       end
 
       def device_udid(device)

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -19,7 +19,7 @@ describe Snapshot do
                                 "-destination 'platform=iOS Simulator,id=,OS=#{ios}'",
                                 :build,
                                 :test,
-                                "| tee '#{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests.log')}' | xcpretty "
+                                "| tee #{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests.log')} | xcpretty "
                               ])
       end
     end


### PR DESCRIPTION
Fixed a bug with snapshot failing when there's a single quote character in application's name.
Related issue: https://github.com/fastlane/fastlane/issues/3759
