### PR TITLE
is_ci? checks for XCS (Xcode Server) environment variable

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -61,7 +61,7 @@ module FastlaneCore
     # @return [boolean] true if building in a known CI environment
     def self.ci?
       # Check for Jenkins, Travis CI, ... environment variables
-      ['JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI'].each do |current|
+      ['JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI', 'XCS'].each do |current|
         return true if ENV.key?(current)
       end
       return false

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -20,6 +20,11 @@ describe FastlaneCore do
         stub_const('ENV', { 'GITLAB_CI' => true })
         expect(FastlaneCore::Helper.is_ci?).to be true
       end
+
+      it "returns true when building in Xcode Server" do
+        stub_const('ENV', { 'XCS' => true })
+        expect(FastlaneCore::Helper.is_ci?).to be true
+      end
     end
 
     # Mac OS only (to work on Linux)


### PR DESCRIPTION
### `FastlaneCore::Helper.is_ci?` returns `true` when running in Xcode Server.

Xcode Server exports the environment variable `XCS=1` which is available in pre and post integration triggers. See [WWDC notes](http://devstreaming.apple.com/videos/wwdc/2015/41097fby32x3opk/410/410_continuous_integration_and_code_coverage_in_xcode.pdf?dl=1) which states "XCS: Always set to 1, use to detect Xcode Server"
