### PR TITLE
Improve Crashlytics Action Logging

### DIFF
--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -66,8 +66,8 @@ module Fastlane
     end
 
     # to allow a simple `sh` in the custom actions
-    def self.sh(command, print_command: true, print_command_output: true)
-      Fastlane::Actions.sh_control_output(command, print_command: print_command, print_command_output: print_command_output)
+    def self.sh(command, print_command: true, print_command_output: true, error_callback: nil)
+      Fastlane::Actions.sh_control_output(command, print_command: print_command, print_command_output: print_command_output, error_callback: error_callback)
     end
 
     # instead of "AddGitAction", this will return "add_git" to print it to the user

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -4,16 +4,21 @@ module Fastlane
     # This method will output the string and execute it
     # Just an alias for sh_no_action
     # When running this in tests, it will return the actual command instead of executing it
-    # @param log [boolean] should fastlane print out the executed command
-    def self.sh(command, log: true)
-      sh_control_output(command, print_command: log, print_command_output: log)
+    # @param log [Boolean] should fastlane print out the executed command
+    # @param error_callback [Block] a callback invoked with the command ouptut if there is a non-zero exit status
+    def self.sh(command, log: true, error_callback: nil)
+      sh_control_output(command, print_command: log, print_command_output: log, error_callback: error_callback)
     end
 
-    def self.sh_no_action(command, log: true)
-      sh_control_output(command, print_command: log, print_command_output: log)
+    def self.sh_no_action(command, log: true, error_callback: nil)
+      sh_control_output(command, print_command: log, print_command_output: log, error_callback: error_callback)
     end
 
-    def self.sh_control_output(command, print_command: true, print_command_output: true)
+    # @param command [String] The command to be executed
+    # @param print_command [Boolean] Should we print the command that's being executed
+    # @param print_command_output [Boolean] Should we print the command output during execution
+    # @param error_callback [Block] A block that's called if the command exits with a non-zero status
+    def self.sh_control_output(command, print_command: true, print_command_output: true, error_callback: nil)
       # Set the encoding first, the user might have set it wrong
       previous_encoding = [Encoding.default_external, Encoding.default_internal]
       Encoding.default_external = Encoding::UTF_8
@@ -44,6 +49,8 @@ module Fastlane
                       "Shell command exited with exit status #{exit_status} instead of 0."
                     end
           message += "\n#{result}" if print_command_output
+
+          error_callback.call(result) if error_callback
           UI.user_error!(message)
         end
       end

--- a/fastlane/spec/actions_specs/gradle_spec.rb
+++ b/fastlane/spec/actions_specs/gradle_spec.rb
@@ -5,7 +5,7 @@ describe Fastlane do
         let(:expected_command) { "#{File.expand_path('README.md')} tasks -p ." }
 
         it "prints the command and the command's output by default" do
-          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: true, print_command_output: true).and_call_original
+          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: true, print_command_output: true, error_callback: nil).and_call_original
 
           Fastlane::FastFile.new.parse("lane :build do
             gradle(
@@ -16,7 +16,7 @@ describe Fastlane do
         end
 
         it "suppresses the command text and prints the command's output" do
-          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: true).and_call_original
+          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: true, error_callback: nil).and_call_original
 
           Fastlane::FastFile.new.parse("lane :build do
             gradle(
@@ -28,7 +28,7 @@ describe Fastlane do
         end
 
         it "prints the command text and suppresses the command's output" do
-          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: true, print_command_output: false).and_call_original
+          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: true, print_command_output: false, error_callback: nil).and_call_original
 
           Fastlane::FastFile.new.parse("lane :build do
             gradle(
@@ -40,7 +40,7 @@ describe Fastlane do
         end
 
         it "suppresses the command text and suppresses the command's output" do
-          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: false).and_call_original
+          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: false, error_callback: nil).and_call_original
 
           Fastlane::FastFile.new.parse("lane :build do
             gradle(

--- a/fastlane/spec/spec_helper.rb
+++ b/fastlane/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'coveralls'
+
 Coveralls.wear! unless ENV["FASTLANE_SKIP_UPDATE_CHECK"]
 
 unless ENV["DEBUG"]
@@ -33,4 +34,12 @@ RSpec.configure do |config|
     md_path = "spec/fixtures/fastfiles/README.md"
     File.delete(md_path) if File.exist?(md_path)
   end
+end
+
+def with_verbose(verbose)
+  orig_verbose = $verbose
+  $verbose = verbose
+  yield if block_given?
+ensure
+  $verbose = orig_verbose
 end


### PR DESCRIPTION
Also hides the build secret when errors occur.

Before:
![image](https://cloud.githubusercontent.com/assets/665326/15052366/59994200-12cb-11e6-88a5-0cd7c45ffdb1.png)

After:
![image](https://cloud.githubusercontent.com/assets/665326/15052406/883df272-12cb-11e6-869f-1fcadeda2c37.png)
