### PR TITLE
Stop skipping first line of csv in pilot import

### DIFF
--- a/pilot/lib/pilot/tester_importer.rb
+++ b/pilot/lib/pilot/tester_importer.rb
@@ -13,16 +13,15 @@ module Pilot
       tester_manager = Pilot::TesterManager.new
       imported_tester_count = 0
 
-      is_first = true
       CSV.foreach(file, "r") do |row|
-        if is_first
-          is_first = false
-          next
-        end
-
         first_name, last_name, email = row
 
         unless email
+          UI.error("No email found in row: #{row}")
+          next
+        end
+
+        unless email.index("@")
           UI.error("No email found in row: #{row}")
           next
         end


### PR DESCRIPTION
`pilot import` skips the first line of the csv file. This patch removes the skipping logic.

To test this, run `pilot import` on a csv with 3 rows, for example. Master will say

```
Successfully imported 2 testers from ./testers.csv
```

Whereas my patch will say

```
Successfully imported 3 testers from ./testers.csv
```

Which is the behaviour that matches Testflight's import from csv function.
