### PR TITLE
Go back to the original working directory

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -24,10 +24,17 @@ module Fastlane
           '&&'
         ].join(' ')
 
+        command_suffix = [
+          '&&',
+          'cd',
+          '-'
+        ].join(' ')
+
         command = [
           command_prefix,
           'agvtool',
-          params[:build_number] ? "new-version -all #{params[:build_number]}" : 'next-version -all'
+          params[:build_number] ? "new-version -all #{params[:build_number]}" : 'next-version -all',
+          command_suffix
         ].join(' ')
 
         if Helper.test?


### PR DESCRIPTION
`increment_build_number` change the working directory but don't clean up after it self, which causes subsequent actions that work in lanes that don't use `increment_build_number` to fail.
