### PR TITLE
Update the help text when no codesigning identities are found:

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -20,7 +20,7 @@ module FastlaneCore
 
       available = `security find-identity -v -p codesigning`
       if available.include?("0 valid identities found")
-        UI.error("Looks like there are no local code signing identities found, you can run `security find-identity -v -p codesigning` to get this output. Check out this reply for more: https://stackoverflow.com/questions/35390072/this-certificate-has-an-invalid-issuer-apple-push-services")
+        UI.error("There are no local code signing identities found. You can run `security find-identity -v -p codesigning` to get this output. This Stack Overflow thread has more information: http://stackoverflow.com/q/35390072/774. (Check in Keychain Access for an expired WWDR certificate: http://stackoverflow.com/a/35409835/774 has more info.)")
       end
 
       ids = []


### PR DESCRIPTION
As of February 2016, the most likely cause is an expired WWDC intermediate certificate.
Update the text to include text about that, and better Stack Overflow links.
