### PR TITLE
Enhanced DeployGate Action to support updating distribution page automatically after deploy

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -957,6 +957,7 @@ deploygate(
   user: 'target username or organization name',
   ipa: './ipa_file.ipa',
   message: "Build #{lane_context[SharedValues::BUILD_NUMBER]}",
+  distribution_key: '(Optional) Target Distribution Key'
 )
 ```
 

--- a/fastlane/lib/fastlane/actions/deploygate.rb
+++ b/fastlane/lib/fastlane/actions/deploygate.rb
@@ -31,7 +31,12 @@ module Fastlane
 
         return options[:ipa] if Helper.test?
 
-        response = client.upload_build(options[:ipa], options.values)
+        filter = [:message, :distribution_key, :release_note]
+        response = client.upload_build(
+          options[:ipa],
+          options.values.select do |key, _|
+            filter.include? key
+          end)
         if parse_response(response)
           UI.message("DeployGate URL: #{Actions.lane_context[SharedValues::DEPLOYGATE_URL]}")
           UI.success("Build successfully uploaded to DeployGate as revision \##{Actions.lane_context[SharedValues::DEPLOYGATE_REVISION]}!")
@@ -105,7 +110,15 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :message,
                                        env_name: "DEPLOYGATE_MESSAGE",
                                        description: "Release Notes",
-                                       default_value: "No changelog provided")
+                                       default_value: "No changelog provided"),
+          FastlaneCore::ConfigItem.new(key: :distribution_key,
+                                       optional: true,
+                                       env_name: "DEPLOYGATE_DISTRIBUTION_KEY",
+                                       description: "Target Distribution Key"),
+          FastlaneCore::ConfigItem.new(key: :release_note,
+                                       optional: true,
+                                       env_name: "DEPLOYGATE_RELEASE_NOTE",
+                                       description: "Release note for distribution page")
         ]
       end
 

--- a/fastlane/spec/actions_specs/deploygate_spec.rb
+++ b/fastlane/spec/actions_specs/deploygate_spec.rb
@@ -65,6 +65,19 @@ describe Fastlane do
           end").runner.execute(:test)
         end.not_to raise_error
       end
+
+      it "works with valid parameters include optionals" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            deploygate({
+              ipa: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+              user: 'deploygate',
+              api_token: 'thisistest',
+              release_note: 'This is a test release.',
+            })
+          end").runner.execute(:test)
+        end.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
This makes update DeployGate distribution page automatically 
when it was successfully deployed.

This adds distribution_key and release_note options to deploygate action.
It simply passes them to Shenzhen DeployGate Plugin

Without the distribution_key option, deploygate action desn't update distribution page.

These options are described in the deploygate API document.

Sorry but I couldn't update test code for distribution_key
because I don't know the distribution key for testing deploygate project.

Fix #3839
