### PR TITLE
Spaceship - sync video trailers

### DIFF
--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -34,7 +34,7 @@ module Spaceship
       upload_file(app_version, upload_file, '/upload/purple-video', content_provider_id, sso_token_for_video)
     end
 
-    def upload_video_preview(app_version, upload_file, content_provider_id, sso_token_for_image)
+    def upload_trailer_preview(app_version, upload_file, content_provider_id, sso_token_for_image)
       upload_file(app_version, upload_file, '/upload/app-screenshot-image', content_provider_id, sso_token_for_image)
     end
 


### PR DESCRIPTION
While working on adding trailer upload for spaceship, we found out that a method 
had wrong name inside spaceship. It was mocked so the problem was never found out.
