### PR TITLE
Shell escape gradle_path in GradleHelper

### DIFF
--- a/fastlane/lib/fastlane/helper/gradle_helper.rb
+++ b/fastlane/lib/fastlane/helper/gradle_helper.rb
@@ -15,6 +15,9 @@ module Fastlane
       # Path to the gradle script
       attr_accessor :gradle_path
 
+      # Read-only path to the shell-escaped gradle script, suitable for use in shell commands
+      attr_reader :escaped_gradle_path
+
       # All the available tasks
       attr_accessor :tasks
 
@@ -25,7 +28,7 @@ module Fastlane
       # Run a certain action
       def trigger(task: nil, flags: nil, serial: nil)
         android_serial = (serial != "") ? "ANDROID_SERIAL=#{serial}" : nil
-        command = [android_serial, gradle_path, task, flags].reject(&:nil?).join(" ")
+        command = [android_serial, escaped_gradle_path, task, flags].compact.join(" ")
         Action.sh(command)
       end
 
@@ -34,12 +37,17 @@ module Fastlane
         return tasks.collect(&:title).include?(task)
       end
 
+      def gradle_path=(gradle_path)
+        @gradle_path = gradle_path
+        @escaped_gradle_path = gradle_path.shellescape
+      end
+
       private
 
       def load_all_tasks
         self.tasks = []
 
-        command = [gradle_path, "tasks", "--console=plain"].join(" ")
+        command = [escaped_gradle_path, "tasks", "--console=plain"].join(" ")
         output = Actions.sh(command, log: false)
         output.split("\n").each do |line|
           if (result = line.match(/(\w+)\s\-\s([\w\s]+)/))

--- a/fastlane/spec/actions_specs/gradle_spec.rb
+++ b/fastlane/spec/actions_specs/gradle_spec.rb
@@ -9,6 +9,25 @@ describe Fastlane do
         expect(result).to eq("#{File.expand_path('README.md')} assembleWorldDominationRelease -p . -PversionCode=200")
       end
 
+      it "correctly escapes the gradle path" do
+        gradle_path = '/fake gradle/path' # this value is interesting because it contains a space in the path
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(gradle_path).and_return(true)
+
+        result = Fastlane::FastFile.new.parse("lane :build do
+          gradle(
+            task: 'assemble',
+            flavor: 'WorldDomination',
+            build_type: 'Release',
+            properties: {'versionCode' => 200},
+            serial: 'abc123',
+            gradle_path: '#{gradle_path}'
+          )
+        end").runner.execute(:build)
+
+        expect(result).to eq("ANDROID_SERIAL=abc123 #{gradle_path.shellescape} assembleWorldDominationRelease -p . -PversionCode=200")
+      end
+
       it "correctly uses the serial" do
         result = Fastlane::FastFile.new.parse("lane :build do
           gradle(task: 'assemble', flavor: 'WorldDomination', build_type: 'Release', properties: { 'versionCode' => 200}, serial: 'abc123', gradle_path: './fastlane/README.md')

--- a/fastlane/spec/gradle_helper_spec.rb
+++ b/fastlane/spec/gradle_helper_spec.rb
@@ -1,0 +1,20 @@
+describe Fastlane::Helper::GradleHelper do
+  describe 'parameter handling' do
+    it 'stores a shell-escaped version of the gradle_path when constructed' do
+      gradle_path = '/fake gradle/path'
+      helper = Fastlane::Helper::GradleHelper.new(gradle_path: gradle_path)
+
+      expect(helper.gradle_path).to eq(gradle_path)
+      expect(helper.escaped_gradle_path).to eq(gradle_path.shellescape)
+    end
+
+    it 'updates a shell-escaped version of the gradle_path when modified' do
+      gradle_path = '/fake gradle/path'
+      helper = Fastlane::Helper::GradleHelper.new(gradle_path: '/different/when/constructed')
+      helper.gradle_path = gradle_path
+
+      expect(helper.gradle_path).to eq(gradle_path)
+      expect(helper.escaped_gradle_path).to eq(gradle_path.shellescape)
+    end
+  end
+end

--- a/fastlane/spec/spec_helper.rb
+++ b/fastlane/spec/spec_helper.rb
@@ -5,6 +5,8 @@ unless ENV["DEBUG"]
   $stdout = File.open("/tmp/spaceship_tests", "w")
 end
 
+require 'shellwords'
+
 require 'fastlane'
 require 'fastlane_core'
 require 'webmock/rspec'


### PR DESCRIPTION
This Builds upon the fix by @icyleaf in #4063 and makes a couple small adjustments:
1. Moves the shell escaping of the `gradle_path` into the `GradleHelper` so that future users of that class get the right behavior by default
2. Simplifies the added test a bit using some method stubbing

Addresses #4018
