### PR TITLE
[match] Add note about the adhoc type during "match nuke"

### DIFF
--- a/match/bin/match
+++ b/match/bin/match
@@ -97,7 +97,7 @@ class MatchApplication
       c.syntax = "match nuke"
       c.description = "Delete all certificates and provisioning profiles from the Apple Dev Portal"
       c.action do |args, options|
-        FastlaneCore::UI.user_error!("Please run `match nuke [type], allowed values: distribution and development")
+        FastlaneCore::UI.user_error!("Please run `match nuke [type], allowed values: distribution and development. For the 'adhoc' type, please use 'distribution' instead.")
       end
     end
 


### PR DESCRIPTION
This references #4186 and adds a bit more explanatory detail around using the `adhoc` type during `match nuke`.
