### PR TITLE
Fix #4060 - Allow disabling colors in xcodebuild action

### DIFF
--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -162,7 +162,7 @@ module Fastlane
 
         case output_style
         when :standard
-          xcpretty_args << '--color'
+          xcpretty_args << '--color' unless Helper.colors_disabled?
         when :basic
           xcpretty_args << '--no-utf'
         end


### PR DESCRIPTION
Makes xcpretty in the xcodebuild action obey `FASTLANE_DISABLE_COLORS`
