### PR TITLE
Added "--track_promote_to" option for promoting APK between tracks.  …

### DIFF
--- a/supply/README.md
+++ b/supply/README.md
@@ -173,7 +173,7 @@ You can add changelog files under the `changelogs/` directory for each locale. T
 
 A common Play publishing scenario might involve uploading an APK version to a test track, testing it, and finally promoting that version to production. 
 
-This can be done using the "--track_promote_to=" parameter.  The "--track_promote_to=" parameter works with the "--track=" parameter to command the Play API to promote existing Play track APK version(s) (those active on the track identified by the "--track=" param value) to a new track ("--track_promote_to=" value).
+This can be done using the `--track_promote_to` parameter.  The `--track_promote_to` parameter works with the `--track` parameter to command the Play API to promote existing Play track APK version(s) (those active on the track identified by the `--track` param value) to a new track (`--track_promote_to` value).
 
 ## Tips
 

--- a/supply/README.md
+++ b/supply/README.md
@@ -169,6 +169,12 @@ You can add changelog files under the `changelogs/` directory for each locale. T
                     └── 100100.txt
 ```
 
+## Track Promotion
+
+A common Play publishing scenario might involve uploading an APK version to a test track, testing it, and finally promoting that version to production. 
+
+This can be done using the "--track_promote_to=" parameter.  The "--track_promote_to=" parameter works with the "--track=" parameter to command the Play API to promote existing Play track APK version(s) (those active on the track identified by the "--track=" param value) to a new track ("--track_promote_to=" value).
+
 ## Tips
 
 ### [`fastlane`](https://fastlane.tools) Toolchain

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -215,7 +215,7 @@ module Supply
     # Get list of version codes for track
     def track_version_codes(track)
       ensure_active_edit!
-      
+
       result = android_publisher.get_track(
         current_package_name,
         current_edit.id,

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -212,6 +212,18 @@ module Supply
         track_body)
     end
 
+    # Get list of version codes for track
+    def track_version_codes(track)
+      ensure_active_edit!
+      
+      result = android_publisher.get_track(
+        current_package_name,
+        current_edit.id,
+        track)
+
+      return result.version_codes
+    end
+
     def update_apk_listing_for_language(apk_listing)
       ensure_active_edit!
 

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -111,7 +111,16 @@ module Supply
                                      optional: true,
                                      description: "Whether to skip uploading SCREENSHOTS",
                                      is_string: false,
-                                     default_value: false)
+                                     default_value: false),
+        FastlaneCore::ConfigItem.new(key: :track_promote_to,
+                                     env_name: "SUPPLY_TRACK_PROMOTE_TO",
+                                     optional: true,
+                                     description: "The Track to promote to: production, beta, alpha or rollout",
+                                     verify_block: proc do |value|
+                                       available = %w(production beta alpha rollout)
+                                       raise "Invalid value '#{value}', must be #{available.join(', ')}".red unless available.include? value
+                                     end)
+
       ]
     end
   end

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -4,6 +4,7 @@ require 'credentials_manager'
 module Supply
   class Options
     def self.available_options
+      valid_tracks = %w(production beta alpha rollout)
       @options ||= [
         FastlaneCore::ConfigItem.new(key: :package_name,
                                      env_name: "SUPPLY_PACKAGE_NAME",
@@ -13,10 +14,10 @@ module Supply
         FastlaneCore::ConfigItem.new(key: :track,
                                      short_option: "-a",
                                      env_name: "SUPPLY_TRACK",
-                                     description: "The Track to upload the Application to: production, beta, alpha or rollout",
+                                     description: "The Track to upload the Application to: #{valid_tracks.join(', ')}",
                                      default_value: 'production',
                                      verify_block: proc do |value|
-                                       available = %w(production beta alpha rollout)
+                                       available = valid_tracks
                                        UI.user_error! "Invalid value '#{value}', must be #{available.join(', ')}" unless available.include? value
                                      end),
         FastlaneCore::ConfigItem.new(key: :rollout,
@@ -115,10 +116,10 @@ module Supply
         FastlaneCore::ConfigItem.new(key: :track_promote_to,
                                      env_name: "SUPPLY_TRACK_PROMOTE_TO",
                                      optional: true,
-                                     description: "The Track to promote to: production, beta, alpha or rollout",
+                                     description: "The Track to promote to: #{valid_tracks.join(', ')}",
                                      verify_block: proc do |value|
-                                       available = %w(production beta alpha rollout)
-                                       raise "Invalid value '#{value}', must be #{available.join(', ')}".red unless available.include? value
+                                       available = valid_tracks
+                                       UI.user_error! "Invalid value '#{value}', must be #{available.join(', ')}" unless available.include? value
                                      end)
 
       ]

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -25,9 +25,19 @@ module Supply
 
       upload_binaries unless Supply.config[:skip_upload_apk]
 
+      promote_track if Supply.config[:track_promote_to]
+
       UI.message("Uploading all changes to Google Play...")
       client.commit_current_edit!
       UI.success("Successfully finished the upload to Google Play")
+    end
+
+    def promote_track
+      version_codes = client.track_version_codes(Supply.config[:track])
+      client.update_track(Supply.config[:track], 1.0, nil)
+      version_codes.each do |apk_version_code|
+        client.update_track(Supply.config[:track_promote_to], 1.0, apk_version_code)
+      end
     end
 
     def upload_changelogs(language)


### PR DESCRIPTION
Finally got around to adding track promotion feature to new mono repo.

See issue #4563. 

See https://github.com/fastlane-old/supply/pull/52.
