### PR TITLE
Fixes Demo Account on update_build_information

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -571,6 +571,10 @@ module Spaceship
         current["feedbackEmail"]["value"] = feedback_email if feedback_email
       end
 
+      review_user_name = build_info['reviewUserName']['value']
+      review_password = build_info['reviewPassword']['value']
+      build_info['reviewAccountRequired']['value'] = ((review_user_name || "").to_s + (review_password || "").to_s).length > 0
+
       # Now send everything back to iTC
       r = request(:post) do |req| # same URL, but a POST request
         req.url url


### PR DESCRIPTION
Correctly sets `reviewAccountRequired` when calling `update_build_information`.

Previously, only `submit_testflight_build_for_review` was fixed to handle this.
Used the same technique to make it work on `update_build_information`.
Tested and it worked.

Before the change, this is the error:

```
pry(main)> app = Spaceship::Tunes::Application.find(BUNDLE_ID)
pry(main)> app.builds.sort_by {|app| app.upload_date}.last.update_build_information!(whats_new: "Fixes")
Spaceship::TunesClient::ITunesConnectError: A demo account user name is required. A demo account password is required. A demo account user name is required. A demo account password is required.
from /Users/carlos/.gems/gems/spaceship-0.26.0/lib/spaceship/tunes/tunes_client.rb:174:in `handle_itc_response'
```

With this commit, everything works! 🎉

This is related to #4241.
