### PR TITLE
Covert Copy Artifacts to Ruby, add tests

### DIFF
--- a/fastlane/lib/fastlane/actions/copy_artifacts.rb
+++ b/fastlane/lib/fastlane/actions/copy_artifacts.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'shellwords'
 
 module Fastlane
   module Actions
@@ -7,18 +8,24 @@ module Fastlane
         # we want to make sure that our target folder exist already
         FileUtils.mkdir_p(params[:target_path])
 
-        # Replace any spaces in any of the artifact paths with '\ '
-        artifacts = params[:artifacts].map { |e| e.tr(' ', '\ ') }
+        # Ensure that artifacts is an array
+        artifacts_to_search = [params[:artifacts]].flatten
 
-        if params[:verbose]
-          UI.message("Copying artifacts #{artifacts.join(', ')} to #{params[:target_path]}")
-          UI.message(params[:keep_original] ? "Keeping originals files" : "Not keeping original files")
-        end
+        # If any of the paths include "*", we assume that we are referring to the Unix entries
+        # e.g /tmp/fastlane/* refers to all the files in /tmp/fastlane
+        # We use Dir.glob to expand all those paths, this would create an array of arrays though, so flatten
+        # Lastly, we shell escape everything in case they contain incompatible symbols (e.g. spaces)
+        artifacts = artifacts_to_search.map { |f| f.include?("*") ? Dir.glob(f) : f }.flatten.map(&:shellescape)
+
+        UI.verbose("Copying artifacts #{artifacts.join(', ')} to #{params[:target_path]}")
+        UI.verbose(params[:keep_original] ? "Keeping original files" : "Not keeping original files")
 
         if params[:fail_on_missing]
           missing = artifacts.select { |a| !File.exist?(a) }
-          UI.error "Not all files were present in copy artifacts. \
-                      Missing #{missing.join(', ')}" unless missing.empty?
+          UI.user_error! "Not all files were present in copy artifacts. Missing #{missing.join(', ')}" unless missing.empty?
+        else
+          # If we don't fail on non-existant files, don't try to copy non-existant files
+          artifacts.reject! { |artifact| !File.exist?(artifact) }
         end
 
         if params[:keep_original]
@@ -57,11 +64,6 @@ module Fastlane
                                        default_value: []),
           FastlaneCore::ConfigItem.new(key: :fail_on_missing,
                                        description: "Fail when a source file isn't found",
-                                       is_string: false,
-                                       optional: true,
-                                       default_value: false),
-          FastlaneCore::ConfigItem.new(key: :verbose,
-                                       description: "Print out additional logs that are useful for debugging or tracking the action",
                                        is_string: false,
                                        optional: true,
                                        default_value: false)

--- a/fastlane/spec/actions_specs/copy_artifacts_spec.rb
+++ b/fastlane/spec/actions_specs/copy_artifacts_spec.rb
@@ -1,0 +1,94 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Copy Artifacts Integration" do
+      before do
+        # Reset directories
+        FileUtils.rm_rf('/tmp/fastlane')
+        FileUtils.rm_rf('/tmp/fastlane2')
+
+        # Create base test directory
+        FileUtils.mkdir_p('/tmp/fastlane')
+      end
+
+      it "Copies a file to target path" do
+        FileUtils.touch('/tmp/fastlane/copy_artifacts')
+
+        Fastlane::FastFile.new.parse("lane :test do
+          copy_artifacts(artifacts: '/tmp/fastlane/copy_artifacts', target_path: '/tmp/fastlane2')
+        end").runner.execute(:test)
+
+        expect(File.exist?('/tmp/fastlane2/copy_artifacts')).to eq(true)
+      end
+
+      it "Copies a directory and subfiles to target path" do
+        FileUtils.mkdir_p('/tmp/fastlane/dir')
+        FileUtils.touch('/tmp/fastlane/dir/copy_artifacts')
+
+        Fastlane::FastFile.new.parse("lane :test do
+          copy_artifacts(artifacts: '/tmp/fastlane/*', target_path: '/tmp/fastlane2')
+        end").runner.execute(:test)
+        expect(Dir.exist?('/tmp/fastlane2/dir')).to eq(true)
+        expect(File.exist?('/tmp/fastlane2/dir/copy_artifacts')).to eq(true)
+      end
+
+      it "Copies a file with a space" do
+        FileUtils.touch('/tmp/fastlane/copy_artifacts\ with\ a\ space')
+
+        Fastlane::FastFile.new.parse("lane :test do
+          copy_artifacts(artifacts: '/tmp/fastlane/copy_artifacts with a space', target_path: '/tmp/fastlane2')
+        end").runner.execute(:test)
+        expect(File.exist?('/tmp/fastlane/copy_artifacts\ with\ a\ space')).to eq(true)
+      end
+
+      it "Copies a file with verbose" do
+        FileUtils.touch('/tmp/fastlane/copy_artifacts')
+
+        expect(UI).to receive(:verbose).once.ordered.with('Copying artifacts /tmp/fastlane/copy_artifacts to /tmp/fastlane2')
+        expect(UI).to receive(:verbose).once.ordered.with('Keeping original files')
+
+        with_verbose(true) do
+          Fastlane::FastFile.new.parse("lane :test do
+            copy_artifacts(artifacts: '/tmp/fastlane/copy_artifacts', target_path: '/tmp/fastlane2')
+          end").runner.execute(:test)
+        end
+
+        expect(File.exist?('/tmp/fastlane/copy_artifacts')).to eq(true)
+        expect(File.exist?('/tmp/fastlane2/copy_artifacts')).to eq(true)
+      end
+
+      it "Copies a file without keeping original and verbose" do
+        FileUtils.touch('/tmp/fastlane/copy_artifacts')
+
+        expect(UI).to receive(:verbose).once.ordered.with('Copying artifacts /tmp/fastlane/copy_artifacts to /tmp/fastlane2')
+        expect(UI).to receive(:verbose).once.ordered.with('Not keeping original files')
+
+        with_verbose(true) do
+          Fastlane::FastFile.new.parse("lane :test do
+            copy_artifacts(artifacts: '/tmp/fastlane/copy_artifacts', target_path: '/tmp/fastlane2', keep_original: false)
+          end").runner.execute(:test)
+        end
+
+        expect(File.exist?('/tmp/fastlane2/copy_artifacts')).to eq(true)
+        expect(File.exist?('/tmp/fastlane/copy_artifacts')).to eq(false)
+      end
+
+      it "Copies a file with file missing does not fail (no flag set)" do
+        Fastlane::FastFile.new.parse("lane :test do
+          copy_artifacts(artifacts: '/tmp/fastlane/not_going_to_be_there', target_path: '/tmp/fastlane2')
+        end").runner.execute(:test)
+
+        expect(File.exist?('/tmp/fastlane2/not_going_to_be_there')).to eq(false)
+      end
+
+      it "Copies a file with file missing fails (flag set)" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            copy_artifacts(artifacts: '/tmp/fastlane/not_going_to_be_there', target_path: '/tmp/fastlane2', fail_on_missing: true)
+          end").runner.execute(:test)
+        end.to raise_error "Not all files were present in copy artifacts. Missing /tmp/fastlane/not_going_to_be_there"
+
+        expect(File.exist?('/tmp/fastlane2/not_going_to_be_there')).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this does
- I noticed that copy artifacts used custom built bash commands rather than the built-in `FileUtils` in Ruby
- I also noticed that some parts were not immediately obvious (specifically path parsing), so I commented that part.
- I added some verbose steps that helped to reduce confusion while using it (we had an issue where the path that was being used was not obvious, so this should help there)
- I made the "Fail on missing" a lot better. It will raise an error with the _specific_ files missing, otherwise we just remove the missing files and don't try to copy that.
- It now handles paths like so:
  - `/path/to/dir/*`
  - `/path/to/dir`
  - `/path/to/file.txt`
- Adds tests 🎉 🎉 

Fixes https://github.com/fastlane/fastlane/issues/4653
