### PR TITLE
add variable 'processing_state' to 'build' object (fix #3888)

### DIFF
--- a/spaceship/lib/spaceship/tunes/build.rb
+++ b/spaceship/lib/spaceship/tunes/build.rb
@@ -29,6 +29,9 @@ module Spaceship
       # @return (Boolean) Is this build currently processing?
       attr_accessor :processing
 
+      # @return (String) Is the build processing state
+      attr_accessor :processing_state
+
       # @return (Integer) The number of ticks since 1970 (e.g. 1413966436000)
       attr_accessor :upload_date
 
@@ -91,6 +94,7 @@ module Spaceship
         'id' => :id,
         'valid' => :valid,
         'processing' => :processing,
+        'processingState' => :processing_state,
 
         'installCount' => :install_count,
         'internalInstallCount' => :internal_install_count,
@@ -247,6 +251,7 @@ end
 #  "exceededFileSizeLimit"=>false,
 #  "wentLiveWithVersion"=>false,
 #  "processing"=>false,
+#  "processingState"=>processingFailed,
 #  "id"=>5298023,
 #  "valid"=>true,
 #  "missingExportCompliance"=>false,

--- a/spaceship/lib/spaceship/tunes/build_train.rb
+++ b/spaceship/lib/spaceship/tunes/build_train.rb
@@ -73,7 +73,7 @@ module Spaceship
 
         # since buildsInProcessing appears empty, fallback to also including processing state from @builds
         @builds.each do |build|
-          @processing_builds << build if build.processing == true && build.valid == true
+          @processing_builds << build if build.processing == true && build.valid == true && build.processing_state != 'processingFailed'
         end
       end
 


### PR DESCRIPTION
Added variable for 'processing_state' parameter. In some cases build remain in processing state even if in error.
In this way the build list contains all the processing build without and excludes error builds.
