### PR TITLE
Add to bash and zsh completion scripts support of .fastlane folder

### DIFF
--- a/fastlane/lib/assets/completions/completion.bash
+++ b/fastlane/lib/assets/completions/completion.bash
@@ -8,6 +8,8 @@ _fastlane_complete() {
     file="Fastfile"
   elif [[ -e "fastlane/Fastfile" ]]; then
     file="fastlane/Fastfile"
+  elif [[ -e ".fastlane/Fastfile" ]] then
+    file=".fastlane/Fastfile"
   fi
 
   # parse 'beta' out of 'lane :beta do', etc

--- a/fastlane/lib/assets/completions/completion.zsh
+++ b/fastlane/lib/assets/completions/completion.zsh
@@ -7,6 +7,8 @@ _fastlane_complete() {
     file="Fastfile"
   elif [[ -e "fastlane/Fastfile" ]] then
     file="fastlane/Fastfile"
+  elif [[ -e ".fastlane/Fastfile" ]] then
+    file=".fastlane/Fastfile"
   fi
 
   # parse 'beta' out of 'lane :beta do', etc


### PR DESCRIPTION
Current implementation of completion scripts ignores .fastlane folder
