### PR TITLE
Improve logging when skipping screenshots

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -75,17 +75,16 @@ module Deliver
 
         prefer_framed = Dir.glob(File.join(lng_folder, "*_framed.#{extensions}"), File::FNM_CASEFOLD).count > 0
 
+        UI.important("Framed screenshots are detected! 🖼 Non-framed screenshot files may be skipped. 🏃") if prefer_framed
+
         language = File.basename(lng_folder)
         files.each do |file_path|
-          if file_path.downcase.include?("_framed.")
-            # That's cool
-          else
-            if file_path.downcase.include?("watch")
-              # Watch doesn't support frames (yet)
-            else
-              # That might not be cool... if that screenshot is not framed but we only want framed
-              next if prefer_framed
-            end
+          is_framed = file_path.downcase.include?("_framed.")
+          is_watch = file_path.downcase.include?("watch")
+
+          if prefer_framed && !is_framed && !is_watch
+            UI.important("🏃 Skipping screenshot file: #{file_path}")
+            next
           end
 
           screenshots << AppScreenshot.new(file_path, language)


### PR DESCRIPTION
Requested by #3626

If `deliver` detects some screenshots that are framed, non-framed screenshots may be skipped during the collection process. This provides log messaging to notify the user that this is happening.
