### PR TITLE
Pass git_branch to ChangePassord.update

### DIFF
--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -19,6 +19,7 @@ module Match
       if !Helper.test? and GitHelper.match_version(@dir).nil? and manual_password.nil? and File.exist?(File.join(@dir, "README.md"))
         UI.important "Migrating to new match..."
         ChangePassword.update(params: { git_url: git_url,
+                                 git_branch: branch,
                                  shallow_clone: shallow_clone },
                                           from: "",
                                             to: Encrypt.new.password(git_url))

--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -19,7 +19,7 @@ module Match
       if !Helper.test? and GitHelper.match_version(@dir).nil? and manual_password.nil? and File.exist?(File.join(@dir, "README.md"))
         UI.important "Migrating to new match..."
         ChangePassword.update(params: { git_url: git_url,
-                                 git_branch: branch,
+                                    git_branch: branch,
                                  shallow_clone: shallow_clone },
                                           from: "",
                                             to: Encrypt.new.password(git_url))


### PR DESCRIPTION
This resolves an issue where ChangePassword would set the `branch:` parameter to the value of `params[:branch]`, which would be nil.

Because we were providing the `branch` argument, the default "master" was being ignored. Causing the GitHelper.clone method to explode when trying to clone a nil branch.

I've written up a detailed issue here. https://github.com/fastlane/fastlane/issues/4807

Open to suggestions, as you may want to solve it by having the branch always set to master when nil in the `GitHelper.clone` method or only call `checkout_branch` if there's a branch and it's not equal to master.

Fixes https://github.com/fastlane/fastlane/issues/4807
