### PR TITLE
Fix ruby-gems version check

### DIFF
--- a/fastlane/lib/fastlane/actions/update_fastlane.rb
+++ b/fastlane/lib/fastlane/actions/update_fastlane.rb
@@ -55,7 +55,7 @@ module Fastlane
           return
         end
 
-        if updater.respond_to? :highest_installed_gems
+        unless updater.respond_to? :highest_installed_gems
           UI.important "The update_fastlane action requires rubygems version 2.1.0 or greater."
           UI.important "Please update your version of ruby gems before proceeding."
           UI.command "gem install rubygems-update"


### PR DESCRIPTION
The logic for this check was backwards. We are printing the gem warning and not proceeding with the update check for all ruby-gems versions > 2.1.0
