### PR TITLE
[fastlane_core] Updated changelog loader to follow redirects

### DIFF
--- a/fastlane_core/lib/fastlane_core/update_checker/changelog.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/changelog.rb
@@ -21,6 +21,11 @@ module FastlaneCore
       end
 
       def releases(gem_name)
+        # We have to follow redirects, since some repos were moved
+        # away into a separate org
+        # Taken from https://github.com/excon/excon/issues/115#issuecomment-40647211
+        Excon.defaults[:middlewares] << Excon::Middleware::RedirectFollower
+
         url = "https://api.github.com/repos/fastlane/#{gem_name}/releases"
         JSON.parse(Excon.get(url).body)
       end


### PR DESCRIPTION
After moving the repos to `fastlane-old`
