### PR TITLE
Fixed a deprecated URL on update_rating doc

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -237,7 +237,7 @@ module Spaceship
       # })
       #
       # Available Values
-      # https://github.com/KrauseFx/deliver/blob/master/Reference.md
+      # https://github.com/fastlane/fastlane/blob/master/deliver/Reference.md
       def update_rating(hash)
         raise "Must be a hash" unless hash.kind_of?(Hash)
 


### PR DESCRIPTION
The URL was pointing to an old repo.
