### PR TITLE
notification: support new parameters

### DIFF
--- a/fastlane/lib/fastlane/actions/notification.rb
+++ b/fastlane/lib/fastlane/actions/notification.rb
@@ -4,24 +4,17 @@ module Fastlane
       def self.run(params)
         require 'terminal-notifier'
 
-        if params[:subtitle] && params[:sound]
-          TerminalNotifier.notify(params[:message],
-                                  title: params[:title],
-                                  subtitle: params[:subtitle],
-                                  sound: params[:sound])
-        elsif params[:subtitle]
-          TerminalNotifier.notify(params[:message],
-                                  title: params[:title],
-                                  subtitle: params[:subtitle])
-        elsif params[:sound]
-          TerminalNotifier.notify(params[:message],
-                                  title: params[:title],
-                                  sound: params[:sound])
-        else
-          # It should look nice without a subtitle too
-          TerminalNotifier.notify(params[:message],
-                                  title: params[:title])
-        end
+        options = params.values
+        # :message is non-optional
+        message = options.delete :message
+        # remove nil keys, since `notify` below does not ignore them and instead translates them into empty strings in output, which looks ugly
+        options = options.select { |_, v| v }
+        option_map = {
+          app_icon: :appIcon,
+          content_image: :contentImage
+        }
+        options = Hash[options.map { |k, v| [option_map.fetch(k, k), v] }]
+        TerminalNotifier.notify(message, options)
       end
 
       def self.description
@@ -29,7 +22,7 @@ module Fastlane
       end
 
       def self.author
-        ["champo", "cbowns", "KrauseFx", "amarcadet"]
+        ["champo", "cbowns", "KrauseFx", "amarcadet", "dusek"]
       end
 
       def self.available_options
@@ -45,6 +38,21 @@ module Fastlane
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :sound,
                                        description: "The name of a sound to play when the notification appears (names are listed in Sound Preferences)",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :activate,
+                                       description: "Bundle identifier of application to be opened when the notification is clicked",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :app_icon,
+                                       description: "The URL of an image to display instead of the application icon (Mavericks+ only)",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :content_image,
+                                       description: "The URL of an image to display attached to the notification (Mavericks+ only)",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :open,
+                                       description: "URL of the resource to be opened when the notification is clicked",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :execute,
+                                       description: "Shell command to run when the notification is clicked",
                                        optional: true)
         ]
       end

--- a/fastlane/spec/actions_specs/notification_spec.rb
+++ b/fastlane/spec/actions_specs/notification_spec.rb
@@ -1,0 +1,110 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "notification action" do
+      it "raises without a message" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            notification(
+              title: 'hello',
+              subtitle: 'hi'
+            )
+          end").runner.execute(:test)
+        end.to raise_exception
+      end
+
+      it "works with message argument alone" do
+        # fastlane passes default :title of 'fastlane'
+        expect(TerminalNotifier).to receive(:notify).with("hello", hash_including)
+
+        Fastlane::FastFile.new.parse("lane :test do
+          notification(
+            message: 'hello'
+          )
+        end").runner.execute(:test)
+      end
+
+      it "provides default title of 'fastlane'" do
+        expect(TerminalNotifier).to receive(:notify).with("hello", hash_including(title: 'fastlane'))
+
+        Fastlane::FastFile.new.parse("lane :test do
+          notification(
+            message: 'hello'
+          )
+        end").runner.execute(:test)
+      end
+
+      it "passes all supported specified arguments to terminal-notifier" do
+        args = {
+          title: "My Great App",
+          subtitle: "Check it out at http://store.itunes.com/abcd",
+          sound: "default",
+          activate: "com.apple.Safari",
+          appIcon: "path/to/app_icon.png",
+          contentImage: "path/to/content_image.png",
+          open: "http://store.itunes.com/abcd",
+          execute: "ls"
+        }
+
+        expect(TerminalNotifier).to receive(:notify).with("hello", hash_including(**args))
+
+        Fastlane::FastFile.new.parse("lane :test do
+          notification(
+            message:       'hello',
+            title:         '#{args[:title]}',
+            subtitle:      '#{args[:subtitle]}',
+            sound:         '#{args[:sound]}',
+            activate:      '#{args[:activate]}',
+            app_icon:      '#{args[:appIcon]}',
+            content_image: '#{args[:contentImage]}',
+            open:          '#{args[:open]}',
+            execute:       '#{args[:execute]}'
+          )
+        end").runner.execute(:test)
+      end
+
+      it "does not pass unspecified arguments with message argument" do
+        expect(TerminalNotifier).to receive(:notify).with("hello", hash_excluding(*%i(subtitle sound activate appIcon contentImage open execute)))
+
+        Fastlane::FastFile.new.parse("lane :test do
+          notification(
+            message: 'hello'
+          )
+        end").runner.execute(:test)
+      end
+
+      it "does not pass unspecified arguments with message and title argument" do
+        expect(TerminalNotifier).to receive(:notify).with("hello", hash_excluding(*%i(subtitle sound activate appIcon contentImage open execute)))
+
+        Fastlane::FastFile.new.parse("lane :test do
+          notification(
+            message: 'hello',
+            title: 'My Great App'
+          )
+        end").runner.execute(:test)
+      end
+
+      it "does not pass unspecified arguments with message and subtitle argument" do
+        expect(TerminalNotifier).to receive(:notify).with("hello", hash_excluding(*%i(sound activate appIcon contentImage open execute)))
+
+        Fastlane::FastFile.new.parse("lane :test do
+          notification(
+            message: 'hello',
+            subtitle: 'My Great App'
+          )
+        end").runner.execute(:test)
+      end
+
+      it "does not pass unspecified arguments with message, title and subtitle argument" do
+        expect(TerminalNotifier).to receive(:notify).with("hello", hash_excluding(*%i(sound activate appIcon contentImage open execute)))
+
+        Fastlane::FastFile.new.parse("lane :test do
+          notification(
+            message: 'hello',
+            title: 'hi',
+            subtitle: 'My Great App'
+          )
+        end").runner.execute(:test)
+      end
+    end
+  end
+end

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -1,7 +1,7 @@
 describe Fastlane do
   describe Fastlane::Action do
     describe "No unused options" do
-      let (:all_exceptions) { %w(pilot appstore cert deliver gym match pem produce scan sigh snapshot supply testflight mailgun testfairy ipa import_from_git hockey deploygate crashlytics artifactory appledoc slather screengrab download_dsyms) }
+      let (:all_exceptions) { %w(pilot appstore cert deliver gym match pem produce scan sigh snapshot supply testflight mailgun testfairy ipa import_from_git hockey deploygate crashlytics artifactory appledoc slather screengrab download_dsyms notification) }
 
       Fastlane::ActionsList.all_actions do |action, name|
         next unless action.available_options.kind_of?(Array)


### PR DESCRIPTION
This PR adds support for these `notification` action parameters: `open`, `execute`, `activate`, `app_icon` and `content_image`. Their meaning is described in the [upstream options documentation](https://github.com/julienXX/terminal-notifier#options).

Parameters prefer underscores (unlike upstream) to be consistent with the fastlane "look and feel".

Params passing refactoring done which should greatly simplify adding new options in the future (used for the above options already).

WARNING: first non-bugfix contribution to fastlane, very newbie in Ruby :smile: 
