### PR TITLE
Add support for passing around the keychain value.

### DIFF
--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -5,7 +5,7 @@ module Cert
     def launch
       run
 
-      installed = FastlaneCore::CertChecker.installed?(ENV["CER_FILE_PATH"])
+      installed = FastlaneCore::CertChecker.installed?(ENV["CER_FILE_PATH"], Cert.config[:keychain_path])
       UI.message "Verifying the certificated is properly installed locally..."
       UI.user_error!("Could not find the newly generated certificate installed") unless installed
       UI.success "Successfully installed certificate #{ENV['CER_CERTIFICATE_ID']}"


### PR DESCRIPTION
Cert gives warnings about not being able to install a certificate if it is given a keychain argument.  This passes the keychain path into fastlane_core, and stops the errors.
