### PR TITLE
scan report file name depends from report type

### DIFF
--- a/scan/lib/scan/report_collector.rb
+++ b/scan/lib/scan/report_collector.rb
@@ -38,12 +38,12 @@ module Scan
           next
         end
 
-        case #{type}
-		  when "junit"
-		    file_name = "TEST-report.xml"
-		  else
-		    file_name = "report.#{type}"
-		end
+        case type
+        when "junit"
+          file_name = "TEST-report.xml"
+        else
+          file_name = "report.#{type}"
+        end
         output_path = output_file_name || File.join(File.expand_path(@output_directory), file_name)
         parts = ["cat '#{path}' | "]
         parts << "xcpretty"

--- a/scan/lib/scan/report_collector.rb
+++ b/scan/lib/scan/report_collector.rb
@@ -38,7 +38,12 @@ module Scan
           next
         end
 
-        file_name = "report.#{type}"
+        case #{type}
+		  when "junit"
+		    file_name = "TEST-report.xml"
+		  else
+		    file_name = "report.#{type}"
+		end
         output_path = output_file_name || File.join(File.expand_path(@output_directory), file_name)
         parts = ["cat '#{path}' | "]
         parts << "xcpretty"

--- a/scan/spec/report_collector_spec.rb
+++ b/scan/spec/report_collector_spec.rb
@@ -3,11 +3,12 @@ describe Scan do
     let (:path) { "./spec/fixtures/boring.log" }
 
     it "ignores invalid report types" do
-      commands = Scan::ReportCollector.new(false, "invalid, html", "/tmp").generate_commands(path)
+      commands = Scan::ReportCollector.new(false, "invalid, html, junit", "/tmp").generate_commands(path)
 
-      expect(commands.count).to eq(1)
+      expect(commands.count).to eq(2)
       expect(commands).to eq({
-        "/tmp/report.html" => "cat './spec/fixtures/boring.log' |  xcpretty --report html --output '/tmp/report.html' &> /dev/null "
+        "/tmp/report.html" => "cat './spec/fixtures/boring.log' |  xcpretty --report html --output '/tmp/report.html' &> /dev/null ",
+		"/tmp/TEST-report.xml" => "cat './spec/fixtures/boring.log' |  xcpretty --report junit --output '/tmp/TEST-report.xml' &> /dev/null "
       })
     end
   end

--- a/scan/spec/report_collector_spec.rb
+++ b/scan/spec/report_collector_spec.rb
@@ -8,7 +8,7 @@ describe Scan do
       expect(commands.count).to eq(2)
       expect(commands).to eq({
         "/tmp/report.html" => "cat './spec/fixtures/boring.log' |  xcpretty --report html --output '/tmp/report.html' &> /dev/null ",
-		"/tmp/TEST-report.xml" => "cat './spec/fixtures/boring.log' |  xcpretty --report junit --output '/tmp/TEST-report.xml' &> /dev/null "
+        "/tmp/TEST-report.xml" => "cat './spec/fixtures/boring.log' |  xcpretty --report junit --output '/tmp/TEST-report.xml' &> /dev/null "
       })
     end
   end


### PR DESCRIPTION
Addresses #1942

Define a different default based on report type (e.g. junit wants xml file) otherwise fallback on previous behaviour.
