### PR TITLE
Supply version bump

### DIFF
--- a/supply/lib/supply/version.rb
+++ b/supply/lib/supply/version.rb
@@ -1,4 +1,4 @@
 module Supply
-  VERSION = "0.6.2".freeze
+  VERSION = "0.7.0".freeze
   DESCRIPTION = "Command line tool for updating Android apps and their metadata on the Google Play Store"
 end

--- a/supply/supply.gemspec
+++ b/supply/supply.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google-api-client', '~> 0.9.1' # Google API Client to access Play Publishing API
 
   # fastlane
-  spec.add_dependency 'fastlane_core', '>= 0.40.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.43.4' # all shared code and dependencies
   spec.add_dependency 'credentials_manager', '>= 0.15.0'
 
   # Development only


### PR DESCRIPTION
- Added "--track_promote_to" option to `supply` for promoting APK between tracks (#4562)
