### PR TITLE
Add scheme parameter to get_version_number action

### DIFF
--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -3,12 +3,25 @@ describe Fastlane do
     describe "Get Version Number Integration" do
       require 'shellwords'
 
-      it "gets the version number of the Xcode project" do
-        Fastlane::FastFile.new.parse("lane :test do
+      it "gets the correct version number for 'SchemeA'" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          get_version_number(xcodeproj: '.xcproject', scheme: 'SchemeA')
+        end").runner.execute(:test)
+        expect(result).to eq("4.3.2")
+      end
+
+      it "gets the correct version number for 'SchemeB'" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          get_version_number(xcodeproj: '.xcproject', scheme: 'SchemeB')
+        end").runner.execute(:test)
+        expect(result).to eq("5.4.3")
+      end
+
+      it "gets the correct version number with no scheme" do
+        result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '.xcproject')
         end").runner.execute(:test)
-
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool what-marketing-version -terse1/)
+        expect(result).to eq("4.3.2")
       end
 
       it "raises an exception when use passes workspace" do


### PR DESCRIPTION
This prevents invalid results when working on a project with multiple targets / schemes that have different version numbers. If you do not specify a scheme, the behavior remains the same.
