### PR TITLE
[fastlane_core] Version bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.43.5".freeze
+  VERSION = "0.44.0".freeze
 end


### PR DESCRIPTION
- repare for fastlane plugins (#4770)
- Removed Sentry (#4756)
- Shell escape keychain paths in CertChecker
- Replaced remaining .red and raise blocks (#4709)
