### PR TITLE
[sigh] Add support for specifying short and bundle versions separately

### DIFF
--- a/fastlane/lib/fastlane/actions/resign.rb
+++ b/fastlane/lib/fastlane/actions/resign.rb
@@ -6,7 +6,7 @@ module Fastlane
         require 'sigh'
 
         # try to resign the ipa
-        if Sigh::Resign.resign(params[:ipa], params[:signing_identity], params[:provisioning_profile], params[:entitlements], params[:version], params[:display_name])
+        if Sigh::Resign.resign(params[:ipa], params[:signing_identity], params[:provisioning_profile], params[:entitlements], params[:version], params[:display_name], params[:short_version], params[:bundle_version])
           UI.success('Successfully re-signed .ipa 🔏.')
         else
           UI.user_error!("Failed to re-sign .ipa")
@@ -65,12 +65,25 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: "FL_RESIGN_VERSION",
-                                       description: "Version number to force resigned ipa to use",
+                                       description: "Version number to force resigned ipa to use. Updates both CFBundleShortVersionString and CFBundleIdentifier values in Info.plist. Applies for main app and all nested apps or extensions",
+                                       conflicting_options: [:short_version, :bundle_version],
                                        is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :display_name,
                                        env_name: "FL_DISPLAY_NAME",
                                        description: "Display name to force resigned ipa to use",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :short_version,
+                                       env_name: "FL_RESIGN_SHORT_VERSION",
+                                       description: "Short version string to force resigned ipa to use (CFBundleShortVersionString)",
+                                       conflicting_options: [:version],
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :bundle_version,
+                                       env_name: "FL_RESIGN_BUNDLE_VERSION",
+                                       description: "Bundle version to force resigned ipa to use (CFBundleIdentifier)",
+                                       conflicting_options: [:version],
                                        is_string: true,
                                        optional: true)
         ]

--- a/sigh/bin/sigh
+++ b/sigh/bin/sigh
@@ -61,13 +61,17 @@ class SighApplication
       c.syntax = 'sigh resign'
       c.description = 'Resigns an existing ipa file with the given provisioning profile'
       c.option '-i', '--signing_identity STRING', String, 'The signing identity to use. Must match the one defined in the provisioning profile.'
-      c.option '-x', '--version_number STRING', String, 'Version number to force binary to use'
-      c.option '-p', '--provisioning_profile PATH', String, '(or BUNDLE_ID=PATH) The path to the provisioning profile which should be used.'\
-               'Can be provided multiple times if the application contains nested applications and app extensions, which need their own provisioning profile.'\
+      c.option '-x', '--version_number STRING', String, 'Version number to force binary and all nested binaries to use. Changes both CFBundleShortVersionString and CFBundleIdentifier.'
+      c.option '-p', '--provisioning_profile PATH', String, '(or BUNDLE_ID=PATH) The path to the provisioning profile which should be used. '\
+               'Can be provided multiple times if the application contains nested applications and app extensions, which need their own provisioning profile. '\
                'The path may be prefixed with a identifier in order to determine which provisioning profile should be used on which app.',
                &multiple_values_option_proc(c, "provisioning_profile", &proc { |value| value.split('=', 2) })
       c.option '-d', '--display_name STRING', String, 'Display name to use'
       c.option '-e', '--entitlements PATH', String, 'The path to the entitlements file to use.'
+      c.option '--short-version STRING', String, 'Short version string to force binary to use (CFBundleShortVersionString). '\
+               '\nCannot be used together with -x|--version_number option.'
+      c.option '--bundle-version STRING', String, 'Bundle version to force binary and all nested binaries to use (CFBundleIdentifier). '\
+               'Cannot be used together with -x|--version_number option.'
 
       c.action do |args, options|
         Sigh::Resign.new.run(options, args)

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -6,16 +6,16 @@ module Sigh
     def run(options, args)
       # get the command line inputs and parse those into the vars we need...
 
-      ipa, signing_identity, provisioning_profiles, entitlements, version, display_name = get_inputs(options, args)
+      ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version = get_inputs(options, args)
       # ... then invoke our programmatic interface with these vars
-      resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name)
+      resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version)
     end
 
-    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name)
-      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name)
+    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version)
+      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version)
     end
 
-    def resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name)
+    def resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version)
       resign_path = find_resign_path
       signing_identity = find_signing_identity(signing_identity)
 
@@ -29,6 +29,8 @@ module Sigh
       provisioning_options = provisioning_profiles.map { |fst, snd| "-p #{[fst, snd].compact.map(&:shellescape).join('=')}" }.join(' ')
       version = "-n #{version}" if version
       display_name = "-d #{display_name.shellescape}" if display_name
+      short_version = "--short-version #{short_version}" if short_version
+      bundle_version = "--bundle-version #{bundle_version}" if bundle_version
       verbose = "-v" if $verbose
 
       command = [
@@ -39,6 +41,8 @@ module Sigh
         entitlements,
         version,
         display_name,
+        short_version,
+        bundle_version,
         verbose,
         ipa.shellescape
       ].join(' ')
@@ -62,12 +66,14 @@ module Sigh
       entitlements = options.entitlements || nil
       version = options.version_number || nil
       display_name = options.display_name || nil
+      short_version = options.short_version || nil
+      bundle_version = options.bundle_version || nil
 
       if options.provisioning_name
         UI.important "The provisioning_name (-n) option is not applicable to resign. You should use provisioning_profile (-p) instead"
       end
 
-      return ipa, signing_identity, provisioning_profiles, entitlements, version, display_name
+      return ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version
     end
 
     def find_resign_path


### PR DESCRIPTION
resigh.sh updates:
- Update help message
- Add code for updated CFBundleShortVersionString and CFBundleIdentifier
- Prevent clashes with -x/--version-number option

Add short_version and bundle_version options to resign action

Add short and bundle version options to sigh resign executable

Issue discussion: https://github.com/fastlane/fastlane/issues/4361
