### PR TITLE
Version bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.41.2".freeze
+  VERSION = "0.41.3".freeze
 end


### PR DESCRIPTION
- Have ItunesTransporter check command exit status when determining success
- Ignore IO Error and wait for the iTMSTransporter to exit (Linux)
- Allow to specify the path to iTMSTransporter via environment
- Search keychain when installing WWDR certificate
