### PR TITLE
Version bump

### DIFF
--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,3 +1,3 @@
 module Spaceship
-  VERSION = "0.27.0".freeze
+  VERSION = "0.27.1".freeze
 end


### PR DESCRIPTION
Changes since release 0.27.0:
- Start using Accept-Encoding header against Apple CDN
- [spaceship] Fixed crash when raising an exception (#4669)
