### PR TITLE
[fastlane] Version bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.83.0'.freeze
+  VERSION = '1.84.0'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end


### PR DESCRIPTION
- Updated and unified fastlane description
- update_fastlane is now only called on fastlane deployment
- Removed rake test command for all tools
- Update gradle action documentation for command and output printing controls
- make rubygems deploy happen before we push the release to github
- Add action Pod lib lint
- Make body of commit optional in jenkins changelog generation
