### PR TITLE
Make body of commit optional in jenkins changelog generation

### DIFF
--- a/fastlane/lib/fastlane/actions/make_changelog_from_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/make_changelog_from_jenkins.rb
@@ -9,11 +9,11 @@ module Fastlane
 
         if Helper.is_ci? || Helper.is_test?
           # The "BUILD_URL" environment variable is set automatically by Jenkins in every build
-          jenkins_xml_url = URI(ENV["BUILD_URL"] + "api/json\?wrapper\=changes\&xpath\=//changeSet//comment")
+          jenkins_api_url = URI(ENV["BUILD_URL"] + "api/json\?wrapper\=changes\&xpath\=//changeSet//comment")
           begin
-            json = JSON.parse(Net::HTTP.get(jenkins_xml_url))
+            json = JSON.parse(Net::HTTP.get(jenkins_api_url))
             json['changeSet']['items'].each do |item|
-              comment = item['comment']
+              comment = params[:include_commit_body] ? item['comment'] : item['msg']
               changelog << comment.strip + "\n"
             end
           rescue => ex
@@ -37,7 +37,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :fallback_changelog,
                                        description: "Fallback changelog if there is not one on Jenkins, or it couldn't be read",
                                        optional: true,
-                                       default_value: "")
+                                       default_value: ""),
+          FastlaneCore::ConfigItem.new(key: :include_commit_body,
+                                       description: "Include the commit body along with the summary",
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: true)
         ]
       end
 

--- a/fastlane/spec/actions_specs/make_changelog_from_jenkins_spec.rb
+++ b/fastlane/spec/actions_specs/make_changelog_from_jenkins_spec.rb
@@ -21,7 +21,19 @@ describe Fastlane do
         expect(result).to eq("FOOBAR")
       end
 
-      it "correctly parses the data if it was abl to retrieve it" do
+      it "correctly parses the data if it was able to retrieve it and does not include the commit body" do
+        stub_request(:get, "https://jenkinsurl.com/JOB/api/json\?wrapper\=changes\&xpath\=//changeSet//comment").
+          with(headers: {'Host' => 'jenkinsurl.com'}).
+          to_return(status: 200, body: File.read("./spec/fixtures/requests/make_jenkins_changelog.json"), headers: {})
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          make_changelog_from_jenkins(fallback_changelog: 'FOOBAR', include_commit_body: false)
+        end").runner.execute(:test)
+
+        expect(result).to eq("Disable changelog generation from Jenkins until we sort it out\n")
+      end
+
+      it "correctly parses the data if it was able to retrieve it and include commit body" do
         stub_request(:get, "https://jenkinsurl.com/JOB/api/json\?wrapper\=changes\&xpath\=//changeSet//comment").
           with(headers: {'Host' => 'jenkinsurl.com'}).
           to_return(status: 200, body: File.read("./spec/fixtures/requests/make_jenkins_changelog.json"), headers: {})
@@ -30,7 +42,7 @@ describe Fastlane do
           make_changelog_from_jenkins(fallback_changelog: 'FOOBAR')
         end").runner.execute(:test)
 
-        expect(result).to eq("Disable changelog generation from Jenkins until we sort it out\n")
+        expect(result).to eq("Disable changelog generation from Jenkins until we sort it out\nThis commit has a body\n")
       end
     end
   end

--- a/fastlane/spec/fixtures/requests/make_jenkins_changelog.json
+++ b/fastlane/spec/fixtures/requests/make_jenkins_changelog.json
@@ -62,7 +62,7 @@
 				"absoluteUrl": "http://example.com/user/jerome@wewanttoknow.com",
 				"fullName": "Jerome Lacoste"
 			},
-			"comment": "Disable changelog generation from Jenkins until we sort it out\n",
+			"comment": "Disable changelog generation from Jenkins until we sort it out\nThis commit has a body",
 			"date": "2016-02-18T17:02:23+0100 +0100",
 			"id": "69d3f6b6c48bd36879bbc8b0c9e7795e2b5aacd4",
 			"msg": "Disable changelog generation from Jenkins until we sort it out",


### PR DESCRIPTION
A list of commit summaries is a much better changelog than a list of
commit summaries + their bodies. There are a few reasons for this. For
one, most obvious, a changelog is ideally a summary of changes. Another
is there might be restrictions on the character length of your
changelog. Crashlytics for example has a limit of ~16k characters, so if
everyone wrote really detailed bodies in their commits, the build would
fail after a few commits. Also, it is a lot easier to read and
understand.
