### PR TITLE
[fastlane_core] Updated changelog loader to follow redirects

### DIFF
--- a/fastlane_core/lib/fastlane_core/update_checker/changelog.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/changelog.rb
@@ -23,7 +23,7 @@ module FastlaneCore
       def releases(gem_name)
         url = "https://api.github.com/repos/fastlane/#{gem_name}/releases"
         # We have to follow redirects, since some repos were moved away into a separate org
-        server_response = Excon.get(url, 
+        server_response = Excon.get(url,
                                     middlewares: Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower])
         JSON.parse(server_response.body)
       end

--- a/fastlane_core/lib/fastlane_core/update_checker/changelog.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/changelog.rb
@@ -22,7 +22,10 @@ module FastlaneCore
 
       def releases(gem_name)
         url = "https://api.github.com/repos/fastlane/#{gem_name}/releases"
-        JSON.parse(Excon.get(url).body)
+        # We have to follow redirects, since some repos were moved away into a separate org
+        server_response = Excon.get(url, 
+                                    middlewares: Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower])
+        JSON.parse(server_response.body)
       end
     end
   end


### PR DESCRIPTION
After moving the repos to `fastlane-old`. Moved from https://github.com/fastlane/fastlane/pull/4560
