### PR TITLE
Update slather repo URL in slather action

### DIFF
--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -74,7 +74,7 @@ module Fastlane
       def self.details
         return <<-eos
 Slather works with multiple code coverage formats including Xcode7 code coverage.
-Slather is available at https://github.com/venmo/slather
+Slather is available at https://github.com/SlatherOrg/slather
         eos
       end
 


### PR DESCRIPTION
Slather has moved from venmo to https://github.com/SlatherOrg/slather
