### PR TITLE
Re-add `Helper.log` and add deprecation warning

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -3,6 +3,13 @@ require 'colored'
 
 module FastlaneCore
   module Helper
+    # This method is deprecated, use the `UI` class
+    # https://github.com/fastlane/fastlane/blob/master/fastlane/docs/UI.md
+    def self.log
+      UI.deprecated "Helper.log is deprecated. Use `UI` class instead"
+      UI.current.log
+    end
+
     # Runs a given command using backticks (`)
     # and prints them out using the UI.command method
     def self.backticks(command, print: true)


### PR DESCRIPTION
Fix #4827 

Adds back the method that was removed in #4709. Behavior isn't exactly the same (namely the coloring for different log levels is missing) and adds a deprecation warning that people should use `UI` methods in instead
