### PR TITLE
Clarify setting of `git_branch` in Matchfile

### DIFF
--- a/match/README.md
+++ b/match/README.md
@@ -130,7 +130,7 @@ username "user@fastlane.tools"
 
 #### Important: Use one git branch per team
 
-`match` also supports storing certificates of multiple teams in one repo, by using separate git branches. If you work in multiple teams, make sure to set the `git_branch` parameter to a unique value per team. From there, `match` will automatically create and use the specified branch for you. 
+`match` also supports storing certificates of multiple teams in one repo, by using separate git branches. Whether you work in multiple teams or not, make sure to set the `git_branch` parameter to a unique value per team. From there, `match` will automatically create and use the specified branch for you. (Don't use a pre-existing branch such as `master`.)
 
 ```ruby
 match(git_branch: "team1", username: "user@team1.com")


### PR DESCRIPTION
Issue https://github.com/fastlane/fastlane/issues/4741

Until I set `git_branch` to a branch that didn't yet exist, I got the following cryptic error:

/Library/Ruby/Gems/2.0.0/gems/match-0.6.0/lib/match/git_helper.rb:115:in `block in branch_exists?': [!] undefined method`shellescape' for nil:NilClass (NoMethodError)
    from /Library/Ruby/Gems/2.0.0/gems/match-0.6.0/lib/match/git_helper.rb:114:in `chdir'
    from /Library/Ruby/Gems/2.0.0/gems/match-0.6.0/lib/match/git_helper.rb:114:in`branch_exists?'
    from /Library/Ruby/Gems/2.0.0/gems/match-0.6.0/lib/match/git_helper.rb:89:in `checkout_branch'
    from /Library/Ruby/Gems/2.0.0/gems/match-0.6.0/lib/match/git_helper.rb:17:in`clone'
    from /Library/Ruby/Gems/2.0.0/gems/match-0.6.0/lib/match/change_password.rb:7:in `update'
    from /Library/Ruby/Gems/2.0.0/gems/match-0.6.0/lib/match/git_helper.rb:21:in`clone'
    from /Library/Ruby/Gems/2.0.0/gems/match-0.6.0/lib/match/runner.rb:10:in `run'
    from /Library/Ruby/Gems/2.0.0/gems/match-0.6.0/lib/match/commands_generator.rb:55:in`block (3 levels) in run'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.3.5/lib/commander/command.rb:178:in `call'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.3.5/lib/commander/command.rb:178:in`call'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.3.5/lib/commander/command.rb:153:in `run'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.3.5/lib/commander/runner.rb:428:in`run_active_command'
    from /Library/Ruby/Gems/2.0.0/gems/fastlane_core-0.43.5/lib/fastlane_core/ui/fastlane_runner.rb:26:in `run!'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.3.5/lib/commander/delegates.rb:15:in`run!'
    from /Library/Ruby/Gems/2.0.0/gems/match-0.6.0/lib/match/commands_generator.rb:121:in `run'
    from /Library/Ruby/Gems/2.0.0/gems/match-0.6.0/lib/match/commands_generator.rb:12:in`start'
    from /Library/Ruby/Gems/2.0.0/gems/match-0.6.0/bin/match:6:in `<top (required)>'
    from /usr/local/bin/match:23:in`load'
    from /usr/local/bin/match:23:in `<main>'
