### PR TITLE
[supply] Uploading Multiple Apks

### DIFF
--- a/fastlane/lib/fastlane/actions/supply.rb
+++ b/fastlane/lib/fastlane/actions/supply.rb
@@ -8,7 +8,12 @@ module Fastlane
         begin
           FastlaneCore::UpdateChecker.start_looking_for_update('supply') unless Helper.is_test?
 
-          params[:apk] ||= Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
+          all_apk_paths = Actions.lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS]
+          if all_apk_paths.length > 1
+            params[:apk_paths] ||= all_apk_paths
+          else
+            params[:apk] ||= Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
+          end
 
           Supply.config = params # we already have the finished config
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -193,13 +193,16 @@ module Supply
       return result_upload.version_code
     end
 
+    # Updates the track for the provided version code(s)
     def update_track(track, rollout, apk_version_code)
       ensure_active_edit!
+
+      track_version_codes = apk_version_code.kind_of?(Array) ? apk_version_code : [apk_version_code]
 
       track_body = Androidpublisher::Track.new({
         track: track,
         user_fraction: rollout,
-        version_codes: [apk_version_code]
+        version_codes: track_version_codes
       })
 
       android_publisher.update_track(

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -67,11 +67,26 @@ module Supply
                                      env_name: "SUPPLY_APK",
                                      description: "Path to the APK file to upload",
                                      short_option: "-b",
+                                     conflicting_options: [:apk_paths],
                                      default_value: Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-Release.apk")].last,
                                      optional: true,
                                      verify_block: proc do |value|
                                        UI.user_error! "Could not find apk file at path '#{value}'" unless File.exist?(value)
-                                       UI.user_error! "apk file is not an apk" unless value.end_with?(value)
+                                       UI.user_error! "apk file is not an apk" unless value.end_with?('.apk')
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :apk_paths,
+                                     env_name: "SUPPLY_APK_PATHS",
+                                     conflicting_options: [:apk],
+                                     optional: true,
+                                     type: Array,
+                                     description: "An array of paths to APK files to upload",
+                                     short_option: "-u",
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
+                                       value.each do |path|
+                                         UI.user_error! "Could not find apk file at path '#{path}'" unless File.exist?(path)
+                                         UI.user_error! "file at path '#{path}' is not an apk" unless path.end_with?('.apk')
+                                       end
                                      end),
         FastlaneCore::ConfigItem.new(key: :skip_upload_apk,
                                      env_name: "SUPPLY_SKIP_UPLOAD_APK",


### PR DESCRIPTION
This is an extension to supply to allow multiple apk files to be uploaded to google play on the same release track. It is incredibly helpful for release gradle builds that use [apk splits](http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits) to generate multiple apks.

Here's an example of how to use it:
`supply -p com.example.app -u [apk_path_1],[apk_path_2] -a alpha`

Disclaimer: I'm not _that_ familiar with ruby so if anything needs to be adjusted, feel free to advise. 
