### PR TITLE
Use relocated ToolCollector as the basis for ActionCollector

### DIFF
--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.3' # Support for URI templates
   spec.add_dependency 'multipart-post', '~> 2.0.0' # Needed for uploading builds to appetize
 
-  spec.add_dependency 'fastlane_core', '>= 0.43.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.43.1', '< 1.0.0' # all shared code and dependencies
 
   spec.add_dependency 'credentials_manager', '>= 0.16.0', '< 1.0.0' # Password Manager
   spec.add_dependency 'spaceship', '>= 0.26.2', '< 1.0.0' # communication layer with Apple's web services

--- a/fastlane/lib/fastlane.rb
+++ b/fastlane/lib/fastlane.rb
@@ -1,3 +1,5 @@
+require 'fastlane_core'
+
 require 'fastlane/core_ext/string' # this has to be above most of the other requires
 require 'fastlane/version'
 require 'fastlane/actions/actions_helper' # has to be before fast_file
@@ -14,8 +16,6 @@ require 'fastlane/supported_platforms'
 require 'fastlane/configuration_helper'
 require 'fastlane/command_line_handler'
 require 'fastlane/documentation/docs_generator'
-
-require 'fastlane_core'
 
 module Fastlane
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore

--- a/fastlane/lib/fastlane/action_collector.rb
+++ b/fastlane/lib/fastlane/action_collector.rb
@@ -1,68 +1,17 @@
 module Fastlane
-  class ActionCollector
-    HOST_URL = "https://fastlane-enhancer.herokuapp.com/"
-
-    def did_launch_action(name)
-      if is_official?(name)
-        launches[name] ||= 0
-        launches[name] += 1
-      end
-    end
-
-    def did_raise_error(name)
-      if is_official?(name)
-        @error = name
-      end
-    end
-
-    # Sends the used actions
-    # Example data => [:xcode_select, :deliver, :notify, :slack]
-    def did_finish
-      return if ENV["FASTLANE_OPT_OUT_USAGE"]
-      if !did_show_message? and !Helper.is_ci?
-        UI.message("Sending Crash/Success information. More information on: https://github.com/fastlane/enhancer")
-        UI.message("No personal/sensitive data is sent. Only sharing the following:")
-        UI.message(launches)
-        UI.message(@error) if @error
-        UI.message("This information is used to fix failing actions and improve integrations that are often used.")
-        UI.message("You can disable this by adding `opt_out_usage` to your Fastfile")
-      end
-
-      require 'excon'
-      url = HOST_URL + '/did_launch?'
-      url += URI.encode_www_form(
-        steps: launches.to_json,
-        error: @error
-      )
-
-      unless Helper.is_test? # don't send test data
-        fork do
-          begin
-            Excon.post(url)
-          rescue
-            # we don't want to show a stack trace if something goes wrong
-          end
-        end
-      end
-    rescue
-      # We don't care about connection errors
-    end
-
-    def launches
-      @launches ||= {}
-    end
-
+  class ActionCollector < FastlaneCore::ToolCollector
     def is_official?(name)
       return true if name == :lane_switch
       Actions.get_all_official_actions.include? name
     end
 
-    def did_show_message?
-      path = File.join(File.expand_path('~'), '.did_show_opt_info')
-
-      did_show = File.exist? path
-      File.write(path, '1')
-      did_show
+    def show_message
+      UI.message("Sending Crash/Success information. More information on: https://github.com/fastlane/enhancer")
+      UI.message("No personal/sensitive data is sent. Only sharing the following:")
+      UI.message(launches)
+      UI.message(@error) if @error
+      UI.message("This information is used to fix failing actions and improve integrations that are often used.")
+      UI.message("You can disable this by adding `opt_out_usage` to your Fastfile")
     end
   end
 end

--- a/fastlane/spec/spec_helper.rb
+++ b/fastlane/spec/spec_helper.rb
@@ -8,7 +8,7 @@ end
 require 'shellwords'
 
 require 'fastlane'
-require 'fastlane_core'
+
 require 'webmock/rspec'
 
 UI = FastlaneCore::UI


### PR DESCRIPTION
This depends on changes from #4473 
- Move `require` of `fastlane_core` to be first in `fastlane.rb` so that it is possible to reference in later local code
- Remove `require` of `fastlane_core` from `spec_helper` because it is redundant
