### PR TITLE
Fix password quoting for pilot. Fixes #1503

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -193,7 +193,7 @@ module FastlaneCore
         '"' + Helper.transporter_path + '"',
         "-m lookupMetadata",
         "-u \"#{username}\"",
-        "-p #{shell_escaped_password(password)}",
+        "-p #{password.shellescape}",
         "-apple_id #{apple_id}",
         "-destination '#{destination}'"
       ].join(' ')
@@ -204,27 +204,12 @@ module FastlaneCore
         '"' + Helper.transporter_path + '"',
         "-m upload",
         "-u \"#{username}\"",
-        "-p #{shell_escaped_password(password)}",
+        "-p #{password.shellescape}",
         "-f '#{source}'",
         ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
         "-t 'Signiant'",
         "-k 100000"
       ].join(' ')
-    end
-
-    def shell_escaped_password(password)
-      # because the shell handles passwords with single-quotes incorrectly, use gsub to replace ShellEscape'd single-quotes of this form:
-      #    \'
-      # with a sequence that wraps the escaped single-quote in double-quotes:
-      #    '"\'"'
-      # this allows us to properly handle passwords with single-quotes in them
-      # we use the 'do' version of gsub, because two-param version interprets the replace text as a pattern and does the wrong thing
-      password = Shellwords.escape(password).gsub("\\'") do
-        "'\"\\'\"'"
-      end
-
-      # wrap the fully-escaped password in single quotes, since the transporter expects a escaped password string (which must be single-quoted for the shell's benefit)
-      "'" + password + "'"
     end
   end
 end


### PR DESCRIPTION
This is a more concise version of my previous PR fastlane/fastlane_core#93, which contains a detailed explanation why I (still) think it is the correct solution. Current
code does not work with single quote (despite the attempt to fix it in PR
fastlane/fastlane_core#100), and there have been problems reported with
`<` in passwords (#1503).

Also #3697 handles passwords in the same way.
