### PR TITLE
only set default crashlytics_path value for ios

### DIFF
--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -64,7 +64,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :crashlytics_path,
                                        env_name: "CRASHLYTICS_FRAMEWORK_PATH",
                                        description: "Path to the submit binary in the Crashlytics bundle (iOS) or `crashlytics-devtools.jar` file (Android)",
-                                       default_value: Dir["./Pods/iOS/Crashlytics/Crashlytics.framework"].last || Dir["./**/Crashlytics.framework"].last,
                                        optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find crashlytics at path '#{File.expand_path(value)}'`") unless File.exist?(File.expand_path(value))

--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -42,13 +42,15 @@ module Fastlane
 
       def self.available_options
         platform = Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
+        ipa_path_default = (!platform || platform == :ios) && Dir["*.ipa"].last
+        apk_path_default = platform == :android && Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-release.apk")].last
 
         [
           # iOS Specific
           FastlaneCore::ConfigItem.new(key: :ipa_path,
                                        env_name: "CRASHLYTICS_IPA_PATH",
                                        description: "Path to your IPA file. Optional if you use the `gym` or `xcodebuild` action",
-                                       default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] || (!platform || platform == :ios) && Dir["*.ipa"].last,
+                                       default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] || ipa_path_default,
                                        optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
@@ -57,7 +59,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :apk_path,
                                        env_name: "CRASHLYTICS_APK_PATH",
                                        description: "Path to your APK file",
-                                       default_value: Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH] || platform == :android && Dir[File.join("app", "build", "outputs", "apk", "app-release.apk")].last,
+                                       default_value: Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH] || apk_path_default,
                                        optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find apk file at path '#{value}'") unless File.exist?(value)

--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -42,8 +42,15 @@ module Fastlane
 
       def self.available_options
         platform = Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
-        ipa_path_default = (!platform || platform == :ios) && Dir["*.ipa"].last
-        apk_path_default = platform == :android && Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-release.apk")].last
+
+        ipa_path_default = nil
+        if platform == :ios or platform.nil?
+          ipa_path_default = Dir["*.ipa"].last
+        end
+        apk_path_default = nil
+        if platform == :android
+          apk_path_default = Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-release.apk")].last
+        end
 
         [
           # iOS Specific

--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -41,12 +41,14 @@ module Fastlane
       end
 
       def self.available_options
+        platform = Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
+
         [
           # iOS Specific
           FastlaneCore::ConfigItem.new(key: :ipa_path,
                                        env_name: "CRASHLYTICS_IPA_PATH",
                                        description: "Path to your IPA file. Optional if you use the `gym` or `xcodebuild` action",
-                                       default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] || Dir["*.ipa"].last,
+                                       default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] || (!platform || platform == :ios) && Dir["*.ipa"].last,
                                        optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
@@ -55,7 +57,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :apk_path,
                                        env_name: "CRASHLYTICS_APK_PATH",
                                        description: "Path to your APK file",
-                                       default_value: Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH] || Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-Release.apk")].last,
+                                       default_value: Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH] || platform == :android && Dir[File.join("app", "build", "outputs", "apk", "app-release.apk")].last,
                                        optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find apk file at path '#{value}'") unless File.exist?(value)

--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -3,6 +3,7 @@ module Fastlane
     class CrashlyticsHelper
       class << self
         def generate_ios_command(params)
+          params[:crashlytics_path] = Dir["./Pods/iOS/Crashlytics/Crashlytics.framework"].last || Dir["./**/Crashlytics.framework"].last unless params[:crashlytics_path]
           UI.user_error!("No value found for 'crashlytics_path'") unless params[:crashlytics_path]
           submit_binary = Dir[File.join(params[:crashlytics_path], '**', 'submit')].last
           submit_binary ||= "Crashlytics.framework/submit" if Helper.test?


### PR DESCRIPTION
I have a react-native project for both android and ios app.
The default value of crashlytics_path always got "ios/Crashlytics.framework" even if I build for android platform.
Move the default value to generate_ios_command since it should only run for ios platform.
