### PR TITLE
Add a lane for showing the changelog for a tool

### DIFF
--- a/fastlane/fastlane/Fastfile
+++ b/fastlane/fastlane/Fastfile
@@ -32,6 +32,14 @@ lane :bump do |options|
   end
 end
 
+desc "Display a changelog for a tool since its last release. Run from a tool directory or specify (e.g. tool:deliver)"
+lane :show_changelog do |options|
+  tool_name = options[:tool] || detect_tool
+  old_version = current_version(tool: tool_name)
+
+  print_release_changelog(tool: tool_name, old_version: old_version)
+end
+
 desc "Does everything that's needed for a release, this includes running tests and verifying the GitHub release"
 lane :release do |options|
   # Fetching all information required for the release
@@ -178,7 +186,7 @@ private_lane :print_release_changelog do |options|
   tool_name = options[:tool]
   old_version = options[:old_version]
 
-  cmd = "git log --pretty='* %B' #{tool_name}/#{old_version}...HEAD --no-merges .."
+  cmd = "git log --pretty='* %s' #{tool_name}/#{old_version}...HEAD --no-merges .."
   puts "Changes since release #{old_version}:\n" + `#{cmd}`.gsub("\n\n", "\n")
 end
 


### PR DESCRIPTION
This makes it easier to see what has changed for a tool, to know how to appropriately bump its version.

An equivalent command also gets run during the release process. That is helpful for filling out the GitHub release details, but is too late to help with version change decisions!
