### PR TITLE
Typo in all_builds_for_train ?

### DIFF
--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -211,7 +211,7 @@ module Spaceship
       # useful if the app is not listed in the TestFlight build list
       # which might happen if you don't use TestFlight
       # This is used to receive dSYM files from Apple
-      def all_builds_for_train(train: nil)
+      def all_builds_for_train(train= nil)
         client.all_builds_for_train(app_id: self.apple_id, train: train).fetch("items", []).collect do |attrs|
           attrs[:apple_id] = self.apple_id
           Tunes::Build.factory(attrs)


### PR DESCRIPTION
it originally had `train: nil` , this resulted in unable to call the function , replacing it with `train=nil` made it work.

`/gems/spaceship-0.26.2/lib/spaceship/tunes/application.rb:214:in`all_builds_for_train': wrong number of arguments (1 for 0) (ArgumentError)`

Unless there is some syntactic sugar I'm missing?
