### PR TITLE
Made junit result parsing more robust

### DIFF
--- a/scan/lib/scan/test_result_parser.rb
+++ b/scan/lib/scan/test_result_parser.rb
@@ -2,11 +2,12 @@ module Scan
   class TestResultParser
     def parse_result(output)
       # e.g. ...<testsuites tests='2' failures='1'>...
-      matched = output.match(%r{\<testsuites tests='(\d+)' failures='(\d+)'/?\>})
+      matched = output.scan(%r{<testsuites\b(?=[^<>]*\s+tests='(\d+)')(?=[^<>]*\s+failures='(\d+)')[^<>]+>})
 
-      if matched and matched.length == 3
-        tests = matched[1].to_i
-        failures = matched[2].to_i
+      if matched and matched.length == 1 and matched[0].length == 2
+
+        tests = matched[0][0].to_i
+        failures = matched[0][1].to_i
 
         return {
           tests: tests,

--- a/scan/lib/scan/test_result_parser.rb
+++ b/scan/lib/scan/test_result_parser.rb
@@ -2,7 +2,7 @@ module Scan
   class TestResultParser
     def parse_result(output)
       # e.g. ...<testsuites tests='2' failures='1'>...
-      matched = output.scan(%r{<testsuites\b(?=[^<>]*\s+tests='(\d+)')(?=[^<>]*\s+failures='(\d+)')[^<>]+>})
+      matched = output.scan(/<testsuites\b(?=[^<>]*\s+tests='(\d+)')(?=[^<>]*\s+failures='(\d+)')[^<>]+>/)
 
       if matched and matched.length == 1 and matched[0].length == 2
 

--- a/scan/lib/scan/test_result_parser.rb
+++ b/scan/lib/scan/test_result_parser.rb
@@ -5,7 +5,6 @@ module Scan
       matched = output.scan(/<testsuites\b(?=[^<>]*\s+tests='(\d+)')(?=[^<>]*\s+failures='(\d+)')[^<>]+>/)
 
       if matched and matched.length == 1 and matched[0].length == 2
-
         tests = matched[0][0].to_i
         failures = matched[0][1].to_i
 

--- a/scan/spec/test_resuilt_parser_spec.rb
+++ b/scan/spec/test_resuilt_parser_spec.rb
@@ -2,43 +2,32 @@ describe Scan do
   describe Scan::TestResultParser do
     it "properly parses the xcodebuild output" do
       output = "<?xml version='1.0' encoding='UTF-8'?>
-        <testsuites tests='2' failures='1'>
-        <testsuite name='appTests' tests='2' failures='1'>
-         <testcase classname='appTests' name='testExample'>
-         <failure message='((1 == 2 - 4) is true) failed'>appTests/appTests.m:30</failure>
-         </testcase>
-         <testcase classname='appTests' name='testPerformanceExample' time='0.262'/>
-         </testsuite>
-       </testsuites>"
+      <testsuites tests='2' failures='1'>
+      <testsuite name='appTests' tests='2' failures='1'>
+      <testcase classname='appTests' name='testExample'>
+      <failure message='((1 == 2 - 4) is true) failed'>appTests/appTests.m:30</failure>
+      </testcase>
+      <testcase classname='appTests' name='testPerformanceExample' time='0.262'/>
+      </testsuite>
+      </testsuites>"
 
       result = Scan::TestResultParser.new.parse_result(output)
       expect(result).to eq({
-          tests: 2,
-          failures: 1
+        tests: 2,
+        failures: 1
       })
     end
-    
+
     it "properly parses the xcodebuild output when the properties are in a different order" do
       output = "<?xml version='1.0' encoding='UTF-8'?>
-        <testsuites failures='1' tests='2'>
-        <testsuite name='appTests' tests='2' failures='1'>
-         <testcase classname='appTests' name='testExample'>
-         <failure message='((1 == 2 - 4) is true) failed'>appTests/appTests.m:30</failure>
-         </testcase>
-         <testcase classname='appTests' name='testPerformanceExample' time='0.262'/>
-         </testsuite>
-       </testsuites>"
-       
-       result = Scan::TestResultParser.new.parse_result(output)
-       expect(result).to eq(
-         tests:2,
-         failures: 1
-       )
-    end
-
-    it "properly parses the xcodebuild output" do
-      output = "<?xml version='1.0' encoding='UTF-8'?>
-        <testsuites tests='2' failures='1'/>"
+      <testsuites failures='1' tests='2'>
+      <testsuite name='appTests' tests='2' failures='1'>
+      <testcase classname='appTests' name='testExample'>
+      <failure message='((1 == 2 - 4) is true) failed'>appTests/appTests.m:30</failure>
+      </testcase>
+      <testcase classname='appTests' name='testPerformanceExample' time='0.262'/>
+      </testsuite>
+      </testsuites>"
 
       result = Scan::TestResultParser.new.parse_result(output)
       expect(result).to eq(
@@ -46,23 +35,34 @@ describe Scan do
         failures: 1
       )
     end
-    
+
+    it "properly parses the xcodebuild output " do
+      output = "<?xml version='1.0' encoding='UTF-8'?>
+      <testsuites tests='2' failures='1'/>"
+
+      result = Scan::TestResultParser.new.parse_result(output)
+      expect(result).to eq(
+        tests: 2,
+        failures: 1
+      )
+    end
+
     it "properly parses the xcodebuild output when there are extra properties" do
       output = "<?xml version='1.0' encoding='UTF-8'?>
-        <testsuites foo='1' tests='2' bar='3' failures='1' baz='4'>
-        <testsuite name='appTests' tests='2' failures='1'>
-         <testcase classname='appTests' name='testExample'>
-         <failure message='((1 == 2 - 4) is true) failed'>appTests/appTests.m:30</failure>
-         </testcase>
-         <testcase classname='appTests' name='testPerformanceExample' time='0.262'/>
-         </testsuite>
-       </testsuites>"
-       
-       result = Scan::TestResultParser.new.parse_result(output)
-       expect(result).to eq(
-         tests:2,
-         failures: 1
-       )
+      <testsuites foo='1' tests='2' bar='3' failures='1' baz='4'>
+      <testsuite name='appTests' tests='2' failures='1'>
+      <testcase classname='appTests' name='testExample'>
+      <failure message='((1 == 2 - 4) is true) failed'>appTests/appTests.m:30</failure>
+      </testcase>
+      <testcase classname='appTests' name='testPerformanceExample' time='0.262'/>
+      </testsuite>
+      </testsuites>"
+
+      result = Scan::TestResultParser.new.parse_result(output)
+      expect(result).to eq(
+        tests: 2,
+        failures: 1
+      )
     end
   end
 end

--- a/scan/spec/test_resuilt_parser_spec.rb
+++ b/scan/spec/test_resuilt_parser_spec.rb
@@ -17,6 +17,24 @@ describe Scan do
           failures: 1
       })
     end
+    
+    it "properly parses the xcodebuild output when the properties are in a different order" do
+      output = "<?xml version='1.0' encoding='UTF-8'?>
+        <testsuites failures='1' tests='2'>
+        <testsuite name='appTests' tests='2' failures='1'>
+         <testcase classname='appTests' name='testExample'>
+         <failure message='((1 == 2 - 4) is true) failed'>appTests/appTests.m:30</failure>
+         </testcase>
+         <testcase classname='appTests' name='testPerformanceExample' time='0.262'/>
+         </testsuite>
+       </testsuites>"
+       
+       result = Scan::TestResultParser.new.parse_result(output)
+       expect(result).to eq(
+         tests:2,
+         failures: 1
+       )
+    end
 
     it "properly parses the xcodebuild output" do
       output = "<?xml version='1.0' encoding='UTF-8'?>
@@ -27,6 +45,24 @@ describe Scan do
         tests: 2,
         failures: 1
       )
+    end
+    
+    it "properly parses the xcodebuild output when there are extra properties" do
+      output = "<?xml version='1.0' encoding='UTF-8'?>
+        <testsuites foo='1' tests='2' bar='3' failures='1' baz='4'>
+        <testsuite name='appTests' tests='2' failures='1'>
+         <testcase classname='appTests' name='testExample'>
+         <failure message='((1 == 2 - 4) is true) failed'>appTests/appTests.m:30</failure>
+         </testcase>
+         <testcase classname='appTests' name='testPerformanceExample' time='0.262'/>
+         </testsuite>
+       </testsuites>"
+       
+       result = Scan::TestResultParser.new.parse_result(output)
+       expect(result).to eq(
+         tests:2,
+         failures: 1
+       )
     end
   end
 end


### PR DESCRIPTION
I had a case where my JUnit report looked like this:
`<testsuites name='MyProject.xctest' tests='49' failures='3'>`

This was causing scan to quit with the error "Couldn't parse the number of tests from the output". The regular expression in this pull request is a bit more robust and allows the XML properties to be in any order and also allows for extra properties to exist and for it still to work.

Relevant issue: #4736 
