### PR TITLE
Fix CI problems that started around March 17

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,6 @@ machine:
     version: "7.2"
 dependencies:
   override:
-    - gem install bundler
     - bundle check --path=/tmp/vendor/bundle || bundle install --path=/tmp/vendor/bundle --jobs=4 --retry=3
   cache_directories:
     - /tmp/vendor/bundle

--- a/fastlane/lib/fastlane/actions/xcov.rb
+++ b/fastlane/lib/fastlane/actions/xcov.rb
@@ -21,6 +21,12 @@ module Fastlane
       end
 
       def self.available_options
+        # We call Gem::Specification.find_by_name in many more places than this, but for right now
+        # this is the only place we're having trouble. If there are other reports about RubyGems
+        # 2.6.2 causing problems, we may need to move this code and require it someplace better,
+        # like fastlane_core
+        require 'fastlane/core_ext/bundler_monkey_patch'
+
         begin
           Gem::Specification.find_by_name('xcov')
         rescue Gem::LoadError

--- a/fastlane/lib/fastlane/core_ext/bundler_monkey_patch.rb
+++ b/fastlane/lib/fastlane/core_ext/bundler_monkey_patch.rb
@@ -1,0 +1,14 @@
+# https://github.com/bundler/bundler/issues/4368
+#
+# There is an issue with Rubygems 2.6.2 where it attempts to call Bundler::SpecSet#size, which doesn't exist.
+# If a gem is not installed, a `Gem::Specification.find_by_name` call will trigger this problem.
+if Object.const_defined?(:Bundler) &&
+    Bundler.const_defined?(:SpecSet) &&
+    Bundler::SpecSet.instance_methods.include?(:length) &&
+    !Bundler::SpecSet.instance_methods.include?(:size)
+  module Bundler
+    class SpecSet
+      alias_method :size, :length
+    end
+  end
+end


### PR DESCRIPTION
- Stop running 'gem install bundler' as part of setup, fixing:

```
bundle exec rake test_all
bundle check --path='/tmp/vendor/bundle' || bundle install --path='/tmp/vendor/bundle' --jobs=4 --retry=3
/usr/local/lib/ruby/gems/2.0.0/bin/bundle:22:in `load': cannot load such file -- /usr/local/lib/ruby/gems/2.0.0/gems/bundler-1.11.2/lib/gems/bundler-1.11.2/bin/bundle (LoadError)
    from /usr/local/lib/ruby/gems/2.0.0/bin/bundle:22:in `<main>'
/usr/local/lib/ruby/gems/2.0.0/bin/bundle:22:in `load': cannot load such file -- /usr/local/lib/ruby/gems/2.0.0/gems/bundler-1.11.2/lib/gems/bundler-1.11.2/bin/bundle (LoadError)
    from /usr/local/lib/ruby/gems/2.0.0/bin/bundle:22:in `<main>'
rake aborted!
Command failed with status (1): [bundle check --path='/tmp/vendor/bundle' |...]
/Users/distiller/fastlane/rakelib/test_all.rake:47:in `bundle_install'
/Users/distiller/fastlane/rakelib/test_all.rake:69:in `block in <top (required)>'
Tasks: TOP => test_all

(See full trace by running task with --trace) bundle exec rake test_all returned exit code 1
```
- Monkey patch a Bundler class to solve a Rubygems problem, fixing  https://github.com/bundler/bundler/issues/4368
