### PR TITLE
Version bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.87.1'.freeze
+  VERSION = '1.88.0'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end


### PR DESCRIPTION
Changes since release 1.87.1:
- Fixes build_and_upload_to_appetize for custom build locations (#4591)
- Update fastlane side of ActionCollector to support version and crash
- Improved error message for OneOff when action is not available (#4601)
- Added action to update Urban Airship configuration values (#4485)
- [pem] Migrated binary to use commands_generator (#4575)
- Typo (#4598)
