### PR TITLE
Shell escape git commit / tag messages

### DIFF
--- a/fastlane/lib/fastlane/actions/add_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/add_git_tag.rb
@@ -9,7 +9,7 @@ module Fastlane
         message = options[:message] || "#{tag} (fastlane)"
 
         UI.message "Adding git tag '#{tag}' 🎯."
-        Actions.sh("git tag -am '#{message}' '#{tag}'")
+        Actions.sh("git tag -am #{message.shellescape} '#{tag}'")
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -8,7 +8,7 @@ module Fastlane
           paths = params[:path].map(&:shellescape).join(' ')
         end
 
-        result = Actions.sh("git commit -m '#{params[:message]}' #{paths}")
+        result = Actions.sh("git commit -m #{params[:message].shellescape} #{paths}")
         UI.success("Successfully committed \"#{params[:path]}\" 💾.")
         return result
       end

--- a/fastlane/spec/actions_specs/add_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/add_git_tag_spec.rb
@@ -14,7 +14,7 @@ describe Fastlane do
           add_git_tag
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am \'builds/test/1337 (fastlane)\' \'builds/test/1337\'")
+        expect(result).to eq("git tag -am builds/test/1337\\ \\(fastlane\\) \'builds/test/1337\'")
       end
 
       it "allows you to specify grouping and build number" do
@@ -28,7 +28,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am \'#{grouping}/test/#{specified_build_number} (fastlane)\' \'#{grouping}/test/#{specified_build_number}\'")
+        expect(result).to eq("git tag -am #{grouping}/test/#{specified_build_number}\\ \\(fastlane\\) \'#{grouping}/test/#{specified_build_number}\'")
       end
 
       it "allows you to specify a prefix" do
@@ -40,7 +40,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am \'builds/test/#{prefix}#{build_number} (fastlane)\' \'builds/test/#{prefix}#{build_number}\'")
+        expect(result).to eq("git tag -am builds/test/#{prefix}#{build_number}\\ \\(fastlane\\) \'builds/test/#{prefix}#{build_number}\'")
       end
 
       it "allows you to specify your own tag" do
@@ -52,7 +52,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am \'#{tag} (fastlane)\' \'#{tag}\'")
+        expect(result).to eq("git tag -am #{tag}\\ \\(fastlane\\) \'#{tag}\'")
       end
 
       it "specified tag overrides generate tag" do
@@ -67,12 +67,12 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am \'#{tag} (fastlane)\' \'#{tag}\'")
+        expect(result).to eq("git tag -am #{tag}\\ \\(fastlane\\) \'#{tag}\'")
       end
 
       it "allows you to specify your own message" do
         tag = '2.0.0'
-        message = "Test Message"
+        message = "message"
 
         result = Fastlane::FastFile.new.parse("lane :test do
           add_git_tag ({
@@ -81,7 +81,22 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am \'#{message}\' \'#{tag}\'")
+        expect(result).to eq("git tag -am message \'#{tag}\'")
+      end
+
+      it "properly shell escapes its message" do
+        tag = '2.0.0'
+        message = "message with 'quotes' (and parens)"
+        escaped_message = "message\\ with\\ \\'quotes\\'\\ \\(and\\ parens\\)"
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          add_git_tag ({
+            tag: '#{tag}',
+            message: \"#{message}\"
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("git tag -am #{escaped_message} \'#{tag}\'")
       end
     end
   end

--- a/fastlane/spec/actions_specs/git_commit_spec.rb
+++ b/fastlane/spec/actions_specs/git_commit_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane do
           git_commit(path: './fastlane/README.md', message: 'message')
         end").runner.execute(:test)
 
-        expect(result).to eq("git commit -m 'message' ./fastlane/README.md")
+        expect(result).to eq("git commit -m message ./fastlane/README.md")
       end
 
       it "generates the correct git command with an array of paths" do
@@ -14,7 +14,7 @@ describe Fastlane do
           git_commit(path: ['./fastlane/README.md', './fastlane/LICENSE'], message: 'message')
         end").runner.execute(:test)
 
-        expect(result).to eq("git commit -m 'message' ./fastlane/README.md ./fastlane/LICENSE")
+        expect(result).to eq("git commit -m message ./fastlane/README.md ./fastlane/LICENSE")
       end
 
       it "generates the correct git command with shell-escaped-paths" do
@@ -22,7 +22,14 @@ describe Fastlane do
           git_commit(path: ['./fastlane/README.md', './fastlane/LICENSE', './fastlane/spec/fixtures/git_commit/A FILE WITH SPACE'], message: 'message')
         end").runner.execute(:test)
 
-        expect(result).to eq("git commit -m 'message' ./fastlane/README.md ./fastlane/LICENSE " + "./fastlane/spec/fixtures/git_commit/A FILE WITH SPACE".shellescape)
+        expect(result).to eq("git commit -m message ./fastlane/README.md ./fastlane/LICENSE " + "./fastlane/spec/fixtures/git_commit/A FILE WITH SPACE".shellescape)
+      end
+
+      it "generates the correct git command with a shell-escaped message" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          git_commit(path: './fastlane/README.md', message: \"message with 'quotes' (and parens)\")
+        end").runner.execute(:test)
+        expect(result).to eq("git commit -m message\\ with\\ \\'quotes\\'\\ \\(and\\ parens\\) ./fastlane/README.md")
       end
     end
   end


### PR DESCRIPTION
As per #4445, this commit allows strings passed to the `git_commit` and `add_git_tag` actions' `message` parameters. It achieves this by substituting any occurrences of the single quote (') character in the provided message with an escaped version.
