### PR TITLE
Show the default value when running fastlane action [tool_name]

### DIFF
--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -74,7 +74,7 @@ module Fastlane
         if options
           puts Terminal::Table.new(
             title: filter.green,
-            headings: ['Key', 'Description', 'Env Var'],
+            headings: ['Key', 'Description', 'Env Var', 'Default'],
             rows: options
           )
           required_count = action.available_options.count do |o|
@@ -149,7 +149,7 @@ module Fastlane
             key_name = (current.optional ? "  " : "* ") + current.key.to_s
             description = (current.description || '') + (current.default_value ? " (default: '#{current.default_value}')" : "")
 
-            rows << [key_name.yellow, description, current.env_name]
+            rows << [key_name.yellow, description, current.env_name, current.default_value]
 
           elsif current.kind_of? Array
             # Legacy actions that don't use the new config manager


### PR DESCRIPTION
## Summary

It shows the default value of each parameter, if exists, when running fastlane action [tool_name]
See #4319
## Why

The only way to see what is the default value of a parameter is to run the action, it doesn't help a lot when writing the fastfile.
## Example

Current `fastlane action match`

![image](https://cloud.githubusercontent.com/assets/4053255/14754343/b03ed7da-08d2-11e6-8ec1-c93e7cf03e4f.png)

New `fastlane action match`
![image](https://cloud.githubusercontent.com/assets/4053255/14754384/f68da360-08d2-11e6-90a9-8824481135b5.png)
