### PR TITLE
Change Actions.sh to call UI.user_error for a non-zero exit code

### DIFF
--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -41,7 +41,7 @@ module Fastlane
           else
             message = "Shell command exited with exit status #{exit_status} instead of 0."
           end
-          UI.crash!(message)
+          UI.user_error!(message)
         end
       end
 


### PR DESCRIPTION
`Actions.sh` (which we use to shell out to many external tools in our actions) should not call `UI.crash!` when it detects a non-zero exit status from the shell-out command.

Calling `UI.crash!` prints a big Ruby stack trace and it makes it look like fastlane has crashed, and this actually hides the message about the command and its exit code.

`Actions.sh` should call `UI.user_error!` instead, which will suppress the stack trace, and make the error message very clear for the users.

Before:
![screen shot 2016-04-14 at 5 36 50 pm](https://cloud.githubusercontent.com/assets/343134/14544647/30089742-0268-11e6-86b7-6292307a3fab.png)

After:
![screen shot 2016-04-14 at 5 37 26 pm](https://cloud.githubusercontent.com/assets/343134/14544651/334b43b4-0268-11e6-9670-0294c779cc9a.png)
