### PR TITLE
[fastlane_core] version bump to 0.43.5

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.43.4".freeze
+  VERSION = "0.43.5".freeze
 end


### PR DESCRIPTION
- Allow fastlane core to handle linux errors better
