### PR TITLE
Change set_info_plist_value value option, is_string: false

### DIFF
--- a/fastlane/lib/fastlane/actions/set_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/set_info_plist_value.rb
@@ -34,6 +34,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :value,
                                        env_name: "FL_SET_INFO_PLIST_PARAM_VALUE",
                                        description: "Value to setup",
+                                       is_string: false,
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :path,
                                        env_name: "FL_SET_INFO_PLIST_PATH",


### PR DESCRIPTION
Addresses #4103

Along the way, our options defaults changed, and action code that used to accept a hash as a value now prohibits it. This should restore that behavior.
