### PR TITLE
Add build setting to xcodebuild command ...

### DIFF
--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -7,6 +7,7 @@ module Snapshot
         parts << "xcodebuild"
         parts += options
         parts += destination(device_type)
+        parts += build_settings
         parts += actions
         parts += suffix
         parts += pipe
@@ -37,6 +38,13 @@ module Snapshot
         options << "-derivedDataPath '#{derived_data_path}'"
 
         options
+      end
+
+      def build_settings
+        build_settings = []
+        build_settings << "FASTLANE_SNAPSHOT=YES"
+
+        build_settings
       end
 
       def actions

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -27,6 +27,7 @@ describe Snapshot do
               "-project './example/Example.xcodeproj'",
               "-derivedDataPath '/tmp/path/to/snapshot_derived'",
               "-destination 'platform=iOS Simulator,id=,OS=#{ios}'",
+              "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
               "| tee #{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests.log')} | xcpretty "


### PR DESCRIPTION
…so projects can detect snaphot during build via `$FASTLANE_SNAPSHOT`.

Runtime detection is already provided by the launch_argument in the helper.

https://github.com/fastlane/fastlane/issues/4356
