### PR TITLE
Added figlet ASCII TEXT GENERATOR action

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -2318,6 +2318,28 @@ Add this your `Fastfile` to not send any data to the fastlane web service. You c
 opt_out_usage
 ```
 
+### figlet
+
+This action is a wrapper around the [figlet](http://www.figlet.org) ascii text generation tool.  You can install it on mac with `brew install figlet`.  
+
+```ruby
+figlet(text: "FIGLET TEST")
+```
+
+will print out
+
+```
+ _____ _   _ ___ ____    ___ ____    _____ _______  _______
+|_   _| | | |_ _/ ___|  |_ _/ ___|  |_   _| ____\ \/ /_   _|
+  | | | |_| || |\___ \   | |\___ \    | | |  _|  \  /  | |
+  | | |  _  || | ___) |  | | ___) |   | | | |___ /  \  | |
+  |_| |_| |_|___|____/  |___|____/    |_| |_____/_/\_\ |_|
+
+```
+You can also pass in a custom font with the `font:` option.  run the `figlist` command to list all available fonts on your system
+
+
+
 ### rocket
 
 Print an ascii Rocket :rocket:. Useful after using `crashlytics` or `pilot` to indicate that your new build has been shipped to outer-space.

--- a/fastlane/lib/fastlane/actions/figlet.rb
+++ b/fastlane/lib/fastlane/actions/figlet.rb
@@ -1,0 +1,54 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      FIGLET_CUSTOM_VALUE = :FIGLET_CUSTOM_VALUE
+    end
+
+    class FigletAction < Action
+      def self.run(params)
+        text = params[:text]
+        font = params[:font]
+        output = `figlet  -f #{font}  #{text.upcase}`
+        puts output
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "figlet wraps around the figlet command to create big ASCII ART"
+      end
+
+      def self.details
+        ["This action requires that you have figlet installed.  On a mac you can",
+         " do this with the command:       brew install figlet",
+        ].join(' ')
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :text,
+                                       env_name: "FL_FIGLET_TEXT",
+                                       description: "Text to ASCII-ify",
+                                       verify_block: proc do |value|
+                                         raise "No text given, pass using `text: 'STRING'`".red unless value and !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :font,
+                                       env_name: "FL_FIGLET_FONT",
+                                       description: "custom figlet font",
+                                       is_string: true,
+                                       default_value: "standard")
+        ]
+      end
+
+      def self.authors
+        ["Jeeftor"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include? platform
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added a FIGLET wrapper to do ascii text

``` ruby


lane :text do
  figlet(text: "THIS IS TEXT")
end

```

```
[05:39:37]: -----------------------------
[05:39:37]: --- Step: last_git_commit ---
[05:39:37]: -----------------------------
[05:39:37]: --------------------
[05:39:37]: --- Step: figlet ---
[05:39:37]: --------------------
 _____ _   _ ___ ____    ___ ____    _____ _______  _______
|_   _| | | |_ _/ ___|  |_ _/ ___|  |_   _| ____\ \/ /_   _|
  | | | |_| || |\___ \   | |\___ \    | | |  _|  \  /  | |
  | | |  _  || | ___) |  | | ___) |   | | | |___ /  \  | |
  |_| |_| |_|___|____/  |___|____/    |_| |_____/_/\_\ |_|

[05:39:37]: --------------------------------------------------------
[05:39:37]: --- Step: git checkout -- ../xxxxx/Assets.xcassets/ ---
[05:39:37]: --------------------------------------------------------
[05:39:37]: $ git checkout -- ../xxxxx/Assets.xcassets/


```
