### PR TITLE
Allow frameit to receive options as a lane

### DIFF
--- a/fastlane/lib/fastlane/actions/frameit.rb
+++ b/fastlane/lib/fastlane/actions/frameit.rb
@@ -8,15 +8,12 @@ module Fastlane
 
         begin
           FastlaneCore::UpdateChecker.start_looking_for_update('frameit') unless Helper.is_test?
-          color = Frameit::Color::BLACK
-          color = Frameit::Color::SILVER if config[:white] || config[:silver]
 
           UI.message("Framing screenshots at path #{config[:path]}")
 
           Dir.chdir(config[:path]) do
-            ENV["FRAMEIT_FORCE_DEVICE_TYPE"] = config[:force_device_type] if config[:force_device_type]
-            Frameit::Runner.new.run('.', color)
-            ENV.delete("FRAMEIT_FORCE_DEVICE_TYPE") if config[:force_device_type]
+            Frameit.config = config
+            Frameit::Runner.new.run('.')
           end
         ensure
           FastlaneCore::UpdateChecker.show_update_status('frameit', Frameit::VERSION)
@@ -28,30 +25,13 @@ module Fastlane
       end
 
       def self.available_options
-        [
-          FastlaneCore::ConfigItem.new(key: :white,
-                                         env_name: "FRAMEIT_WHITE_FRAME",
-                                         description: "Use white device frames",
-                                         optional: true,
-                                         is_string: false),
-          FastlaneCore::ConfigItem.new(key: :silver,
-                                       description: "Use white device frames. Alias for :white",
-                                       optional: true,
-                                       is_string: false),
+        require "frameit"
+        require "frameit/options"
+        FastlaneCore::CommanderGenerator.new.generate(Frameit::Options.available_options) + [
           FastlaneCore::ConfigItem.new(key: :path,
                                        env_name: "FRAMEIT_SCREENSHOTS_PATH",
                                        description: "The path to the directory containing the screenshots",
-                                       default_value: Actions.lane_context[SharedValues::SNAPSHOT_SCREENSHOTS_PATH] || FastlaneFolder.path),
-          FastlaneCore::ConfigItem.new(key: :force_device_type,
-                                       env_name: "FRAMEIT_FORCE_DEVICE_TYPE",
-                                       description: "Forces a given device type, useful for Mac screenshots, as their sizes vary",
-                                       optional: true,
-                                       verify_block: proc do |value|
-                                         available = ['iPhone_6_Plus', 'iPhone_5s', 'iPhone_4', 'iPad_mini', 'Mac']
-                                         unless available.include? value
-                                           UI.user_error!("Invalid device type '#{value}'. Available values: #{available}")
-                                         end
-                                       end)
+                                        default_value: Actions.lane_context[SharedValues::SNAPSHOT_SCREENSHOTS_PATH] || FastlaneFolder.path)
         ]
       end
 

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -1,7 +1,7 @@
 describe Fastlane do
   describe Fastlane::Action do
     describe "No unused options" do
-      let (:all_exceptions) { %w(pilot appstore cert deliver gym match pem produce scan sigh snapshot supply testflight mailgun testfairy ipa import_from_git hockey deploygate crashlytics artifactory appledoc slather screengrab download_dsyms notification) }
+      let (:all_exceptions) { %w(pilot appstore cert deliver gym match pem produce scan sigh snapshot supply testflight mailgun testfairy ipa import_from_git hockey deploygate crashlytics artifactory appledoc slather screengrab download_dsyms notification frameit) }
 
       Fastlane::ActionsList.all_actions do |action, name|
         next unless action.available_options.kind_of?(Array)

--- a/frameit/bin/frameit
+++ b/frameit/bin/frameit
@@ -21,15 +21,15 @@ class FrameItApplication
     global_option('--verbose') { $verbose = true }
     FastlaneCore::CommanderGenerator.new.generate(Frameit::Options.available_options)
 
-    default_command :black
+    default_command :run
 
-    command :black do |c|
+    command :run do |c|
       c.syntax = 'frameit black'
       c.description = "Adds a black frame around all screenshots."
 
       c.action do |args, options|
         load_config(options)
-        Frameit::Runner.new.run('.', Frameit::Color::BLACK)
+        Frameit::Runner.new.run('.', nil)
       end
     end
 

--- a/frameit/lib/frameit/options.rb
+++ b/frameit/lib/frameit/options.rb
@@ -2,12 +2,32 @@ module Frameit
   class Options
     def self.available_options
       @options ||= [
-        FastlaneCore::ConfigItem.new(key: :use_legacy_iphone5s,
-                                     env_name: "FRAMEIT_USE_LEGACY_IPHONE_5_S",
+
+        FastlaneCore::ConfigItem.new(key: :white,
+                                       env_name: "FRAMEIT_WHITE_FRAME",
+                                       description: "Use white device frames",
+                                       optional: true,
+                                       is_string: false),
+        FastlaneCore::ConfigItem.new(key: :silver,
+                                     description: "Use white device frames. Alias for :white",
                                      optional: true,
-                                     is_string: false,
-                                     description: "use iPhone 5s instead of iPhone SE frames",
-                                     default_value: false)
+                                     is_string: false),
+        FastlaneCore::ConfigItem.new(key: :force_device_type,
+                                     env_name: "FRAMEIT_FORCE_DEVICE_TYPE",
+                                     description: "Forces a given device type, useful for Mac screenshots, as their sizes vary",
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       available = ['iPhone_6_Plus', 'iPhone_5s', 'iPhone_4', 'iPad_mini', 'Mac']
+                                       unless available.include? value
+                                         UI.user_error!("Invalid device type '#{value}'. Available values: #{available}")
+                                       end
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :use_legacy_iphone5s,
+                           env_name: "FRAMEIT_USE_LEGACY_IPHONE_5_S",
+                           optional: true,
+                           is_string: false,
+                           description: "use iPhone 5s instead of iPhone SE frames",
+                           default_value: false)
       ]
     end
   end

--- a/frameit/lib/frameit/runner.rb
+++ b/frameit/lib/frameit/runner.rb
@@ -14,7 +14,12 @@ module Frameit
       end
     end
 
-    def run(path, color = Color::BLACK)
+    def run(path, color = nil)
+      unless color
+        color = Frameit::Color::BLACK
+        color = Frameit::Color::SILVER if Frameit.config[:white] || Frameit.config[:silver]
+      end
+
       screenshots = Dir.glob("#{path}/**/*.{png,PNG}").uniq # uniq because thanks to {png,PNG} there are duplicates
 
       if screenshots.count > 0


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/4553 by sharing command parsing between the `frameit` binary and action.
