### PR TITLE
Add `test-output/` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage/
 /test/version_tmp/
 /tmp/
 rspec_logs.json
+test_output/
 
 ## Specific to Android
 .gradle/


### PR DESCRIPTION
This ignores the generated output of running `scan` against its example projects.
