### PR TITLE
Allows deliver to work with multiple iTunes Providers

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -135,6 +135,16 @@ module Deliver
                                      verify_block: proc do |value|
                                        ENV["FASTLANE_ITC_TEAM_NAME"] = value
                                      end),
+        FastlaneCore::ConfigItem.new(key: :short_team_id,
+                                     short_option: "-s",
+                                     env_name: "DELIVER_SHORT_TEAM_ID",
+                                     description: "The short ID of your team if you're in multiple teams, different from itc_team_id",
+                                     optional: true,
+                                     is_string: false, # as we also allow integers, which we convert to strings anyway
+                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:team_id),
+                                     verify_block: proc do |value|
+                                       ENV["FASTLANE_SHORT_TEAM_ID"] = value.to_s
+                                     end),
 
         # App Metadata
         # Non Localised

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -125,7 +125,7 @@ module FastlaneCore
 
   # Generates commands and executes the iTMSTransporter through the shell script it provides by the same name
   class ShellScriptTransporterExecutor < TransporterExecutor
-    def build_upload_command(username, password, source = "/tmp")
+    def build_upload_command(username, password, source = "/tmp", team_id = "")
       [
         '"' + Helper.transporter_path + '"',
         "-m upload",
@@ -134,19 +134,21 @@ module FastlaneCore
         "-f '#{source}'",
         ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
         "-t 'Signiant'",
-        "-k 100000"
-      ].join(' ')
+        "-k 100000",
+        ("-itc_provider #{team_id}" if team_id.length > 0)
+      ].compact.join(' ')
     end
 
-    def build_download_command(username, password, apple_id, destination = "/tmp")
+    def build_download_command(username, password, apple_id, destination = "/tmp", team_id = "")
       [
         '"' + Helper.transporter_path + '"',
         "-m lookupMetadata",
         "-u \"#{username}\"",
         "-p #{shell_escaped_password(password)}",
         "-apple_id #{apple_id}",
-        "-destination '#{destination}'"
-      ].join(' ')
+        "-destination '#{destination}'",
+        ("-itc_provider #{team_id}" if team_id.length > 0)
+      ].compact.join(' ')
     end
 
     def handle_error(password)
@@ -182,7 +184,7 @@ module FastlaneCore
   # Generates commands and executes the iTMSTransporter by invoking its Java app directly, to avoid the crazy parameter
   # escaping problems in its accompanying shell script.
   class JavaTransporterExecutor < TransporterExecutor
-    def build_upload_command(username, password, source = "/tmp")
+    def build_upload_command(username, password, source = "/tmp", team_id = "")
       [
         Helper.transporter_java_executable_path.shellescape,
         "-Djava.ext.dirs=#{Helper.transporter_java_ext_dir.shellescape}",
@@ -201,11 +203,12 @@ module FastlaneCore
         ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
         '-t Signiant',
         '-k 100000',
+        ("-itc_provider #{team_id}" if team_id.length > 0),
         '2>&1' # cause stderr to be written to stdout
       ].compact.join(' ') # compact gets rid of the possibly nil ENV value
     end
 
-    def build_download_command(username, password, apple_id, destination = "/tmp")
+    def build_download_command(username, password, apple_id, destination = "/tmp", team_id = "")
       [
         Helper.transporter_java_executable_path.shellescape,
         "-Djava.ext.dirs=#{Helper.transporter_java_ext_dir.shellescape}",
@@ -222,8 +225,9 @@ module FastlaneCore
         "-p #{password.shellescape}",
         "-apple_id #{apple_id.shellescape}",
         "-destination #{destination.shellescape}",
+        ("-itc_provider #{team_id}" if team_id.length > 0),
         '2>&1' # cause stderr to be written to stdout
-      ].join(' ')
+      ].compact.join(' ')
     end
 
     def handle_error(password)
@@ -260,13 +264,17 @@ module FastlaneCore
     # @param use_shell_script if true, forces use of the iTMSTransporter shell script.
     #                         if false, allows a direct call to the iTMSTransporter Java app (preferred).
     #                         see: https://github.com/fastlane/fastlane/pull/4003
-    def initialize(user = nil, password = nil, use_shell_script = false)
+    # @param team_id Represents the developer team id (not the iTC id). If provided, will add the correct
+    #               flag to the uplaod command.
+    #               see: https://github.com/fastlane/fastlane/issues/1524
+    def initialize(user = nil, password = nil, use_shell_script = false, team_id = nil)
       use_shell_script ||= !ENV['FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT'].nil?
       data = CredentialsManager::AccountManager.new(user: user, password: password)
 
       @user = data.user
       @password = data.password
       @transporter_executor = use_shell_script ? ShellScriptTransporterExecutor.new : JavaTransporterExecutor.new
+      @team_id = team_id || (ENV['FASTLANE_SHORT_TEAM_ID'] || '').strip
     end
 
     # Downloads the latest version of the app metadata package from iTC.
@@ -279,8 +287,8 @@ module FastlaneCore
       dir ||= "/tmp"
 
       UI.message("Going to download app metadata from iTunes Connect")
-      command = @transporter_executor.build_download_command(@user, @password, app_id, dir)
-      UI.verbose(@transporter_executor.build_download_command(@user, 'YourPassword', app_id, dir))
+      command = @transporter_executor.build_download_command(@user, @password, app_id, dir, @team_id)
+      UI.verbose(@transporter_executor.build_download_command(@user, 'YourPassword', app_id, dir, @team_id))
 
       result = @transporter_executor.execute(command, ItunesTransporter.hide_transporter_output?)
       return result if Helper.is_test?
@@ -309,9 +317,9 @@ module FastlaneCore
       UI.message("Going to upload updated app to iTunes Connect")
       UI.success("This might take a few minutes, please don't interrupt the script")
 
-      command = @transporter_executor.build_upload_command(@user, @password, dir)
+      command = @transporter_executor.build_upload_command(@user, @password, dir, @team_id)
 
-      UI.verbose(@transporter_executor.build_upload_command(@user, 'YourPassword', dir))
+      UI.verbose(@transporter_executor.build_upload_command(@user, 'YourPassword', dir, @team_id))
 
       result = @transporter_executor.execute(command, ItunesTransporter.hide_transporter_output?)
 

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -10,7 +10,6 @@ describe FastlaneCore do
         '-u "fabric.devtools@gmail.com"',
         "-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'",
         "-f '/tmp/my.app.id.itmsp'",
-        nil, # This represents the environment variable which is not set
         "-t 'Signiant'",
         "-k 100000"
       ].join(' ')
@@ -134,6 +133,50 @@ describe FastlaneCore do
         it 'generates a call to java directly' do
           transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
           expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
+        end
+      end
+    end
+
+    describe "itc_provider is set" do
+      let(:team_id) { "ABCDE" }
+
+      describe "upload command generation" do
+        it 'generates a call to the shell script' do
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true, team_id)
+          upload_command = "#{shell_upload_command} -itc_provider #{team_id}"
+          expect(transporter.upload('my.app.id', '/tmp')).to eq(upload_command)
+        end
+      end
+
+      describe "download command generation" do
+        it 'generates a call to the shell script' do
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true, team_id)
+          download_command = "#{shell_download_command} -itc_provider #{team_id}"
+          expect(transporter.download('my.app.id', '/tmp')).to eq(download_command)
+        end
+      end
+    end
+
+    describe "itc_provider is set in ENV" do
+      let(:team_id) { "ABCDE" }
+
+      describe "upload command generation" do
+        it 'generates a call to the shell script' do
+          with_env_values('FASTLANE_SHORT_TEAM_ID' => team_id) do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true)
+            upload_command = "#{shell_upload_command} -itc_provider #{team_id}"
+            expect(transporter.upload('my.app.id', '/tmp')).to eq(upload_command)
+          end
+        end
+      end
+
+      describe "download command generation" do
+        it 'generates a call to the shell script' do
+          with_env_values('FASTLANE_SHORT_TEAM_ID' => team_id) do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true)
+            download_command = "#{shell_download_command} -itc_provider #{team_id}"
+            expect(transporter.download('my.app.id', '/tmp')).to eq(download_command)
+          end
         end
       end
     end


### PR DESCRIPTION
## What Changed & Why

Ref: #1524 

Recent changes in iTunes Connect caused `deliver` to fail when an account is associated to multiple iTunes Connect accounts or "providers". Based on the error console and comments from @simonmitchell it appears and extra flag is required to be passed to the `iTMSTransporter` command. This value should be the short name of the iTunes Connect provider.

From my exploration it appears that the short name of the provider is actually the `team_id` (not the `itc_team_id` that is used in the previous steps in `deliver`). We already specify this in the `Appfile` of our project, so this PR attempts to grab that value from the `Appfile` and, if it's there, add it to the `iTMSTransporter` command.

I tested this out on one of our projects and it works, but I wasn't sure where to add automated tests for this. I couldn't find a place in `fastlane` where the `itunes_transporter.rb` was tested already. 

It's my first time contributing to `fastlane` so please let me know if there's a better way to accomplish this. :)

Thanks Everyone! @KrauseFx @samrobbins @riffs2005 @simonmitchell
