### PR TITLE
Added support for sub-tools

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -70,7 +70,7 @@ module Deliver
           next
         end
 
-        files = Dir.glob(File.join(lng_folder, "*.#{extensions}"), File::FNM_CASEFOLD)
+        files = Dir.glob(File.join(lng_folder, "*.#{extensions}"), File::FNM_CASEFOLD).sort
         next if files.count == 0
 
         prefer_framed = Dir.glob(File.join(lng_folder, "*_framed.#{extensions}"), File::FNM_CASEFOLD).count > 0

--- a/fastlane/bin/fastlane
+++ b/fastlane/bin/fastlane
@@ -2,5 +2,43 @@
 $LOAD_PATH.push File.expand_path("../../lib", __FILE__)
 
 require "fastlane"
-require "fastlane/commands_generator"
-Fastlane::CommandsGenerator.start
+
+# Array of symbols for the names of the available lanes
+# This doesn't actually use the Fastfile parser, but only
+# the available lanes. This way it's much faster, which
+# is very important in this case, since it will be executed
+# every time one of the tools is launched
+available_lanes = Fastlane::FastlaneFolder.available_lanes
+
+tool_name = ARGV.first
+if tool_name && Fastlane::TOOLS.include?(tool_name.to_sym) && !available_lanes.include?(tool_name.to_sym)
+  # Triggering a specific tool
+  # This happens when the users uses things like
+  #
+  #   fastlane sigh
+  #   fastlane snapshot
+  #
+  require tool_name
+  begin
+    # First, remove the tool's name from the arguments
+    # Since it will be parsed by the `commander` at a later point
+    # and it must not contain the binary name
+    ARGV.shift
+
+    # Import the CommandsGenerator class, which is used to parse
+    # the user input
+    require File.join(tool_name, "commands_generator")
+
+    # Call the tool's CommandsGenerator class and let it do its thing
+    Object.const_get(tool_name.fastlane_class)::CommandsGenerator.start
+  rescue LoadError
+    # This will only happen if the tool we call here, doesn't provide
+    # a CommandsGenerator class yet
+    # When we launch this feature, this should never be the case
+    abort("#{tool_name} can't be called via fastlane, run '#{tool_name}' directly instead".red)
+  end
+else
+  # Triggering fastlane, that's what we did until now
+  require "fastlane/commands_generator"
+  Fastlane::CommandsGenerator.start
+end

--- a/fastlane/lib/fastlane.rb
+++ b/fastlane/lib/fastlane.rb
@@ -1,5 +1,6 @@
 require 'fastlane/core_ext/string' # this has to be above most of the other requires
 require 'fastlane/version'
+require 'fastlane/tools'
 require 'fastlane/actions/actions_helper' # has to be before fast_file
 require 'fastlane/fast_file'
 require 'fastlane/runner'

--- a/fastlane/lib/fastlane.rb
+++ b/fastlane/lib/fastlane.rb
@@ -22,11 +22,13 @@ module Fastlane
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
 
-  Fastlane::Actions.load_default_actions
-  Fastlane::Actions.load_helpers
+  def self.load_actions
+    Fastlane::Actions.load_default_actions
+    Fastlane::Actions.load_helpers
 
-  if Fastlane::FastlaneFolder.path
-    actions_path = File.join(Fastlane::FastlaneFolder.path, 'actions')
-    Fastlane::Actions.load_external_actions(actions_path) if File.directory?(actions_path)
+    if Fastlane::FastlaneFolder.path
+      actions_path = File.join(Fastlane::FastlaneFolder.path, 'actions')
+      Fastlane::Actions.load_external_actions(actions_path) if File.directory?(actions_path)
+    end
   end
 end

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -9,6 +9,7 @@ module Fastlane
 
     def self.start
       FastlaneCore::UpdateChecker.start_looking_for_update('fastlane')
+      Fastlane.load_actions
       self.new.run
     ensure
       FastlaneCore::UpdateChecker.show_update_status('fastlane', Fastlane::VERSION)

--- a/fastlane/lib/fastlane/fastlane_folder.rb
+++ b/fastlane/lib/fastlane/fastlane_folder.rb
@@ -13,16 +13,31 @@ module Fastlane
       return value
     end
 
+    def self.fastfile_path
+      return nil if path.nil?
+      File.join(path, "Fastfile")
+    end
+
     # Does a fastlane configuration already exist?
     def self.setup?
       return false unless path
-      File.exist?(File.join(path, "Fastfile"))
+      File.exist?(self.fastfile_path)
     end
 
     def self.create_folder!(path = nil)
       path = File.join(path || '.', FOLDER_NAME)
       FileUtils.mkdir_p(path)
       UI.success "Created new folder '#{path}'."
+    end
+
+    # Returns an array of symbols for the available lanes for the Fastfile
+    # This doesn't actually use the Fastfile parser, but only
+    # the available lanes. This way it's much faster
+    # Use this only if performance is :key:
+    def self.available_lanes
+      return [] if fastfile_path.nil?
+      output = `cat '#{fastfile_path}' | grep "^\s*lane \:" | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}'`
+      return output.strip.split(" ").collect(&:to_sym)
     end
   end
 end

--- a/fastlane/lib/fastlane/lane.rb
+++ b/fastlane/lib/fastlane/lane.rb
@@ -19,10 +19,7 @@ module Fastlane
       UI.user_error!("lane name must not contain any spaces") if name.to_s.include? " "
       UI.user_error!("lane name must start with :") unless name.kind_of? Symbol
 
-      if self.class.black_list.include?(name.to_s)
-        UI.error "Lane Name '#{name}' can not be one of the followings: #{self.class.black_list}".red
-        UI.user_error!("Name '#{name}' is already taken")
-      end
+      self.class.verify_lane_name(name)
 
       self.platform = platform
       self.name = name
@@ -42,8 +39,27 @@ module Fastlane
     end
 
     class << self
+      # Makes sure the lane name is valid
+      def verify_lane_name(name)
+        if self.black_list.include?(name.to_s)
+          UI.error "Lane Name '#{name}' can not be one of the followings: #{self.black_list}".red
+          UI.user_error!("Name '#{name}' is already taken")
+        end
+
+        if self.gray_list.include?(name.to_sym)
+          UI.error "The name '#{name}' for a lane equals the name of a fastlane tool"
+          UI.error "It is recommended to not use '#{name}' as the name of your lane"
+          # We still allow it, because we're nice
+          # Otherwise we might break existing setups
+        end
+      end
+
       def black_list
         %w(run init new_action lanes list docs action actions help)
+      end
+
+      def gray_list
+        Fastlane::TOOLS
       end
     end
   end

--- a/fastlane/lib/fastlane/tools.rb
+++ b/fastlane/lib/fastlane/tools.rb
@@ -1,0 +1,20 @@
+module Fastlane
+  TOOLS = [
+    :fastlane,
+    :pilot,
+    :spaceship,
+    :produce,
+    :cert,
+    :deliver,
+    :frameit,
+    :pem,
+    :snapshot,
+    :screengrab,
+    :supply,
+    :cert,
+    :sigh,
+    :match,
+    :scan,
+    :gym
+  ]
+end

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.83.0'.freeze
+  VERSION = '1.84.0'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end

--- a/fastlane/spec/spec_helper.rb
+++ b/fastlane/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'fastlane_core'
 require 'webmock/rspec'
 
 UI = FastlaneCore::UI
+Fastlane.load_actions
 
 # This module is only used to check the environment is currently a testing env
 module SpecHelper

--- a/fastlane/spec/tools_spec.rb
+++ b/fastlane/spec/tools_spec.rb
@@ -1,0 +1,21 @@
+describe Fastlane do
+  describe "Fastlane::TOOLS" do
+    it "lists all the fastlane tools" do
+      expect(Fastlane::TOOLS.count).to be >= 15
+    end
+
+    it "contains symbols for each of the tools" do
+      Fastlane::TOOLS.each do |current|
+        expect(current).to be_kind_of(Symbol)
+      end
+    end
+
+    it "warns the user when a lane is called like a tool" do
+      ff = Fastlane::FastFile.new('./spec/fixtures/fastfiles/Fastfile1')
+      expect(UI).to receive(:error).with("The name 'gym' for a lane equals the name of a fastlane tool")
+      expect(UI).to receive(:error).with("It is recommended to not use 'gym' as the name of your lane")
+      ff.lane :gym do
+      end
+    end
+  end
+end


### PR DESCRIPTION
You can now also call tools using 

```
fastlane sigh
fastlane snapshot --scheme "something"
fastlane gym --help
```
### Changes in this PR
- Support for running tools via the fastlane executable
- Introduced a warning when a lane has the same name as a fastlane tool
- Added technique to not run a sub-tool when a lane has the name of a tool
