### PR TITLE
[fastlane] Version bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.90.0'.freeze
+  VERSION = '1.91.0'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end


### PR DESCRIPTION
- Update slather action with new commands (#4825)
- Show message when trying to enable or disable the crash reporter (#4805)
- Updated internal dependencies to fix an issue with WWDR certificates
- Fixed an issue with local plugins not being able to access `Helper.log`
- Convert `copy_artifacts` action to `FileUtils` (#4654)
