### PR TITLE
[slather action] Fix --decimals flag type

### DIFF
--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -223,6 +223,7 @@ Slather is available at https://github.com/SlatherOrg/slather
           FastlaneCore::ConfigItem.new(key: :decimals,
                                       env_name: "FL_SLATHER_DECIMALS",
                                       description: "The amount of decimals to use for % coverage reporting",
+                                      is_string: false,
                                       default_value: false,
                                       optional: true)
         ]


### PR DESCRIPTION
> Fix 'decimals' value must be a String! Found Fixnum instead.

Slather with --decimals support isn't [released yet](https://github.com/SlatherOrg/slather/issues/216) so this shouldn't break anyones code. The intended usage is passing an integer, not a string. I didn't realize the default type is a string.

Fix #4881
