### PR TITLE
Augment verify_xcode action's accepted codesign info

### DIFF
--- a/fastlane/spec/actions_specs/verify_xcode_spec.rb
+++ b/fastlane/spec/actions_specs/verify_xcode_spec.rb
@@ -1,0 +1,35 @@
+describe Fastlane::Actions::VerifyXcodeAction do
+  describe 'codesign verification' do
+    it "reports success for AppStore codesign details" do
+      fixture_data = File.read('spec/fixtures/verify_xcode/xcode_codesign_appstore.txt')
+
+      allow(FastlaneCore::UI).to receive(:message)
+      expect(Fastlane::Actions).to receive(:sh).with(/codesign/).and_return(fixture_data)
+      expect(FastlaneCore::UI).to receive(:success).with(/Successfully verified/)
+
+      Fastlane::Actions::VerifyXcodeAction.verify_codesign({xcode_path: ''})
+    end
+
+    it "reports success for developer.apple.com codesign details" do
+      fixture_data = File.read('spec/fixtures/verify_xcode/xcode_codesign_developer_portal.txt')
+
+      allow(FastlaneCore::UI).to receive(:message)
+      expect(Fastlane::Actions).to receive(:sh).with(/codesign/).and_return(fixture_data)
+      expect(FastlaneCore::UI).to receive(:success).with(/Successfully verified/)
+
+      Fastlane::Actions::VerifyXcodeAction.verify_codesign({xcode_path: ''})
+    end
+
+    it "raises an error for invalid codesign details" do
+      fixture_data = File.read('spec/fixtures/verify_xcode/xcode_codesign_invalid.txt')
+
+      allow(FastlaneCore::UI).to receive(:message)
+      allow(FastlaneCore::UI).to receive(:error)
+      expect(Fastlane::Actions).to receive(:sh).with(/codesign/).and_return(fixture_data)
+
+      expect do
+        Fastlane::Actions::VerifyXcodeAction.verify_codesign({xcode_path: ''})
+      end.to raise_error FastlaneCore::Interface::FastlaneError
+    end
+  end
+end

--- a/fastlane/spec/fixtures/verify_xcode/xcode_codesign_appstore.txt
+++ b/fastlane/spec/fixtures/verify_xcode/xcode_codesign_appstore.txt
@@ -1,0 +1,16 @@
+Executable=/Applications/Xcode.app/Contents/MacOS/Xcode
+Identifier=com.apple.dt.Xcode
+Format=app bundle with Mach-O thin (x86_64)
+CodeDirectory v=20200 size=322 flags=0x200(kill) hashes=7+5 location=embedded
+Hash type=sha1 size=20
+CandidateCDHash sha1=1bf95c3d5e168d5cd63b041d05962ba3fd6c5e44
+Hash choices=sha1
+CDHash=1bf95c3d5e168d5cd63b041d05962ba3fd6c5e44
+Signature size=4167
+Authority=Apple Mac OS Application Signing
+Authority=Apple Worldwide Developer Relations Certification Authority
+Authority=Apple Root CA
+Info.plist entries=34
+TeamIdentifier=59GAB85EFG
+Sealed Resources version=2 rules=12 files=401968
+Internal requirements count=1 size=108

--- a/fastlane/spec/fixtures/verify_xcode/xcode_codesign_developer_portal.txt
+++ b/fastlane/spec/fixtures/verify_xcode/xcode_codesign_developer_portal.txt
@@ -1,0 +1,16 @@
+Executable=/Users/mfurtak/Desktop/Xcode.app/Contents/MacOS/Xcode
+Identifier=com.apple.dt.Xcode
+Format=app bundle with Mach-O thin (x86_64)
+CodeDirectory v=20100 size=307 flags=0x0(none) hashes=7+5 location=embedded
+Hash type=sha1 size=20
+CandidateCDHash sha1=dc74c741271f69129ef4121960857bdd171f19cd
+Hash choices=sha1
+CDHash=dc74c741271f69129ef4121960857bdd171f19cd
+Signature size=4105
+Authority=Software Signing
+Authority=Apple Code Signing Certification Authority
+Authority=Apple Root CA
+Info.plist entries=34
+TeamIdentifier=not set
+Sealed Resources version=2 rules=12 files=387668
+Internal requirements count=1 size=68

--- a/fastlane/spec/fixtures/verify_xcode/xcode_codesign_invalid.txt
+++ b/fastlane/spec/fixtures/verify_xcode/xcode_codesign_invalid.txt
@@ -1,0 +1,16 @@
+Executable=/Users/mfurtak/Desktop/Xcode.app/Contents/MacOS/Xcode
+Identifier=com.apple.dt.Xcode
+Format=app bundle with Mach-O thin (x86_64)
+CodeDirectory v=20100 size=307 flags=0x0(none) hashes=7+5 location=embedded
+Hash type=sha1 size=20
+CandidateCDHash sha1=dc74c741271f69129ef4121960857bdd171f19cd
+Hash choices=sha1
+CDHash=dc74c741271f69129ef4121960857bdd171f19cd
+Signature size=4105
+Authority=Software Signing
+Authority=Apple Code Hacking Certification Authority
+Authority=Apple Fake CA
+Info.plist entries=34
+TeamIdentifier=not set
+Sealed Resources version=2 rules=12 files=387668
+Internal requirements count=1 size=68


### PR DESCRIPTION
Addresses #4073
- Adds another set of acceptable `codesign` details so that Xcode installations which are downloaded from developer.apple.com (which are signed differently) are also seen as valid.
- Changes value quoting to shell escaping for the `xcode_path`
- No longer reports the information that couldn't be found after a failed `codesign` verification, as there's now two sets of information that we'd have to report, and it starts to feel more confusing than helpful.
- Adds tests for `codesign` checks
- Changes some `success` logging to be `message` logging, where it is not reporting success
