### PR TITLE
Revert "Added support for invocation from actionscript to gradle.rb"

### DIFF
--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -18,7 +18,7 @@ module Fastlane
 
         gradle_task = [task, flavor, build_type].join
 
-        project_dir = params[:project_dir] || '.'
+        project_dir = params[:project_dir]
 
         gradle_path_param = params[:gradle_path] || './gradlew'
 


### PR DESCRIPTION
Reverts fastlane/fastlane#4710

Because this is already the default value
