### PR TITLE
Make deliver aware of review_user_needed

### DIFF
--- a/deliver/deliver.gemspec
+++ b/deliver/deliver.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   # fastlane dependencies
   spec.add_dependency 'fastlane_core', '>= 0.41.2', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'credentials_manager', '>= 0.12.0', '< 1.0.0'
-  spec.add_dependency 'spaceship', '>= 0.24.1', '< 1.0.0' # Communication with iTunes Connect
+  spec.add_dependency 'spaceship', '>= 0.26.1', '< 1.0.0' # Communication with iTunes Connect
 
   # third party dependencies
   spec.add_dependency 'fastimage', '~> 1.6' # fetch the image sizes from the screenshots

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -172,6 +172,7 @@ module Deliver
       v.review_email = info[:email_address] if info[:email_address]
       v.review_demo_user = info[:demo_user] if info[:demo_user]
       v.review_demo_password = info[:demo_password] if info[:demo_password]
+      v.review_user_needed = (v.review_demo_user.to_s + v.review_demo_password.to_s).length > 0
       v.review_notes = info[:notes] if info[:notes]
     end
 


### PR DESCRIPTION
The `review_user_needed` checkbox strikes again: Deliver isn't aware of it.
Added the same logic as before. Did _not_ test by actually submitting something to review.

 #4241, #4255
