### PR TITLE
[Core] Use full keychain path for `security` command

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -73,7 +73,7 @@ module FastlaneCore
         keychains = Helper.backticks(command, print: $verbose).split("\n")
         unless keychains.empty?
           # Select first keychain name from returned keychains list
-          return keychains[0].strip.tr('"', '').split(File::SEPARATOR)[-1]
+          return keychains[0].strip.tr('"', '')
         end
       end
       return ""


### PR DESCRIPTION
Solves #4387.

I'm running `cert` lane on a Xcode Server bot.

Cert was trying to find the WWDR certificate with the following command:

```
security find-certificate -c 'Apple Worldwide Developer Relations Certification Authority' Portal.keychain
```

And it was failed with the following output:

```
security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.
```

Security requires keychain path to be given as a full path, so the following works:

```
security find-certificate -c 'Apple Worldwide Developer Relations Certification Authority' /Library/Developer/XcodeServer/Keychains/Portal.keychain
```

PR fixes this by removing the part which gets the last path component.
