### PR TITLE
Log crashlytics output

### DIFF
--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -29,7 +29,7 @@ module Fastlane
 
         UI.success('Uploading the build to Crashlytics Beta. Time for some ☕️.')
         UI.verbose(command.join(" ")) if $verbose
-        Actions.sh(command.join(" "), log: false)
+        Actions.sh(command.join(" "), log: true)
 
         return command if Helper.test?
 


### PR DESCRIPTION
When the Crashlytics action fails, it does not print sufficient error information to the console. This makes it difficult for users to diagnose their issues, as it just prints this unhelpful message:
`Shell command exited with exit status 1 instead of 0.`
This manifests in the following issues:
https://github.com/fastlane/fastlane/issues/4407
https://github.com/fastlane/fastlane/issues/4222

When the crashlytics output is shown in the console, it often becomes obvious what's going wrong. This PR specifies `log: true` when the Crashlytics submit command is executed so that helpful error information is printed.

With this change, here is some example failure output when I specify a group that doesn't exist:

```
[14:59:10]: fastlane finished with errors

[!] Exit status of command './Pods/Crashlytics/iOS/Crashlytics.framework/submit <redacted> <redacted> -ipaPath <redacted> -groupAliases 'this-group-does-not-exist' -notifications
 NO -debug NO' was 1 instead of 0.
2016-05-05 14:58:56.162 submit Crashlytics: Crashlytics.framework/submit 1.3.5 (17)
2016-05-05 14:59:10.652 submit Crashlytics: Unable to add testers: Could not find a group for one or more of: ["this-group-does-not-exist"]
2016-05-05 14:59:10.652 submit Crashlytics: Failed to add testers/groups to the release
```
