### PR TITLE
bump version for cat fix

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.86.1'.freeze
+  VERSION = '1.87.0'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end


### PR DESCRIPTION
- Added new Jira action to post comments to Jira
- Improved error handling when `Fastfile` is not available
- Fix `get_version_number` action's support of target using the `-terse1` flag
- Improved appetize docs
- Auto-follow links when receiving a GitHub release
- Updated dependencies
