### PR TITLE
auto detect email and author from git config

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
@@ -6,8 +6,8 @@ module Fastlane
 
     def collect_info(initial_name = nil)
       plugin_name = collect_plugin_name(initial_name)
-      author = collect_author
-      email = collect_email
+      author = collect_author(detect_author)
+      email = collect_email(detect_email)
       summary = collect_summary
 
       PluginInfo.new(plugin_name, author, email, summary)
@@ -72,7 +72,13 @@ module Fastlane
     # Author
     #
 
-    def collect_author
+    def detect_author
+      git_name = Helper.backticks('git config --get user.name').strip
+      return git_name.empty? ? nil : git_name
+    end
+
+    def collect_author(initial_author = nil)
+      return initial_author if author_valid?(initial_author)
       author = nil
       loop do
         author = @ui.input("\nWhat is the plugin author's name?")
@@ -92,8 +98,13 @@ module Fastlane
     # Email
     #
 
-    def collect_email
-      @ui.input("\nWhat is the plugin author's email address?")
+    def detect_email
+      git_email = Helper.backticks('git config --get user.email').strip
+      return git_email.empty? ? nil : git_email
+    end
+
+    def collect_email(initial_email = nil)
+      return initial_email || @ui.input("\nWhat is the plugin author's email address?")
     end
 
     #

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -30,6 +30,9 @@ describe Fastlane::PluginGenerator do
         oldwd = Dir.pwd
         Dir.chdir(tmp_dir)
 
+        expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.email').and_return('')
+        expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.name').and_return('')
+
         expect(test_ui).to receive(:input).and_return(plugin_name)
         expect(test_ui).to receive(:input).and_return(author)
         expect(test_ui).to receive(:input).and_return(email)

--- a/fastlane/spec/plugins_specs/plugin_info_collector_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_info_collector_spec.rb
@@ -148,6 +148,23 @@ describe Fastlane::PluginInfoCollector do
 
       expect(collector.collect_author).to eq('Fabricio Devtoolio')
     end
+
+    it "has an author name from git config" do
+      expect(test_ui).not_to receive(:input)
+      expect(collector.collect_author('Fabricio Devtoolio')).to eq('Fabricio Devtoolio')
+    end
+  end
+
+  describe "author detection" do
+    it "has an email from git config" do
+      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.name').and_return('Fabricio Devtoolio')
+      expect(collector.detect_author).to eq('Fabricio Devtoolio')
+    end
+
+    it "does not have an email from git config" do
+      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.name').and_return('')
+      expect(collector.detect_author).to be(nil)
+    end
   end
 
   describe '#author_valid?' do
@@ -175,6 +192,23 @@ describe Fastlane::PluginInfoCollector do
       expect(test_ui).to receive(:input).and_return('')
 
       expect(collector.collect_email).to eq('')
+    end
+
+    it "has an email from git config" do
+      expect(test_ui).not_to receive(:input)
+      expect(collector.collect_email('fabric.devtools@gmail.com')).to eq('fabric.devtools@gmail.com')
+    end
+  end
+
+  describe "email detection" do
+    it "has an email from git config" do
+      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.email').and_return('fabric.devtools@gmail.com')
+      expect(collector.detect_email).to eq('fabric.devtools@gmail.com')
+    end
+
+    it "does not have email in git config" do
+      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.email').and_return('')
+      expect(collector.detect_email).to be(nil)
     end
   end
 
@@ -213,9 +247,10 @@ describe Fastlane::PluginInfoCollector do
       expect(test_ui).to receive(:input).and_return('Fabricio Devtoolio')
       expect(test_ui).to receive(:input).and_return('fabric.devtools@gmail.com')
       expect(test_ui).to receive(:input).and_return('summary')
+      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.email').and_return('')
+      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.name').and_return('')
 
       info = Fastlane::PluginInfo.new('test_name', 'Fabricio Devtoolio', 'fabric.devtools@gmail.com', 'summary')
-
       expect(collector.collect_info).to eq(info)
     end
   end


### PR DESCRIPTION
Follow CocoaPods's example of getting information about the plugin from git config.
