### PR TITLE
Added option to specify scheme in update_info_plist

### DIFF
--- a/fastlane/lib/fastlane/actions/update_info_plist.rb
+++ b/fastlane/lib/fastlane/actions/update_info_plist.rb
@@ -5,7 +5,7 @@ module Fastlane
 
     class UpdateInfoPlistAction < Action
       def self.run(params)
-        require 'plist'
+        require 'xcodeproj'
 
         # Check if parameters are set
         if params[:app_identifier] or params[:display_name] or params[:block]
@@ -17,10 +17,24 @@ module Fastlane
           # Assign folder from parameter or search for xcodeproj file
           folder = params[:xcodeproj] || Dir["*.xcodeproj"].first
 
+          if params[:scheme]
+            project = Xcodeproj::Project.open(folder)
+            scheme = project.native_targets.detect { |target| target.name == params[:scheme] }
+            UI.user_error!("Couldn't find scheme named '#{params[:scheme]}'") unless scheme
+
+            params[:plist_path] = scheme.build_configurations.first.build_settings["INFOPLIST_FILE"]
+            UI.user_error!("Scheme named '#{params[:scheme]}' doesn't have a plist file") unless params[:plist_path]
+            params[:plist_path] = params[:plist_path].gsub("$(SRCROOT)", ".")
+          end
+
+          if params[:plist_path].nil?
+            UI.user_error!("You must specify either a plist path or a scheme")
+          end
+
           # Read existing plist file
           info_plist_path = File.join(folder, "..", params[:plist_path])
           UI.user_error!("Couldn't find info plist file at path '#{params[:plist_path]}'") unless File.exist?(info_plist_path)
-          plist = Plist.parse_xml(info_plist_path)
+          plist = Xcodeproj::Plist.read_from_path(info_plist_path)
 
           # Update plist values
           plist['CFBundleIdentifier'] = params[:app_identifier] if params[:app_identifier]
@@ -28,11 +42,10 @@ module Fastlane
           params[:block].call(plist) if params[:block]
 
           # Write changes to file
-          plist_string = Plist::Emit.dump(plist)
-          File.write(info_plist_path, plist_string)
+          Xcodeproj::Plist.write_to_path(plist, info_plist_path)
 
           UI.success("Updated #{params[:plist_path]} 💾.")
-          plist_string
+          File.read(info_plist_path)
         else
           UI.important("You haven't specified any parameters to update your plist.")
           false
@@ -65,9 +78,14 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :plist_path,
                                        env_name: "FL_UPDATE_PLIST_PATH",
                                        description: "Path to info plist",
+                                       optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Invalid plist file") unless value[-6..-1].casecmp(".plist").zero?
                                        end),
+          FastlaneCore::ConfigItem.new(key: :scheme,
+                                       env_name: "FL_UPDATE_PLIST_APP_SCHEME",
+                                       description: "Scheme of info plist",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        env_name: 'FL_UPDATE_PLIST_APP_IDENTIFIER',
                                        description: 'The App Identifier of your app',

--- a/fastlane/spec/actions_specs/update_info_plist_spec.rb
+++ b/fastlane/spec/actions_specs/update_info_plist_spec.rb
@@ -2,15 +2,22 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Update Info Plist Integration" do
       let (:test_path) { "/tmp/fastlane/tests/fastlane" }
-      let (:xcodeproj) { "/tmp/fastlane/tests/fastlane/Test.xcodeproj" }
-      let (:plist_path) { "com.test.plist" }
+      let (:fixtures_path) { "./spec/fixtures/xcodeproj" }
+      let (:proj_file) { "bundle.xcodeproj" }
+      let (:xcodeproj) { File.join(test_path, proj_file) }
+      let (:plist_path) { "Info.plist" }
+      let (:scheme) { "bundle" }
       let (:app_identifier) { "com.test.plist" }
       let (:display_name) { "Update Info Plist Test" }
 
       before do
         # Set up example info.plist
         FileUtils.mkdir_p(test_path)
-        FileUtils.mkdir_p(xcodeproj)
+        source = File.join(fixtures_path, proj_file)
+        destination = File.join(test_path, proj_file)
+
+        # Copy .xcodeproj fixture, as it will be modified during the test
+        FileUtils.cp_r(source, destination)
         File.write(File.join(test_path, plist_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>CFBundleDisplayName</key><string>empty</string><key>CFBundleIdentifier</key><string>empty</string></dict></plist>')
       end
 
@@ -42,6 +49,19 @@ describe Fastlane do
         expect(result).to include("<string>#{app_identifier}</string>")
       end
 
+      it "obtains info plist from the scheme" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          update_info_plist ({
+            xcodeproj: '#{xcodeproj}',
+            scheme: '#{scheme}',
+            block: lambda { |plist|
+              plist['TEST_PLIST_SUCCESSFULLY_RETRIEVED'] = true
+            }
+          })
+        end").runner.execute(:test)
+        expect(result).to include("TEST_PLIST_SUCCESSFULLY_RETRIEVED")
+      end
+
       it "throws an error when the info plist file does not exist" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
@@ -53,6 +73,19 @@ describe Fastlane do
             })
           end").runner.execute(:test)
         end.to raise_error("Couldn't find info plist file at path 'NOEXIST-#{plist_path}'")
+      end
+
+      it "throws an error when the scheme does not exist" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            update_info_plist ({
+              xcodeproj: '#{xcodeproj}',
+              scheme: 'NOEXIST-#{scheme}',
+              app_identifier: '#{app_identifier}',
+              display_name: '#{display_name}'
+            })
+          end").runner.execute(:test)
+        end.to raise_error("Couldn't find scheme named 'NOEXIST-#{scheme}'")
       end
 
       it "returns 'false' if no plist parameters are specified" do

--- a/fastlane/spec/fixtures/xcodeproj/bundle.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/xcodeproj/bundle.xcodeproj/project.pbxproj
@@ -206,7 +206,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				INFOPLIST_FILE = bundle/Info.plist;
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = tools.fastlane.bundle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -217,7 +217,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				INFOPLIST_FILE = bundle/Info.plist;
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = tools.fastlane.bundle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -243,6 +243,7 @@
 				0EB04CFD1BCD87E700FE17C5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
The action can now find the info plist path based on the scheme instead of being forced to supply the path
- [x] Add Tests

Issue #4698 
