### PR TITLE
Adds tab completing for fastlane lane names

### DIFF
--- a/fastlane/bin/fastlane
+++ b/fastlane/bin/fastlane
@@ -153,6 +153,16 @@ class FastlaneApplication
       end
     end
 
+    command :enable_auto_complete do |c|
+      c.syntax = 'fastlane enable_auto_complete'
+      c.description = 'Enable tab auto completion'
+
+      c.action do |args, options|
+        require 'fastlane/auto_complete'
+        Fastlane::AutoComplete.execute
+      end
+    end
+
     default_command :trigger
 
     run!

--- a/fastlane/lib/assets/completions/completion.bash
+++ b/fastlane/lib/assets/completions/completion.bash
@@ -1,0 +1,19 @@
+_fastlane_complete() {
+  COMPREPLY=()
+  local word="${COMP_WORDS[COMP_CWORD]}"
+  local completions=""
+
+  # look for Fastfile either in this directory or fastlane/ then grab the lane names
+  if [[ -e "Fastfile" ]]; then
+    file="Fastfile"
+  elif [[ -e "fastlane/Fastfile" ]]; then
+    file="fastlane/Fastfile"
+  fi
+
+  # parse 'beta' out of 'lane :beta do', etc
+  completions=`cat $file | grep "^\s*lane \:" | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}'`
+
+  COMPREPLY=( $(compgen -W "$completions" -- "$word") )
+}
+
+complete -F _fastlane_complete fastlane

--- a/fastlane/lib/assets/completions/completion.sh
+++ b/fastlane/lib/assets/completions/completion.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+if [ -n "$BASH_VERSION" ]; then
+  source ~/.fastlane/completions/completion.bash
+
+elif [ -n "$ZSH_VERSION" ]; then
+  source ~/.fastlane/completions/completion.zsh
+fi
+
+# Do not remove v0.0.1

--- a/fastlane/lib/assets/completions/completion.zsh
+++ b/fastlane/lib/assets/completions/completion.zsh
@@ -1,0 +1,18 @@
+_fastlane_complete() {
+  local word completions
+  word="$1"
+
+  # look for Fastfile either in this directory or fastlane/ then grab the lane names
+  if [[ -e "Fastfile" ]] then
+    file="Fastfile"
+  elif [[ -e "fastlane/Fastfile" ]] then
+    file="fastlane/Fastfile"
+  fi
+
+  # parse 'beta' out of 'lane :beta do', etc
+  completions=`cat $file | grep "^\s*lane \:" | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}'`
+
+  reply=( "${(ps:\n:)completions}" )
+}
+
+compctl -K _fastlane_complete fastlane

--- a/fastlane/lib/fastlane/auto_complete.rb
+++ b/fastlane/lib/fastlane/auto_complete.rb
@@ -1,0 +1,24 @@
+require 'fileutils'
+
+module Fastlane
+  # Enable tab auto completion
+  class AutoComplete
+    def self.execute
+      fastlane_conf_dir = "~/.fastlane"
+      confirm = UI.confirm "This will copy a shell script into #{fastlane_conf_dir} that provides the command tab completion. Sound good?"
+      return unless confirm
+
+      # create the ~/.fastlane directory
+      fastlane_conf_dir = File.expand_path fastlane_conf_dir
+      FileUtils.mkdir_p fastlane_conf_dir
+
+      # then copy all of the completions files into it from the gem
+      completion_script_path = File.join(Fastlane::Helper.gem_path('fastlane'), 'lib', 'assets', 'completions')
+      FileUtils.cp_r completion_script_path, fastlane_conf_dir
+
+      UI.success "Copied! To use auto complete for fastlane, add the following line to your favorite rc file (e.g. ~/.bashrc)"
+      UI.important "  . ~/.fastlane/completions/completion.sh"
+      UI.success "Don't forget to source that file in your current shell! 🐚"
+    end
+  end
+end


### PR DESCRIPTION
Adds bash and zsh tab completion for fastlane lane names

To enable:

```
fastlane enable_auto_complete
```

And follow the on screen prompt to add a line to your bash/zsh profile

Then `fastlane <tab>` to use it! 

![image](https://cloud.githubusercontent.com/assets/1848683/14332918/eeb926e8-fc19-11e5-88fe-18a8fc3bdcaa.png)

created with help from @mlbileschi :shell: 
