### PR TITLE
Forcing command output to UTF8 to prevent incompatible character enco…

### DIFF
--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -45,7 +45,7 @@ module FastlaneCore
         begin
           PTY.spawn(command) do |stdin, stdout, pid|
             stdin.each do |l|
-              line = l.strip # strip so that \n gets removed
+              line = l.force_encoding("utf-8").strip # strip so that \n gets removed
               output << line
 
               next unless print_all


### PR DESCRIPTION
Fix for issue #3969 

Command output is forced to UTF8 to make sure no incompatible encodings are combined when prefixing strings.
