### PR TITLE
[cocoapods] add --repo-update as default 

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -19,6 +19,7 @@ module Fastlane
 
         cmd << '--no-clean' unless params[:clean]
         cmd << '--no-integrate' unless params[:integrate]
+        cmd << '--repo-update' if params[:repo_update]
         cmd << '--no-repo-update' unless params[:repo_update]
         cmd << '--silent' if params[:silent]
         cmd << '--verbose' if params[:verbose]

--- a/fastlane/spec/actions_specs/cocoapods_spec.rb
+++ b/fastlane/spec/actions_specs/cocoapods_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane do
           cocoapods
         end").runner.execute(:test)
 
-        expect(result).to eq("bundle exec pod install")
+        expect(result).to eq("bundle exec pod install --repo-update")
       end
 
       it "default use case with no bundle exec" do
@@ -14,7 +14,7 @@ describe Fastlane do
           cocoapods(use_bundle_exec: false)
         end").runner.execute(:test)
 
-        expect(result).to eq("pod install")
+        expect(result).to eq("pod install --repo-update")
       end
 
       it "adds no-clean to command if clean is set to false" do
@@ -24,7 +24,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("bundle exec pod install --no-clean")
+        expect(result).to eq("bundle exec pod install --no-clean --repo-update")
       end
 
       it "adds no-integrate to command if integrate is set to false" do
@@ -34,7 +34,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("bundle exec pod install --no-integrate")
+        expect(result).to eq("bundle exec pod install --no-integrate --repo-update")
       end
 
       it "adds no-repo-update to command if repo_update is set to false" do
@@ -54,7 +54,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("bundle exec pod install --silent")
+        expect(result).to eq("bundle exec pod install --repo-update --silent")
       end
 
       it "adds verbose to command if verbose is set to true" do
@@ -64,7 +64,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("bundle exec pod install --verbose")
+        expect(result).to eq("bundle exec pod install --repo-update --verbose")
       end
 
       it "adds no-ansi to command if ansi is set to false" do
@@ -74,7 +74,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("bundle exec pod install --no-ansi")
+        expect(result).to eq("bundle exec pod install --repo-update --no-ansi")
       end
 
       it "changes directory if podfile is set to the Podfile path" do
@@ -84,7 +84,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("cd 'Project' && bundle exec pod install")
+        expect(result).to eq("cd 'Project' && bundle exec pod install --repo-update")
       end
 
       it "changes directory if podfile is set to a directory" do
@@ -94,7 +94,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("cd 'Project' && bundle exec pod install")
+        expect(result).to eq("cd 'Project' && bundle exec pod install --repo-update")
       end
     end
   end

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -333,7 +333,7 @@ describe Fastlane do
           cocoapods
         end").runner.execute(:test)
 
-        expect(result).to eq("bundle exec pod install")
+        expect(result).to eq("bundle exec pod install --repo-update")
       end
 
       it "calls the error block when an error occurs" do


### PR DESCRIPTION
🔑

This PR add `--repo-update` as default for cocoapods action as requested in issue #4497.
I leave support for `--no-repo-update` for previous versions of cocoapods.
### Problem:

`pod install` in cocoapods 1.0.0 will not run `pod repo update` by default
### Solution:

They added param `--repo-update` that may be called to update repository before `pod install`
### Example:

action `cocoapods`
will run cmd `cocoapods --repo-update`
- on cocoapods 0.39 - repo is updated by default
- on cocoapods 1.0.0 - repo update will be triggered by this param

action `cocoapods(repo_update: false)`
will run cmd `cocoapods --no-repo-update`
- on cocoapods 0.39 - repo will be not updated because this param
- on cocoapods 1.0.0 - repo is not updated by default

Issue link: https://github.com/fastlane/fastlane/issues/4497
