### PR TITLE
[Deliver] Split keywords on commas or newlines

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,6 @@ machine:
     version: "7.2"
 dependencies:
   override:
-    - gem install bundler
     - bundle check --path=/tmp/vendor/bundle || bundle install --path=/tmp/vendor/bundle --jobs=4 --retry=3
   cache_directories:
     - /tmp/vendor/bundle

--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -138,7 +138,7 @@
           <div class="app-keyword">
               <div class="cat-headline">Keywords</div>
               <ul class="app-keyword-list">
-                <% @options[:keywords][language].split(" ").each do |keyword| %>
+                <% split_keywords(@options[:keywords][language]).each do |keyword| %>
                   <li><%= keyword %></li>
                 <% end %>
               </ul>

--- a/deliver/lib/deliver/html_generator.rb
+++ b/deliver/lib/deliver/html_generator.rb
@@ -1,5 +1,10 @@
 module Deliver
   class HtmlGenerator
+    # Splits keywords supporting:
+    # * separated by commas (with optional whitespace)
+    # * separated by newlines
+    KEYWORD_SPLITTER = /(?:,\s?|\r?\n)/
+
     def run(options, screenshots)
       begin
         html_path = self.render(options, screenshots, '.')
@@ -44,6 +49,12 @@ module Deliver
       File.write(export_path, html)
 
       return export_path
+    end
+
+    # Splits a string of keywords separated by comma or newlines into a presentable list
+    # @param keywords (String)
+    def split_keywords(keywords)
+      keywords.split(KEYWORD_SPLITTER)
     end
   end
 end

--- a/deliver/spec/html_generator_spec.rb
+++ b/deliver/spec/html_generator_spec.rb
@@ -1,0 +1,87 @@
+require 'deliver/html_generator'
+require 'tmpdir'
+
+describe Deliver::HtmlGenerator do
+  let(:generator) { Deliver::HtmlGenerator.new }
+
+  describe :render do
+    let(:screenshots) { [] }
+
+    context 'minimal configuration' do
+      let(:options) do
+        {
+          name: { 'en-US' => 'Fastlane Demo' },
+          description: { 'en-US' => 'Demo description' }
+        }
+      end
+
+      it 'renders HTML' do
+        expect(render(options, screenshots)).to match(/<html>/)
+      end
+    end
+
+    context 'with keywords' do
+      let(:options) do
+        {
+          name: { 'en-US' => 'Fastlane Demo' },
+          description: { 'en-US' => 'Demo description' },
+          keywords: { 'en-US' => 'Some, key, words' }
+        }
+      end
+
+      it 'renders HTML' do
+        capture = render(options, screenshots)
+        expect(capture).to match(/<html>/)
+        expect(capture).to include('<li>Some</li>')
+        expect(capture).to include('<li>key</li>')
+        expect(capture).to include('<li>words</li>')
+      end
+    end
+
+    private
+
+    def render(options, screenshots)
+      Dir.mktmpdir do |dir|
+        path = generator.render(options, screenshots, dir)
+        return File.read(path)
+      end
+    end
+  end
+
+  describe :split_keywords do
+    context 'only commas' do
+      let(:keywords) { 'One,Two, Three, Four Token,' }
+
+      it 'splits correctly' do
+        expected = ['One', 'Two', 'Three', 'Four Token']
+        expect(generator.split_keywords(keywords)).to eq(expected)
+      end
+    end
+
+    context 'only newlines' do
+      let(:keywords) { "One\nTwo\r\nThree\nFour Token\n" }
+
+      it 'splits correctly' do
+        expected = ['One', 'Two', 'Three', 'Four Token']
+        expect(generator.split_keywords(keywords)).to eq(expected)
+      end
+    end
+
+    context 'mixed' do
+      let(:keywords) { "One,Two, Three, Four Token,Or\nNewlines\r\nEverywhere" }
+
+      it 'splits correctly' do
+        expected = [
+          'One',
+          'Two',
+          'Three',
+          'Four Token',
+          'Or',
+          'Newlines',
+          'Everywhere'
+        ]
+        expect(generator.split_keywords(keywords)).to eq(expected)
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/xcov.rb
+++ b/fastlane/lib/fastlane/actions/xcov.rb
@@ -21,6 +21,12 @@ module Fastlane
       end
 
       def self.available_options
+        # We call Gem::Specification.find_by_name in many more places than this, but for right now
+        # this is the only place we're having trouble. If there are other reports about RubyGems
+        # 2.6.2 causing problems, we may need to move this code and require it someplace better,
+        # like fastlane_core
+        require 'fastlane/core_ext/bundler_monkey_patch'
+
         begin
           Gem::Specification.find_by_name('xcov')
         rescue Gem::LoadError

--- a/fastlane/lib/fastlane/core_ext/bundler_monkey_patch.rb
+++ b/fastlane/lib/fastlane/core_ext/bundler_monkey_patch.rb
@@ -1,0 +1,14 @@
+# https://github.com/bundler/bundler/issues/4368
+#
+# There is an issue with Rubygems 2.6.2 where it attempts to call Bundler::SpecSet#size, which doesn't exist.
+# If a gem is not installed, a `Gem::Specification.find_by_name` call will trigger this problem.
+if Object.const_defined?(:Bundler) &&
+    Bundler.const_defined?(:SpecSet) &&
+    Bundler::SpecSet.instance_methods.include?(:length) &&
+    !Bundler::SpecSet.instance_methods.include?(:size)
+  module Bundler
+    class SpecSet
+      alias_method :size, :length
+    end
+  end
+end


### PR DESCRIPTION
This PR handles #1573:
- A keyword list can be separated by commas, e.g. `One,Two,Three Token`
- A keyword list can be separated by commas with blanks, e.g. `One, Two, Three Token`
- A keyword list can be separated by newlines, e.g.

``` txt
One
Two
Three Token
```

All results in:
- One
- Two
- Three Token
