### PR TITLE
Introducing sub-tools

### DIFF
--- a/fastlane/bin/fastlane
+++ b/fastlane/bin/fastlane
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 $LOAD_PATH.push File.expand_path("../../lib", __FILE__)
 
-require "fastlane"
-require "fastlane/commands_generator"
-Fastlane::CommandsGenerator.start
+require "fastlane/cli_tools_distributor"
+Fastlane::CLIToolsDistributor.take_off

--- a/fastlane/bin/🚀
+++ b/fastlane/bin/🚀
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 $LOAD_PATH.push File.expand_path("../../lib", __FILE__)
 
-require "fastlane"
-require "fastlane/commands_generator"
-Fastlane::CommandsGenerator.start
+require "fastlane/cli_tools_distributor"
+Fastlane::CLIToolsDistributor.take_off

--- a/fastlane/lib/fastlane.rb
+++ b/fastlane/lib/fastlane.rb
@@ -23,11 +23,13 @@ module Fastlane
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
 
-  Fastlane::Actions.load_default_actions
-  Fastlane::Actions.load_helpers
+  def self.load_actions
+    Fastlane::Actions.load_default_actions
+    Fastlane::Actions.load_helpers
 
-  if Fastlane::FastlaneFolder.path
-    actions_path = File.join(Fastlane::FastlaneFolder.path, 'actions')
-    Fastlane::Actions.load_external_actions(actions_path) if File.directory?(actions_path)
+    if Fastlane::FastlaneFolder.path
+      actions_path = File.join(Fastlane::FastlaneFolder.path, 'actions')
+      Fastlane::Actions.load_external_actions(actions_path) if File.directory?(actions_path)
+    end
   end
 end

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -1,0 +1,52 @@
+module Fastlane
+  # This class is responsible for checking the ARGV
+  # to see if the user wants to launch another fastlane
+  # tool or fastlane itself
+  class CLIToolsDistributor
+    class << self
+      def take_off
+        require "fastlane"
+
+        # Array of symbols for the names of the available lanes
+        # This doesn't actually use the Fastfile parser, but only
+        # the available lanes. This way it's much faster, which
+        # is very important in this case, since it will be executed
+        # every time one of the tools is launched
+        available_lanes = Fastlane::FastlaneFolder.available_lanes
+
+        tool_name = ARGV.first
+        if tool_name && Fastlane::TOOLS.include?(tool_name.to_sym) && !available_lanes.include?(tool_name.to_sym)
+          # Triggering a specific tool
+          # This happens when the users uses things like
+          #
+          #   fastlane sigh
+          #   fastlane snapshot
+          #
+          require tool_name
+          begin
+            # First, remove the tool's name from the arguments
+            # Since it will be parsed by the `commander` at a later point
+            # and it must not contain the binary name
+            ARGV.shift
+
+            # Import the CommandsGenerator class, which is used to parse
+            # the user input
+            require File.join(tool_name, "commands_generator")
+
+            # Call the tool's CommandsGenerator class and let it do its thing
+            Object.const_get(tool_name.fastlane_class)::CommandsGenerator.start
+          rescue LoadError
+            # This will only happen if the tool we call here, doesn't provide
+            # a CommandsGenerator class yet
+            # When we launch this feature, this should never be the case
+            abort("#{tool_name} can't be called via `fastlane #{tool_name}`, run '#{tool_name}' directly instead".red)
+          end
+        else
+          # Triggering fastlane to call a lane
+          require "fastlane/commands_generator"
+          Fastlane::CommandsGenerator.start
+        end
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -9,6 +9,7 @@ module Fastlane
 
     def self.start
       FastlaneCore::UpdateChecker.start_looking_for_update('fastlane')
+      Fastlane.load_actions
       self.new.run
     ensure
       FastlaneCore::UpdateChecker.show_update_status('fastlane', Fastlane::VERSION)

--- a/fastlane/lib/fastlane/fastlane_folder.rb
+++ b/fastlane/lib/fastlane/fastlane_folder.rb
@@ -13,16 +13,31 @@ module Fastlane
       return value
     end
 
+    def self.fastfile_path
+      return nil if path.nil?
+      File.join(path, "Fastfile")
+    end
+
     # Does a fastlane configuration already exist?
     def self.setup?
       return false unless path
-      File.exist?(File.join(path, "Fastfile"))
+      File.exist?(self.fastfile_path)
     end
 
     def self.create_folder!(path = nil)
       path = File.join(path || '.', FOLDER_NAME)
       FileUtils.mkdir_p(path)
       UI.success "Created new folder '#{path}'."
+    end
+
+    # Returns an array of symbols for the available lanes for the Fastfile
+    # This doesn't actually use the Fastfile parser, but only
+    # the available lanes. This way it's much faster
+    # Use this only if performance is :key:
+    def self.available_lanes
+      return [] if fastfile_path.nil?
+      output = Helper.backticks("cat #{fastfile_path.shellescape} | grep \"^\s*lane \:\" | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}'")
+      return output.strip.split(" ").collect(&:to_sym)
     end
   end
 end

--- a/fastlane/spec/cli_tools_distributor_spec.rb
+++ b/fastlane/spec/cli_tools_distributor_spec.rb
@@ -1,0 +1,19 @@
+require 'fastlane/cli_tools_distributor'
+
+describe Fastlane::CLIToolsDistributor do
+  it "runs the lane instead of the tool when there is a conflict" do
+    require 'fastlane/commands_generator'
+    ARGV = ["sigh"]
+    expect(Fastlane::FastlaneFolder).to receive(:fastfile_path).and_return("./spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
+    expect(Fastlane::CommandsGenerator).to receive(:start).and_return(nil)
+    Fastlane::CLIToolsDistributor.take_off
+  end
+
+  it "runs a separate tool when the tool is available and the name is not used in a lane" do
+    ARGV = ["gym"]
+    require 'gym/commands_generator'
+    expect(Fastlane::FastlaneFolder).to receive(:fastfile_path).and_return("./spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
+    expect(Gym::CommandsGenerator).to receive(:start).and_return(nil)
+    Fastlane::CLIToolsDistributor.take_off
+  end
+end

--- a/fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane
+++ b/fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane
@@ -1,0 +1,3 @@
+lane :sigh do
+  rocket
+end

--- a/fastlane/spec/spec_helper.rb
+++ b/fastlane/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require 'fastlane'
 
 require 'webmock/rspec'
 
+Fastlane.load_actions
 UI = FastlaneCore::UI
 
 # This module is only used to check the environment is currently a testing env


### PR DESCRIPTION
You can now also call tools using 

```
fastlane sigh
fastlane snapshot --scheme "something"
fastlane gym --help
```
### Changes in this PR
- Support for running tools via the fastlane executable
- Introduced a warning when a lane has the same name as a fastlane tool
- Added technique to not run a sub-tool when a lane has the name of a tool
- Added tests
