### PR TITLE
Version bump

### DIFF
--- a/snapshot/lib/snapshot/version.rb
+++ b/snapshot/lib/snapshot/version.rb
@@ -1,4 +1,4 @@
 module Snapshot
-  VERSION = "1.12.1".freeze
+  VERSION = "1.12.2".freeze
   DESCRIPTION = "Automate taking localized screenshots of your iOS app on every device"
 end


### PR DESCRIPTION
Changes since release 1.12.1:
- Explicitly open the simulator before the test run
- Updated fastlane description in docs of other fastlane docs
- Removed rake test command for all tools
- Fixed markdown for example output
- Fixes #1634 - Device Locale Not Changed to Match Language
- Update SnapshotHelper.swift
- Replace Helper.log with UI.\* calls
- Updated `raise` calls to `UI.user_error!` or `UI.crash!`
