### PR TITLE
Fix gym with path with spaces

### DIFF
--- a/gym/README.md
+++ b/gym/README.md
@@ -226,7 +226,7 @@ After building the archive it is being checked by `gym`. If it's valid, it gets 
 ### Xcode 7 and above
 
 ```
-/usr/bin/xcrun 'path/to/xcbuild-safe.sh' -exportArchive \
+/usr/bin/xcrun path/to/xcbuild-safe.sh -exportArchive \
 -exportOptionsPlist '/tmp/gym_config_1442852529.plist' \
 -archivePath '/Users/fkrause/Library/Developer/Xcode/Archives/2015-09-21/App 2015-09-21 09.21.56.xcarchive' \
 -exportPath '/tmp/1442852529'
@@ -241,7 +241,7 @@ Note: the [xcbuild-safe.sh script](https://github.com/fastlane/fastlane/tree/mas
 ### Xcode 6 and below
 
 ```
-/usr/bin/xcrun '/path/to/PackageApplication4Gym' -v \
+/usr/bin/xcrun /path/to/PackageApplication4Gym -v \
 '/Users/felixkrause/Library/Developer/Xcode/Archives/2015-08-11/ExampleProductName 2015-08-11 18.15.30.xcarchive/Products/Applications/name.app' -o \
 '/Users/felixkrause/Library/Developer/Xcode/Archives/2015-08-11/ExampleProductName.ipa' \
 --sign "identity" --embed "provProfile"

--- a/gym/README.md
+++ b/gym/README.md
@@ -226,7 +226,7 @@ After building the archive it is being checked by `gym`. If it's valid, it gets 
 ### Xcode 7 and above
 
 ```
-/usr/bin/xcrun path/to/xcbuild-safe.sh -exportArchive \
+/usr/bin/xcrun 'path/to/xcbuild-safe.sh' -exportArchive \
 -exportOptionsPlist '/tmp/gym_config_1442852529.plist' \
 -archivePath '/Users/fkrause/Library/Developer/Xcode/Archives/2015-09-21/App 2015-09-21 09.21.56.xcarchive' \
 -exportPath '/tmp/1442852529'
@@ -241,7 +241,7 @@ Note: the [xcbuild-safe.sh script](https://github.com/fastlane/fastlane/tree/mas
 ### Xcode 6 and below
 
 ```
-/usr/bin/xcrun /path/to/PackageApplication4Gym -v \
+/usr/bin/xcrun '/path/to/PackageApplication4Gym' -v \
 '/Users/felixkrause/Library/Developer/Xcode/Archives/2015-08-11/ExampleProductName 2015-08-11 18.15.30.xcarchive/Products/Applications/name.app' -o \
 '/Users/felixkrause/Library/Developer/Xcode/Archives/2015-08-11/ExampleProductName.ipa' \
 --sign "identity" --embed "provProfile"

--- a/gym/lib/gym.rb
+++ b/gym/lib/gym.rb
@@ -11,6 +11,7 @@ require 'gym/xcode'
 
 require 'fastlane_core'
 require 'terminal-table'
+require 'shellwords'
 
 module Gym
   class << self

--- a/gym/lib/gym/generators/package_command_generator_legacy.rb
+++ b/gym/lib/gym/generators/package_command_generator_legacy.rb
@@ -11,7 +11,7 @@ module Gym
   class PackageCommandGeneratorLegacy
     class << self
       def generate
-        parts = ["/usr/bin/xcrun #{XcodebuildFixes.patch_package_application} -v"]
+        parts = ["/usr/bin/xcrun '#{XcodebuildFixes.patch_package_application}' -v"]
         parts += options
         parts += pipe
 

--- a/gym/lib/gym/generators/package_command_generator_legacy.rb
+++ b/gym/lib/gym/generators/package_command_generator_legacy.rb
@@ -11,7 +11,7 @@ module Gym
   class PackageCommandGeneratorLegacy
     class << self
       def generate
-        parts = ["/usr/bin/xcrun '#{XcodebuildFixes.patch_package_application}' -v"]
+        parts = ["/usr/bin/xcrun #{XcodebuildFixes.patch_package_application.shellescape} -v"]
         parts += options
         parts += pipe
 

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -12,7 +12,7 @@ module Gym
       def generate
         print_legacy_information unless Helper.fastlane_enabled?
 
-        parts = ["/usr/bin/xcrun '#{XcodebuildFixes.wrap_xcodebuild}' -exportArchive"]
+        parts = ["/usr/bin/xcrun #{XcodebuildFixes.wrap_xcodebuild.shellescape} -exportArchive"]
         parts += options
         parts += pipe
 

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -12,7 +12,7 @@ module Gym
       def generate
         print_legacy_information unless Helper.fastlane_enabled?
 
-        parts = ["/usr/bin/xcrun #{XcodebuildFixes.wrap_xcodebuild} -exportArchive"]
+        parts = ["/usr/bin/xcrun '#{XcodebuildFixes.wrap_xcodebuild}' -exportArchive"]
         parts += options
         parts += pipe
 

--- a/gym/spec/package_command_generator_legacy_spec.rb
+++ b/gym/spec/package_command_generator_legacy_spec.rb
@@ -47,12 +47,12 @@ describe Gym do
 
       result = Gym::PackageCommandGeneratorLegacy.generate
       expect(result).to eq([
-                            "/usr/bin/xcrun /tmp/path\\ with\\ spaces -v",
-                            "''",
-                            "-o '#{Gym::PackageCommandGeneratorLegacy.ipa_path}'",
-                            "exportFormat ipa",
-                            ""
-                          ])
+                             "/usr/bin/xcrun /tmp/path\\ with\\ spaces -v",
+                             "''",
+                             "-o '#{Gym::PackageCommandGeneratorLegacy.ipa_path}'",
+                             "exportFormat ipa",
+                             ""
+                           ])
     end
 
     it "supports passing a path to a provisioning profile" do

--- a/gym/spec/package_command_generator_legacy_spec.rb
+++ b/gym/spec/package_command_generator_legacy_spec.rb
@@ -15,7 +15,7 @@ describe Gym do
 
       result = Gym::PackageCommandGeneratorLegacy.generate
       expect(result).to eq([
-                             "/usr/bin/xcrun /tmp/PackageApplication4Gym -v",
+                             "/usr/bin/xcrun '/tmp/PackageApplication4Gym' -v",
                              "''",
                              "-o '#{Gym::PackageCommandGeneratorLegacy.ipa_path}'",
                              "exportFormat ipa",
@@ -31,7 +31,7 @@ describe Gym do
 
       result = Gym::PackageCommandGeneratorLegacy.generate
       expect(result).to eq([
-                             "/usr/bin/xcrun /tmp/PackageApplication4Gym -v",
+                             "/usr/bin/xcrun '/tmp/PackageApplication4Gym' -v",
                              "Krause\\'s\\ App",
                              "-o '#{Gym::PackageCommandGeneratorLegacy.ipa_path}'",
                              "exportFormat ipa",
@@ -50,7 +50,7 @@ describe Gym do
 
       result = Gym::PackageCommandGeneratorLegacy.generate
       expect(result).to eq([
-                             "/usr/bin/xcrun /tmp/PackageApplication4Gym -v",
+                             "/usr/bin/xcrun '/tmp/PackageApplication4Gym' -v",
                              "''",
                              "-o '#{Gym::PackageCommandGeneratorLegacy.ipa_path}'",
                              "exportFormat ipa",

--- a/gym/spec/package_command_generator_legacy_spec.rb
+++ b/gym/spec/package_command_generator_legacy_spec.rb
@@ -15,7 +15,7 @@ describe Gym do
 
       result = Gym::PackageCommandGeneratorLegacy.generate
       expect(result).to eq([
-                             "/usr/bin/xcrun '/tmp/PackageApplication4Gym' -v",
+                             "/usr/bin/xcrun /tmp/PackageApplication4Gym -v",
                              "''",
                              "-o '#{Gym::PackageCommandGeneratorLegacy.ipa_path}'",
                              "exportFormat ipa",
@@ -31,7 +31,7 @@ describe Gym do
 
       result = Gym::PackageCommandGeneratorLegacy.generate
       expect(result).to eq([
-                             "/usr/bin/xcrun '/tmp/PackageApplication4Gym' -v",
+                             "/usr/bin/xcrun /tmp/PackageApplication4Gym -v",
                              "Krause\\'s\\ App",
                              "-o '#{Gym::PackageCommandGeneratorLegacy.ipa_path}'",
                              "exportFormat ipa",
@@ -50,7 +50,7 @@ describe Gym do
 
       result = Gym::PackageCommandGeneratorLegacy.generate
       expect(result).to eq([
-                             "/usr/bin/xcrun '/tmp/PackageApplication4Gym' -v",
+                             "/usr/bin/xcrun /tmp/PackageApplication4Gym -v",
                              "''",
                              "-o '#{Gym::PackageCommandGeneratorLegacy.ipa_path}'",
                              "exportFormat ipa",

--- a/gym/spec/package_command_generator_legacy_spec.rb
+++ b/gym/spec/package_command_generator_legacy_spec.rb
@@ -39,6 +39,22 @@ describe Gym do
                            ])
     end
 
+    it "works with spaces in path name" do
+      options = { project: "./examples/standard/Example.xcodeproj" }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      allow(Gym::XcodebuildFixes).to receive(:patch_package_application).and_return("/tmp/path with spaces")
+
+      result = Gym::PackageCommandGeneratorLegacy.generate
+      expect(result).to eq([
+                            "/usr/bin/xcrun /tmp/path\\ with\\ spaces -v",
+                            "''",
+                            "-o '#{Gym::PackageCommandGeneratorLegacy.ipa_path}'",
+                            "exportFormat ipa",
+                            ""
+                          ])
+    end
+
     it "supports passing a path to a provisioning profile" do
       # Profile Installation
       expect(FastlaneCore::ProvisioningProfile).to receive(:install).with("./spec/fixtures/dummy.mobileprovision")

--- a/gym/spec/package_command_generator_xcode7_spec.rb
+++ b/gym/spec/package_command_generator_xcode7_spec.rb
@@ -23,7 +23,7 @@ describe Gym do
                            ])
     end
 
-    it "works with spaces in path name", now: true do
+    it "works with spaces in path name" do
       options = { project: "./examples/standard/Example.xcodeproj" }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 
@@ -31,12 +31,12 @@ describe Gym do
 
       result = Gym::PackageCommandGeneratorXcode7.generate
       expect(result).to eq([
-                            "/usr/bin/xcrun /tmp/path\\ with\\ spaces -exportArchive",
-                            "-exportOptionsPlist '#{Gym::PackageCommandGeneratorXcode7.config_path}'",
-                            "-archivePath '#{Gym::BuildCommandGenerator.archive_path}'",
-                            "-exportPath '#{Gym::PackageCommandGeneratorXcode7.temporary_output_path}'",
-                            ""
-                          ])
+                             "/usr/bin/xcrun /tmp/path\\ with\\ spaces -exportArchive",
+                             "-exportOptionsPlist '#{Gym::PackageCommandGeneratorXcode7.config_path}'",
+                             "-archivePath '#{Gym::BuildCommandGenerator.archive_path}'",
+                             "-exportPath '#{Gym::PackageCommandGeneratorXcode7.temporary_output_path}'",
+                             ""
+                           ])
     end
 
     it "generates a valid plist file we need" do

--- a/gym/spec/package_command_generator_xcode7_spec.rb
+++ b/gym/spec/package_command_generator_xcode7_spec.rb
@@ -23,6 +23,22 @@ describe Gym do
                            ])
     end
 
+    it "works with spaces in path name", now: true do
+      options = { project: "./examples/standard/Example.xcodeproj" }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      allow(Gym::XcodebuildFixes).to receive(:wrap_xcodebuild).and_return("/tmp/path with spaces")
+
+      result = Gym::PackageCommandGeneratorXcode7.generate
+      expect(result).to eq([
+                            "/usr/bin/xcrun /tmp/path\\ with\\ spaces -exportArchive",
+                            "-exportOptionsPlist '#{Gym::PackageCommandGeneratorXcode7.config_path}'",
+                            "-archivePath '#{Gym::BuildCommandGenerator.archive_path}'",
+                            "-exportPath '#{Gym::PackageCommandGeneratorXcode7.temporary_output_path}'",
+                            ""
+                          ])
+    end
+
     it "generates a valid plist file we need" do
       options = { project: "./examples/standard/Example.xcodeproj" }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)

--- a/gym/spec/package_command_generator_xcode7_spec.rb
+++ b/gym/spec/package_command_generator_xcode7_spec.rb
@@ -15,7 +15,7 @@ describe Gym do
 
       result = Gym::PackageCommandGeneratorXcode7.generate
       expect(result).to eq([
-                             "/usr/bin/xcrun #{Gym::XcodebuildFixes.wrap_xcodebuild} -exportArchive",
+                             "/usr/bin/xcrun '#{Gym::XcodebuildFixes.wrap_xcodebuild}' -exportArchive",
                              "-exportOptionsPlist '#{Gym::PackageCommandGeneratorXcode7.config_path}'",
                              "-archivePath '#{Gym::BuildCommandGenerator.archive_path}'",
                              "-exportPath '#{Gym::PackageCommandGeneratorXcode7.temporary_output_path}'",

--- a/gym/spec/package_command_generator_xcode7_spec.rb
+++ b/gym/spec/package_command_generator_xcode7_spec.rb
@@ -15,7 +15,7 @@ describe Gym do
 
       result = Gym::PackageCommandGeneratorXcode7.generate
       expect(result).to eq([
-                             "/usr/bin/xcrun '#{Gym::XcodebuildFixes.wrap_xcodebuild}' -exportArchive",
+                             "/usr/bin/xcrun #{Gym::XcodebuildFixes.wrap_xcodebuild.shellescape} -exportArchive",
                              "-exportOptionsPlist '#{Gym::PackageCommandGeneratorXcode7.config_path}'",
                              "-archivePath '#{Gym::BuildCommandGenerator.archive_path}'",
                              "-exportPath '#{Gym::PackageCommandGeneratorXcode7.temporary_output_path}'",


### PR DESCRIPTION
When `gym` tries to execute `xcrun`, it requires to pass path as argument, but this path can be erroneous if contents spaces:

```
$ /usr/bin/xcrun /Users/ticketea/.jenkins/jobs/geminis - Upload Build/workspace/vendor/bundle/ruby/2.2.0/gems/gym-1.6.2/lib/assets/wrap_xcodebuild/xcbuild-safe.sh -exportArchive -exportOptionsPlist '/var/folders/y4/b42dq_sx4yj_xhxgccq_f6740000gn/T/gym20160518-1642-1c5xdwc_config.plist' -archivePath '/Users/ticketea/Library/Developer/Xcode/Archives/2016-05-18/geminis 2016-05-18 15.04.42.xcarchive' -exportPath '/var/folders/y4/b42dq_sx4yj_xhxgccq_f6740000gn/T/gym20160518-1642-1c4rtj6.gym_output' 
```

which returns: `xcrun: error: can't exec '/Users/ticketea/.jenkins/jobs/geminis' (errno=No such file or directory)``.

I just added apostrophes to this path, so it will do now:

```
$ /usr/bin/xcrun '/Users/ticketea/.jenkins/jobs/geminis - Upload Build/workspace/vendor/bundle/ruby/2.2.0/gems/gym-1.6.2/lib/assets/wrap_xcodebuild/xcbuild-safe.sh' -exportArchive -exportOptionsPlist '/var/folders/y4/b42dq_sx4yj_xhxgccq_f6740000gn/T/gym20160518-1642-1c5xdwc_config.plist' -archivePath '/Users/ticketea/Library/Developer/Xcode/Archives/2016-05-18/geminis 2016-05-18 15.04.42.xcarchive' -exportPath '/var/folders/y4/b42dq_sx4yj_xhxgccq_f6740000gn/T/gym20160518-1642-1c4rtj6.gym_output' 
```
