### PR TITLE
[Ready] Updated `raise` calls to `UI.user_error!` or `UI.crash!`

### DIFF
--- a/credentials_manager/lib/credentials_manager/appfile_config.rb
+++ b/credentials_manager/lib/credentials_manager/appfile_config.rb
@@ -21,7 +21,7 @@ module CredentialsManager
 
     def initialize(path = nil)
       if path
-        raise "Could not find Appfile at path '#{path}'".red unless File.exist?(path)
+        UI.user_error!("Could not find Appfile at path '#{path}'") unless File.exist?(path)
       end
 
       path ||= self.class.default_path

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -31,12 +31,12 @@ module Deliver
                                      description: "Path to your ipa file",
                                      default_value: Dir["*.ipa"].first,
                                      verify_block: proc do |value|
-                                       raise "Could not find ipa file at path '#{value}'".red unless File.exist?(value)
-                                       raise "'#{value}' doesn't seem to be an ipa file".red unless value.end_with?(".ipa")
+                                       UI.user_error!("Could not find ipa file at path '#{value}'") unless File.exist?(value)
+                                       UI.user_error!("'#{value}' doesn't seem to be an ipa file") unless value.end_with?(".ipa")
                                      end,
                                      conflicting_options: [:pkg],
                                      conflict_block: proc do |value|
-                                       raise "You can't use 'ipa' and '#{value.key}' options in one run.".red
+                                       UI.user_error!("You can't use 'ipa' and '#{value.key}' options in one run.")
                                      end),
         FastlaneCore::ConfigItem.new(key: :pkg,
                                      short_option: "-c",
@@ -45,12 +45,12 @@ module Deliver
                                      description: "Path to your pkg file",
                                      default_value: Dir["*.pkg"].first,
                                      verify_block: proc do |value|
-                                       raise "Could not find pkg file at path '#{value}'".red unless File.exist?(value)
-                                       raise "'#{value}' doesn't seem to be a pkg file".red unless value.end_with?(".pkg")
+                                       UI.user_error!("Could not find pkg file at path '#{value}'") unless File.exist?(value)
+                                       UI.user_error!("'#{value}' doesn't seem to be a pkg file") unless value.end_with?(".pkg")
                                      end,
                                      conflicting_options: [:ipa],
                                      conflict_block: proc do |value|
-                                       raise "You can't use 'pkg' and '#{value.key}' options in one run.".red
+                                       UI.user_error!("You can't use 'pkg' and '#{value.key}' options in one run.")
                                      end),
         FastlaneCore::ConfigItem.new(key: :metadata_path,
                                      short_option: '-m',
@@ -100,7 +100,7 @@ module Deliver
                                      optional: true,
                                      conflicting_options: [:ipa, :pkg],
                                      conflict_block: proc do |value|
-                                       raise "You can't use 'build_number' and '#{value.key}' options in one run.".red
+                                       UI.user_error!("You can't use 'build_number' and '#{value.key}' options in one run.")
                                      end),
         FastlaneCore::ConfigItem.new(key: :app_rating_config_path,
                                      short_option: "-g",
@@ -108,8 +108,8 @@ module Deliver
                                      is_string: true,
                                      optional: true,
                                      verify_block: proc do |value|
-                                       raise "Could not find config file at path '#{value}'".red unless File.exist?(value)
-                                       raise "'#{value}' doesn't seem to be a JSON file".red unless value.end_with?(".json")
+                                       UI.user_error!("Could not find config file at path '#{value}'") unless File.exist?(value)
+                                       UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless value.end_with?(".json")
                                      end),
         FastlaneCore::ConfigItem.new(key: :submission_information,
                                      short_option: "-b",
@@ -143,16 +143,16 @@ module Deliver
                                      optional: true,
                                      short_option: "-l",
                                      verify_block: proc do |value|
-                                       raise "Could not find png file at path '#{value}'".red unless File.exist?(value)
-                                       raise "'#{value}' doesn't seem to be a png file".red unless value.end_with?(".png")
+                                       UI.user_error!("Could not find png file at path '#{value}'") unless File.exist?(value)
+                                       UI.user_error!("'#{value}' doesn't seem to be a png file") unless value.end_with?(".png")
                                      end),
         FastlaneCore::ConfigItem.new(key: :apple_watch_app_icon,
                                      description: "Metadata: The path to the Apple Watch app icon",
                                      optional: true,
                                      short_option: "-q",
                                      verify_block: proc do |value|
-                                       raise "Could not find png file at path '#{value}'".red unless File.exist?(value)
-                                       raise "'#{value}' doesn't seem to be a png file".red unless value.end_with?(".png")
+                                       UI.user_error!("Could not find png file at path '#{value}'") unless File.exist?(value)
+                                       UI.user_error!("'#{value}' doesn't seem to be a png file") unless value.end_with?(".png")
                                      end),
         FastlaneCore::ConfigItem.new(key: :copyright,
                                      description: "Metadata: The copyright notice",

--- a/fastlane/lib/assets/custom_action_template.rb
+++ b/fastlane/lib/assets/custom_action_template.rb
@@ -43,8 +43,8 @@ module Fastlane
                                        env_name: "FL_[[NAME_UP]]_API_TOKEN", # The name of the environment variable
                                        description: "API Token for [[NAME_CLASS]]", # a short description of this parameter
                                        verify_block: proc do |value|
-                                          raise "No API token for [[NAME_CLASS]] given, pass using `api_token: 'token'`".red unless (value and not value.empty?)
-                                          # raise "Couldn't find file at path '#{value}'".red unless File.exist?(value)
+                                          UI.user_error!("No API token for [[NAME_CLASS]] given, pass using `api_token: 'token'`") unless (value and not value.empty?)
+                                          # UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :development,
                                        env_name: "FL_[[NAME_UP]]_DEVELOPMENT",

--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -53,7 +53,7 @@ module Fastlane
       #
       #  [:ios, :mac].include?(platform)
       #
-      raise "Implementing `is_supported?` for all actions is mandatory. Please update #{self}".red
+      UI.crash!("Implementing `is_supported?` for all actions is mandatory. Please update #{self}")
     end
 
     # Is printed out in the Steps: output in the terminal

--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -25,7 +25,7 @@ module Fastlane
     #   This might be nil, in which case the step is not printed out to the terminal
     def self.execute_action(step_name)
       start = Time.now # before the raise block, since `start` is required in the ensure block
-      raise 'No block given'.red unless block_given?
+      UI.crash!("No block given") unless block_given?
 
       error = nil
       exc = nil
@@ -75,7 +75,7 @@ module Fastlane
     end
 
     def self.load_external_actions(path)
-      raise 'You need to pass a valid path' unless File.exist?(path)
+      UI.user_error!("You need to pass a valid path") unless File.exist?(path)
 
       Dir[File.expand_path('*.rb', path)].each do |file|
         require file

--- a/fastlane/lib/fastlane/actions/appaloosa.rb
+++ b/fastlane/lib/fastlane/actions/appaloosa.rb
@@ -180,7 +180,7 @@ module Fastlane
                                        description: 'Binary path. Optional for ipa if you use the `ipa` or `xcodebuild` action',
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        verify_block: proc do |value|
-                                         raise "Couldn't find ipa || apk file at path '#{value}'".red unless File.exist?(value)
+                                         UI.user_error!("Couldn't find ipa || apk file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_token,
                                        env_name: 'FL_APPALOOSA_API_TOKEN',

--- a/fastlane/lib/fastlane/actions/appetize.rb
+++ b/fastlane/lib/fastlane/actions/appetize.rb
@@ -34,7 +34,7 @@ module Fastlane
         req.body = JSON.generate(params)
         response = https.request(req)
 
-        raise 'Error when trying to upload ipa to Appetize.io'.red unless parse_response(response)
+        UI.user_error!("Error when trying to upload ipa to Appetize.io") unless parse_response(response)
         UI.message("App URL: #{Actions.lane_context[SharedValues::APPETIZE_APP_URL]}")
         UI.message("Manage URL: #{Actions.lane_context[SharedValues::APPETIZE_MANAGE_URL]}")
         UI.message("App Private Key: #{Actions.lane_context[SharedValues::APPETIZE_PRIVATE_KEY]}")
@@ -83,14 +83,14 @@ module Fastlane
                                       description: "Appetize.io API Token",
                                       is_string: true,
                                       verify_block: proc do |value|
-                                        raise "No API Token for Appetize.io given, pass using `api_token: 'token'`".red unless value.to_s.length > 0
+                                        UI.user_error!("No API Token for Appetize.io given, pass using `api_token: 'token'`") unless value.to_s.length > 0
                                       end),
          FastlaneCore::ConfigItem.new(key: :url,
                                       env_name: "APPETIZE_URL",
                                       description: "Target url of the zipped build",
                                       is_string: true,
                                       verify_block: proc do |value|
-                                        raise "No URL of your zipped build".red unless value.to_s.length > 0
+                                        UI.user_error!("No URL of your zipped build") unless value.to_s.length > 0
                                       end),
          FastlaneCore::ConfigItem.new(key: :private_key,
                                       env_name: "APPETIZE_PRIVATEKEY",

--- a/fastlane/lib/fastlane/actions/appium.rb
+++ b/fastlane/lib/fastlane/actions/appium.rb
@@ -29,7 +29,7 @@ module Fastlane
         rspec_args << params[:spec_path]
         status = RSpec::Core::Runner.run(rspec_args).to_i
         if status != 0
-          raise "Failed to run Appium spec. status code: #{status}".red
+          UI.user_error!("Failed to run Appium spec. status code: #{status}")
         end
       ensure
         Actions.sh "kill #{appium_pid}" if appium_pid
@@ -54,7 +54,7 @@ module Fastlane
         end
 
         unless File.exist?(appium_path)
-          raise 'You have to install Appium using `npm install -g appium`'.red
+          UI.user_error!("You have to install Appium using `npm install -g appium`")
         end
 
         if appium_path.end_with?('.app')
@@ -70,7 +70,7 @@ module Fastlane
           break if `lsof -i:#{params[:port]}`.to_s.length != 0
 
           if count * 5 > INVOKE_TIMEOUT
-            raise 'Invoke Appium server timed out'.red
+            UI.user_error!("Invoke Appium server timed out")
           end
           sleep 5
         end

--- a/fastlane/lib/fastlane/actions/appledoc.rb
+++ b/fastlane/lib/fastlane/actions/appledoc.rb
@@ -55,7 +55,7 @@ module Fastlane
       def self.run(params)
         unless Helper.test?
           UI.message("Install using `brew install homebrew/boneyard/appledoc`")
-          raise "appledoc not installed".red if `which appledoc`.length == 0
+          UI.user_error!("appledoc not installed") if `which appledoc`.length == 0
         end
 
         params_hash = params.values

--- a/fastlane/lib/fastlane/actions/backup_xcarchive.rb
+++ b/fastlane/lib/fastlane/actions/backup_xcarchive.rb
@@ -66,14 +66,14 @@ module Fastlane
                                        optional: false,
                                        env_name: 'BACKUP_XCARCHIVE_ARCHIVE',
                                        verify_block: proc do |value|
-                                         raise "Couldn't find xcarchive file at path '#{value}'".red if !Helper.test? && !File.exist?(value)
+                                         UI.user_error!("Couldn't find xcarchive file at path '#{value}'") if !Helper.test? && !File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :destination,
                                        description: 'Where your archive will be placed',
                                        optional: false,
                                        env_name: 'BACKUP_XCARCHIVE_DESTINATION',
                                        verify_block: proc do |value|
-                                         raise "Couldn't find the destination folder at '#{value}'".red if !Helper.test? && !File.directory?(value) && !File.exist?(value)
+                                         UI.user_error!("Couldn't find the destination folder at '#{value}'") if !Helper.test? && !File.directory?(value) && !File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :zip,
                                        description: 'Enable compression of the archive. Default value `true`',

--- a/fastlane/lib/fastlane/actions/badge.rb
+++ b/fastlane/lib/fastlane/actions/badge.rb
@@ -43,14 +43,14 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "dark is only a flag and should always be true".red unless value == true
+                                         UI.user_error!("dark is only a flag and should always be true") unless value == true
                                        end),
           FastlaneCore::ConfigItem.new(key: :custom,
                                        env_name: "FL_BADGE_CUSTOM",
                                        description: "Add your custom overlay/badge image",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "custom should be a valid file path".red unless value and File.exist?(value)
+                                         UI.user_error!("custom should be a valid file path") unless value and File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :no_badge,
                                        env_name: "FL_BADGE_NO_BADGE",
@@ -58,7 +58,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "no_badge is only a flag and should always be true".red unless value == true
+                                         UI.user_error!("no_badge is only a flag and should always be true") unless value == true
                                        end),
           FastlaneCore::ConfigItem.new(key: :shield,
                                        env_name: "FL_BADGE_SHIELD",
@@ -71,7 +71,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "alpha is only a flag and should always be true".red unless value == true
+                                         UI.user_error!("alpha is only a flag and should always be true") unless value == true
                                        end),
           FastlaneCore::ConfigItem.new(key: :path,
                                        env_name: "FL_BADGE_PATH",
@@ -80,7 +80,7 @@ module Fastlane
                                        is_string: true,
                                        default_value: '.',
                                        verify_block: proc do |value|
-                                         raise "path needs to be a valid directory".red if Dir[value].empty?
+                                         UI.user_error!("path needs to be a valid directory") if Dir[value].empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :shield_io_timeout,
                                        env_name: "FL_BADGE_SHIELD_IO_TIMEOUT",
@@ -88,7 +88,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "shield_io_timeout needs to be an integer > 0".red if value.to_i < 1
+                                         UI.user_error!("shield_io_timeout needs to be an integer > 0") if value.to_i < 1
                                        end),
           FastlaneCore::ConfigItem.new(key: :glob,
                                        env_name: "FL_BADGE_GLOB",
@@ -101,7 +101,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "alpha_channel is only a flag and should always be true".red unless value == true
+                                         UI.user_error!("alpha_channel is only a flag and should always be true") unless value == true
                                        end),
           FastlaneCore::ConfigItem.new(key: :shield_gravity,
                                        env_name: "FL_BADGE_SHIELD_GRAVITY",
@@ -114,7 +114,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "shield_no_resize is only a flag and should always be true".red unless value == true
+                                         UI.user_error!("shield_no_resize is only a flag and should always be true") unless value == true
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -26,7 +26,7 @@ module Fastlane
                                        description: "Carthage command (one of `build`, `bootstrap`, `update`)",
                                        default_value: 'bootstrap',
                                        verify_block: proc do |value|
-                                         raise "Please pass a valid command. Use one of the following: build, bootstrap, update" unless %w(build bootstrap update).include? value
+                                         UI.user_error!("Please pass a valid command. Use one of the following: build, bootstrap, update") unless %w(build bootstrap update).include? value
                                        end),
           FastlaneCore::ConfigItem.new(key: :use_ssh,
                                        env_name: "FL_CARTHAGE_USE_SSH",
@@ -34,7 +34,7 @@ module Fastlane
                                        is_string: false,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass a valid value for use_ssh. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                         UI.user_error!("Please pass a valid value for use_ssh. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
                                        end),
           FastlaneCore::ConfigItem.new(key: :use_submodules,
                                        env_name: "FL_CARTHAGE_USE_SUBMODULES",
@@ -42,7 +42,7 @@ module Fastlane
                                        is_string: false,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass a valid value for use_submodules. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                         UI.user_error!("Please pass a valid value for use_submodules. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
                                        end),
           FastlaneCore::ConfigItem.new(key: :use_binaries,
                                        env_name: "FL_CARTHAGE_USE_BINARIES",
@@ -50,7 +50,7 @@ module Fastlane
                                        is_string: false,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass a valid value for use_binaries. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                         UI.user_error!("Please pass a valid value for use_binaries. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
                                        end),
           FastlaneCore::ConfigItem.new(key: :no_build,
                                        env_name: "FL_CARTHAGE_NO_BUILD",
@@ -58,7 +58,7 @@ module Fastlane
                                        is_string: false,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass a valid value for no_build. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                         UI.user_error!("Please pass a valid value for no_build. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
                                        end),
           FastlaneCore::ConfigItem.new(key: :verbose,
                                        env_name: "FL_CARTHAGE_VERBOSE",
@@ -66,14 +66,14 @@ module Fastlane
                                        is_string: false,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass a valid value for verbose. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                         UI.user_error!("Please pass a valid value for verbose. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
                                        end),
           FastlaneCore::ConfigItem.new(key: :platform,
                                        env_name: "FL_CARTHAGE_PLATFORM",
                                        description: "Define which platform to build for",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass a valid platform. Use one of the following: all, iOS, Mac, watchOS" unless ["all", "iOS", "Mac", "watchOS"].include? value
+                                         UI.user_error!("Please pass a valid platform. Use one of the following: all, iOS, Mac, watchOS") unless ["all", "iOS", "Mac", "watchOS"].include? value
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -57,9 +57,9 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise ":between must be of type array".red unless value.kind_of?(Array)
-                                         raise ":between must not contain nil values".red if value.any?(&:nil?)
-                                         raise ":between must be an array of size 2".red unless (value || []).size == 2
+                                         UI.user_error!(":between must be of type array") unless value.kind_of?(Array)
+                                         UI.user_error!(":between must not contain nil values") if value.any?(&:nil?)
+                                         UI.user_error!(":between must be an array of size 2") unless (value || []).size == 2
                                        end),
           FastlaneCore::ConfigItem.new(key: :pretty,
                                        env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_PRETTY',
@@ -92,7 +92,7 @@ module Fastlane
                                        default_value: 'include_merges',
                                        verify_block: proc do |value|
                                          matches_option = GIT_MERGE_COMMIT_FILTERING_OPTIONS.any? { |opt| opt.to_s == value }
-                                         raise "Valid values for :merge_commit_filtering are #{GIT_MERGE_COMMIT_FILTERING_OPTIONS.map {|o| "'#{o}'" }.join(', ')}".red unless matches_option
+                                         UI.user_error!("Valid values for :merge_commit_filtering are #{GIT_MERGE_COMMIT_FILTERING_OPTIONS.map {|o| "'#{o}'" }.join(', ')}") unless matches_option
                                        end
                                       )
         ]

--- a/fastlane/lib/fastlane/actions/chatwork.rb
+++ b/fastlane/lib/fastlane/actions/chatwork.rb
@@ -27,7 +27,7 @@ module Fastlane
         else
           require 'json'
           json = JSON.parse(response.body)
-          raise "HTTP Error: #{response.code} #{json['errors']}".red
+          UI.user_error!("HTTP Error: #{response.code} #{json['errors']}")
         end
       end
 
@@ -43,7 +43,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          unless value.to_s.length > 0
                                            UI.error("Please add 'ENV[\"CHATWORK_API_TOKEN\"] = \"your token\"' to your Fastfile's `before_all` section.")
-                                           raise 'No CHATWORK_API_TOKEN given.'.red
+                                           UI.user_error!("No CHATWORK_API_TOKEN given.")
                                          end
                                        end),
           FastlaneCore::ConfigItem.new(key: :message,

--- a/fastlane/lib/fastlane/actions/clean_cocoapods_cache.rb
+++ b/fastlane/lib/fastlane/actions/clean_cocoapods_cache.rb
@@ -24,7 +24,7 @@ module Fastlane
                                        optional: true,
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "You must specify pod name which should be removed from cache".red if value.to_s.empty?
+                                         UI.user_error!("You must specify pod name which should be removed from cache") if value.to_s.empty?
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -74,7 +74,7 @@ module Fastlane
                                        optional: true,
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "Could not find Podfile".red unless File.exist?(value) || Helper.test?
+                                         UI.user_error!("Could not find Podfile") unless File.exist?(value) || Helper.test?
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -17,18 +17,18 @@ module Fastlane
 
         if xcodeproj_path
           # ensure that the xcodeproj passed in was OK
-          raise "Could not find the specified xcodeproj: #{xcodeproj_path}" unless File.directory?(xcodeproj_path)
+          UI.user_error!("Could not find the specified xcodeproj: #{xcodeproj_path}") unless File.directory?(xcodeproj_path)
         else
           # find an xcodeproj (ignoring the Cocoapods one)
           xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))].reject { |path| %r{Pods\/.*.xcodeproj} =~ path }
 
           # no projects found: error
-          raise 'Could not find a .xcodeproj in the current repository\'s working directory.'.red if xcodeproj_paths.count == 0
+          UI.user_error!('Could not find a .xcodeproj in the current repository\'s working directory.') if xcodeproj_paths.count == 0
 
           # too many projects found: error
           if xcodeproj_paths.count > 1
             relative_projects = xcodeproj_paths.map { |e| Pathname.new(e).relative_path_from(repo_pathname).to_s }.join("\n")
-            raise "Found multiple .xcodeproj projects in the current repository's working directory. Please specify your app's main project: \n#{relative_projects}".red
+            UI.user_error!("Found multiple .xcodeproj projects in the current repository's working directory. Please specify your app's main project: \n#{relative_projects}")
           end
 
           # one project found: great
@@ -65,7 +65,7 @@ module Fastlane
         git_dirty_files = Actions.sh('git diff --name-only HEAD').split("\n") + Actions.sh('git ls-files --other --exclude-standard').split("\n")
 
         # little user hint
-        raise 'No file changes picked up. Make sure you run the `increment_build_number` action first.'.red if git_dirty_files.empty?
+        UI.user_error!("No file changes picked up. Make sure you run the `increment_build_number` action first.") if git_dirty_files.empty?
 
         # check if the files changed are the ones we expected to change (these should be only the files that have version info in them)
         changed_files_as_expected = (Set.new(git_dirty_files.map(&:downcase)).subset? Set.new(expected_changed_files.map(&:downcase)))
@@ -125,8 +125,8 @@ module Fastlane
                                        description: "The path to your project file (Not the workspace). If you have only one, this is optional",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                                         raise "Could not find Xcode project".red unless File.exist?(value)
+                                         UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
+                                         UI.user_error!("Could not find Xcode project") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :force,
                                        env_name: "FL_FORCE_COMMIT",

--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -24,7 +24,7 @@ module Fastlane
         elsif params[:apk_path]
           command = Helper::CrashlyticsHelper.generate_android_command(params)
         else
-          raise "You have to either pass an ipa or an apk file to the Crashlytics action".red
+          UI.user_error!("You have to either pass an ipa or an apk file to the Crashlytics action")
         end
 
         UI.success('Uploading the build to Crashlytics Beta. Time for some ☕️.')
@@ -49,7 +49,7 @@ module Fastlane
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] || Dir["*.ipa"].last,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find ipa file at path '#{value}'".red unless File.exist?(value)
+                                         UI.user_error!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
                                        end),
           # Android Specific
           FastlaneCore::ConfigItem.new(key: :apk_path,
@@ -58,7 +58,7 @@ module Fastlane
                                        default_value: Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH] || Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-Release.apk")].last,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find apk file at path '#{value}'".red unless File.exist?(value)
+                                         UI.user_error!("Couldn't find apk file at path '#{value}'") unless File.exist?(value)
                                        end),
           # General
           FastlaneCore::ConfigItem.new(key: :crashlytics_path,
@@ -67,26 +67,26 @@ module Fastlane
                                        default_value: Dir["./Pods/iOS/Crashlytics/Crashlytics.framework"].last || Dir["./**/Crashlytics.framework"].last,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find crashlytics at path '#{File.expand_path(value)}'`".red unless File.exist?(File.expand_path(value))
+                                         UI.user_error!("Couldn't find crashlytics at path '#{File.expand_path(value)}'`") unless File.exist?(File.expand_path(value))
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_token,
                                        env_name: "CRASHLYTICS_API_TOKEN",
                                        description: "Crashlytics Beta API Token",
                                        verify_block: proc do |value|
-                                         raise "No API token for Crashlytics given, pass using `api_token: 'token'`".red unless value && !value.empty?
+                                         UI.user_error!("No API token for Crashlytics given, pass using `api_token: 'token'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :build_secret,
                                        env_name: "CRASHLYTICS_BUILD_SECRET",
                                        description: "Crashlytics Build Secret",
                                        verify_block: proc do |value|
-                                         raise "No build secret for Crashlytics given, pass using `build_secret: 'secret'`".red unless value && !value.empty?
+                                         UI.user_error!("No build secret for Crashlytics given, pass using `build_secret: 'secret'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :notes_path,
                                        env_name: "CRASHLYTICS_NOTES_PATH",
                                        description: "Path to the release notes",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Path '#{value}' not found".red unless File.exist?(value)
+                                         UI.user_error!("Path '#{value}' not found") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :notes,
                                        env_name: "CRASHLYTICS_NOTES",

--- a/fastlane/lib/fastlane/actions/default_platform.rb
+++ b/fastlane/lib/fastlane/actions/default_platform.rb
@@ -6,7 +6,7 @@ module Fastlane
 
     class DefaultPlatformAction < Action
       def self.run(params)
-        raise "You forgot to pass the default platform".red if params.first.nil?
+        UI.user_error!("You forgot to pass the default platform") if params.first.nil?
 
         platform = params.first.to_sym
 

--- a/fastlane/lib/fastlane/actions/deploygate.rb
+++ b/fastlane/lib/fastlane/actions/deploygate.rb
@@ -41,7 +41,7 @@ module Fastlane
           UI.message("DeployGate URL: #{Actions.lane_context[SharedValues::DEPLOYGATE_URL]}")
           UI.success("Build successfully uploaded to DeployGate as revision \##{Actions.lane_context[SharedValues::DEPLOYGATE_REVISION]}!")
         else
-          raise 'Error when trying to upload ipa to DeployGate'.red
+          UI.user_error!("Error when trying to upload ipa to DeployGate")
         end
       end
 
@@ -92,20 +92,20 @@ module Fastlane
                                        env_name: "DEPLOYGATE_API_TOKEN",
                                        description: "Deploygate API Token",
                                        verify_block: proc do |value|
-                                         raise "No API Token for DeployGate given, pass using `api_token: 'token'`".red unless value.to_s.length > 0
+                                         UI.user_error!("No API Token for DeployGate given, pass using `api_token: 'token'`") unless value.to_s.length > 0
                                        end),
           FastlaneCore::ConfigItem.new(key: :user,
                                        env_name: "DEPLOYGATE_USER",
                                        description: "Target username or organization name",
                                        verify_block: proc do |value|
-                                         raise "No User for app given, pass using `user: 'user'`".red unless value.to_s.length > 0
+                                         UI.user_error!("No User for app given, pass using `user: 'user'`") unless value.to_s.length > 0
                                        end),
           FastlaneCore::ConfigItem.new(key: :ipa,
                                        env_name: "DEPLOYGATE_IPA_PATH",
                                        description: "Path to your IPA file. Optional if you use the `gym` or `xcodebuild` action",
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        verify_block: proc do |value|
-                                         raise "Couldn't find ipa file at path '#{value}'".red unless File.exist?(value)
+                                         UI.user_error!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :message,
                                        env_name: "DEPLOYGATE_MESSAGE",

--- a/fastlane/lib/fastlane/actions/dotgpg_environment.rb
+++ b/fastlane/lib/fastlane/actions/dotgpg_environment.rb
@@ -28,7 +28,7 @@ module Fastlane
                                        default_value: Dir["dotgpg/*.gpg"].last,
                                        optional: false,
                                        verify_block: proc do |value|
-                                         raise "Dotgpg file '#{File.expand_path(value)}' not found".red unless File.exist?(value)
+                                         UI.user_error!("Dotgpg file '#{File.expand_path(value)}' not found") unless File.exist?(value)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/download.rb
+++ b/fastlane/lib/fastlane/actions/download.rb
@@ -17,7 +17,7 @@ module Fastlane
           end
           Actions.lane_context[SharedValues::DOWNLOAD_CONTENT] = result
         rescue => ex
-          raise "Error fetching remote file: #{ex}"
+          UI.user_error!("Error fetching remote file: #{ex}")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/dsym_zip.rb
+++ b/fastlane/lib/fastlane/actions/dsym_zip.rb
@@ -46,7 +46,7 @@ module Fastlane
                                        optional: true,
                                        env_name: 'DSYM_ZIP_XCARCHIVE_PATH',
                                        verify_block: proc do |value|
-                                         raise "Couldn't find xcarchive file at path '#{value}'".red if !Helper.test? && !File.exist?(value)
+                                         UI.user_error!("Couldn't find xcarchive file at path '#{value}'") if !Helper.test? && !File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :dsym_path,
                                        description: 'Path for generated dsym. Optional, default is your apps root directory',

--- a/fastlane/lib/fastlane/actions/ensure_git_branch.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_branch.rb
@@ -11,7 +11,7 @@ module Fastlane
         if Actions.git_branch =~ branch_expr
           UI.success("Git branch match `#{branch}`, all good! 💪")
         else
-          raise "Git is not on a branch matching `#{branch}`. Current branch is `#{Actions.git_branch}`! Please ensure the repo is checked out to the correct branch.".red
+          UI.user_error!("Git is not on a branch matching `#{branch}`. Current branch is `#{Actions.git_branch}`! Please ensure the repo is checked out to the correct branch.")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
+++ b/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
@@ -33,7 +33,7 @@ module Fastlane
           found << current_raw.strip
         end
 
-        raise "Found debug code '#{params[:text]}': \n\n#{found.join("\n")}" if found.count > 0
+        UI.user_error!("Found debug code '#{params[:text]}': \n\n#{found.join("\n")}") if found.count > 0
         UI.message("No debug code found in code base 🐛")
       end
 
@@ -63,7 +63,7 @@ module Fastlane
                                        description: "The directory containing all the source files",
                                        default_value: ".",
                                        verify_block: proc do |value|
-                                         raise "Couldn't find the folder at '#{File.absolute_path(value)}'".red unless File.directory?(value)
+                                         UI.user_error!("Couldn't find the folder at '#{File.absolute_path(value)}'") unless File.directory?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :extension,
                                        env_name: "FL_ENSURE_NO_DEBUG_CODE_EXTENSION",

--- a/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
+++ b/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
@@ -18,7 +18,7 @@ module Fastlane
           UI.message("Selected Xcode version is not correct: #{selected_version}. You expected #{required_version}.")
           UI.message("To correct this, use: `xcode_select(version: #{required_version})`.")
 
-          raise "Selected Xcode version doesn't match your requirement.\nExpected: Xcode #{required_version}\nActual: #{selected_version}\n"
+          UI.user_error!("Selected Xcode version doesn't match your requirement.\nExpected: Xcode #{required_version}\nActual: #{selected_version}\n")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/fastlane_version.rb
+++ b/fastlane/lib/fastlane/actions/fastlane_version.rb
@@ -9,10 +9,10 @@ module Fastlane
         value = (params || []).first
         defined_version = Gem::Version.new(value) if value
 
-        raise "Please pass minimum fastlane version as parameter to fastlane_version".red unless defined_version
+        UI.user_error!("Please pass minimum fastlane version as parameter to fastlane_version") unless defined_version
 
         if Gem::Version.new(Fastlane::VERSION) < defined_version
-          raise "The Fastfile requires a fastlane version of >= #{defined_version}. You are on #{Fastlane::VERSION}. Please update using `sudo gem update fastlane`.".red
+          UI.user_error!("The Fastfile requires a fastlane version of >= #{defined_version}. You are on #{Fastlane::VERSION}. Please update using `sudo gem update fastlane`.")
         end
 
         UI.message("fastlane version valid")

--- a/fastlane/lib/fastlane/actions/frameit.rb
+++ b/fastlane/lib/fastlane/actions/frameit.rb
@@ -49,7 +49,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          available = ['iPhone_6_Plus', 'iPhone_5s', 'iPhone_4', 'iPad_mini', 'Mac']
                                          unless available.include? value
-                                           raise "Invalid device type '#{value}'. Available values: #{available}".red
+                                           UI.user_error!("Invalid device type '#{value}'. Available values: #{available}")
                                          end
                                        end)
         ]

--- a/fastlane/lib/fastlane/actions/gcovr.rb
+++ b/fastlane/lib/fastlane/actions/gcovr.rb
@@ -53,7 +53,7 @@ module Fastlane
 
       def self.run(params)
         unless Helper.test?
-          raise "gcovr not installed".red if `which gcovr`.length == 0
+          UI.user_error!("gcovr not installed") if `which gcovr`.length == 0
         end
 
         # The args we will build with

--- a/fastlane/lib/fastlane/actions/get_build_number.rb
+++ b/fastlane/lib/fastlane/actions/get_build_number.rb
@@ -59,8 +59,8 @@ module Fastlane
                              description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
                              optional: true,
                              verify_block: proc do |value|
-                               raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                               raise "Could not find Xcode project".red if !File.exist?(value) and !Helper.is_test?
+                               UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
+                               UI.user_error!("Could not find Xcode project") if !File.exist?(value) and !Helper.is_test?
                              end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/get_build_number_repository.rb
+++ b/fastlane/lib/fastlane/actions/get_build_number_repository.rb
@@ -51,7 +51,7 @@ module Fastlane
             return 'hg parent --template "{node|short}"'
           end
         else
-          raise "No repository detected"
+          UI.user_error!("No repository detected")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/get_github_release.rb
+++ b/fastlane/lib/fastlane/actions/get_github_release.rb
@@ -110,8 +110,8 @@ module Fastlane
                                        env_name: "FL_GET_GITHUB_RELEASE_URL",
                                        description: "The path to your repo, e.g. 'KrauseFx/fastlane'",
                                        verify_block: proc do |value|
-                                         raise "Please only pass the path, e.g. 'KrauseFx/fastlane'".red if value.include? "github.com"
-                                         raise "Please only pass the path, e.g. 'KrauseFx/fastlane'".red if value.split('/').count != 2
+                                         UI.user_error!("Please only pass the path, e.g. 'KrauseFx/fastlane'") if value.include? "github.com"
+                                         UI.user_error!("Please only pass the path, e.g. 'KrauseFx/fastlane'") if value.split('/').count != 2
                                        end),
           FastlaneCore::ConfigItem.new(key: :server_url,
                                        env_name: "FL_GITHUB_RELEASE_SERVER_URL",
@@ -119,7 +119,7 @@ module Fastlane
                                        default_value: "https://api.github.com",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please include the protocol in the server url, e.g. https://your.github.server".red unless value.include? "//"
+                                         UI.user_error!("Please include the protocol in the server url, e.g. https://your.github.server") unless value.include? "//"
                                        end),
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: "FL_GET_GITHUB_RELEASE_VERSION",

--- a/fastlane/lib/fastlane/actions/get_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/get_info_plist_value.rb
@@ -37,7 +37,7 @@ module Fastlane
                                        description: "Path to plist file you want to read",
                                        optional: false,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find plist file at path '#{value}'".red unless File.exist?(value)
+                                         UI.user_error!("Couldn't find plist file at path '#{value}'") unless File.exist?(value)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -59,8 +59,8 @@ module Fastlane
                              description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
                              optional: true,
                              verify_block: proc do |value|
-                               raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                               raise "Could not find Xcode project at path '#{File.expand_path(value)}'".red if !File.exist?(value) and !Helper.is_test?
+                               UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
+                               UI.user_error!("Could not find Xcode project at path '#{File.expand_path(value)}'") if !File.exist?(value) and !Helper.is_test?
                              end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -32,10 +32,10 @@ module Fastlane
                                        is_string: false,
                                        verify_block: proc do |value|
                                          if value.kind_of?(String)
-                                           raise "Couldn't find file at path '#{value}'".red unless File.exist?(value)
+                                           UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                          else
                                            value.each do |x|
-                                             raise "Couldn't find file at path '#{x}'".red unless File.exist?(x)
+                                             UI.user_error!("Couldn't find file at path '#{x}'") unless File.exist?(x)
                                            end
                                          end
                                        end)

--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -32,10 +32,10 @@ module Fastlane
                                        is_string: false,
                                        verify_block: proc do |value|
                                          if value.kind_of?(String)
-                                           raise "Couldn't find file at path '#{value}'".red unless File.exist?(value)
+                                           UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                          else
                                            value.each do |x|
-                                             raise "Couldn't find file at path '#{x}'".red unless File.exist?(x)
+                                             UI.user_error!("Couldn't find file at path '#{x}'") unless File.exist?(x)
                                            end
                                          end
                                        end),

--- a/fastlane/lib/fastlane/actions/git_pull.rb
+++ b/fastlane/lib/fastlane/actions/git_pull.rb
@@ -25,7 +25,7 @@ module Fastlane
                                        optional: true,
                                        default_value: false,
                                        verify_block: proc do |value|
-                                         raise "Please pass a valid value for only_tags. Use one of the following: true, false" unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                         UI.user_error!("Please pass a valid value for only_tags. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -30,7 +30,7 @@ module Fastlane
                       end
 
         # Ensure we ended up with a valid path to gradle
-        raise "Couldn't find gradlew at path '#{File.expand_path(gradle_path)}'".red unless File.exist?(gradle_path)
+        UI.user_error!("Couldn't find gradlew at path '#{File.expand_path(gradle_path)}'") unless File.exist?(gradle_path)
 
         # Construct our flags
         flags = []

--- a/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
@@ -22,19 +22,19 @@ module Fastlane
         if xcodeproj_path
           # ensure that the xcodeproj passed in was OK
           unless Helper.is_test?
-            raise "Could not find the specified xcodeproj: #{xcodeproj_path}" unless File.directory?(xcodeproj_path)
+            UI.user_error!("Could not find the specified xcodeproj: #{xcodeproj_path}") unless File.directory?(xcodeproj_path)
           end
         else
           # find an xcodeproj (ignoring the Cocoapods one)
           xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))].reject { |path| %r{Pods\/.*.xcodeproj} =~ path }
 
           # no projects found: error
-          raise 'Could not find a .xcodeproj in the current repository\'s working directory.'.red if xcodeproj_paths.count == 0
+          UI.user_error!('Could not find a .xcodeproj in the current repository\'s working directory.') if xcodeproj_paths.count == 0
 
           # too many projects found: error
           if xcodeproj_paths.count > 1
             relative_projects = xcodeproj_paths.map { |e| Pathname.new(e).relative_path_from(repo_pathname).to_s }.join("\n")
-            raise "Found multiple .xcodeproj projects in the current repository's working directory. Please specify your app's main project: \n#{relative_projects}".red
+            UI.user_error!("Found multiple .xcodeproj projects in the current repository's working directory. Please specify your app's main project: \n#{relative_projects}")
           end
 
           # one project found: great
@@ -76,7 +76,7 @@ module Fastlane
         end
 
         # little user hint
-        raise 'No file changes picked up. Make sure you run the `increment_build_number` action first.'.red if hg_dirty_files.empty?
+        UI.user_error!("No file changes picked up. Make sure you run the `increment_build_number` action first.") if hg_dirty_files.empty?
 
         # check if the files changed are the ones we expected to change (these should be only the files that have version info in them)
         dirty_set = Set.new(hg_dirty_files.map(&:downcase))
@@ -91,7 +91,7 @@ module Fastlane
                    "stage in your lane, and don't touch the working directory while your lane is running. You can also use the :force option to ",
                    "bypass this check, and always commit a version bump regardless of the state of the working directory."
                   ].join("\n")
-            raise str.red
+            UI.user_error!(str)
           end
         end
 
@@ -123,8 +123,8 @@ module Fastlane
                                        description: "The path to your project file (Not the workspace). If you have only one, this is optional",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                                         raise "Could not find Xcode project".red unless File.exist?(value)
+                                         UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
+                                         UI.user_error!("Could not find Xcode project") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :force,
                                        env_name: "FL_FORCE_COMMIT",

--- a/fastlane/lib/fastlane/actions/hipchat.rb
+++ b/fastlane/lib/fastlane/actions/hipchat.rb
@@ -31,7 +31,7 @@ module Fastlane
         if api_version.to_i == 1
           ########## running on V1 ##########
           if user?(channel)
-            raise 'HipChat private message not working with API V1 please use API V2 instead'.red
+            UI.user_error!("HipChat private message not working with API V1 please use API V2 instead")
           else
             uri = URI.parse("https://#{api_host}/v1/rooms/message")
             response = Net::HTTP.post_form(uri, { 'from' => from,
@@ -78,11 +78,11 @@ module Fastlane
         when 200, 204
           true
         when 404
-          raise "Channel `#{channel}` not found".red
+          UI.user_error!("Channel `#{channel}` not found")
         when 401
-          raise "Access denied for channel `#{channel}`".red
+          UI.user_error!("Access denied for channel `#{channel}`")
         else
-          raise "Unexpected #{response.code} for `#{channel}` with response: #{response.body}".red
+          UI.user_error!("Unexpected #{response.code} for `#{channel}` with response: #{response.body}")
         end
       end
 
@@ -105,7 +105,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          unless value.to_s.length > 0
                                            UI.error("Please add 'ENV[\"HIPCHAT_API_TOKEN\"] = \"your token\"' to your Fastfile's `before_all` section.")
-                                           raise 'No HIPCHAT_API_TOKEN given.'.red
+                                           UI.user_error!("No HIPCHAT_API_TOKEN given.")
                                          end
                                        end),
           FastlaneCore::ConfigItem.new(key: :custom_color,
@@ -125,7 +125,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          if value.nil? || ![1, 2].include?(value.to_i)
                                            UI.error("Please add 'ENV[\"HIPCHAT_API_VERSION\"] = \"1 or 2\"' to your Fastfile's `before_all` section.")
-                                           raise 'No HIPCHAT_API_VERSION given.'.red
+                                           UI.user_error!("No HIPCHAT_API_VERSION given.")
                                          end
                                        end),
           FastlaneCore::ConfigItem.new(key: :notify_room,
@@ -147,7 +147,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          unless ["html", "text"].include?(value.to_s)
                                            UI.error("Please specify the message format as either 'html' or 'text'.")
-                                           raise 'Unrecognized message_format.'.red
+                                           UI.user_error!("Unrecognized message_format.")
                                          end
                                        end),
           FastlaneCore::ConfigItem.new(key: :include_html_header,

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -40,7 +40,7 @@ module Fastlane
           end
         end
 
-        raise "Symbols on path '#{File.expand_path(dsym_filename)}' not found".red if dsym_filename && !File.exist?(dsym_filename)
+        UI.user_error!("Symbols on path '#{File.expand_path(dsym_filename)}' not found") if dsym_filename && !File.exist?(dsym_filename)
 
         UI.success('Starting with ipa upload to HockeyApp... this could take some time.')
 
@@ -67,9 +67,9 @@ module Fastlane
           UI.success('Build successfully uploaded to HockeyApp!')
         else
           if response.body.to_s.include?("App could not be created")
-            raise "Hockey has an issue processing this app. Please confirm that an app in Hockey matches this IPA's bundle ID or that you are using the correct API upload token. If error persists, please provide the :public_identifier option from the HockeyApp website. More information https://github.com/fastlane/fastlane/issues/400"
+            UI.user_error!("Hockey has an issue processing this app. Please confirm that an app in Hockey matches this IPA's bundle ID or that you are using the correct API upload token. If error persists, please provide the :public_identifier option from the HockeyApp website. More information https://github.com/fastlane/fastlane/issues/400")
           else
-            raise "Error when trying to upload ipa to HockeyApp: #{response.body}".red
+            UI.user_error!("Error when trying to upload ipa to HockeyApp: #{response.body}")
           end
         end
       end
@@ -86,17 +86,17 @@ module Fastlane
                                        default_value: Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH],
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find apk file at path '#{value}'".red unless File.exist?(value)
+                                         UI.user_error!("Couldn't find apk file at path '#{value}'") unless File.exist?(value)
                                        end,
                                        conflicting_options: [:ipa],
                                        conflict_block: proc do |value|
-                                         raise "You can't use 'apk' and '#{value.key}' options in one run".red
+                                         UI.user_error!("You can't use 'apk' and '#{value.key}' options in one run")
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_token,
                                        env_name: "FL_HOCKEY_API_TOKEN",
                                        description: "API Token for Hockey Access",
                                        verify_block: proc do |value|
-                                         raise "No API token for Hockey given, pass using `api_token: 'token'`".red unless value and !value.empty?
+                                         UI.user_error!("No API token for Hockey given, pass using `api_token: 'token'`") unless value and !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :ipa,
                                        env_name: "FL_HOCKEY_IPA",
@@ -104,11 +104,11 @@ module Fastlane
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find ipa file at path '#{value}'".red unless File.exist?(value)
+                                         UI.user_error!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
                                        end,
                                        conflicting_options: [:apk],
                                        conflict_block: proc do |value|
-                                         raise "You can't use 'ipa' and '#{value.key}' options in one run".red
+                                         UI.user_error!("You can't use 'ipa' and '#{value.key}' options in one run")
                                        end),
           FastlaneCore::ConfigItem.new(key: :dsym,
                                        env_name: "FL_HOCKEY_DSYM",

--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -61,8 +61,8 @@ module Fastlane
                                        description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                                         raise "Could not find Xcode project".red if !File.exist?(value) and !Helper.is_test?
+                                         UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
+                                         UI.user_error!("Could not find Xcode project") if !File.exist?(value) and !Helper.is_test?
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -34,7 +34,7 @@ module Fastlane
           if Helper.test?
             version_array = [1, 0, 0]
           else
-            raise "Your current version (#{current_version}) does not respect the format A.B.C" unless current_version =~ /\d+.\d+.\d+/
+            UI.user_error!("Your current version (#{current_version}) does not respect the format A.B.C") unless current_version =~ /\d+.\d+.\d+/
             version_array = current_version.split(".").map(&:to_i)
           end
 
@@ -93,7 +93,7 @@ module Fastlane
                                        description: "The type of this version bump. Available: patch, minor, major",
                                        default_value: "patch",
                                        verify_block: proc do |value|
-                                         raise "Available values are 'patch', 'minor' and 'major'" unless ['patch', 'minor', 'major'].include? value
+                                         UI.user_error!("Available values are 'patch', 'minor' and 'major'") unless ['patch', 'minor', 'major'].include? value
                                        end),
           FastlaneCore::ConfigItem.new(key: :version_number,
                                        env_name: "FL_VERSION_NUMBER_VERSION_NUMBER",
@@ -104,8 +104,8 @@ module Fastlane
                                        env_name: "FL_VERSION_NUMBER_PROJECT",
                                        description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                                         raise "Could not find Xcode project".red unless File.exist?(value)
+                                         UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
+                                         UI.user_error!("Could not find Xcode project") unless File.exist?(value)
                                        end,
                                        optional: true)
         ]

--- a/fastlane/lib/fastlane/actions/install_on_device.rb
+++ b/fastlane/lib/fastlane/actions/install_on_device.rb
@@ -5,7 +5,7 @@ module Fastlane
     class InstallOnDeviceAction < Action
       def self.run(params)
         unless Helper.test?
-          raise "ios-deploy not installed, see https://github.com/phonegap/ios-deploy for instructions".red if `which ios-deploy`.length == 0
+          UI.user_error!("ios-deploy not installed, see https://github.com/phonegap/ios-deploy for instructions") if `which ios-deploy`.length == 0
         end
         taxi_cmd = [
           "ios-deploy",
@@ -60,8 +60,8 @@ module Fastlane
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] || Dir["*.ipa"].first,
                                        verify_block: proc do |value|
                                          unless Helper.test?
-                                           raise "Could not find ipa file at path '#{value}'" unless File.exist? value
-                                           raise "'#{value}' doesn't seem to be an ipa file" unless value.end_with? ".ipa"
+                                           UI.user_error!("Could not find ipa file at path '#{value}'") unless File.exist? value
+                                           UI.user_error!("'#{value}' doesn't seem to be an ipa file") unless value.end_with? ".ipa"
                                          end
                                        end
                                       )

--- a/fastlane/lib/fastlane/actions/install_xcode_plugin.rb
+++ b/fastlane/lib/fastlane/actions/install_xcode_plugin.rb
@@ -28,8 +28,8 @@ module Fastlane
                                        env_name: "FL_XCODE_PLUGIN_URL",
                                        description: "URL for Xcode plugin ZIP file",
                                        verify_block: proc do |value|
-                                         raise "No URL for InstallXcodePluginAction given, pass using `url: 'url'`".red if value.to_s.length == 0
-                                         raise "URL doesn't use HTTPS".red unless value.start_with?("https://")
+                                         UI.user_error!("No URL for InstallXcodePluginAction given, pass using `url: 'url'`") if value.to_s.length == 0
+                                         UI.user_error!("URL doesn't use HTTPS") unless value.start_with?("https://")
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/installr.rb
+++ b/fastlane/lib/fastlane/actions/installr.rb
@@ -17,7 +17,7 @@ module Fastlane
           Actions.lane_context[SharedValues::INSTALLR_BUILD_INFORMATION] = response.body
           UI.success('Build successfully uploaded to Installr!')
         else
-          raise "Error when trying to upload build file to Installr: #{response.body}".red
+          UI.user_error!("Error when trying to upload build file to Installr: #{response.body}")
         end
       end
 
@@ -69,14 +69,14 @@ module Fastlane
                                      env_name: "INSTALLR_API_TOKEN",
                                      description: "API Token for Installr Access",
                                      verify_block: proc do |value|
-                                       raise "No API token for Installr given, pass using `api_token: 'token'`".red unless value and !value.empty?
+                                       UI.user_error!("No API token for Installr given, pass using `api_token: 'token'`") unless value and !value.empty?
                                      end),
           FastlaneCore::ConfigItem.new(key: :ipa,
                                      env_name: "INSTALLR_IPA_PATH",
                                      description: "Path to your IPA file. Optional if you use the `gym` or `xcodebuild` action",
                                      default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                      verify_block: proc do |value|
-                                       raise "Couldn't find build file at path '#{value}'".red unless File.exist?(value)
+                                       UI.user_error!("Couldn't find build file at path '#{value}'") unless File.exist?(value)
                                      end),
           FastlaneCore::ConfigItem.new(key: :notes,
                                      env_name: "INSTALLR_NOTES",

--- a/fastlane/lib/fastlane/actions/ipa.rb
+++ b/fastlane/lib/fastlane/actions/ipa.rb
@@ -89,7 +89,7 @@ module Fastlane
           end
 
           # Raise a custom exception, as the the normal one is useless for the user
-          raise "A build error occured, this is usually related to code signing. Take a look at the error above".red
+          UI.user_error!("A build error occured, this is usually related to code signing. Take a look at the error above")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -33,7 +33,7 @@ module Fastlane
         begin
           build_number = train.builds.map(&:build_version).map(&:to_i).sort.last
         rescue
-          raise "could not find a build on iTC - and 'initial_build_number' option is not set" unless params[:initial_build_number]
+          UI.user_error!("could not find a build on iTC - and 'initial_build_number' option is not set") unless params[:initial_build_number]
           build_number = params[:initial_build_number]
         end
 

--- a/fastlane/lib/fastlane/actions/lcov.rb
+++ b/fastlane/lib/fastlane/actions/lcov.rb
@@ -8,7 +8,7 @@ module Fastlane
 
       def self.run(options)
         unless Helper.test?
-          raise 'lcov not installed, please install using `brew install lcov`'.red if `which lcov`.length == 0
+          UI.user_error!("lcov not installed, please install using `brew install lcov`") if `which lcov`.length == 0
         end
         gen_cov(options)
       end

--- a/fastlane/lib/fastlane/actions/nexus_upload.rb
+++ b/fastlane/lib/fastlane/actions/nexus_upload.rb
@@ -74,7 +74,7 @@ module Fastlane
                                        optional: false,
                                        verify_block: proc do |value|
                                          file_path = File.expand_path(value)
-                                         raise "Couldn't find file at path '#{file_path}'".red unless File.exist?(file_path)
+                                         UI.user_error!("Couldn't find file at path '#{file_path}'") unless File.exist?(file_path)
                                        end),
           FastlaneCore::ConfigItem.new(key: :repo_id,
                                        env_name: "FL_NEXUS_REPO_ID",

--- a/fastlane/lib/fastlane/actions/number_of_commits.rb
+++ b/fastlane/lib/fastlane/actions/number_of_commits.rb
@@ -12,7 +12,7 @@ module Fastlane
         if is_git?
           command = 'git rev-list HEAD --count'
         else
-          raise "Not in a git repository."
+          UI.user_error!("Not in a git repository.")
         end
         return Actions.sh(command).strip.to_i
       end

--- a/fastlane/lib/fastlane/actions/oclint.rb
+++ b/fastlane/lib/fastlane/actions/oclint.rb
@@ -9,11 +9,11 @@ module Fastlane
       def self.run(params)
         oclint_path = params[:oclint_path]
         if `which #{oclint_path}`.to_s.empty? and !Helper.test?
-          raise "You have to install oclint or provide path to oclint binary. Fore more details: ".red + "http://docs.oclint.org/en/stable/intro/installation.html".yellow
+          UI.user_error!("You have to install oclint or provide path to oclint binary. Fore more details: ") + "http://docs.oclint.org/en/stable/intro/installation.html".yellow
         end
 
         compile_commands = params[:compile_commands]
-        raise "Could not find json compilation database at path '#{compile_commands}'".red unless File.exist?(compile_commands)
+        UI.user_error!("Could not find json compilation database at path '#{compile_commands}'") unless File.exist?(compile_commands)
 
         if params[:select_reqex]
           UI.important("'select_reqex' paramter is deprecated. Please use 'select_regex' instead.")

--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -51,7 +51,7 @@ module Fastlane
         when 200, 204
           puts "Succesfully created new OneSignal app".green
         else
-          raise "Unexpected #{response.code} with response: #{response.body}".red
+          UI.user_error!("Unexpected #{response.code} with response: #{response.body}")
         end
       end
 
@@ -71,7 +71,7 @@ module Fastlane
                                       verify_block: proc do |value|
                                         unless value.to_s.length > 0
                                           UI.error("Please add 'ENV[\"ONE_SIGNAL_AUTH_KEY\"] = \"your token\"' to your Fastfile's `before_all` section.")
-                                          raise 'No ONE_SIGNAL_AUTH_KEY given.'.red
+                                          UI.user_error!("No ONE_SIGNAL_AUTH_KEY given.")
                                         end
                                       end),
 
@@ -81,7 +81,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          unless value.to_s.length > 0
                                            UI.error("Please add 'ENV[\"ONE_SIGNAL_APP_NAME\"] = \"Your app name\"' to your Fastfile's `before_all` section.")
-                                           raise 'No ONE_SIGNAL_APP_NAME given.'.red
+                                           UI.user_error!("No ONE_SIGNAL_APP_NAME given.")
                                          end
                                        end),
 

--- a/fastlane/lib/fastlane/actions/pod_push.rb
+++ b/fastlane/lib/fastlane/actions/pod_push.rb
@@ -45,8 +45,8 @@ module Fastlane
                                        description: "The Podspec you want to push",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find file at path '#{value}'".red unless File.exist?(value)
-                                         raise "File must be a `.podspec`".red unless value.end_with?(".podspec")
+                                         UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+                                         UI.user_error!("File must be a `.podspec`") unless value.end_with?(".podspec")
                                        end),
           FastlaneCore::ConfigItem.new(key: :repo,
                                        description: "The repo you want to push. Pushes to Trunk by default",
@@ -60,7 +60,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "Sources must be an array.".red unless value.kind_of?(Array)
+                                         UI.user_error!("Sources must be an array.") unless value.kind_of?(Array)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/podio_item.rb
+++ b/fastlane/lib/fastlane/actions/podio_item.rb
@@ -39,41 +39,41 @@ module Fastlane
                                        description: 'Client ID for Podio API (see https://developers.podio.com/api-key)',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "No Client ID for Podio given, pass using `client_id: 'id'`".red unless value && !value.empty?
+                                         UI.user_error!("No Client ID for Podio given, pass using `client_id: 'id'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :client_secret,
                                        env_name: 'PODIO_ITEM_CLIENT_SECRET',
                                        description: 'Client secret for Podio API (see https://developers.podio.com/api-key)',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "No Client Secret for Podio given, pass using `client_secret: 'secret'`".red unless value && !value.empty?
+                                         UI.user_error!("No Client Secret for Podio given, pass using `client_secret: 'secret'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :app_id,
                                        env_name: 'PODIO_ITEM_APP_ID',
                                        description: 'App ID of the app you intend to authenticate with (see https://developers.podio.com/authentication/app_auth)',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "No App ID for Podio given, pass using `app_id: 'id'`".red unless value && !value.empty?
+                                         UI.user_error!("No App ID for Podio given, pass using `app_id: 'id'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :app_token,
                                        env_name: 'PODIO_ITEM_APP_TOKEN',
                                        description: 'App token of the app you intend to authenticate with (see https://developers.podio.com/authentication/app_auth)',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "No App token for Podio given, pass using `app_token: 'token'`".red unless value && !value.empty?
+                                         UI.user_error!("No App token for Podio given, pass using `app_token: 'token'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :identifying_field,
                                        env_name: 'PODIO_ITEM_IDENTIFYING_FIELD',
                                        description: 'String specifying the field key used for identification of an item',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "No Identifying field given, pass using `identifying_field: 'field name'`".red unless value && !value.empty?
+                                         UI.user_error!("No Identifying field given, pass using `identifying_field: 'field name'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :identifying_value,
                                        description: 'String uniquely specifying an item within the app',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         raise "No Identifying value given, pass using `identifying_value: 'unique value'`".red unless value && !value.empty?
+                                         UI.user_error!("No Identifying value given, pass using `identifying_value: 'unique value'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :other_fields,
                                        description: 'Dictionary of your app fields. Podio supports several field types, see https://developers.podio.com/doc/items',
@@ -131,7 +131,7 @@ module Fastlane
                                                   app_token: app_token,
                                                   client_id: client_id,
                                                   client_secret: client_secret
-        raise 'Failed to authenticate with Podio API' if auth_response.code != 200
+        UI.user_error!("Failed to authenticate with Podio API") if auth_response.code != 200
 
         auth_response_dictionary = JSON.parse(auth_response.body)
         access_token = auth_response_dictionary['access_token']
@@ -152,7 +152,7 @@ module Fastlane
       def self.get_existing_item(auth_config, identifying_value, app_id)
         filter_request_body = { query: identifying_value, limit: 1, ref_type: 'item' }.to_json
         filter_response = RestClient.post "#{BASE_URL}/search/app/#{app_id}/", filter_request_body, auth_config
-        raise "Failed to search for already existing item #{identifying_value}" if filter_response.code != 200
+        UI.user_error!("Failed to search for already existing item #{identifying_value}") if filter_response.code != 200
 
         existing_items = JSON.parse(filter_response.body)
         existing_item_id = nil
@@ -171,7 +171,7 @@ module Fastlane
       def self.create_item(auth_config, identifying_field, identifying_value, app_id)
         item_request_body = { fields: { identifying_field => identifying_value } }.to_json
         item_response = RestClient.post "#{BASE_URL}/item/app/#{app_id}", item_request_body, auth_config
-        raise "Failed to create item \"#{identifying_value}\"" if item_response.code != 200
+        UI.user_error!("Failed to create item \"#{identifying_value}\"") if item_response.code != 200
 
         item_response_dictionary = JSON.parse(item_response.body)
         [item_response_dictionary['item_id'], item_response_dictionary['link']]
@@ -181,14 +181,14 @@ module Fastlane
         if fields.length > 0
           item_request_body = { fields: fields }.to_json
           item_response = RestClient.put "#{BASE_URL}/item/#{item_id}", item_request_body, auth_config
-          raise "Failed to update item values \"#{fields}\"" unless item_response.code != 200 || item_response.code != 204
+          UI.user_error!("Failed to update item values \"#{fields}\"") unless item_response.code != 200 || item_response.code != 204
         end
       end
 
       def self.get_embed_id(auth_config, url)
         embed_request_body = { url: url }.to_json
         embed_response = RestClient.post "#{BASE_URL}/embed/", embed_request_body, auth_config
-        raise "Failed to create embed for link #{link}" if embed_response.code != 200
+        UI.user_error!("Failed to create embed for link #{link}") if embed_response.code != 200
 
         embed_response_dictionary = JSON.parse(embed_response.body)
         embed_response_dictionary['embed_id']

--- a/fastlane/lib/fastlane/actions/read_podspec.rb
+++ b/fastlane/lib/fastlane/actions/read_podspec.rb
@@ -42,7 +42,7 @@ module Fastlane
                                        description: "Path to the podspec to be read",
                                        default_value: Dir['*.podspec*'].first,
                                        verify_block: proc do |value|
-                                         raise "File #{value} not found".red unless File.exist?(value)
+                                         UI.user_error!("File #{value} not found") unless File.exist?(value)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -22,14 +22,14 @@ module Fastlane
 
         if devices
           device_objs = devices.map do |k, v|
-            raise "Passed invalid UDID: #{v} for device: #{k}".red unless UDID_REGEXP =~ v
+            UI.user_error!("Passed invalid UDID: #{v} for device: #{k}") unless UDID_REGEXP =~ v
             Spaceship::Device.create!(name: k, udid: v)
           end
         elsif devices_file
           require 'csv'
 
           devices_file = CSV.read(File.expand_path(File.join(devices_file)), col_sep: "\t")
-          raise 'Please provide a file according to the Apple Sample UDID file (https://devimages.apple.com.edgekey.net/downloads/devices/Multiple-Upload-Samples.zip)'.red unless devices_file.first == ['Device ID', 'Device Name']
+          UI.user_error!("Please provide a file according to the Apple Sample UDID file (https://devimages.apple.com.edgekey.net/downloads/devices/Multiple-Upload-Samples.zip)") unless devices_file.first == ['Device ID', 'Device Name']
 
           UI.message("Fetching list of currently registered devices...")
           existing_devices = Spaceship::Device.all
@@ -37,13 +37,13 @@ module Fastlane
           device_objs = devices_file.drop(1).map do |device|
             next if existing_devices.map(&:udid).include?(device[0])
 
-            raise 'Invalid device line, please provide a file according to the Apple Sample UDID file (https://devimages.apple.com.edgekey.net/downloads/devices/Multiple-Upload-Samples.zip)'.red unless device.count == 2
-            raise "Passed invalid UDID: #{device[0]} for device: #{device[1]}".red unless UDID_REGEXP =~ device[0]
+            UI.user_error!("Invalid device line, please provide a file according to the Apple Sample UDID file (https://devimages.apple.com.edgekey.net/downloads/devices/Multiple-Upload-Samples.zip)") unless device.count == 2
+            UI.user_error!("Passed invalid UDID: #{device[0]} for device: #{device[1]}") unless UDID_REGEXP =~ device[0]
 
             Spaceship::Device.create!(name: device[1], udid: device[0])
           end
         else
-          raise 'You must pass either a valid `devices` or `devices_file`. Please check the readme.'.red
+          UI.user_error!("You must pass either a valid `devices` or `devices_file`. Please check the readme.")
         end
 
         UI.success("Successfully registered new devices.")
@@ -69,7 +69,7 @@ module Fastlane
                                        description: "Provide a path to the devices to register",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Could not find file '#{value}'".red unless File.exist?(value)
+                                         UI.user_error!("Could not find file '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :team_id,
                                        env_name: "FASTLANE_TEAM_ID",

--- a/fastlane/lib/fastlane/actions/reset_git_repo.rb
+++ b/fastlane/lib/fastlane/actions/reset_git_repo.rb
@@ -61,7 +61,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "Please pass an array only" unless value.kind_of? Array
+                                         UI.user_error!("Please pass an array only") unless value.kind_of? Array
                                        end),
           FastlaneCore::ConfigItem.new(key: :force,
                                        env_name: "FL_RESET_GIT_FORCE",

--- a/fastlane/lib/fastlane/actions/resign.rb
+++ b/fastlane/lib/fastlane/actions/resign.rb
@@ -9,7 +9,7 @@ module Fastlane
         if Sigh::Resign.resign(params[:ipa], params[:signing_identity], params[:provisioning_profile], params[:entitlements], params[:version], params[:display_name])
           UI.success('Successfully re-signed .ipa 🔏.')
         else
-          raise 'Failed to re-sign .ipa'.red
+          UI.user_error!("Failed to re-sign .ipa")
         end
       end
 
@@ -38,7 +38,7 @@ module Fastlane
                                        description: "Path to the ipa file to resign. Optional if you use the `gym` or `xcodebuild` action",
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        verify_block: proc do |value|
-                                         raise "Couldn't find ipa file at path '#{value}'".red unless File.exist?(value)
+                                         UI.user_error!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :signing_identity,
                                        env_name: "FL_RESIGN_SIGNING_IDENTITY",
@@ -60,7 +60,7 @@ module Fastlane
                                                  else [value]
                                                  end
                                          files.each do |file|
-                                           raise "Couldn't find provisiong profile at path '#{file}'".red unless File.exist?(file)
+                                           UI.user_error!("Couldn't find provisiong profile at path '#{file}'") unless File.exist?(file)
                                          end
                                        end),
           FastlaneCore::ConfigItem.new(key: :version,

--- a/fastlane/lib/fastlane/actions/restore_file.rb
+++ b/fastlane/lib/fastlane/actions/restore_file.rb
@@ -4,7 +4,7 @@ module Fastlane
       def self.run(params)
         path = params[:path]
         backup_path = "#{path}.back"
-        raise "Could not find file '#{backup_path}'" unless File.exist? backup_path
+        UI.user_error!("Could not find file '#{backup_path}'") unless File.exist? backup_path
         FileUtils.cp(backup_path, path, {preserve: true})
         FileUtils.rm(backup_path)
         UI.message("Successfully restored backup 📤")

--- a/fastlane/lib/fastlane/actions/s3.rb
+++ b/fastlane/lib/fastlane/actions/s3.rb
@@ -54,10 +54,10 @@ module Fastlane
         dsym_file = params[:dsym]
         s3_path = params[:path]
 
-        raise "No S3 access key given, pass using `access_key: 'key'`".red unless s3_access_key.to_s.length > 0
-        raise "No S3 secret access key given, pass using `secret_access_key: 'secret key'`".red unless s3_secret_access_key.to_s.length > 0
-        raise "No S3 bucket given, pass using `bucket: 'bucket'`".red unless s3_bucket.to_s.length > 0
-        raise "No IPA file path given, pass using `ipa: 'ipa path'`".red unless ipa_file.to_s.length > 0
+        UI.user_error!("No S3 access key given, pass using `access_key: 'key'`") unless s3_access_key.to_s.length > 0
+        UI.user_error!("No S3 secret access key given, pass using `secret_access_key: 'secret key'`") unless s3_secret_access_key.to_s.length > 0
+        UI.user_error!("No S3 bucket given, pass using `bucket: 'bucket'`") unless s3_bucket.to_s.length > 0
+        UI.user_error!("No IPA file path given, pass using `ipa: 'ipa path'`") unless ipa_file.to_s.length > 0
 
         plist_template_path = params[:plist_template_path]
         html_template_path = params[:html_template_path]

--- a/fastlane/lib/fastlane/actions/say.rb
+++ b/fastlane/lib/fastlane/actions/say.rb
@@ -4,7 +4,7 @@ module Fastlane
       def self.run(params)
         text = params.join(' ') if params.kind_of?(Array) # that's usually the case
         text = params if params.kind_of?(String)
-        raise "You can't call the `say` action as OneOff" unless text
+        UI.user_error!("You can't call the `say` action as OneOff") unless text
         text = text.tr("'", '"')
 
         Actions.sh("say '#{text}'")

--- a/fastlane/lib/fastlane/actions/set_github_release.rb
+++ b/fastlane/lib/fastlane/actions/set_github_release.rb
@@ -52,7 +52,7 @@ module Fastlane
             get_response = self.call_releases_endpoint("get", server_url, repo_name, "/releases/#{release_id}", api_token, nil)
             if get_response[:status] != 200
               UI.error("GitHub responded with #{response[:status]}:#{response[:body]}")
-              raise "Failed to fetch the newly created release, but it *has been created* successfully.".red
+              UI.user_error!("Failed to fetch the newly created release, but it *has been created* successfully.")
             end
 
             get_body = JSON.parse(get_response.body)
@@ -67,10 +67,10 @@ module Fastlane
           UI.error("Release on tag #{params[:tag_name]} already exists!")
         when 404
           UI.error(response.body)
-          raise "Repository #{params[:repository_name]} cannot be found, please double check its name and that you provided a valid API token (if it's a private repository).".red
+          UI.user_error!("Repository #{params[:repository_name]} cannot be found, please double check its name and that you provided a valid API token (if it's a private repository).")
         when 401
           UI.error(response.body)
-          raise "You are not authorized to access #{params[:repository_name]}, please make sure you provided a valid API token.".red
+          UI.user_error!("You are not authorized to access #{params[:repository_name]}, please make sure you provided a valid API token.")
         else
           if response[:status] != 200
             UI.error("GitHub responded with #{response[:status]}:#{response[:body]}")
@@ -90,7 +90,7 @@ module Fastlane
         absolute_path = File.absolute_path(asset_path)
 
         # check that the asset even exists
-        raise "Asset #{absolute_path} doesn't exist" unless File.exist?(absolute_path)
+        UI.user_error!("Asset #{absolute_path} doesn't exist") unless File.exist?(absolute_path)
 
         name = File.basename(absolute_path)
         response = nil
@@ -124,7 +124,7 @@ module Fastlane
           UI.success("Successfully uploaded #{name}.")
         else
           UI.error("GitHub responded with #{response[:status]}:#{response[:body]}")
-          raise "Failed to upload asset #{name} to GitHub."
+          UI.user_error!("Failed to upload asset #{name} to GitHub.")
         end
       end
 
@@ -136,7 +136,7 @@ module Fastlane
         when "get"
           response = Excon.get(url, headers: headers, body: body)
         else
-          raise "Unsupported method #{method}"
+          UI.user_error!("Unsupported method #{method}")
         end
         return response
       end
@@ -175,8 +175,8 @@ module Fastlane
                                        env_name: "FL_SET_GITHUB_RELEASE_REPOSITORY_NAME",
                                        description: "The path to your repo, e.g. 'fastlane/fastlane'",
                                        verify_block: proc do |value|
-                                         raise "Please only pass the path, e.g. 'fastlane/fastlane'".red if value.include? "github.com"
-                                         raise "Please only pass the path, e.g. 'fastlane/fastlane'".red if value.split('/').count != 2
+                                         UI.user_error!("Please only pass the path, e.g. 'fastlane/fastlane'") if value.include? "github.com"
+                                         UI.user_error!("Please only pass the path, e.g. 'fastlane/fastlane'") if value.split('/').count != 2
                                        end),
           FastlaneCore::ConfigItem.new(key: :server_url,
                                        env_name: "FL_GITHUB_RELEASE_SERVER_URL",
@@ -184,7 +184,7 @@ module Fastlane
                                        default_value: "https://api.github.com",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please include the protocol in the server url, e.g. https://your.github.server/api/v3".red unless value.include? "//"
+                                         UI.user_error!("Please include the protocol in the server url, e.g. https://your.github.server/api/v3") unless value.include? "//"
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_token,
                                        env_name: "FL_GITHUB_RELEASE_API_TOKEN",
@@ -230,7 +230,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "upload_assets must be an Array of paths to assets" unless value.kind_of? Array
+                                         UI.user_error!("upload_assets must be an Array of paths to assets") unless value.kind_of? Array
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/set_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/set_info_plist_value.rb
@@ -40,7 +40,7 @@ module Fastlane
                                        description: "Path to plist file you want to update",
                                        optional: false,
                                        verify_block: proc do |value|
-                                         raise "Couldn't find plist file at path '#{value}'".red unless File.exist?(value)
+                                         UI.user_error!("Couldn't find plist file at path '#{value}'") unless File.exist?(value)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -47,7 +47,7 @@ module Fastlane
           UI.success('Successfully sent Slack notification')
         else
           UI.verbose(result)
-          raise 'Error pushing Slack message, maybe the integration has no permission to post on this channel? Try removing the channel parameter in your Fastfile.'.red
+          UI.user_error!("Error pushing Slack message, maybe the integration has no permission to post on this channel? Try removing the channel parameter in your Fastfile.")
         end
       end
 
@@ -75,7 +75,7 @@ module Fastlane
                                        env_name: "SLACK_URL",
                                        description: "Create an Incoming WebHook for your Slack group",
                                        verify_block: proc do |value|
-                                         raise "Invalid URL, must start with https://" unless value.start_with? "https://"
+                                         UI.user_error!("Invalid URL, must start with https://") unless value.start_with? "https://"
                                        end),
           FastlaneCore::ConfigItem.new(key: :username,
                                        env_name: "FL_SLACK_USERNAME",

--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -89,7 +89,7 @@ Slather is available at https://github.com/venmo/slather
                                        env_name: "FL_SLATHER_PROJ", # The name of the environment variable
                                        description: "The project file that slather looks at", # a short description of this parameter
                                        verify_block: proc do |value|
-                                         raise "No project file specified, pass using `proj: 'Project.xcodeproj'`".red unless value and !value.empty?
+                                         UI.user_error!("No project file specified, pass using `proj: 'Project.xcodeproj'`") unless value and !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :scheme,
                                        env_name: "FL_SLATHER_SCHEME", # The name of the environment variable

--- a/fastlane/lib/fastlane/actions/sonar.rb
+++ b/fastlane/lib/fastlane/actions/sonar.rb
@@ -30,7 +30,7 @@ module Fastlane
       end
 
       def self.verify_sonar_runner_binary
-        raise "You have to install sonar-runner using `brew install sonar-runner`".red unless `which sonar-runner`.to_s.length > 0
+        UI.user_error!("You have to install sonar-runner using `brew install sonar-runner`") unless `which sonar-runner`.to_s.length > 0
       end
 
       #####################################################
@@ -52,7 +52,7 @@ module Fastlane
                                         description: "The path to your sonar project configuration file; defaults to `sonar-project.properties`", # default is enforced by sonar-runner binary
                                         optional: true,
                                         verify_block: proc do |value|
-                                          raise "Couldn't find file at path '#{value}'".red unless value.nil? or File.exist?(value)
+                                          UI.user_error!("Couldn't find file at path '#{value}'") unless value.nil? or File.exist?(value)
                                         end),
           FastlaneCore::ConfigItem.new(key: :project_key,
                                        env_name: "FL_SONAR_RUNNER_PROJECT_KEY",

--- a/fastlane/lib/fastlane/actions/splunkmint.rb
+++ b/fastlane/lib/fastlane/actions/splunkmint.rb
@@ -22,7 +22,7 @@ module Fastlane
 
       def self.fail_on_error(result)
         if result.include?("error")
-          raise "Server error, failed to upload the dSYM file".red
+          UI.user_error!("Server error, failed to upload the dSYM file")
         end
       end
 
@@ -45,11 +45,11 @@ module Fastlane
 
         if file_path
           expanded_file_path = File.expand_path(file_path)
-          raise "Couldn't find file at path '#{expanded_file_path}'".red unless File.exist?(expanded_file_path)
+          UI.user_error!("Couldn't find file at path '#{expanded_file_path}'") unless File.exist?(expanded_file_path)
 
           return expanded_file_path
         else
-          raise "Couldn't find any dSYM file".red
+          UI.user_error!("Couldn't find any dSYM file")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/ssh.rb
+++ b/fastlane/lib/fastlane/actions/ssh.rb
@@ -51,7 +51,7 @@ module Fastlane
             UI.important(['[SSH COMMAND]', cmd].join(': ')) if params[:log]
             return_value = ssh_exec!(ssh, cmd)
             UI.error("SSH Command failed '#{cmd}' Exit-Code: #{return_value[:exit_code]}") if return_value[:exit_code] > 0
-            raise "SSH Command failed" if return_value[:exit_code] > 0
+            UI.user_error!("SSH Command failed") if return_value[:exit_code] > 0
 
             stderr << return_value[:stderr]
             stdout << return_value[:stdout]

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -3,12 +3,12 @@ module Fastlane
     class SwiftlintAction < Action
       def self.run(params)
         if `which swiftlint`.to_s.length == 0 and !Helper.test?
-          raise "You have to install swiftlint using `brew install swiftlint`".red
+          UI.user_error!("You have to install swiftlint using `brew install swiftlint`")
         end
 
         version = Gem::Version.new(Helper.test? ? '0.0.0' : `swiftlint version`.chomp)
         if params[:mode] == :autocorrect and version < Gem::Version.new('0.5.0') and !Helper.test?
-          raise "Your version of swiftlint (#{version}) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`".red
+          UI.user_error!("Your version of swiftlint (#{version}) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
         end
 
         command = "swiftlint #{params[:mode]}"
@@ -17,7 +17,7 @@ module Fastlane
 
         if params[:files]
           if version < Gem::Version.new('0.5.1') and !Helper.test?
-            raise "Your version of swiftlint (#{version}) does not support list of files as input.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`".red
+            UI.user_error!("Your version of swiftlint (#{version}) does not support list of files as input.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
           end
 
           files = params[:files].map.with_index(0) { |f, i| "SCRIPT_INPUT_FILE_#{i}=#{f.shellescape}" }.join(" ")

--- a/fastlane/lib/fastlane/actions/team_id.rb
+++ b/fastlane/lib/fastlane/actions/team_id.rb
@@ -7,7 +7,7 @@ module Fastlane
       def self.run(params)
         params = nil unless params.kind_of? Array
         team = (params || []).first
-        raise "Please pass your Team ID (e.g. team_id 'Q2CBPK58CA')".red unless team.to_s.length > 0
+        UI.user_error!("Please pass your Team ID (e.g. team_id 'Q2CBPK58CA')") unless team.to_s.length > 0
 
         UI.message("Setting Team ID to '#{team}' for all build steps")
 

--- a/fastlane/lib/fastlane/actions/team_name.rb
+++ b/fastlane/lib/fastlane/actions/team_name.rb
@@ -7,7 +7,7 @@ module Fastlane
       def self.run(params)
         params = nil unless params.kind_of? Array
         team = (params || []).first
-        raise "Please pass your Team Name (e.g. team_name 'Felix Krause')".red unless team.to_s.length > 0
+        UI.user_error!("Please pass your Team Name (e.g. team_name 'Felix Krause')") unless team.to_s.length > 0
 
         UI.message("Setting Team Name to '#{team}' for all build steps")
 

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -22,7 +22,7 @@ module Fastlane
           UI.success("Build URL: #{Actions.lane_context[SharedValues::TESTFAIRY_BUILD_URL]}")
           UI.success("Build successfully uploaded to TestFairy.")
         else
-          raise 'Error when trying to upload ipa to TestFairy'.red
+          UI.user_error!("Error when trying to upload ipa to TestFairy")
         end
       end
 
@@ -55,14 +55,14 @@ module Fastlane
                                        env_name: "FL_TESTFAIRY_API_KEY", # The name of the environment variable
                                        description: "API Key for TestFairy", # a short description of this parameter
                                        verify_block: proc do |value|
-                                         raise "No API key for TestFairy given, pass using `api_key: 'key'`".red unless value.to_s.length > 0
+                                         UI.user_error!("No API key for TestFairy given, pass using `api_key: 'key'`") unless value.to_s.length > 0
                                        end),
           FastlaneCore::ConfigItem.new(key: :ipa,
                                        env_name: 'TESTFAIRY_IPA_PATH',
                                        description: 'Path to your IPA file. Optional if you use the `gym` or `xcodebuild` action',
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        verify_block: proc do |value|
-                                         raise "Couldn't find ipa file at path '#{value}'".red unless File.exist?(value)
+                                         UI.user_error!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :comment,
                                        env_name: "FL_TESTFAIRY_COMMENT",

--- a/fastlane/lib/fastlane/actions/testmunk.rb
+++ b/fastlane/lib/fastlane/actions/testmunk.rb
@@ -28,7 +28,7 @@ module Fastlane
         if response
           UI.success('Your tests are being executed right now. Please wait for the mail with results and decide if you want to continue.')
         else
-          raise 'Something went wrong while uploading your app to Testmunk'.red
+          UI.user_error!("Something went wrong while uploading your app to Testmunk")
         end
       end
 
@@ -43,25 +43,25 @@ module Fastlane
                                        description: "Path to IPA",
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        verify_block: proc do |value|
-                                         raise "Please pass to existing ipa" unless File.exist? value
+                                         UI.user_error!("Please pass to existing ipa") unless File.exist? value
                                        end),
           FastlaneCore::ConfigItem.new(key: :email,
                                        env_name: "TESTMUNK_EMAIL",
                                        description: "Your email address",
                                        verify_block: proc do |value|
-                                         raise "Please pass your Testmunk email address using `ENV['TESTMUNK_EMAIL'] = 'value'`" unless value
+                                         UI.user_error!("Please pass your Testmunk email address using `ENV['TESTMUNK_EMAIL'] = 'value'`") unless value
                                        end),
           FastlaneCore::ConfigItem.new(key: :api,
                                        env_name: "TESTMUNK_API",
                                        description: "Testmunk API Key",
                                        verify_block: proc do |value|
-                                         raise "Please pass your Testmunk API Key using `ENV['TESTMUNK_API'] = 'value'`" unless value
+                                         UI.user_error!("Please pass your Testmunk API Key using `ENV['TESTMUNK_API'] = 'value'`") unless value
                                        end),
           FastlaneCore::ConfigItem.new(key: :app,
                                        env_name: "TESTMUNK_APP",
                                        description: "Testmunk App Name",
                                        verify_block: proc do |value|
-                                         raise "Please pass your Testmunk app name using `ENV['TESTMUNK_APP'] = 'value'`" unless value
+                                         UI.user_error!("Please pass your Testmunk app name using `ENV['TESTMUNK_APP'] = 'value'`") unless value
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/tryouts.rb
+++ b/fastlane/lib/fastlane/actions/tryouts.rb
@@ -19,7 +19,7 @@ module Fastlane
           UI.success('Build successfully uploaded to Tryouts!')
           UI.message("Release download url: #{response.body['download_url']}") if response.body["download_url"]
         else
-          raise "Error when trying to upload build file to Tryouts: #{response.body}".red
+          UI.user_error!("Error when trying to upload build file to Tryouts: #{response.body}")
         end
       end
 
@@ -68,20 +68,20 @@ module Fastlane
                                      env_name: "TRYOUTS_APP_ID",
                                      description: "Tryouts application hash",
                                      verify_block: proc do |value|
-                                       raise "No application identifier for Tryouts given, pass using `app_id: 'application id'`".red unless value and !value.empty?
+                                       UI.user_error!("No application identifier for Tryouts given, pass using `app_id: 'application id'`") unless value and !value.empty?
                                      end),
           FastlaneCore::ConfigItem.new(key: :api_token,
                                      env_name: "TRYOUTS_API_TOKEN",
                                      description: "API Token for Tryouts Access",
                                      verify_block: proc do |value|
-                                       raise "No API token for Tryouts given, pass using `api_token: 'token'`".red unless value and !value.empty?
+                                       UI.user_error!("No API token for Tryouts given, pass using `api_token: 'token'`") unless value and !value.empty?
                                      end),
           FastlaneCore::ConfigItem.new(key: :build_file,
                                      env_name: "TRYOUTS_BUILD_FILE",
                                      description: "Path to your IPA or APK file. Optional if you use the `gym` or `xcodebuild` action",
                                      default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                      verify_block: proc do |value|
-                                       raise "Couldn't find build file at path '#{value}'".red unless File.exist?(value)
+                                       UI.user_error!("Couldn't find build file at path '#{value}'") unless File.exist?(value)
                                      end),
           FastlaneCore::ConfigItem.new(key: :notes,
                                      env_name: "TRYOUTS_NOTES",
@@ -92,7 +92,7 @@ module Fastlane
                                      env_name: "TRYOUTS_NOTES_PATH",
                                      description: "Release notes text file path. Overrides the :notes paramether",
                                      verify_block: proc do |value|
-                                       raise "Couldn't find notes file at path '#{value}'".red unless File.exist?(value)
+                                       UI.user_error!("Couldn't find notes file at path '#{value}'") unless File.exist?(value)
                                      end,
                                      optional: true),
           FastlaneCore::ConfigItem.new(key: :notify,
@@ -105,7 +105,7 @@ module Fastlane
                                      description: "2 to make your release public. Release will be distributed to available testers. 1 to make your release private. Release won't be distributed to testers. This also prevents release from showing up for SDK update",
                                      verify_block: proc do |value|
                                        available_options = ["1", "2"]
-                                       raise "'#{value}' is not a valid 'status' value. Available options are #{available_options.join(', ')}".red unless available_options.include?(value.to_s)
+                                       UI.user_error!("'#{value}' is not a valid 'status' value. Available options are #{available_options.join(', ')}") unless available_options.include?(value.to_s)
                                      end,
                                      is_string: false,
                                      default_value: 2)

--- a/fastlane/lib/fastlane/actions/typetalk.rb
+++ b/fastlane/lib/fastlane/actions/typetalk.rb
@@ -11,7 +11,7 @@ module Fastlane
         }.merge(params || {})
 
         [:message, :topic_id, :typetalk_token].each do |key|
-          raise "No #{key} given.".red unless options[key]
+          UI.user_error!("No #{key} given.") unless options[key]
         end
 
         emoticon = (options[:success] ? ':smile:' : ':rage:')
@@ -47,7 +47,7 @@ module Fastlane
         when 200, 204
           true
         else
-          raise "Could not sent Typetalk notification".red
+          UI.user_error!("Could not sent Typetalk notification")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/unlock_keychain.rb
+++ b/fastlane/lib/fastlane/actions/unlock_keychain.rb
@@ -63,7 +63,7 @@ module Fastlane
           end
         end
 
-        raise "Could not find the keychain file in: #{possible_locations}".red
+        UI.user_error!("Could not find the keychain file in: #{possible_locations}")
       end
 
       #####################################################

--- a/fastlane/lib/fastlane/actions/update_app_group_identifiers.rb
+++ b/fastlane/lib/fastlane/actions/update_app_group_identifiers.rb
@@ -12,15 +12,15 @@ module Fastlane
         UI.message("New App Group Identifiers: #{params[:app_group_identifiers]}")
 
         entitlements_file = params[:entitlements_file]
-        raise "Could not find entitlements file at path '#{entitlements_file}'".red unless File.exist?(entitlements_file)
+        UI.user_error!("Could not find entitlements file at path '#{entitlements_file}'") unless File.exist?(entitlements_file)
 
         # parse entitlements
         result = Plist.parse_xml(entitlements_file)
-        raise "Entitlements file at '#{entitlements_file}' cannot be parsed.".red unless result
+        UI.user_error!("Entitlements file at '#{entitlements_file}' cannot be parsed.") unless result
 
         # get app group field
         app_group_field = result['com.apple.security.application-groups']
-        raise 'No existing App group field specified. Please specify an App Group in the entitlements file.'.red unless app_group_field
+        UI.user_error!("No existing App group field specified. Please specify an App Group in the entitlements file.") unless app_group_field
 
         # set new app group identifiers
         UI.message("Old App Group Identifiers: #{app_group_field}")
@@ -43,15 +43,15 @@ module Fastlane
                                        env_name: "FL_UPDATE_APP_GROUP_IDENTIFIER_ENTITLEMENTS_FILE_PATH", # The name of the environment variable
                                        description: "The path to the entitlement file which contains the app group identifiers", # a short description of this parameter
                                        verify_block: proc do |value|
-                                         raise "Please pass a path to an entitlements file. ".red unless value.include? ".entitlements"
-                                         raise "Could not find entitlements file".red if !File.exist?(value) and !Helper.is_test?
+                                         UI.user_error!("Please pass a path to an entitlements file. ") unless value.include? ".entitlements"
+                                         UI.user_error!("Could not find entitlements file") if !File.exist?(value) and !Helper.is_test?
                                        end),
           FastlaneCore::ConfigItem.new(key: :app_group_identifiers,
                                        env_name: "FL_UPDATE_APP_GROUP_IDENTIFIER_APP_GROUP_IDENTIFIERS",
                                        description: "An Array of unique identifiers for the app groups. Eg. ['group.com.test.testapp']",
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         raise "The parameter app_group_identifiers need to be an Array.".red unless value.kind_of? Array
+                                         UI.user_error!("The parameter app_group_identifiers need to be an Array.") unless value.kind_of? Array
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/update_app_identifier.rb
+++ b/fastlane/lib/fastlane/actions/update_app_identifier.rb
@@ -10,7 +10,7 @@ module Fastlane
 
         # Read existing plist file
         info_plist_path = File.join(params[:xcodeproj], '..', params[:plist_path])
-        raise "Couldn't find info plist file at path '#{params[:plist_path]}'".red unless File.exist?(info_plist_path)
+        UI.user_error!("Couldn't find info plist file at path '#{params[:plist_path]}'") unless File.exist?(info_plist_path)
         plist = Plist.parse_xml(info_plist_path)
 
         # Check if current app identifier product bundle identifier
@@ -21,10 +21,10 @@ module Fastlane
 
           # Fetch the build configuration objects
           configs = project.objects.select { |obj| obj.isa == 'XCBuildConfiguration' && !obj.build_settings[identifier_key].nil? }
-          raise "Info plist uses $(#{identifier_key}), but xcodeproj does not".red unless configs.count > 0
+          UI.user_error!("Info plist uses $(#{identifier_key}), but xcodeproj does not") unless configs.count > 0
 
           configs = configs.select { |obj| obj.build_settings[info_plist_key] == params[:plist_path] }
-          raise "Xcodeproj doesn't have configuration with info plist #{params[:plist_path]}.".red unless configs.count > 0
+          UI.user_error!("Xcodeproj doesn't have configuration with info plist #{params[:plist_path]}.") unless configs.count > 0
 
           # For each of the build configurations, set app identifier
           configs.each do |c|
@@ -66,14 +66,14 @@ module Fastlane
                                        description: "Path to your Xcode project",
                                        default_value: Dir['*.xcodeproj'].first,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red unless value.end_with?(".xcodeproj")
-                                         raise "Could not find Xcode project".red unless File.exist?(value)
+                                         UI.user_error!("Please pass the path to the project, not the workspace") unless value.end_with?(".xcodeproj")
+                                         UI.user_error!("Could not find Xcode project") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :plist_path,
                                        env_name: "FL_UPDATE_APP_IDENTIFIER_PLIST_PATH",
                                        description: "Path to info plist, relative to your Xcode project",
                                        verify_block: proc do |value|
-                                         raise "Invalid plist file".red unless value[-6..-1].casecmp(".plist").zero?
+                                         UI.user_error!("Invalid plist file") unless value[-6..-1].casecmp(".plist").zero?
                                        end),
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        env_name: 'FL_UPDATE_APP_IDENTIFIER',

--- a/fastlane/lib/fastlane/actions/update_info_plist.rb
+++ b/fastlane/lib/fastlane/actions/update_info_plist.rb
@@ -19,7 +19,7 @@ module Fastlane
 
           # Read existing plist file
           info_plist_path = File.join(folder, "..", params[:plist_path])
-          raise "Couldn't find info plist file at path '#{params[:plist_path]}'".red unless File.exist?(info_plist_path)
+          UI.user_error!("Couldn't find info plist file at path '#{params[:plist_path]}'") unless File.exist?(info_plist_path)
           plist = Plist.parse_xml(info_plist_path)
 
           # Update plist values
@@ -59,14 +59,14 @@ module Fastlane
                                        description: "Path to your Xcode project",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Please pass the path to the project, not the workspace".red if value.end_with? ".xcworkspace"
-                                         raise "Could not find Xcode project".red unless File.exist?(value)
+                                         UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
+                                         UI.user_error!("Could not find Xcode project") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :plist_path,
                                        env_name: "FL_UPDATE_PLIST_PATH",
                                        description: "Path to info plist",
                                        verify_block: proc do |value|
-                                         raise "Invalid plist file".red unless value[-6..-1].casecmp(".plist").zero?
+                                         UI.user_error!("Invalid plist file") unless value[-6..-1].casecmp(".plist").zero?
                                        end),
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        env_name: 'FL_UPDATE_PLIST_APP_IDENTIFIER',

--- a/fastlane/lib/fastlane/actions/update_project_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/update_project_code_signing.rb
@@ -11,7 +11,7 @@ module Fastlane
 
         path = params[:path]
         path = File.join(path, "project.pbxproj")
-        raise "Could not find path to project config '#{path}'. Pass the path to your project (not workspace)!".red unless File.exist?(path)
+        UI.user_error!("Could not find path to project config '#{path}'. Pass the path to your project (not workspace)!") unless File.exist?(path)
 
         UI.message("Updating provisioning profile UDID (#{params[:udid]}) for the given project '#{path}'")
 
@@ -35,7 +35,7 @@ module Fastlane
                                        env_name: "FL_PROJECT_SIGNING_PROJECT_PATH",
                                        description: "Path to your Xcode project",
                                        verify_block: proc do |value|
-                                         raise "Path is invalid".red unless File.exist?(value)
+                                         UI.user_error!("Path is invalid") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :udid,
                                        env_name: "FL_PROJECT_SIGNING_UDID",

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -15,7 +15,7 @@ module Fastlane
 
         # validate folder
         project_file_path = File.join(folder, "project.pbxproj")
-        raise "Could not find path to project config '#{project_file_path}'. Pass the path to your project (not workspace)!".red unless File.exist?(project_file_path)
+        UI.user_error!("Could not find path to project config '#{project_file_path}'. Pass the path to your project (not workspace)!") unless File.exist?(project_file_path)
 
         # download certificate
         unless File.exist?(params[:certificate])
@@ -31,7 +31,7 @@ module Fastlane
         profile = File.read(params[:profile])
         p7 = OpenSSL::PKCS7.new(profile)
         store = OpenSSL::X509::Store.new
-        raise "Could not find valid certificate at '#{params[:certificate]}'" unless File.size(params[:certificate]) > 0
+        UI.user_error!("Could not find valid certificate at '#{params[:certificate]}'") unless File.size(params[:certificate]) > 0
         cert = OpenSSL::X509::Certificate.new(File.read(params[:certificate]))
         store.add_cert(cert)
         p7.verify([cert], store)
@@ -94,14 +94,14 @@ module Fastlane
                                        description: "Path to your Xcode project",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         raise "Path to xcode project is invalid".red unless File.exist?(value)
+                                         UI.user_error!("Path to xcode project is invalid") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :profile,
                                        env_name: "FL_PROJECT_PROVISIONING_PROFILE_FILE",
                                        description: "Path to provisioning profile (.mobileprovision)",
                                        default_value: Actions.lane_context[SharedValues::SIGH_PROFILE_PATH],
                                        verify_block: proc do |value|
-                                         raise "Path to provisioning profile is invalid".red unless File.exist?(value)
+                                         UI.user_error!("Path to provisioning profile is invalid") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :target_filter,
                                        env_name: "FL_PROJECT_PROVISIONING_PROFILE_TARGET_FILTER",

--- a/fastlane/lib/fastlane/actions/update_project_team.rb
+++ b/fastlane/lib/fastlane/actions/update_project_team.rb
@@ -7,7 +7,7 @@ module Fastlane
       def self.run(params)
         path = params[:path]
         path = File.join(path, "project.pbxproj")
-        raise "Could not find path to project config '#{path}'. Pass the path to your project (not workspace)!".red unless File.exist?(path)
+        UI.user_error!("Could not find path to project config '#{path}'. Pass the path to your project (not workspace)!") unless File.exist?(path)
 
         UI.message("Updating development team (#{params[:teamid]}) for the given project '#{path}'")
 
@@ -31,7 +31,7 @@ module Fastlane
                                        env_name: "FL_PROJECT_SIGNING_PROJECT_PATH",
                                        description: "Path to your Xcode project",
                                        verify_block: proc do |value|
-                                         raise "Path is invalid".red unless File.exist?(value)
+                                         UI.user_error!("Path is invalid") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :teamid,
                                        env_name: "FL_PROJECT_TEAM_ID",

--- a/fastlane/lib/fastlane/actions/update_url_schemes.rb
+++ b/fastlane/lib/fastlane/actions/update_url_schemes.rb
@@ -25,7 +25,7 @@ module Fastlane
             is_string: true,
             optional: false,
             verify_block: proc do |path|
-              raise "Could not find plist at path '#{path}'".red unless File.exist?(path)
+              UI.user_error!("Could not find plist at path '#{path}'") unless File.exist?(path)
             end
           ),
 

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
@@ -69,19 +69,19 @@ module Fastlane
                                        env_name: "SENTRY_API_KEY",
                                        description: "API Key for Sentry",
                                        verify_block: proc do |value|
-                                         raise "No API token for SentryAction given, pass using `api_key: 'key'`".red unless value and !value.empty?
+                                         UI.user_error!("No API token for SentryAction given, pass using `api_key: 'key'`") unless value and !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :org_slug,
                                        env_name: "SENTRY_ORG_SLUG",
                                        description: "Organization slug for Sentry project",
                                        verify_block: proc do |value|
-                                         raise "No organization slug for SentryAction given, pass using `org_slug: 'org'`".red unless value and !value.empty?
+                                         UI.user_error!("No organization slug for SentryAction given, pass using `org_slug: 'org'`") unless value and !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :project_slug,
                                        env_name: "SENTRY_PROJECT_SLUG",
                                        description: "Prgoject slug for Sentry",
                                        verify_block: proc do |value|
-                                         raise "No project slug for SentryAction given, pass using `project_slug: 'project'`".red unless value and !value.empty?
+                                         UI.user_error!("No project slug for SentryAction given, pass using `project_slug: 'project'`") unless value and !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :dsym_path,
                                        env_name: "SENTRY_DSYM_PATH",

--- a/fastlane/lib/fastlane/actions/verify_build.rb
+++ b/fastlane/lib/fastlane/actions/verify_build.rb
@@ -23,11 +23,11 @@ module Fastlane
 
       def self.app_path(params, dir)
         ipa_path = params[:ipa_path] || Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] || ''
-        raise "Unable to find ipa file '#{ipa_path}'." unless File.exist?(ipa_path)
+        UI.user_error!("Unable to find ipa file '#{ipa_path}'.") unless File.exist?(ipa_path)
         ipa_path = File.expand_path(ipa_path)
 
         `unzip '#{ipa_path}' -d #{dir}`
-        raise "Unable to unzip ipa".red unless $? == 0
+        UI.user_error!("Unable to unzip ipa") unless $? == 0
 
         app_path = File.expand_path("#{dir}/Payload/*.app")
 
@@ -36,7 +36,7 @@ module Fastlane
 
       def self.gather_cert_info(app_path)
         cert_info = `codesign -vv -d #{app_path} 2>&1`
-        raise "Unable to verify code signing".red unless $? == 0
+        UI.user_error!("Unable to verify code signing") unless $? == 0
 
         values = {}
 
@@ -59,7 +59,7 @@ module Fastlane
 
       def self.update_with_profile_info(app_path, values)
         profile = `cat #{app_path}/embedded.mobileprovision | security cms -D`
-        raise "Unable to extract profile".red unless $? == 0
+        UI.user_error!("Unable to extract profile") unless $? == 0
 
         plist = Plist.parse_xml(profile)
 
@@ -70,8 +70,8 @@ module Fastlane
         application_identifier_prefix = plist['ApplicationIdentifierPrefix'][0]
         full_bundle_identifier = "#{application_identifier_prefix}.#{values['bundle_identifier']}"
 
-        raise "Inconsistent identifier found; #{plist['Entitlements']['application-identifier']}, found in the embedded.mobileprovision file, should match #{full_bundle_identifier}, which is embedded in the codesign identity" unless plist['Entitlements']['application-identifier'] == full_bundle_identifier
-        raise "Inconsistent identifier found" unless plist['Entitlements']['com.apple.developer.team-identifier'] == values['team_identifier']
+        UI.user_error!("Inconsistent identifier found; #{plist['Entitlements']['application-identifier']}, found in the embedded.mobileprovision file, should match #{full_bundle_identifier}, which is embedded in the codesign identity") unless plist['Entitlements']['application-identifier'] == full_bundle_identifier
+        UI.user_error!("Inconsistent identifier found") unless plist['Entitlements']['com.apple.developer.team-identifier'] == values['team_identifier']
 
         values
       end
@@ -103,22 +103,22 @@ module Fastlane
 
       def self.evaulate(params, values)
         if params[:provisioning_type]
-          raise "Mismatched provisioning_type. Required: '#{params[:provisioning_type]}''; Found: '#{values['provisioning_type']}'".red unless params[:provisioning_type] == values['provisioning_type']
+          UI.user_error!("Mismatched provisioning_type. Required: '#{params[:provisioning_type]}''; Found: '#{values['provisioning_type']}'") unless params[:provisioning_type] == values['provisioning_type']
         end
         if params[:provisioning_uuid]
-          raise "Mismatched provisioning_uuid. Required: '#{params[:provisioning_uuid]}'; Found: '#{values['provisioning_uuid']}'".red unless params[:provisioning_uuid] == values['provisioning_uuid']
+          UI.user_error!("Mismatched provisioning_uuid. Required: '#{params[:provisioning_uuid]}'; Found: '#{values['provisioning_uuid']}'") unless params[:provisioning_uuid] == values['provisioning_uuid']
         end
         if params[:team_identifier]
-          raise "Mismatched team_identifier. Required: '#{params[:team_identifier]}'; Found: '#{values['team_identifier']}'".red unless params[:team_identifier] == values['team_identifier']
+          UI.user_error!("Mismatched team_identifier. Required: '#{params[:team_identifier]}'; Found: '#{values['team_identifier']}'") unless params[:team_identifier] == values['team_identifier']
         end
         if params[:team_name]
-          raise "Mismatched team_name. Required: '#{params[:team_name]}'; Found: 'values['team_name']'".red unless params[:team_name] == values['team_name']
+          UI.user_error!("Mismatched team_name. Required: '#{params[:team_name]}'; Found: 'values['team_name']'") unless params[:team_name] == values['team_name']
         end
         if params[:app_name]
-          raise "Mismatched app_name. Required: '#{params[:app_name]}'; Found: '#{values['app_name']}'".red unless params[:app_name] == values['app_name']
+          UI.user_error!("Mismatched app_name. Required: '#{params[:app_name]}'; Found: '#{values['app_name']}'") unless params[:app_name] == values['app_name']
         end
         if params[:bundle_identifier]
-          raise "Mismatched bundle_identifier. Required: '#{params[:bundle_identifier]}'; Found: '#{values['bundle_identifier']}'".red unless params[:bundle_identifier] == values['bundle_identifier']
+          UI.user_error!("Mismatched bundle_identifier. Required: '#{params[:bundle_identifier]}'; Found: '#{values['bundle_identifier']}'") unless params[:bundle_identifier] == values['bundle_identifier']
         end
 
         UI.success "Build is verified, have a 🍪."
@@ -143,7 +143,7 @@ module Fastlane
                                        optional: true,
                                        verify_block: proc do |value|
                                          av = %w(distribution development)
-                                         raise "Unsupported provisioning_type, must be: #{av}" unless av.include?(value)
+                                         UI.user_error!("Unsupported provisioning_type, must be: #{av}") unless av.include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :provisioning_uuid,
                                        env_name: "FL_VERIFY_BUILD_PROVISIONING_UUID",

--- a/fastlane/lib/fastlane/actions/verify_xcode.rb
+++ b/fastlane/lib/fastlane/actions/verify_xcode.rb
@@ -64,7 +64,7 @@ module Fastlane
         UI.error("This might be a false alarm, if so, please submit an issue on GitHub")
         UI.error("The following information couldn't be found:")
         UI.error(error)
-        raise "The Xcode installation at path '#{xcode_path}' might be compromised."
+        UI.user_error!("The Xcode installation at path '#{xcode_path}' might be compromised.")
       end
 
       #####################################################
@@ -90,7 +90,7 @@ module Fastlane
                                        description: "The path to the Xcode installation to test",
                                        default_value: File.expand_path('../../', FastlaneCore::Helper.xcode_path),
                                        verify_block: proc do |value|
-                                         raise "Couldn't find Xcode at path '#{value}'".red unless File.exist?(value)
+                                         UI.user_error!("Couldn't find Xcode at path '#{value}'") unless File.exist?(value)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/version_bump_podspec.rb
+++ b/fastlane/lib/fastlane/actions/version_bump_podspec.rb
@@ -8,7 +8,7 @@ module Fastlane
       def self.run(params)
         podspec_path = params[:path]
 
-        raise "Could not find podspec file at path #{podspec_path}".red unless File.exist? podspec_path
+        UI.user_error!("Could not find podspec file at path #{podspec_path}") unless File.exist? podspec_path
 
         version_podspec_file = Helper::PodspecHelper.new(podspec_path)
 
@@ -45,14 +45,14 @@ module Fastlane
                                        description: "You must specify the path to the podspec file to update",
                                        default_value: Dir["*.podspec"].last,
                                        verify_block: proc do |value|
-                                         raise "Please pass a path to the `version_bump_podspec` action".red if value.length == 0
+                                         UI.user_error!("Please pass a path to the `version_bump_podspec` action") if value.length == 0
                                        end),
           FastlaneCore::ConfigItem.new(key: :bump_type,
                                        env_name: "FL_VERSION_BUMP_PODSPEC_BUMP_TYPE",
                                        description: "The type of this version bump. Available: patch, minor, major",
                                        default_value: "patch",
                                        verify_block: proc do |value|
-                                         raise "Available values are 'patch', 'minor' and 'major'" unless ['patch', 'minor', 'major'].include? value
+                                         UI.user_error!("Available values are 'patch', 'minor' and 'major'") unless ['patch', 'minor', 'major'].include? value
                                        end),
           FastlaneCore::ConfigItem.new(key: :version_number,
                                        env_name: "FL_VERSION_BUMP_PODSPEC_VERSION_NUMBER",

--- a/fastlane/lib/fastlane/actions/version_get_podspec.rb
+++ b/fastlane/lib/fastlane/actions/version_get_podspec.rb
@@ -4,7 +4,7 @@ module Fastlane
       def self.run(params)
         podspec_path = params[:path]
 
-        raise "Could not find podspec file at path '#{podspec_path}'".red unless File.exist? podspec_path
+        UI.user_error!("Could not find podspec file at path '#{podspec_path}'") unless File.exist? podspec_path
 
         version_podspec_file = Helper::PodspecHelper.new(podspec_path)
 
@@ -27,7 +27,7 @@ module Fastlane
                                        is_string: true,
                                        default_value: Dir["*.podspec"].last,
                                        verify_block: proc do |value|
-                                         raise "Please pass a path to the `version_get_podspec` action".red if value.length == 0
+                                         UI.user_error!("Please pass a path to the `version_get_podspec` action") if value.length == 0
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/xcode_install.rb
+++ b/fastlane/lib/fastlane/actions/xcode_install.rb
@@ -20,7 +20,7 @@ module Fastlane
         end
 
         xcode = installer.installed_versions.find { |x| x.version == params[:version] }
-        raise "Could not find Xcode with version '#{params[:version]}'" unless xcode
+        UI.user_error!("Could not find Xcode with version '#{params[:version]}'") unless xcode
         UI.message("Using Xcode #{params[:version]} on path '#{xcode.path}'")
         xcode.approve_license
 

--- a/fastlane/lib/fastlane/actions/xcode_select.rb
+++ b/fastlane/lib/fastlane/actions/xcode_select.rb
@@ -23,10 +23,10 @@ module Fastlane
         xcode_path = (params || []).first
 
         # Verify that a param was passed in
-        raise "Path to Xcode application required (e.x. \"/Applications/Xcode.app\")".red unless xcode_path.to_s.length > 0
+        UI.user_error!("Path to Xcode application required (e.x. \"/Applications/Xcode.app\")") unless xcode_path.to_s.length > 0
 
         # Verify that a path to a directory was passed in
-        raise "Path '#{xcode_path}' doesn't exist".red unless Dir.exist?(xcode_path)
+        UI.user_error!("Path '#{xcode_path}' doesn't exist") unless Dir.exist?(xcode_path)
 
         UI.message("Setting Xcode version to #{xcode_path} for all build steps")
 

--- a/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
+++ b/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
@@ -37,7 +37,7 @@ module Fastlane
 
         # match the bot name with a found bot, otherwise fail
         found_bots = bots.select { |bot| bot['name'] == bot_name }
-        raise "Failed to find a Bot with name #{bot_name} on server #{host}, only available Bots: #{bot_names}".red if found_bots.count == 0
+        UI.user_error!("Failed to find a Bot with name #{bot_name} on server #{host}, only available Bots: #{bot_names}") if found_bots.count == 0
 
         bot = found_bots[0]
 
@@ -45,12 +45,12 @@ module Fastlane
 
         # we have our bot, get finished integrations, sorted from newest to oldest
         integrations = xcs.fetch_integrations(bot['_id']).select { |i| i['currentStep'] == 'completed' }
-        raise "Failed to find any completed integration for Bot \"#{bot_name}\"".red if (integrations || []).count == 0
+        UI.user_error!("Failed to find any completed integration for Bot \"#{bot_name}\"") if (integrations || []).count == 0
 
         # if no integration number is specified, pick the newest one (this is sorted from newest to oldest)
         if integration_number_override
           integration = integrations.find { |i| i['number'] == integration_number_override }
-          raise "Specified integration number #{integration_number_override} does not exist.".red unless integration
+          UI.user_error!("Specified integration number #{integration_number_override} does not exist.") unless integration
         else
           integration = integrations.first
         end
@@ -61,7 +61,7 @@ module Fastlane
 
         # fetch assets for this integration
         assets_path = xcs.fetch_assets(integration['_id'], target_folder, self)
-        raise "Failed to fetch assets for integration #{integration['number']}." unless assets_path
+        UI.user_error!("Failed to fetch assets for integration #{integration['number']}.") unless assets_path
 
         asset_entries = Dir.entries(assets_path).map { |i| File.join(assets_path, i) }
 
@@ -117,14 +117,14 @@ module Fastlane
 
         def fetch_all_bots
           response = get_endpoint('/bots')
-          raise "You are unauthorized to access data on #{@host}, please check that you're passing in a correct username and password.".red if response.status == 401
-          raise "Failed to fetch Bots from Xcode Server at #{@host}, response: #{response.status}: #{response.body}.".red if response.status != 200
+          UI.user_error!("You are unauthorized to access data on #{@host}, please check that you're passing in a correct username and password.") if response.status == 401
+          UI.user_error!("Failed to fetch Bots from Xcode Server at #{@host}, response: #{response.status}: #{response.body}.") if response.status != 200
           JSON.parse(response.body)['results']
         end
 
         def fetch_integrations(bot_id)
           response = get_endpoint("/bots/#{bot_id}/integrations?last=10")
-          raise "Failed to fetch Integrations for Bot #{bot_id} from Xcode Server at #{@host}, response: #{response.status}: #{response.body}".red if response.status != 200
+          UI.user_error!("Failed to fetch Integrations for Bot #{bot_id} from Xcode Server at #{@host}, response: #{response.status}: #{response.body}") if response.status != 200
           JSON.parse(response.body)['results']
         end
 
@@ -145,8 +145,8 @@ module Fastlane
             response = self.get_endpoint("/integrations/#{integration_id}/assets", streamer)
             f.close
 
-            raise "Integration doesn't have any assets (it probably never ran).".red if response.status == 500
-            raise "Failed to fetch Assets zip for Integration #{integration_id} from Xcode Server at #{@host}, response: #{response.status}: #{response.body}".red if response.status != 200
+            UI.user_error!("Integration doesn't have any assets (it probably never ran).") if response.status == 500
+            UI.user_error!("Failed to fetch Assets zip for Integration #{integration_id} from Xcode Server at #{@host}, response: #{response.status}: #{response.body}") if response.status != 200
 
             # unzip it, it's a .tar.gz file
             out_folder = File.join(dir, "out_#{rand(1000000)}")
@@ -161,7 +161,7 @@ module Fastlane
             # rename the folder in out_folder to asset_foldername
             found_folder = Dir.entries(out_folder).select { |item| item != '.' && item != '..' }[0]
 
-            raise "Internal error, couldn't find unzipped folder".red if found_folder.nil?
+            UI.user_error!("Internal error, couldn't find unzipped folder") if found_folder.nil?
 
             unzipped_folder_temp_name = File.join(out_folder, found_folder)
             unzipped_folder = File.join(out_folder, asset_foldername)

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -57,7 +57,7 @@ module Fastlane
 
       def self.run(params)
         unless Helper.test?
-          raise "xcodebuild not installed".red if `which xcodebuild`.length == 0
+          UI.user_error!("xcodebuild not installed") if `which xcodebuild`.length == 0
         end
 
         # The args we will build with
@@ -155,7 +155,7 @@ module Fastlane
         # Formatting style
         if params && params[:output_style]
           output_style = params[:output_style]
-          raise "Invalid output_style #{output_style}".red unless [:standard, :basic].include?(output_style)
+          UI.user_error!("Invalid output_style #{output_style}") unless [:standard, :basic].include?(output_style)
         else
           output_style = :standard
         end

--- a/fastlane/lib/fastlane/actions/xctool.rb
+++ b/fastlane/lib/fastlane/actions/xctool.rb
@@ -4,7 +4,7 @@ module Fastlane
       def self.run(params)
         UI.important("Have you seen the new 'scan' tool to run tests? https://github.com/fastlane/fastlane/tree/master/scan")
         unless Helper.test?
-          raise 'xctool not installed, please install using `brew install xctool`'.red if `which xctool`.length == 0
+          UI.user_error!("xctool not installed, please install using `brew install xctool`") if `which xctool`.length == 0
         end
 
         params = [] if params.kind_of? FastlaneCore::Configuration

--- a/fastlane/lib/fastlane/command_line_handler.rb
+++ b/fastlane/lib/fastlane/command_line_handler.rb
@@ -9,7 +9,7 @@ module Fastlane
       args.each do |current|
         if current.include? ":" # that's a key/value which we want to pass to the lane
           key, value = current.split(":", 2)
-          raise "Please pass values like this: key:value" unless key.length > 0
+          UI.user_error!("Please pass values like this: key:value") unless key.length > 0
           value = convert_value(value)
           UI.verbose("Using #{key}: #{value}")
           lane_parameters[key.to_sym] = value

--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -153,7 +153,7 @@ module Fastlane
 
           elsif current.kind_of? Array
             # Legacy actions that don't use the new config manager
-            raise "Invalid number of elements in this row: #{current}. Must be 2 or 3".red unless [2, 3].include? current.count
+            UI.user_error!("Invalid number of elements in this row: #{current}. Must be 2 or 3") unless [2, 3].include? current.count
             rows << current
             rows.last[0] = rows.last.first.yellow # color it yellow :)
             rows.last << nil while fill_all and rows.last.count < 3 # to have a nice border in the table

--- a/fastlane/lib/fastlane/erb_template_helper.rb
+++ b/fastlane/lib/fastlane/erb_template_helper.rb
@@ -8,7 +8,7 @@ module Fastlane
 
     def self.load_from_path(template_filepath)
       unless File.exist?(template_filepath)
-        raise "Could not find Template at path '#{template_filepath}'".red
+        UI.user_error!("Could not find Template at path '#{template_filepath}'")
       end
       File.read(template_filepath)
     end

--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -3,10 +3,10 @@ module Fastlane
     class CrashlyticsHelper
       class << self
         def generate_ios_command(params)
-          raise "No value found for 'crashlytics_path'" unless params[:crashlytics_path]
+          UI.user_error!("No value found for 'crashlytics_path'") unless params[:crashlytics_path]
           submit_binary = Dir[File.join(params[:crashlytics_path], '**', 'submit')].last
           submit_binary ||= "Crashlytics.framework/submit" if Helper.test?
-          raise "Could not find submit binary in crashlytics bundle at path '#{params[:crashlytics_path]}'" unless submit_binary
+          UI.user_error!("Could not find submit binary in crashlytics bundle at path '#{params[:crashlytics_path]}'") unless submit_binary
 
           command = []
           command << submit_binary
@@ -31,7 +31,7 @@ module Fastlane
 
           params[:crashlytics_path] = download_android_tools unless params[:crashlytics_path]
 
-          raise "The `crashlytics_path` must be a jar file for Android" unless params[:crashlytics_path].end_with?(".jar") || Helper.test?
+          UI.user_error!("The `crashlytics_path` must be a jar file for Android") unless params[:crashlytics_path].end_with?(".jar") || Helper.test?
 
           command = ["java"]
           command << "-jar #{File.expand_path(params[:crashlytics_path])}"
@@ -70,11 +70,11 @@ module Fastlane
             # Now unzip the file
             Action.sh "unzip '#{zip_path}' -d '#{containing}'"
 
-            raise "Coulnd't find 'crashlytics-devtools.jar'" unless File.exist?(jar_path)
+            UI.user_error!("Coulnd't find 'crashlytics-devtools.jar'") unless File.exist?(jar_path)
 
             UI.success "Succesfully downloaded Crashlytics Support Library to '#{jar_path}'"
           rescue => ex
-            raise "Error fetching remote file: #{ex}"
+            UI.user_error!("Error fetching remote file: #{ex}")
           end
 
           return jar_path

--- a/fastlane/lib/fastlane/helper/podspec_helper.rb
+++ b/fastlane/lib/fastlane/helper/podspec_helper.rb
@@ -12,7 +12,7 @@ module Fastlane
         @version_regex = /^(?<begin>[^#]*#{version_var_name}\s*=\s*['"])(?<value>(?<major>[0-9]+)(\.(?<minor>[0-9]+))?(\.(?<patch>[0-9]+))?)(?<end>['"])/i
 
         return unless (path || '').length > 0
-        raise "Could not find podspec file at path '#{path}'".red unless File.exist?(path)
+        UI.user_error!("Could not find podspec file at path '#{path}'") unless File.exist?(path)
 
         @path = File.expand_path(path)
         podspec_content = File.read(path)
@@ -23,7 +23,7 @@ module Fastlane
       def parse(podspec_content)
         @podspec_content = podspec_content
         @version_match = @version_regex.match(@podspec_content)
-        raise "Could not find version in podspec content '#{@podspec_content}'".red if @version_match.nil?
+        UI.user_error!("Could not find version in podspec content '#{@podspec_content}'") if @version_match.nil?
         @version_value = @version_match[:value]
       end
 

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -5,9 +5,9 @@ module Fastlane
     # @param parameters [Hash] The parameters passed from the command line to the lane
     # @param env Dot Env Information
     def self.cruise_lane(platform, lane, parameters = nil, env = nil)
-      raise 'lane must be a string' unless lane.kind_of?(String) or lane.nil?
-      raise 'platform must be a string' unless platform.kind_of?(String) or platform.nil?
-      raise 'parameters must be a hash' unless parameters.kind_of?(Hash) or parameters.nil?
+      UI.user_error!("lane must be a string") unless lane.kind_of?(String) or lane.nil?
+      UI.user_error!("platform must be a string") unless platform.kind_of?(String) or platform.nil?
+      UI.user_error!("parameters must be a hash") unless parameters.kind_of?(Hash) or parameters.nil?
 
       ff = Fastlane::FastFile.new(File.join(Fastlane::FastlaneFolder.path, 'Fastfile'))
 

--- a/fastlane/lib/fastlane/one_off.rb
+++ b/fastlane/lib/fastlane/one_off.rb
@@ -8,7 +8,7 @@ module Fastlane
       args.each do |current|
         if current.include? ":" # that's a key/value which we want to pass to the lane
           key, value = current.split(":", 2)
-          raise "Please pass values like this: key:value" unless key.length > 0
+          UI.user_error!("Please pass values like this: key:value") unless key.length > 0
           value = CommandLineHandler.convert_value(value)
           UI.verbose("Using #{key}: #{value}")
           action_parameters[key.to_sym] = value
@@ -17,14 +17,14 @@ module Fastlane
         end
       end
 
-      raise "invalid syntax" unless action_name
+      UI.crash!("invalid syntax") unless action_name
 
       class_name = action_name.fastlane_class + 'Action'
       class_ref = nil
       begin
         class_ref = Fastlane::Actions.const_get(class_name)
       rescue NameError
-        raise "Action not found"
+        UI.crash!("Action '#{class_name}' not found")
       end
 
       r = Runner.new

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -20,15 +20,15 @@ module Fastlane
     # @param parameters [Hash] The parameters passed from the command line to the lane
     # rubocop:disable Metrics/AbcSize
     def execute(lane, platform = nil, parameters = nil)
-      raise "No lane given" unless lane
+      UI.crash!("No lane given") unless lane
 
       self.current_lane = lane.to_sym
       self.current_platform = (platform ? platform.to_sym : nil)
 
       lane_obj = lanes.fetch(current_platform, {}).fetch(current_lane, nil)
 
-      raise "Could not find lane '#{full_lane_name}'. Available lanes: #{available_lanes.join(', ')}".red unless lane_obj
-      raise "You can't call the private lane '#{lane}' directly" if lane_obj.is_private
+      UI.user_error!("Could not find lane '#{full_lane_name}'. Available lanes: #{available_lanes.join(', ')}") unless lane_obj
+      UI.user_error!("You can't call the private lane '#{lane}' directly") if lane_obj.is_private
 
       ENV["FASTLANE_LANE_NAME"] = current_lane.to_s
       ENV["FASTLANE_PLATFORM_NAME"] = (current_platform ? current_platform.to_s : nil)
@@ -97,7 +97,7 @@ module Fastlane
         original_full = full_lane_name
         original_lane = current_lane
 
-        raise "Parameters for a lane must always be a hash".red unless (parameters.first || {}).kind_of? Hash
+        UI.user_error!("Parameters for a lane must always be a hash") unless (parameters.first || {}).kind_of? Hash
 
         pretty = [new_lane]
         pretty = [current_platform, new_lane] if current_platform
@@ -137,7 +137,7 @@ module Fastlane
               # This action does not use the new action format
               # Just passing the arguments to this method
             else
-              raise "You have to call the integration like `#{method_sym}(key: \"value\")`. Run `fastlane action #{method_sym}` for all available keys. Please check out the current documentation on GitHub.".red
+              UI.user_error!("You have to call the integration like `#{method_sym}(key: \"value\")`. Run `fastlane action #{method_sym}` for all available keys. Please check out the current documentation on GitHub.")
             end
 
             class_ref.run(arguments)
@@ -156,7 +156,7 @@ module Fastlane
           platform = Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
 
           unless class_ref.is_supported?(platform)
-            raise "Action '#{name}' doesn't support required operating system '#{platform}'.".red
+            UI.user_error!("Action '#{name}' doesn't support required operating system '#{platform}'.")
           end
         end
       end
@@ -179,7 +179,7 @@ module Fastlane
       lanes[lane.platform] ||= {}
 
       if !override and lanes[lane.platform][lane.name]
-        raise "Lane '#{lane.name}' was defined multiple times!".red
+        UI.user_error!("Lane '#{lane.name}' was defined multiple times!")
       end
 
       lanes[lane.platform][lane.name] = lane

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -20,7 +20,7 @@ module Fastlane
       elsif platform == :android
         SetupAndroid.new.run
       else
-        raise "Couldn't find platform '#{platform}'"
+        UI.user_error!("Couldn't find platform '#{platform}'")
       end
     end
 

--- a/fastlane/lib/fastlane/supported_platforms.rb
+++ b/fastlane/lib/fastlane/supported_platforms.rb
@@ -11,7 +11,7 @@ module Fastlane
     # this will throw an exception if the passed platform is not supported
     def self.verify!(platform)
       unless all.include? platform.to_s.to_sym
-        raise "Platform '#{platform}' is not supported. Must be either #{self.all}".red
+        UI.user_error!("Platform '#{platform}' is not supported. Must be either #{self.all}")
       end
     end
   end

--- a/fastlane/spec/actions_helper_spec.rb
+++ b/fastlane/spec/actions_helper_spec.rb
@@ -13,7 +13,7 @@ describe Fastlane do
       it "stores the action properly when an exeception occurred" do
         expect do
           Fastlane::Actions.execute_action(step_name) do
-            raise "Some error"
+            UI.user_error!("Some error")
           end
         end.to raise_error "Some error"
 

--- a/fastlane/spec/actions_md_spec.rb
+++ b/fastlane/spec/actions_md_spec.rb
@@ -11,7 +11,7 @@ describe "Actions.md" do
     it "Actions.md contains the action '#{name}'" do
       next if @exceptions.include?(name)
       unless @actions_md.include?(name)
-        raise "#{name} needs to be added to docs/Actions.md"
+        UI.user_error!("#{name} needs to be added to docs/Actions.md")
       end
     end
   end

--- a/fastlane/spec/actions_specs/appium_spec.rb
+++ b/fastlane/spec/actions_specs/appium_spec.rb
@@ -77,7 +77,7 @@ describe Fastlane do
                 spec_path: 'appium/spec'
               })
             end").runner.execute(:test)
-          end.to raise_error("Failed to run Appium spec. status code: #{status_code}".red)
+          end.to raise_error("Failed to run Appium spec. status code: #{status_code}")
         end
       end
 

--- a/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -46,7 +46,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             changelog_from_git_commits(between: 'abcd...1234')
           end").runner.execute(:test)
-        end.to raise_error(":between must be of type array".red)
+        end.to raise_error(":between must be of type array")
       end
 
       it "Does not accept a :between array of size 1" do
@@ -54,7 +54,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             changelog_from_git_commits(between: ['abcd'])
           end").runner.execute(:test)
-        end.to raise_error(":between must be an array of size 2".red)
+        end.to raise_error(":between must be an array of size 2")
       end
 
       it "Does not accept a :between array with nil values" do
@@ -62,12 +62,12 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             changelog_from_git_commits(between: ['abcd', nil])
           end").runner.execute(:test)
-        end.to raise_error(":between must not contain nil values".red)
+        end.to raise_error(":between must not contain nil values")
       end
 
       it "Does not accept an invalid value for :merge_commit_filtering" do
         values = Fastlane::Actions::GIT_MERGE_COMMIT_FILTERING_OPTIONS.map {|o| "'#{o}'" }.join(', ')
-        error_msg = "Valid values for :merge_commit_filtering are #{values}".red
+        error_msg = "Valid values for :merge_commit_filtering are #{values}"
 
         expect do
           Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/clipboard_spec.rb
+++ b/fastlane/spec/actions_specs/clipboard_spec.rb
@@ -18,7 +18,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             clipboard 'Some Value!'
           end").runner.execute(:test)
-        end.to raise_error "You have to call the integration like `clipboard(key: \"value\")`. Run `fastlane action clipboard` for all available keys. Please check out the current documentation on GitHub.".red
+        end.to raise_error "You have to call the integration like `clipboard(key: \"value\")`. Run `fastlane action clipboard` for all available keys. Please check out the current documentation on GitHub."
       end
     end
   end

--- a/fastlane/spec/actions_specs/crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/crashlytics_spec.rb
@@ -262,7 +262,7 @@ describe Fastlane do
                   ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1'
                 })
               end").runner.execute(:test)
-            end.to raise_error("No API token for Crashlytics given, pass using `api_token: 'token'`".red)
+            end.to raise_error("No API token for Crashlytics given, pass using `api_token: 'token'`")
           end
 
           it "raises an error if no build secret was given" do
@@ -274,7 +274,7 @@ describe Fastlane do
                   ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1'
                 })
               end").runner.execute(:test)
-            end.to raise_error("No build secret for Crashlytics given, pass using `build_secret: 'secret'`".red)
+            end.to raise_error("No build secret for Crashlytics given, pass using `build_secret: 'secret'`")
           end
 
           it "raises an error if no ipa path was given" do
@@ -286,7 +286,7 @@ describe Fastlane do
                   build_secret: 'wadus'
                 })
               end").runner.execute(:test)
-            end.to raise_error("You have to either pass an ipa or an apk file to the Crashlytics action".red)
+            end.to raise_error("You have to either pass an ipa or an apk file to the Crashlytics action")
           end
 
           it "raises an error if the given ipa path was not found" do
@@ -299,7 +299,7 @@ describe Fastlane do
                   ipa_path: './fastlane/wadus'
                 })
               end").runner.execute(:test)
-            end.to raise_error("Couldn't find ipa file at path './fastlane/wadus'".red)
+            end.to raise_error("Couldn't find ipa file at path './fastlane/wadus'")
           end
         end
       end

--- a/fastlane/spec/actions_specs/default_platform_spec.rb
+++ b/fastlane/spec/actions_specs/default_platform_spec.rb
@@ -9,13 +9,13 @@ describe Fastlane do
       it "raises an error if platform is not supported" do
         expect do
           Fastlane::Actions::DefaultPlatformAction.run(['notSupportedOS'])
-        end.to raise_error("Platform 'notSupportedOS' is not supported. Must be either [:ios, :mac, :android]".red)
+        end.to raise_error("Platform 'notSupportedOS' is not supported. Must be either [:ios, :mac, :android]")
       end
 
       it "raises an error if no platform is given" do
         expect do
           Fastlane::Actions::DefaultPlatformAction.run([])
-        end.to raise_error("You forgot to pass the default platform".red)
+        end.to raise_error("You forgot to pass the default platform")
       end
 
       it "works as expected inside a Fastfile" do

--- a/fastlane/spec/actions_specs/deliver_action_spec.rb
+++ b/fastlane/spec/actions_specs/deliver_action_spec.rb
@@ -19,7 +19,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             deliver
           end").runner.execute(:test)
-        end.to raise_error("Could not find ipa file at path 'something.ipa'".red)
+        end.to raise_error(/Could not find ipa file at path 'something.ipa'/)
       end
     end
   end

--- a/fastlane/spec/actions_specs/fastlane_version_spec.rb
+++ b/fastlane/spec/actions_specs/fastlane_version_spec.rb
@@ -12,7 +12,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             fastlane_version '9999'
           end").runner.execute(:test)
-        end.to raise_error("The Fastfile requires a fastlane version of >= 9999. You are on #{Fastlane::VERSION}. Please update using `sudo gem update fastlane`.".red)
+        end.to raise_error("The Fastfile requires a fastlane version of >= 9999. You are on #{Fastlane::VERSION}. Please update using `sudo gem update fastlane`.")
       end
 
       it "raises an error if no team ID is given" do
@@ -20,7 +20,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             fastlane_version
           end").runner.execute(:test)
-        end.to raise_error("Please pass minimum fastlane version as parameter to fastlane_version".red)
+        end.to raise_error("Please pass minimum fastlane version as parameter to fastlane_version")
       end
     end
   end

--- a/fastlane/spec/actions_specs/get_build_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_build_number_action_spec.rb
@@ -16,7 +16,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             get_build_number(xcodeproj: 'project.xcworkspace')
           end").runner.execute(:test)
-        end.to raise_error("Please pass the path to the project, not the workspace".red)
+        end.to raise_error("Please pass the path to the project, not the workspace")
       end
     end
   end

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -16,7 +16,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             get_version_number(xcodeproj: 'project.xcworkspace')
           end").runner.execute(:test)
-        end.to raise_error("Please pass the path to the project, not the workspace".red)
+        end.to raise_error("Please pass the path to the project, not the workspace")
       end
     end
   end

--- a/fastlane/spec/actions_specs/hg_commit_version_bump_spec.rb
+++ b/fastlane/spec/actions_specs/hg_commit_version_bump_spec.rb
@@ -53,7 +53,7 @@ describe Fastlane do
             test_expected_files: '#{expected_files}',
           })
         end").runner.execute(:test)
-        end.to raise_exception('No file changes picked up. Make sure you run the `increment_build_number` action first.'.red)
+        end.to raise_exception('No file changes picked up. Make sure you run the `increment_build_number` action first.')
       end
     end
   end

--- a/fastlane/spec/actions_specs/hockey_spec.rb
+++ b/fastlane/spec/actions_specs/hockey_spec.rb
@@ -20,7 +20,7 @@ describe Fastlane do
                 ipa: './notHere.ipa'
               })
             end").runner.execute(:test)
-          end.to raise_error("Couldn't find ipa file at path './notHere.ipa'".red)
+          end.to raise_error("Couldn't find ipa file at path './notHere.ipa'")
         end
       end
 
@@ -33,7 +33,7 @@ describe Fastlane do
                 apk: './notHere.ipa'
               })
             end").runner.execute(:test)
-          end.to raise_error("Couldn't find apk file at path './notHere.ipa'".red)
+          end.to raise_error("Couldn't find apk file at path './notHere.ipa'")
         end
       end
 
@@ -46,7 +46,7 @@ describe Fastlane do
               dsym: './notHere.dSYM.zip'
             })
           end").runner.execute(:test)
-        end.to raise_error("Symbols on path '#{File.expand_path('../notHere.dSYM.zip')}' not found".red)
+        end.to raise_error("Symbols on path '#{File.expand_path('../notHere.dSYM.zip')}' not found")
       end
 
       it "raises an error if both ipa and apk provided" do
@@ -58,7 +58,7 @@ describe Fastlane do
               apk: './fastlane/spec/fixtures/fastfiles/Fastfile1'
             })
           end").runner.execute(:test)
-        end.to raise_error("You can't use 'ipa' and 'apk' options in one run".red)
+        end.to raise_error("You can't use 'ipa' and 'apk' options in one run")
       end
 
       it "works with valid parameters" do

--- a/fastlane/spec/actions_specs/increment_build_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_build_number_action_spec.rb
@@ -24,7 +24,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             increment_build_number(xcodeproj: 'project.xcworkspace')
           end").runner.execute(:test)
-        end.to raise_error("Please pass the path to the project, not the workspace".red)
+        end.to raise_error("Please pass the path to the project, not the workspace")
       end
     end
   end

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -56,7 +56,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             increment_version_number(xcodeproj: '/nothere')
           end").runner.execute(:test)
-        end.to raise_error("Could not find Xcode project".red)
+        end.to raise_error("Could not find Xcode project")
       end
 
       it "raises an exception when use passes workspace" do
@@ -64,7 +64,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             increment_version_number(xcodeproj: 'project.xcworkspace')
           end").runner.execute(:test)
-        end.to raise_error("Please pass the path to the project, not the workspace".red)
+        end.to raise_error("Please pass the path to the project, not the workspace")
       end
     end
   end

--- a/fastlane/spec/actions_specs/nexus_upload_spec.rb
+++ b/fastlane/spec/actions_specs/nexus_upload_spec.rb
@@ -51,7 +51,7 @@ describe Fastlane do
                         proxy_username: 'admin',
                         proxy_password: 'admin')
           end").runner.execute(:test)
-        end.to raise_exception "Couldn't find file at path '#{file_path}'".red
+        end.to raise_exception("Couldn't find file at path '#{file_path}'")
       end
 
       it "mandatory options are used correctly" do

--- a/fastlane/spec/actions_specs/oclint_spec.rb
+++ b/fastlane/spec/actions_specs/oclint_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             oclint
           end").runner.execute(:test)
-        end.to raise_error("Could not find json compilation database at path 'compile_commands.json'".red)
+        end.to raise_error("Could not find json compilation database at path 'compile_commands.json'")
       end
 
       it "works with compilation database only" do

--- a/fastlane/spec/actions_specs/produce_spec.rb
+++ b/fastlane/spec/actions_specs/produce_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
               produce('text')
             end").runner.execute(:test)
-        end.to raise_error("You have to call the integration like `produce(key: \"value\")`. Run `fastlane action produce` for all available keys. Please check out the current documentation on GitHub.".red)
+        end.to raise_error("You have to call the integration like `produce(key: \"value\")`. Run `fastlane action produce` for all available keys. Please check out the current documentation on GitHub.")
       end
     end
   end

--- a/fastlane/spec/actions_specs/s3_spec.rb
+++ b/fastlane/spec/actions_specs/s3_spec.rb
@@ -14,7 +14,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             s3({})
           end").runner.execute(:test)
-        end.to raise_error("No S3 access key given, pass using `access_key: 'key'`".red)
+        end.to raise_error("No S3 access key given, pass using `access_key: 'key'`")
       end
 
       it "raise an error if no S3 secret access key was given" do
@@ -24,7 +24,7 @@ describe Fastlane do
               access_key: 'access_key'
               })
           end").runner.execute(:test)
-        end.to raise_error("No S3 secret access key given, pass using `secret_access_key: 'secret key'`".red)
+        end.to raise_error("No S3 secret access key given, pass using `secret_access_key: 'secret key'`")
       end
 
       it "raise an error if no S3 bucket was given" do
@@ -35,7 +35,7 @@ describe Fastlane do
               secret_access_key: 'secret_access_key'
               })
           end").runner.execute(:test)
-        end.to raise_error("No S3 bucket given, pass using `bucket: 'bucket'`".red)
+        end.to raise_error("No S3 bucket given, pass using `bucket: 'bucket'`")
       end
 
       it "raise an error if no IPA was given" do
@@ -47,7 +47,7 @@ describe Fastlane do
               bucket: 'bucket'
               })
           end").runner.execute(:test)
-        end.to raise_error("No IPA file path given, pass using `ipa: 'ipa path'`".red)
+        end.to raise_error("No IPA file path given, pass using `ipa: 'ipa path'`")
       end
 
       it "raise an error if no IPA was given" do
@@ -59,7 +59,7 @@ describe Fastlane do
               bucket: 'bucket'
               })
           end").runner.execute(:test)
-        end.to raise_error("No IPA file path given, pass using `ipa: 'ipa path'`".red)
+        end.to raise_error("No IPA file path given, pass using `ipa: 'ipa path'`")
       end
     end
   end

--- a/fastlane/spec/actions_specs/splunkmint_spec.rb
+++ b/fastlane/spec/actions_specs/splunkmint_spec.rb
@@ -20,7 +20,7 @@ describe Fastlane do
           Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DSYM_ZIP_PATH] = nil
 
           Fastlane::Actions::SplunkmintAction.dsym_path(params: nil)
-        end.to raise_exception "Couldn't find any dSYM file".red
+        end.to raise_exception("Couldn't find any dSYM file")
       end
 
       it "raises an error if no dsym source has been found in SharedValues::DSYM_OUTPUT_PATH" do
@@ -31,7 +31,7 @@ describe Fastlane do
 
         expect do
           Fastlane::Actions::SplunkmintAction.dsym_path(params: nil)
-        end.to raise_exception "Couldn't find file at path '#{file_path}'".red
+        end.to raise_exception("Couldn't find file at path '#{file_path}'")
       end
 
       it "raises an error if no dsym source has been found in SharedValues::DSYM_ZIP_PATH" do
@@ -42,7 +42,7 @@ describe Fastlane do
 
         expect do
           Fastlane::Actions::SplunkmintAction.dsym_path(params: nil)
-        end.to raise_exception "Couldn't find file at path '#{file_path}'".red
+        end.to raise_exception("Couldn't find file at path '#{file_path}'")
       end
 
       it "raises an error if no dsym source has been found in ENV['DSYM_OUTPUT_PATH']" do
@@ -54,7 +54,7 @@ describe Fastlane do
 
         expect do
           Fastlane::Actions::SplunkmintAction.dsym_path(params: nil)
-        end.to raise_exception "Couldn't find file at path '#{file_path}'".red
+        end.to raise_exception("Couldn't find file at path '#{file_path}'")
       end
 
       it "raises an error if no dsym source has been found in ENV['DSYM_ZIP_PATH']" do
@@ -66,7 +66,7 @@ describe Fastlane do
 
         expect do
           Fastlane::Actions::SplunkmintAction.dsym_path(params: nil)
-        end.to raise_exception "Couldn't find file at path '#{file_path}'".red
+        end.to raise_exception("Couldn't find file at path '#{file_path}'")
       end
 
       it "proxy options are set correctly" do
@@ -89,7 +89,7 @@ describe Fastlane do
                         api_key: '33823d3a',
                         api_token: 'e05ba40754c4869fb7e0b61')
           end").runner.execute(:test)
-        end.to raise_exception "Couldn't find file at path '#{file_path}'".red
+        end.to raise_exception("Couldn't find file at path '#{file_path}'")
       end
 
       it "raises an error if file could not be read from any source" do
@@ -103,7 +103,7 @@ describe Fastlane do
             splunkmint(api_key: '33823d3a',
                         api_token: 'e05ba40754c4869fb7e0b61')
           end").runner.execute(:test)
-        end.to raise_exception "Couldn't find any dSYM file".red
+        end.to raise_exception("Couldn't find any dSYM file")
       end
 
       it "mandatory options are used correctly" do

--- a/fastlane/spec/actions_specs/team_id_spec.rb
+++ b/fastlane/spec/actions_specs/team_id_spec.rb
@@ -17,7 +17,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             team_id
           end").runner.execute(:test)
-        end.to raise_error("Please pass your Team ID (e.g. team_id 'Q2CBPK58CA')".red)
+        end.to raise_error("Please pass your Team ID (e.g. team_id 'Q2CBPK58CA')")
       end
     end
   end

--- a/fastlane/spec/actions_specs/team_name_spec.rb
+++ b/fastlane/spec/actions_specs/team_name_spec.rb
@@ -17,7 +17,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             team_name
           end").runner.execute(:test)
-        end.to raise_error("Please pass your Team Name (e.g. team_name 'Felix Krause')".red)
+        end.to raise_error("Please pass your Team Name (e.g. team_name 'Felix Krause')")
       end
     end
   end

--- a/fastlane/spec/actions_specs/update_app_group_identifiers_spec.rb
+++ b/fastlane/spec/actions_specs/update_app_group_identifiers_spec.rb
@@ -30,7 +30,7 @@ describe Fastlane do
             app_group_identifiers: ['#{new_app_group}']
           )
           end").runner.execute(:test)
-        end.to raise_error("Could not find entitlements file at path 'xyz.#{File.join(test_path, entitlements_path)}'".red)
+        end.to raise_error("Could not find entitlements file at path 'xyz.#{File.join(test_path, entitlements_path)}'")
       end
 
       it "throws an error when the identifiers are not in an array" do
@@ -41,7 +41,7 @@ describe Fastlane do
             app_group_identifiers: '#{new_app_group}'
           )
           end").runner.execute(:test)
-        end.to raise_error('The parameter app_group_identifiers need to be an Array.'.red)
+        end.to raise_error('The parameter app_group_identifiers need to be an Array.')
       end
 
       it "throws an error when the entitlements file is not parsable" do
@@ -54,7 +54,7 @@ describe Fastlane do
             app_group_identifiers: ['#{new_app_group}']
           )
           end").runner.execute(:test)
-        end.to raise_error("Entitlements file at '#{File.join(test_path, entitlements_path)}' cannot be parsed.".red)
+        end.to raise_error("Entitlements file at '#{File.join(test_path, entitlements_path)}' cannot be parsed.")
       end
 
       it "throws an error when the entitlements file doesn't contain an app group" do
@@ -67,7 +67,7 @@ describe Fastlane do
             app_group_identifiers: ['#{new_app_group}']
           )
           end").runner.execute(:test)
-        end.to raise_error("No existing App group field specified. Please specify an App Group in the entitlements file.".red)
+        end.to raise_error("No existing App group field specified. Please specify an App Group in the entitlements file.")
       end
 
       after do

--- a/fastlane/spec/actions_specs/update_app_identifier_spec.rb
+++ b/fastlane/spec/actions_specs/update_app_identifier_spec.rb
@@ -97,7 +97,7 @@ describe Fastlane do
                 app_identifier: '#{app_identifier}'
               })
             end").runner.execute(:test)
-          end.to raise_error("Xcodeproj doesn't have configuration with info plist #{plist_path}.".red)
+          end.to raise_error("Xcodeproj doesn't have configuration with info plist #{plist_path}.")
         end
 
         it "should raise an exception when PRODUCT_BUNDLE_IDENTIFIER in info plist but not project" do
@@ -112,13 +112,13 @@ describe Fastlane do
           create_plist_with_identifier("$(#{identifier_key})")
           expect do
             Fastlane::FastFile.new.parse("lane :test do
-            update_app_identifier ({
+            update_app_identifier({
               xcodeproj: '#{xcodeproj}',
               plist_path: '#{plist_path}',
               app_identifier: '#{app_identifier}'
             })
             end").runner.execute(:test)
-          end.to raise_error("Info plist uses $(#{identifier_key}), but xcodeproj does not".red)
+          end.to raise_error("Info plist uses $(#{identifier_key}), but xcodeproj does not")
         end
       end
 

--- a/fastlane/spec/actions_specs/update_info_plist_spec.rb
+++ b/fastlane/spec/actions_specs/update_info_plist_spec.rb
@@ -52,7 +52,7 @@ describe Fastlane do
               display_name: '#{display_name}'
             })
           end").runner.execute(:test)
-        end.to raise_error("Couldn't find info plist file at path 'NOEXIST-#{plist_path}'".red)
+        end.to raise_error("Couldn't find info plist file at path 'NOEXIST-#{plist_path}'")
       end
 
       it "returns 'false' if no plist parameters are specified" do

--- a/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
+++ b/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
@@ -8,20 +8,20 @@ describe Fastlane do
       it "raises an exception when an incorrect path is given" do
         expect do
           Fastlane::Helper::PodspecHelper.new('invalid_podspec')
-        end.to raise_error("Could not find podspec file at path 'invalid_podspec'".red)
+        end.to raise_error("Could not find podspec file at path 'invalid_podspec'")
       end
 
       it "raises an exception when there is no version in podspec" do
         expect do
           Fastlane::Helper::PodspecHelper.new.parse("")
-        end.to raise_error("Could not find version in podspec content ''".red)
+        end.to raise_error("Could not find version in podspec content ''")
       end
 
       it "raises an exception when the version is commented-out in podspec" do
         test_content = '# version = "1.3.2"'
         expect do
           Fastlane::Helper::PodspecHelper.new.parse(test_content)
-        end.to raise_error("Could not find version in podspec content '#{test_content}'".red)
+        end.to raise_error("Could not find version in podspec content '#{test_content}'")
       end
 
       it "returns the current version once parsed" do
@@ -95,7 +95,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             version_get_podspec
           end").runner.execute(:test)
-        end.to raise_error("Please pass a path to the `version_get_podspec` action".red)
+        end.to raise_error("Please pass a path to the `version_get_podspec` action")
       end
 
       it "gets the version from a podspec file" do
@@ -117,7 +117,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             version_bump_podspec
           end").runner.execute(:test)
-        end.to raise_error("Please pass a path to the `version_bump_podspec` action".red)
+        end.to raise_error("Please pass a path to the `version_bump_podspec` action")
       end
 
       it "bumps patch version when only the path is given" do

--- a/fastlane/spec/actions_specs/xcode_select_spec.rb
+++ b/fastlane/spec/actions_specs/xcode_select_spec.rb
@@ -18,7 +18,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             xcode_select
           end").runner.execute(:test)
-        end.to raise_error("Path to Xcode application required (e.x. \"/Applications/Xcode.app\")".red)
+        end.to raise_error("Path to Xcode application required (e.x. \"/Applications/Xcode.app\")")
       end
 
       it "throws an exception if the Xcode path is not a valid directory" do
@@ -26,7 +26,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             xcode_select \"#{invalid_path}\"
           end").runner.execute(:test)
-        end.to raise_error("Path '/path/to/nonexistent/dir' doesn't exist".red)
+        end.to raise_error("Path '/path/to/nonexistent/dir' doesn't exist")
       end
 
       it "sets the DEVELOPER_DIR environment variable" do

--- a/fastlane/spec/actions_specs/xcode_server_get_assets_spec.rb
+++ b/fastlane/spec/actions_specs/xcode_server_get_assets_spec.rb
@@ -12,7 +12,7 @@ describe Fastlane do
               )
             end").runner.execute(:test)
         rescue => e
-          expect(e.to_s).to eq("Failed to fetch Bots from Xcode Server at https://1.2.3.4, response: 500: .".red)
+          expect(e.to_s).to eq("Failed to fetch Bots from Xcode Server at https://1.2.3.4, response: 500: .")
         else
           fail "Error should have been raised"
         end
@@ -32,7 +32,7 @@ describe Fastlane do
               )
           end").runner.execute(:test)
         rescue => e
-          expect(e.to_s).to eq("Failed to find any completed integration for Bot \"bot-2\"".red)
+          expect(e.to_s).to eq("Failed to find any completed integration for Bot \"bot-2\"")
         else
           fail "Error should have been raised"
         end
@@ -53,7 +53,7 @@ describe Fastlane do
               )
           end").runner.execute(:test)
         rescue => e
-          expect(e.to_s).to eq("Specified integration number 3 does not exist.".red)
+          expect(e.to_s).to eq("Specified integration number 3 does not exist.")
         else
           fail "Error should have been raised"
         end
@@ -75,7 +75,7 @@ describe Fastlane do
               )
           end").runner.execute(:test)
         rescue => e
-          expect(e.to_s).to eq("Integration doesn't have any assets (it probably never ran).".red)
+          expect(e.to_s).to eq("Integration doesn't have any assets (it probably never ran).")
         else
           fail "Error should have been raised"
         end

--- a/fastlane/spec/erb_template_helper_spec.rb
+++ b/fastlane/spec/erb_template_helper_spec.rb
@@ -4,7 +4,7 @@ describe Fastlane do
       it "raises an error if file does not exist" do
         expect do
           Fastlane::ErbTemplateHelper.load('invalid_name')
-        end.to raise_exception "Could not find Template at path './/lib/assets/invalid_name.erb'".red
+        end.to raise_exception("Could not find Template at path './/lib/assets/invalid_name.erb'")
       end
 
       it "should load file if exists" do

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -126,7 +126,7 @@ describe Fastlane do
       it "raises an exception if unsupported action is called in unsupported platform" do
         expect do
           @ff.runner.execute('unsupported_action', 'android')
-        end.to raise_error "Action 'frameit' doesn't support required operating system 'android'.".red
+        end.to raise_error "Action 'frameit' doesn't support required operating system 'android'."
       end
     end
 
@@ -235,7 +235,7 @@ describe Fastlane do
           ff = Fastlane::FastFile.new('./spec/fixtures/fastfiles/SwitcherFastfile')
           expect do
             ff.runner.execute(:invalid_parameters, :ios)
-          end.to raise_error "Parameters for a lane must always be a hash".red
+          end.to raise_error "Parameters for a lane must always be a hash"
         end
       end
 
@@ -291,7 +291,7 @@ describe Fastlane do
         ff = Fastlane::FastFile.new('./spec/fixtures/fastfiles/Fastfile1')
         expect do
           ff.runner.execute(:not_here)
-        end.to raise_exception("Could not find lane 'not_here'. Available lanes: test, deploy, error_causing_lane, mac specific".red)
+        end.to raise_exception("Could not find lane 'not_here'. Available lanes: test, deploy, error_causing_lane, mac specific")
       end
 
       it "raises an error if the lane name contains spaces" do
@@ -331,7 +331,7 @@ describe Fastlane do
           end
           lane :test do
           end")
-        end.to raise_exception "Lane 'test' was defined multiple times!".red
+        end.to raise_exception("Lane 'test' was defined multiple times!")
       end
     end
   end

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -12,7 +12,7 @@ describe Fastlane do
           content = File.read(File.join("lib", "fastlane", "actions", name + ".rb"))
           action.available_options.each do |option|
             unless content.include?("[:#{option.key}]")
-              raise "Action '#{name}' doesn't use the option :#{option.key}"
+              UI.user_error!("Action '#{name}' doesn't use the option :#{option.key}")
             end
           end
         end

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -2,7 +2,7 @@ module FastlaneCore
   # This class checks if a specific certificate is installed on the current mac
   class CertChecker
     def self.installed?(path)
-      raise "Could not find file '#{path}'".red unless File.exist?(path)
+      UI.user_error!("Could not find file '#{path}'") unless File.exist?(path)
 
       ids = installed_identies
       finger_print = sha1_fingerprint(path)
@@ -69,7 +69,7 @@ module FastlaneCore
         return result
       rescue
         Helper.log.info result
-        raise "Error parsing certificate '#{path}'"
+        UI.user_error!("Error parsing certificate '#{path}'")
       end
     end
   end

--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -84,7 +84,7 @@ module FastlaneCore
           if error
             error.call(o, status)
           else
-            raise "Exit status: #{status}"
+            UI.user_error!("Exit status: #{status}")
           end
         end
 

--- a/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
@@ -70,10 +70,10 @@ module FastlaneCore
     def validate_short_switch(used_switches, short_switch)
       return if short_switch.nil?
 
-      raise "Short option #{short_switch} already taken for key #{option.key}".red if used_switches.include?(short_switch)
-      raise "-v is already used for the version (key #{option.key})".red if short_switch == "-v"
-      raise "-h is already used for the help screen (key #{option.key})".red if short_switch == "-h"
-      raise "-t is already used for the trace screen (key #{option.key})".red if short_switch == "-t"
+      UI.user_error!("Short option #{short_switch} already taken for key #{option.key}") if used_switches.include?(short_switch)
+      UI.user_error!("-v is already used for the version (key #{option.key})") if short_switch == "-v"
+      UI.user_error!("-h is already used for the help screen (key #{option.key})") if short_switch == "-h"
+      UI.user_error!("-t is already used for the trace screen (key #{option.key})") if short_switch == "-t"
 
       used_switches << short_switch
     end

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -17,23 +17,23 @@ module FastlaneCore
     # @param conflicting_options ([]) array of conflicting option keys(@param key). This allows to resolve conflicts intelligently
     # @param conflict_block an optional block which is called when options conflict happens
     def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, type: nil, optional: false, conflicting_options: nil, conflict_block: nil)
-      raise "key must be a symbol" unless key.kind_of? Symbol
-      raise "env_name must be a String" unless (env_name || '').kind_of? String
+      UI.user_error!("key must be a symbol") unless key.kind_of? Symbol
+      UI.user_error!("env_name must be a String") unless (env_name || '').kind_of? String
 
       if short_option
-        raise "short_option must be a String of length 1" unless short_option.kind_of? String and short_option.delete('-').length == 1
+        UI.user_error!("short_option must be a String of length 1") unless short_option.kind_of? String and short_option.delete('-').length == 1
       end
       if description
-        raise "Do not let descriptions end with a '.', since it's used for user inputs as well".red if description[-1] == '.'
+        UI.user_error!("Do not let descriptions end with a '.', since it's used for user inputs as well") if description[-1] == '.'
       end
 
       if type.to_s.length > 0 and short_option.to_s.length == 0
-        raise "Type '#{type}' for key '#{key}' requires a short option"
+        UI.user_error!("Type '#{type}' for key '#{key}' requires a short option")
       end
 
       if conflicting_options
         conflicting_options.each do |conflicting_option_key|
-          raise "Conflicting option key must be a symbol" unless conflicting_option_key.kind_of? Symbol
+          UI.user_error!("Conflicting option key must be a symbol") unless conflicting_option_key.kind_of? Symbol
         end
       end
 

--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -25,7 +25,7 @@ module FastlaneCore
         # rubocop:enable Lint/Eval
       rescue SyntaxError => ex
         line = ex.to_s.match(/\(eval\):(\d+)/)[1]
-        raise "Syntax error in your configuration file '#{path}' on line #{line}: #{ex}".red
+        UI.user_error!("Syntax error in your configuration file '#{path}' on line #{line}: #{ex}")
       end
     end
 

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -135,7 +135,7 @@ module FastlaneCore
         result = File.join(self.xcode_path, path)
         return result if File.exist?(result)
       end
-      raise "Could not find transporter at #{self.xcode_path}. Please make sure you set the correct path to your Xcode installation.".red
+      UI.user_error!("Could not find transporter at #{self.xcode_path}. Please make sure you set the correct path to your Xcode installation.")
     end
 
     def self.fastlane_enabled?

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -5,7 +5,7 @@ module FastlaneCore
       # Project discovery
       def detect_projects(config)
         if config[:workspace].to_s.length > 0 and config[:project].to_s.length > 0
-          raise "You can only pass either a workspace or a project path, not both".red
+          UI.user_error!("You can only pass either a workspace or a project path, not both")
         end
 
         return if config[:project].to_s.length > 0
@@ -72,7 +72,7 @@ module FastlaneCore
       self.is_workspace = (options[:workspace].to_s.length > 0)
 
       if !path or !File.directory?(path)
-        raise "Could not find project at path '#{path}'".red
+        UI.user_error!("Could not find project at path '#{path}'")
       end
     end
 
@@ -123,7 +123,7 @@ module FastlaneCore
         elsif Helper.is_ci?
           Helper.log.error "Multiple schemes found but you haven't specified one.".red
           Helper.log.error "Since this is a CI, please pass one using the `scheme` option".red
-          raise "Multiple schemes found".red
+          UI.user_error!("Multiple schemes found")
         else
           puts "Select Scheme: "
           options[:scheme] = choose(*schemes)
@@ -132,7 +132,7 @@ module FastlaneCore
         Helper.log.error "Couldn't find any schemes in this project, make sure that the scheme is shared if you are using a workspace".red
         Helper.log.error "Open Xcode, click on `Manage Schemes` and check the `Shared` box for the schemes you want to use".red
 
-        raise "No Schemes found".red
+        UI.user_error!("No Schemes found")
       end
     end
     # rubocop:enable Metrics/AbcSize
@@ -267,11 +267,11 @@ module FastlaneCore
         timeout = FastlaneCore::Project.xcode_list_timeout
         @raw = FastlaneCore::Project.run_command(command, timeout: timeout)
       rescue Timeout::Error
-        raise "xcodebuild -list timed-out after #{timeout} seconds. You might need to recreate the user schemes." \
-          " You can override the timeout value with the environment variable FASTLANE_XCODE_LIST_TIMEOUT".red
+        UI.user_error!("xcodebuild -list timed-out after #{timeout} seconds. You might need to recreate the user schemes." \
+          " You can override the timeout value with the environment variable FASTLANE_XCODE_LIST_TIMEOUT")
       end
 
-      raise "Error parsing xcode file using `#{command}`".red if @raw.length == 0
+      UI.user_error!("Error parsing xcode file using `#{command}`") if @raw.length == 0
 
       return @raw
     end

--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -58,7 +58,7 @@ module FastlaneCore
           # copy to Xcode provisioning profile directory
           FileUtils.copy(path, destination)
           unless File.exist?(destination)
-            raise "Failed installation of provisioning profile at location: '#{destination}'".red
+            UI.user_error!("Failed installation of provisioning profile at location: '#{destination}'")
           end
         end
 

--- a/fastlane_core/lib/fastlane_core/simulator.rb
+++ b/fastlane_core/lib/fastlane_core/simulator.rb
@@ -20,7 +20,7 @@ module FastlaneCore
 
         unless output.include?("== Devices ==")
           Helper.log.error "xcrun simctl CLI broken, run `xcrun simctl list devices` and make sure it works".red
-          raise "xcrun simctl not working.".red
+          UI.user_error!("xcrun simctl not working.")
         end
 
         output.split(/\n/).each do |line|
@@ -71,7 +71,7 @@ module FastlaneCore
       #   rescue => ex
       #     Helper.log.error ex
       #     Helper.log.error "xcrun simctl CLI broken, run `xcrun simctl list devices` and make sure it works".red
-      #     raise "xcrun simctl not working.".red
+      #     UI.user_error!("xcrun simctl not working.")
       #   end
 
       #   data["devices"].each do |os_version, l|

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -136,7 +136,7 @@ module FastlaneCore
     # @!group Helpers
     #####################################################
     def not_implemented(method_name)
-      raise "Current UI '#{self}' doesn't support method '#{method_name}'".red
+      UI.user_error!("Current UI '#{self}' doesn't support method '#{method_name}'")
     end
 
     def to_s

--- a/fastlane_core/lib/fastlane_core/ui/ui.rb
+++ b/fastlane_core/lib/fastlane_core/ui/ui.rb
@@ -9,7 +9,7 @@ module FastlaneCore
     def self.method_missing(method_sym, *args, &_block)
       # not using `responds` beacuse we don't care about methods like .to_s and so on
       interface_methods = Interface.instance_methods - Object.instance_methods
-      raise "Unknown method '#{method_sym}', supported #{interface_methods}" unless interface_methods.include?(method_sym)
+      UI.user_error!("Unknown method '#{method_sym}', supported #{interface_methods}") unless interface_methods.include?(method_sym)
 
       self.current.send(method_sym, *args)
     end

--- a/fastlane_core/spec/configuration_file_spec.rb
+++ b/fastlane_core/spec/configuration_file_spec.rb
@@ -21,7 +21,7 @@ describe FastlaneCore do
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        description: "Mac",
                                        verify_block: proc do |value|
-                                         raise "Invalid identifier '#{value}'" unless value.split('.').count == 3
+                                         UI.user_error!("Invalid identifier '#{value}'") unless value.split('.').count == 3
                                        end),
           FastlaneCore::ConfigItem.new(key: :apple_id,
                                        description: "yo",
@@ -40,7 +40,7 @@ describe FastlaneCore do
         expect do
           config = FastlaneCore::Configuration.create(options, {})
           config.load_configuration_file("ConfigFileInvalidIdentifier")
-        end.to raise_error "Invalid identifier 'such invalid'"
+        end.to raise_error("Invalid identifier 'such invalid'")
       end
 
       it "raises an exception if method is not available" do
@@ -94,9 +94,9 @@ describe FastlaneCore do
               expect do
                 block.call(arguments.first, "custom")
               end.to raise_error "Yeah: parameter custom"
-            else raise 'no'
+            else UI.user_error!("no")
             end
-          else raise 'no'
+          else UI.user_error!("no")
           end
         end)
       end

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -31,7 +31,7 @@ describe FastlaneCore do
             key: :cert_name,
        env_name: "asdf",
     description: "Set the profile name.")], {})
-        end.to raise_error "Do not let descriptions end with a '.', since it's used for user inputs as well".red
+        end.to raise_error "Do not let descriptions end with a '.', since it's used for user inputs as well"
       end
 
       it "raises an error if a a key was used twice" do
@@ -87,14 +87,14 @@ describe FastlaneCore do
                                        short_option: "-f",
                                        conflicting_options: [:bar, :oof],
                                        conflict_block: proc do |value|
-                                         raise "You can't use option '#{value.short_option}' along with '-f'"
+                                         UI.user_error!("You can't use option '#{value.short_option}' along with '-f'")
                                        end),
           FastlaneCore::ConfigItem.new(key: :bar,
                                        short_option: "-b"),
           FastlaneCore::ConfigItem.new(key: :oof,
                                        short_option: "-o",
                                        conflict_block: proc do |value|
-                                         raise "You can't use option '#{value.short_option}' along with '-o'"
+                                         UI.user_error!("You can't use option '#{value.short_option}' along with '-o'")
                                        end)
         ]
 
@@ -135,14 +135,14 @@ describe FastlaneCore do
                                        short_option: "-f",
                                        conflicting_options: [:bar, :oof],
                                        conflict_block: proc do |value|
-                                         raise "You can't use option '#{value.short_option}' along with '-f'".red
+                                         UI.user_error!("You can't use option '#{value.short_option}' along with '-f'")
                                        end),
           FastlaneCore::ConfigItem.new(key: :bar,
                                        short_option: "-b"),
           FastlaneCore::ConfigItem.new(key: :oof,
                                        short_option: "-o",
                                        conflict_block: proc do |value|
-                                         raise "You can't use option '#{value.short_option}' along with '-o'".red
+                                         UI.user_error!("You can't use option '#{value.short_option}' along with '-o'")
                                        end)
         ]
 
@@ -153,7 +153,7 @@ describe FastlaneCore do
 
         expect do
           FastlaneCore::Configuration.create(conflicting_options, values)
-        end.to raise_error "You can't use option '-b' along with '-f'".red
+        end.to raise_error "You can't use option '-b' along with '-f'"
       end
 
       it "raises an error for unresolved conflict between options" do
@@ -183,14 +183,14 @@ describe FastlaneCore do
                                        short_option: "-f",
                                        conflicting_options: [:bar, :oof],
                                        conflict_block: proc do |value|
-                                         raise "You can't use option '#{value.short_option}' along with '-f'".red
+                                         UI.user_error!("You can't use option '#{value.short_option}' along with '-f'")
                                        end),
           FastlaneCore::ConfigItem.new(key: :bar,
                                        short_option: "-b"),
           FastlaneCore::ConfigItem.new(key: :oof,
                                        short_option: "-o",
                                        conflict_block: proc do |value|
-                                         raise "You can't use option '#{value.short_option}' along with '-o'".red
+                                         UI.user_error!("You can't use option '#{value.short_option}' along with '-o'")
                                        end)
         ]
 
@@ -201,7 +201,7 @@ describe FastlaneCore do
 
         expect do
           FastlaneCore::Configuration.create(conflicting_options, values)
-        end.to raise_error "You can't use option '-b' along with '-f'".red
+        end.to raise_error "You can't use option '-b' along with '-f'"
       end
 
       it "sets the data type correctly if `is_string` is not set but type is specified" do
@@ -306,7 +306,7 @@ describe FastlaneCore do
                                description: "Directory in which the profile should be stored",
                              default_value: "notExistent",
                               verify_block: proc do |value|
-                                raise "Could not find output directory '#{value}'"
+                                UI.user_error!("Could not find output directory '#{value}'")
                               end)
         expect do
           @config = FastlaneCore::Configuration.create([c], {})
@@ -388,7 +388,7 @@ describe FastlaneCore do
                                  description: "Directory in which the profile should be stored",
                                default_value: ".",
                                 verify_block: proc do |value|
-                                  raise "Could not find output directory '#{value}'" unless File.exist?(value)
+                                  UI.user_error!("Could not find output directory '#{value}'") unless File.exist?(value)
                                 end)
           ]
           @values = {

--- a/fastlane_core/spec/print_table_spec.rb
+++ b/fastlane_core/spec/print_table_spec.rb
@@ -11,7 +11,7 @@ describe FastlaneCore do
                              description: "Directory in which the profile should be stored",
                            default_value: ".",
                             verify_block: proc do |value|
-                              raise "Could not find output directory '#{value}'".red unless File.exist?(value)
+                              UI.user_error!("Could not find output directory '#{value}'") unless File.exist?(value)
                             end),
         FastlaneCore::ConfigItem.new(key: :a_bool,
                                      description: "Metadata: A bool",

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -158,7 +158,7 @@ describe FastlaneCore do
     it "raises an exception if path was not found" do
       expect do
         FastlaneCore::Project.new(project: "/tmp/notHere123")
-      end.to raise_error "Could not find project at path '/tmp/notHere123'".red
+      end.to raise_error "Could not find project at path '/tmp/notHere123'"
     end
 
     describe "Valid Standard Project" do

--- a/fastlane_core/spec/simulator_spec.rb
+++ b/fastlane_core/spec/simulator_spec.rb
@@ -30,7 +30,7 @@ describe FastlaneCore do
 
       expect do
         devices = FastlaneCore::Simulator.all
-      end.to raise_error("xcrun simctl not working.".red)
+      end.to raise_error("xcrun simctl not working.")
     end
 
     it "properly parses the simctl output and generates Device objects for iOS" do

--- a/fastlane_core/spec/spec_helper.rb
+++ b/fastlane_core/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'coveralls'
 Coveralls.wear! unless ENV["FASTLANE_SKIP_UPDATE_CHECK"]
 
 require 'fastlane_core'
+UI = FastlaneCore::UI
 
 require 'webmock/rspec'
 

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -3,7 +3,7 @@ module Pilot
     def upload(options)
       start(options)
 
-      raise "No ipa file given".red unless config[:ipa]
+      UI.user_error!("No ipa file given") unless config[:ipa]
 
       Helper.log.info "Ready to upload new build to TestFlight (App: #{app.apple_id})...".green
 
@@ -28,7 +28,7 @@ module Pilot
           Helper.log.info "Successfully distributed build to beta testers 🚀"
         end
       else
-        raise "Error uploading ipa file, more information see above".red
+        UI.user_error!("Error uploading ipa file, more information see above")
       end
     end
 
@@ -99,7 +99,7 @@ module Pilot
         Helper.log.info "iTunes Connect #iosprocessingtime #{minutes} minutes".yellow
         return full_build
       else
-        raise "Error: Seems like iTunes Connect didn't properly pre-process the binary".red
+        UI.user_error!("Error: Seems like iTunes Connect didn't properly pre-process the binary")
       end
     end
 

--- a/pilot/lib/pilot/commands_generator.rb
+++ b/pilot/lib/pilot/commands_generator.rb
@@ -39,7 +39,7 @@ module Pilot
           Helper.log.info "[#{address}]: #{ex}".red
         end
       end
-      raise "Some operations failed: #{failures}".red unless failures.empty?
+      UI.user_error!("Some operations failed: #{failures}") unless failures.empty?
     end
 
     def run

--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -23,7 +23,7 @@ module Pilot
 
       @app ||= Spaceship::Application.find(@apple_id)
       unless @app
-        raise "Could not find app with #{(config[:apple_id] || config[:app_identifier])}"
+        UI.user_error!("Could not find app with #{(config[:apple_id] || config[:app_identifier])}")
       end
       return @app
     end
@@ -40,7 +40,7 @@ module Pilot
 
       if config[:app_identifier]
         @app ||= Spaceship::Application.find(config[:app_identifier])
-        raise "Couldn't find app '#{config[:app_identifier]}' on the account of '#{config[:username]}' on iTunes Connect".red unless @app
+        UI.user_error!("Couldn't find app '#{config[:app_identifier]}' on the account of '#{config[:username]}' on iTunes Connect") unless @app
         app_id ||= @app.apple_id
       end
 

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -26,8 +26,8 @@ module Pilot
                                      description: "Path to the ipa file to upload",
                                      default_value: Dir["*.ipa"].first,
                                      verify_block: proc do |value|
-                                       raise "Could not find ipa file at path '#{value}'" unless File.exist? value
-                                       raise "'#{value}' doesn't seem to be an ipa file" unless value.end_with? ".ipa"
+                                       UI.user_error!("Could not find ipa file at path '#{value}'") unless File.exist? value
+                                       UI.user_error!("'#{value}' doesn't seem to be an ipa file") unless value.end_with? ".ipa"
                                      end),
         FastlaneCore::ConfigItem.new(key: :changelog,
                                      short_option: "-w",
@@ -67,7 +67,7 @@ module Pilot
                                      description: "The tester's email",
                                      optional: true,
                                      verify_block: proc do |value|
-                                       raise "Please pass a valid email address" unless value.include? "@"
+                                       UI.user_error!("Please pass a valid email address") unless value.include? "@"
                                      end),
         FastlaneCore::ConfigItem.new(key: :testers_file_path,
                                      short_option: "-c",
@@ -82,7 +82,7 @@ module Pilot
                                      default_value: 30,
                                      type: Integer,
                                      verify_block: proc do |value|
-                                       raise "Please enter a valid positive number of seconds" unless value.to_i > 0
+                                       UI.user_error!("Please enter a valid positive number of seconds") unless value.to_i > 0
                                      end),
         FastlaneCore::ConfigItem.new(key: :team_id,
                                      short_option: "-q",

--- a/pilot/lib/pilot/tester_exporter.rb
+++ b/pilot/lib/pilot/tester_exporter.rb
@@ -4,7 +4,7 @@ require "pilot/tester_util"
 module Pilot
   class TesterExporter < Manager
     def export_testers(options)
-      raise "Export file path is required".red unless options[:testers_file_path]
+      UI.user_error!("Export file path is required") unless options[:testers_file_path]
 
       start(options)
       require 'csv'

--- a/pilot/lib/pilot/tester_importer.rb
+++ b/pilot/lib/pilot/tester_importer.rb
@@ -3,7 +3,7 @@ require "fastlane_core"
 module Pilot
   class TesterImporter < Manager
     def import_testers(options)
-      raise "Import file path is required".red unless options[:testers_file_path]
+      UI.user_error!("Import file path is required") unless options[:testers_file_path]
 
       start(options)
 

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -23,7 +23,7 @@ module Pilot
         if app_filter
           begin
             app = Spaceship::Application.find(app_filter)
-            raise "Couldn't find app with '#{app_filter}'" unless app
+            UI.user_error!("Couldn't find app with '#{app_filter}'") unless app
             tester.add_to_app!(app.apple_id)
             Helper.log.info "Successfully added tester to app #{app_filter}".green
           rescue => ex
@@ -43,7 +43,7 @@ module Pilot
       tester = Spaceship::Tunes::Tester::Internal.find(config[:email])
       tester ||= Spaceship::Tunes::Tester::External.find(config[:email])
 
-      raise "Tester #{config[:email]} not found".red unless tester
+      UI.user_error!("Tester #{config[:email]} not found") unless tester
 
       describe_tester(tester)
       return tester
@@ -60,7 +60,7 @@ module Pilot
         if app_filter
           begin
             app = Spaceship::Application.find(app_filter)
-            raise "Couldn't find app with '#{app_filter}'" unless app
+            UI.user_error!("Couldn't find app with '#{app_filter}'") unless app
             tester.remove_from_app!(app.apple_id)
             Helper.log.info "Successfully removed tester #{tester.email} from app #{app_filter}".green
           rescue => ex
@@ -83,7 +83,7 @@ module Pilot
       app_filter = (config[:apple_id] || config[:app_identifier])
       if app_filter
         app = Spaceship::Application.find(app_filter)
-        raise "Couldn't find app with '#{app_filter}'" unless app
+        UI.user_error!("Couldn't find app with '#{app_filter}'") unless app
         int_testers = Spaceship::Tunes::Tester::Internal.all_by_app(app.apple_id)
         ext_testers = Spaceship::Tunes::Tester::External.all_by_app(app.apple_id)
       else

--- a/produce/lib/produce/group.rb
+++ b/produce/lib/produce/group.rb
@@ -29,7 +29,7 @@ module Produce
 
         Helper.log.info "Created group #{group.app_group_id}"
 
-        raise "Something went wrong when creating the new app group - it's not listed in the app groups list" unless app_group_exists? group_identifier
+        UI.user_error!("Something went wrong when creating the new app group - it's not listed in the app groups list") unless app_group_exists? group_identifier
 
         ENV["CREATED_NEW_GROUP_ID"] = Time.now.to_i.to_s
 
@@ -46,7 +46,7 @@ module Produce
         Helper.log.info "[DevCenter] App '#{Produce.config[:app_identifier]}' does not exist, nothing to associate with the groups".red
       else
         app = Spaceship.app.find(app_identifier)
-        raise "Something went wrong when fetching the app - it's not listed in the apps list" if app.nil?
+        UI.user_error!("Something went wrong when fetching the app - it's not listed in the apps list") if app.nil?
 
         new_groups = []
 

--- a/produce/lib/produce/service.rb
+++ b/produce/lib/produce/service.rb
@@ -77,7 +77,7 @@ module Produce
           when "untilfirstauth"
             app.update_service(Spaceship.app_service.data_protection.until_first_auth)
           else
-            raise "Unknown service '#{options.data_protection}'. Valid values: 'complete', 'unlessopen', 'untilfirstauth'".red
+            UI.user_error!("Unknown service '#{options.data_protection}'. Valid values: 'complete', 'unlessopen', 'untilfirstauth'")
           end
         else
           app.update_service(Spaceship.app_service.data_protection.off)
@@ -126,7 +126,7 @@ module Produce
             app.update_service(Spaceship.app_service.icloud.on)
             app.update_service(Spaceship.app_service.cloud_kit.cloud_kit)
           else
-            raise "Unknown service '#{options.icloud}'. Valid values: 'legacy', 'cloudkit'".red
+            UI.user_error!("Unknown service '#{options.icloud}'. Valid values: 'legacy', 'cloudkit'")
           end
         else
           app.update_service(Spaceship.app_service.icloud.off)

--- a/scan/lib/scan/commands_generator.rb
+++ b/scan/lib/scan/commands_generator.rb
@@ -48,7 +48,7 @@ module Scan
         c.action do |_args, options|
           containing = (Helper.fastlane_enabled? ? 'fastlane' : '.')
           path = File.join(containing, Scan.scanfile_name)
-          raise "Scanfile already exists".yellow if File.exist?(path)
+          UI.user_error!("Scanfile already exists").yellow if File.exist?(path)
           template = File.read("#{Helper.gem_path('scan')}/lib/assets/ScanfileTemplate")
           File.write(path, template)
           Helper.log.info "Successfully created '#{path}'. Open the file using a code editor.".green

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -64,7 +64,7 @@ module Scan
 
       Scan.device = found
 
-      raise "No simulators found".red unless Scan.device
+      UI.user_error!("No simulators found") unless Scan.device
     end
 
     def self.default_device_tvos
@@ -95,7 +95,7 @@ module Scan
 
       Scan.device = found
 
-      raise "No simulators found".red unless Scan.device
+      UI.user_error!("No simulators found") unless Scan.device
     end
 
     # Is it an iOS device or a Mac?

--- a/scan/lib/scan/error_handler.rb
+++ b/scan/lib/scan/error_handler.rb
@@ -21,7 +21,7 @@ module Scan
           print "For more information visit this stackoverflow answer:"
           print "https://stackoverflow.com/a/17031697/445598"
         when /Testing failed/
-          raise "Error building the application - see the log above".red
+          UI.user_error!("Error building the application - see the log above")
         when /Executed/
           # this is *really* important:
           # we don't want to raise an exception here
@@ -29,7 +29,7 @@ module Scan
           # after parsing the actual test results
           return
         end
-        raise "Error building/testing the application - see the log above".red
+        UI.user_error!("Error building/testing the application - see the log above")
       end
 
       private

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -14,9 +14,9 @@ module Scan
                                      description: "Path the workspace file",
                                      verify_block: proc do |value|
                                        v = File.expand_path(value.to_s)
-                                       raise "Workspace file not found at path '#{v}'".red unless File.exist?(v)
-                                       raise "Workspace file invalid".red unless File.directory?(v)
-                                       raise "Workspace file is not a workspace, must end with .xcworkspace".red unless v.include?(".xcworkspace")
+                                       UI.user_error!("Workspace file not found at path '#{v}'") unless File.exist?(v)
+                                       UI.user_error!("Workspace file invalid") unless File.directory?(v)
+                                       UI.user_error!("Workspace file is not a workspace, must end with .xcworkspace") unless v.include?(".xcworkspace")
                                      end),
         FastlaneCore::ConfigItem.new(key: :project,
                                      short_option: "-p",
@@ -25,9 +25,9 @@ module Scan
                                      description: "Path the project file",
                                      verify_block: proc do |value|
                                        v = File.expand_path(value.to_s)
-                                       raise "Project file not found at path '#{v}'".red unless File.exist?(v)
-                                       raise "Project file invalid".red unless File.directory?(v)
-                                       raise "Project file is not a project file, must end with .xcodeproj".red unless v.include?(".xcodeproj")
+                                       UI.user_error!("Project file not found at path '#{v}'") unless File.exist?(v)
+                                       UI.user_error!("Project file invalid") unless File.directory?(v)
+                                       UI.user_error!("Project file is not a project file, must end with .xcodeproj") unless v.include?(".xcodeproj")
                                      end),
         FastlaneCore::ConfigItem.new(key: :device,
                                      short_option: "-a",
@@ -66,7 +66,7 @@ module Scan
                                      description: "Define how the output should look like (standard, basic or rspec)",
                                      optional: true,
                                      verify_block: proc do |value|
-                                       raise "Invalid output_style #{value}".red unless ['standard', 'basic', "rspec"].include?(value)
+                                       UI.user_error!("Invalid output_style #{value}") unless ['standard', 'basic', "rspec"].include?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :output_types,
                                      short_option: "-f",
@@ -121,7 +121,7 @@ module Scan
                                      description: "Use an extra XCCONFIG file to build your app",
                                      optional: true,
                                      verify_block: proc do |value|
-                                       raise "File not found at path '#{File.expand_path(value)}'".red unless File.exist?(value)
+                                       UI.user_error!("File not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :slack_url,
                                      short_option: "-i",
@@ -129,7 +129,7 @@ module Scan
                                      description: "Create an Incoming WebHook for your Slack group to post results there",
                                      optional: true,
                                      verify_block: proc do |value|
-                                       raise "Invalid URL, must start with https://" unless value.start_with? "https://"
+                                       UI.user_error!("Invalid URL, must start with https://") unless value.start_with? "https://"
                                      end),
         FastlaneCore::ConfigItem.new(key: :slack_channel,
                                      short_option: "-e",

--- a/scan/lib/scan/report_collector.rb
+++ b/scan/lib/scan/report_collector.rb
@@ -10,7 +10,7 @@ module Scan
     end
 
     def parse_raw_file(path)
-      raise "Couldn't find file at path '#{path}'".red unless File.exist?(path)
+      UI.user_error!("Couldn't find file at path '#{path}'") unless File.exist?(path)
 
       commands = generate_commands(path)
       commands.each do |output_path, command|

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -23,7 +23,7 @@ module Scan
       def project_path_array
         proj = Scan.project.xcodebuild_parameters
         return proj if proj.count > 0
-        raise "No project/workspace found"
+        UI.user_error!("No project/workspace found")
       end
 
       def options

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -13,7 +13,7 @@ describe Scan do
       expect do
         options = { project: "/notExistent" }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
-      end.to raise_error "Project file not found at path '/notExistent'".red
+      end.to raise_error "Project file not found at path '/notExistent'"
     end
 
     it "supports additional parameters" do

--- a/snapshot/lib/snapshot/latest_ios_version.rb
+++ b/snapshot/lib/snapshot/latest_ios_version.rb
@@ -14,11 +14,11 @@ module Snapshot
 
       matched = output.match(/iOS ([\d\.]+) \(.*/)
       if matched.nil?
-        raise "Could not determine installed iOS SDK version. Try running the _xcodebuild_ command manually to ensure it works."
+        UI.user_error!("Could not determine installed iOS SDK version. Try running the _xcodebuild_ command manually to ensure it works.")
       elsif matched.length > 1
         return @version ||= matched[1]
       else
-        raise "Could not determine installed iOS SDK version. Please pass it via the environment variable 'SNAPSHOT_IOS_VERSION'".red
+        UI.user_error!("Could not determine installed iOS SDK version. Please pass it via the environment variable 'SNAPSHOT_IOS_VERSION'")
       end
     end
   end

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -14,9 +14,9 @@ module Snapshot
                                      description: "Path the workspace file",
                                      verify_block: proc do |value|
                                        v = File.expand_path(value.to_s)
-                                       raise "Workspace file not found at path '#{v}'".red unless File.exist?(v)
-                                       raise "Workspace file invalid".red unless File.directory?(v)
-                                       raise "Workspace file is not a workspace, must end with .xcworkspace".red unless v.include?(".xcworkspace")
+                                       UI.user_error!("Workspace file not found at path '#{v}'") unless File.exist?(v)
+                                       UI.user_error!("Workspace file invalid") unless File.directory?(v)
+                                       UI.user_error!("Workspace file is not a workspace, must end with .xcworkspace") unless v.include?(".xcworkspace")
                                      end),
         FastlaneCore::ConfigItem.new(key: :project,
                                      short_option: "-p",
@@ -25,9 +25,9 @@ module Snapshot
                                      description: "Path the project file",
                                      verify_block: proc do |value|
                                        v = File.expand_path(value.to_s)
-                                       raise "Project file not found at path '#{v}'".red unless File.exist?(v)
-                                       raise "Project file invalid".red unless File.directory?(v)
-                                       raise "Project file is not a project file, must end with .xcodeproj".red unless v.include?(".xcodeproj")
+                                       UI.user_error!("Project file not found at path '#{v}'") unless File.exist?(v)
+                                       UI.user_error!("Project file invalid") unless File.directory?(v)
+                                       UI.user_error!("Project file is not a project file, must end with .xcodeproj") unless v.include?(".xcodeproj")
                                      end),
         FastlaneCore::ConfigItem.new(key: :devices,
                                      description: "A list of devices you want to take the screenshots from",
@@ -38,7 +38,7 @@ module Snapshot
                                        available = FastlaneCore::Simulator.all
                                        value.each do |current|
                                          unless available.any? { |d| d.name.strip == current.strip }
-                                           raise "Device '#{current}' not in list of available simulators '#{available.join(', ')}'".red
+                                           UI.user_error!("Device '#{current}' not in list of available simulators '#{available.join(', ')}'")
                                          end
                                        end
                                      end),

--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -7,7 +7,7 @@ module Snapshot
 
       sure = true if ENV["SNAPSHOT_FORCE_DELETE"]
       sure = agree("Are you sure? All your simulators will be DELETED and new ones will be created! (y/n)".red, true) unless sure
-      raise "User cancelled action" unless sure
+      UI.user_error!("User cancelled action") unless sure
 
       devices.each do |device|
         _, name, id = device

--- a/snapshot/lib/snapshot/setup.rb
+++ b/snapshot/lib/snapshot/setup.rb
@@ -5,7 +5,7 @@ module Snapshot
       snapfile_path = File.join(path, 'Snapfile')
 
       if File.exist?(snapfile_path)
-        raise "Snapfile already exists at path '#{snapfile_path}'. Run 'snapshot' to use snapshot.".red
+        UI.user_error!("Snapfile already exists at path '#{snapfile_path}'. Run 'snapshot' to use snapshot.")
       end
 
       gem_path = Helper.gem_path("snapshot")

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -24,7 +24,7 @@ module Snapshot
       def project_path_array
         proj = Snapshot.project.xcodebuild_parameters
         return proj if proj.count > 0
-        raise "No project/workspace found"
+        UI.user_error!("No project/workspace found")
       end
 
       def options

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -76,7 +76,7 @@ module Supply
 
     # Begin modifying a certain package
     def begin_edit(package_name: nil)
-      raise "You currently have an active edit" if @current_edit
+      UI.user_error!("You currently have an active edit") if @current_edit
 
       self.current_edit = android_publisher.insert_edit(package_name)
 
@@ -280,7 +280,7 @@ module Supply
     private
 
     def ensure_active_edit!
-      raise "You need to have an active edit, make sure to call `begin_edit`" unless @current_edit
+      UI.user_error!("You need to have an active edit, make sure to call `begin_edit`") unless @current_edit
     end
   end
 end

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -5,7 +5,7 @@ module Supply
 
       client.begin_edit(package_name: Supply.config[:package_name])
 
-      raise "No local metadata found, make sure to run `supply init` to setup supply".red unless metadata_path || Supply.config[:apk]
+      UI.user_error!("No local metadata found, make sure to run `supply init` to setup supply") unless metadata_path || Supply.config[:apk]
 
       if metadata_path
         UI.user_error!("Could not find folder #{metadata_path}") unless File.directory? metadata_path

--- a/watchbuild/lib/watchbuild/runner.rb
+++ b/watchbuild/lib/watchbuild/runner.rb
@@ -22,7 +22,7 @@ module WatchBuild
     end
 
     def wait_for_build(start_time)
-      raise "Could not find app with app identiifer #{WatchBuild.config[:app_identifier]}".red unless app
+      UI.user_error!("Could not find app with app identiifer #{WatchBuild.config[:app_identifier]}") unless app
 
       loop do
         begin


### PR DESCRIPTION
Oh yeah :rocket: 

All fastlane exceptions (except for spaceship ones) are now triggered using `UI.user_error!` or `UI.crash!`

**Old:**
![screenshot 2016-03-24 11 47 09](https://cloud.githubusercontent.com/assets/869950/14027983/950ae3a0-f1b7-11e5-9698-d83b5f0af181.png)

**New:**
![screenshot 2016-03-24 11 47 23](https://cloud.githubusercontent.com/assets/869950/14027985/9794e31e-f1b7-11e5-8586-b848248c74d0.png)

Code I used

``` ruby
task :converter do
  path = "./**/*.rb"
  Dir[path].each do |current|
    next if current.include?("spaceship/")
    content = File.read(current)
    ["'", '"'].each do |esc|
      other = (esc == "'" ? '"' : "'")
      content.gsub!(/raise #{esc}([\w\^\(\)\#\.\[\]\,\-\{\}\|\:\>\<\=\/\:\`\?\.\s#{other}]*)#{esc}(\.red){0,1}/) do |line|
        error_message = Regexp.last_match[1]
        puts "error:"
        puts error_message
        puts "line:"
        puts line
        "UI.user_error!(\"#{error_message}\")"
      end

      # end.to raise_error "Error message here".red
      content.gsub!(/end.to raise_error(.*)\.red/) do |line|
        error_message = Regexp.last_match[1]
        line.gsub(".red", "")
      end
    end
    File.write(current, content)
    puts content
  end
end
```
