### PR TITLE
Adding more options to pod_lib_lint action

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_lib_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_lib_lint.rb
@@ -23,6 +23,11 @@ module Fastlane
           command << "--allow-warnings"
         end
 
+        command << "--use-libraries" if params[:use_libraries]
+        command << "--fail-fast" if params[:fail_fast]
+        command << "--private" if params[:private]
+        command << "--quick" if params[:quick]
+
         result = Actions.sh(command.join(' '))
         UI.success("Pod lib lint Successfully ⬆️ ")
         return result
@@ -60,7 +65,23 @@ module Fastlane
                                          is_string: false,
                                          verify_block: proc do |value|
                                            UI.user_error!("Sources must be an array.") unless value.kind_of?(Array)
-                                         end)
+                                         end),
+          FastlaneCore::ConfigItem.new(key: :use_libraries,
+                                       description: "Lint uses static libraries to install the spec",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :fail_fast,
+                                       description: "Lint stops on the first failing platform or subspec",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :private,
+                                       description: "Lint skips checks that apply only to public specs",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :quick,
+                                       description: "Lint skips checks that would require to download and build the spec",
+                                       is_string: false,
+                                       default_value: false)
         ]
       end
 

--- a/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
+++ b/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
@@ -24,6 +24,38 @@ describe Fastlane do
 
         expect(result).to eq("bundle exec pod lib lint --allow-warnings")
       end
+
+      it "generates the correct pod lib lint command with quick parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_lib_lint(quick: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod lib lint --quick")
+      end
+
+      it "generates the correct pod lib lint command with private parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_lib_lint(private: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod lib lint --private")
+      end
+
+      it "generates the correct pod lib lint command with fail-fast parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_lib_lint(fail_fast: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod lib lint --fail-fast")
+      end
+
+      it "generates the correct pod lib lint command with use-libraries parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_lib_lint(use_libraries: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod lib lint --use-libraries")
+      end
     end
   end
 end


### PR DESCRIPTION
This adds support to more options to `pod_lib_lint` action:
- `use_libraries`
- `fail_fast`
- `private`
- `quick`
