### PR TITLE
Scan Oclint integration

### DIFF
--- a/fastlane/lib/fastlane/actions/oclint.rb
+++ b/fastlane/lib/fastlane/actions/oclint.rb
@@ -45,7 +45,7 @@ module Fastlane
         report_type = params[:report_type]
         report_path = params[:report_path] ? params[:report_path] : 'oclint_report.' + report_type
 
-        oclint_args = ["-report-type=#{report_type}", "-o=#{report_path}"]
+        oclint_args = ["-report-type=#{report_type}", "-o=#{File.dirname(report_path)}"]
 
         oclint_args << "-list-enabled-rules" if params[:list_enabled_rules]
 

--- a/fastlane/lib/fastlane/actions/oclint.rb
+++ b/fastlane/lib/fastlane/actions/oclint.rb
@@ -45,7 +45,7 @@ module Fastlane
         report_type = params[:report_type]
         report_path = params[:report_path] ? params[:report_path] : 'oclint_report.' + report_type
 
-        oclint_args = ["-report-type=#{report_type}", "-o=#{File.dirname(report_path)}"]
+        oclint_args = ["-report-type=#{report_type}", "-o=#{report_path}"]
 
         oclint_args << "-list-enabled-rules" if params[:list_enabled_rules]
 
@@ -66,7 +66,7 @@ module Fastlane
         oclint_args << "-enable-clang-static-analyzer" if params[:enable_clang_static_analyzer]
         oclint_args << "-enable-global-analysis" if params[:enable_global_analysis]
         oclint_args << "-allow-duplicated-violations" if params[:allow_duplicated_violations]
-        oclint_args << "-p #{params[:compile_commands]}" if params[:compile_commands]
+        oclint_args << "-p #{File.dirname(params[:compile_commands])}" if params[:compile_commands]
 
         command = [
           command_prefix,

--- a/fastlane/spec/actions_specs/oclint_spec.rb
+++ b/fastlane/spec/actions_specs/oclint_spec.rb
@@ -16,7 +16,7 @@ describe Fastlane do
             )
           end").runner.execute(:test)
 
-        expect(result).to match(/cd .* && oclint -report-type=html -o=oclint_report.html -p .\/fastlane\/spec\/fixtures\/oclint \".*/)
+        expect(result).to match(%r{cd .* && oclint -report-type=html -o=oclint_report.html -p ./fastlane/spec/fixtures/oclint \".*})
       end
 
       it "works with all parameters" do

--- a/fastlane/spec/actions_specs/oclint_spec.rb
+++ b/fastlane/spec/actions_specs/oclint_spec.rb
@@ -1,7 +1,7 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "OCLint Integration" do
-      it "raises an exception when not the default compile_commands.json is present" do
+      it "raises an exception when the default compile_commands.json is not present" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             oclint
@@ -16,7 +16,7 @@ describe Fastlane do
             )
           end").runner.execute(:test)
 
-        expect(result).to match(/cd .* && oclint -report-type=html -o=oclint_report.html -p .*?compile_commands\.json \".*/)
+        expect(result).to match(/cd .* && oclint -report-type=html -o=oclint_report.html -p .\/fastlane\/spec\/fixtures\/oclint \".*/)
       end
 
       it "works with all parameters" do

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -173,6 +173,10 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :slack_only_on_failure,
                                     description: "Only post on Slack if the tests fail",
                                     is_string: false,
+                                    default_value: false),
+        FastlaneCore::ConfigItem.new(key: :use_clang_report_name,
+                                    description: "Generate the json compilation database with clang naming convention (compile_commands.json)",
+                                    is_string: false,
                                     default_value: false)
       ]
     end

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -53,7 +53,8 @@ module Scan
 
       report_collector = ReportCollector.new(Scan.config[:open_report],
                                              Scan.config[:output_types],
-                                             Scan.config[:output_directory])
+                                             Scan.config[:output_directory],
+                                             Scan.config[:use_clang_report_name])
 
       cmd = report_collector.generate_commands(TestCommandGenerator.xcodebuild_log_path,
                                                types: 'junit',

--- a/scan/spec/report_collector_spec.rb
+++ b/scan/spec/report_collector_spec.rb
@@ -3,12 +3,30 @@ describe Scan do
     let (:path) { "./spec/fixtures/boring.log" }
 
     it "ignores invalid report types" do
-      commands = Scan::ReportCollector.new(false, "invalid, html", "/tmp").generate_commands(path)
+      commands = Scan::ReportCollector.new(false, "invalid, html", "/tmp", false).generate_commands(path)
 
       expect(commands.count).to eq(1)
       expect(commands).to eq({
         "/tmp/report.html" => "cat './spec/fixtures/boring.log' |  xcpretty --report html --output '/tmp/report.html' &> /dev/null "
       })
+    end
+
+    it "names the json compilation database with the correct name when the json_compilation_database_clang option is set" do
+      commands = Scan::ReportCollector.new(false, "json-compilation-database", "/tmp", true).generate_commands(path)
+
+      expect(commands.count).to eq(1)
+      expect(commands).to eq({
+        "/tmp/compile_commands.json" => "cat './spec/fixtures/boring.log' |  xcpretty --report json-compilation-database --output '/tmp/compile_commands.json' &> /dev/null "
+      })
+    end
+
+    it "names the json compilation database with the correct name when the json_compilation_database_clang option is not set" do
+      commands = Scan::ReportCollector.new(false, "json-compilation-database", "/tmp", false).generate_commands(path)
+
+      expect(commands.count).to eq(1)
+      expect(commands).to eq({
+        "/tmp/report.json-compilation-database" => "cat './spec/fixtures/boring.log' |  xcpretty --report json-compilation-database --output '/tmp/report.json-compilation-database' &> /dev/null "
+                             })
     end
   end
 end

--- a/scan/spec/report_collector_spec.rb
+++ b/scan/spec/report_collector_spec.rb
@@ -7,8 +7,8 @@ describe Scan do
 
       expect(commands.count).to eq(1)
       expect(commands).to eq({
-        "/tmp/report.html" => "cat './spec/fixtures/boring.log' |  xcpretty --report html --output '/tmp/report.html' &> /dev/null "
-      })
+                                 "/tmp/report.html" => "cat './spec/fixtures/boring.log' |  xcpretty --report html --output '/tmp/report.html' &> /dev/null "
+                             })
     end
 
     it "names the json compilation database with the correct name when the json_compilation_database_clang option is set" do
@@ -16,8 +16,8 @@ describe Scan do
 
       expect(commands.count).to eq(1)
       expect(commands).to eq({
-        "/tmp/compile_commands.json" => "cat './spec/fixtures/boring.log' |  xcpretty --report json-compilation-database --output '/tmp/compile_commands.json' &> /dev/null "
-      })
+                                 "/tmp/compile_commands.json" => "cat './spec/fixtures/boring.log' |  xcpretty --report json-compilation-database --output '/tmp/compile_commands.json' &> /dev/null "
+                             })
     end
 
     it "names the json compilation database with the correct name when the json_compilation_database_clang option is not set" do
@@ -25,8 +25,8 @@ describe Scan do
 
       expect(commands.count).to eq(1)
       expect(commands).to eq({
-        "/tmp/report.json-compilation-database" => "cat './spec/fixtures/boring.log' |  xcpretty --report json-compilation-database --output '/tmp/report.json-compilation-database' &> /dev/null "
-                             })
+                                 "/tmp/report.json-compilation-database" => "cat './spec/fixtures/boring.log' |  xcpretty --report json-compilation-database --output '/tmp/report.json-compilation-database' &> /dev/null "
+                              })
     end
   end
 end


### PR DESCRIPTION
This pull request addresses issues #4327 and #1934, and allows integration between the Scan and OCLint actions. It also fixes an issue that I found with the current OCLint action.

OCLint requires (at least the current version does) the path of the directory containing the compilation database. The current OCLint action in Master instead provides the path to the actual file, which doesn't work. I have rectified this.

I also added an extra configuration parameter (`use_clang_report_name`) to Scan to output the compilation database JSON with the naming convention that OCLint expects [http://clang.llvm.org/docs/JSONCompilationDatabase.html](http://clang.llvm.org/docs/JSONCompilationDatabase.html). I decided to add this as a config parameter rather than the default to avoid breaking any existing workflows that may use the current naming of this file.

Basically, this means that a Scan + OCLint workflow could look like this:

```
fastlane_version "1.89.0"

default_platform :ios

platform :ios do
  desc "Runs all the tests"
  lane :test do
    scan(
        clean: true,
        scheme: "MyApp",
        output_types: "json-compilation-database",
        use_clang_report_name: true
    )

    oclint(
        compile_commands: Dir.pwd + "/test_output/compile_commands.json",
        report_type: 'pmd'
    )
  end
end
```
