### PR TITLE
Fix crash in supply action when there are no apk paths from gradle

### DIFF
--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'produce', '>= 1.1.1', '< 2.0.0'
   spec.add_dependency 'gym', '>= 1.6.2', '< 2.0.0'
   spec.add_dependency 'pilot', '>= 1.4.1', '< 2.0.0'
-  spec.add_dependency 'supply', '>= 0.4.0', '< 1.0.0'
+  spec.add_dependency 'supply', '>= 0.6.0', '< 1.0.0'
   spec.add_dependency 'scan', '>= 0.5.2', '< 1.0.0'
   spec.add_dependency 'match', '>= 0.4.0', '< 1.0.0'
   spec.add_dependency 'screengrab', '>= 0.3.1', '< 1.0.0'

--- a/fastlane/lib/fastlane/actions/supply.rb
+++ b/fastlane/lib/fastlane/actions/supply.rb
@@ -8,7 +8,7 @@ module Fastlane
         begin
           FastlaneCore::UpdateChecker.start_looking_for_update('supply') unless Helper.is_test?
 
-          all_apk_paths = Actions.lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS]
+          all_apk_paths = Actions.lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] || []
           if all_apk_paths.length > 1
             params[:apk_paths] ||= all_apk_paths
           else

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,3 +1,3 @@
 module Fastlane
-  VERSION = '1.69.0'.freeze
+  VERSION = '1.70.0'.freeze
 end


### PR DESCRIPTION
- Fixes #4010 
- bumps fastlane dependency on supply to latest version
- bumps version of fastlane gem
