### PR TITLE
Allow to specify the path to iTMSTransporter via environment

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -151,6 +151,7 @@ module FastlaneCore
 
     # @return the full path to the iTMSTransporter executable
     def self.itms_path
+      return ENV["FASTLANE_ITUNES_TRANSPORTER_PATH"] if ENV["FASTLANE_ITUNES_TRANSPORTER_PATH"]
       return '' unless self.is_mac? # so tests work on Linx too
 
       [


### PR DESCRIPTION
This is especially handy on non-OSX machines, since iTMSTransporter happily runs on any (Java-) platform.
