### PR TITLE
[sigh] New parameter for sigh resign which changes current application bundle ID

### DIFF
--- a/fastlane/lib/fastlane/actions/resign.rb
+++ b/fastlane/lib/fastlane/actions/resign.rb
@@ -6,7 +6,7 @@ module Fastlane
         require 'sigh'
 
         # try to resign the ipa
-        if Sigh::Resign.resign(params[:ipa], params[:signing_identity], params[:provisioning_profile], params[:entitlements], params[:version], params[:display_name], params[:short_version], params[:bundle_version])
+        if Sigh::Resign.resign(params[:ipa], params[:signing_identity], params[:provisioning_profile], params[:entitlements], params[:version], params[:display_name], params[:short_version], params[:bundle_version], params[:bundle_id])
           UI.success('Successfully re-signed .ipa 🔏.')
         else
           UI.user_error!("Failed to re-sign .ipa")
@@ -84,6 +84,11 @@ module Fastlane
                                        env_name: "FL_RESIGN_BUNDLE_VERSION",
                                        description: "Bundle version to force resigned ipa to use (CFBundleIdentifier)",
                                        conflicting_options: [:version],
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :bundle_id,
+                                       env_name: "FL_RESIGN_BUNDLE_ID",
+                                       description: "Set new bundle ID during resign",
                                        is_string: true,
                                        optional: true)
         ]

--- a/sigh/bin/sigh
+++ b/sigh/bin/sigh
@@ -72,6 +72,7 @@ class SighApplication
                '\nCannot be used together with -x|--version_number option.'
       c.option '--bundle-version STRING', String, 'Bundle version to force binary and all nested binaries to use (CFBundleIdentifier). '\
                'Cannot be used together with -x|--version_number option.'
+      c.option '-g', '--new_bundle_id STRING', String, 'New application bundle ID'
 
       c.action do |args, options|
         Sigh::Resign.new.run(options, args)

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -6,16 +6,16 @@ module Sigh
     def run(options, args)
       # get the command line inputs and parse those into the vars we need...
 
-      ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version = get_inputs(options, args)
+      ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id = get_inputs(options, args)
       # ... then invoke our programmatic interface with these vars
-      resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version)
+      resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id)
     end
 
-    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version)
-      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version)
+    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id)
+      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id)
     end
 
-    def resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version)
+    def resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id)
       resign_path = find_resign_path
       signing_identity = find_signing_identity(signing_identity)
 
@@ -32,6 +32,7 @@ module Sigh
       short_version = "--short-version #{short_version}" if short_version
       bundle_version = "--bundle-version #{bundle_version}" if bundle_version
       verbose = "-v" if $verbose
+      bundle_id = "-b '#{new_bundle_id}'" if new_bundle_id
 
       command = [
         resign_path.shellescape,
@@ -44,6 +45,7 @@ module Sigh
         short_version,
         bundle_version,
         verbose,
+        bundle_id,
         ipa.shellescape
       ].join(' ')
 
@@ -68,12 +70,13 @@ module Sigh
       display_name = options.display_name || nil
       short_version = options.short_version || nil
       bundle_version = options.bundle_version || nil
+      new_bundle_id = options.new_bundle_id || nil
 
       if options.provisioning_name
         UI.important "The provisioning_name (-n) option is not applicable to resign. You should use provisioning_profile (-p) instead"
       end
 
-      return ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version
+      return ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id
     end
 
     def find_resign_path


### PR DESCRIPTION
In relation of issues #1758 and #1779 (which I guess are duplicated)

As there are many flags already for sigh / sigh resign, I've chosen -g. It just adds the -b parameter to the underlying resign.sh command if the parameter has been added
