### PR TITLE
Version bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.42.0".freeze
+  VERSION = "0.42.1".freeze
 end


### PR DESCRIPTION
Changes since release 0.42.0:
- Change `ItunesTransporter` to default to shell script execution for Xcode 6.x
- Fix integer and float default issue (Thanks @ravron)
