### PR TITLE
Add an action to upload a folder to S3

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -1018,6 +1018,24 @@ The uploaded `version.json` file provides an easy way for apps to poll if a new 
 }
 ```
 
+### AWS S3 Folder uploading
+
+A simpler action than `s3`, the `upload_folder_to_s3` can be used as following:
+
+```ruby
+upload_folder_to_s3(
+  access_key_id:      ENV["S3_ACCESS_KEY"],
+  secret_access_key:  ENV["S3_SECRET_ACCESS_KEY"],
+  bucket:             ENV["S3_BUCKET"],
+  region:             ENV["S3_REGION"],
+  local_path:         ENV["LOCAL_PATH"],
+  remote_path:        ENV["S3_PATH"]
+)
+```
+
+There is no way to exclude files (e.g. using a regex) in the folder you want to upload. But you can easily create a subset of your product files in `/tmp` for example.
+
+
 ### [DeployGate](https://deploygate.com/)
 
 You can retrieve your username and API token on [your settings page](https://deploygate.com/settings).

--- a/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
+++ b/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
@@ -27,11 +27,13 @@ module Fastlane
 
           obj = write_file_to_bucket(local_path, bucket, s3_path)
 
-          if obj.exists? == false
-            result = "Error while uploadin file #{local_path}"
-            Actions.lane_context[SharedValues::UPLOAD_FOLDER_TO_S3_RESULT] = result
-            return result
+          if obj.exists?
+            next
           end
+
+          result = "Error while uploadin file #{local_path}"
+          Actions.lane_context[SharedValues::UPLOAD_FOLDER_TO_S3_RESULT] = result
+          return result
         end
 
         Actions.lane_context[SharedValues::UPLOAD_FOLDER_TO_S3_RESULT] = result
@@ -96,35 +98,45 @@ module Fastlane
                                        env_name: "FL_UPLOAD_FOLDER_TO_S3_ACCESS_KEY_ID",
                                        description: "Access key ID",
                                        verify_block: proc do |value|
-                                         UI.user_error!("No Access key ID for UploadFolderToS3Action given, pass using `access_key_id: 'token'`") unless (value and not value.empty?)
+                                         unless value and !value.empty?
+                                           UI.user_error!("No Access key ID for UploadFolderToS3Action given, pass using `access_key_id: 'token'`")
+                                         end
                                        end),
 
           FastlaneCore::ConfigItem.new(key: :secret_access_key,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_SECRET_ACCESS_KEY",
                                       description: "Secret access key",
-                                      verify_block: proc do |value|
-                                        UI.user_error!("No Secret access key for UploadFolderToS3Action given, pass using `secret_access_key: 'token'`") unless (value and not value.empty?)
+                                      unless value and !value.empty?
+                                        verify_block: proc do |value|
+                                          UI.user_error!("No Secret access key for UploadFolderToS3Action given, pass using `secret_access_key: 'token'`")
+                                        end
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :region,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_REGION",
                                       description: "The region",
                                       verify_block: proc do |value|
-                                        UI.user_error!("No region for UploadFolderToS3Action given, pass using `region: 'token'`") unless (value and not value.empty?)
+                                        unless value and !value.empty?
+                                          UI.user_error!("No region for UploadFolderToS3Action given, pass using `region: 'token'`")
+                                        end
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :bucket,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_BUCKET",
                                       description: "Bucket",
                                       verify_block: proc do |value|
-                                        UI.user_error!("No bucket for UploadFolderToS3Action given, pass using `bucket: 'token'`") unless (value and not value.empty?)
+                                        unless value and !value.empty?
+                                          UI.user_error!("No bucket for UploadFolderToS3Action given, pass using `bucket: 'token'`")
+                                        end
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :local_path,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_LOCAL_PATH",
                                       description: "Path to local folder to upload",
                                       verify_block: proc do |value|
-                                        UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+                                        unless value and !value.empty?
+                                          UI.user_error!("Couldn't find file at path '#{value}'")
+                                        end
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :remote_path,

--- a/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
+++ b/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
@@ -79,7 +79,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Upload a folder, and all its content, to a S3 bucket."
+        "Upload a folder, and all its content, to a S3 bucket"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
+++ b/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
@@ -105,41 +105,43 @@ module Fastlane
                                        env_name: "FL_UPLOAD_FOLDER_TO_S3_ACCESS_KEY_ID",
                                        description: "Access key ID",
                                        verify_block: proc do |value|
-                                         UI.user_error!("No Access key ID for UploadFolderToS3Action given, pass using `access_key_id: 'token'`") if value.to_s.length == 0
+                                         UI.user_error!(UploadFolderToS3Action.no_access_key_id_error_message) if value.to_s.length == 0
                                        end),
 
           FastlaneCore::ConfigItem.new(key: :secret_access_key,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_SECRET_ACCESS_KEY",
                                       description: "Secret access key",
                                       verify_block: proc do |value|
-                                        UI.user_error!("No Secret access key for UploadFolderToS3Action given, pass using `secret_access_key: 'token'`") if value.to_s.length == 0
+                                        UI.user_error!(UploadFolderToS3Action.no_secret_access_key_error_message) if value.to_s.length == 0
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :region,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_REGION",
                                       description: "The region",
                                       verify_block: proc do |value|
-                                        UI.user_error!("No region for UploadFolderToS3Action given, pass using `region: 'token'`") if value.to_s.length == 0
+                                        UI.user_error!(UploadFolderToS3Action.no_region_error_message) if value.to_s.length == 0
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :bucket,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_BUCKET",
                                       description: "Bucket",
                                       verify_block: proc do |value|
-                                        UI.user_error!("No bucket for UploadFolderToS3Action given, pass using `bucket: 'token'`") if value.to_s.length == 0
+                                        UI.user_error!(UploadFolderToS3Action.no_bucket_error_message) if value.to_s.length == 0
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :local_path,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_LOCAL_PATH",
                                       description: "Path to local folder to upload",
                                       verify_block: proc do |value|
-                                        UI.user_error!("Couldn't find file at path '#{value}'") if value.to_s.length == 0
+                                        UI.user_error!(UploadFolderToS3Action.invalid_local_folder_path_message) if value.to_s.length == 0
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :remote_path,
                                        env_name: "FL_UPLOAD_FOLDER_TO_S3_REMOTE_PATH",
                                        description: "The remote base path",
-                                       default_value: "")
+                                       verify_block: proc do |value|
+                                         UI.user_error!(UploadFolderToS3Action.invalid_remote_folder_path_message) if value.to_s.length == 0
+                                       end)
         ]
       end
 
@@ -183,6 +185,23 @@ module Fastlane
           extensions_to_type[file_extension]
         end
       end
+
+      @no_access_key_id_error_message     = "No Access key ID for upload_folder_to_s3 given, pass using `access_key_id: 'key_id'`"
+      @no_secret_access_key_error_message = "No Secret access key for upload_folder_to_s3 given, pass using `secret_access_key: 'access_key'`"
+      @no_region_error_message            = "No region for upload_folder_to_s3 given, pass using `region: 'region'`"
+      @no_bucket_error_message            = "No bucket for upload_folder_to_s3 given, pass using `bucket: 'bucket'`"
+      @invalid_local_folder_path_message  = "Invalid local folder path"
+      @invalid_remote_folder_path_message = "Invalid remote folder path"
+
+      class << self
+        attr_accessor :no_access_key_id_error_message
+        attr_accessor :no_secret_access_key_error_message
+        attr_accessor :no_region_error_message
+        attr_accessor :no_bucket_error_message
+        attr_accessor :invalid_local_folder_path_message
+        attr_accessor :invalid_remote_folder_path_message
+      end
+
     end
   end
 end

--- a/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
+++ b/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
@@ -12,13 +12,13 @@ module Fastlane
         base_remote_path  = params[:remote_path]
         s3_region         = params[:region]
         s3_bucket         = params[:bucket]
-                
+
         awscreds = {
-          access_key_id:      params[:access_key_id], 
-          secret_access_key:  params[:secret_access_key], 
+          access_key_id:      params[:access_key_id],
+          secret_access_key:  params[:secret_access_key],
           region:             s3_region
         }
-        
+
         result  = ""
         bucket  = valid_bucket awscreds, s3_bucket
         files   = files_at_path base_local_path
@@ -28,7 +28,7 @@ module Fastlane
           s3_path     = base_remote_path + file
 
           obj = write_file_to_bucket(local_path, bucket, s3_path)
-          
+
           if obj.exists? == false
             result = "Error while uploadin file #{local_path}"
             Actions.lane_context[SharedValues::UPLOAD_FOLDER_TO_S3_RESULT] = result
@@ -39,10 +39,10 @@ module Fastlane
         Actions.lane_context[SharedValues::UPLOAD_FOLDER_TO_S3_RESULT] = result
         result
       end
-      
+
       def self.files_at_path(path)
         files = Dir.glob(path + "/**/*")
-        
+
         files.each do |file|
           if File.directory?(file)
             files.remove file
@@ -51,23 +51,23 @@ module Fastlane
           end
         end
       end
-      
+
       def self.write_file_to_bucket(local_path, bucket, s3_path)
         obj = bucket.objects[s3_path]
         obj.write(file: local_path, content_type: content_type_for_file(local_path))
         obj
       end
-      
+
       def self.valid_s3(awscreds, s3_bucket)
         s3 = AWS::S3.new(awscreds)
-        
+
         if s3.buckets[s3_bucket].location_constraint != awscreds[:region] then
           s3 = AWS::S3.new(awscreds.merge(region: s3.buckets[s3_bucket].location_constraint))
         end
-        
+
         s3
       end
-      
+
       def self.valid_bucket(awscreds, s3_bucket)
         s3 = valid_s3 awscreds, s3_bucket
         s3.buckets[s3_bucket]
@@ -97,35 +97,35 @@ module Fastlane
                                        verify_block: proc do |value|
                                           UI.user_error!("No Access key ID for UploadFolderToS3Action given, pass using `access_key_id: 'token'`") unless (value and not value.empty?)
                                        end),
-                                       
+
           FastlaneCore::ConfigItem.new(key: :secret_access_key,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_SECRET_ACCESS_KEY",
                                       description: "Secret access key",
                                       verify_block: proc do |value|
                                          UI.user_error!("No Secret access key for UploadFolderToS3Action given, pass using `secret_access_key: 'token'`") unless (value and not value.empty?)
                                       end),
-                                      
+
           FastlaneCore::ConfigItem.new(key: :region,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_REGION",
                                       description: "The region",
                                       verify_block: proc do |value|
                                          UI.user_error!("No region for UploadFolderToS3Action given, pass using `region: 'token'`") unless (value and not value.empty?)
                                       end),
-                                      
+
           FastlaneCore::ConfigItem.new(key: :bucket,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_BUCKET",
                                       description: "Bucket",
                                       verify_block: proc do |value|
                                          UI.user_error!("No bucket for UploadFolderToS3Action given, pass using `bucket: 'token'`") unless (value and not value.empty?)
                                       end),
-                                      
+
           FastlaneCore::ConfigItem.new(key: :local_path,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_LOCAL_PATH",
                                       description: "Path to local folder to upload",
                                       verify_block: proc do |value|
                                            UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                       end),
-                                      
+
           FastlaneCore::ConfigItem.new(key: :remote_path,
                                        env_name: "FL_UPLOAD_FOLDER_TO_S3_REMOTE_PATH",
                                        description: "The remote base path",
@@ -153,20 +153,20 @@ module Fastlane
       def self.is_supported?(platform)
         true
       end
-      
+
       def self.content_type_for_file(file)
         file_extension = File.extname(file)
-        
-        extensions_to_type = { 
-          ".html" => "text/html" , 
-          ".png"  => "image/png" , 
-          ".jpg"  => "text/jpeg", 
-          ".gif"  => "image/gif", 
-          ".log"  => "text/plain", 
-          ".css"  => "text/css", 
+
+        extensions_to_type = {
+          ".html" => "text/html" ,
+          ".png"  => "image/png" ,
+          ".jpg"  => "text/jpeg",
+          ".gif"  => "image/gif",
+          ".log"  => "text/plain",
+          ".css"  => "text/css",
           ".js"   => "application/javascript"
         }
-        
+
         if extensions_to_type[file_extension] == nil
           "application/octet-stream"
         else

--- a/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
+++ b/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
@@ -1,5 +1,3 @@
-require 'aws-sdk-v1'
-
 module Fastlane
   module Actions
     module SharedValues
@@ -59,6 +57,9 @@ module Fastlane
       end
 
       def self.valid_s3(awscreds, s3_bucket)
+        Actions.verify_gem!('aws-sdk')
+        require 'aws-sdk'
+
         s3 = AWS::S3.new(awscreds)
 
         if s3.buckets[s3_bucket].location_constraint != awscreds[:region]

--- a/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
+++ b/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
@@ -1,0 +1,178 @@
+require 'aws-sdk-v1'
+
+module Fastlane
+  module Actions
+    module SharedValues
+      UPLOAD_FOLDER_TO_S3_RESULT = :UPLOAD_FOLDER_TO_S3_RESULT
+    end
+
+    class UploadFolderToS3Action < Action
+      def self.run(params)
+        base_local_path   = params[:local_path]
+        base_remote_path  = params[:remote_path]
+        s3_region         = params[:region]
+        s3_bucket         = params[:bucket]
+                
+        awscreds = {
+          access_key_id:      params[:access_key_id], 
+          secret_access_key:  params[:secret_access_key], 
+          region:             s3_region
+        }
+        
+        result  = ""
+        bucket  = valid_bucket awscreds, s3_bucket
+        files   = files_at_path base_local_path
+
+        files.each do |file|
+          local_path  = base_local_path  + file
+          s3_path     = base_remote_path + file
+
+          obj = write_file_to_bucket(local_path, bucket, s3_path)
+          
+          if obj.exists? == false
+            result = "Error while uploadin file #{local_path}"
+            Actions.lane_context[SharedValues::UPLOAD_FOLDER_TO_S3_RESULT] = result
+            return result
+          end
+        end
+
+        Actions.lane_context[SharedValues::UPLOAD_FOLDER_TO_S3_RESULT] = result
+        result
+      end
+      
+      def self.files_at_path(path)
+        files = Dir.glob(path + "/**/*")
+        
+        files.each do |file|
+          if File.directory?(file)
+            files.remove file
+          else
+            file.slice! path
+          end
+        end
+      end
+      
+      def self.write_file_to_bucket(local_path, bucket, s3_path)
+        obj = bucket.objects[s3_path]
+        obj.write(file: local_path, content_type: content_type_for_file(local_path))
+        obj
+      end
+      
+      def self.valid_s3(awscreds, s3_bucket)
+        s3 = AWS::S3.new(awscreds)
+        
+        if s3.buckets[s3_bucket].location_constraint != awscreds[:region] then
+          s3 = AWS::S3.new(awscreds.merge(region: s3.buckets[s3_bucket].location_constraint))
+        end
+        
+        s3
+      end
+      
+      def self.valid_bucket(awscreds, s3_bucket)
+        s3 = valid_s3 awscreds, s3_bucket
+        s3.buckets[s3_bucket]
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Upload a folder, and all its content, to a S3 bucket."
+      end
+
+      def self.details
+        [
+          "If you want to use regex to exclude some files, please contribute to this action.",
+          "Else, just do like me and from your artifacts/builds/product folder,",
+          "create the subset you want to upload in another folder and upload it using this action."
+        ].join("\n")
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :access_key_id,
+                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_ACCESS_KEY_ID",
+                                       description: "Access key ID",
+                                       verify_block: proc do |value|
+                                          UI.user_error!("No Access key ID for UploadFolderToS3Action given, pass using `access_key_id: 'token'`") unless (value and not value.empty?)
+                                       end),
+                                       
+          FastlaneCore::ConfigItem.new(key: :secret_access_key,
+                                      env_name: "FL_UPLOAD_FOLDER_TO_S3_SECRET_ACCESS_KEY",
+                                      description: "Secret access key",
+                                      verify_block: proc do |value|
+                                         UI.user_error!("No Secret access key for UploadFolderToS3Action given, pass using `secret_access_key: 'token'`") unless (value and not value.empty?)
+                                      end),
+                                      
+          FastlaneCore::ConfigItem.new(key: :region,
+                                      env_name: "FL_UPLOAD_FOLDER_TO_S3_REGION",
+                                      description: "The region",
+                                      verify_block: proc do |value|
+                                         UI.user_error!("No region for UploadFolderToS3Action given, pass using `region: 'token'`") unless (value and not value.empty?)
+                                      end),
+                                      
+          FastlaneCore::ConfigItem.new(key: :bucket,
+                                      env_name: "FL_UPLOAD_FOLDER_TO_S3_BUCKET",
+                                      description: "Bucket",
+                                      verify_block: proc do |value|
+                                         UI.user_error!("No bucket for UploadFolderToS3Action given, pass using `bucket: 'token'`") unless (value and not value.empty?)
+                                      end),
+                                      
+          FastlaneCore::ConfigItem.new(key: :local_path,
+                                      env_name: "FL_UPLOAD_FOLDER_TO_S3_LOCAL_PATH",
+                                      description: "Path to local folder to upload",
+                                      verify_block: proc do |value|
+                                           UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+                                      end),
+                                      
+          FastlaneCore::ConfigItem.new(key: :remote_path,
+                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_REMOTE_PATH",
+                                       description: "The remote base path",
+                                       default_value: "") # the default value if the user didn't provide one
+        ]
+      end
+
+      def self.output
+        [
+          ['UPLOAD_FOLDER_TO_S3_RESULT', 'An empty string if everything is fine, a short description of the error otherwise'],
+        ]
+      end
+
+      def self.return_value
+        [
+          "The return value is an empty string if everything went fine,",
+          "or an explanation of the error encountered."
+        ].join("\n")
+      end
+
+      def self.authors
+        ["teriiehina"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+      
+      def self.content_type_for_file(file)
+        file_extension = File.extname(file)
+        
+        extensions_to_type = { 
+          ".html" => "text/html" , 
+          ".png"  => "image/png" , 
+          ".jpg"  => "text/jpeg", 
+          ".gif"  => "image/gif", 
+          ".log"  => "text/plain", 
+          ".css"  => "text/css", 
+          ".js"   => "application/javascript"
+        }
+        
+        if extensions_to_type[file_extension] == nil
+          "application/octet-stream"
+        else
+          extensions_to_type[file_extension]
+        end
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
+++ b/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
@@ -61,7 +61,7 @@ module Fastlane
       def self.valid_s3(awscreds, s3_bucket)
         s3 = AWS::S3.new(awscreds)
 
-        if s3.buckets[s3_bucket].location_constraint != awscreds[:region] then
+        if s3.buckets[s3_bucket].location_constraint != awscreds[:region]
           s3 = AWS::S3.new(awscreds.merge(region: s3.buckets[s3_bucket].location_constraint))
         end
 
@@ -95,41 +95,41 @@ module Fastlane
                                        env_name: "FL_UPLOAD_FOLDER_TO_S3_ACCESS_KEY_ID",
                                        description: "Access key ID",
                                        verify_block: proc do |value|
-                                          UI.user_error!("No Access key ID for UploadFolderToS3Action given, pass using `access_key_id: 'token'`") unless (value and not value.empty?)
+                                         UI.user_error!("No Access key ID for UploadFolderToS3Action given, pass using `access_key_id: 'token'`") unless (value and not value.empty?)
                                        end),
 
           FastlaneCore::ConfigItem.new(key: :secret_access_key,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_SECRET_ACCESS_KEY",
                                       description: "Secret access key",
                                       verify_block: proc do |value|
-                                         UI.user_error!("No Secret access key for UploadFolderToS3Action given, pass using `secret_access_key: 'token'`") unless (value and not value.empty?)
+                                        UI.user_error!("No Secret access key for UploadFolderToS3Action given, pass using `secret_access_key: 'token'`") unless (value and not value.empty?)
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :region,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_REGION",
                                       description: "The region",
                                       verify_block: proc do |value|
-                                         UI.user_error!("No region for UploadFolderToS3Action given, pass using `region: 'token'`") unless (value and not value.empty?)
+                                        UI.user_error!("No region for UploadFolderToS3Action given, pass using `region: 'token'`") unless (value and not value.empty?)
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :bucket,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_BUCKET",
                                       description: "Bucket",
                                       verify_block: proc do |value|
-                                         UI.user_error!("No bucket for UploadFolderToS3Action given, pass using `bucket: 'token'`") unless (value and not value.empty?)
+                                        UI.user_error!("No bucket for UploadFolderToS3Action given, pass using `bucket: 'token'`") unless (value and not value.empty?)
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :local_path,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_LOCAL_PATH",
                                       description: "Path to local folder to upload",
                                       verify_block: proc do |value|
-                                           UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+                                        UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :remote_path,
                                        env_name: "FL_UPLOAD_FOLDER_TO_S3_REMOTE_PATH",
                                        description: "The remote base path",
-                                       default_value: "") # the default value if the user didn't provide one
+                                       default_value: "")
         ]
       end
 
@@ -158,8 +158,8 @@ module Fastlane
         file_extension = File.extname(file)
 
         extensions_to_type = {
-          ".html" => "text/html" ,
-          ".png"  => "image/png" ,
+          ".html" => "text/html",
+          ".png"  => "image/png",
           ".jpg"  => "text/jpeg",
           ".gif"  => "image/gif",
           ".log"  => "text/plain",
@@ -167,7 +167,7 @@ module Fastlane
           ".js"   => "application/javascript"
         }
 
-        if extensions_to_type[file_extension] == nil
+        if extensions_to_type[file_extension].nil?
           "application/octet-stream"
         else
           extensions_to_type[file_extension]

--- a/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
+++ b/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
@@ -98,45 +98,35 @@ module Fastlane
                                        env_name: "FL_UPLOAD_FOLDER_TO_S3_ACCESS_KEY_ID",
                                        description: "Access key ID",
                                        verify_block: proc do |value|
-                                         unless value and !value.empty?
-                                           UI.user_error!("No Access key ID for UploadFolderToS3Action given, pass using `access_key_id: 'token'`")
-                                         end
+                                           UI.user_error!("No Access key ID for UploadFolderToS3Action given, pass using `access_key_id: 'token'`") if value.to_s.length == 0
                                        end),
 
           FastlaneCore::ConfigItem.new(key: :secret_access_key,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_SECRET_ACCESS_KEY",
                                       description: "Secret access key",
-                                      unless value and !value.empty?
                                         verify_block: proc do |value|
-                                          UI.user_error!("No Secret access key for UploadFolderToS3Action given, pass using `secret_access_key: 'token'`")
-                                        end
+                                          UI.user_error!("No Secret access key for UploadFolderToS3Action given, pass using `secret_access_key: 'token'`") if value.to_s.length == 0
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :region,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_REGION",
                                       description: "The region",
                                       verify_block: proc do |value|
-                                        unless value and !value.empty?
-                                          UI.user_error!("No region for UploadFolderToS3Action given, pass using `region: 'token'`")
-                                        end
+                                        UI.user_error!("No region for UploadFolderToS3Action given, pass using `region: 'token'`") if value.to_s.length == 0
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :bucket,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_BUCKET",
                                       description: "Bucket",
                                       verify_block: proc do |value|
-                                        unless value and !value.empty?
-                                          UI.user_error!("No bucket for UploadFolderToS3Action given, pass using `bucket: 'token'`")
-                                        end
+                                        UI.user_error!("No bucket for UploadFolderToS3Action given, pass using `bucket: 'token'`") if value.to_s.length == 0
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :local_path,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_LOCAL_PATH",
                                       description: "Path to local folder to upload",
                                       verify_block: proc do |value|
-                                        unless value and !value.empty?
-                                          UI.user_error!("Couldn't find file at path '#{value}'")
-                                        end
+                                        UI.user_error!("Couldn't find file at path '#{value}'") if value.to_s.length == 0
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :remote_path,

--- a/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
+++ b/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
@@ -42,14 +42,21 @@ module Fastlane
 
       def self.files_at_path(path)
         files = Dir.glob(path + "/**/*")
+        to_remove = []
 
         files.each do |file|
           if File.directory?(file)
-            files.remove file
+            to_remove.push file
           else
             file.slice! path
           end
         end
+
+        to_remove.each do |file|
+          files.delete file
+        end
+
+        files
       end
 
       def self.write_file_to_bucket(local_path, bucket, s3_path)

--- a/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
+++ b/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
@@ -138,7 +138,7 @@ module Fastlane
 
       def self.output
         [
-          ['UPLOAD_FOLDER_TO_S3_RESULT', 'An empty string if everything is fine, a short description of the error otherwise'],
+          ['UPLOAD_FOLDER_TO_S3_RESULT', 'An empty string if everything is fine, a short description of the error otherwise']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
+++ b/fastlane/lib/fastlane/actions/upload_folder_to_s3.rb
@@ -98,14 +98,14 @@ module Fastlane
                                        env_name: "FL_UPLOAD_FOLDER_TO_S3_ACCESS_KEY_ID",
                                        description: "Access key ID",
                                        verify_block: proc do |value|
-                                           UI.user_error!("No Access key ID for UploadFolderToS3Action given, pass using `access_key_id: 'token'`") if value.to_s.length == 0
+                                         UI.user_error!("No Access key ID for UploadFolderToS3Action given, pass using `access_key_id: 'token'`") if value.to_s.length == 0
                                        end),
 
           FastlaneCore::ConfigItem.new(key: :secret_access_key,
                                       env_name: "FL_UPLOAD_FOLDER_TO_S3_SECRET_ACCESS_KEY",
                                       description: "Secret access key",
-                                        verify_block: proc do |value|
-                                          UI.user_error!("No Secret access key for UploadFolderToS3Action given, pass using `secret_access_key: 'token'`") if value.to_s.length == 0
+                                      verify_block: proc do |value|
+                                        UI.user_error!("No Secret access key for UploadFolderToS3Action given, pass using `secret_access_key: 'token'`") if value.to_s.length == 0
                                       end),
 
           FastlaneCore::ConfigItem.new(key: :region,

--- a/fastlane/spec/actions_specs/upload_folder_to_s3_spec.rb
+++ b/fastlane/spec/actions_specs/upload_folder_to_s3_spec.rb
@@ -2,7 +2,7 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Upload folder to S3" do
       before(:each) do
-        ['FL_UPLOAD_FOLDER_TO_S3_ACCESS_KEY_ID' , 'FL_UPLOAD_FOLDER_TO_S3_SECRET_ACCESS_KEY' , 'FL_UPLOAD_FOLDER_TO_S3_REGION' , 'FL_UPLOAD_FOLDER_TO_S3_BUCKET' , 'FL_UPLOAD_FOLDER_TO_S3_LOCAL_PATH' , 'FL_UPLOAD_FOLDER_TO_S3_REMOTE_PATH'].each do |key|
+        ['FL_UPLOAD_FOLDER_TO_S3_ACCESS_KEY_ID', 'FL_UPLOAD_FOLDER_TO_S3_SECRET_ACCESS_KEY', 'FL_UPLOAD_FOLDER_TO_S3_REGION', 'FL_UPLOAD_FOLDER_TO_S3_BUCKET', 'FL_UPLOAD_FOLDER_TO_S3_LOCAL_PATH', 'FL_UPLOAD_FOLDER_TO_S3_REMOTE_PATH'].each do |key|
           ENV[key] = nil
         end
         @dumb_config = {secret_access_key: 'secret', access_key_id: 'id', local_path: '/tmp', remote_path: 'whatever', region: 'region', bucket: 'bucket'}

--- a/fastlane/spec/actions_specs/upload_folder_to_s3_spec.rb
+++ b/fastlane/spec/actions_specs/upload_folder_to_s3_spec.rb
@@ -1,0 +1,67 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Upload folder to S3" do
+      before(:each) do
+        ['FL_UPLOAD_FOLDER_TO_S3_ACCESS_KEY_ID' , 'FL_UPLOAD_FOLDER_TO_S3_SECRET_ACCESS_KEY' , 'FL_UPLOAD_FOLDER_TO_S3_REGION' , 'FL_UPLOAD_FOLDER_TO_S3_BUCKET' , 'FL_UPLOAD_FOLDER_TO_S3_LOCAL_PATH' , 'FL_UPLOAD_FOLDER_TO_S3_REMOTE_PATH'].each do |key|
+          ENV[key] = nil
+        end
+        @dumb_config = {secret_access_key: 'secret', access_key_id: 'id', local_path: '/tmp', remote_path: 'whatever', region: 'region', bucket: 'bucket'}
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::UPLOAD_FOLDER_TO_S3_RESULT] = nil
+      end
+
+      it "raise an error if no S3 secret access key was given" do
+        expect do
+          @dumb_config[:secret_access_key] = nil
+          Fastlane::FastFile.new.parse("lane :test do
+            upload_folder_to_s3(#{@dumb_config})
+          end").runner.execute(:test)
+        end.to raise_error(Fastlane::Actions::UploadFolderToS3Action.no_secret_access_key_error_message)
+      end
+
+      it "raise an error if no S3 access key ID was given" do
+        expect do
+          @dumb_config[:access_key_id] = nil
+          Fastlane::FastFile.new.parse("lane :test do
+            upload_folder_to_s3(#{@dumb_config})
+          end").runner.execute(:test)
+        end.to raise_error(Fastlane::Actions::UploadFolderToS3Action.no_access_key_id_error_message)
+      end
+
+      it "raise an error if no S3 region was given" do
+        expect do
+          @dumb_config[:region] = nil
+          Fastlane::FastFile.new.parse("lane :test do
+            upload_folder_to_s3(#{@dumb_config})
+          end").runner.execute(:test)
+        end.to raise_error(Fastlane::Actions::UploadFolderToS3Action.no_region_error_message)
+      end
+
+      it "raise an error if no S3 bucket was given" do
+        expect do
+          @dumb_config[:bucket] = nil
+          Fastlane::FastFile.new.parse("lane :test do
+            upload_folder_to_s3(#{@dumb_config})
+          end").runner.execute(:test)
+        end.to raise_error(Fastlane::Actions::UploadFolderToS3Action.no_bucket_error_message)
+      end
+
+      it "raise an error if no valid local path was given" do
+        expect do
+          @dumb_config[:local_path] = nil
+          Fastlane::FastFile.new.parse("lane :test do
+            upload_folder_to_s3(#{@dumb_config})
+          end").runner.execute(:test)
+        end.to raise_error(Fastlane::Actions::UploadFolderToS3Action.invalid_local_folder_path_message)
+      end
+
+      it "raise an error if no valid remote path was given" do
+        expect do
+          @dumb_config[:remote_path] = nil
+          Fastlane::FastFile.new.parse("lane :test do
+            upload_folder_to_s3(#{@dumb_config})
+          end").runner.execute(:test)
+        end.to raise_error(Fastlane::Actions::UploadFolderToS3Action.invalid_remote_folder_path_message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is intented to solve the hurdles described in https://github.com/fastlane/fastlane/issues/4671.

In particular, it enables to encapsulates issues like [regions and buckets mismatch](https://github.com/aws/aws-sdk-ruby/issues/510).

It could also make feature request like https://github.com/fastlane/fastlane/issues/3696 obsolete.

One point of improvement could be the number of content type handled when uploading.
