### PR TITLE
Give Gradle action better control over command output

### DIFF
--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -62,8 +62,8 @@ module Fastlane
     end
 
     # to allow a simple `sh` in the custom actions
-    def self.sh(command)
-      Fastlane::Actions.sh(command)
+    def self.sh(command, print_command: true, print_command_output: true)
+      Fastlane::Actions.sh_control_output(command, print_command: print_command, print_command_output: print_command_output)
     end
 
     # instead of "AddGitAction", this will return "add_git" to print it to the user

--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -46,7 +46,11 @@ module Fastlane
         Actions.lane_context[SharedValues::GRADLE_FLAVOR] = flavor if flavor
 
         # We run the actual gradle task
-        result = gradle.trigger(task: gradle_task, serial: params[:serial], flags: flags.join(' '))
+        result = gradle.trigger(task: gradle_task,
+                                serial: params[:serial],
+                                flags: flags.join(' '),
+                                print_command: params[:print_command],
+                                print_command_output: params[:print_command_output])
 
         # If we didn't build, then we return now, as it makes no sense to search for apk's in a non-`assemble` scenario
         return result unless task.start_with?('assemble')
@@ -125,7 +129,17 @@ module Fastlane
                                        env_name: 'FL_ANDROID_SERIAL',
                                        description: 'Android serial, wich device should be used for this command',
                                        is_string: true,
-                                       default_value: '')
+                                       default_value: ''),
+          FastlaneCore::ConfigItem.new(key: :print_command,
+                                       env_name: 'FL_GRADLE_PRINT_COMMAND',
+                                       description: 'Control whether the generated Gradle command is printed as output before running it',
+                                       is_string: false,
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :print_command_output,
+                                       env_name: 'FL_GRADLE_PRINT_COMMAND_OUTPUT',
+                                       description: 'Control whether the output produced by given Gradle command is printed while running',
+                                       is_string: false,
+                                       default_value: true)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -132,12 +132,12 @@ module Fastlane
                                        default_value: ''),
           FastlaneCore::ConfigItem.new(key: :print_command,
                                        env_name: 'FL_GRADLE_PRINT_COMMAND',
-                                       description: 'Control whether the generated Gradle command is printed as output before running it',
+                                       description: 'Control whether the generated Gradle command is printed as output before running it (true/false)',
                                        is_string: false,
                                        default_value: true),
           FastlaneCore::ConfigItem.new(key: :print_command_output,
                                        env_name: 'FL_GRADLE_PRINT_COMMAND_OUTPUT',
-                                       description: 'Control whether the output produced by given Gradle command is printed while running',
+                                       description: 'Control whether the output produced by given Gradle command is printed while running (true/false)',
                                        is_string: false,
                                        default_value: true)
         ]

--- a/fastlane/lib/fastlane/helper/gradle_helper.rb
+++ b/fastlane/lib/fastlane/helper/gradle_helper.rb
@@ -26,10 +26,10 @@ module Fastlane
       end
 
       # Run a certain action
-      def trigger(task: nil, flags: nil, serial: nil)
+      def trigger(task: nil, flags: nil, serial: nil, print_command: true, print_command_output: true)
         android_serial = (serial != "") ? "ANDROID_SERIAL=#{serial}" : nil
         command = [android_serial, escaped_gradle_path, task, flags].compact.join(" ")
-        Action.sh(command)
+        Action.sh(command, print_command: print_command, print_command_output: print_command_output)
       end
 
       def task_available?(task)
@@ -48,7 +48,7 @@ module Fastlane
         self.tasks = []
 
         command = [escaped_gradle_path, "tasks", "--console=plain"].join(" ")
-        output = Actions.sh(command, log: false)
+        output = Action.sh(command, print_command: false, print_command_output: false)
         output.split("\n").each do |line|
           if (result = line.match(/(\w+)\s\-\s([\w\s]+)/))
             self.tasks << GradleTask.new(title: result[1], description: result[2])

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -38,15 +38,12 @@ module Fastlane
         end
 
         if exit_status != 0
-          # this will also append the output to the exception
-          if print_command
-            message = "Exit status of command '#{command}' was #{exit_status} instead of 0."
-          elsif print_command && print_command_output
-            message = "Exit status of command '#{command}' was #{exit_status} instead of 0."
-            message += "\n#{result}"
-          else
-            message = "Shell command exited with exit status #{exit_status} instead of 0."
-          end
+          message = if print_command
+                      "Exit status of command '#{command}' was #{exit_status} instead of 0."
+                    else
+                      "Shell command exited with exit status #{exit_status} instead of 0."
+                    end
+          message += "\n#{result}" if print_command_output
           UI.user_error!(message)
         end
       end

--- a/fastlane/spec/actions_specs/gradle_spec.rb
+++ b/fastlane/spec/actions_specs/gradle_spec.rb
@@ -1,6 +1,58 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "gradle" do
+      describe "output controls" do
+        let(:expected_command) { "#{File.expand_path('README.md')} tasks -p ." }
+
+        it "prints the command and the command's output by default" do
+          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: true, print_command_output: true).and_call_original
+
+          Fastlane::FastFile.new.parse("lane :build do
+            gradle(
+              task: 'tasks',
+              gradle_path: './fastlane/README.md'
+            )
+          end").runner.execute(:build)
+        end
+
+        it "suppresses the command text and prints the command's output" do
+          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: true).and_call_original
+
+          Fastlane::FastFile.new.parse("lane :build do
+            gradle(
+              task: 'tasks',
+              gradle_path: './fastlane/README.md',
+              print_command: false
+            )
+          end").runner.execute(:build)
+        end
+
+        it "prints the command text and suppresses the command's output" do
+          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: true, print_command_output: false).and_call_original
+
+          Fastlane::FastFile.new.parse("lane :build do
+            gradle(
+              task: 'tasks',
+              gradle_path: './fastlane/README.md',
+              print_command_output: false
+            )
+          end").runner.execute(:build)
+        end
+
+        it "suppresses the command text and suppresses the command's output" do
+          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: false).and_call_original
+
+          Fastlane::FastFile.new.parse("lane :build do
+            gradle(
+              task: 'tasks',
+              gradle_path: './fastlane/README.md',
+              print_command: false,
+              print_command_output: false
+            )
+          end").runner.execute(:build)
+        end
+      end
+
       it "generates a valid command" do
         result = Fastlane::FastFile.new.parse("lane :build do
           gradle(task: 'assemble', flavor: 'WorldDomination', build_type: 'Release', properties: { 'versionCode' => 200}, gradle_path: './fastlane/README.md')

--- a/fastlane/spec/actions_specs/zip_spec.rb
+++ b/fastlane/spec/actions_specs/zip_spec.rb
@@ -3,7 +3,7 @@ describe Fastlane do
     describe "zip" do
       it "generates a valid zip command" do
         path = "./fastlane/spec/fixtures/actions/archive.rb"
-        expect(Fastlane::Actions).to receive(:sh).with("zip -r #{path}.zip #{path}")
+        expect(Fastlane::Action).to receive(:sh).with("zip -r #{path}.zip #{path}")
 
         result = Fastlane::FastFile.new.parse("lane :test do
           zip(path: '#{path}')


### PR DESCRIPTION
Addresses https://github.com/fastlane/fastlane/issues/4385

`Actions.sh` does not currently have a way to control printing of the command text to be executed separately from printing the output of that command.

The `CommandExecutor` does handle this, so this adds that capability to the `Actions.sh` family of methods. This capability is then used by the `gradle` action to allow people to suppress printing of the command text. This allows them to pass sensitive information (like passwords) as part of the command without having them become part of the log, but still view the output of the running command.
- Add options to control printing command text and printing command output
- Augment Actions.sh to add inputs that control printing command text separately from command output
