### PR TITLE
Frameit compatibility with iPhone SE

### DIFF
--- a/frameit/lib/frameit/offsets.rb
+++ b/frameit/lib/frameit/offsets.rb
@@ -20,8 +20,8 @@ module Frameit
           }
         when size::IOS_40
           return {
-            'offset' => "+54+197",
-            'width' => 544
+            'offset' => "+48+178",
+            'width' => 485
           }
         when size::IOS_35
           return {

--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -26,7 +26,7 @@ module Frameit
       when sizes::IOS_47
         return 'iPhone-6s'
       when sizes::IOS_40
-        return 'iPhone_5s'
+        return 'iPhone-SE'
       when sizes::IOS_35
         return 'iPhone_4'
       when sizes::IOS_IPAD

--- a/frameit/lib/frameit/template_finder.rb
+++ b/frameit/lib/frameit/template_finder.rb
@@ -11,18 +11,27 @@ module Frameit
       ]
       joiner = "_"
 
-      if screenshot.device_name.include?('iPad') || screenshot.device_name.include?('6s')
+      if screenshot.device_name.include?('iPad') || screenshot.device_name.include?('6s') || screenshot.device_name.include?('SE')
         parts = [
           screenshot.device_name,
-          (screenshot.color == 'SpaceGray' ? "Space-Gray" : "Silver"),
-          (screenshot.orientation_name == "Horz" ? "horizontal" : "vertical")
+          (screenshot.color == 'SpaceGray' ? "Space-Gray" : "Silver")
         ]
         joiner = "-"
+
+        # Transform the orientation_name to the correct form with the exception of the iPhone SE vertical one.
+        orientation_name_vertical = screenshot.device_name.include?('SE') ? nil : "vertical"
+        orientation_name = screenshot.orientation_name == "Horz" ? "horizontal" : orientation_name_vertical
+        if orientation_name != nil
+            parts.push(orientation_name)
+        end
       end
 
+      # Strict template finder according to the device name
+      strict_finder = screenshot.device_name.include?('SE') ? "" : "*"
+
       templates_path = [ENV['HOME'], FrameConverter::FRAME_PATH].join('/')
-      templates = Dir["../**/#{parts.join(joiner)}*.{png,jpg}"] # local directory
-      templates += Dir["#{templates_path}/**/#{parts.join(joiner)}*.{png,jpg}"] # ~/.frameit folder
+      templates = Dir["../**/#{parts.join(joiner)}#{strict_finder}.{png,jpg}"] # local directory
+      templates += Dir["#{templates_path}/**/#{parts.join(joiner)}#{strict_finder}.{png,jpg}"] # ~/.frameit folder
 
       if templates.count == 0
         if screenshot.screen_size == Deliver::AppScreenshot::ScreenSize::IOS_35

--- a/frameit/lib/frameit/template_finder.rb
+++ b/frameit/lib/frameit/template_finder.rb
@@ -21,8 +21,8 @@ module Frameit
         # Transform the orientation_name to the correct form with the exception of the iPhone SE vertical one.
         orientation_name_vertical = screenshot.device_name.include?('SE') ? nil : "vertical"
         orientation_name = screenshot.orientation_name == "Horz" ? "horizontal" : orientation_name_vertical
-        if orientation_name != nil
-            parts.push(orientation_name)
+        if !orientation_name.nil?
+          parts.push(orientation_name)
         end
       end
 

--- a/frameit/lib/frameit/template_finder.rb
+++ b/frameit/lib/frameit/template_finder.rb
@@ -12,18 +12,14 @@ module Frameit
       joiner = "_"
 
       if screenshot.device_name.include?('iPad') || screenshot.device_name.include?('6s') || screenshot.device_name.include?('SE')
-        parts = [
-          screenshot.device_name,
-          (screenshot.color == 'SpaceGray' ? "Space-Gray" : "Silver")
-        ]
-        joiner = "-"
-
         # Transform the orientation_name to the correct form with the exception of the iPhone SE vertical one.
         orientation_name_vertical = screenshot.device_name.include?('SE') ? nil : "vertical"
-        orientation_name = screenshot.orientation_name == "Horz" ? "horizontal" : orientation_name_vertical
-        if !orientation_name.nil?
-          parts.push(orientation_name)
-        end
+        parts = [
+          screenshot.device_name,
+          (screenshot.color == 'SpaceGray' ? "Space-Gray" : "Silver"),
+          screenshot.orientation_name == "Horz" ? "horizontal" : orientation_name_vertical
+        ].compact
+        joiner = "-"
       end
 
       # Strict template finder according to the device name


### PR DESCRIPTION
Request by #3970

As the [Apple product page](https://developer.apple.com/app-store/marketing/guidelines/#images) removes the iPhone 5 / 5s images in favour of the iPhone SE, this PR makes `frameit` compatible with it.
