### PR TITLE
Check for Settings.bundle/Root.plist was in the wrong place

### DIFF
--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -67,6 +67,10 @@ module Fastlane
         # little user hint
         UI.user_error!("No file changes picked up. Make sure you run the `increment_build_number` action first.") if git_dirty_files.empty?
 
+        if params[:settings]
+          expected_changed_files << 'Settings.bundle/Root.plist'
+        end
+
         # check if the files changed are the ones we expected to change (these should be only the files that have version info in them)
         changed_files_as_expected = (Set.new(git_dirty_files.map(&:downcase)).subset? Set.new(expected_changed_files.map(&:downcase)))
         unless changed_files_as_expected
@@ -81,10 +85,6 @@ module Fastlane
             ].join("\n")
             raise error.red
           end
-        end
-
-        if params[:settings]
-          expected_changed_files << 'Settings.bundle/Root.plist'
         end
 
         # get the absolute paths to the files


### PR DESCRIPTION
When FL_COMMIT_INCLUDE_SETTINGS is used, the exception gets thrown before the setting ever has a chance to be considered.
