### PR TITLE
Add a `message` option to the add_git_tag action

### DIFF
--- a/fastlane/lib/fastlane/actions/add_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/add_git_tag.rb
@@ -6,9 +6,10 @@ module Fastlane
         lane_name = Actions.lane_context[Actions::SharedValues::LANE_NAME].delete(' ') # no spaces allowed
 
         tag = options[:tag] || "#{options[:grouping]}/#{lane_name}/#{options[:prefix]}#{options[:build_number]}"
+        message = options[:message] || "#{tag} (fastlane)"
 
         UI.message "Adding git tag '#{tag}' 🎯."
-        Actions.sh("git tag -am '#{tag} (fastlane)' '#{tag}'")
+        Actions.sh("git tag -am '#{message}' '#{tag}'")
       end
 
       def self.description
@@ -33,7 +34,11 @@ module Fastlane
                                        env_name: "FL_GIT_TAG_BUILD_NUMBER",
                                        description: "The build number. Defaults to the result of increment_build_number if you\'re using it",
                                        default_value: Actions.lane_context[Actions::SharedValues::BUILD_NUMBER],
-                                       is_string: false)
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :message,
+                                       env_name: "FL_GIT_TAG_MESSAGE",
+                                       description: "The tag message. Defaults to the tag's name",
+                                       optional: true)
         ]
       end
 

--- a/fastlane/spec/actions_specs/add_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/add_git_tag_spec.rb
@@ -69,6 +69,20 @@ describe Fastlane do
 
         expect(result).to eq("git tag -am \'#{tag} (fastlane)\' \'#{tag}\'")
       end
+
+      it "allows you to specify your own message" do
+        tag = '2.0.0'
+        message = "Test Message"
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          add_git_tag ({
+            tag: '#{tag}',
+            message: '#{message}'
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("git tag -am \'#{message}\' \'#{tag}\'")
+      end
     end
   end
 end


### PR DESCRIPTION
As per #4377, this is a basic implementation of how messages could be added to this action.

One potential issue with this approach is that we're not currently escaping shell special characters in the commit message, I'm not sure if that's something I need to do or something that fastlane's option parsing can do for me?
