### PR TITLE
* add decrypt support

### DIFF
--- a/match/bin/match
+++ b/match/bin/match
@@ -82,6 +82,16 @@ class MatchApplication
       end
     end
 
+    command :decrypt do |c|
+      c.syntax = "match decrypt"
+      c.description = "Decrypts the repository and keeps it on the filesystem"
+      c.action do |args, options|
+        params = FastlaneCore::Configuration.create(Match::Options.available_options, options.__hash__)
+        params.load_configuration_file("Matchfile")
+        decrypted_repo = Match::GitHelper.clone(params[:git_url], params[:shallow_clone])
+        UI.success "Repo is at: '#{decrypted_repo}'"
+      end
+    end
     command "nuke" do |c|
       # We have this empty command here, since otherwise the normal `match` command will be executed
       c.syntax = "match nuke"


### PR DESCRIPTION
Decrypts the repo, and leaves it arround:

```
match decrypt  -r ssh://git@gitlab.krone.at/mobile/IOS-CERTIFICATES.git
```

sample output:

```
[08:17:50]: Cloning remote git repo...
[08:17:52]: 🔓  Successfully decrypted certificates repo
[08:17:52]: Repo is at: '/var/folders/dx/z94090d97ydbnpk21m4clpjjqqx4h1/T/d20160318-66187-rcoxet'
```
