### PR TITLE
[Fastlane_Core] Adding platform fetch support ipa for fastlane core

### DIFF
--- a/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
@@ -17,6 +17,15 @@ module FastlaneCore
       return nil
     end
 
+    # Fetches the app platform from the given ipa file.
+    def self.fetch_app_platform(path)
+      plist = self.fetch_info_plist_file(path)
+      platform = "ios"
+      platform = plist['DTPlatformName'] if plist
+      platform = "ios" if platform == "iphoneos" # via https://github.com/fastlane/spaceship/issues/247
+      return platform
+    end
+
     def self.fetch_info_plist_file(path)
       Zip::File.open(path) do |zipfile|
         file = zipfile.glob('**/Payload/*.app/Info.plist').first


### PR DESCRIPTION
This is an attempt at adding in basic platform support for iTunes Connect TestFlight Build Trains.

This is the second of 3 pull requests to fix: #4427
