### PR TITLE
Updated docs to show faster installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ fastlane beta
 
 ## Installation
 
-    sudo gem install fastlane --verbose
+    sudo gem install fastlane --verbose --no-ri --no-rdoc
 
 Make sure you have the latest version of the Xcode command line tools installed:
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -102,7 +102,7 @@ fastlane appstore
 
 I recommend following the [fastlane guide](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Guide.md) to get started.
 
-    sudo gem install fastlane --verbose
+    sudo gem install fastlane --verbose --no-ri --no-rdoc
 
 Make sure, you have the latest version of the Xcode command line tools installed:
 


### PR DESCRIPTION
I just installed fastlane on a fresh Mac and it took longer than it should. By providing those additional parameters the installation is faster. This adds complexity.

Originally

```
gem install fastlane
```

and now

```
sudo gem install fastlane --verbose --no-ri --no-rdoc
```

We should probably do some additional testing on fresh Macs to see if it's worth the extra complexity

Via https://stackoverflow.com/questions/1381725/how-to-make-no-ri-no-rdoc-the-default-for-gem-install
