### PR TITLE
Adding support for slather --workspace option

### DIFF
--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -9,6 +9,7 @@ module Fastlane
       ARGS_MAP = {
         build_directory: "--build-directory",
         input_format: "--input-format",
+        workspace: "--workspace",
         scheme: "--scheme",
         buildkite: "--buildkite",
         jenkins: "--jenkins",
@@ -91,6 +92,11 @@ Slather is available at https://github.com/SlatherOrg/slather
                                        verify_block: proc do |value|
                                          UI.user_error!("No project file specified, pass using `proj: 'Project.xcodeproj'`") unless value and !value.empty?
                                        end),
+          FastlaneCore::ConfigItem.new(key: :workspace,
+                                       env_name: "FL_SLATHER_WORKSPACE", # The name of the environment variable
+                                       description: "The workspace file that slather looks at",
+                                       optional: true
+                                      ),
           FastlaneCore::ConfigItem.new(key: :scheme,
                                        env_name: "FL_SLATHER_SCHEME", # The name of the environment variable
                                        description: "Scheme to use when calling slather",

--- a/fastlane/spec/actions_specs/slather_spec.rb
+++ b/fastlane/spec/actions_specs/slather_spec.rb
@@ -7,6 +7,7 @@ describe Fastlane do
             use_bundle_exec: false,
             build_directory: 'foo',
             input_format: 'bah',
+            workspace: 'bar.xcworkspace',
             scheme: 'Foo',
             buildkite: true,
             jenkins: true,
@@ -27,7 +28,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("slather coverage --build-directory foo --input-format bah --scheme Foo --buildkite --jenkins --travis --circleci --coveralls --simple-output --gutter-json --cobertura-xml --html --show --source-directory baz --output-directory 123 --binary-basename YourApp --binary-file you --ignore nothing foo.xcodeproj")
+        expect(result).to eq("slather coverage --build-directory foo --input-format bah --workspace bar.xcworkspace --scheme Foo --buildkite --jenkins --travis --circleci --coveralls --simple-output --gutter-json --cobertura-xml --html --show --source-directory baz --output-directory 123 --binary-basename YourApp --binary-file you --ignore nothing foo.xcodeproj")
       end
 
       it "works with bundle" do
@@ -36,6 +37,7 @@ describe Fastlane do
             use_bundle_exec: true,
             build_directory: 'foo',
             input_format: 'bah',
+            workspace: 'bar.xcworkspace',
             scheme: 'Foo',
             buildkite: true,
             jenkins: true,
@@ -56,7 +58,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("bundle exec slather coverage --build-directory foo --input-format bah --scheme Foo --buildkite --jenkins --travis --circleci --coveralls --simple-output --gutter-json --cobertura-xml --html --show --source-directory baz --output-directory 123 --binary-basename YourApp --binary-file you --ignore nothing foo.xcodeproj")
+        expect(result).to eq("bundle exec slather coverage --build-directory foo --input-format bah --workspace bar.xcworkspace --scheme Foo --buildkite --jenkins --travis --circleci --coveralls --simple-output --gutter-json --cobertura-xml --html --show --source-directory baz --output-directory 123 --binary-basename YourApp --binary-file you --ignore nothing foo.xcodeproj")
       end
 
       it "requires project to be specified" do


### PR DESCRIPTION
`slather` provides support to workspaces through the `--workspace` option. Currently this option is not supported by the slather action, so I'm adding it.
