### PR TITLE
Added support for 2 step passwords for iTC Transporter

### DIFF
--- a/credentials_manager/lib/credentials_manager/account_manager.rb
+++ b/credentials_manager/lib/credentials_manager/account_manager.rb
@@ -3,7 +3,11 @@ require 'highline/import' # to hide the entered password
 
 module CredentialsManager
   class AccountManager
-    def initialize(user: nil, password: nil)
+    # @param prefix [String] Very optional, is used for the
+    #   iTunes Transporter which uses application specofic passwords
+    def initialize(user: nil, prefix: nil, password: nil)
+      @prefix = prefix || "deliver"
+
       @user = user
       @password = password
     end
@@ -82,7 +86,7 @@ module CredentialsManager
     end
 
     def server_name
-      "deliver.#{user}"
+      "#{@prefix}.#{user}"
     end
   end
 end


### PR DESCRIPTION
This change was necessary, since the real password can't be used with iTunes Transporter. It requires an application specific password. 

This PR adds the following:
- Account manager now allows a custom prefix, which is used to store the application specific password
- The transporter will now silently try to load the application specific password from the keychain (if it exists), and fallback to the standard way of handling the password
- If the upload fails due to 2 step verification, the user will be prompted for an application specific password

Obligatory 🚀 
