### PR TITLE
[deliver] Use fastlane_core >= 0.41.2 for password fixes

### DIFF
--- a/deliver/deliver.gemspec
+++ b/deliver/deliver.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # fastlane dependencies
-  spec.add_dependency 'fastlane_core', '>= 0.37.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.41.2', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'credentials_manager', '>= 0.12.0', '< 1.0.0'
-  spec.add_dependency 'spaceship', '>= 0.19.0', '< 1.0.0' # Communication with iTunes Connect
+  spec.add_dependency 'spaceship', '>= 0.24.1', '< 1.0.0' # Communication with iTunes Connect
 
   # third party dependencies
   spec.add_dependency 'fastimage', '~> 1.6' # fetch the image sizes from the screenshots

--- a/deliver/lib/deliver/version.rb
+++ b/deliver/lib/deliver/version.rb
@@ -1,4 +1,4 @@
 module Deliver
-  VERSION = "1.10.5"
+  VERSION = "1.11.0"
   DESCRIPTION = 'Upload screenshots, metadata and your app to the App Store using a single command'
 end


### PR DESCRIPTION
- Bump spaceship dependency minimum version
- Bump version for release
