### PR TITLE
Remove the line that creates xcent file

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -57,7 +57,6 @@
 # 2. enables the -p option to be used more than once
 # 3. ensures the provisioning profile's bundle-identifier matches the app's bundle identifier
 # 4. extracts the entitlements from the provisioning profile
-# 5. copy the entitlements as archived-expanded-entitlements.xcent inside the app bundle (because Xcode does too)
 #
 
 # Logging functions
@@ -480,7 +479,6 @@ function resign {
 
         log "Resigning application using certificate: '$CERTIFICATE'"
         log "and entitlements: $ENTITLEMENTS"
-        cp -- "$ENTITLEMENTS" "$APP_PATH/archived-expanded-entitlements.xcent"
         /usr/bin/codesign ${VERBOSE} -f -s "$CERTIFICATE" --entitlements="$ENTITLEMENTS" "$APP_PATH"
         checkStatus
     else
@@ -489,7 +487,6 @@ function resign {
         checkStatus
         log "Resigning application using certificate: '$CERTIFICATE'"
         log "and entitlements from provisioning profile: $NEW_PROVISION"
-        cp -- "$TEMP_DIR/newEntitlements" "$APP_PATH/archived-expanded-entitlements.xcent"
         /usr/bin/codesign ${VERBOSE} -f -s "$CERTIFICATE" --entitlements="$TEMP_DIR/newEntitlements" "$APP_PATH"
         checkStatus
     fi


### PR DESCRIPTION
The description says:
`# 5. copy the entitlements as archived-expanded-entitlements.xcent inside the app bundle (because Xcode does too)`
However, this is not correct.

Xcode does create the xcent file, but only when creating xcarchive!
When the archive is exported with -exportArchive command, the xcent file is removed.
This is easy to verify by creating archive first then exporting it via command line.

So as a result, exported .ipa file never has .xcent file inside.

Another reason to remove this code is the following:
The resigning script must not add or remove files to/from the bundle.
It needs to resign only, adding or removing files is simply not correct, unless that's what the user of the script wants and explicitly specifies files to be added/removed.

We have actually faced a very serious issue due to addition of .xcent file.

Example:
- Version 1.0 was resigned with sigh and contains .xcent file
- Version 2.0 was created using xcodebuild archive/exportArchive command and DOES NOT contain .xcent file

Version 1.0 is launched and writes data to shared keychain.
Version 2.0 is then launched and fails to see shared kechain, all because of this extra .xcent file.
We've spend literally days trying to figure out the source of the problem.
We have verified that removing .xcent while resigning fixes the problem.

As a summary:
When both IPAs contain .xcent the keychain works fine
With both IPAs do not contain .xcent the keychain works fine
When the IPAs are different with regards to .xcent file the very annoying and actually dangerous issue occurs.

As a matter of fact, Apple removes this .xcent file from AppStore and TestFlight builds.
We've veriefied by uploading IPA with .xcent to TestFlight, then downloading it and checking the contents of the IPA processed by Apple.
