### PR TITLE
Add a new invocation strategy to ItunesTransporter

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -124,15 +124,40 @@ module FastlaneCore
       @xcode_version
     end
 
+    def self.transporter_java_executable_path
+      return File.join(self.transporter_java_path, 'bin', 'java')
+    end
+
+    def self.transporter_java_ext_dir
+      return File.join(self.transporter_java_path, 'lib', 'ext')
+    end
+
+    def self.transporter_java_jar_path
+      return File.join(self.itms_path, 'lib', 'itmstransporter-launcher.jar')
+    end
+
+    def self.transporter_user_dir
+      return File.join(self.itms_path, 'bin')
+    end
+
+    def self.transporter_java_path
+      return File.join(self.itms_path, 'java')
+    end
+
     # @return the full path to the iTMSTransporter executable
     def self.transporter_path
+      return File.join(self.itms_path, 'bin', 'iTMSTransporter')
+    end
+
+    # @return the full path to the iTMSTransporter executable
+    def self.itms_path
       return '' unless self.is_mac? # so tests work on Linx too
 
       [
-        "../Applications/Application Loader.app/Contents/MacOS/itms/bin/iTMSTransporter",
-        "../Applications/Application Loader.app/Contents/itms/bin/iTMSTransporter"
+        "../Applications/Application Loader.app/Contents/MacOS/itms",
+        "../Applications/Application Loader.app/Contents/itms"
       ].each do |path|
-        result = File.join(self.xcode_path, path)
+        result = File.expand_path(File.join(self.xcode_path, path))
         return result if File.exist?(result)
       end
       UI.user_error!("Could not find transporter at #{self.xcode_path}. Please make sure you set the correct path to your Xcode installation.")

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -1,5 +1,6 @@
 require 'pty'
 require 'shellwords'
+require 'fileutils'
 require 'credentials_manager/account_manager'
 
 module FastlaneCore
@@ -11,7 +12,8 @@ module FastlaneCore
   class TransporterTransferError < StandardError
   end
 
-  class ItunesTransporter
+  # Base class for executing the iTMSTransporter
+  class TransporterExecutor
     ERROR_REGEX = />\s*ERROR:\s+(.+)/
     WARNING_REGEX = />\s*WARN:\s+(.+)/
     OUTPUT_REGEX = />\s+(.+)/
@@ -21,93 +23,13 @@ module FastlaneCore
 
     private_constant :ERROR_REGEX, :WARNING_REGEX, :OUTPUT_REGEX, :RETURN_VALUE_REGEX, :SKIP_ERRORS
 
-    # This will be called from the Deliverfile, and disables the logging of the transporter output
-    def self.hide_transporter_output
-      @hide_transporter_output = true
+    def execute(command, hide_output)
+      return command if Helper.is_test?
 
-      @hide_transporter_output = false if $verbose
-    end
-
-    # Returns a new instance of the iTunesTransporter.
-    # If no username or password given, it will be taken from
-    # the #{CredentialsManager::AccountManager}
-    def initialize(user = nil, password = nil)
-      data = CredentialsManager::AccountManager.new(user: user, password: password)
-      @user = data.user
-      @password = data.password
-    end
-
-    # Downloads the latest version of the app metadata package from iTC.
-    # @param app_id [Integer] The unique App ID
-    # @param dir [String] the path in which the package file should be stored
-    # @return (Bool) True if everything worked fine
-    # @raise [Deliver::TransporterTransferError] when something went wrong
-    #   when transfering
-    def download(app_id, dir = nil)
-      dir ||= "/tmp"
-
-      UI.message("Going to download app metadata from iTunes Connect")
-      command = build_download_command(@user, @password, app_id, dir)
-      UI.verbose(build_download_command(@user, 'YourPassword', app_id, dir)) if $verbose
-
-      result = execute_transporter(command)
-
-      itmsp_path = File.join(dir, "#{app_id}.itmsp")
-      if result and File.directory? itmsp_path
-        UI.success("Successfully downloaded the latest package from iTunes Connect.")
-      else
-        handle_error(@password)
-      end
-
-      result
-    end
-
-    # Uploads the modified package back to iTunes Connect
-    # @param app_id [Integer] The unique App ID
-    # @param dir [String] the path in which the package file is located
-    # @return (Bool) True if everything worked fine
-    # @raise [Deliver::TransporterTransferError] when something went wrong
-    #   when transfering
-    def upload(app_id, dir)
-      dir = File.join(dir, "#{app_id}.itmsp")
-
-      UI.message("Going to upload updated app to iTunes Connect")
-      UI.success("This might take a few minutes, please don't interrupt the script")
-
-      command = build_upload_command(@user, @password, dir)
-      UI.verbose(build_upload_command(@user, 'YourPassword', dir)) if $verbose
-
-      result = execute_transporter(command)
-
-      if result
-        UI.success("-" * 102)
-        UI.success("Successfully uploaded package to iTunes Connect. It might take a few minutes until it's visible online.")
-        UI.success("-" * 102)
-
-        FileUtils.rm_rf(dir) unless Helper.is_test? # we don't need the package any more, since the upload was successful
-      else
-        handle_error(@password)
-      end
-
-      result
-    end
-
-    private
-
-    def handle_error(password)
-      # rubocop:disable Style/CaseEquality
-      unless /^[0-9a-zA-Z\.\$\_]*$/ === password
-        UI.error("Password contains special characters, which may not be handled properly by iTMSTransporter. If you experience problems uploading to iTunes Connect, please consider changing your password to something with only alphanumeric characters.")
-      end
-      # rubocop:enable Style/CaseEquality
-      UI.error("Could not download/upload from iTunes Connect! It's probably related to your password or your internet connection.")
-    end
-
-    def execute_transporter(command)
       @errors = []
       @warnings = []
 
-      if defined?@hide_transporter_output
+      if hide_output
         # Show a one time message instead
         UI.success("Waiting for iTunes Connect transporter to be finished.")
         UI.success("iTunes Transporter progress... this might take a few minutes...")
@@ -116,7 +38,7 @@ module FastlaneCore
       begin
         PTY.spawn(command) do |stdin, stdout, pid|
           stdin.each do |line|
-            parse_line(line) # this is where the parsing happens
+            parse_line(line, hide_output) # this is where the parsing happens
           end
         end
       rescue => ex
@@ -136,7 +58,9 @@ module FastlaneCore
       true
     end
 
-    def parse_line(line)
+    private
+
+    def parse_line(line, hide_output)
       # Taken from https://github.com/sshaw/itunes_store_transporter/blob/master/lib/itunes/store/transporter/output_parser.rb
 
       output_done = false
@@ -180,12 +104,28 @@ module FastlaneCore
         end
       end
 
-      if !defined?@hide_transporter_output and line =~ OUTPUT_REGEX
+      if !hide_output and line =~ OUTPUT_REGEX
         # General logging for debug purposes
         unless output_done
           UI.verbose("[Transporter]: #{$1}")
         end
       end
+    end
+  end
+
+  # Generates commands and executes the iTMSTransporter through the shell script it provides by the same name
+  class ShellScriptTransporterExecutor < TransporterExecutor
+    def build_upload_command(username, password, source = "/tmp")
+      [
+        '"' + Helper.transporter_path + '"',
+        "-m upload",
+        "-u \"#{username}\"",
+        "-p #{shell_escaped_password(password)}",
+        "-f '#{source}'",
+        ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
+        "-t 'Signiant'",
+        "-k 100000"
+      ].join(' ')
     end
 
     def build_download_command(username, password, apple_id, destination = "/tmp")
@@ -199,18 +139,7 @@ module FastlaneCore
       ].join(' ')
     end
 
-    def build_upload_command(username, password, source = "/tmp")
-      [
-        '"' + Helper.transporter_path + '"',
-        "-m upload",
-        "-u \"#{username}\"",
-        "-p #{shell_escaped_password(password)}",
-        "-f '#{source}'",
-        ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
-        "-t 'Signiant'",
-        "-k 100000"
-      ].join(' ')
-    end
+    private
 
     def shell_escaped_password(password)
       # because the shell handles passwords with single-quotes incorrectly, use gsub to replace ShellEscape'd single-quotes of this form:
@@ -225,6 +154,159 @@ module FastlaneCore
 
       # wrap the fully-escaped password in single quotes, since the transporter expects a escaped password string (which must be single-quoted for the shell's benefit)
       "'" + password + "'"
+    end
+  end
+
+  # Generates commands and executes the iTMSTransporter by invoking its Java app directly, to avoid the crazy parameter
+  # escaping problems in its accompanying shell script.
+  class JavaTransporterExecutor < TransporterExecutor
+    def build_upload_command(username, password, source = "/tmp")
+      [
+        Helper.transporter_java_executable_path.shellescape,
+        "-Djava.ext.dirs=#{Helper.transporter_java_ext_dir.shellescape}",
+        '-XX:NewSize=2m',
+        '-Xms32m',
+        '-Xmx1024m',
+        '-Xms1024m',
+        '-Djava.awt.headless=true',
+        '-Dsun.net.http.retryPost=false',
+        "-classpath #{Helper.transporter_java_jar_path.shellescape}",
+        'com.apple.transporter.Application',
+        '-m upload',
+        "-u #{username.shellescape}",
+        "-p #{password.shellescape}",
+        "-f #{source.shellescape}",
+        ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
+        '-t Signiant',
+        '-k 100000',
+        '2>&1' # cause stderr to be written to stdout
+      ].compact.join(' ') # compact gets rid of the possibly nil ENV value
+    end
+
+    def build_download_command(username, password, apple_id, destination = "/tmp")
+      [
+        Helper.transporter_java_executable_path.shellescape,
+        "-Djava.ext.dirs=#{Helper.transporter_java_ext_dir.shellescape}",
+        '-XX:NewSize=2m',
+        '-Xms32m',
+        '-Xmx1024m',
+        '-Xms1024m',
+        '-Djava.awt.headless=true',
+        '-Dsun.net.http.retryPost=false',
+        "-classpath #{Helper.transporter_java_jar_path.shellescape}",
+        'com.apple.transporter.Application',
+        '-m lookupMetadata',
+        "-u #{username.shellescape}",
+        "-p #{password.shellescape}",
+        "-apple_id #{apple_id.shellescape}",
+        "-destination #{destination.shellescape}",
+        '2>&1' # cause stderr to be written to stdout
+      ].join(' ')
+    end
+
+    def execute(command, hide_output)
+      # The Java command needs to be run starting in a working directory in the iTMSTransporter
+      # file area. The shell script takes care of changing directories over to there, but we'll
+      # handle it manually here for this strategy.
+      FileUtils.cd(Helper.itms_path) do
+        return super(command, hide_output)
+      end
+    end
+  end
+
+  class ItunesTransporter
+    # This will be called from the Deliverfile, and disables the logging of the transporter output
+    def self.hide_transporter_output
+      @hide_transporter_output = !$verbose
+    end
+
+    def self.hide_transporter_output?
+      @hide_transporter_output
+    end
+
+    # Returns a new instance of the iTunesTransporter.
+    # If no username or password given, it will be taken from
+    # the #{CredentialsManager::AccountManager}
+    def initialize(user = nil, password = nil, avoid_shell_script = false)
+      avoid_shell_script ||= !ENV['FASTLANE_EXPERIMENTAL_TRANSPORTER_AVOID_SHELL_SCRIPT'].nil?
+      data = CredentialsManager::AccountManager.new(user: user, password: password)
+
+      @user = data.user
+      @password = data.password
+      @transporter_executor = avoid_shell_script ? JavaTransporterExecutor.new : ShellScriptTransporterExecutor.new
+    end
+
+    # Downloads the latest version of the app metadata package from iTC.
+    # @param app_id [Integer] The unique App ID
+    # @param dir [String] the path in which the package file should be stored
+    # @return (Bool) True if everything worked fine
+    # @raise [Deliver::TransporterTransferError] when something went wrong
+    #   when transfering
+    def download(app_id, dir = nil)
+      dir ||= "/tmp"
+
+      UI.message("Going to download app metadata from iTunes Connect")
+      command = @transporter_executor.build_download_command(@user, @password, app_id, dir)
+      UI.verbose(@transporter_executor.build_download_command(@user, 'YourPassword', app_id, dir))
+
+      result = @transporter_executor.execute(command, ItunesTransporter.hide_transporter_output?)
+      return result if Helper.is_test?
+
+      itmsp_path = File.join(dir, "#{app_id}.itmsp")
+      successful = result && File.directory?(itmsp_path)
+
+      if successful
+        UI.success("✅ Successfully downloaded the latest package from iTunes Connect to #{itmsp_path}")
+      else
+        handle_error(@password)
+      end
+
+      successful
+    end
+
+    # Uploads the modified package back to iTunes Connect
+    # @param app_id [Integer] The unique App ID
+    # @param dir [String] the path in which the package file is located
+    # @return (Bool) True if everything worked fine
+    # @raise [Deliver::TransporterTransferError] when something went wrong
+    #   when transfering
+    def upload(app_id, dir)
+      dir = File.join(dir, "#{app_id}.itmsp")
+
+      UI.message("Going to upload updated app to iTunes Connect")
+      UI.success("This might take a few minutes, please don't interrupt the script")
+
+      command = @transporter_executor.build_upload_command(@user, @password, dir)
+
+      UI.verbose(@transporter_executor.build_upload_command(@user, 'YourPassword', dir))
+
+      result = @transporter_executor.execute(command, ItunesTransporter.hide_transporter_output?)
+
+      if result
+        UI.success("-" * 102)
+        UI.success("Successfully uploaded package to iTunes Connect. It might take a few minutes until it's visible online.")
+        UI.success("-" * 102)
+
+        FileUtils.rm_rf(dir) unless Helper.is_test? # we don't need the package any more, since the upload was successful
+      else
+        handle_error(@password)
+      end
+
+      result
+    end
+
+    private
+
+    def handle_error(password)
+      # rubocop:disable Style/CaseEquality
+      unless /^[0-9a-zA-Z\.\$\_]*$/ === password
+        UI.error([
+          "Password contains special characters, which may not be handled properly by iTMSTransporter.",
+          "If you experience problems uploading to iTunes Connect, please consider changing your password to something with only alphanumeric characters."
+        ].join(' '))
+      end
+      # rubocop:enable Style/CaseEquality
+      UI.error("Could not download/upload from iTunes Connect! It's probably related to your password or your internet connection.")
     end
   end
 end

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -37,7 +37,7 @@ describe FastlaneCore do
         end
 
         it "#transporter_path" do
-          expect(FastlaneCore::Helper.transporter_path).to match(%r{/Applications/Xcode.*.app/Contents/Developer/\.\./Applications/Application Loader.app/Contents/itms/bin/iTMSTransporter})
+          expect(FastlaneCore::Helper.transporter_path).to match(%r{/Applications/Xcode.*.app/Contents/Applications/Application Loader.app/Contents/itms/bin/iTMSTransporter})
         end
 
         it "#xcode_version" do

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -1,0 +1,121 @@
+require 'shellwords'
+require 'credentials_manager'
+
+describe FastlaneCore do
+  describe FastlaneCore::ItunesTransporter do
+    let(:java_upload_command) do
+      [
+        FastlaneCore::Helper.transporter_java_executable_path.shellescape,
+        "-Djava.ext.dirs=#{FastlaneCore::Helper.transporter_java_ext_dir.shellescape}",
+        '-XX:NewSize=2m',
+        '-Xms32m',
+        '-Xmx1024m',
+        '-Xms1024m',
+        '-Djava.awt.headless=true',
+        '-Dsun.net.http.retryPost=false',
+        "-classpath #{FastlaneCore::Helper.transporter_java_jar_path.shellescape}",
+        'com.apple.transporter.Application',
+        "-m upload",
+        "-u fabric.devtools@gmail.com",
+        "-p \\!\\>\\ p@\\$s_-\\+\\=w\\'o\\%rd\\\"\\&\\#\\*\\<",
+        "-f /tmp/my.app.id.itmsp",
+        "-t Signiant",
+        "-k 100000",
+        '2>&1'
+      ].join(' ')
+    end
+
+    let(:java_download_command) do
+      [
+        FastlaneCore::Helper.transporter_java_executable_path.shellescape,
+        "-Djava.ext.dirs=#{FastlaneCore::Helper.transporter_java_ext_dir.shellescape}",
+        '-XX:NewSize=2m',
+        '-Xms32m',
+        '-Xmx1024m',
+        '-Xms1024m',
+        '-Djava.awt.headless=true',
+        '-Dsun.net.http.retryPost=false',
+        "-classpath #{FastlaneCore::Helper.transporter_java_jar_path.shellescape}",
+        'com.apple.transporter.Application',
+        '-m lookupMetadata',
+        '-u fabric.devtools@gmail.com',
+        "-p \\!\\>\\ p@\\$s_-\\+\\=w\\'o\\%rd\\\"\\&\\#\\*\\<",
+        '-apple_id my.app.id',
+        '-destination /tmp',
+        '2>&1'
+      ].join(' ')
+    end
+
+    describe "experimental ENV var is set" do
+      describe "upload command generation" do
+        it 'generates a call to java directly' do
+          with_env_values('FASTLANE_EXPERIMENTAL_TRANSPORTER_AVOID_SHELL_SCRIPT' => 'true') do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
+            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
+          end
+        end
+      end
+
+      describe "download command generation" do
+        it 'generates a call to java directly' do
+          with_env_values('FASTLANE_EXPERIMENTAL_TRANSPORTER_AVOID_SHELL_SCRIPT' => 'true') do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
+            expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
+          end
+        end
+      end
+    end
+
+    describe "avoid_shell_script is true" do
+      describe "upload command generation" do
+        it 'generates a call to java directly' do
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true)
+          expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
+        end
+      end
+
+      describe "download command generation" do
+        it 'generates a call to java directly' do
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true)
+          expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
+        end
+      end
+    end
+
+    describe "avoid_shell_script is false" do
+      describe "upload command generation" do
+        it 'generates a call to the shell script' do
+          expected_command = [
+            '"' + FastlaneCore::Helper.transporter_path + '"',
+            "-m upload",
+            '-u "fabric.devtools@gmail.com"',
+            "-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'",
+            "-f '/tmp/my.app.id.itmsp'",
+            nil, # This represents the environment variable which is not set
+            "-t 'Signiant'",
+            "-k 100000"
+          ].join(' ')
+
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
+          expect(transporter.upload('my.app.id', '/tmp')).to eq(expected_command)
+        end
+      end
+
+      describe "download command generation" do
+        it 'generates a call to shell script' do
+          expected_command = [
+            '"' + FastlaneCore::Helper.transporter_path + '"',
+            '-m lookupMetadata',
+            '-u "fabric.devtools@gmail.com"',
+            "-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'",
+            "-apple_id my.app.id",
+            "-destination '/tmp'"
+          ].join(' ')
+
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
+          expect(transporter.download('my.app.id', '/tmp')).to eq(expected_command)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# We are currently have a lot of problems with passing passwords that contain special characters through the iTMSTransporter shell script. ( #3953 #1503 #3832 #3876 ) That shell script does some inscrutable things with parameter escaping, and we could not find a reasonable work-around that would work for all varieties of special characters.

This PR introduces an alternative invocation strategy (which is off by default) that avoids calling through the shell script and instead invokes the ITunes transporter Java app directly.

The new invocation strategy can be turned on via an environment variable so that people can opt-in to trying it out.
