### PR TITLE
Update fastlane version

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,3 +1,3 @@
 module Fastlane
-  VERSION = '1.81.0'.freeze
+  VERSION = '1.82.0'.freeze
 end


### PR DESCRIPTION
[12:45:00]: Changes since release 1.81.0:
- Refactor actions_list for clarity
- Show the default value when running fastlane action [tool_name]
- Typo in slather action
- Fixing document paths
- [fastlane] Added danger integration
- Updated Guide to be more up to date
- Add a lane for showing the changelog for a tool
- Change Actions.sh to call UI.user_error for a non-zero exit code
- Improve Crashlytics Beta action documentation
- Correcting additional occurrences of the broken link.
- Fixing additional broken links.
- Moved UI documentation to docs folder
- [fastlane] Augment verify_xcode action's accepted codesign info
- Escaping UploadSymbolsToCrashlyticsAction binary_path
- Updated super class sample
- Add to bash and zsh completion scripts support of .fastlane folder
- Support additional parameters in `notification`
- Flock integration
- Fix minor typo in readme
- Add workspace command line option to slather action
- Go back to the original working directory
