### PR TITLE
Fix deliver summary HTML generation to URL-escape file paths

### DIFF
--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -181,7 +181,7 @@
               <div class="app-screenshot-row">
 
               <% screenshots.each_with_index do |screenshot, index| %>
-                <a href="<%= screenshot.path %>" target="_blank"><img class="app-screenshot" src="<%= screenshot.path %>" title="Screenshot #<%=index%> for <%=language%>"></a>
+                <a href="<%= URI.escape(screenshot.path) %>" target="_blank"><img class="app-screenshot" src="<%= URI.escape(screenshot.path) %>" title="Screenshot #<%=index%> for <%=language%>"></a>
               <% end %>
               </div>
             <% end %>


### PR DESCRIPTION
Addresses #1448 

The only part that is really experiencing problems is the HTML generation for the preview.
