### PR TITLE
Fix Integer and Float ConfigItem defaulting

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -92,11 +92,11 @@ module FastlaneCore
       when data_type == Array
         return value.split(',') if value.kind_of?(String)
       when data_type == Integer
-        return value.to_i
+        return value.to_i unless value.nil?
       when data_type == Float
-        return value.to_f
+        return value.to_f unless value.nil?
       else
-        # Special treatment if the user specififed true, false or YES, NO
+        # Special treatment if the user specified true, false or YES, NO
         # There is no boolean type, so we just do it here
         if %w(YES yes true TRUE).include?(value)
           return true


### PR DESCRIPTION
This PR fixes https://github.com/fastlane/fastlane/issues/4336. 🔑
- Add tests covering the conversion of `ConfigItem`s with `data_type` of `Integer` or `Float`
- Change `auto_convert_value`'s implementation to return `nil` whenever the the input is `nil`

I did a quick grep through the codebase for `ConfigItem`s of `data_type` `Integer` or `Float`. The only one I found other than [`pilot`'s `wait_processing_interval`](https://github.com/fastlane/fastlane/blob/master/pilot/lib/pilot/options.rb#L78) was [`snapshot`'s `number_of_retries`](https://github.com/fastlane/fastlane/blob/master/snapshot/lib/snapshot/options.rb#L142) (note that there are a few other `Integer` or `Float` `ConfigItem`s, but only in tests). Though I haven't tested my changes against that, I don't expect there to be any issues. 

The added tests should catch any regression in this behavior. 
