### PR TITLE
Remove `cert` output in `clean_build_artifacts`

### DIFF
--- a/fastlane/lib/fastlane/actions/clean_build_artifacts.rb
+++ b/fastlane/lib/fastlane/actions/clean_build_artifacts.rb
@@ -4,7 +4,8 @@ module Fastlane
       def self.run(options)
         paths = [
           Actions.lane_context[Actions::SharedValues::IPA_OUTPUT_PATH],
-          Actions.lane_context[Actions::SharedValues::DSYM_OUTPUT_PATH]
+          Actions.lane_context[Actions::SharedValues::DSYM_OUTPUT_PATH],
+          Actions.lane_context[Actions::SharedValues::CERT_FILE_PATH]
         ]
 
         paths += Actions.lane_context[Actions::SharedValues::SIGH_PROFILE_PATHS] || []
@@ -34,7 +35,7 @@ module Fastlane
       end
 
       def self.description
-        "Deletes files created as result of running ipa or sigh"
+        "Deletes files created as result of running ipa, cert, sigh or download_dsyms"
       end
 
       def self.author


### PR DESCRIPTION
No more need for `FileUtils.rm("../#{cert}.cer")` instead of the plain
`cert` to have clean git status when running `cert` followed somewhere
later by `clean_build_artifacts`.

(While at it, fix action description to also mention that this action
deletes result of `download_dsyms` (which this action does through
consulting the `DSYM_PATHS` shared context key).)
