### PR TITLE
Version bump and bring in the new frameit

### DIFF
--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   # All the fastlane tools
   spec.add_dependency 'deliver', '>= 1.11.2', '< 2.0.0'
   spec.add_dependency 'snapshot', '>= 1.12.1', '< 2.0.0'
-  spec.add_dependency 'frameit', '>= 2.6.1', '< 3.0.0'
+  spec.add_dependency 'frameit', '>= 2.6.2', '< 3.0.0'
   spec.add_dependency 'pem', '>= 1.3.1', '< 2.0.0'
   spec.add_dependency 'cert', '>= 1.4.1', '< 2.0.0'
   spec.add_dependency 'sigh', '>= 1.8.0', '< 2.0.0'

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.87.0'.freeze
+  VERSION = '1.87.1'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end


### PR DESCRIPTION
- Version bump and bring in the new frameit
- Allow frameit to receive options as a lane
- Updated get_github_release action to pass middleware per request (#4583)
- [fastlane] Updated dependencies (#4573)
- [fastlane] Removed duplicate tool entry (#4578)
- add a description to rake push to make it print when calling --tasks (#4571)
- Make appetize work for android (#4487)
