### PR TITLE
Comment for push_to_git_remote was wrong

### DIFF
--- a/fastlane/lib/fastlane/actions/push_to_git_remote.rb
+++ b/fastlane/lib/fastlane/actions/push_to_git_remote.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Actions
-    # Adds a git tag to the current commit
+    # Push local changes to the remote branch
     class PushToGitRemoteAction < Action
       def self.run(params)
         local_branch = params[:local_branch]


### PR DESCRIPTION
The file was probably copied from add_git_tag.rb and the comment wasn't updated.
