### PR TITLE
[Pilot] Adding in platform support for pilot

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -7,7 +7,7 @@ module Pilot
 
       UI.success("Ready to upload new build to TestFlight (App: #{app.apple_id})...")
 
-      platform = FastlaneCore::IpaFileAnalyser.fetch_app_platform(config[:ipa])
+      platform = fetch_app_platform
       package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(app_id: app.apple_id,
                                                                       ipa_path: config[:ipa],
                                                                   package_path: "/tmp",

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -83,6 +83,7 @@ module Pilot
         config[:app_platform] = ask("App Platform (ios, appletvos, osx): ")
       end
 
+      UI.user_error!("App Platform must be ios, appletvos, or osx") unless ['ios', 'appletvos', 'osx'].include? config[:app_platform]
       builds = app.all_processing_builds(platform: config[:app_platform]) + app.builds(platform: config[:app_platform])
       # sort by upload_date
       builds.sort! { |a, b| a.upload_date <=> b.upload_date }

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -7,9 +7,7 @@ module Pilot
 
       UI.success("Ready to upload new build to TestFlight (App: #{app.apple_id})...")
 
-      plist = FastlaneCore::IpaFileAnalyser.fetch_info_plist_file(config[:ipa]) || {}
-      platform = plist["DTPlatformName"]
-      platform = "ios" if platform == "iphoneos" # via https://github.com/fastlane/spaceship/issues/247
+      platform = FastlaneCore::IpaFileAnalyser.fetch_app_platform(config[:ipa])
       package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(app_id: app.apple_id,
                                                                       ipa_path: config[:ipa],
                                                                   package_path: "/tmp",
@@ -81,7 +79,11 @@ module Pilot
         config[:app_identifier] = UI.input("App Identifier: ")
       end
 
-      builds = app.all_processing_builds + app.builds
+      if config[:app_platform].to_s.length == 0
+        config[:app_platform] = ask("App Platform (ios, appletvos, osx): ")
+      end
+
+      builds = app.all_processing_builds(platform: config[:app_platform]) + app.builds(platform: config[:app_platform])
       # sort by upload_date
       builds.sort! { |a, b| a.upload_date <=> b.upload_date }
       rows = builds.collect { |build| describe_build(build) }
@@ -111,7 +113,8 @@ module Pilot
 
     # This method will takes care of checking for the processing builds every few seconds
     # @return [Build] The build that we just uploaded
-    def wait_for_processing_build(options)
+
+    def wait_for_processing_build(platform: nil)
       # the upload date of the new buid
       # we use it to identify the build
       start = Time.now
@@ -130,7 +133,7 @@ module Pilot
         if app.build_trains.count == 0
           UI.message("New application; waiting for build train to appear on iTunes Connect")
         else
-          builds = app.all_processing_builds
+          builds = app.all_processing_builds(platform: platform)
           break if builds.count == 0
           latest_build = builds.last
 
@@ -155,9 +158,7 @@ module Pilot
         # true -> false, where the second true is transient. This causes a spurious failure. Find build by build_version
         # and ensure it's not processing before proceeding - it had to have already been false before, to get out of the
         # previous loop.
-        build_train = app.build_trains[latest_build.train_version]
-        builds = build_train ? build_train.builds : []
-        full_build = builds.find do |b|
+        full_build = app.build_trains(platform: platform)[latest_build.train_version].builds.find do |b|
           b.build_version == latest_build.build_version
         end
 

--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -56,5 +56,13 @@ module Pilot
       UI.verbose("App identifier (#{result})")
       return result
     end
+
+    def fetch_app_platform
+      result = config[:app_platform]
+      result ||= FastlaneCore::IpaFileAnalyser.fetch_app_platform(config[:ipa])
+      result ||= ask("Please enter the app's platform (appletvos, ios, osx): ")
+      UI.verbose("App Platform (#{result})")
+      return result
+    end
   end
 end

--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -61,6 +61,7 @@ module Pilot
       result = config[:app_platform]
       result ||= FastlaneCore::IpaFileAnalyser.fetch_app_platform(config[:ipa])
       result ||= ask("Please enter the app's platform (appletvos, ios, osx): ")
+      UI.user_error!("App Platform must be ios, appletvos, or osx") unless ['ios', 'appletvos', 'osx'].include? result
       UI.verbose("App Platform (#{result})")
       return result
     end

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -19,6 +19,15 @@ module Pilot
                                      description: "The bundle identifier of the app to upload or manage testers (optional)",
                                      optional: true,
                                      default_value: ENV["TESTFLIGHT_APP_IDENTITIFER"] || CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)),
+        FastlaneCore::ConfigItem.new(key: :app_platform,
+                                     short_option: "-m",
+                                     env_name: "PILOT_PLATFORM",
+                                     description: "The platform to use (optional)",
+                                     optional: true,
+                                     default_value: "ios",
+                                     verify_block: proc do |value|
+                                       UI.user_error!("The platform can only be ios, appletvos, or osx") unless ['ios', 'appletvos', 'osx'].include? value
+                                     end),
         FastlaneCore::ConfigItem.new(key: :ipa,
                                      short_option: "-i",
                                      optional: true,


### PR DESCRIPTION
This is an attempt at adding in basic platform support for iTunes Connect TestFlight Build Trains.

This is the third of 3 pull requests to fix: #4427
