### PR TITLE
Fix CertChecker identity count edge case

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -18,9 +18,15 @@ module FastlaneCore
     def self.installed_identies
       install_wwdr_certificate unless wwdr_certificate_installed?
 
-      available = `security find-identity -v -p codesigning`
-      if available.include?("0 valid identities found")
-        UI.error("There are no local code signing identities found. You can run `security find-identity -v -p codesigning` to get this output. This Stack Overflow thread has more information: http://stackoverflow.com/q/35390072/774. (Check in Keychain Access for an expired WWDR certificate: http://stackoverflow.com/a/35409835/774 has more info.)")
+      available = list_available_identities
+      # Match for this text against word boundaries to avoid edge cases around multiples of 10 identities!
+      if /\b0 valid identities found\b/ =~ available
+        UI.error([
+          "There are no local code signing identities found.",
+          "You can run `security find-identity -v -p codesigning` to get this output.",
+          "This Stack Overflow thread has more information: http://stackoverflow.com/q/35390072/774.",
+          "(Check in Keychain Access for an expired WWDR certificate: http://stackoverflow.com/a/35409835/774 has more info.)"
+        ].join(' '))
       end
 
       ids = []
@@ -34,6 +40,10 @@ module FastlaneCore
       end
 
       return ids
+    end
+
+    def self.list_available_identities
+      `security find-identity -v -p codesigning`
     end
 
     def self.wwdr_certificate_installed?

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe FastlaneCore do
+  describe FastlaneCore::CertChecker do
+    describe '#installed_identies' do
+      it 'should print an error when no local code signing identities are found' do
+        allow(FastlaneCore::CertChecker).to receive(:wwdr_certificate_installed?).and_return(true)
+        allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     0 valid identities found\n")
+        expect(FastlaneCore::UI).to receive(:error).with(/There are no local code signing identities found/)
+
+        FastlaneCore::CertChecker.installed_identies
+      end
+
+      it 'should not be fooled by 10 local code signing identities available' do
+        allow(FastlaneCore::CertChecker).to receive(:wwdr_certificate_installed?).and_return(true)
+        allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     10 valid identities found\n")
+        expect(FastlaneCore::UI).not_to receive(:error)
+
+        FastlaneCore::CertChecker.installed_identies
+      end
+    end
+  end
+end


### PR DESCRIPTION
Uses the strategy from #3823 to correct the bug from #3769 while adding tests but leaving the misspelled method name for now.
