### PR TITLE
Updated plist header to match what it should be

### DIFF
--- a/fastlane/spec/actions_specs/update_app_group_identifiers_spec.rb
+++ b/fastlane/spec/actions_specs/update_app_group_identifiers_spec.rb
@@ -8,7 +8,7 @@ describe Fastlane do
       before do
         # Set up example info.plist
         FileUtils.mkdir_p(test_path)
-        File.write(File.join(test_path, entitlements_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>com.apple.security.application-groups</key><array><string>group.com.test</string></array></dict></plist>')
+        File.write(File.join(test_path, entitlements_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>com.apple.security.application-groups</key><array><string>group.com.test</string></array></dict></plist>')
       end
 
       it "updates the app group of the entitlements file" do
@@ -45,7 +45,7 @@ describe Fastlane do
       end
 
       it "throws an error when the entitlements file is not parsable" do
-        File.write(File.join(test_path, entitlements_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>com.apple.security.application-groups</key><array><string>group.com.</array></dict></plist>')
+        File.write(File.join(test_path, entitlements_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>com.apple.security.application-groups</key><array><string>group.com.</array></dict></plist>')
 
         expect do
           Fastlane::FastFile.new.parse("lane :test do
@@ -58,7 +58,7 @@ describe Fastlane do
       end
 
       it "throws an error when the entitlements file doesn't contain an app group" do
-        File.write(File.join(test_path, entitlements_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict></dict></plist>')
+        File.write(File.join(test_path, entitlements_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict></dict></plist>')
 
         expect do
           Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
Xcode 7 seems to be generating `plist` files with the heading:

``` xml
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
```

Where as this action as writing the header:

``` xml
<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
```

Also if you look here: https://developer.apple.com/library/safari/documentation/Tools/Conceptual/SafariExtensionGuide/UpdatingExtensions/UpdatingExtensions.html they use the **Apple** not **Apple Computer** header as well.

This action was adding **Apple Computer** to the plist file which is causing all sorts of extra git errors if you commit the changes, and then open Xcode (which seems to rewrite the header)
