### PR TITLE
Add option to specify entitlements and allow script to autodetect them

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -134,6 +134,7 @@ Metrics/MethodLength:
     - '**/lib/fastlane/actions/*.rb'
     - '**/bin/fastlane'
     - '**/lib/*/options.rb'
+    - '**/bin/sigh'
   Max: 60
 
 AllCops:

--- a/sigh/bin/sigh
+++ b/sigh/bin/sigh
@@ -67,6 +67,7 @@ class SighApplication
                'The path may be prefixed with a identifier in order to determine which provisioning profile should be used on which app.',
                &multiple_values_option_proc(c, "provisioning_profile", &proc { |value| value.split('=', 2) })
       c.option '-d', '--display_name STRING', String, 'Display name to use'
+      c.option '-e', '--entitlements PATH', String, 'The path to the entitlements file to use.'
 
       c.action do |args, options|
         Sigh::Resign.new.run(options, args)

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -59,7 +59,7 @@ module Sigh
       ipa = args.first || find_ipa || ask('Path to ipa file: ')
       signing_identity = options.signing_identity || ask_for_signing_identity
       provisioning_profiles = options.provisioning_profile || find_provisioning_profile || ask('Path to provisioning file: ')
-      entitlements = options.entitlements || find_entitlements
+      entitlements = options.entitlements || nil
       version = options.version_number || nil
       display_name = options.display_name || nil
 
@@ -80,10 +80,6 @@ module Sigh
 
     def find_provisioning_profile
       Dir[File.join(Dir.pwd, '*.mobileprovision')].sort { |a, b| File.mtime(a) <=> File.mtime(b) }.first
-    end
-
-    def find_entitlements
-      Dir[File.join(Dir.pwd, '*.entitlements')].sort { |a, b| File.mtime(a) <=> File.mtime(b) }.first
     end
 
     def find_signing_identity(signing_identity)


### PR DESCRIPTION
For non-trivial project setup with more than 1 target, there's also more than 1 entitlements file
For example, MyAppProd.entitlements and MyAppTest.entitlements
The default implementation of  find_entitlements will find _first_ matching file, which is not the one really needed
In my case I had it picking up Test entitlements while I was resigning Prod target.
So I'm adding `-e` option to be able to specify explicitly which entitlements to use.

Second change is related to passing argumetns to resigh.sh script
We should not use find_entitlements at all
The `resign.sh` script has support for reading entitlements from provisioning profile
As a matter of fact, that's quite a common setup, developers would put keychain group, APN and some other things in entitlements file, but not the :application-identifier or :com.apple.developer.team-identifier
Those are normally missing in Code Signign Entitlements, but are present in provisioning profile
It's a common thing and is covered here: https://developer.apple.com/library/ios/technotes/tn2319/_index.html
