### PR TITLE
Update deliver category reference

### DIFF
--- a/deliver/Reference.md
+++ b/deliver/Reference.md
@@ -20,7 +20,7 @@ You can always prefix the category using `MZGenre.` (e.g. `MZGenre.Book`). `deli
 - `Photography`
 - `Productivity`
 - `Reference`
-- `Shopping`
+- `Apps.Shopping`
 - `SocialNetworking`
 - `Sports`
 - `Travel`


### PR DESCRIPTION
Nothing major really.

Updating to what Apple actually uses, confirmed this by downloading metadata for an existing app:

`deliver download_metadata`
