### PR TITLE
[fastlane] Version bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.85.0'.freeze
+  VERSION = '1.86.0'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end


### PR DESCRIPTION
- Introducing sub-tools, you can now run `fastlane gym` to run `gym`
- Added new Nexus upload classifier parameter
- Fix HttpForbidden and SSL connection problems on Appaloosa action
- Make it easier to call another action from an action, you can now use `other_action.rocket` :rocket:
- Added new `set_pod_key` action
- Improved default `crashlytics_path`
- Added `use_libraries` option to `pod_push` action
- Added new Apteligent
- Make it possible to use `.slather.yml` on `slather` action
- Added new `Fastlane::TOOLS` constant
- Improved Crashlytics logging
