### PR TITLE
Add ignore_exit_status option to swiftlint action

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -726,7 +726,8 @@ swiftlint(
   files: [                              # List of files to process (optional)
     'AppDelegate.swift',
     'path/to/project/Model.swift'
-  ]
+  ],
+  ignore_exit_status: true              # Allow fastlane to continue even if SwiftLint returns a non-zero exit status
 )
 ```
 


### PR DESCRIPTION
Addresses #1442

Option off (default):
<img width="669" alt="screen shot 2016-04-07 at 8 23 03 pm" src="https://cloud.githubusercontent.com/assets/343134/14370715/ab4f5806-fcfe-11e5-9147-821e9a974d46.png">

Option on:
<img width="652" alt="screen shot 2016-04-07 at 8 22 38 pm" src="https://cloud.githubusercontent.com/assets/343134/14370722/b3140bfe-fcfe-11e5-8c9c-280b4704a4a0.png">
