### PR TITLE
Explicitly open the simulator before the test run

### DIFF
--- a/snapshot/lib/snapshot.rb
+++ b/snapshot/lib/snapshot.rb
@@ -38,7 +38,8 @@ module Snapshot
     end
 
     def kill_simulator
-      `killall iOS Simulator &> /dev/null`
+      `killall 'iOS Simulator' &> /dev/null`
+      `killall Simulator &> /dev/null`
     end
   end
 

--- a/snapshot/lib/snapshot/fixes/hardware_keyboard_fix.rb
+++ b/snapshot/lib/snapshot/fixes/hardware_keyboard_fix.rb
@@ -5,8 +5,6 @@ module Snapshot
 
     class HardwareKeyboardFix
       def self.patch
-        Snapshot.kill_simulator # First we need to kill the simulator
-
         UI.verbose "Patching simulator to work with secure text fields"
 
         Helper.backticks("defaults write com.apple.iphonesimulator ConnectHardwareKeyboard 0", print: $verbose)

--- a/snapshot/lib/snapshot/fixes/simulator_zoom_fix.rb
+++ b/snapshot/lib/snapshot/fixes/simulator_zoom_fix.rb
@@ -7,8 +7,6 @@ module Snapshot
 
     class SimulatorZoomFix
       def self.patch
-        Snapshot.kill_simulator # First we need to kill the simulator
-
         UI.message "Patching '#{config_path}' to scale simulator to 100%"
 
         FastlaneCore::Simulator.all.each do |simulator|


### PR DESCRIPTION
Work towards addressing https://github.com/fastlane/fastlane/issues/3921

This feature-switched workaround seems to address problems where the Simulator gets stuck on a black screen when booting
