### PR TITLE
Add experimental work-around for hanging simulators

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -10,6 +10,8 @@ module Scan
     end
 
     def test_app
+      open_simulator_for_device(Scan.device)
+
       command = TestCommandGenerator.generate
       prefix_hash = [
         {
@@ -75,6 +77,16 @@ module Scan
 
       UI.user_error!("Test execution failed. Exit status: #{tests_exit_status}") unless tests_exit_status == 0
       UI.user_error!("Tests failed") unless result[:failures] == 0
+    end
+
+    def open_simulator_for_device(device)
+      return unless ENV['FASTLANE_EXPLICIT_OPEN_SIMULATOR']
+
+      UI.message("Killing all running simulators")
+      `killall Simulator &> /dev/null`
+
+      UI.message("Explicitly opening simulator for device: #{device.name}")
+      `open -a Simulator --args -CurrentDeviceUDID #{device.udid}`
     end
   end
 end


### PR DESCRIPTION
A similar experiment to https://github.com/fastlane/fastlane/pull/4531, trying to provide a work-around for https://github.com/fastlane/fastlane/issues/3921

Provides a feature-switched step before running tests that kills any running simulators and explicitly starts the one we want.
