### PR TITLE
[PEM] Adds Web Push, Passbook, Apple Pay and Mac Push Cert types

### DIFF
--- a/pem/lib/pem/manager.rb
+++ b/pem/lib/pem/manager.rb
@@ -5,28 +5,40 @@ module PEM
   # Creates the push profile and stores it in the correct location
   class Manager
     class << self
+      PEM_CERTIFICATE_DISPLAY = {
+          Spaceship::Portal::App::MAC => "Push Certificate",
+          Spaceship::Portal::App::IOS => "Push Certificate",
+          Spaceship::Portal::App::PASS => "Pass Certificate",
+          Spaceship::Portal::App::WEB => "Website Push Certificate",
+          Spaceship::Portal::App::MERCHANT => "Apple Pay Certificate"
+      }.freeze
+
       def start
         FastlaneCore::PrintTable.print_values(config: PEM.config, hide_keys: [], title: "Summary for PEM #{PEM::VERSION}")
         login
 
-        existing_certificate = certificate.all.detect do |c|
+        app = Spaceship.app.find_by_platform(PEM.config[:app_identifier], platform: PEM.config[:platform])
+        raise UI.error "Could not find an app with the identifier #{PEM.config[:app_identifier]}" if app.nil?
+
+        PEM.config[:platform] = app.platform if PEM.config[:platform].nil?
+
+        existing_certificate = certificate.all_by_platform(platform: PEM.config[:platform]).detect do |c|
           c.name == PEM.config[:app_identifier]
         end
 
         if existing_certificate
           remaining_days = (existing_certificate.expires - Time.now) / 60 / 60 / 24
-          UI.message "Existing push notification profile '#{existing_certificate.owner_name}' is valid for #{remaining_days.round} more days."
+          UI.message "Existing #{PEM_CERTIFICATE_DISPLAY[PEM.config[:platform]]} profile '#{existing_certificate.owner_name}' is valid for #{remaining_days.round} more days."
           if remaining_days > 30
             if PEM.config[:force]
-              UI.success "You already have an existing push certificate, but a new one will be created since the --force option has been set."
+              UI.success "You already have an existing #{PEM_CERTIFICATE_DISPLAY[PEM.config[:platform]]}, but a new one will be created since the --force option has been set."
             else
-              UI.success "You already have a push certificate, which is active for more than 30 more days. No need to create a new one"
+              UI.success "You already have a  #{PEM_CERTIFICATE_DISPLAY[PEM.config[:platform]]}, which is active for more than 30 more days. No need to create a new one"
               UI.success "If you still want to create a new one, use the --force option when running PEM."
               return false
             end
           end
         end
-
         return create_certificate
       end
 
@@ -38,8 +50,8 @@ module PEM
       end
 
       # rubocop:disable Metrics/AbcSize
-      def create_certificate
-        UI.important "Creating a new push certificate for app '#{PEM.config[:app_identifier]}'."
+      def create_certificate(app: nil)
+        UI.important "Creating a new #{PEM_CERTIFICATE_DISPLAY[PEM.config[:platform]]} for app '#{PEM.config[:app_identifier]}'."
 
         csr, pkey = Spaceship.certificate.create_certificate_signing_request
 
@@ -49,7 +61,7 @@ module PEM
           if ex.to_s.include? "You already have a current"
             # That's the most common failure probably
             UI.message ex.to_s
-            UI.user_error!("You already have 2 active push profiles for this application/environment. You'll need to revoke an old certificate to make room for a new one")
+            UI.user_error!("You already have 2 active #{PEM_CERTIFICATE_DISPLAY[PEM.config[:platform]]}s for this application/environment. You'll need to revoke an old certificate to make room for a new one")
           else
             raise ex
           end
@@ -83,10 +95,24 @@ module PEM
       # rubocop:enable Metrics/AbcSize
 
       def certificate
-        if PEM.config[:development]
-          Spaceship.certificate.development_push
-        else
-          Spaceship.certificate.production_push
+        if PEM.config[:platform] == Spaceship::Portal::App::IOS
+          if PEM.config[:development]
+            Spaceship.certificate.development_push
+          else
+            Spaceship.certificate.production_push
+          end
+        elsif PEM.config[:platform] == Spaceship::Portal::App::MAC
+          if PEM.config[:development]
+            Spaceship.certificate.mac_development_push
+          else
+            Spaceship.certificate.mac_production_push
+          end
+        elsif PEM.config[:platform] == Spaceship::Portal::App::WEB
+          Spaceship.certificate.website_push
+        elsif PEM.config[:platform] == Spaceship::Portal::App::MERCHANT
+          Spaceship.certificate.apple_pay
+        elsif PEM.config[:platform] == Spaceship::Portal::App::PASS
+          Spaceship.certificate.passbook
         end
       end
     end

--- a/pem/lib/pem/options.rb
+++ b/pem/lib/pem/options.rb
@@ -71,7 +71,15 @@ module PEM
                                      short_option: "-e",
                                      env_name: "PEM_OUTPUT_PATH",
                                      description: "The path to a directory in which all certificates and private keys should be stored",
-                                     default_value: ".")
+                                     default_value: "."),
+        FastlaneCore::ConfigItem.new(key: :platform,
+                                     short_option: "-f",
+                                     env_name: "PEM_PLATFORM",
+                                     optional: true,
+                                     description: "The platform to search on with the specified bundle id",
+                                     verify_block: proc do |value|
+                                       UI.user_error!("The platform can only be ios, web, merchant, pass or mac") unless %("ios", "merchant", "mac", "web", "pass").include? value
+                                     end)
       ]
     end
   end


### PR DESCRIPTION
This adds the ability for PEM to download different App Id Certificates for the various app "Platforms". Mainly this adds Website Push, Passbook, Apple Pay and Mac Push Cert types.

This depends on #3825.

PEM portion of #3693.
