### PR TITLE
Make action_collector available in fastlane_core for more comprehensive collection

### DIFF
--- a/fastlane_core/lib/fastlane_core.rb
+++ b/fastlane_core/lib/fastlane_core.rb
@@ -19,6 +19,7 @@ require 'fastlane_core/project'
 require 'fastlane_core/device_manager'
 require 'fastlane_core/crash_reporting/crash_reporting'
 require 'fastlane_core/ui/ui'
+require 'fastlane_core/tool_collector'
 
 # Third Party code
 require 'colored'

--- a/fastlane_core/lib/fastlane_core/tool_collector.rb
+++ b/fastlane_core/lib/fastlane_core/tool_collector.rb
@@ -1,0 +1,71 @@
+module FastlaneCore
+  class ToolCollector
+    HOST_URL = "https://fastlane-enhancer.herokuapp.com"
+
+    attr_reader :error
+
+    def did_launch_action(name)
+      name = name.to_sym
+      launches[name] += 1 if is_official?(name)
+    end
+
+    def did_raise_error(name)
+      name = name.to_sym
+      @error = name if is_official?(name)
+    end
+
+    def did_finish
+      return false if ENV["FASTLANE_OPT_OUT_USAGE"]
+
+      if !did_show_message? and !Helper.is_ci?
+        show_message
+      end
+
+      require 'excon'
+      url = HOST_URL + '/did_launch?'
+      url += URI.encode_www_form(
+        steps: launches.to_json,
+        error: @error
+      )
+
+      if Helper.is_test? # don't send test data
+        return url
+      else
+        fork do
+          begin
+            Excon.post(url)
+          rescue
+            # we don't want to show a stack trace if something goes wrong
+          end
+        end
+        return true
+      end
+    rescue
+      # We don't care about connection errors
+    end
+
+    def show_message
+      UI.message("Sending Crash/Success information. More information on: https://github.com/fastlane/enhancer")
+      UI.message("No personal/sensitive data is sent. Only sharing the following:")
+      UI.message(launches)
+      UI.message(@error) if @error
+      UI.message("This information is used to fix failing tools and improve those that are most often used.")
+      UI.message("You can disable this by setting the environment variable: FASTLANE_OPT_OUT_USAGE=1")
+    end
+
+    def launches
+      @launches ||= Hash.new(0)
+    end
+
+    def is_official?(name)
+      return true
+    end
+
+    def did_show_message?
+      path = File.join(File.expand_path('~'), '.did_show_opt_info')
+      did_show = File.exist?(path)
+      File.write(path, '1') unless did_show
+      did_show
+    end
+  end
+end

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -19,8 +19,12 @@ module Commander
       parse_global_options
       remove_global_options options, @args
 
+      collector = FastlaneCore::ToolCollector.new
+
       begin
+        collector.did_launch_action(@program[:name])
         run_active_command
+        collector.did_finish
       rescue InvalidCommandError => e
         abort "#{e}. Use --help for more information"
       rescue Interrupt => ex
@@ -36,8 +40,10 @@ module Commander
         OptionParser::MissingArgument => e
         abort e.to_s
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
+        collector.did_raise_error(@program[:name])
         display_user_error!(e, e.message)
       rescue => e # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
+        collector.did_raise_error(@program[:name])
         handle_unknown_error!(e)
       end
     end

--- a/fastlane_core/spec/fastlane_runner_spec.rb
+++ b/fastlane_core/spec/fastlane_runner_spec.rb
@@ -1,6 +1,65 @@
 require 'spec_helper'
 
 describe Commander::Runner do
+  describe 'tool collector interactions' do
+    class CommandsGenerator
+      include Commander::Methods
+
+      def initialize(raise_error: false)
+        @raise_error = raise_error
+      end
+
+      def run
+        program :name, 'tool_name'
+        program :version, '1.9'
+        program :description, 'Description'
+
+        # This is required because we're running this real Commander instance inside of
+        # the real rspec tests command. When we run rspec for all projects, these options
+        # get set, and Commander is going to validate that they are something that our
+        # fake program accepts.
+        #
+        # This is not ideal, but the downside is potential broken tests in the future,
+        # which we can quickly adjust.
+        global_option '--format', String
+        global_option '--out', String
+
+        command :run do |c|
+          c.action do |args, options|
+            raise StandardError if @raise_error
+          end
+        end
+
+        default_command :run
+
+        run!
+      end
+    end
+
+    let(:mock_tool_collector) { FastlaneCore::ToolCollector.new }
+
+    before(:each) do
+      allow(Commander::Runner).to receive(:instance).and_return(Commander::Runner.new)
+      expect(FastlaneCore::ToolCollector).to receive(:new).and_return(mock_tool_collector)
+    end
+
+    it "calls the tool collector lifecycle methods for a successful run" do
+      expect(mock_tool_collector).to receive(:did_launch_action).with("tool_name").and_call_original
+      expect(mock_tool_collector).to receive(:did_finish).and_call_original
+
+      CommandsGenerator.new.run
+    end
+
+    it "calls the tool collector lifecycle methods for a failed run" do
+      expect(mock_tool_collector).to receive(:did_launch_action).with("tool_name").and_call_original
+      expect(mock_tool_collector).to receive(:did_raise_error).with("tool_name").and_call_original
+
+      expect do
+        CommandsGenerator.new(raise_error: true).run
+      end.to raise_error(StandardError)
+    end
+  end
+
   describe '#handle_unknown_error' do
     class CustomError < StandardError
       def preferred_error_info

--- a/fastlane_core/spec/tool_collector_spec.rb
+++ b/fastlane_core/spec/tool_collector_spec.rb
@@ -1,0 +1,39 @@
+describe FastlaneCore::ToolCollector do
+  before(:all) { ENV.delete("FASTLANE_OPT_OUT_USAGE") }
+
+  let(:collector) { FastlaneCore::ToolCollector.new }
+
+  it "keeps track of what tools get invoked" do
+    collector.did_launch_action(:scan)
+
+    expect(collector.launches[:scan]).to eq(1)
+    expect(collector.launches[:gym]).to eq(0)
+  end
+
+  it "tracks which tool raises an error" do
+    collector.did_raise_error(:scan)
+
+    expect(collector.error).to eq(:scan)
+  end
+
+  it "does not post the collected data if the opt-out ENV var is set" do
+    with_env_values('FASTLANE_OPT_OUT_USAGE' => '1') do
+      collector.did_launch_action(:scan)
+      expect(collector.did_finish).to eq(false)
+    end
+  end
+
+  it "posts the collected data when finished" do
+    collector.did_launch_action(:gym)
+    collector.did_launch_action(:scan)
+    collector.did_raise_error(:scan)
+    url = collector.did_finish
+
+    form = Hash[URI.decode_www_form(url.split("?")[1])]
+    form["steps"] = JSON.parse form["steps"]
+
+    expect(form["steps"]["gym"]).to eq(1)
+    expect(form["steps"]["scan"]).to eq(1)
+    expect(form["error"]).to eq("scan")
+  end
+end


### PR DESCRIPTION
The goal is to improve the success rate for new customers who are trying fastlane for the first time + improve stability for existing fastlane users.

Unlike our `fastlane` actions, right now we don't know anything about the success/failure of tools that are invoked separately from `fastlane`. This will allow us to complete our understanding of fastlane stability so we can know how to best apply our efforts to help customers 😄 
