### PR TITLE
Default to using direct Java execution in ItunesTransporter

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -227,13 +227,16 @@ module FastlaneCore
     # Returns a new instance of the iTunesTransporter.
     # If no username or password given, it will be taken from
     # the #{CredentialsManager::AccountManager}
-    def initialize(user = nil, password = nil, avoid_shell_script = false)
-      avoid_shell_script ||= !ENV['FASTLANE_EXPERIMENTAL_TRANSPORTER_AVOID_SHELL_SCRIPT'].nil?
+    # @param use_shell_script if true, forces use of the iTMSTransporter shell script.
+    #                         if false, allows a direct call to the iTMSTransporter Java app (preferred).
+    #                         see: https://github.com/fastlane/fastlane/pull/4003
+    def initialize(user = nil, password = nil, use_shell_script = false)
+      use_shell_script ||= !ENV['FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT'].nil?
       data = CredentialsManager::AccountManager.new(user: user, password: password)
 
       @user = data.user
       @password = data.password
-      @transporter_executor = avoid_shell_script ? JavaTransporterExecutor.new : ShellScriptTransporterExecutor.new
+      @transporter_executor = use_shell_script ? ShellScriptTransporterExecutor.new : JavaTransporterExecutor.new
     end
 
     # Downloads the latest version of the app metadata package from iTC.

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -3,6 +3,30 @@ require 'credentials_manager'
 
 describe FastlaneCore do
   describe FastlaneCore::ItunesTransporter do
+    let(:shell_upload_command) do
+      [
+        '"' + FastlaneCore::Helper.transporter_path + '"',
+        "-m upload",
+        '-u "fabric.devtools@gmail.com"',
+        "-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'",
+        "-f '/tmp/my.app.id.itmsp'",
+        nil, # This represents the environment variable which is not set
+        "-t 'Signiant'",
+        "-k 100000"
+      ].join(' ')
+    end
+
+    let(:shell_download_command) do
+      [
+        '"' + FastlaneCore::Helper.transporter_path + '"',
+        '-m lookupMetadata',
+        '-u "fabric.devtools@gmail.com"',
+        "-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'",
+        "-apple_id my.app.id",
+        "-destination '/tmp'"
+      ].join(' ')
+    end
+
     let(:java_upload_command) do
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
@@ -46,74 +70,70 @@ describe FastlaneCore do
       ].join(' ')
     end
 
-    describe "experimental ENV var is set" do
+    describe "by default" do
       describe "upload command generation" do
         it 'generates a call to java directly' do
-          with_env_values('FASTLANE_EXPERIMENTAL_TRANSPORTER_AVOID_SHELL_SCRIPT' => 'true') do
-            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
-          end
-        end
-      end
-
-      describe "download command generation" do
-        it 'generates a call to java directly' do
-          with_env_values('FASTLANE_EXPERIMENTAL_TRANSPORTER_AVOID_SHELL_SCRIPT' => 'true') do
-            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
-            expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
-          end
-        end
-      end
-    end
-
-    describe "avoid_shell_script is true" do
-      describe "upload command generation" do
-        it 'generates a call to java directly' do
-          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true)
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
           expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
         end
       end
 
       describe "download command generation" do
         it 'generates a call to java directly' do
-          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true)
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
           expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
         end
       end
     end
 
-    describe "avoid_shell_script is false" do
+    describe "when use shell script ENV var is set" do
       describe "upload command generation" do
         it 'generates a call to the shell script' do
-          expected_command = [
-            '"' + FastlaneCore::Helper.transporter_path + '"',
-            "-m upload",
-            '-u "fabric.devtools@gmail.com"',
-            "-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'",
-            "-f '/tmp/my.app.id.itmsp'",
-            nil, # This represents the environment variable which is not set
-            "-t 'Signiant'",
-            "-k 100000"
-          ].join(' ')
-
-          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
-          expect(transporter.upload('my.app.id', '/tmp')).to eq(expected_command)
+          with_env_values('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT' => 'true') do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
+            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+          end
         end
       end
 
       describe "download command generation" do
-        it 'generates a call to shell script' do
-          expected_command = [
-            '"' + FastlaneCore::Helper.transporter_path + '"',
-            '-m lookupMetadata',
-            '-u "fabric.devtools@gmail.com"',
-            "-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'",
-            "-apple_id my.app.id",
-            "-destination '/tmp'"
-          ].join(' ')
+        it 'generates a call to the shell script' do
+          with_env_values('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT' => 'true') do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
+            expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+          end
+        end
+      end
+    end
 
+    describe "use_shell_script is true" do
+      describe "upload command generation" do
+        it 'generates a call to the shell script' do
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true)
+          expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+        end
+      end
+
+      describe "download command generation" do
+        it 'generates a call to the shell script' do
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true)
+          expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+        end
+      end
+    end
+
+    describe "use_shell_script is false" do
+      describe "upload command generation" do
+        it 'generates a call to java directly' do
           transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
-          expect(transporter.download('my.app.id', '/tmp')).to eq(expected_command)
+          expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
+        end
+      end
+
+      describe "download command generation" do
+        it 'generates a call to java directly' do
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
+          expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
         end
       end
     end


### PR DESCRIPTION
Follow-on to #4003

The experimental password fix performed well in user testing - let's make it the new executor by default.
