### PR TITLE
Adds Android tools to fastlane tools banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Usually you'll use fastlane by triggering individual lanes:
 
 Additionally to the `fastlane` commands, you now have access to these `fastlane` tools:
 
-- [`deliver`](https://github.com/fastlane/fastlane/tree/master/deliver): Upload screenshots, metadata, and your app to the App Store
+- [`deliver`](https://github.com/fastlane/fastlane/tree/master/deliver): Upload screenshots, metadata and your app to Google Play
 - [`supply`](https://github.com/fastlane/fastlane/tree/master/supply): Command line tool for updating Android apps and their metadata on the Google Play Store
 - [`snapshot`](https://github.com/fastlane/fastlane/tree/master/snapshot): Automate taking localized screenshots of your iOS app on every device
 - [`screengrab`](https://github.com/fastlane/fastlane/tree/master/screengrab): Automated localized screenshots of your Android app on every device

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Usually you'll use fastlane by triggering individual lanes:
 Additionally to the `fastlane` commands, you now have access to these `fastlane` tools:
 
 - [`deliver`](https://github.com/fastlane/fastlane/tree/master/deliver): Upload screenshots, metadata, and your app to the App Store
+- [`supply`](https://github.com/fastlane/fastlane/tree/master/supply): Command line tool for updating Android apps and their metadata on the Google Play Store
 - [`snapshot`](https://github.com/fastlane/fastlane/tree/master/snapshot): Automate taking localized screenshots of your iOS app on every device
+- [`screengrab`](https://github.com/fastlane/fastlane/tree/master/screengrab): Automated localized screenshots of your Android app on every device
 - [`frameit`](https://github.com/fastlane/fastlane/tree/master/frameit): Quickly put your screenshots into the right device frames
 - [`pem`](https://github.com/fastlane/fastlane/tree/master/pem): Automatically generate and renew your push notification profiles
 - [`sigh`](https://github.com/fastlane/fastlane/tree/master/sigh): Because you would rather spend your time building stuff than fighting provisioning

--- a/cert/README.md
+++ b/cert/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/deliver/README.md
+++ b/deliver/README.md
@@ -10,7 +10,6 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/deliver/README.md
+++ b/deliver/README.md
@@ -7,7 +7,10 @@
 </h3>
 <p align="center">
   <b>deliver</b> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -3,7 +3,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/fastlane_core/README.md
+++ b/fastlane_core/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/frameit/README.md
+++ b/frameit/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <b>frameit</b> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/gym/README.md
+++ b/gym/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/match/README.md
+++ b/match/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/pem/README.md
+++ b/pem/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <b>pem</b> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/pilot/README.md
+++ b/pilot/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/produce/README.md
+++ b/produce/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/scan/README.md
+++ b/scan/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/screengrab/README.md
+++ b/screengrab/README.md
@@ -7,6 +7,8 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
   <b>screengrab</b> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;

--- a/sigh/README.md
+++ b/sigh/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <b>sigh</b> &bull;

--- a/snapshot/README.md
+++ b/snapshot/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <b>snapshot</b> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/supply/README.md
+++ b/supply/README.md
@@ -36,7 +36,7 @@ supply
 [![Gem](https://img.shields.io/gem/v/supply.svg?style=flat)](http://rubygems.org/gems/supply)
 [![Build Status](https://img.shields.io/circleci/project/fastlane/fastlane/master.svg?style=flat)](https://circleci.com/gh/fastlane/fastlane)
 
-###### Command line tool for updating Android apps and their metadata on the Google Play Store
+###### Upload screenshots, metadata and your app to Google Play
 
 Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.com/FastlaneTools)
 

--- a/supply/README.md
+++ b/supply/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;

--- a/watchbuild/README.md
+++ b/watchbuild/README.md
@@ -7,7 +7,9 @@
 </h3>
 <p align="center">
   <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/supply">supply</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
+  <a href="https://github.com/fastlane/fastlane/tree/master/screengrab">screengrab</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;


### PR DESCRIPTION
Builds on top of two different Issues:
1. https://github.com/fastlane/fastlane/issues/4477
2. https://github.com/fastlane/fastlane/issues/4495

The addition to the "banner" causes wrapping which Github's Markdown previewer does not depict. 
![image](https://cloud.githubusercontent.com/assets/446889/15002983/e1d69ae4-115b-11e6-87ef-cee51acf792f.png)
