### PR TITLE
Add a rake task to print a table of time-since-last-release info

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 GEMS = %w(fastlane fastlane_core deliver snapshot frameit pem sigh produce cert gym pilot credentials_manager spaceship scan supply watchbuild match screengrab)
 RAILS = %w(boarding refresher enhancer)
 
+SECONDS_PER_DAY = 60 * 60 * 24
+
 #####################################################
 # @!group Everything to be executed in the root folder containing all fastlane repos
 #####################################################
@@ -25,26 +27,6 @@ desc 'Run `bundle update` and `rake install` for all the gems.'
 task install: :bundle do
   GEMS.each do |repo|
     sh "cd #{repo} && rake install"
-  end
-end
-
-desc 'Print out the # of unreleased commits'
-task :unreleased do
-  GEMS.each do |repo|
-    Dir.chdir(repo) do
-      `git pull --tags`
-
-      last_tag = `git describe --abbrev=0 --tags`.strip
-      output = `git log #{last_tag}..HEAD --oneline`.strip
-
-      if output.length > 0
-        box "#{repo}: #{output.split("\n").count} Commits"
-        output.split("\n").each do |line|
-          puts "\t" + line.split(' ', 1).last # we don't care about the commit ID
-        end
-        puts "\nhttps://github.com/fastlane/#{repo}/compare/#{last_tag}...master"
-      end
-    end
   end
 end
 

--- a/rakelib/issue_stats.rake
+++ b/rakelib/issue_stats.rake
@@ -6,8 +6,6 @@ require 'colored'
 
 QUERY_DAYS = (ENV["DAYS"] || 4).to_i
 
-SECONDS_PER_DAY = 86_400
-
 FASTLANE_MEMBERS = %w(asfalcone chaselatta fastlane-bot hemal i2amsam kimyoutora KrauseFx mfurtak MichaelDoyle mpirri ohwutup samrobbins snatchev vpolouchkine)
 
 ALL_TOOL_LABELS = %w(fastlane fastlane_core deliver snapshot frameit pem sigh produce cert gym pilot credentials_manager spaceship scan supply watchbuild match screengrab)
@@ -98,8 +96,9 @@ task :issue_stats do
     total_row
   end
 
-  box("Issue statistics over the past #{QUERY_DAYS} days")
-  table = Terminal::Table.new :headings => ['Labels', 'Opened', 'Closed', 'Net'], :rows => pretty_issues
+  table = Terminal::Table.new(title: "Issue statistics over the past #{QUERY_DAYS} days".green,
+                              headings: ['Labels', 'Opened', 'Closed', 'Net'],
+                              rows: pretty_issues)
   table.add_separator
   table.add_row colorized_row(totals)
   puts table

--- a/rakelib/release_stats.rake
+++ b/rakelib/release_stats.rake
@@ -1,0 +1,51 @@
+require 'date'
+require 'terminal-table'
+require 'colored'
+
+RED_COMMIT_COUNT = 5
+RED_DAY_COUNT = 14
+
+def should_row_be_red?(row)
+  row[1] > RED_COMMIT_COUNT || (row[2] > RED_DAY_COUNT && row[1] > 0)
+end
+
+def colorize_rows(rows)
+  rows.map do |row|
+    if should_row_be_red?(row)
+      row.map { |item| item.to_s.red }
+    else
+      row.map(&:to_s)
+    end
+  end
+end
+
+def sort_by_commit_count(rows)
+  rows.sort_by! { |row| row[1].to_i }.reverse
+end
+
+desc 'Print stats about how much time has passed and work has happened since the last release of each tool'
+task :release_stats do
+  `git pull --tags`
+
+  now = Time.now
+  rows = []
+
+  GEMS.each do |repo|
+    Dir.chdir(repo) do
+      last_tag_sha = `git rev-list --tags=#{repo}/* --max-count=1`.chomp
+      last_tag_name = `git describe --tags #{last_tag_sha}`.chomp
+      commit_count = `git log #{last_tag_name.shellescape}...HEAD --no-merges --oneline .`.chomp.split("\n").count
+      commit_time = DateTime.parse(`git show -s --format=%ci #{last_tag_sha}`.chomp).to_time
+      days_since_release = (now - commit_time) / SECONDS_PER_DAY
+
+      rows << [repo, commit_count, days_since_release.round]
+    end
+  end
+
+  rows = sort_by_commit_count(rows)
+  rows = colorize_rows(rows)
+
+  puts Terminal::Table.new(title: 'How Long Since the Last Release?'.green,
+                           headings: ['Tool', 'Commits', 'Days'],
+                           rows: rows)
+end


### PR DESCRIPTION
Run with `rake release_stats` from the repo root

![screen shot 2016-04-19 at 12 53 27 pm](https://cloud.githubusercontent.com/assets/343134/14647902/ba0ed5e6-062d-11e6-9434-c6e0f866722f.png)
