### PR TITLE
Fix failing CI builds with new bundle cache dir

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,9 +3,9 @@ machine:
     version: "7.3"
 dependencies:
   override:
-    - bundle check --path=~/.bundle || bundle install --path=~/.bundle --jobs=4 --retry=3
+    - bundle check --path=~/.fastlane_bundle || bundle install --path=~/.fastlane_bundle --jobs=4 --retry=3
   cache_directories:
-    - ~/.bundle
+    - ~/.fastlane_bundle
 test:
   override:
     - bundle exec danger

--- a/rakelib/test_all.rake
+++ b/rakelib/test_all.rake
@@ -40,7 +40,7 @@ end
 
 def bundle_install
   if ENV['CI']
-    cache_path = File.expand_path("~/.bundle")
+    cache_path = File.expand_path("~/.fastlane_bundle")
     path = " --path=#{cache_path}"
   end
 


### PR DESCRIPTION
Circle has started failing when we use `~/.bundle` as our bundle cache dir and install/check path. We're not sure if this is because of a poisoned cache or some other infrastructure change on Circle's part.
