### PR TITLE
validate provisioning profile against entitlements

### DIFF
--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -100,12 +100,54 @@ module Gym
       UI.verbose("Stored the archive in: " + BuildCommandGenerator.archive_path)
     end
 
+    def check_prov_entitlement(path)
+      profile = `cat "#{path}/embedded.mobileprovision" | security cms -D`
+      UI.user_error!("Unable to extract profile") unless $? == 0
+
+      plist = Plist.parse_xml(profile)
+      prov_entitlements = plist["Entitlements"]
+      archived_entitlements = `cat "#{path}/archived-expanded-entitlements.xcent"`
+      # if we have no entitlements ignore check
+      if $? == 0
+
+        archived_plist = Plist.parse_xml(archived_entitlements)
+        archived_plist.each do |key, value|
+          unless prov_entitlements.key?(key)
+            UI.user_error!("Provisioning Profile is missing #{key} as set in entitlements")
+          end
+        end
+      end
+      UI.success "Prov match Entl. (#{File.basename(path)}): #{archived_plist.keys.join(',')}"
+    end
+
+    # check prov against entitlement
+    def check_prov_against_entitlement
+      # check if entitlements match provisioning keys.
+      app_path = Dir[File.join(BuildCommandGenerator.archive_path, "Products/Applications/*.app")].last
+      # check main app
+      check_prov_entitlement app_path
+
+      # check appex -> e.g today, watch-app
+      Dir[File.join(app_path, "*", "*.appex")].each do |appex|
+        check_prov_entitlement  appex
+      end
+      Dir[File.join(app_path, "*", "*", "*.appex")].each do |appex|
+        check_prov_entitlement  appex
+      end
+      # check embeded apps -> eg. watch-ext
+      Dir[File.join(app_path, "*", "*.app")].each do |app|
+        check_prov_entitlement  app
+      end
+      true
+    end
+
     # Makes sure the archive is there and valid
     def verify_archive
       # from https://github.com/fastlane/gym/issues/115
       if (Dir[BuildCommandGenerator.archive_path + "/*"]).count == 0
         ErrorHandler.handle_empty_archive
       end
+      check_prov_against_entitlement
     end
 
     def package_app


### PR DESCRIPTION
i recently got stuck in an signing issue - wich was a result of (as i guess) - "fix issue" on capabilities.
it drove me nuts and took me 1.5 days to figure out why the hell it failed.

it seems  that in my entitlements file there was a property set wich was missing in my provisioning profile.

output on my CI was like:

```
[09:43:16]: ▸ Touching Krone.app.dSYM
[09:43:24]: ▸ Archive Succeeded
[09:43:25]: Successfully stored the archive. You can find it in the Xcode Organizer.
RVM detected, forcing to use system ruby
Now using system ruby.
+ xcodebuild -exportArchive -exportOptionsPlist /var/folders/2h/vvk1jc1n171bxtbqqn45ddsh0000gp/T/gym20160422-17650-jop0id_config.plist -archivePath '/Users/ios/Library/Developer/Xcode/Archives/2016-04-22/Krone 2016-04-22 09.39.53.xcarchive' -exportPath /var/folders/2h/vvk1jc1n171bxtbqqn45ddsh0000gp/T/gym20160422-17650-qqjvxu.gym_output
2016-04-22 09:43:27.381 xcodebuild[23004:4192439] [MT] IDEDistribution: -[IDEDistributionLogging _createLoggingBundleAtPath:]: Created bundle at path '/var/folders/2h/vvk1jc1n171bxtbqqn45ddsh0000gp/T/Krone_2016-04-22_09-43-27.379.xcdistributionlogs'.
2016-04-22 09:43:27.586 xcodebuild[23004:4192439] [MT] DeveloperPortal: Using pre-existing current store at URL (file:///Users/ios/Library/Developer/Xcode/DeveloperPortal%207.3.db).
2016-04-22 09:43:28.738 xcodebuild[23004:4192439] [MT] IDEDistribution: -[IDEDistributionProvisioning _itemToSigningInfoMap:]: Can't find any applicable signing identities for items: (
"<IDEDistributionItem: 0x7fbdfd6cbdd0 'krone.at-sport' '<DVTFilePath:0x7fbdfb66c520:'/Users/ios/Library/Developer/Xcode/Archives/2016-04-22/Krone 2016-04-22 09.39.53.xcarchive/Products/Applications/Krone.app'>'>",
"<IDEDistributionItem: 0x7fbdfb67f1e0 'krone.at-sport.today' '<DVTFilePath:0x7fbdfe1385f0:'/Users/ios/Library/Developer/Xcode/Archives/2016-04-22/Krone 2016-04-22 09.39.53.xcarchive/Products/Applications/Krone.app/PlugIns/today.appex'>'>",
"<IDEDistributionItem: 0x7fbdfe21ab50 'krone.at-sport.watchkitapp' '<DVTFilePath:0x7fbdfe1cecd0:'/Users/ios/Library/Developer/Xcode/Archives/2016-04-22/Krone 2016-04-22 09.39.53.xcarchive/Products/Applications/Krone.app/Watch/Krone Sport WatchKit App.app'>'>",
"<IDEDistributionItem: 0x7fbdfb67e500 'krone.at-sport.watchkitapp.wk2' '<DVTFilePath:0x7fbdfe1ec560:'/Users/ios/Library/Developer/Xcode/Archives/2016-04-22/Krone 2016-04-22 09.39.53.xcarchive/Products/Applications/Krone.app/Watch/Krone Sport WatchKit App.app/PlugIns/Krone Sport WatchKit Extension.appex'>'>",
"<IDEDistributionItem: 0x7fbdfe2039c0 '(null)' '<DVTFilePath:0x7fbdfe1d2510:'/Users/ios/Library/Developer/Xcode/Archives/2016-04-22/Krone 2016-04-22 09.39.53.xcarchive/Products/Applications/Krone.app/Watch/Krone Sport WatchKit App.app/_WatchKitStub/WK'>'>"
)
Errors={
"<DVTSigningCertificate: 0x7fbdfe20fa20; name='iPhone Distribution: Krone Multimedia GmbH & Co KG (H2YB79SEHH)', hash='5DFBE1E10AD234C0AD9A4FFB135F9CFD7F628D70', certificateKind='1.2.840.113635.100.6.1.4'>" =     {
"<IDEDistributionItem: 0x7fbdfd6cbdd0 'krone.at-sport' '<DVTFilePath:0x7fbdfb66c520:'/Users/ios/Library/Developer/Xcode/Archives/2016-04-22/Krone 2016-04-22 09.39.53.xcarchive/Products/Applications/Krone.app'>'>" = "Error Domain=IDECodesignResolverErrorDomain Code=7 \"No matching provisioning profiles found\" UserInfo={NSLocalizedRecoverySuggestion=None of the valid provisioning profiles allowed the specified entitlements: com.apple.developer.icloud-container-identifiers, beta-reports-active, com.apple.developer.ubiquity-kvstore-identifier, com.apple.security.application-groups, com.apple.developer.icloud-services., NSLocalizedDescription=No matching provisioning profiles found, IDECodesignResolverError_ResolutionInputsKey=<IDECodesignResolutionInputs: 0x7fbdfd6c7ba0; portalTeamID='H2YB79SEHH', usingTeamBasedSigning='NO', bundleIdentifier='krone.at-sport', targetName='(null)', provisioningProfilePurpose='1', requiresProvisioningProfile='YES', provisioningProfilePlatform='iOS', certificateKind='1.2.840.113635.100.6.1.4', requiredEntitlements='{\n    \"beta-reports-active\" = 1;\n    \"com.apple.developer.icloud-container-identifiers\" =     (\n        \"iCloud.krone.at-sport\"\n    );\n    \"com.apple.developer.icloud-services\" =     (\n        CloudKit\n    );\n    \"com.apple.developer.ubiquity-kvstore-identifier\" = \"H2YB79SEHH.krone.at-sport\";\n    \"com.apple.security.application-groups\" =     (\n        \"group.krone.at-sport\"\n    );\n}', requiredCodesignableDevices='(null)', requiredFeatures='(null)'>\n}";
"<IDEDistributionItem: 0x7fbdfb67e500 'krone.at-sport.watchkitapp.wk2' '<DVTFilePath:0x7fbdfe1ec560:'/Users/ios/Library/Developer/Xcode/Archives/2016-04-22/Krone 2016-04-22 09.39.53.xcarchive/Products/Applications/Krone.app/Watch/Krone Sport WatchKit App.app/PlugIns/Krone Sport WatchKit Extension.appex'>'>" = "Error Domain=IDECodesignResolverErrorDomain Code=7 \"No matching provisioning profiles found\" UserInfo={NSLocalizedRecoverySuggestion=None of the valid provisioning profiles allowed the specified entitlements: com.apple.developer.icloud-container-identifiers, beta-reports-active., NSLocalizedDescription=No matching provisioning profiles found, IDECodesignResolverError_ResolutionInputsKey=<IDECodesignResolutionInputs: 0x7fbdfe2d46b0; portalTeamID='H2YB79SEHH', usingTeamBasedSigning='NO', bundleIdentifier='krone.at-sport.watchkitapp.wk2', targetName='(null)', provisioningProfilePurpose='1', requiresProvisioningProfile='YES', provisioningProfilePlatform='iOS', certificateKind='1.2.840.113635.100.6.1.4', requiredEntitlements='{\n    \"beta-reports-active\" = 1;\n    \"com.apple.developer.icloud-container-identifiers\" =     (\n    );\n}', requiredCodesignableDevices='(null)', requiredFeatures='(null)'>\n}";
};
}
2016-04-22 09:43:28.739 xcodebuild[23004:4192439] [MT] IDEDistribution: Step failed: <IDEDistributionSigningAssetsStep: 0x7fbdfd5567e0>: Error Domain=IDEDistributionErrorDomain Code=3 "(null)" UserInfo={IDEDistributionErrorSigningIdentityToItemToUnderlyingErrorKey={
"<DVTSigningCertificate: 0x7fbdfe20fa20; name='iPhone Distribution: Krone Multimedia GmbH & Co KG (H2YB79SEHH)', hash='5DFBE1E10AD234C0AD9A4FFB135F9CFD7F628D70', certificateKind='1.2.840.113635.100.6.1.4'>" =     {
"<IDEDistributionItem: 0x7fbdfd6cbdd0 'krone.at-sport' '<DVTFilePath:0x7fbdfb66c520:'/Users/ios/Library/Developer/Xcode/Archives/2016-04-22/Krone 2016-04-22 09.39.53.xcarchive/Products/Applications/Krone.app'>'>" = "Error Domain=IDECodesignResolverErrorDomain Code=7 \"No matching provisioning profiles found\" UserInfo={NSLocalizedRecoverySuggestion=None of the valid provisioning profiles allowed the specified entitlements: com.apple.developer.icloud-container-identifiers, beta-reports-active, com.apple.developer.ubiquity-kvstore-identifier, com.apple.security.application-groups, com.apple.developer.icloud-services., NSLocalizedDescription=No matching provisioning profiles found, IDECodesignResolverError_ResolutionInputsKey=<IDECodesignResolutionInputs: 0x7fbdfd6c7ba0; portalTeamID='H2YB79SEHH', usingTeamBasedSigning='NO', bundleIdentifier='krone.at-sport', targetName='(null)', provisioningProfilePurpose='1', requiresProvisioningProfile='YES', provisioningProfilePlatform='iOS', certificateKind='1.2.840.113635.100.6.1.4', requiredEntitlements='{\n    \"beta-reports-active\" = 1;\n    \"com.apple.developer.icloud-container-identifiers\" =     (\n        \"iCloud.krone.at-sport\"\n    );\n    \"com.apple.developer.icloud-services\" =     (\n        CloudKit\n    );\n    \"com.apple.developer.ubiquity-kvstore-identifier\" = \"H2YB79SEHH.krone.at-sport\";\n    \"com.apple.security.application-groups\" =     (\n        \"group.krone.at-sport\"\n    );\n}', requiredCodesignableDevices='(null)', requiredFeatures='(null)'>\n}";
"<IDEDistributionItem: 0x7fbdfb67e500 'krone.at-sport.watchkitapp.wk2' '<DVTFilePath:0x7fbdfe1ec560:'/Users/ios/Library/Developer/Xcode/Archives/2016-04-22/Krone 2016-04-22 09.39.53.xcarchive/Products/Applications/Krone.app/Watch/Krone Sport WatchKit App.app/PlugIns/Krone Sport WatchKit Extension.appex'>'>" = "Error Domain=IDECodesignResolverErrorDomain Code=7 \"No matching provisioning profiles found\" UserInfo={NSLocalizedRecoverySuggestion=None of the valid provisioning profiles allowed the specified entitlements: com.apple.developer.icloud-container-identifiers, beta-reports-active., NSLocalizedDescription=No matching provisioning profiles found, IDECodesignResolverError_ResolutionInputsKey=<IDECodesignResolutionInputs: 0x7fbdfe2d46b0; portalTeamID='H2YB79SEHH', usingTeamBasedSigning='NO', bundleIdentifier='krone.at-sport.watchkitapp.wk2', targetName='(null)', provisioningProfilePurpose='1', requiresProvisioningProfile='YES', provisioningProfilePlatform='iOS', certificateKind='1.2.840.113635.100.6.1.4', requiredEntitlements='{\n    \"beta-reports-active\" = 1;\n    \"com.apple.developer.icloud-container-identifiers\" =     (\n    );\n}', requiredCodesignableDevices='(null)', requiredFeatures='(null)'>\n}";
};
}}
error: exportArchive: The operation couldn’t be completed. (IDEDistributionErrorDomain error 3.)

Error Domain=IDEDistributionErrorDomain Code=3 "(null)" UserInfo={IDEDistributionErrorSigningIdentityToItemToUnderlyingErrorKey={
"<DVTSigningCertificate: 0x7fbdfe20fa20; name='iPhone Distribution: Krone Multimedia GmbH & Co KG (H2YB79SEHH)', hash='5DFBE1E10AD234C0AD9A4FFB135F9CFD7F628D70', certificateKind='1.2.840.113635.100.6.1.4'>" =     {
"<IDEDistributionItem: 0x7fbdfd6cbdd0 'krone.at-sport' '<DVTFilePath:0x7fbdfb66c520:'/Users/ios/Library/Developer/Xcode/Archives/2016-04-22/Krone 2016-04-22 09.39.53.xcarchive/Products/Applications/Krone.app'>'>" = "Error Domain=IDECodesignResolverErrorDomain Code=7 \"No matching provisioning profiles found\" UserInfo={NSLocalizedRecoverySuggestion=None of the valid provisioning profiles allowed the specified entitlements: com.apple.developer.icloud-container-identifiers, beta-reports-active, com.apple.developer.ubiquity-kvstore-identifier, com.apple.security.application-groups, com.apple.developer.icloud-services., NSLocalizedDescription=No matching provisioning profiles found, IDECodesignResolverError_ResolutionInputsKey=<IDECodesignResolutionInputs: 0x7fbdfd6c7ba0; portalTeamID='H2YB79SEHH', usingTeamBasedSigning='NO', bundleIdentifier='krone.at-sport', targetName='(null)', provisioningProfilePurpose='1', requiresProvisioningProfile='YES', provisioningProfilePlatform='iOS', certificateKind='1.2.840.113635.100.6.1.4', requiredEntitlements='{\n    \"beta-reports-active\" = 1;\n    \"com.apple.developer.icloud-container-identifiers\" =     (\n        \"iCloud.krone.at-sport\"\n    );\n    \"com.apple.developer.icloud-services\" =     (\n        CloudKit\n    );\n    \"com.apple.developer.ubiquity-kvstore-identifier\" = \"H2YB79SEHH.krone.at-sport\";\n    \"com.apple.security.application-groups\" =     (\n        \"group.krone.at-sport\"\n    );\n}', requiredCodesignableDevices='(null)', requiredFeatures='(null)'>\n}";
"<IDEDistributionItem: 0x7fbdfb67e500 'krone.at-sport.watchkitapp.wk2' '<DVTFilePath:0x7fbdfe1ec560:'/Users/ios/Library/Developer/Xcode/Archives/2016-04-22/Krone 2016-04-22 09.39.53.xcarchive/Products/Applications/Krone.app/Watch/Krone Sport WatchKit App.app/PlugIns/Krone Sport WatchKit Extension.appex'>'>" = "Error Domain=IDECodesignResolverErrorDomain Code=7 \"No matching provisioning profiles found\" UserInfo={NSLocalizedRecoverySuggestion=None of the valid provisioning profiles allowed the specified entitlements: com.apple.developer.icloud-container-identifiers, beta-reports-active., NSLocalizedDescription=No matching provisioning profiles found, IDECodesignResolverError_ResolutionInputsKey=<IDECodesignResolutionInputs: 0x7fbdfe2d46b0; portalTeamID='H2YB79SEHH', usingTeamBasedSigning='NO', bundleIdentifier='krone.at-sport.watchkitapp.wk2', targetName='(null)', provisioningProfilePurpose='1', requiresProvisioningProfile='YES', provisioningProfilePlatform='iOS', certificateKind='1.2.840.113635.100.6.1.4', requiredEntitlements='{\n    \"beta-reports-active\" = 1;\n    \"com.apple.developer.icloud-container-identifiers\" =     (\n    );\n}', requiredCodesignableDevices='(null)', requiredFeatures='(null)'>\n}";
};
}}

** EXPORT FAILED **
```

the solution was to drop and regenerate the entitlement files, drop and re-install provisioning profiles.
with this PR - gym is going to validate the provisioning profile against the entitlement file - and check if atleast all keys are in the provisioning profile - that are in the entitlement (i guess this should be something xcode should validate it self, but atleast in my case it didn't)

output with this pr is like:

```
[15:21:53]: ▸ Signing /tmp/asdf/Build/Intermediates/ArchiveIntermediates/Krone/InstallationBuildProductsLocation/Applications/Krone.app
[15:21:56]: ▸ Touching Krone.app.dSYM
[15:21:58]: ▸ Archive Succeeded
[15:21:58]: Prov match Entl. (Krone.app): com.apple.developer.icloud-container-identifiers,com.apple.developer.icloud-services,com.apple.developer.ubiquity-kvstore-identifier,com.apple.security.application-groups
[15:21:58]: Prov match Entl. (today.appex): com.apple.security.application-groups
[15:21:58]: Prov match Entl. (Krone Sport WatchKit App.app): application-identifier,keychain-access-groups

[15:22:13]: Successfully exported and compressed dSYM file
[15:22:13]: Successfully exported and signed the ipa file:
```

this issue brought me on the right track btw: https://github.com/fastlane/fastlane/issues/1980
