### PR TITLE
Allow spaceship errors to communicate preferred error info

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,9 @@ Style/FileName:
 Style/SpecialGlobalVars:
   Enabled: false
 
+Style/RaiseArgs:
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 63
   Exclude:
@@ -106,7 +109,7 @@ Style/GuardClause:
 # Split
 
 
-# e.g. 
+# e.g.
 # def self.is_supported?(platform)
 # we may never use `platform`
 Lint/UnusedMethodArgument:
@@ -285,7 +288,7 @@ Style/MutableConstant:
 Style/ZeroLengthPredicate:
   Enabled: false
 
-Style/ConditionalAssignment: 
+Style/ConditionalAssignment:
   Enabled: false
 
 Style/SpaceAroundKeyword:

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -43,11 +43,12 @@ module Commander
     end
 
     def handle_unknown_error!(e)
-      # Some spaceship exception classes implement this method in order to share error information sent by Apple.
-      # However, fastlane_core and spaceship can not know about each other's classes! To make this information
-      # passing work, we use a bit of Ruby duck-typing to check whether the unknown exception type implements
-      # the right method. If so, we'll present any returned error info in the manner of a user_error!
-      error_info = e.respond_to?(:apple_provided_error_info) ? e.apple_provided_error_info : nil
+      # Some spaceship exception classes implement #preferred_error_info in order to share error info
+      # that we'd rather display instead of crashing with a stack trace. However, fastlane_core and
+      # spaceship can not know about each other's classes! To make this information passing work, we
+      # use a bit of Ruby duck-typing to check whether the unknown exception type implements the right
+      # method. If so, we'll present any returned error info in the manner of a user_error!
+      error_info = e.respond_to?(:preferred_error_info) ? e.preferred_error_info : nil
 
       if error_info
         message = error_info.unshift("Apple provided the following error info:").join("\n\t")

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -50,20 +50,20 @@ module Commander
           FastlaneCore::CrashReporting.handle_crash(e)
           # From https://stackoverflow.com/a/4789702/445598
           # We do this to make the actual error message red and therefore more visible
-          reraise_formatted(e, e.message)
+          reraise_formatted!(e, e.message)
         end
       end
     end
 
     def display_user_error!(e, message)
       if $verbose # with stack trace
-        reraise_formatted(e, message)
+        reraise_formatted!(e, message)
       else
         abort "\n[!] #{message}".red # without stack trace
       end
     end
 
-    def reraise_formatted(e, message)
+    def reraise_formatted!(e, message)
       raise e, "[!] #{message}".red, e.backtrace
     end
   end

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -38,20 +38,23 @@ module Commander
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         display_user_error!(e, e.message)
       rescue => e # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
+        handle_unknown_error!(e)
+      end
+    end
 
-        # Some spaceship exception classes implement this method in order to share error information sent by Apple
-        # However, fastlane_core and spaceship can not know about each other's classes! To make this information
-        # passing work, we use a bit of Ruby duck-typing to check whether the unknown exception type has any of
-        # this kind of information to share with us. If so, we'll present it in the manner of a user_error!
-        if e.respond_to? :apple_provided_error_info
-          message = e.apple_provided_error_info.unshift("Apple provided the following error info:").join("\n\t")
-          display_user_error!(e, message)
-        else
-          FastlaneCore::CrashReporting.handle_crash(e)
-          # From https://stackoverflow.com/a/4789702/445598
-          # We do this to make the actual error message red and therefore more visible
-          reraise_formatted!(e, e.message)
-        end
+    def handle_unknown_error!(e)
+      # Some spaceship exception classes implement this method in order to share error information sent by Apple
+      # However, fastlane_core and spaceship can not know about each other's classes! To make this information
+      # passing work, we use a bit of Ruby duck-typing to check whether the unknown exception type has any of
+      # this kind of information to share with us. If so, we'll present it in the manner of a user_error!
+      if e.respond_to? :apple_provided_error_info
+        message = e.apple_provided_error_info.unshift("Apple provided the following error info:").join("\n\t")
+        display_user_error!(e, message)
+      else
+        FastlaneCore::CrashReporting.handle_crash(e)
+        # From https://stackoverflow.com/a/4789702/445598
+        # We do this to make the actual error message red and therefore more visible
+        reraise_formatted!(e, e.message)
       end
     end
 

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -43,12 +43,14 @@ module Commander
     end
 
     def handle_unknown_error!(e)
-      # Some spaceship exception classes implement this method in order to share error information sent by Apple
+      # Some spaceship exception classes implement this method in order to share error information sent by Apple.
       # However, fastlane_core and spaceship can not know about each other's classes! To make this information
-      # passing work, we use a bit of Ruby duck-typing to check whether the unknown exception type has any of
-      # this kind of information to share with us. If so, we'll present it in the manner of a user_error!
-      if e.respond_to? :apple_provided_error_info
-        message = e.apple_provided_error_info.unshift("Apple provided the following error info:").join("\n\t")
+      # passing work, we use a bit of Ruby duck-typing to check whether the unknown exception type implements
+      # the right method. If so, we'll present any returned error info in the manner of a user_error!
+      error_info = e.respond_to?(:apple_provided_error_info) ? e.apple_provided_error_info : nil
+
+      if error_info
+        message = error_info.unshift("Apple provided the following error info:").join("\n\t")
         display_user_error!(e, message)
       else
         FastlaneCore::CrashReporting.handle_crash(e)

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -51,8 +51,8 @@ module Commander
       error_info = e.respond_to?(:preferred_error_info) ? e.preferred_error_info : nil
 
       if error_info
-        message = error_info.unshift("Apple provided the following error info:").join("\n\t")
-        display_user_error!(e, message)
+        error_info = error_info.join("\n\t") if error_info.kind_of?(Array)
+        display_user_error!(e, error_info)
       else
         FastlaneCore::CrashReporting.handle_crash(e)
         # From https://stackoverflow.com/a/4789702/445598

--- a/fastlane_core/spec/fastlane_runner_spec.rb
+++ b/fastlane_core/spec/fastlane_runner_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe Commander::Runner do
+  describe '#handle_unknown_error' do
+    class CustomError < StandardError
+      def apple_provided_error_info
+        ['Line 1', 'Line 2']
+      end
+    end
+
+    it 'should reraise errors that are not of special interest' do
+      expect do
+        Commander::Runner.new.handle_unknown_error!(StandardError.new('my message'))
+      end.to raise_error(StandardError, '[!] my message'.red)
+    end
+
+    it 'should abort and show custom info for errors that have the Apple error info provider method with $verbose=false' do
+      runner = Commander::Runner.new
+      expect(runner).to receive(:abort).with("\n[!] Apple provided the following error info:\n\tLine 1\n\tLine 2".red)
+
+      with_verbose(false) do
+        runner.handle_unknown_error!(CustomError.new)
+      end
+    end
+
+    it 'should reraise and show custom info for errors that have the Apple error info provider method with $verbose=true' do
+      with_verbose(true) do
+        expect do
+          Commander::Runner.new.handle_unknown_error!(CustomError.new)
+        end.to raise_error(CustomError, "[!] Apple provided the following error info:\n\tLine 1\n\tLine 2".red)
+      end
+    end
+  end
+end

--- a/fastlane_core/spec/fastlane_runner_spec.rb
+++ b/fastlane_core/spec/fastlane_runner_spec.rb
@@ -4,7 +4,7 @@ describe Commander::Runner do
   describe '#handle_unknown_error' do
     class CustomError < StandardError
       def preferred_error_info
-        ['Line 1', 'Line 2']
+        ['Title', 'Line 1', 'Line 2']
       end
     end
 
@@ -28,7 +28,7 @@ describe Commander::Runner do
 
     it 'should abort and show custom info for errors that have the Apple error info provider method with $verbose=false' do
       runner = Commander::Runner.new
-      expect(runner).to receive(:abort).with("\n[!] Apple provided the following error info:\n\tLine 1\n\tLine 2".red)
+      expect(runner).to receive(:abort).with("\n[!] Title\n\tLine 1\n\tLine 2".red)
 
       with_verbose(false) do
         runner.handle_unknown_error!(CustomError.new)
@@ -39,7 +39,7 @@ describe Commander::Runner do
       with_verbose(true) do
         expect do
           Commander::Runner.new.handle_unknown_error!(CustomError.new)
-        end.to raise_error(CustomError, "[!] Apple provided the following error info:\n\tLine 1\n\tLine 2".red)
+        end.to raise_error(CustomError, "[!] Title\n\tLine 1\n\tLine 2".red)
       end
     end
   end

--- a/fastlane_core/spec/fastlane_runner_spec.rb
+++ b/fastlane_core/spec/fastlane_runner_spec.rb
@@ -8,9 +8,21 @@ describe Commander::Runner do
       end
     end
 
+    class NilReturningError < StandardError
+      def apple_provided_error_info
+        nil
+      end
+    end
+
     it 'should reraise errors that are not of special interest' do
       expect do
         Commander::Runner.new.handle_unknown_error!(StandardError.new('my message'))
+      end.to raise_error(StandardError, '[!] my message'.red)
+    end
+
+    it 'should reraise errors that return nil from #apple_provided_error_info' do
+      expect do
+        Commander::Runner.new.handle_unknown_error!(NilReturningError.new('my message'))
       end.to raise_error(StandardError, '[!] my message'.red)
     end
 

--- a/fastlane_core/spec/fastlane_runner_spec.rb
+++ b/fastlane_core/spec/fastlane_runner_spec.rb
@@ -3,13 +3,13 @@ require 'spec_helper'
 describe Commander::Runner do
   describe '#handle_unknown_error' do
     class CustomError < StandardError
-      def apple_provided_error_info
+      def preferred_error_info
         ['Line 1', 'Line 2']
       end
     end
 
     class NilReturningError < StandardError
-      def apple_provided_error_info
+      def preferred_error_info
         nil
       end
     end
@@ -20,7 +20,7 @@ describe Commander::Runner do
       end.to raise_error(StandardError, '[!] my message'.red)
     end
 
-    it 'should reraise errors that return nil from #apple_provided_error_info' do
+    it 'should reraise errors that return nil from #preferred_error_info' do
       expect do
         Commander::Runner.new.handle_unknown_error!(NilReturningError.new('my message'))
       end.to raise_error(StandardError, '[!] my message'.red)

--- a/fastlane_core/spec/spec_helper.rb
+++ b/fastlane_core/spec/spec_helper.rb
@@ -32,6 +32,14 @@ ensure
   end
 end
 
+def with_verbose(verbose)
+  orig_verbose = $verbose
+  $verbose = verbose
+  yield if block_given?
+ensure
+  $verbose = orig_verbose
+end
+
 def stub_commander_runner_args(args)
   runner = Commander::Runner.new(args)
   allow(Commander::Runner).to receive(:instance).and_return(runner)

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -28,15 +28,20 @@ module Spaceship
     # /tmp/spaceship[time]_[pid].log by default
     attr_accessor :logger
 
-    # Invalid user credentials were provided
-    class InvalidUserCredentialsError < StandardError
-      def apple_provided_error_info
+    # Base class for errors that want to present their message as
+    # preferred error info for fastlane error handling. See:
+    # fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+    class BasicPreferredInfoError < StandardError
+      def preferred_error_info
         message ? [message] : nil
       end
     end
 
+    # Invalid user credentials were provided
+    class InvalidUserCredentialsError < BasicPreferredInfoError; end
+
     # Raised when no user credentials were passed at all
-    class NoUserCredentialsError < StandardError; end
+    class NoUserCredentialsError < BasicPreferredInfoError; end
 
     class UnexpectedResponse < StandardError
       attr_reader :error_info
@@ -46,18 +51,18 @@ module Spaceship
         @error_info = error_info
       end
 
-      def apple_provided_error_info
-        return nil unless @error_info.is_a?(Hash) && @error_info['resultString']
+      def preferred_error_info
+        return nil unless @error_info.kind_of?(Hash) && @error_info['resultString']
 
         [@error_info['resultString'], @error_info['userString']].compact.uniq
       end
     end
 
     # Raised when 302 is received from portal request
-    class AppleTimeoutError < StandardError; end
+    class AppleTimeoutError < BasicPreferredInfoError; end
 
     # Raised when 401 is received from portal request
-    class UnauthorizedAccessError < StandardError; end
+    class UnauthorizedAccessError < BasicPreferredInfoError; end
 
     # Authenticates with Apple's web services. This method has to be called once
     # to generate a valid session. The session will automatically be used from then

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -35,8 +35,17 @@ module Spaceship
     class NoUserCredentialsError < StandardError; end
 
     class UnexpectedResponse < StandardError
+      attr_reader :error_info
+
+      def initialize(error_info = nil)
+        super(error_info)
+        @error_info = error_info
+      end
+
       def apple_provided_error_info
-        ['Line 1', 'Line 2']
+        return nil unless @error_info && @error_info['resultString']
+
+        [@error_info['resultString'], @error_info['userString']].compact.uniq
       end
     end
 
@@ -301,7 +310,7 @@ module Spaceship
       end
 
       if content.nil?
-        raise UnexpectedResponse.new, response.body
+        raise UnexpectedResponse.new(response.body)
       else
         store_csrf_tokens(response)
         content

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -34,7 +34,11 @@ module Spaceship
     # Raised when no user credentials were passed at all
     class NoUserCredentialsError < StandardError; end
 
-    class UnexpectedResponse < StandardError; end
+    class UnexpectedResponse < StandardError
+      def apple_provided_error_info
+        ['Line 1', 'Line 2']
+      end
+    end
 
     # Raised when 302 is received from portal request
     class AppleTimeoutError < StandardError; end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -29,7 +29,11 @@ module Spaceship
     attr_accessor :logger
 
     # Invalid user credentials were provided
-    class InvalidUserCredentialsError < StandardError; end
+    class InvalidUserCredentialsError < StandardError
+      def apple_provided_error_info
+        message ? [message] : nil
+      end
+    end
 
     # Raised when no user credentials were passed at all
     class NoUserCredentialsError < StandardError; end
@@ -43,7 +47,7 @@ module Spaceship
       end
 
       def apple_provided_error_info
-        return nil unless @error_info && @error_info['resultString']
+        return nil unless @error_info.is_a?(Hash) && @error_info['resultString']
 
         [@error_info['resultString'], @error_info['userString']].compact.uniq
       end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -32,8 +32,10 @@ module Spaceship
     # preferred error info for fastlane error handling. See:
     # fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
     class BasicPreferredInfoError < StandardError
+      TITLE = 'The request could not be completed because:'.freeze
+
       def preferred_error_info
-        message ? [message] : nil
+        message ? [TITLE, message] : nil
       end
     end
 
@@ -54,7 +56,11 @@ module Spaceship
       def preferred_error_info
         return nil unless @error_info.kind_of?(Hash) && @error_info['resultString']
 
-        [@error_info['resultString'], @error_info['userString']].compact.uniq
+        [
+          "Apple provided the following error info:",
+          @error_info['resultString'],
+          @error_info['userString']
+        ].compact.uniq # sometimes 'resultString' and 'userString' are the same value
       end
     end
 

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -2,7 +2,7 @@ module Spaceship
   # rubocop:disable Metrics/ClassLength
   class TunesClient < Spaceship::Client
     # ITunesConnectError is only thrown when iTunes Connect raises an exception
-    class ITunesConnectError < StandardError
+    class ITunesConnectError < BasicPreferredInfoError
     end
 
     # raised if the server failed to save temporarily


### PR DESCRIPTION
This is a second iteration on attempting to provide cleaner/nicer output for errors that originate from `spaceship`.

The idea is to go from something like:

<img width="1402" alt="screen shot 2016-03-16 at 4 22 46 pm" src="https://cloud.githubusercontent.com/assets/343134/13828491/2f14cf54-eb98-11e5-9f4f-76c4baadd80e.png">

To something like:

<img width="402" alt="screen shot 2016-03-16 at 4 25 06 pm" src="https://cloud.githubusercontent.com/assets/343134/13828514/45f2fd68-eb98-11e5-8096-77f07ecff402.png">

This approach is better than #3782 because it does not introduce `abort` into `spaceship`. That was a Bad Idea (TM).

Things that are challenging:
1. Nice presentation of errors is handled in `fastlane_core`, but `fastlane_core` and `spaceship` can not know about each other.
2. `spaceship` defines many custom error types
3. Apple returns many different shapes of JSON structures containing error information

The nice things about this approach are:
1. It centralizes error handling and presentation at a very high level (close to the tool entry point) so we don't have to rescue exceptions at every `spaceship` call-site
2. Each kind of custom exception in `spaceship` can opt-in separately. So, for places where we implement support on the spaceship side, we'll get nicer presentation. If we go back later and extend it to more places, those will just start to work.
