### PR TITLE
[frameit] Fix offsets for latest Apple shots

### DIFF
--- a/frameit/lib/frameit/offsets.rb
+++ b/frameit/lib/frameit/offsets.rb
@@ -10,13 +10,13 @@ module Frameit
         case screenshot.screen_size
         when size::IOS_55
           return {
-            'offset' => '+41+146',
-            'width' => 541
+            'offset' => '+42+146',
+            'width' => 540
           }
         when size::IOS_47
           return {
-            'offset' => "+43+154",
-            'width' => 530
+            'offset' => "+40+153",
+            'width' => 532
           }
         when size::IOS_40
           return {


### PR DESCRIPTION
Examples below with the new offsets and the latest Apple press shots downloaded earlier today...

Apple why can't you just keep to the same positioning :sob: 

![iphone6-02-shoppingcart_framed](https://cloud.githubusercontent.com/assets/2766321/13886230/dec7f552-ed2d-11e5-9eaf-4950da1792b9.png)
![iphone6plus-02-shoppingcart_framed](https://cloud.githubusercontent.com/assets/2766321/13886234/e2d3da30-ed2d-11e5-922b-cc8309655023.png)
