### PR TITLE
Revert "Move rescue within the block"

### DIFF
--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -44,27 +44,24 @@ module FastlaneCore
 
         begin
           PTY.spawn(command) do |stdin, stdout, pid|
-            begin
-              stdin.each do |l|
-                line = l.strip # strip so that \n gets removed
-                output << line
+            stdin.each do |l|
+              line = l.strip # strip so that \n gets removed
+              output << line
 
-                next unless print_all
+              next unless print_all
 
-                # Prefix the current line with a string
-                prefix.each do |element|
-                  line = element[:prefix] + line if element[:block] && element[:block].call(line)
-                end
-
-                UI.command_output(line)
+              # Prefix the current line with a string
+              prefix.each do |element|
+                line = element[:prefix] + line if element[:block] && element[:block].call(line)
               end
-            rescue Errno::EIO
-              # This is expected on some linux systems, that indicates that the subcommand finished
-              # and we kept trying to read, ignore ix
-            ensure
-              Process.wait(pid)
+
+              UI.command_output(line)
             end
+            Process.wait(pid)
           end
+        rescue Errno::EIO
+          # This is expected on some linux systems, that indicates that the subcommand finished
+          # and we kept trying to read, ignore it
         rescue => ex
           # This could happen when the environment is wrong:
           # > invalid byte sequence in US-ASCII (ArgumentError)

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -9,27 +9,19 @@ describe FastlaneCore do
         # we raise when the line is cleaned up with `strip` afterward
         expect(explodes_on_strip).to receive(:strip).and_raise Errno::EIO
 
-        # Make a fake child process so we have a valid PID and $? is set correctly
-        child_process_id = nil
-        PTY.spawn('echo') do |stdin, stdout, pid|
-          child_process_id = pid
-        end
-
         expect(PTY).to receive(:spawn) do |command, &block|
           expect(command).to eq('ls')
-          block.yield fake_std_in, 'not_really_std_out', child_process_id
+          block.yield fake_std_in, 'not_really_std_out', Process.pid
         end
+
+        expect($?).to receive(:exitstatus).and_return 0
 
         result = FastlaneCore::CommandExecutor.execute(command: 'ls')
 
         # We are implicity also checking that the error was not rethrown because that would
         # have crashed the test
-        expect(result).to eq('a_filename')
-      end
 
-      it 'does some basic command' do
-        result = FastlaneCore::CommandExecutor.execute(command: "echo foobar")
-        expect(result).to eq('foobar')
+        expect(result).to eq('a_filename')
       end
     end
 


### PR DESCRIPTION
Reverts fastlane/fastlane#3805

These tests are flaky, reverting to make better tests.
