### PR TITLE
Change ItunesTransporter to default to shell script execution for Xcode 6.x

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -261,6 +261,9 @@ module FastlaneCore
     #                         if false, allows a direct call to the iTMSTransporter Java app (preferred).
     #                         see: https://github.com/fastlane/fastlane/pull/4003
     def initialize(user = nil, password = nil, use_shell_script = false)
+      # Xcode 6.x doesn't have the same iTMSTransporter Java setup as later Xcode versions, so
+      # we can't default to using the better direct Java invocation strategy for those versions.
+      use_shell_script ||= Helper.xcode_version.start_with?('6.')
       use_shell_script ||= !ENV['FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT'].nil?
       data = CredentialsManager::AccountManager.new(user: user, password: password)
 

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -70,70 +70,92 @@ describe FastlaneCore do
       ].join(' ')
     end
 
-    describe "by default" do
-      describe "upload command generation" do
-        it 'generates a call to java directly' do
-          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
-          expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
-        end
-      end
+    describe "with Xcode 7.x installed" do
+      before(:each) { allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('7.3') }
 
-      describe "download command generation" do
-        it 'generates a call to java directly' do
-          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
-          expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
-        end
-      end
-    end
-
-    describe "when use shell script ENV var is set" do
-      describe "upload command generation" do
-        it 'generates a call to the shell script' do
-          with_env_values('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT' => 'true') do
+      describe "by default" do
+        describe "upload command generation" do
+          it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
+          end
+        end
+
+        describe "download command generation" do
+          it 'generates a call to java directly' do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
+            expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
           end
         end
       end
 
-      describe "download command generation" do
-        it 'generates a call to the shell script' do
-          with_env_values('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT' => 'true') do
-            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
+      describe "when use shell script ENV var is set" do
+        describe "upload command generation" do
+          it 'generates a call to the shell script' do
+            with_env_values('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT' => 'true') do
+              transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
+              expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+            end
+          end
+        end
+
+        describe "download command generation" do
+          it 'generates a call to the shell script' do
+            with_env_values('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT' => 'true') do
+              transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
+              expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+            end
+          end
+        end
+      end
+
+      describe "use_shell_script is true" do
+        describe "upload command generation" do
+          it 'generates a call to the shell script' do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true)
+            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+          end
+        end
+
+        describe "download command generation" do
+          it 'generates a call to the shell script' do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true)
             expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
           end
         end
       end
+
+      describe "use_shell_script is false" do
+        describe "upload command generation" do
+          it 'generates a call to java directly' do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
+            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
+          end
+        end
+
+        describe "download command generation" do
+          it 'generates a call to java directly' do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
+            expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
+          end
+        end
+      end
     end
 
-    describe "use_shell_script is true" do
+    describe "with Xcode 6.x installed" do
+      before(:each) { allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('6.4') }
+
       describe "upload command generation" do
         it 'generates a call to the shell script' do
-          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true)
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
           expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
         end
       end
 
       describe "download command generation" do
         it 'generates a call to the shell script' do
-          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true)
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
           expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
-        end
-      end
-    end
-
-    describe "use_shell_script is false" do
-      describe "upload command generation" do
-        it 'generates a call to java directly' do
-          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
-          expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
-        end
-      end
-
-      describe "download command generation" do
-        it 'generates a call to java directly' do
-          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
-          expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
         end
       end
     end


### PR DESCRIPTION
Addresses #4339

Because the structure of the Java app has changed from Xcode 6.x to 7.x, our new default direct Java execution strategy can't work for Xcode 6.x.

This change detects the Xcode version and selects the older shell script execution strategy by default if Xcode 6.x is being used.
