### PR TITLE
[testfairy action] enable parameters/options

### DIFF
--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -17,13 +17,58 @@ module Fastlane
 
         return params[:ipa] if Helper.test?
 
-        client_options = params.values
+        metrics_to_client = lambda do |metrics|
+          metrics.map do |metric|
+          case metric
+            when :cpu,:memory,:network,:gps,:battery,:mic,:wifi
+              metric.to_s
+            when :phone_signal
+              'phone-signal'
+            else
+              UI.user_error!("Unknown metric: #{metric}")
+            end
+          end
+        end
 
-        client_options[:testers_groups] = client_options[:testers_groups].join(',') if client_options.key?(:testers_groups)
-        client_options[:metrics] = client_options[:metrics].join(',') if client_options.key?(:metrics)
-        client_options[:options] = client_options[:options].join(',') if client_options.key?(:options)
-        client_options['auto-update'] = client_options.delete(:auto_update) if client_options.key?(:auto_update)
-        client_options['icon-watermark'] = client_options.delete(:icon_watermark) if client_options.key?(:icon_watermark)
+        options_to_client = lambda do |options|
+          options.map do |option|
+          case option
+            when :shake,:anonymous
+              option.to_s
+            when :video_only_wifi
+              'video-only-wifi'
+            else
+              UI.user_error!("Unknown option: #{option}")
+            end
+          end
+        end
+
+        client_options = Hash[params.values.map do |key,value|
+          case key
+          when :api_key
+            [key, value]
+          when :ipa
+            [key, value]
+          when :symbols_file
+            [key, value]
+          when :testers_groups
+            [key, value.join(',')]
+          when :metrics
+            [key, metrics_to_client.(value).join(',')]
+          when :icon_watermark
+            ['icon-watermark', value]
+          when :comment
+            [key, value]
+          when :auto_update
+            ['auto-update', value]
+          when :notify
+            [key, value]
+          when :options
+            [key, options_to_client.(value).join(',')]
+          else
+            UI.user_error!("Unknown parameter: #{key}")
+          end
+        end]
 
         response = client.upload_build(params[:ipa], client_options)
         if parse_response(response)
@@ -59,6 +104,7 @@ module Fastlane
 
       def self.available_options
         [
+          # required
           FastlaneCore::ConfigItem.new(key: :api_key,
                                        env_name: "FL_TESTFAIRY_API_KEY", # The name of the environment variable
                                        description: "API Key for TestFairy", # a short description of this parameter
@@ -72,45 +118,59 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
                                        end),
-          FastlaneCore::ConfigItem.new(key: :comment,
-                                       env_name: "FL_TESTFAIRY_COMMENT",
-                                       description: "Additional release notes for this upload. This text will be added to email notifications",
-                                       default_value: 'No comment provided'), # the default value if the user didn't provide one
-          FastlaneCore::ConfigItem.new(key: :testers_groups,
-                                       type: Array,
-                                       short_option: '-g',
-                                       env_name: "FL_TESTFAIRY_TESTERS_GROUPS",
-                                       description: "Array of tester groups to be notified",
-                                       default_value: []), # the default value is an empty list
+          # optional
           FastlaneCore::ConfigItem.new(key: :symbols_file,
+                                       optional: true,
                                        env_name: "FL_TESTFAIRY_SYMBOLS_FILE",
                                        description: "Symbols mapping file",
                                        default_value: Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH],
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find dSYM file at path '#{value}'") unless File.exist?(value)
                                        end),
-          FastlaneCore::ConfigItem.new(key: :notify,
-                                       env_name: "FL_TESTFAIRY_NOTIFY",
-                                       description: "Send email to testers",
-                                       default_value: 'on'),
-          FastlaneCore::ConfigItem.new(key: :auto_update,
-                                       env_name: "FL_TESTFAIRY_AUTO_UPDATE",
-                                       description: "Allows easy upgrade of all users to current version",
-                                       default_value: 'on'),
-          FastlaneCore::ConfigItem.new(key: :icon_watermark,
-                                       env_name: "FL_TESTFAIRY_ICON_WATERMARK",
-                                       description: "Add a small watermark to app icon",
-                                       default_value: 'on'),
+          FastlaneCore::ConfigItem.new(key: :testers_groups,
+                                       optional: true,
+                                       type: Array,
+                                       short_option: '-g',
+                                       env_name: "FL_TESTFAIRY_TESTERS_GROUPS",
+                                       description: "Array of tester groups to be notified",
+                                       default_value: []), # the default value is an empty list
           FastlaneCore::ConfigItem.new(key: :metrics,
+                                       optional: true,
                                        type: Array,
                                        env_name: "FL_TESTFAIRY_METRICS",
-                                       description: "Array of metrics to record (cpu,memory,network,phone-signal,gps,battery,mic,wifi)",
-                                       default_value: [:cpu, :memory, :network, :wifi]),
+                                       description: "Array of metrics to record (cpu,memory,network,phone_signal,gps,battery,mic,wifi)",
+                                       default_value: []),
+          # max-duration
+          # video
+          # video-quality
+          # video-rate
+          FastlaneCore::ConfigItem.new(key: :icon_watermark,
+                                       optional: true,
+                                       env_name: "FL_TESTFAIRY_ICON_WATERMARK",
+                                       description: "Add a small watermark to app icon",
+                                       default_value: 'off'),
+          FastlaneCore::ConfigItem.new(key: :comment,
+                                       optional: true,
+                                       env_name: "FL_TESTFAIRY_COMMENT",
+                                       description: "Additional release notes for this upload. This text will be added to email notifications",
+                                       default_value: 'No comment provided'), # the default value if the user didn't provide one
+          FastlaneCore::ConfigItem.new(key: :auto_update,
+                                       optional: true,
+                                       env_name: "FL_TESTFAIRY_AUTO_UPDATE",
+                                       description: "Allows easy upgrade of all users to current version",
+                                       default_value: 'off'),
+          # not well documented
+          FastlaneCore::ConfigItem.new(key: :notify,
+                                       optional: true,
+                                       env_name: "FL_TESTFAIRY_NOTIFY",
+                                       description: "Send email to testers",
+                                       default_value: 'off'),
           FastlaneCore::ConfigItem.new(key: :options,
+                                       optional: true,
                                        type: Array,
                                        env_name: "FL_TESTFAIRY_OPTIONS",
-                                       description: "Array of options (shake,video-only-wifi,anonymous)",
-                                       default_value: [])
+                                       description: "Array of options (shake,video_only_wifi,anonymous)",
+                                       default_value: []),
         ]
       end
 
@@ -121,7 +181,7 @@ module Fastlane
       end
 
       def self.authors
-        ["taka0125"]
+        ["taka0125","tcurdt"]
       end
 
       def self.is_supported?(platform)

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -105,7 +105,7 @@ module Fastlane
                                        type: Array,
                                        env_name: "FL_TESTFAIRY_METRICS",
                                        description: "Array of metrics to record (cpu,memory,network,phone-signal,gps,battery,mic,wifi)",
-                                       default_value: [ :cpu, :memory, :network, :wifi ]),
+                                       default_value: [:cpu, :memory, :network, :wifi]),
           FastlaneCore::ConfigItem.new(key: :options,
                                        type: Array,
                                        env_name: "FL_TESTFAIRY_OPTIONS",

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -20,7 +20,7 @@ module Fastlane
         metrics_to_client = lambda do |metrics|
           metrics.map do |metric|
             case metric
-            when :cpu,:memory,:network,:gps,:battery,:mic,:wifi
+            when :cpu, :memory, :network, :gps, :battery, :mic, :wifi
               metric.to_s
             when :phone_signal
               'phone-signal'
@@ -33,7 +33,7 @@ module Fastlane
         options_to_client = lambda do |options|
           options.map do |option|
             case option
-            when :shake,:anonymous
+            when :shake, :anonymous
               option.to_s
             when :video_only_wifi
               'video-only-wifi'
@@ -170,7 +170,7 @@ module Fastlane
                                        type: Array,
                                        env_name: "FL_TESTFAIRY_OPTIONS",
                                        description: "Array of options (shake,video_only_wifi,anonymous)",
-                                       default_value: []),
+                                       default_value: [])
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -19,7 +19,7 @@ module Fastlane
 
         metrics_to_client = lambda do |metrics|
           metrics.map do |metric|
-          case metric
+            case metric
             when :cpu,:memory,:network,:gps,:battery,:mic,:wifi
               metric.to_s
             when :phone_signal
@@ -32,7 +32,7 @@ module Fastlane
 
         options_to_client = lambda do |options|
           options.map do |option|
-          case option
+            case option
             when :shake,:anonymous
               option.to_s
             when :video_only_wifi
@@ -43,7 +43,7 @@ module Fastlane
           end
         end
 
-        client_options = Hash[params.values.map do |key,value|
+        client_options = Hash[params.values.map do |key, value|
           case key
           when :api_key
             [key, value]
@@ -54,7 +54,7 @@ module Fastlane
           when :testers_groups
             [key, value.join(',')]
           when :metrics
-            [key, metrics_to_client.(value).join(',')]
+            [key, metrics_to_client.call(value).join(',')]
           when :icon_watermark
             ['icon-watermark', value]
           when :comment
@@ -64,7 +64,7 @@ module Fastlane
           when :notify
             [key, value]
           when :options
-            [key, options_to_client.(value).join(',')]
+            [key, options_to_client.call(value).join(',')]
           else
             UI.user_error!("Unknown parameter: #{key}")
           end
@@ -181,7 +181,7 @@ module Fastlane
       end
 
       def self.authors
-        ["taka0125","tcurdt"]
+        ["taka0125", "tcurdt"]
       end
 
       def self.is_supported?(platform)

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -87,7 +87,7 @@ module Fastlane
                                        description: "Symbols mapping file",
                                        default_value: Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH],
                                        verify_block: proc do |value|
-                                         UI.user_error!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
+                                         UI.user_error!("Couldn't find dSYM file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :notify,
                                        env_name: "FL_TESTFAIRY_NOTIFY",


### PR DESCRIPTION
Right now the parameters for the testfairy upload are very limited.
This PR enables the following parameters:
- symbols_file
- notify
- auto-update
- icon-watermark
- metrics
- options

Fix https://github.com/fastlane/fastlane/issues/4819
