### PR TITLE
This is a tentative solution for #3720

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
@@ -17,6 +17,7 @@ module FastlaneCore
         validate_short_switch(used_switches, short_switch)
 
         type = option.data_type
+        type = nil if type == :bool
 
         # This is an important bit of trickery to solve the boolean option situation.
         #

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -104,6 +104,44 @@ describe FastlaneCore do
         end
       end
 
+      describe "boolean 'type' and transition from deprecated is_string", booleans: true do
+        it "either type or is_string must be there" do
+          expect(FastlaneCore::UI).to receive(:deprecated).with("`type` parameter missing. Using `String` by default")
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo')
+          expect(config_item.data_type).to eq(String)
+        end
+
+        # it "If both type and is_string are defined an error happens FIXME" do
+        #  expect do
+        #    config_item = FastlaneCore::ConfigItem.new(key: :foo,
+        #                                               short_option: '-f',
+        #                                               description: 'foo',
+        #                                               is_string: true,
+        #                                               type: Array)
+        #  end.to raise_error "Both `type` and `is_string` are defined"
+        # end
+
+        it "old style booleans are detected" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo',
+                                                     is_string: false)
+          expect(config_item.data_type).to eq(:bool)
+        end
+
+        it "sets the data type correctly if boolean are explicit" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo',
+                                                     default_value: false,
+                                                     type: :bool)
+
+          expect(config_item.data_type).to eq(:bool)
+        end
+      end
+
       describe "data_type" do
         it "sets the data type correctly if `is_string` is not set but type is specified" do
           config_item = FastlaneCore::ConfigItem.new(key: :foo,
@@ -113,7 +151,8 @@ describe FastlaneCore do
           expect(config_item.data_type).to eq(Array)
         end
 
-        it "sets the data type correctly if `is_string` is set but the type is specified" do
+        it "uses `type` over `is_string` if both are set, but displays a warning" do
+          expect(FastlaneCore::UI).to receive(:important).with("Both `type` and `is_string` are defined. Ignoring `is_string`")
           config_item = FastlaneCore::ConfigItem.new(key: :foo,
                                                      description: 'foo',
                                                      is_string: true,
@@ -317,13 +356,15 @@ describe FastlaneCore do
           expect(config.values).to eq({})
         end
 
-        it "doesn't remove --verbose if it's a valid option" do
+        it "doesn't remove --verbose if it's a valid option", booleans: true do
           options = [
             FastlaneCore::ConfigItem.new(key: :verbose,
+                                short_option: '-f',
                                    is_string: false)
           ]
           config = FastlaneCore::Configuration.create(options, { verbose: true })
           expect(config[:verbose]).to eq(true)
+          expect(options[0].data_type).to eq(:bool)
         end
       end
 


### PR DESCRIPTION
Provide a way out of the deprecated `is_string` parameter in `ConfigItem`, by using `:bool` as `type` for Booleans, as there's no matching type in ruby

See #3720 

The PR needs work. For example:
- to use `:bool` or not (see below for alternative)
- adapt to https://github.com/lacostej/fastlane/blob/boolean_type_configitem/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb#L24-L49
- here it seems we don't validate booleans at all (`data_type` is `nil`) https://github.com/lacostej/fastlane/blob/9c6382079cea6e3e8a0113276cc018ed0af5a45d/fastlane_core/lib/fastlane_core/configuration/config_item.rb#L75 I wonder if it's because of the `auto_convert`, but this means that the ConfigItem will fail if involved programatically.
- change existing actions / action template (remove `is_string`)

**Alternative**

Implemented as #4142
