### PR TITLE
Add option to show complete frame

### DIFF
--- a/frameit/README.md
+++ b/frameit/README.md
@@ -141,7 +141,8 @@ Use it to define the general information:
       "color": "#545454"
     },
     "background": "./background.jpg",
-    "padding": 50
+    "padding": 50,
+    "show_complete_frame": false
   },
 
   "data": [
@@ -172,6 +173,7 @@ Use it to define the general information:
   ]
 }
 ```
+The `show_complete_frame` value specifies whether frameit should shrink the device and frame so that they show in full in the framed screenshot. If it is false, then they can hang over the bottom of the screenshot.
 
 The `filter` value is a part of the screenshot named for which the given option should be used. If a screenshot is named `iPhone5_Brainstorming.png` the first entry in the `data` array will be used.
 

--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -87,6 +87,10 @@ module Frameit
           if key == 'padding'
             UI.user_error! "padding must be type integer or pair of integers of format 'AxB'" unless value.kind_of?(Integer) || value.split('x').length == 2
           end
+
+          if key == 'show_complete_frame'
+            UI.user_error! "show_complete_frame must be true or false" unless !!value == value
+          end
         end
       end
     end

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -142,6 +142,12 @@ module Frameit
     end
 
     def put_device_into_background(background)
+      show_complete_frame = fetch_config['show_complete_frame']
+      if show_complete_frame
+        max_height = background.height - top_space_above_device
+        image.resize "x#{max_height}>"
+      end
+
       left_space = (background.width / 2.0 - image.width / 2.0).round
 
       @image = background.composite(image, "png") do |c|


### PR DESCRIPTION
For some apps, the bottom of the screen is important. This allows the
developer to specify that this is the case.

Frameit will then shrink the screenshot (if necessary) to ensure that
the entire device and frame is visible in the framed output.

so - if the developer enables this option, it replaces this:

![ipadpro-01zoomscreen_framed](https://cloud.githubusercontent.com/assets/586910/14919782/4c610d64-0e22-11e6-8107-8055325fc225.png)

with this:

![ipadpro-01zoomscreen_framed](https://cloud.githubusercontent.com/assets/586910/14919793/5ae35e46-0e22-11e6-9332-ad90da628616.png)

See issue: #1732
