### PR TITLE
make rubygems deploy happen before we push the release to github

### DIFF
--- a/fastlane/fastlane/Fastfile
+++ b/fastlane/fastlane/Fastfile
@@ -58,6 +58,10 @@ lane :release do |options|
     UI.user_error!("Version number #{version} was already deployed")
   end
 
+  # Actual release
+  #
+  sh "gem push ../pkg/#{tool_name}-#{version}.gem"
+
   # Git verification
   #
   ensure_git_status_clean
@@ -93,10 +97,6 @@ lane :release do |options|
     message = [title, description, release_url].join("\n\n")
     add_fastlane_git_tag(tag: "#{tool_name}/#{version}", message: message)
   end
-
-  # Actual release
-  #
-  sh "gem push ../pkg/#{tool_name}-#{version}.gem"
 
   # After publishing
   #


### PR DESCRIPTION
In order to get the bundle building with releases, this change will make sure that the version on RubyGems.org will be up to date before committing to github which will trigger the bundle's build.

In some discussion with @mfurtak and @asfalcone, we determined this also might be slightly better as it would not create the GH release if there is a failure when trying to push to RubyGems.
