### PR TITLE
Handle non UTF-8 metadata more gracefully

### DIFF
--- a/supply/lib/supply/setup.rb
+++ b/supply/lib/supply/setup.rb
@@ -32,7 +32,7 @@ module Supply
       Supply::AVAILABLE_METADATA_FIELDS.each do |key|
         path = File.join(containing, "#{key}.txt")
         UI.message("Writing to #{path}...")
-        File.write(path, listing.send(key))
+        File.open(path, 'w:UTF-8') { |file| file.write(listing.send(key)) }
       end
     end
 

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -50,7 +50,12 @@ module Supply
         path = File.join(metadata_path, language, "#{key}.txt")
         listing.send("#{key}=".to_sym, File.read(path)) if File.exist?(path)
       end
-      listing.save
+      begin
+        listing.save
+      rescue Encoding::InvalidByteSequenceError => ex
+        message = (ex.message || '').capitalize
+        UI.user_error!("Metadata must be UTF-8 encoded. #{message}")
+      end
     end
 
     def upload_images(language)

--- a/supply/supply.gemspec
+++ b/supply/supply.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google-api-client', '~> 0.9.1' # Google API Client to access Play Publishing API
 
   # fastlane
-  spec.add_dependency 'fastlane_core', '>= 0.35.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.40.0' # all shared code and dependencies
   spec.add_dependency 'credentials_manager', '>= 0.15.0'
 
   # Development only


### PR DESCRIPTION
Fixes #1967 by writing data as UTF-8 and giving a better error message when trying to upload data that is not saved as UTF-8. 
