### PR TITLE
Sort screenshots

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -70,7 +70,7 @@ module Deliver
           next
         end
 
-        files = Dir.glob(File.join(lng_folder, "*.#{extensions}"), File::FNM_CASEFOLD)
+        files = Dir.glob(File.join(lng_folder, "*.#{extensions}"), File::FNM_CASEFOLD).sort
         next if files.count == 0
 
         prefer_framed = Dir.glob(File.join(lng_folder, "*_framed.#{extensions}"), File::FNM_CASEFOLD).count > 0


### PR DESCRIPTION
Screenshots are uploaded in undefined order, probably as they are stored in filesystem. I'm on macbook pro with Case-Sensitive Journaled HFS+, however screenshots are being uploaded directly from Samba share. Files are named like in this snippet from deliver (after proposed change in code):
...
[11:39:48]: Uploading './screenshots/en-US/iPhone4s-010_Summary.png'...
[11:39:55]: Uploading './screenshots/en-US/iPhone4s-020_Coverage.png'...
[11:39:59]: Uploading './screenshots/en-US/iPhone4s-030_Stats.png'...
[11:40:03]: Uploading './screenshots/en-US/iPhone4s-040_MyGames.png'...
[11:40:07]: Uploading './screenshots/en-US/iPhone4s-050_LiveTable.png'...
[11:40:11]: Uploading './screenshots/en-US/iPhone5s-010_Summary.png'...
[11:40:14]: Uploading './screenshots/en-US/iPhone5s-020_Coverage.png'...
[11:40:17]: Uploading './screenshots/en-US/iPhone5s-030_Stats.png'...
[11:40:21]: Uploading './screenshots/en-US/iPhone5s-040_MyGames.png'...
[11:40:25]: Uploading './screenshots/en-US/iPhone5s-050_LiveTable.png'...
...
