### PR TITLE
[snapshot] Fixed copy failure when using only 1 set of launch arguments

### DIFF
--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -80,9 +80,9 @@ module Snapshot
 
     def config_launch_arguments
       launch_arguments = Array(Snapshot.config[:launch_arguments])
-      # if more than 1 set of arguments, use a tuple with an index
+      # use a tuple with an index, nil denoting only 1 set of arguments
       if launch_arguments.count == 1
-        [launch_arguments]
+        [[nil, launch_arguments.first]]
       else
         launch_arguments.map.with_index { |e, i| [i, e] }
       end


### PR DESCRIPTION
Hi there,

I came across a copy failure when using 1 set of launch arguments with snapshot.
Basically what happened is that it was trying to use the whole text of the launch arguments in the output filename when collecting the screenshot.

This PR proposes a fix for that issue.

Here's an example Fastfile causing the problem:

``` ruby
snapshot(
  launch_arguments: [
    "-FVBoltDemoTS /Users/jean/src/github.com/fanvision/tv_mobile_apps2/FvBoltIOS/Examples/FanVisionBolt/FanVisionBolt/demo.ts",
  ],
)
```

Then it shows the following errors:

```
...
INFO [2016-05-19 12:31:13.82]: Collecting screenshots...
DEBUG [2016-05-19 12:31:13.82]: Loading up '/var/folders/bd/rv_syh756ys0z9y48jd2_2400000gn/T/snapshot_derived20160519-84546-gwjv7d/Logs/Test/670D4A75-9AE5-4B80-81AB-CDCC8954B379_TestSummaries.plist'...
INFO [2016-05-19 12:31:13.85]: Found 5 screenshots...
DEBUG [2016-05-19 12:31:13.85]: Found Screenshot_DEFAD717-22ED-42C5-A276-E873166540B4.png, Screenshot_009AF7B6-9C0C-4ADA-B5EA-0C28D8A8A107.png, Screenshot_6176E38D-CCF0-43A2-AE02-FF4D864D5E70.png, Screenshot_945D42D8-600B-48F5-9192-BB1BD9A02FED.png, Screenshot_F9E4514B-FCAA-4F0F-A79A-E542C26A6CF3.png
INFO [2016-05-19 12:31:13.85]: Copying file '/var/folders/bd/rv_syh756ys0z9y48jd2_2400000gn/T/snapshot_derived20160519-84546-gwjv7d/Logs/Test/Attachments/Screenshot_DEFAD717-22ED-42C5-A276-E873166540B4.png' to '/Users/jean/src/github.com/fanvision/tv_mobile_apps2/FvBoltIOS/fastlane/screenshots/en-US/iPhone6--FVBoltDemoTS /Users/jean/src/github.com/fanvision/tv_mobile_apps2/FvBoltIOS/Examples/FanVisionBolt/FanVisionBolt/demo.ts-0MainScreen.png'...
ERROR [2016-05-19 12:31:13.85]: No such file or directory @ rb_sysopen - /Users/jean/src/github.com/fanvision/tv_mobile_apps2/FvBoltIOS/fastlane/screenshots/en-US/iPhone6--FVBoltDemoTS /Users/jean/src/github.com/fanvision/tv_mobile_apps2/FvBoltIOS/Examples/FanVisionBolt/FanVisionBolt/demo.ts-0MainScreen.png
```

This was using fastlane `1.89.0` with bundler under rbenv (`ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin15]`).

Let me know what you think.
