### PR TITLE
Add 3BQKVH9I2X to iOS production push identifiers

### DIFF
--- a/spaceship/spec/portal/certificate_spec.rb
+++ b/spaceship/spec/portal/certificate_spec.rb
@@ -44,6 +44,13 @@ describe Spaceship::Certificate do
     end
   end
 
+  it "Can consistently resolve every Certificate type to a single Apple ID alphanum" do
+    Spaceship::Portal::Certificate::CERTIFICATE_TYPES.each do |key, value|
+      expect(value).not_to be_empty
+      expect(Spaceship::Portal::Certificate::CERTIFICATE_TYPE_IDS[value]).to eq(key)
+    end
+  end
+
   it "Correctly filters the listed certificates" do
     certs = Spaceship::Portal::Certificate::Development.all
     expect(certs.count).to eq(1)

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -118,7 +118,7 @@ end
 
 def adp_stub_certificates
   stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/certificate/listCertRequests.action").
-    with(body: { "pageNumber" => "1", "pageSize" => "500", "sort" => "certRequestStatusCode=asc", "teamId" => "XXXXXXXXXX", "types" => "5QPB9NHCEI,R58UK2EWSO,9RQEK7MSXA,LA30L5BJEU,BKLRAVXMGM,UPV3DW712I,Y3B2F3TYSI,3T2ZP62QW8,E5D663CMZW,4APLUP237T,T44PTHVNID,DZQUP8189Y,FGQUP4785Z,S5WE21TULA,3BQKVH9I2X,FUOY7LWJET" }).
+    with(body: { "pageNumber" => "1", "pageSize" => "500", "sort" => "certRequestStatusCode=asc", "teamId" => "XXXXXXXXXX", "types" => "5QPB9NHCEI,R58UK2EWSO,9RQEK7MSXA,LA30L5BJEU,BKLRAVXMGM,UPV3DW712I,Y3B2F3TYSI,3T2ZP62QW8,E5D663CMZW,4APLUP237T,3BQKVH9I2X,T44PTHVNID,DZQUP8189Y,FGQUP4785Z,S5WE21TULA,FUOY7LWJET" }).
     to_return(status: 200, body: adp_read_fixture_file('listCertRequests.action.json'), headers: { 'Content-Type' => 'application/json' })
 
   stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/certificate/listCertRequests.action").


### PR DESCRIPTION
Square has legacy iOS APN certificates issued under this identifier.
This change allows some of our internal tools to use
certificate.production_push rather than certificates.all to find
production push certificates when we need to reissue.

I've verified that new production push certificates issued in ADC
do not use this identifier.

Notably the certificate type -> Apple ID alphanum relationship
is no longer 1:1
