### PR TITLE
Add "archive" command and "no_skip_current" option to Carthage action

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -55,9 +55,13 @@ More options are available:
 
 ```ruby
 carthage(
+  command: "bootstrap"    # One of: build, bootstrap, update, archive. (default: bootstrap)
   use_ssh: false,         # Use SSH for downloading GitHub repositories.
   use_submodules: false,  # Add dependencies as Git submodules.
   use_binaries: true,     # Check out dependency repositories even when prebuilt frameworks exist
+  no_build: false,        # When bootstrapping Carthage do not build
+  no_skip_current: false, # Don't skip building the current project (only for frameworks)
+  verbose: false,         # Print xcodebuild output inline
   platform: "all"         # Define which platform to build for
 )
 ```

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -9,6 +9,7 @@ module Fastlane
         cmd << "--use-submodules" if params[:use_submodules]
         cmd << "--no-use-binaries" if params[:use_binaries] == false
         cmd << "--no-build" if params[:no_build] == true
+        cmd << "--no-skip-current" if params[:no_skip_current] == true
         cmd << "--verbose" if params[:verbose] == true
         cmd << "--platform #{params[:platform]}" if params[:platform]
 
@@ -19,14 +20,18 @@ module Fastlane
         "Runs `carthage bootstrap` or `carthage update` for your project"
       end
 
+      def self.available_commands
+        %w(build bootstrap update archive)
+      end
+
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :command,
                                        env_name: "FL_CARTHAGE_COMMAND",
-                                       description: "Carthage command (one of `build`, `bootstrap`, `update`)",
+                                       description: "Carthage command (one of: #{available_commands.join(', ')})",
                                        default_value: 'bootstrap',
                                        verify_block: proc do |value|
-                                         UI.user_error!("Please pass a valid command. Use one of the following: build, bootstrap, update") unless %w(build bootstrap update).include? value
+                                         UI.user_error!("Please pass a valid command. Use one of the following: #{available_commands.join(', ')}") unless available_commands.include? value
                                        end),
           FastlaneCore::ConfigItem.new(key: :use_ssh,
                                        env_name: "FL_CARTHAGE_USE_SSH",
@@ -60,6 +65,14 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Please pass a valid value for no_build. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
                                        end),
+          FastlaneCore::ConfigItem.new(key: :no_skip_current,
+                                       env_name: "FL_CARTHAGE_NO_SKIP_CURRENT",
+                                       description: "Don't skip building the Carthage project (in addition to its dependencies)",
+                                       is_string: false,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Please pass a valid value for no_skip_current. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                       end),
           FastlaneCore::ConfigItem.new(key: :verbose,
                                        env_name: "FL_CARTHAGE_VERBOSE",
                                        description: "Print xcodebuild output inline",
@@ -83,7 +96,7 @@ module Fastlane
       end
 
       def self.authors
-        ["bassrock", "petester42", "jschmid", "JaviSoto", "uny"]
+        ["bassrock", "petester42", "jschmid", "JaviSoto", "uny", "phatblat"]
       end
     end
   end

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -8,7 +8,7 @@ describe Fastlane do
               command: 'thisistest'
             )
           end").runner.execute(:test)
-        end.to raise_error("Please pass a valid command. Use one of the following: build, bootstrap, update")
+        end.to raise_error("Please pass a valid command. Use one of the following: build, bootstrap, update, archive")
       end
 
       it "raises an error if use_ssh is invalid" do
@@ -49,6 +49,16 @@ describe Fastlane do
             )
           end").runner.execute(:test)
         end.to raise_error("Please pass a valid value for no_build. Use one of the following: true, false")
+      end
+
+      it "raises an error if no_skip_current is invalid" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_skip_current: 'thisistest'
+            )
+          end").runner.execute(:test)
+        end.to raise_error("Please pass a valid value for no_skip_current. Use one of the following: true, false")
       end
 
       it "raises an error if verbose is invalid" do
@@ -101,6 +111,14 @@ describe Fastlane do
           end").runner.execute(:test)
 
         expect(result).to eq("carthage update")
+      end
+
+      it "sets the command to archive" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(command: 'archive')
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage archive")
       end
 
       it "adds use-ssh flag to command if use_ssh is set to true" do
@@ -181,6 +199,28 @@ describe Fastlane do
           end").runner.execute(:test)
 
         expect(result).to eq("carthage bootstrap")
+      end
+
+      it "adds no-skip-current flag to command if no_skip_current is set to true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              command: 'build',
+              no_skip_current: true
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage build --no-skip-current")
+      end
+
+      it "doesn't add a no-skip-current flag to command if no_skip_current is set to false" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              command: 'build',
+              no_skip_current: false
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage build")
       end
 
       it "adds verbose flag to command if verbose is set to true" do


### PR DESCRIPTION
Exposing the Carthage `archive` command and `--no-skip-current` option for framework projects to use.

Example usage:

``` ruby
carthage(command: "build", no_skip_current: true, platform: "iOS")
carthage(command: "archive")
```

Output:

```
[14:46:54]: ----------------------
[14:46:54]: --- Step: carthage ---
[14:46:54]: ----------------------
[14:46:54]: $ carthage build --no-skip-current --platform iOS
[14:47:18]: ▸ *** xcodebuild output can be found in /var/folders/96/rcjvzrkn5lzfl0_krn8c151h0000gn/T/carthage-xcodebuild.bTVX9z.log
[14:47:18]: ▸ *** Building scheme "FitnessKit" in FitnessKit.xcworkspace
[14:47:18]: ----------------------
[14:47:18]: --- Step: carthage ---
[14:47:18]: ----------------------
[14:47:18]: $ carthage archive
[14:47:26]: ▸ *** Found Carthage/Build/iOS/FitnessKit.framework
[14:47:26]: ▸ *** Found Carthage/Build/iOS/FitnessKit.framework.dSYM
[14:47:26]: ▸ *** Found Carthage/Build/iOS/0DD05358-2A79-3A2E-B8A6-98C9CAA85224.bcsymbolmap
[14:47:26]: ▸ *** Found Carthage/Build/iOS/F30FAA5E-A0ED-3EA7-82EE-5AE0928A67BC.bcsymbolmap
[14:47:26]: ▸ *** Created FitnessKit.framework.zip
```
