### PR TITLE
Update appetize action for new api, add multipart form upload

### DIFF
--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'plist', '~> 3.1.0' # Needed for set_build_number_repository and get_info_plist_value actions
   spec.add_dependency 'addressable', '~> 2.3.8' # Support for URI templates
 
+  spec.add_dependency 'multipart-post', '~> 2.0.0' # Needed for uploading builds to appetize
+
   spec.add_dependency 'fastlane_core', '>= 0.37.0', '< 1.0.0' # all shared code and dependencies
 
   spec.add_dependency 'credentials_manager', '>= 0.15.0', '< 1.0.0' # Password Manager

--- a/fastlane/lib/fastlane/actions/appetize.rb
+++ b/fastlane/lib/fastlane/actions/appetize.rb
@@ -8,38 +8,61 @@ module Fastlane
     end
 
     class AppetizeAction < Action
-      APPETIZE_URL_BASE = 'https://api.appetize.io/v1/app/update'
-
       def self.is_supported?(platform)
         platform == :ios
       end
 
       def self.run(options)
         require 'net/http'
+        require 'net/http/post/multipart'
         require 'uri'
         require 'json'
 
-        uri = URI.parse(APPETIZE_URL_BASE)
-        https = Net::HTTP.new(uri.host, uri.port)
-        https.use_ssl = true
-
-        req = Net::HTTP::Post.new(uri.request_uri, initheader: {'Content-Type' => 'application/json'})
         params = {
-            token: options[:api_token],
-            url: options[:url],
             platform: 'ios'
         }
 
-        params[:privateKey] = options[:private_key] unless options[:private_key].nil?
-        req.body = JSON.generate(params)
-        response = https.request(req)
+        if options[:path]
+          params[:file] = UploadIO.new(options[:path], 'application/zip')
+        else
+          UI.user_error!('url parameter is required if no file path is specified') if options[:url].nil?
+          params[:url] = options[:url]
+        end
 
-        UI.user_error!("Error when trying to upload ipa to Appetize.io") unless parse_response(response)
+        params[:note] = options[:note] if options[:note].to_s.length > 0
+
+        uri = URI.parse(appetize_url(options))
+        req = create_request(uri, params)
+        req.basic_auth(options[:api_token], nil)
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+
+        response = http.request(req)
+
+        UI.user_error!("Error uploading app to Appetize.io") unless parse_response(response)
         UI.message("App URL: #{Actions.lane_context[SharedValues::APPETIZE_APP_URL]}")
         UI.message("Manage URL: #{Actions.lane_context[SharedValues::APPETIZE_MANAGE_URL]}")
         UI.message("App Private Key: #{Actions.lane_context[SharedValues::APPETIZE_PRIVATE_KEY]}")
         UI.success("Build successfully uploaded to Appetize.io")
       end
+
+      def self.appetize_url(options)
+        "https://api.appetize.io/v1/apps/#{options[:public_key]}"
+      end
+      private_class_method :appetize_url
+
+      def self.create_request(uri, params)
+        if params[:url]
+          req = Net::HTTP::Post.new(uri.request_uri, initheader: {'Content-Type' => 'application/json'})
+          req.body = JSON.generate(params)
+        else
+          req = Net::HTTP::Post::Multipart.new(uri.path, params)
+        end
+
+        req
+      end
+      private_class_method :create_request
 
       def self.parse_response(response)
         body = JSON.parse(response.body)
@@ -55,61 +78,57 @@ module Fastlane
         return true
       rescue
         UI.error("Error uploading to Appetize.io: #{response.body}")
-        help_message(response)
         return false
       end
       private_class_method :parse_response
-
-      def self.help_message(response)
-        message = case response.body
-                  when 'Invalid token'
-                    'Invalid API Token specified.'
-                  when 'Error downloading zip file'
-                    'URL should be wrong'
-                  when 'No app with specified privateKey found'
-                    'Invalid privateKey specified'
-                  end
-        UI.error(message) if message
-      end
-      private_class_method :help_message
 
       def self.description
         "Create or Update apps on Appetize.io"
       end
 
       def self.available_options
-        [FastlaneCore::ConfigItem.new(key: :api_token,
-                                      env_name: "APPETIZE_API_TOKEN",
-                                      description: "Appetize.io API Token",
-                                      is_string: true,
-                                      verify_block: proc do |value|
-                                        UI.user_error!("No API Token for Appetize.io given, pass using `api_token: 'token'`") unless value.to_s.length > 0
-                                      end),
-         FastlaneCore::ConfigItem.new(key: :url,
-                                      env_name: "APPETIZE_URL",
-                                      description: "Target url of the zipped build",
-                                      is_string: true,
-                                      verify_block: proc do |value|
-                                        UI.user_error!("No URL of your zipped build") unless value.to_s.length > 0
-                                      end),
-         FastlaneCore::ConfigItem.new(key: :private_key,
-                                      env_name: "APPETIZE_PRIVATEKEY",
-                                      description: "privateKey which specify each applications",
-                                      optional: true)
+        [
+          FastlaneCore::ConfigItem.new(key: :api_token,
+                                       env_name: "APPETIZE_API_TOKEN",
+                                       description: "Appetize.io API Token",
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No API Token for Appetize.io given, pass using `api_token: 'token'`") unless value.to_s.length > 0
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :url,
+                                       env_name: "APPETIZE_URL",
+                                       description: "Target url of the zipped build. Either this or `path` must be specified",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: "APPETIZE_FILE_PATH",
+                                       description: "Path to zipped build on the local filesystem. Either this or `url` must be specified",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :public_key,
+                                       env_name: "APPETIZE_PUBLICKEY",
+                                       description: "Public key of the app you wish to update. If not provided, then a new app entry will be created on Appetize.io",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :note,
+                                       env_name: "APPETIZE_NOTE",
+                                       description: "Notes you wish to add to the uploaded app",
+                                       is_string: true,
+                                       optional: true)
         ]
       end
 
       def self.output
         [
-          ['APPETIZE_PRIVATE_KEY', 'a string that is used to prove "ownership" of your app - save this so that you may subsequently update the app'],
-          ['APPETIZE_PUBLIC_KEY', 'a public identiifer for your app'],
-          ['APPETIZE_APP_URL', 'a page to test and share your app'],
-          ['APPETIZE_MANAGE_URL', 'a page to manage your app']
+          ['APPETIZE_PRIVATE_KEY', 'a string that is used to prove "ownership" of your app.'],
+          ['APPETIZE_PUBLIC_KEY', 'a public identiifer for your app. Use this to update your app after it has been initially created'],
+          ['APPETIZE_APP_URL', 'a page to test and share your app.'],
+          ['APPETIZE_MANAGE_URL', 'a page to manage your app.']
         ]
       end
 
-      def self.author
-        "giginet"
+      def self.authors
+        ["klundberg", "giginet"]
       end
     end
   end

--- a/fastlane/spec/actions_specs/appetize_spec.rb
+++ b/fastlane/spec/actions_specs/appetize_spec.rb
@@ -10,6 +10,7 @@ describe Fastlane do
       }
       EOS
     end
+
     let(:api_token) { 'mysecrettoken' }
     let(:url) { 'https://example.com/app.zip' }
     let(:http) { double('http') }
@@ -20,14 +21,20 @@ describe Fastlane do
        url: url,
        platform: 'ios'}
     end
+
     before do
       allow(Net::HTTP).to receive(:new).and_return(http)
       allow(Net::HTTP::Post).to receive(:new).and_return(request)
+
       allow(http).to receive(:use_ssl=).with(true)
       allow(http).to receive(:request).with(request).and_return(response)
+
+      allow(request).to receive(:basic_auth).with(api_token, nil)
       allow(request).to receive(:body=).with(kind_of(String)).and_return(response)
+
       allow(response).to receive(:body).and_return(response_string)
     end
+
     describe "Appetize Integration" do
       it "raises an error if no parameters were given" do
         expect do
@@ -36,7 +43,7 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error
       end
-      it "raises an error if no url was given" do
+      it "raises an error if no url or path was given" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             appetize({
@@ -54,7 +61,7 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error
       end
-      it "works with valid parameter" do
+      it "works with valid parameters" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             appetize({


### PR DESCRIPTION
Hello!

This change updates the action to work with appetize.io's currently documented API, and allows developers to directly upload apps to appetize without needing to store it on a public URL first.

This adds a gem dependency to make the multipart upload simple to implement in the action itself.
