### PR TITLE
[fastlane] Version bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.89.0'.freeze
+  VERSION = '1.90.0'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end


### PR DESCRIPTION
**New:**
- Provide an `xcversion` action to select Xcode via version specifier (#4421)
- `scan` can now run scan on multiple devices using the new `devices` option
- `match` now supports storing of multiple dev accounts and teams in one git repo using the `git_branch` option
- Adding more options to pod_lib_lint action (#4771)
- Added support for carthage `--derived-data`. (#4163)
- Prepare `fastlane` foundation to support plugins: https://github.com/fastlane/fastlane/issues/4744

**Improvements:**
- Updated platform docs to mention Android by default (#4764)
- Updated `xcode-install` depdendency (#4757)
- Updated internal dependencies
- Replaced remaining .red and raise blocks (#4709)
- Don't show private lanes in lanes table (#4690)
- Updates `Xcake` Action to support  new `xcake make` command. (#4068)
- Carthage configuration option and tvOS platform support (#4054)
- Fix typo in Copy Artifacts (#4645)
- [fastlane] Show custom action message only on verbose mode (#4640)
- jira action is now verifying 'jira-ruby' gem installed
- Fixed escaping of Keychain path
- Removed Sentry crash reporting(#4756)
