### PR TITLE
add support for rbenv in wrap_xcodebuild/xcbuild-safe.sh

### DIFF
--- a/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
+++ b/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
@@ -41,6 +41,14 @@ if [[ $? -eq 0 ]]; then
   unset BUNDLE_GEMFILE
 fi
 
+if which rbenv > /dev/null; then
+  echo "rbenv detected, removing env variables"
+  unset RUBYLIB
+  unset RUBYOPT
+  unset GEM_HOME
+  unset GEM_PATH
+fi
+
 # to help troubleshooting
 # env | sort > /tmp/env.wrapper
 # rvm info >> /tmp/env.wrapper


### PR DESCRIPTION
Adds support for rbenv in `xcbuild-safe.sh`

This is an alternative to #4456
Implementation differences:
1. Less code changed (not touching the rvm code path)
2. only clear the environment variables without using `rbenv shell system` since `ipatool` points to the system ruby specifically (via `#!/usr/bin/sandbox-exec -n no-network /usr/bin/ruby -v`)

Related issues:
https://github.com/fastlane/fastlane/issues/4458
https://github.com/fastlane/fastlane/issues/4413
https://github.com/fastlane/fastlane/issues/3178
