### PR TITLE
Add :dev_portal_team_id option to pilot

### DIFF
--- a/pilot/lib/pilot.rb
+++ b/pilot/lib/pilot.rb
@@ -1,5 +1,6 @@
 require "json"
 require "pilot/version"
+require "pilot/options"
 require "pilot/manager"
 require "pilot/build_manager"
 require "pilot/tester_manager"

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -108,8 +108,16 @@ module Pilot
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:itc_team_name),
                                      verify_block: proc do |value|
                                        ENV["FASTLANE_ITC_TEAM_NAME"] = value
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :dev_portal_team_id,
+                                     env_name: "PILOT_DEV_PORTAL_TEAM_ID",
+                                     description: "The short ID of your team in the developer portal, if you're in multiple teams. Different from your iTC team ID!",
+                                     optional: true,
+                                     is_string: true,
+                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:team_id),
+                                     verify_block: proc do |value|
+                                       ENV["FASTLANE_TEAM_ID"] = value.to_s
                                      end)
-
       ]
     end
   end

--- a/pilot/spec/options_spec.rb
+++ b/pilot/spec/options_spec.rb
@@ -1,0 +1,15 @@
+describe Pilot::Options do
+  before(:each) do
+    ENV.delete('FASTLANE_TEAM_ID')
+  end
+
+  after(:each) do
+    ENV.delete('FASTLANE_TEAM_ID')
+  end
+
+  it "accepts a developer portal team ID" do
+    FastlaneCore::Configuration.create(Pilot::Options.available_options, { dev_portal_team_id: 'ABCD1234' })
+
+    expect(ENV['FASTLANE_TEAM_ID']).to eq('ABCD1234')
+  end
+end


### PR DESCRIPTION
Addresses https://github.com/fastlane/fastlane/issues/4878

This helps the iTunes Transporter deal with situations involving multiple teams, taking advantage of the work in https://github.com/fastlane/fastlane/pull/4746
