### PR TITLE
fastlane_core version bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.44.1".freeze
+  VERSION = "0.44.2".freeze
 end


### PR DESCRIPTION
- Re-add Helper.log and add deprecation warning (#4832)
- Only query for xcode version on macs (#4631)
