### PR TITLE
Fix bash syntax in auto completion script

### DIFF
--- a/fastlane/lib/assets/completions/completion.bash
+++ b/fastlane/lib/assets/completions/completion.bash
@@ -8,7 +8,7 @@ _fastlane_complete() {
     file="Fastfile"
   elif [[ -e "fastlane/Fastfile" ]]; then
     file="fastlane/Fastfile"
-  elif [[ -e ".fastlane/Fastfile" ]] then
+  elif [[ -e ".fastlane/Fastfile" ]]; then
     file=".fastlane/Fastfile"
   fi
 


### PR DESCRIPTION
This broke in https://github.com/fastlane/fastlane/pull/4152 with a syntax error
