### PR TITLE
Alias installed_identies to the correct spelling

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -1,75 +1,78 @@
 module FastlaneCore
   # This class checks if a specific certificate is installed on the current mac
   class CertChecker
-    def self.installed?(path)
-      raise "Could not find file '#{path}'".red unless File.exist?(path)
+    class << self
+      def installed?(path)
+        raise "Could not find file '#{path}'".red unless File.exist?(path)
 
-      ids = installed_identies
-      finger_print = sha1_fingerprint(path)
+        ids = installed_identities
+        finger_print = sha1_fingerprint(path)
 
-      return ids.include? finger_print
-    end
-
-    # Legacy Method, use `installed?` instead
-    def self.is_installed?(path)
-      installed?(path)
-    end
-
-    def self.installed_identies
-      install_wwdr_certificate unless wwdr_certificate_installed?
-
-      available = list_available_identities
-      # Match for this text against word boundaries to avoid edge cases around multiples of 10 identities!
-      if /\b0 valid identities found\b/ =~ available
-        UI.error([
-          "There are no local code signing identities found.",
-          "You can run `security find-identity -v -p codesigning` to get this output.",
-          "This Stack Overflow thread has more information: http://stackoverflow.com/q/35390072/774.",
-          "(Check in Keychain Access for an expired WWDR certificate: http://stackoverflow.com/a/35409835/774 has more info.)"
-        ].join(' '))
+        return ids.include? finger_print
       end
 
-      ids = []
-      available.split("\n").each do |current|
-        next if current.include? "REVOKED"
-        begin
-          (ids << current.match(/.*\) (.*) \".*/)[1])
-        rescue
-          # the last line does not match
+      # Legacy Method, use `installed?` instead
+      def is_installed?(path)
+        installed?(path)
+      end
+
+      def installed_identities
+        install_wwdr_certificate unless wwdr_certificate_installed?
+
+        available = list_available_identities
+        # Match for this text against word boundaries to avoid edge cases around multiples of 10 identities!
+        if /\b0 valid identities found\b/ =~ available
+          UI.error([
+            "There are no local code signing identities found.",
+            "You can run `security find-identity -v -p codesigning` to get this output.",
+            "This Stack Overflow thread has more information: http://stackoverflow.com/q/35390072/774.",
+            "(Check in Keychain Access for an expired WWDR certificate: http://stackoverflow.com/a/35409835/774 has more info.)"
+          ].join(' '))
+        end
+
+        ids = []
+        available.split("\n").each do |current|
+          next if current.include? "REVOKED"
+          begin
+            (ids << current.match(/.*\) (.*) \".*/)[1])
+          rescue
+            # the last line does not match
+          end
+        end
+
+        return ids
+      end
+      alias_method :installed_identies, :installed_identities
+
+      def list_available_identities
+        `security find-identity -v -p codesigning`
+      end
+
+      def wwdr_certificate_installed?
+        certificate_name = "Apple Worldwide Developer Relations Certification Authority"
+        response = Helper.backticks("security find-certificate -c '#{certificate_name}'", print: $verbose)
+        return response.include?("attributes:")
+      end
+
+      def install_wwdr_certificate
+        Dir.chdir('/tmp') do
+          url = 'https://developer.apple.com/certificationauthority/AppleWWDRCA.cer'
+          filename = File.basename(url)
+          `curl -O #{url} && security import #{filename} -k login.keychain`
+          UI.user_error!("Could not install WWDR certificate") unless $?.success?
         end
       end
 
-      return ids
-    end
-
-    def self.list_available_identities
-      `security find-identity -v -p codesigning`
-    end
-
-    def self.wwdr_certificate_installed?
-      certificate_name = "Apple Worldwide Developer Relations Certification Authority"
-      response = Helper.backticks("security find-certificate -c '#{certificate_name}'", print: $verbose)
-      return response.include?("attributes:")
-    end
-
-    def self.install_wwdr_certificate
-      Dir.chdir('/tmp') do
-        url = 'https://developer.apple.com/certificationauthority/AppleWWDRCA.cer'
-        filename = File.basename(url)
-        `curl -O #{url} && security import #{filename} -k login.keychain`
-        UI.user_error!("Could not install WWDR certificate") unless $?.success?
-      end
-    end
-
-    def self.sha1_fingerprint(path)
-      result = `openssl x509 -in "#{path}" -inform der -noout -sha1 -fingerprint`
-      begin
-        result = result.match(/SHA1 Fingerprint=(.*)/)[1]
-        result.delete!(':')
-        return result
-      rescue
-        Helper.log.info result
-        raise "Error parsing certificate '#{path}'"
+      def sha1_fingerprint(path)
+        result = `openssl x509 -in "#{path}" -inform der -noout -sha1 -fingerprint`
+        begin
+          result = result.match(/SHA1 Fingerprint=(.*)/)[1]
+          result.delete!(':')
+          return result
+        rescue
+          Helper.log.info result
+          raise "Error parsing certificate '#{path}'"
+        end
       end
     end
   end

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -2,18 +2,28 @@ require 'spec_helper'
 
 describe FastlaneCore do
   describe FastlaneCore::CertChecker do
-    describe '#installed_identies' do
+    describe '#installed_identities' do
       it 'should print an error when no local code signing identities are found' do
         allow(FastlaneCore::CertChecker).to receive(:wwdr_certificate_installed?).and_return(true)
-        allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     0 valid identities found\n")
+        expect(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     0 valid identities found\n")
         expect(FastlaneCore::UI).to receive(:error).with(/There are no local code signing identities found/)
 
-        FastlaneCore::CertChecker.installed_identies
+        FastlaneCore::CertChecker.installed_identities
       end
 
       it 'should not be fooled by 10 local code signing identities available' do
         allow(FastlaneCore::CertChecker).to receive(:wwdr_certificate_installed?).and_return(true)
-        allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     10 valid identities found\n")
+        expect(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     10 valid identities found\n")
+        expect(FastlaneCore::UI).not_to receive(:error)
+
+        FastlaneCore::CertChecker.installed_identities
+      end
+    end
+
+    describe '#installed_identies' do
+      it 'should be aliased to the correct spelling' do
+        allow(FastlaneCore::CertChecker).to receive(:wwdr_certificate_installed?).and_return(true)
+        expect(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     10 valid identities found\n")
         expect(FastlaneCore::UI).not_to receive(:error)
 
         FastlaneCore::CertChecker.installed_identies


### PR DESCRIPTION
Follow-on work to #3853, identified in #3823

This is mostly whitespace changes due to wrapping the methods in `class << self` - I recommend the [whitespace-free view](https://github.com/fastlane/fastlane/pull/3855/files?w=1) for reviewing
