### PR TITLE
Proposed fix for #4166 (get_version_number doesn't fetch correct version number)

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -23,26 +23,26 @@ module Fastlane
         ].join(' ')
 
         line = ""
-        scheme = params[:scheme] || ""
+        target = params[:target] || ""
         results = []
 
         if Helper.test?
           results = [
-            '"SampleProject.xcodeproj/../SchemeA/SchemeA-Info.plist"=4.3.2',
-            '"SampleProject.xcodeproj/../SchemeATests/Info.plist"=4.3.2',
-            '"SampleProject.xcodeproj/../SchemeB/SchemeB-Info.plist"=5.4.3',
-            '"SampleProject.xcodeproj/../SchemeBTests/Info.plist"=5.4.3'
+            '"SampleProject.xcodeproj/../TargetA/TargetA-Info.plist"=4.3.2',
+            '"SampleProject.xcodeproj/../TargetATests/Info.plist"=4.3.2',
+            '"SampleProject.xcodeproj/../TargetB/TargetB-Info.plist"=5.4.3',
+            '"SampleProject.xcodeproj/../TargetBTests/Info.plist"=5.4.3'
           ]
         else
           results = (Actions.sh command).split("\n")
         end
 
-        if scheme.empty?
+        if target.empty?
           line = results.first unless results.first.nil?
         else
-          scheme_string = "/#{scheme}/"
+          target_string = "/#{target}/"
           results.any? do |result|
-            if result.include? scheme_string
+            if result.include? target_string
               line = result
               break
             end
@@ -85,9 +85,9 @@ module Fastlane
                                UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
                                UI.user_error!("Could not find Xcode project at path '#{File.expand_path(value)}'") if !File.exist?(value) and !Helper.is_test?
                              end),
-          FastlaneCore::ConfigItem.new(key: :scheme,
-                             env_name: "FL_VERSION_NUMBER_SCHEME",
-                             description: "Specify a specific scheme if you have multiple per project, optional",
+          FastlaneCore::ConfigItem.new(key: :target,
+                             env_name: "FL_VERSION_NUMBER_TARGET",
+                             description: "Specify a specific target if you have multiple per project, optional",
                              optional: true)
         ]
       end

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -3,21 +3,21 @@ describe Fastlane do
     describe "Get Version Number Integration" do
       require 'shellwords'
 
-      it "gets the correct version number for 'SchemeA'" do
+      it "gets the correct version number for 'TargetA'" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '.xcproject', scheme: 'SchemeA')
+          get_version_number(xcodeproj: '.xcproject', target: 'TargetA')
         end").runner.execute(:test)
         expect(result).to eq("4.3.2")
       end
 
-      it "gets the correct version number for 'SchemeB'" do
+      it "gets the correct version number for 'TargetB'" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '.xcproject', scheme: 'SchemeB')
+          get_version_number(xcodeproj: '.xcproject', target: 'TargetB')
         end").runner.execute(:test)
         expect(result).to eq("5.4.3")
       end
 
-      it "gets the correct version number with no scheme" do
+      it "gets the correct version number with no target specified" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '.xcproject')
         end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -10,11 +10,46 @@ describe Fastlane do
         expect(result).to eq("4.3.2")
       end
 
+      it "gets the correct version number for 'TargetATests'" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          get_version_number(xcodeproj: '.xcproject', target: 'TargetATests')
+        end").runner.execute(:test)
+        expect(result).to eq("4.3.2")
+      end
+
       it "gets the correct version number for 'TargetB'" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '.xcproject', target: 'TargetB')
         end").runner.execute(:test)
         expect(result).to eq("5.4.3")
+      end
+
+      it "gets the correct version number for 'TargetBTests'" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          get_version_number(xcodeproj: '.xcproject', target: 'TargetBTests')
+        end").runner.execute(:test)
+        expect(result).to eq("5.4.3")
+      end
+
+      it "gets the correct version number for 'TargetC_internal'" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          get_version_number(xcodeproj: '.xcproject', target: 'TargetC_internal')
+        end").runner.execute(:test)
+        expect(result).to eq("7.5.2")
+      end
+
+      it "gets the correct version number for 'TargetC_production'" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          get_version_number(xcodeproj: '.xcproject', target: 'TargetC_production')
+        end").runner.execute(:test)
+        expect(result).to eq("6.4.9")
+      end
+
+      it "gets the correct version number for 'SampleProject_tests'" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          get_version_number(xcodeproj: '.xcproject', target: 'SampleProject_tests')
+        end").runner.execute(:test)
+        expect(result).to eq("1.0")
       end
 
       it "gets the correct version number with no target specified" do


### PR DESCRIPTION
This PR fixes a few problems with `get_version_number`
1. Based on comments, it seems passing the `-terse``' flag sometimes returns nonsense as the first item in the array of results. Now we iterate this list of results until we find and actual result. Then return that. This should emulate the`-terse1``` flag more accurately.
2. Using the word `scheme` was misleading. Now we can accept a `target` as a parameter and find that appropriately. 

This PR also adds spec tests to simulate the above behavior.

Associated issue: #4166

Thanks!
