### PR TITLE
Improve spec by ensuring crashreporting is off for each test of error handling

### DIFF
--- a/fastlane_core/spec/fastlane_runner_spec.rb
+++ b/fastlane_core/spec/fastlane_runner_spec.rb
@@ -14,6 +14,10 @@ describe Commander::Runner do
       end
     end
 
+    before(:each) do
+      allow(FastlaneCore::CrashReporting).to receive(:enabled?).and_return(false)
+    end
+
     it 'should reraise errors that are not of special interest' do
       expect do
         Commander::Runner.new.handle_unknown_error!(StandardError.new('my message'))


### PR DESCRIPTION
So that the specs will pass regardless of whether crash reporting is enabled on your machine
