### PR TITLE
Improve error display in `spaceship`

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -34,7 +34,16 @@ module Spaceship
     # Raised when no user credentials were passed at all
     class NoUserCredentialsError < StandardError; end
 
-    class UnexpectedResponse < StandardError; end
+    class UnexpectedResponse < StandardError;
+      def self.handle_response(response)
+        if (response.body["userString"])
+          msg = "🍎 returned an unexpected response:\n#{}{response.body['resultString']}\n#{response.body['userString']}"
+          UI.user_error!(msg)
+        else
+          raise UnexpectedResponse.new, response.body
+        end
+      end
+    end
 
     # Raised when 302 is received from portal request
     class AppleTimeoutError < StandardError; end
@@ -297,7 +306,7 @@ module Spaceship
       end
 
       if content.nil?
-        raise UnexpectedResponse.new, response.body
+        UnexpectedResponse.handle_response(response)
       else
         store_csrf_tokens(response)
         content

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -34,7 +34,7 @@ module Spaceship
     # Raised when no user credentials were passed at all
     class NoUserCredentialsError < StandardError; end
 
-    class UnexpectedResponse < StandardError;
+    class UnexpectedResponse < StandardError
       class << self
         def handle_response(response)
           if response.body['userString']
@@ -49,7 +49,6 @@ module Spaceship
           require 'colored'
 
           if $verbose # with stack trace
-            puts e.backtrace.nil?
             raise e, "[!] #{e.message}".red, e.backtrace
           else # without stack trace
             abort "\n[!] #{e.message}".red

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -35,12 +35,25 @@ module Spaceship
     class NoUserCredentialsError < StandardError; end
 
     class UnexpectedResponse < StandardError;
-      def self.handle_response(response)
-        if (response.body["userString"])
-          msg = "🍎 returned an unexpected response:\n#{}{response.body['resultString']}\n#{response.body['userString']}"
-          UI.user_error!(msg)
-        else
-          raise UnexpectedResponse.new, response.body
+      class << self
+        def handle_response(response)
+          if response.body['userString']
+            msg = "🍎 returned an unexpected response:\n#{response.body['resultString']}\n#{response.body['userString']}"
+            user_error!(UnexpectedResponse.new(msg))
+          else
+            raise UnexpectedResponse.new, response.body
+          end
+        end
+
+        def user_error!(e)
+          require 'colored'
+
+          if $verbose # with stack trace
+            puts e.backtrace.nil?
+            raise e, "[!] #{e.message}".red, e.backtrace
+          else # without stack trace
+            abort "\n[!] #{e.message}".red
+          end
         end
       end
     end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -38,20 +38,19 @@ module Spaceship
       class << self
         def handle_response(response)
           if response.body['userString']
-            msg = "🍎 returned an unexpected response:\n#{response.body['resultString']}\n#{response.body['userString']}"
-            user_error!(UnexpectedResponse.new(msg))
+            user_error!("Apple returned an unexpected response:\n#{response.body['resultString']}\n#{response.body['userString']}")
           else
-            raise UnexpectedResponse.new, response.body
+            raise UnexpectedResponse, response.body
           end
         end
 
-        def user_error!(e)
+        def user_error!(msg)
           require 'colored'
 
           if $verbose # with stack trace
-            raise e, "[!] #{e.message}".red, e.backtrace
+            raise UnexpectedResponse, "[!] #{msg}".red
           else # without stack trace
-            abort "\n[!] #{e.message}".red
+            abort "\n[!] #{msg}".red
           end
         end
       end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -38,7 +38,11 @@ module Spaceship
       class << self
         def handle_response!(response)
           if response.body['userString']
-            user_error!("Apple returned an unexpected response:\n#{response.body['resultString']}\n#{response.body['userString']}")
+            require 'cgi'
+
+            result_string = CGI.unescapeHTML(response.body['resultString'])
+            user_string = CGI.unescapeHTML(response.body['userString'])
+            user_error!("Apple returned an unexpected response:\n\t#{result_string}\n\t#{user_string}")
           else
             raise UnexpectedResponse, response.body
           end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -36,7 +36,7 @@ module Spaceship
 
     class UnexpectedResponse < StandardError
       class << self
-        def handle_response(response)
+        def handle_response!(response)
           if response.body['userString']
             user_error!("Apple returned an unexpected response:\n#{response.body['resultString']}\n#{response.body['userString']}")
           else
@@ -317,7 +317,7 @@ module Spaceship
       end
 
       if content.nil?
-        UnexpectedResponse.handle_response(response)
+        UnexpectedResponse.handle_response!(response)
       else
         store_csrf_tokens(response)
         content

--- a/spaceship/spec/portal/fixtures/create_profile_failure.json
+++ b/spaceship/spec/portal/fixtures/create_profile_failure.json
@@ -1,0 +1,17 @@
+{
+  "responseId": "612597ae-99e2-44af-bf8a-c721678335ba",
+  "resultCode": 35,
+  "resultString": "There were errors in the data supplied. Please correct and re-submit.",
+  "userString": "There are no current devices on this team matching the provided device IDs.",
+  "creationTimestamp": "2016-03-11T07:23:20Z",
+  "protocolVersion": "QH65B2",
+  "userLocale": "en_US",
+  "requestUrl": "https://developer.apple.com/services-account/QH65B2/account/ios/profile/createProvisioningProfile.action",
+  "httpCode": 200,
+  "validationMessages": [
+    {
+      "validationKey": "deviceIds",
+      "validationUserMessage": "There are no current devices on this team matching the provided device IDs."
+    }
+  ]
+}

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -216,6 +216,26 @@ describe Spaceship::Client do
           response = subject.create_provisioning_profile!("taken", "limited", 'R9YNDTPLJX', ['C8DL7464RQ'], ['C8DLAAAARQ'])
         end.to raise_error(Spaceship::Client::UnexpectedResponse, error_text)
       end
+
+      it "aborts with a user-friendly error message when a parsable error response is returned and $verbose is false" do
+        msg = "\n[!] Apple returned an unexpected response:\nThere were errors in the data supplied. Please correct and re-submit.\nThere are no current devices on this team matching the provided device IDs.".red
+        expect(Spaceship::Client::UnexpectedResponse).to receive(:abort).with(msg)
+
+        subject.create_provisioning_profile!("parsable_error", "limited", 'R9YNDTPLJX', ['C8DL7464RQ'], ['C8DLAAAARQ'])
+      end
+
+      it "raises with a user-friendly error message when a parsable error response is returned and $verbose is true" do
+        msg = "[!] Apple returned an unexpected response:\nThere were errors in the data supplied. Please correct and re-submit.\nThere are no current devices on this team matching the provided device IDs.".red
+
+        expectation = proc do |error|
+          expect(error.message).to eq(msg)
+          expect(error.backtrace).to_not be_empty
+        end
+
+        with_verbosity(true) do
+          expect { subject.create_provisioning_profile!("parsable_error", "limited", 'R9YNDTPLJX', ['C8DL7464RQ'], ['C8DLAAAARQ']) }.to raise_error(&expectation)
+        end
+      end
     end
 
     describe '#delete_provisioning_profile!' do

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -218,14 +218,14 @@ describe Spaceship::Client do
       end
 
       it "aborts with a user-friendly error message when a parsable error response is returned and $verbose is false" do
-        msg = "\n[!] Apple returned an unexpected response:\nThere were errors in the data supplied. Please correct and re-submit.\nThere are no current devices on this team matching the provided device IDs.".red
+        msg = "\n[!] Apple returned an unexpected response:\n\tThere were errors in the data supplied. Please correct and re-submit.\n\tThere are no current devices on this team matching the provided device IDs.".red
         expect(Spaceship::Client::UnexpectedResponse).to receive(:abort).with(msg)
 
         subject.create_provisioning_profile!("parsable_error", "limited", 'R9YNDTPLJX', ['C8DL7464RQ'], ['C8DLAAAARQ'])
       end
 
       it "raises with a user-friendly error message when a parsable error response is returned and $verbose is true" do
-        msg = "[!] Apple returned an unexpected response:\nThere were errors in the data supplied. Please correct and re-submit.\nThere are no current devices on this team matching the provided device IDs.".red
+        msg = "[!] Apple returned an unexpected response:\n\tThere were errors in the data supplied. Please correct and re-submit.\n\tThere are no current devices on this team matching the provided device IDs.".red
 
         expectation = proc do |error|
           expect(error.message).to eq(msg)

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -65,6 +65,11 @@ def adp_stub_provisioning
     with(body: { "appIdId" => "R9YNDTPLJX", "certificateIds" => "C8DL7464RQ", "deviceIds" => "C8DLAAAARQ", "distributionType" => "limited", "provisioningProfileName" => "taken", "teamId" => "XXXXXXXXXX" }).
     to_return(status: 200, body: adp_read_fixture_file("create_profile_name_taken.txt"))
 
+  # Failure to create a profile
+  stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/profile/createProvisioningProfile.action").
+    with(body: { "appIdId" => "R9YNDTPLJX", "certificateIds" => "C8DL7464RQ", "deviceIds" => "C8DLAAAARQ", "distributionType" => "limited", "provisioningProfileName" => "parsable_error", "teamId" => "XXXXXXXXXX" }).
+    to_return(status: 500, body: adp_read_fixture_file("create_profile_failure.json"), headers: { 'Content-Type' => 'application/json' })
+
   # Repair Profiles
   stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/profile/regenProvisioningProfile.action").
     with(body: { "appIdId" => "572XTN75U2", "certificateIds" => "XC5PH8D47H", "deviceIds" => ["AAAAAAAAAA", "BBBBBBBBBB", "CCCCCCCCCC", "DDDDDDDDDD"], "distributionType" => "store", "provisioningProfileName" => "net.sunapps.7 AppStore", "teamId" => "XXXXXXXXXX" }).

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -15,10 +15,12 @@ SimpleCov.at_exit do
   SimpleCov.result.format!
 end
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-])
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+)
 
 SimpleCov.start
 

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -15,10 +15,10 @@ SimpleCov.at_exit do
   SimpleCov.result.format!
 end
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
-]
+])
 
 SimpleCov.start
 

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -32,10 +32,6 @@ ENV["DELIVER_USER"] = "spaceship@krausefx.com"
 ENV["DELIVER_PASSWORD"] = "so_secret"
 ENV.delete("FASTLANE_USER") # just in case the dev env has it
 
-unless ENV["DEBUG"]
-  $stdout = File.open("/tmp/spaceship_tests", "w")
-end
-
 cache_paths = [
   File.expand_path("~/Library/Caches/spaceship_api_key.txt"),
   "/tmp/spaceship_itc_login_url.txt"
@@ -43,6 +39,14 @@ cache_paths = [
 
 def try_delete(path)
   FileUtils.rm_f path if File.exist? path
+end
+
+def with_verbosity(verbose)
+  orig_verbose = $verbose
+  $verbose = verbose
+  yield if block_given?
+ensure
+  $verbose = orig_verbose
 end
 
 RSpec.configure do |config|

--- a/spaceship/spec/unexpected_response_spec.rb
+++ b/spaceship/spec/unexpected_response_spec.rb
@@ -2,49 +2,47 @@ require 'spec_helper'
 require 'colored'
 
 describe Spaceship::Client::UnexpectedResponse do
-	describe '#handle_response' do
-		def with_verbosity(verbose)
-			begin
-				orig_verbose = $verbose
-				$verbose = verbose
-				yield if block_given?
-			ensure
-				$verbose = orig_verbose
-			end
-		end
+  describe '#handle_response' do
+    def with_verbosity(verbose)
+      orig_verbose = $verbose
+      $verbose = verbose
+      yield if block_given?
+    ensure
+      $verbose = orig_verbose
+    end
 
-		def stub_response_body(body)
-			allow(response).to receive(:body).and_return(body)
-		end
+    def stub_response_body(body)
+      allow(response).to receive(:body).and_return(body)
+    end
 
-		let(:response) { "response" }
+    let(:response) { "response" }
 
-		it 'should raise UnexpectedResponse when the response does not contain embedded error info' do
-			stub_response_body({'something' => 'whatever'})
+    it 'should raise UnexpectedResponse when the response does not contain embedded error info' do
+      stub_response_body({'something' => 'whatever'})
 
-			expect do
-				Spaceship::Client::UnexpectedResponse.handle_response(response)
-			end.to raise_error(Spaceship::Client::UnexpectedResponse, {'something' => 'whatever'}.to_s)
-		end
+      expect do
+        Spaceship::Client::UnexpectedResponse.handle_response(response)
+      end.to raise_error(Spaceship::Client::UnexpectedResponse, {'something' => 'whatever'}.to_s)
+    end
 
-		it 'should use user_error! to re-raise if an Apple-provided error message is present in the response and $verbose is true' do
-			stub_response_body({'userString' => 'User string', 'resultString' => 'Result string'})
+    it 'should use user_error! to re-raise if an Apple-provided error message is present in the response and $verbose is true' do
+      stub_response_body({'userString' => 'User string', 'resultString' => 'Result string'})
 
-			with_verbosity(true) do
-				expect do
-					Spaceship::Client::UnexpectedResponse.handle_response(response)
-				end.to raise_error(Spaceship::Client::UnexpectedResponse, "[!] 🍎 returned an unexpected response:\nResult string\nUser string".red)
-			end
-		end
+      with_verbosity(true) do
+        expect do
+          Spaceship::Client::UnexpectedResponse.handle_response(response)
+        end.to raise_error(Spaceship::Client::UnexpectedResponse, "[!] 🍎 returned an unexpected response:\nResult string\nUser string".red)
+      end
+    end
 
-		it 'should use user_error! to abort if an Apple-provided error message is present in the response and $verbose is false' do
-			stub_response_body({'userString' => 'User string', 'resultString' => 'Result string'})
+    it 'should use user_error! to abort if an Apple-provided error message is present in the response and $verbose is false' do
+      stub_response_body({'userString' => 'User string', 'resultString' => 'Result string'})
 
-			with_verbosity(false) do
-				expect(Spaceship::Client::UnexpectedResponse).to receive(:abort).with("\n[!] 🍎 returned an unexpected response:\nResult string\nUser string".red)
+      with_verbosity(false) do
+        expect(Spaceship::Client::UnexpectedResponse).to receive(:abort).with("\n[!] 🍎 returned an unexpected response:\nResult string\nUser string".red)
 
-				Spaceship::Client::UnexpectedResponse.handle_response(response)
-			end
-		end
-	end
+        Spaceship::Client::UnexpectedResponse.handle_response(response)
+      end
+    end
+  end
 end

--- a/spaceship/spec/unexpected_response_spec.rb
+++ b/spaceship/spec/unexpected_response_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'colored'
+
+describe Spaceship::Client::UnexpectedResponse do
+	describe '#handle_response' do
+		def with_verbosity(verbose)
+			begin
+				orig_verbose = $verbose
+				$verbose = verbose
+				yield if block_given?
+			ensure
+				$verbose = orig_verbose
+			end
+		end
+
+		def stub_response_body(body)
+			allow(response).to receive(:body).and_return(body)
+		end
+
+		let(:response) { "response" }
+
+		it 'should raise UnexpectedResponse when the response does not contain embedded error info' do
+			stub_response_body({'something' => 'whatever'})
+
+			expect do
+				Spaceship::Client::UnexpectedResponse.handle_response(response)
+			end.to raise_error(Spaceship::Client::UnexpectedResponse, {'something' => 'whatever'}.to_s)
+		end
+
+		it 'should use user_error! to re-raise if an Apple-provided error message is present in the response and $verbose is true' do
+			stub_response_body({'userString' => 'User string', 'resultString' => 'Result string'})
+
+			with_verbosity(true) do
+				expect do
+					Spaceship::Client::UnexpectedResponse.handle_response(response)
+				end.to raise_error(Spaceship::Client::UnexpectedResponse, "[!] 🍎 returned an unexpected response:\nResult string\nUser string".red)
+			end
+		end
+
+		it 'should use user_error! to abort if an Apple-provided error message is present in the response and $verbose is false' do
+			stub_response_body({'userString' => 'User string', 'resultString' => 'Result string'})
+
+			with_verbosity(false) do
+				expect(Spaceship::Client::UnexpectedResponse).to receive(:abort).with("\n[!] 🍎 returned an unexpected response:\nResult string\nUser string".red)
+
+				Spaceship::Client::UnexpectedResponse.handle_response(response)
+			end
+		end
+	end
+end

--- a/spaceship/spec/unexpected_response_spec.rb
+++ b/spaceship/spec/unexpected_response_spec.rb
@@ -13,7 +13,7 @@ describe Spaceship::Client::UnexpectedResponse do
       stub_response_body({'something' => 'whatever'})
 
       expect do
-        Spaceship::Client::UnexpectedResponse.handle_response(response)
+        Spaceship::Client::UnexpectedResponse.handle_response!(response)
       end.to raise_error(Spaceship::Client::UnexpectedResponse, {'something' => 'whatever'}.to_s)
     end
 
@@ -22,7 +22,7 @@ describe Spaceship::Client::UnexpectedResponse do
 
       with_verbosity(true) do
         expect do
-          Spaceship::Client::UnexpectedResponse.handle_response(response)
+          Spaceship::Client::UnexpectedResponse.handle_response!(response)
         end.to raise_error(Spaceship::Client::UnexpectedResponse, "[!] Apple returned an unexpected response:\nResult string\nUser string".red)
       end
     end
@@ -33,7 +33,7 @@ describe Spaceship::Client::UnexpectedResponse do
       with_verbosity(false) do
         expect(Spaceship::Client::UnexpectedResponse).to receive(:abort).with("\n[!] Apple returned an unexpected response:\nResult string\nUser string".red)
 
-        Spaceship::Client::UnexpectedResponse.handle_response(response)
+        Spaceship::Client::UnexpectedResponse.handle_response!(response)
       end
     end
   end

--- a/spaceship/spec/unexpected_response_spec.rb
+++ b/spaceship/spec/unexpected_response_spec.rb
@@ -23,7 +23,7 @@ describe Spaceship::Client::UnexpectedResponse do
       with_verbosity(true) do
         expect do
           Spaceship::Client::UnexpectedResponse.handle_response!(response)
-        end.to raise_error(Spaceship::Client::UnexpectedResponse, "[!] Apple returned an unexpected response:\nResult string\nUser string".red)
+        end.to raise_error(Spaceship::Client::UnexpectedResponse, "[!] Apple returned an unexpected response:\n\tResult string\n\tUser string".red)
       end
     end
 
@@ -31,7 +31,7 @@ describe Spaceship::Client::UnexpectedResponse do
       stub_response_body({'userString' => 'User string', 'resultString' => 'Result string'})
 
       with_verbosity(false) do
-        expect(Spaceship::Client::UnexpectedResponse).to receive(:abort).with("\n[!] Apple returned an unexpected response:\nResult string\nUser string".red)
+        expect(Spaceship::Client::UnexpectedResponse).to receive(:abort).with("\n[!] Apple returned an unexpected response:\n\tResult string\n\tUser string".red)
 
         Spaceship::Client::UnexpectedResponse.handle_response!(response)
       end

--- a/spaceship/spec/unexpected_response_spec.rb
+++ b/spaceship/spec/unexpected_response_spec.rb
@@ -3,14 +3,6 @@ require 'colored'
 
 describe Spaceship::Client::UnexpectedResponse do
   describe '#handle_response' do
-    def with_verbosity(verbose)
-      orig_verbose = $verbose
-      $verbose = verbose
-      yield if block_given?
-    ensure
-      $verbose = orig_verbose
-    end
-
     def stub_response_body(body)
       allow(response).to receive(:body).and_return(body)
     end
@@ -31,7 +23,7 @@ describe Spaceship::Client::UnexpectedResponse do
       with_verbosity(true) do
         expect do
           Spaceship::Client::UnexpectedResponse.handle_response(response)
-        end.to raise_error(Spaceship::Client::UnexpectedResponse, "[!] 🍎 returned an unexpected response:\nResult string\nUser string".red)
+        end.to raise_error(Spaceship::Client::UnexpectedResponse, "[!] Apple returned an unexpected response:\nResult string\nUser string".red)
       end
     end
 
@@ -39,7 +31,7 @@ describe Spaceship::Client::UnexpectedResponse do
       stub_response_body({'userString' => 'User string', 'resultString' => 'Result string'})
 
       with_verbosity(false) do
-        expect(Spaceship::Client::UnexpectedResponse).to receive(:abort).with("\n[!] 🍎 returned an unexpected response:\nResult string\nUser string".red)
+        expect(Spaceship::Client::UnexpectedResponse).to receive(:abort).with("\n[!] Apple returned an unexpected response:\nResult string\nUser string".red)
 
         Spaceship::Client::UnexpectedResponse.handle_response(response)
       end


### PR DESCRIPTION
When we get an unexpected response from Apple servers, we'll now examine their contents more closely to see if they contain user-presentable error messages. If they do, we'll present those more clearly so that users have a better chance at identifying what went wrong.

![screen shot 2016-03-16 at 11 59 31 am](https://cloud.githubusercontent.com/assets/343134/13819088/a001a220-eb6e-11e5-95ee-b434af762104.png)

This also removes the `stdout` redirection from the `spec_helper`. Before knowing it was there, it was extremely confusing to not understand where all my `puts` and `pry` output was going. Even with it removed, the default testing output is not overwhelming.
