### PR TITLE
Escaping UploadSymbolsToCrashlyticsAction binary_path

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -52,7 +52,7 @@ module Fastlane
       def self.upload_dsym(params, path)
         UI.message("Uploading '#{path}'...")
         command = []
-        command << params[:binary_path]
+        command << params[:binary_path].shellescape
         command << "-a #{params[:api_token]}"
         command << "-p #{params[:platform]}"
         command << File.expand_path(path).shellescape


### PR DESCRIPTION
Uploading dSYMs with the UploadSymbolsToCrashlyticsAction action can cause failures with a custom binary_path where the binary_path contains spaces. This proposed change shellescape's the binary_path.
