### PR TITLE
Start using Accept-Encoding header against Apple CDN

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -309,9 +309,11 @@ module Spaceship
 
     def itc_service_key
       return @service_key if @service_key
-      # Some clients have had trouble with GZip encoding, so we'll request the server to return unmodified plain-text
-      headers = ENV['SPACESHIP_LOGIN_ENCODING_IDENTITY'] ? {'Accept-Encoding' => 'identity'} : {}
-      logger.debug("itc_service_key headers: #{headers}")
+      # Some customers in Asia have had trouble with the CDNs there that cache and serve this content, leading
+      # to "buffer error (Zlib::BufError)" from deep in the Ruby HTTP stack. Setting this header requests that
+      # the content be served only as plain-text, which seems to work around their problem, while not affecting
+      # other clients.
+      headers = {'Accept-Encoding' => 'identity'}
       # We need a service key from a JS file to properly auth
       js = request(:get, "https://itunesconnect.apple.com/itc/static-resources/controllers/login_cntrl.js", nil, headers)
       @service_key ||= js.body.match(/itcServiceKey = '(.*)'/)[1]


### PR DESCRIPTION
Addresses #4610, #4590, #4240

To work-around problems we've seen with CDNs that serve this content in Asia, and are doing something bad when allowed to serve data as gzip. This lead to `buffer error (Zlib::BufError)` in the Ruby HTTP stack.
