### PR TITLE
[fastlane] Removed new-line for get_build_number_repository

### DIFF
--- a/fastlane/lib/fastlane/actions/get_build_number.rb
+++ b/fastlane/lib/fastlane/actions/get_build_number.rb
@@ -30,6 +30,7 @@ module Fastlane
           # Store the number in the shared hash
           Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number
         end
+        return build_number
       rescue => ex
         UI.error('Make sure to follow the steps to setup your Xcode project: https://developer.apple.com/library/ios/qa/qa1827/_index.html')
         raise ex

--- a/fastlane/lib/fastlane/actions/get_build_number_repository.rb
+++ b/fastlane/lib/fastlane/actions/get_build_number_repository.rb
@@ -56,9 +56,9 @@ module Fastlane
       end
 
       def self.run(params)
-        build_number = Action.sh command(params[:use_hg_revision_number])
+        build_number = Action.sh(command(params[:use_hg_revision_number])).strip
         Actions.lane_context[SharedValues::BUILD_NUMBER_REPOSITORY] = build_number
-        build_number
+        return build_number
       end
 
       #####################################################


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/3883
