### PR TITLE
Add `skip_docs` option to match

### DIFF
--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -4,7 +4,7 @@ module Match
       to ||= ChangePassword.ask_password(message: "New passphrase for Git Repo: ", confirm: false)
       from ||= ChangePassword.ask_password(message: "Old passphrase for Git Repo: ", confirm: true)
       GitHelper.clear_changes
-      workspace = GitHelper.clone(params[:git_url], params[:shallow_clone], manual_password: from)
+      workspace = GitHelper.clone(params[:git_url], params[:shallow_clone], manual_password: from, skip_docs: params[:skip_docs])
       Encrypt.new.clear_password(params[:git_url])
       Encrypt.new.store_password(params[:git_url], to)
 

--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -1,6 +1,6 @@
 module Match
   class GitHelper
-    def self.clone(git_url, shallow_clone, manual_password: nil)
+    def self.clone(git_url, shallow_clone, manual_password: nil, skip_docs: false)
       return @dir if @dir
 
       @dir = Dir.mktmpdir
@@ -23,7 +23,7 @@ module Match
         return self.clone(git_url, shallow_clone)
       end
 
-      copy_readme(@dir)
+      copy_readme(@dir) unless skip_docs
       Encrypt.new.decrypt_repo(path: @dir, git_url: git_url, manual_password: manual_password)
 
       return @dir

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -11,7 +11,7 @@ module Match
       self.params = params
       self.type = type
 
-      params[:workspace] = GitHelper.clone(params[:git_url], params[:shallow_clone])
+      params[:workspace] = GitHelper.clone(params[:git_url], params[:shallow_clone], skip_docs: params[:skip_docs])
 
       had_app_identifier = self.params[:app_identifier]
       self.params[:app_identifier] = '' # we don't really need a value here

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -96,6 +96,11 @@ module Match
                                      env_name: "MATCH_FORCE_FOR_NEW_DEVICES",
                                      description: "Renew the provisioning profiles if the device count on the developer portal has changed",
                                      is_string: false,
+                                     default_value: false),
+        FastlaneCore::ConfigItem.new(key: :skip_docs,
+                                     env_name: "MATCH_SKIP_DOCS",
+                                     description: "Skip generation of a README.md for the created git repository",
+                                     is_string: false,
                                      default_value: false)
       ]
     end

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -7,7 +7,7 @@ module Match
                                          hide_keys: [:workspace],
                                              title: "Summary for match #{Match::VERSION}")
 
-      params[:workspace] = GitHelper.clone(params[:git_url], params[:shallow_clone])
+      params[:workspace] = GitHelper.clone(params[:git_url], params[:shallow_clone], skip_docs: params[:skip_docs])
       spaceship = SpaceshipEnsure.new(params[:username]) unless params[:readonly]
 
       # Verify the App ID (as we don't want 'match' to fail at a later point)

--- a/match/spec/git_helper_spec.rb
+++ b/match/spec/git_helper_spec.rb
@@ -12,6 +12,28 @@ describe Match do
     end
 
     describe "#clone" do
+      it "skips README file generation if so requested" do
+        path = Dir.mktmpdir # to have access to the actual path
+        expect(Dir).to receive(:mktmpdir).and_return(path)
+        git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
+        shallow_clone = false
+        command = "git clone '#{git_url}' '#{path}'"
+        to_params = {
+          command: command,
+          print_all: nil,
+          print_command: nil
+        }
+
+        expect(FastlaneCore::CommandExecutor).
+          to receive(:execute).
+          with(to_params).
+          and_return(nil)
+
+        result = Match::GitHelper.clone(git_url, shallow_clone, skip_docs: true)
+        expect(File.directory?(result)).to eq(true)
+        expect(File.exist?(File.join(result, 'README.md'))).to eq(false)
+      end
+
       it "clones the repo" do
         path = Dir.mktmpdir # to have access to the actual path
         expect(Dir).to receive(:mktmpdir).and_return(path)
@@ -31,6 +53,7 @@ describe Match do
 
         result = Match::GitHelper.clone(git_url, shallow_clone)
         expect(File.directory?(result)).to eq(true)
+        expect(File.exist?(File.join(result, 'README.md'))).to eq(true)
       end
 
       it "clones the repo (not shallow)" do
@@ -52,6 +75,7 @@ describe Match do
 
         result = Match::GitHelper.clone(git_url, shallow_clone)
         expect(File.directory?(result)).to eq(true)
+        expect(File.exist?(File.join(result, 'README.md'))).to eq(true)
       end
 
       after(:each) do

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -14,7 +14,7 @@ describe Match do
       cert_path = File.join(repo_dir, "something")
       profile_path = "./spec/fixtures/test.mobileprovision"
 
-      expect(Match::GitHelper).to receive(:clone).with(git_url, true).and_return(repo_dir)
+      expect(Match::GitHelper).to receive(:clone).with(git_url, true, skip_docs: false).and_return(repo_dir)
       expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution).and_return(cert_path)
       expect(Match::Generator).to receive(:generate_provisioning_profile).with(params: config,
                                                                             prov_type: :appstore,
@@ -45,7 +45,7 @@ describe Match do
       key_path = "./spec/fixtures/existing/certs/distribution/E7P4EE896K.p12"
       keychain = "login.keychain"
 
-      expect(Match::GitHelper).to receive(:clone).with(git_url, false).and_return(repo_dir)
+      expect(Match::GitHelper).to receive(:clone).with(git_url, false, skip_docs: false).and_return(repo_dir)
       expect(Match::Utils).to receive(:import).with(key_path, keychain).and_return(nil)
       expect(Match::GitHelper).to_not receive(:commit_changes)
 


### PR DESCRIPTION
The `skip_docs` option can be used to ask `match` to avoid creating a README.md for the generated git repo.

Requested in #3796 :tada: 
