### PR TITLE
Improve xcbuild-safe when working with rbenv

### DIFF
--- a/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
+++ b/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
@@ -52,7 +52,7 @@ if command_exists rbenv; then
   # Unset environment variables that could break xcodebuild
   unset RUBYLIB
   unset RUBYOPT
-  uset _ORIGINAL_GEM_PATH
+  unset _ORIGINAL_GEM_PATH
   unset BUNDLE_BIN_PATH
   unset BUNDLE_GEMFILE
   unset BUNDLE_BIN_PATH

--- a/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
+++ b/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
@@ -21,9 +21,12 @@
 # † Because, you know, that *never* happens when you are building
 # Xcode projects, say with abstruse tools like Rake or CocoaPods.
 
-which rvm > /dev/null
+# function to detect commands
+command_exists() {
+  type "$1" &> /dev/null;  
+}
 
-if [[ $? -eq 0 ]]; then
+if command_exists rvm; then
   echo "RVM detected, forcing to use system ruby"
   # This allows you to use rvm in a script. Otherwise you get a BS
   # error along the lines of "cannot use rvm as function". Jeez.
@@ -39,6 +42,22 @@ if [[ $? -eq 0 ]]; then
   unset BUNDLE_BIN_PATH
   unset _ORIGINAL_GEM_PATH
   unset BUNDLE_GEMFILE
+fi
+
+if command_exists rbenv; then
+  # Cause rbenv to use system ruby. Lasts only for the scope of this
+  # session which will normally just be this script.
+  rbenv shell system
+
+  # Unset environment variables that could break xcodebuild
+  unset RUBYLIB
+  unset RUBYOPT
+  uset _ORIGINAL_GEM_PATH
+  unset BUNDLE_BIN_PATH
+  unset BUNDLE_GEMFILE
+  unset BUNDLE_BIN_PATH
+  unset GEM_HOME
+  unset GEM_PATH
 fi
 
 # to help troubleshooting

--- a/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
+++ b/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
@@ -55,7 +55,6 @@ if command_exists rbenv; then
   unset _ORIGINAL_GEM_PATH
   unset BUNDLE_BIN_PATH
   unset BUNDLE_GEMFILE
-  unset BUNDLE_BIN_PATH
   unset GEM_HOME
   unset GEM_PATH
 fi


### PR DESCRIPTION
🔑

This PR improves support for xcbuild-safe when using rbenv rather than rvm. 

Currently using rbenv and `bundle exec gym` will always result in failed builds when exporting an enterprise build thanks to some inherit issues in `ipatool`.

In general I think `bundler` has been a bigger culprit of xcodebuild failures over rvm/rbenv and anyone using `bundle exec` has probably seen one of these build issues crop up!
