### PR TITLE
[fastlane] Use backticks instead of Helper.backticks

### DIFF
--- a/fastlane/lib/fastlane/fastlane_folder.rb
+++ b/fastlane/lib/fastlane/fastlane_folder.rb
@@ -36,7 +36,7 @@ module Fastlane
     # Use this only if performance is :key:
     def self.available_lanes
       return [] if fastfile_path.nil?
-      output = Helper.backticks("cat #{fastfile_path.shellescape} | grep \"^\s*lane \:\" | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}'")
+      output = `cat #{fastfile_path.shellescape} | grep \"^\s*lane \:\" | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}'`
       return output.strip.split(" ").collect(&:to_sym)
     end
   end


### PR DESCRIPTION
When using Helper.backticks by default the executed command and the output is printed out. Since `available_lanes` is called every time you run fastlane, it's super confusing for the user when we print out this every time you run fastlane:

```
[00:44:05]: $ cat ./fastlane/Fastfile | grep "^ *lane :" | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}'
[00:44:05]: ▸ bump
[00:44:05]: ▸ show_changelog
[00:44:05]: ▸ release
```
