### PR TITLE
Add warning logging around param to resign

### DIFF
--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -63,6 +63,10 @@ module Sigh
       version = options.version_number || nil
       display_name = options.display_name || nil
 
+      if options.provisioning_name
+        UI.important "The provisioning_name (-n) option is not applicable to resign. You should use provisioning_profile (-p) instead"
+      end
+
       return ipa, signing_identity, provisioning_profiles, entitlements, version, display_name
     end
 


### PR DESCRIPTION
`provisioning_name` is a param that is only applicable to `sigh` not `resign`. When calling `sign resign` instead of the `resign` action, the param is passed but not used, so this provides some warning logging to let people know they might be using the wrong param. 
