### PR TITLE
Added support for 2 step passwords for iTC Transporter

### DIFF
--- a/credentials_manager/lib/credentials_manager/account_manager.rb
+++ b/credentials_manager/lib/credentials_manager/account_manager.rb
@@ -3,7 +3,11 @@ require 'highline/import' # to hide the entered password
 
 module CredentialsManager
   class AccountManager
-    def initialize(user: nil, password: nil)
+    # @param prefix [String] Very optional, is used for the
+    #   iTunes Transporter which uses application specofic passwords
+    def initialize(user: nil, prefix: nil, password: nil)
+      @prefix = prefix || "deliver"
+
       @user = user
       @password = password
     end
@@ -82,7 +86,7 @@ module CredentialsManager
     end
 
     def server_name
-      "deliver.#{user}"
+      "#{@prefix}.#{user}"
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -12,6 +12,10 @@ module FastlaneCore
   class TransporterTransferError < StandardError
   end
 
+  # Used internally
+  class TransporterRequiresApplicationSpecificPasswordError < StandardError
+  end
+
   # Base class for executing the iTMSTransporter
   class TransporterExecutor
     ERROR_REGEX = />\s*ERROR:\s+(.+)/
@@ -37,15 +41,8 @@ module FastlaneCore
 
       begin
         PTY.spawn(command) do |stdin, stdout, pid|
-          begin
-            stdin.each do |line|
-              parse_line(line, hide_output) # this is where the parsing happens
-            end
-          rescue Errno::EIO
-            # Exception ignored intentionally.
-            # https://stackoverflow.com/questions/10238298/ruby-on-linux-pty-goes-away-without-eof-raises-errnoeio
-          ensure
-            Process.wait(pid)
+          stdin.each do |line|
+            parse_line(line, hide_output) # this is where the parsing happens
           end
         end
       rescue => ex
@@ -55,6 +52,10 @@ module FastlaneCore
 
       if @warnings.count > 0
         UI.important(@warnings.join("\n"))
+      end
+
+      if @errors.join("").include?("Sign in with the app-specific")
+        raise TransporterRequiresApplicationSpecificPasswordError
       end
 
       if @errors.count > 0
@@ -222,6 +223,8 @@ module FastlaneCore
   end
 
   class ItunesTransporter
+    TWO_STEP_HOST_PREFIX = "deliver.appspecific"
+
     # This will be called from the Deliverfile, and disables the logging of the transporter output
     def self.hide_transporter_output
       @hide_transporter_output = !$verbose
@@ -234,16 +237,25 @@ module FastlaneCore
     # Returns a new instance of the iTunesTransporter.
     # If no username or password given, it will be taken from
     # the #{CredentialsManager::AccountManager}
-    # @param use_shell_script if true, forces use of the iTMSTransporter shell script.
-    #                         if false, allows a direct call to the iTMSTransporter Java app (preferred).
-    #                         see: https://github.com/fastlane/fastlane/pull/4003
-    def initialize(user = nil, password = nil, use_shell_script = false)
-      use_shell_script ||= !ENV['FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT'].nil?
-      data = CredentialsManager::AccountManager.new(user: user, password: password)
+    def initialize(user = nil, password = nil, avoid_shell_script = false)
+      avoid_shell_script ||= !ENV['FASTLANE_EXPERIMENTAL_TRANSPORTER_AVOID_SHELL_SCRIPT'].nil?
 
+      # First, see if we have an application specific password
+      data = CredentialsManager::AccountManager.new(user: user,
+                                                  prefix: TWO_STEP_HOST_PREFIX)
       @user = data.user
-      @password = data.password
-      @transporter_executor = use_shell_script ? ShellScriptTransporterExecutor.new : JavaTransporterExecutor.new
+      @password ||= data.password(ask_if_missing: false)
+
+      if @password.to_s.length == 0
+        # No specific password found, just using the iTC/Dev Portal one
+        # default to the given password here
+        data = CredentialsManager::AccountManager.new(user: user,
+                                                  password: password)
+        @user = data.user
+        @password ||= data.password
+      end
+
+      @transporter_executor = avoid_shell_script ? JavaTransporterExecutor.new : ShellScriptTransporterExecutor.new
     end
 
     # Downloads the latest version of the app metadata package from iTC.
@@ -259,7 +271,13 @@ module FastlaneCore
       command = @transporter_executor.build_download_command(@user, @password, app_id, dir)
       UI.verbose(@transporter_executor.build_download_command(@user, 'YourPassword', app_id, dir))
 
-      result = @transporter_executor.execute(command, ItunesTransporter.hide_transporter_output?)
+      begin
+        result = @transporter_executor.execute(command, ItunesTransporter.hide_transporter_output?)
+      rescue TransporterRequiresApplicationSpecificPasswordError => ex
+        handle_two_step_failure(ex)
+        return download(app_id, dir)
+      end
+
       return result if Helper.is_test?
 
       itmsp_path = File.join(dir, "#{app_id}.itmsp")
@@ -281,23 +299,27 @@ module FastlaneCore
     # @raise [Deliver::TransporterTransferError] when something went wrong
     #   when transfering
     def upload(app_id, dir)
-      dir = File.join(dir, "#{app_id}.itmsp")
+      actual_dir = File.join(dir, "#{app_id}.itmsp")
 
       UI.message("Going to upload updated app to iTunes Connect")
       UI.success("This might take a few minutes, please don't interrupt the script")
 
-      command = @transporter_executor.build_upload_command(@user, @password, dir)
+      command = @transporter_executor.build_upload_command(@user, @password, actual_dir)
+      UI.verbose(@transporter_executor.build_upload_command(@user, 'YourPassword', actual_dir))
 
-      UI.verbose(@transporter_executor.build_upload_command(@user, 'YourPassword', dir))
-
-      result = @transporter_executor.execute(command, ItunesTransporter.hide_transporter_output?)
+      begin
+        result = @transporter_executor.execute(command, ItunesTransporter.hide_transporter_output?)
+      rescue TransporterRequiresApplicationSpecificPasswordError => ex
+        handle_two_step_failure(ex)
+        return upload(app_id, dir)
+      end
 
       if result
         UI.success("-" * 102)
         UI.success("Successfully uploaded package to iTunes Connect. It might take a few minutes until it's visible online.")
         UI.success("-" * 102)
 
-        FileUtils.rm_rf(dir) unless Helper.is_test? # we don't need the package any more, since the upload was successful
+        FileUtils.rm_rf(actual_dir) unless Helper.is_test? # we don't need the package any more, since the upload was successful
       else
         handle_error(@password)
       end
@@ -307,16 +329,36 @@ module FastlaneCore
 
     private
 
+    # Tells the user how to get an application specific password
+    def handle_two_step_failure(ex)
+      a = CredentialsManager::AccountManager.new(user: @user,
+                                               prefix: TWO_STEP_HOST_PREFIX)
+      if a.password(ask_if_missing: false).to_s.length > 0
+        # user already entered one.. delete the old one
+        UI.error("Application specific password seems wrong")
+        UI.error("Please make sure to follow the instructions")
+        a.remove_from_keychain
+      end
+      UI.error("Your account has 2 step verification enabled")
+      UI.error("Please go to https://appleid.apple.com/account/manage")
+      UI.error("and generate an application specific password for")
+      UI.error("the iTunes Transporter, which is used to upload builds")
+      @password = a.password # to ask the user for the missing value
+
+      return true
+    end
+
     def handle_error(password)
       # rubocop:disable Style/CaseEquality
-      unless /^[0-9a-zA-Z\.\$\_]*$/ === password
+      unless /^[0-9a-zA-Z\.\$\_\-]*$/ === password
         UI.error([
           "Password contains special characters, which may not be handled properly by iTMSTransporter.",
           "If you experience problems uploading to iTunes Connect, please consider changing your password to something with only alphanumeric characters."
         ].join(' '))
       end
       # rubocop:enable Style/CaseEquality
-      UI.error("Could not download/upload from iTunes Connect! It's probably related to your password or your internet connection.")
+
+      UI.error("Could not download/upload from iTunes Connect! This might be related to your internet connection.")
     end
   end
 end


### PR DESCRIPTION
This change was necessary, since the real password can't be used with iTunes Transporter. It requires an application specific password. 

This PR adds the following:
- Account manager now allows a custom prefix, which is used to store the application specific password
- The transporter will now silently try to load the application specific password from the keychain (if it exists), and fallback to the standard way of handling the password
- If the upload fails due to 2 step verification, the user will be prompted for an application specific password

Obligatory 🚀 
