### PR TITLE
WIP Add test for fastlane executor

### DIFF
--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -23,6 +23,11 @@ describe FastlaneCore do
 
         expect(result).to eq('a_filename')
       end
+
+      it 'does some basic command' do
+        result = FastlaneCore::CommandExecutor.execute(command: "echo foobar")
+        expect(result).to eq('foobar')
+      end
     end
 
     describe "which" do


### PR DESCRIPTION
:warning: 
#### Do not merge until we have a fix

:warning:

This is the follow up to #3821 

This adds a simple test to the existing command executor.  Unfortunately this test is flakey.

``` bash
samp@samp fastlane/fastlane_core (add-test-for-fastlane-executor *) $\
for i in {1..500}; do\
    rspec ./spec/command_executor_spec.rb:29 | grep "failure";\
done\
| sort | uniq -c

 498 1 example, 0 failures
   2 1 example, 1 failure
```

I believe this indicates a bug somewhere in our command executor.
