### PR TITLE
Update the documentation to reflect the changed placement of submit.

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -886,7 +886,7 @@ See how [Artsy](https://github.com/fastlane/examples/blob/master/Artsy/eidolon/F
 ### [Crashlytics Beta](http://try.crashlytics.com/beta/)
 ```ruby
 crashlytics(
-  crashlytics_path: './Crashlytics.framework', # path to your 'Crashlytics.framework'
+  crashlytics_path: './Pods/Crashlytics/', # path to your Crashlytics submit binary.
   api_token: '...',
   build_secret: '...',
   ipa_path: './app.ipa'


### PR DESCRIPTION
At least when using cocopods the submit binary has moved from Crashlytics.framework into the root. Since the action is using the submit binary and not the framework, I think it is better to refer to this in the documentation instead of the framework.

Issue: https://github.com/fastlane/fastlane/issues/4475
