### PR TITLE
Improved lane selection description output

### DIFF
--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -110,7 +110,7 @@ module Fastlane
 
       rows = []
       available.each_with_index do |lane, index|
-        rows << [index + 1, lane.last.pretty_name, lane.last.description.first]
+        rows << [index + 1, lane.last.pretty_name, lane.last.description.join("\n")]
       end
 
       rows << [0, "cancel", "No selection, exit fastlane!"]


### PR DESCRIPTION
### Join description using new lines

**From:**
<img width="747" alt="screenshot 2016-05-02 14 41 00" src="https://cloud.githubusercontent.com/assets/869950/14954608/129563ce-1074-11e6-840c-cb688a3183b6.png">

**To:**
<img width="852" alt="screenshot 2016-05-02 14 40 57" src="https://cloud.githubusercontent.com/assets/869950/14954595/fc03991e-1073-11e6-8d12-cfe584fc1bd3.png">

cc @hemal 

Up until now we only printed the first line
