### PR TITLE
[fastlane] Improved GitHub releases

### DIFF
--- a/fastlane/fastlane/Fastfile
+++ b/fastlane/fastlane/Fastfile
@@ -155,7 +155,11 @@ end
 
 desc "e.g. fastlane/deliver"
 private_lane :github_url do |options|
-  ["fastlane", options[:tool]].join("/")
+  if options[:tool] == "fastlane"
+    "fastlane/fastlane"
+  else
+    File.join("fastlane-old", options[:tool])
+  end
 end
 
 desc "Get the version number of the last release"

--- a/fastlane/lib/fastlane/actions/get_github_release.rb
+++ b/fastlane/lib/fastlane/actions/get_github_release.rb
@@ -10,6 +10,9 @@ module Fastlane
         require 'excon'
         require 'base64'
 
+        # To still get the data when a repo has been moved
+        Excon.defaults[:middlewares] << Excon::Middleware::RedirectFollower
+
         server_url = params[:server_url]
         server_url = server_url[0..-2] if server_url.end_with? '/'
 


### PR DESCRIPTION
2 commits

1) auto follow when receiving a GitHub release
2) use of different org names for different tools when deploying fastlane
