### PR TITLE
Fix member center landing url

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -17,7 +17,7 @@ module Spaceship
       end
       return cached if cached
 
-      landing_url = "https://developer.apple.com/membercenter/index.action"
+      landing_url = "https://developer.apple.com/account/"
       logger.info("GET: " + landing_url)
       headers = @client.get(landing_url).headers
       results = headers['location'].match(/.*appIdKey=(\h+)/)

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -24,7 +24,7 @@ end
 def adp_stub_login
   # Most stuff is stubbed in tunes_stubbing (since it's shared)
 
-  stub_request(:get, "https://developer.apple.com/membercenter/index.action").
+  stub_request(:get, "https://developer.apple.com/account/").
     to_return(status: 200, body: nil,
     headers: { 'Location' => "https://idmsa.apple.com/IDMSWebAuth/login?&appIdKey=aaabd3417a7776362562d2197faaa80a8aaab108fd934911bcbea0110d07faaa&path=%2F%2Fmembercenter%2Findex.action" })
 


### PR DESCRIPTION
Seemingly `https://developer.apple.com/membercenter/index.action` is not working because it returns `301` and does not include `appIdKey`. Thus spaceship fails to fetch api key.

``` sh
% curl --verbose https://developer.apple.com/membercenter/index.action
*   Trying 17.146.1.15...
* Connected to developer.apple.com (17.146.1.15) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
* Server certificate: developer.apple.com
* Server certificate: Symantec Class 3 EV SSL CA - G3
* Server certificate: VeriSign Class 3 Public Primary Certification Authority - G5
> GET /membercenter/index.action HTTP/1.1
> Host: developer.apple.com
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Date: Fri, 08 Apr 2016 04:14:18 GMT
< Content-Type: text/html; charset=iso-8859-1
< Content-Length: 243
< Connection: keep-alive
< X-Frame-Options: SAMEORIGIN
< Strict-Transport-Security: max-age=31536000; includeSubDomains
< Location: http://developer.apple.com/account/
< Server: Shield
< Strict-Transport-Security: max-age=31536000; includeSubdomains
< Host: developer.apple.com
< X-Frame-Options: SAMEORIGIN
<
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="http://developer.apple.com/account/">here</a>.</p>
</body></html>
* Connection #0 to host developer.apple.com left intact
```

I changed `landing_url` to `http://developer.apple.com/account` since it has `appIdKey` in location header, and spaceship works fine.
