### PR TITLE
Add flag for optionally forcing the snapshot helper files to update.

### DIFF
--- a/snapshot/bin/snapshot
+++ b/snapshot/bin/snapshot
@@ -53,6 +53,7 @@ class SnapshotApplication
       c.description = "Updates your SnapshotHelper.swift to the latest version"
 
       c.action do |args, options|
+        load_config(options)
         require 'snapshot/update'
         Snapshot::Update.new.update
       end

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -154,7 +154,13 @@ module Snapshot
                                      short_option: "-f",
                                      env_name: "SNAPSHOT_DERIVED_DATA_PATH",
                                      description: "The directory where build products and other derived data will go",
-                                     optional: true)
+                                     optional: true),
+        # Everything around Updating
+        FastlaneCore::ConfigItem.new(key: :force_update,
+                                     env_name: 'FORCE_UPDATE_HELPER_FILES',
+                                     description: "Force the helper files to be overwritten if a new update is available",
+                                     is_string: false,
+                                     default_value: false)
       ]
     end
   end

--- a/snapshot/lib/snapshot/update.rb
+++ b/snapshot/lib/snapshot/update.rb
@@ -12,12 +12,17 @@ module Snapshot
 
       UI.message "Found the following SnapshotHelper:"
       paths.each { |p| UI.message "\t#{p}" }
-      UI.important "Are you sure you want to automatically update the helpers listed above?"
-      UI.message "This will overwrite all its content with the latest code."
-      UI.message "The underlying API will not change. You can always migrate manually by looking at"
-      UI.message "https://github.com/fastlane/snapshot/blob/master/lib/assets/SnapshotHelper.swift"
 
-      return 1 unless UI.confirm("Overwrite configuration files?")
+      if Snapshot.config[:force_update]
+        UI.important "Force update flag has been set. Files will be automatically updated."
+      else
+        UI.important "Are you sure you want to automatically update the helpers listed above?"
+        UI.message "This will overwrite all its content with the latest code."
+        UI.message "The underlying API will not change. You can always migrate manually by looking at"
+        UI.message "https://github.com/fastlane/snapshot/blob/master/lib/assets/SnapshotHelper.swift"
+
+        return 1 unless UI.confirm("Overwrite configuration files?")
+      end
 
       paths.each do |path|
         UI.message "Updating '#{path}'..."


### PR DESCRIPTION
This is useful for when your CI Build tools automatically update, but the snapshot files do not update for specific repos.
Raised in issue: https://github.com/fastlane/fastlane/issues/3774
