### PR TITLE
Add -p param to oclint action to fix file relative paths

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,6 @@ machine:
     version: "7.2"
 dependencies:
   override:
-    - gem install bundler
     - bundle check --path=/tmp/vendor/bundle || bundle install --path=/tmp/vendor/bundle --jobs=4 --retry=3
   cache_directories:
     - /tmp/vendor/bundle

--- a/fastlane/lib/fastlane/actions/oclint.rb
+++ b/fastlane/lib/fastlane/actions/oclint.rb
@@ -23,7 +23,11 @@ module Fastlane
         select_regex = params[:select_regex] if params[:select_regex] # Overwrite deprecated select_reqex
         exclude_regex = params[:exclude_regex]
 
-        files = JSON.parse(File.read(compile_commands)).map { |compile_command| compile_command['file'] }
+        files = JSON.parse(File.read(compile_commands)).map do |compile_command|
+          file = compile_command['file']
+          File.exist?(file) ? file : File.join(compile_command['directory'], file)
+        end
+
         files.uniq!
         files.select! do |file|
           file_ruby = file.gsub('\ ', ' ')
@@ -62,6 +66,7 @@ module Fastlane
         oclint_args << "-enable-clang-static-analyzer" if params[:enable_clang_static_analyzer]
         oclint_args << "-enable-global-analysis" if params[:enable_global_analysis]
         oclint_args << "-allow-duplicated-violations" if params[:allow_duplicated_violations]
+        oclint_args << "-p #{params[:compile_commands]}" if params[:compile_commands]
 
         command = [
           command_prefix,

--- a/fastlane/lib/fastlane/actions/xcov.rb
+++ b/fastlane/lib/fastlane/actions/xcov.rb
@@ -21,6 +21,12 @@ module Fastlane
       end
 
       def self.available_options
+        # We call Gem::Specification.find_by_name in many more places than this, but for right now
+        # this is the only place we're having trouble. If there are other reports about RubyGems
+        # 2.6.2 causing problems, we may need to move this code and require it someplace better,
+        # like fastlane_core
+        require 'fastlane/core_ext/bundler_monkey_patch'
+
         begin
           Gem::Specification.find_by_name('xcov')
         rescue Gem::LoadError

--- a/fastlane/lib/fastlane/core_ext/bundler_monkey_patch.rb
+++ b/fastlane/lib/fastlane/core_ext/bundler_monkey_patch.rb
@@ -1,0 +1,14 @@
+# https://github.com/bundler/bundler/issues/4368
+#
+# There is an issue with Rubygems 2.6.2 where it attempts to call Bundler::SpecSet#size, which doesn't exist.
+# If a gem is not installed, a `Gem::Specification.find_by_name` call will trigger this problem.
+if Object.const_defined?(:Bundler) &&
+    Bundler.const_defined?(:SpecSet) &&
+    Bundler::SpecSet.instance_methods.include?(:length) &&
+    !Bundler::SpecSet.instance_methods.include?(:size)
+  module Bundler
+    class SpecSet
+      alias_method :size, :length
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/oclint_spec.rb
+++ b/fastlane/spec/actions_specs/oclint_spec.rb
@@ -16,7 +16,7 @@ describe Fastlane do
             )
           end").runner.execute(:test)
 
-        expect(result).to match(/cd .* && oclint -report-type=html -o=oclint_report.html \".*/)
+        expect(result).to match(/cd .* && oclint -report-type=html -o=oclint_report.html -p .*?compile_commands\.json \".*/)
       end
 
       it "works with all parameters" do


### PR DESCRIPTION
oclint action missing -p parameter and compile_commands.json fails on file relative paths
