### PR TITLE
Feature - Adding cocoapods action new version parameter

### DIFF
--- a/lib/fastlane/actions/cocoapods.rb
+++ b/lib/fastlane/actions/cocoapods.rb
@@ -15,7 +15,9 @@ module Fastlane
         end
 
         cmd << ['bundle exec'] if File.exist?('Gemfile') && params[:use_bundle_exec]
-        cmd << ['pod install']
+        cmd << ['pod']
+        cmd << "_#{params[:version]}_" if params[:version]
+        cmd << ['install']
 
         cmd << '--no-clean' unless params[:clean]
         cmd << '--no-integrate' unless params[:integrate]
@@ -68,6 +70,11 @@ module Fastlane
                                        description: "Use bundle exec when there is a Gemfile presented",
                                        is_string: false,
                                        default_value: true),
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       env_name: "FL_COCOAPODS_VERSION",
+                                       description: "Explicitly uses a specific version of cocoapds",
+                                       optional: true,
+                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :podfile,
                                        env_name: "FL_COCOAPODS_PODFILE",
                                        description: "Explicitly specify the path to the Cocoapods' Podfile. You can either set it to the Podfile's path or to the folder containing the Podfile file",

--- a/spec/actions_specs/cocoapods_spec.rb
+++ b/spec/actions_specs/cocoapods_spec.rb
@@ -88,6 +88,16 @@ describe Fastlane do
 
         expect(result).to eq("cd 'Project' && pod install")
       end
+
+      it "changes gem version if a specific one is set" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          cocoapods(
+            version: '0.39.0'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("pod _0.39.0_ install")
+      end
     end
   end
 end


### PR DESCRIPTION
Added a `version` parameter to cocoapods `pod install` to allow fixed cocoapods version running so that

```
lane :test do
  cocoapods(
    version: '0.39.0'
  )
end
```

would execute 

```
pod _0.39.0_ install
```

Different cocoapods version number incompatibility is a common problem when dealing with several projects at the same time, specially when not al of them are ready to be running the latest cocoapods version (`1.0`) that [introduced a lot of breaking changes](http://blog.cocoapods.org/CocoaPods-1.0/#changes) 
