### PR TITLE
This is the alternative to PR #4133

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/boolean.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/boolean.rb
@@ -1,0 +1,22 @@
+module FastlaneCore
+  class Boolean
+    def self.convert(value)
+      klass = value.class
+      case
+      when klass == TrueClass || klass == FalseClass
+        return value
+      when klass == String
+        if %w(YES yes true TRUE).include?(value)
+          return true
+        elsif %w(NO no false FALSE).include?(value)
+          return false
+        end
+        # FIXME: remove this ?
+        raise "Unexpected String value #{value} for Boolean"
+      end
+      return value
+    end
+  end
+end
+
+Boolean = FastlaneCore::Boolean

--- a/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
@@ -17,7 +17,6 @@ module FastlaneCore
         validate_short_switch(used_switches, short_switch)
 
         type = option.data_type
-        type = nil if type == :bool
 
         # This is an important bit of trickery to solve the boolean option situation.
         #
@@ -46,7 +45,7 @@ module FastlaneCore
         # later coerce into a boolean.
         #
         # In this way we support handling boolean flags with or without trailing values.
-        value_appendix = (type || '[VALUE]').to_s.upcase
+        value_appendix = ( type == Boolean ? '[VALUE]' : type.to_s.upcase )
         long_switch = "--#{option.key} #{value_appendix}"
 
         description = option.description
@@ -61,7 +60,8 @@ module FastlaneCore
         # If we don't have a data type for this option, we tell it to act like a String.
         # This allows us to get a reasonable value for boolean options that can be
         # automatically coerced or otherwise handled by the ConfigItem for others.
-        args = [short_switch, long_switch, (type || String), description].compact
+        commander_type = (type == Boolean ? String : type)
+        args = [short_switch, long_switch, commander_type, description].compact
 
         # This is the call to Commander to set up the option we've been building.
         global_option(*args)

--- a/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
@@ -17,6 +17,7 @@ module FastlaneCore
         validate_short_switch(used_switches, short_switch)
 
         type = option.data_type
+        type = nil if type == :bool
 
         # This is an important bit of trickery to solve the boolean option situation.
         #

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -12,7 +12,7 @@ module FastlaneCore
     #   Check value is valid. This could be type checks or if a folder/file exists
     #   You have to raise a specific exception if something goes wrong. Append .red after the string
     # @param is_string *DEPRECATED: Use `type` instead* (Boolean) is that parameter a string? Defaults to true. If it's true, the type string will be verified.
-    # @param type (Class or :bool) the data type of this config item. Takes precedence over `is_string`
+    # @param type (Class) the data type of this config item. Takes precedence over `is_string`. Use `Boolean` for booleans.
     # @param optional (Boolean) is false by default. If set to true, also string values will not be asked to the user
     # @param conflicting_options ([]) array of conflicting option keys(@param key). This allows to resolve conflicts intelligently
     # @param conflict_block an optional block which is called when options conflict happens
@@ -69,7 +69,7 @@ module FastlaneCore
       # we also allow nil values, which do not have to be verified.
       if value
         # Verify that value is the type that we're expecting, if we are expecting a type
-        if data_type != :bool && !value.kind_of?(data_type)
+        if data_type != Boolean && !value.kind_of?(data_type)
           UI.user_error!("'#{self.key}' value must be a #{data_type}! Found #{value.class} instead.")
         end
 
@@ -96,17 +96,9 @@ module FastlaneCore
         return value.to_i
       when data_type == Float
         return value.to_f
-      else
-        # FIXME: should we enforce data_type == :bool ?
-        # Special treatment if the user specififed true, false or YES, NO
-        # There is no boolean type, so we just do it here
-        if %w(YES yes true TRUE).include?(value)
-          return true
-        elsif %w(NO no false FALSE).include?(value)
-          return false
-        end
+      when data_type == Boolean
+        return Boolean.convert(value)
       end
-
       return value # fallback to not doing anything
     end
 
@@ -132,7 +124,7 @@ module FastlaneCore
           if is_string
             type = String
           else
-            type = :bool
+            type = Boolean
           end
         end
       else

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -1,3 +1,4 @@
+require 'fastlane_core/configuration/boolean'
 require 'fastlane_core/configuration/config_item'
 require 'fastlane_core/configuration/commander_generator'
 require 'fastlane_core/configuration/configuration_file'

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -128,7 +128,7 @@ describe FastlaneCore do
                                                      short_option: '-f',
                                                      description: 'foo',
                                                      is_string: false)
-          expect(config_item.data_type).to eq(:bool)
+          expect(config_item.data_type).to eq(Boolean)
         end
 
         it "sets the data type correctly if boolean are explicit" do
@@ -136,9 +136,9 @@ describe FastlaneCore do
                                                      short_option: '-f',
                                                      description: 'foo',
                                                      default_value: false,
-                                                     type: :bool)
+                                                     type: Boolean)
 
-          expect(config_item.data_type).to eq(:bool)
+          expect(config_item.data_type).to eq(Boolean)
         end
       end
 
@@ -227,10 +227,10 @@ describe FastlaneCore do
 
         it "auto converts booleans as strings to booleans" do
           c = [
-            FastlaneCore::ConfigItem.new(key: :true_value),
-            FastlaneCore::ConfigItem.new(key: :true_value2),
-            FastlaneCore::ConfigItem.new(key: :false_value),
-            FastlaneCore::ConfigItem.new(key: :false_value2)
+            FastlaneCore::ConfigItem.new(key: :true_value, type: Boolean),
+            FastlaneCore::ConfigItem.new(key: :true_value2, type: Boolean),
+            FastlaneCore::ConfigItem.new(key: :false_value, type: Boolean),
+            FastlaneCore::ConfigItem.new(key: :false_value2, type: Boolean)
           ]
           config = FastlaneCore::Configuration.create(c, {
             true_value: "true",
@@ -364,7 +364,7 @@ describe FastlaneCore do
           ]
           config = FastlaneCore::Configuration.create(options, { verbose: true })
           expect(config[:verbose]).to eq(true)
-          expect(options[0].data_type).to eq(:bool)
+          expect(options[0].data_type).to eq(Boolean)
         end
       end
 

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -104,6 +104,44 @@ describe FastlaneCore do
         end
       end
 
+      describe "boolean 'type' and transition from deprecated is_string", booleans: true do
+        it "either type or is_string must be there" do
+          expect(FastlaneCore::UI).to receive(:deprecated).with("`type` parameter missing. Using `String` by default")
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo')
+          expect(config_item.data_type).to eq(String)
+        end
+
+        # it "If both type and is_string are defined an error happens FIXME" do
+        #  expect do
+        #    config_item = FastlaneCore::ConfigItem.new(key: :foo,
+        #                                               short_option: '-f',
+        #                                               description: 'foo',
+        #                                               is_string: true,
+        #                                               type: Array)
+        #  end.to raise_error "Both `type` and `is_string` are defined"
+        # end
+
+        it "old style booleans are detected" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo',
+                                                     is_string: false)
+          expect(config_item.data_type).to eq(:bool)
+        end
+
+        it "sets the data type correctly if boolean are explicit" do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     short_option: '-f',
+                                                     description: 'foo',
+                                                     default_value: false,
+                                                     type: :bool)
+
+          expect(config_item.data_type).to eq(:bool)
+        end
+      end
+
       describe "data_type" do
         it "sets the data type correctly if `is_string` is not set but type is specified" do
           config_item = FastlaneCore::ConfigItem.new(key: :foo,
@@ -113,7 +151,8 @@ describe FastlaneCore do
           expect(config_item.data_type).to eq(Array)
         end
 
-        it "sets the data type correctly if `is_string` is set but the type is specified" do
+        it "uses `type` over `is_string` if both are set, but displays a warning" do
+          expect(FastlaneCore::UI).to receive(:important).with("Both `type` and `is_string` are defined. Ignoring `is_string`")
           config_item = FastlaneCore::ConfigItem.new(key: :foo,
                                                      description: 'foo',
                                                      is_string: true,
@@ -317,13 +356,15 @@ describe FastlaneCore do
           expect(config.values).to eq({})
         end
 
-        it "doesn't remove --verbose if it's a valid option" do
+        it "doesn't remove --verbose if it's a valid option", booleans: true do
           options = [
             FastlaneCore::ConfigItem.new(key: :verbose,
+                                short_option: '-f',
                                    is_string: false)
           ]
           config = FastlaneCore::Configuration.create(options, { verbose: true })
           expect(config[:verbose]).to eq(true)
+          expect(options[0].data_type).to eq(:bool)
         end
       end
 


### PR DESCRIPTION
Fixes #3720 (ouh ouh danger ! the link is here !)

An alternative to `:bool` (See #4133 f) is to really create a `Boolean` class (or `BooleanOption`)

Note that there's a weird change required under https://github.com/fastlane/fastlane/pull/4142/files#diff-a57cb37ed0300bc17ef34e10e8790763R340 that is caused by the fact that today a String is automatically turned into a Boolean value. I don't know why we want that to be implicit instead of explicit.

If we want to conserve that behaviour, the patch is

``` ruby
diff --git a/fastlane_core/lib/fastlane_core/configuration/boolean.rb b/fastlane_core/lib/fastlane_core/configuration/boolean.rb
index 3882dc2..1c46c95 100644
--- a/fastlane_core/lib/fastlane_core/configuration/boolean.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/boolean.rb
@@ -12,7 +12,7 @@ module FastlaneCore
           return false
         end
         # FIXME: remove this ?
-        raise "Unexpected String value #{value} for Boolean"
+        #raise "Unexpected String value #{value} for Boolean"
       end
       return value
     end
diff --git a/fastlane_core/lib/fastlane_core/configuration/config_item.rb b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
index 767b293..e5e5b76 100644
--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -104,6 +104,8 @@ module FastlaneCore
         return value.to_f
       when data_type == Boolean
         return Boolean.convert(value)
+      when data_type == String
+        return Boolean.convert(value)
       end
       return value # fallback to not doing anything
     end
diff --git a/fastlane_core/spec/configuration_spec.rb b/fastlane_core/spec/configuration_spec.rb
index 9554a8f..2c344b0 100644
--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -337,10 +337,10 @@ describe FastlaneCore do

         it "auto converts booleans as strings to booleans" do
           c = [
-            FastlaneCore::ConfigItem.new(key: :true_value, type: Boolean),
-            FastlaneCore::ConfigItem.new(key: :true_value2, type: Boolean),
-            FastlaneCore::ConfigItem.new(key: :false_value, type: Boolean),
-            FastlaneCore::ConfigItem.new(key: :false_value2, type: Boolean)
+            FastlaneCore::ConfigItem.new(key: :true_value),
+            FastlaneCore::ConfigItem.new(key: :true_value2),
+            FastlaneCore::ConfigItem.new(key: :false_value),
+            FastlaneCore::ConfigItem.new(key: :false_value2)
           ]
           config = FastlaneCore::Configuration.create(c, {
             true_value: "true",
```
