### PR TITLE
Update fastlane version and versions for dependencies

### DIFF
--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -31,24 +31,24 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.3' # Support for URI templates
   spec.add_dependency 'multipart-post', '~> 2.0.0' # Needed for uploading builds to appetize
 
-  spec.add_dependency 'fastlane_core', '>= 0.42.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.42.1', '< 1.0.0' # all shared code and dependencies
 
-  spec.add_dependency 'credentials_manager', '>= 0.15.0', '< 1.0.0' # Password Manager
-  spec.add_dependency 'spaceship', '>= 0.25.1', '< 1.0.0' # communication layer with Apple's web services
+  spec.add_dependency 'credentials_manager', '>= 0.16.0', '< 1.0.0' # Password Manager
+  spec.add_dependency 'spaceship', '>= 0.26.1', '< 1.0.0' # communication layer with Apple's web services
 
   # All the fastlane tools
-  spec.add_dependency 'deliver', '>= 1.11.0', '< 2.0.0'
+  spec.add_dependency 'deliver', '>= 1.11.2', '< 2.0.0'
   spec.add_dependency 'snapshot', '>= 1.12.1', '< 2.0.0'
   spec.add_dependency 'frameit', '>= 2.5.1', '< 3.0.0'
   spec.add_dependency 'pem', '>= 1.3.0', '< 2.0.0'
   spec.add_dependency 'cert', '>= 1.4.0', '< 2.0.0'
-  spec.add_dependency 'sigh', '>= 1.6.1', '< 2.0.0'
+  spec.add_dependency 'sigh', '>= 1.7.0', '< 2.0.0'
   spec.add_dependency 'produce', '>= 1.1.1', '< 2.0.0'
   spec.add_dependency 'gym', '>= 1.6.2', '< 2.0.0'
   spec.add_dependency 'pilot', '>= 1.5.0', '< 2.0.0'
-  spec.add_dependency 'supply', '>= 0.6.1', '< 1.0.0'
+  spec.add_dependency 'supply', '>= 0.6.2', '< 1.0.0'
   spec.add_dependency 'scan', '>= 0.5.2', '< 1.0.0'
-  spec.add_dependency 'match', '>= 0.4.0', '< 1.0.0'
+  spec.add_dependency 'match', '>= 0.5.0', '< 1.0.0'
   spec.add_dependency 'screengrab', '>= 0.3.2', '< 1.0.0'
 
   # Development only

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,3 +1,3 @@
 module Fastlane
-  VERSION = '1.82.0'.freeze
+  VERSION = '1.83.0'.freeze
 end


### PR DESCRIPTION
[11:08:50]: Changes since release 1.82.0:
- Adds support to verbose and DANGER_GITHUB_API_TOKEN in danger action
- [sigh] Add support for specifying short and bundle versions separately
- Refactor the message composition logic
- [fastlane] Give Gradle action better control over command output
- Fix bash syntax in auto completion script
- Add a `message` option to the add_git_tag action
