### PR TITLE
Bump minimagick to latest version

### DIFF
--- a/frameit/frameit.gemspec
+++ b/frameit/frameit.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'fastlane_core', '>= 0.36.1', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'fastimage', '~> 1.6.3' # fetch the image sizes from the screenshots
-  spec.add_dependency 'mini_magick', '~> 4.2' # To open, edit and export PSD files
+  spec.add_dependency 'mini_magick', '~> 4.5.1' # To open, edit and export PSD files
   spec.add_dependency 'deliver', '> 0.3' # To determine the device type based on a screenshot file
 
   # Development only


### PR DESCRIPTION
Following up to https://github.com/fastlane/fastlane/pull/4480 this bumps `mini_magick` to the latest version.  I also got crashes with `4.2`
