### PR TITLE
Remove targetSdkVersion declaration from the AAR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ test_output/
 *.iml
 local.properties
 
+## Specific to screengrab
+/screengrab/example/fastlane/metadata/
+
 ## Specific to RubyMotion:
 .dat*
 .repl_history

--- a/screengrab/screengrab-lib/build.gradle
+++ b/screengrab/screengrab-lib/build.gradle
@@ -23,7 +23,6 @@ android {
     buildToolsVersion "23.0.2"
 
     defaultConfig {
-        targetSdkVersion 23
         versionCode versionCodeInt
         versionName versionNameString
         minSdkVersion 8


### PR DESCRIPTION
Addresses https://github.com/fastlane/fastlane/issues/3885

Libraries should not specify a `targetSdkVersion`. Tested against an app targeting API 23 and one targeting 21.
