### PR TITLE
Enhanced DeployGate Action to support updating distribution page automatically after deploy

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -957,6 +957,7 @@ deploygate(
   user: 'target username or organization name',
   ipa: './ipa_file.ipa',
   message: "Build #{lane_context[SharedValues::BUILD_NUMBER]}",
+  distribution_key: '(Optional) Target Distribution Key'
 )
 ```
 

--- a/fastlane/lib/fastlane/actions/deploygate.rb
+++ b/fastlane/lib/fastlane/actions/deploygate.rb
@@ -31,7 +31,10 @@ module Fastlane
 
         return options[:ipa] if Helper.test?
 
-        response = client.upload_build(options[:ipa], options.values)
+        response = client.upload_build(options[:ipa], {
+            message: options[:message],
+            distribution_key: options[:distribution_key]
+        })
         if parse_response(response)
           UI.message("DeployGate URL: #{Actions.lane_context[SharedValues::DEPLOYGATE_URL]}")
           UI.success("Build successfully uploaded to DeployGate as revision \##{Actions.lane_context[SharedValues::DEPLOYGATE_REVISION]}!")
@@ -105,7 +108,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :message,
                                        env_name: "DEPLOYGATE_MESSAGE",
                                        description: "Release Notes",
-                                       default_value: "No changelog provided")
+                                       default_value: "No changelog provided"),
+          FastlaneCore::ConfigItem.new(key: :distribution_key,
+                                       optional: true,
+                                       env_name: "DEPLOYGATE_DISTRIBUTION_KEY",
+                                       description: "Target Distribution Key",
+                                       default_value: nil)
         ]
       end
 


### PR DESCRIPTION
This makes update DeployGate distribution page automatically 
when it was successfully deployed.

This adds distribution_key option to `deploygate` action.
It simply passes `distribution_key` to [Shenzhen DeployGate Plugin](https://github.com/nomad/shenzhen/blob/0.14.2/lib/shenzhen/plugins/deploygate.rb)

Without this option, `deploygate` action desn't update distribution page.

The distribution key is described in [the deploygate API document](https://deploygate.com/docs/api?locale=en).

Sorry but I couldn't update test code because I don't know the distribution key for testing deploygate project.

Fix #3839
