### PR TITLE
Raise an exception if xcode_version is nil.

### DIFF
--- a/gym/lib/gym/xcode.rb
+++ b/gym/lib/gym/xcode.rb
@@ -11,6 +11,7 @@ module Gym
 
       # Below Xcode 7 (which offers a new nice API to sign the app)
       def pre_7?
+        raise "Unable to locate Xcode. Please make sure to have Xcode installed on your machine." if xcode_version.nil?
         v = xcode_version
         is_pre = v.split('.')[0].to_i < 7
         is_pre


### PR DESCRIPTION
Came across this during testing on a machine without Xcode installed.
