### PR TITLE
Improve caching by running bundle install for all tools in the dependencies phase of CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     version: "7.3"
 dependencies:
   override:
-    - bundle check --path=~/.fastlane_bundle || bundle install --path=~/.fastlane_bundle --jobs=4 --retry=3
+    - rake bundle_install_all
   cache_directories:
     - ~/.fastlane_bundle
 test:

--- a/rakelib/test_all.rake
+++ b/rakelib/test_all.rake
@@ -47,6 +47,18 @@ def bundle_install
   sh "bundle check#{path} || bundle install#{path} --jobs=4 --retry=3"
 end
 
+task :bundle_install_all do
+  puts "Fetching dependencies in the root"
+  bundle_install
+
+  for_each_gem do |repo|
+    Dir.chdir(repo) do
+      puts "Fetching dependencies for #{repo}"
+      bundle_install
+    end
+  end
+end
+
 def get_line_from_file(line_number, file)
   File.open(file) do |io|
     io.each_with_index do |line, index|
@@ -66,7 +78,6 @@ task :test_all do
   repos_with_exceptions = []
   rspec_log_file = "rspec_logs.json"
 
-  bundle_install
   for_each_gem do |repo|
     box "Testing #{repo}"
     Dir.chdir(repo) do
@@ -85,7 +96,6 @@ task :test_all do
             rspec_command_parts << "--format RspecJunitFormatter --out #{output_file}"
           end
 
-          bundle_install
           sh rspec_command_parts.join(' ')
           sh "bundle exec rubocop"
         end


### PR DESCRIPTION
Previously, only the dependencies from fastlane (and the root) were cached because bundle install was only run for each tool during the test phase (not the dependencies phase). This should save some time because now they'll be cached.
