### PR TITLE
[fastlane_core] Fix issue in fastlane_core test

### DIFF
--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -33,7 +33,7 @@ describe FastlaneCore do
       end
 
       it "finds commands without extensions which are on the PATH" do
-        Tempfile.new('foobarbaz') do |f|
+        Tempfile.open('foobarbaz') do |f|
           File.chmod(0777, f)
 
           temp_dir = File.dirname(f)
@@ -46,7 +46,7 @@ describe FastlaneCore do
       end
 
       it "finds commands with known extensions which are on the PATH" do
-        Tempfile.new(['foobarbaz', '.exe']) do |f|
+        Tempfile.open(['foobarbaz', '.exe']) do |f|
           File.chmod(0777, f)
 
           temp_dir = File.dirname(f)
@@ -59,7 +59,7 @@ describe FastlaneCore do
       end
 
       it "does not find commands with unknown extensions which are on the PATH" do
-        Tempfile.new(['foobarbaz', '.exe']) do |f|
+        Tempfile.open(['foobarbaz', '.exe']) do |f|
           File.chmod(0777, f)
 
           temp_dir = File.dirname(f)


### PR DESCRIPTION
`new` does not run the block and prints out a helpful warning instead.

``` ruby
      does not find commands which are not on the PATH
Tempfile.new doesn't call the given block.
      finds commands without extensions which are on the PATH
```
