### PR TITLE
Add 'use_libraries' option to pod_push action

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_push.rb
+++ b/fastlane/lib/fastlane/actions/pod_push.rb
@@ -22,6 +22,10 @@ module Fastlane
           command << " --allow-warnings"
         end
 
+        if params[:use_libraries]
+          command << " --use-libraries"
+        end
+
         result = Actions.sh(command.to_s)
         UI.success("Successfully pushed Podspec ⬆️ ")
         return result
@@ -53,6 +57,10 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :allow_warnings,
                                        description: "Allow warnings during pod push",
+                                       optional: true,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :use_libraries,
+                                       description: "Allow lint to use static libraries to install the spec",
                                        optional: true,
                                        is_string: false),
           FastlaneCore::ConfigItem.new(key: :sources,

--- a/fastlane/spec/actions_specs/pod_push_spec.rb
+++ b/fastlane/spec/actions_specs/pod_push_spec.rb
@@ -24,6 +24,14 @@ describe Fastlane do
 
         expect(result).to eq("pod repo push MyRepo './fastlane/spec/fixtures/podspecs/test.podspec'")
       end
+
+      it "generates the correct pod push command with a repo parameter with the allow warnings and use libraries flags" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_push(path: './fastlane/spec/fixtures/podspecs/test.podspec', repo: 'MyRepo', allow_warnings: true, use_libraries: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("pod repo push MyRepo './fastlane/spec/fixtures/podspecs/test.podspec' --allow-warnings --use-libraries")
+      end
     end
   end
 end


### PR DESCRIPTION
Adds the ability to specify the --use-libraries flag in the pod_push action.
