### PR TITLE
Removed * from fastlane docs for required parameters

### DIFF
--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -98,14 +98,6 @@ module Fastlane
           headings: ['Key', 'Description', 'Env Var', 'Default'],
           rows: options
         )
-        required_count = action.available_options.count do |o|
-          o.kind_of?(FastlaneCore::ConfigItem) && o.optional == false
-        end
-
-        if required_count > 0
-          puts "#{required_count} of the available parameters are required".magenta
-          puts "They are marked with an asterisk *".magenta
-        end
       else
         puts "No available options".yellow
       end
@@ -163,8 +155,7 @@ module Fastlane
       if options.kind_of? Array
         options.each do |current|
           if current.kind_of? FastlaneCore::ConfigItem
-            key_name = (current.optional ? "  " : "* ") + current.key.to_s
-            rows << [key_name.yellow, current.description, current.env_name, current.default_value]
+            rows << [current.key.to_s.yellow, current.description, current.env_name, current.default_value]
           elsif current.kind_of? Array
             # Legacy actions that don't use the new config manager
             UI.user_error!("Invalid number of elements in this row: #{current}. Must be 2 or 3") unless [2, 3].include? current.count


### PR DESCRIPTION
This led to confusion, in particular when a default value is set anyway

<img width="1060" alt="screenshot 2016-05-03 22 01 59" src="https://cloud.githubusercontent.com/assets/869950/15011458/324dcfd8-11f2-11e6-8aa4-da3e4422d2f7.png">

via @irace
