### PR TITLE
Moved `gem push` to a later point when deploying fastlane

### DIFF
--- a/fastlane/fastlane/Fastfile
+++ b/fastlane/fastlane/Fastfile
@@ -56,15 +56,16 @@ lane :release do |options|
     UI.user_error!("Version number #{version} was already deployed")
   end
 
-  # Actual release
-  #
-  sh "gem push ../pkg/#{tool_name}-#{version}.gem"
-
   # Git verification
   #
   ensure_git_status_clean
   ensure_git_branch(branch: 'master')
   git_pull
+  # Actual release
+  #
+  sh "gem push ../pkg/#{tool_name}-#{version}.gem"
+  # Then push to git remote
+  #
   push_to_git_remote
 
   # Preparing GitHub Release


### PR DESCRIPTION
Reverts https://github.com/fastlane/fastlane/pull/4410

I pushed a new release of `spaceship`, `gem push` was successful, and then my git status was dirty, so the rest of the deployment failed. I cleaned my git directory, but now the version was already deployed.

We can easily overwrite or skip the GitHub release if it's already there, however we can never change the RubyGems gem. This should be the last thing.

cc @ohwutup @mfurtak @asfalcone
