### PR TITLE
Updating upload_symbols_to_sentry action to allow for bearer authenti…

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -987,14 +987,17 @@ This action allows you to upload symbolication files to Sentry.
 
 ```ruby
 upload_symbols_to_sentry(
-  api_key: '...',
+  api_key: '...', # Do not use if using auth_token
+  auth_token: '...', # Do not use if using api_key
   org_slug: '...',
   project_slug: '...',
   dsym_path: './App.dSYM.zip'
 )
 ```
 
-The following environment variables may be used in place of parameters: `SENTRY_API_KEY`, `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG`, and `SENTRY_DSYM_PATH`.
+`auth_token` is the preferred way to authentication method with Sentry. `api_key` will eventually become deprecated.
+
+The following environment variables may be used in place of parameters: `SENTRY_API_KEY`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG`, and `SENTRY_DSYM_PATH`.
 
 
 ### AWS S3 Distribution

--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -994,8 +994,6 @@ upload_symbols_to_sentry(
 )
 ```
 
-`auth_token` is the preferred way to authentication method with Sentry.
-
 The following environment variables may be used in place of parameters: `SENTRY_AUTH_TOKEN`, `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG`, and `SENTRY_DSYM_PATH`.
 
 

--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -987,17 +987,16 @@ This action allows you to upload symbolication files to Sentry.
 
 ```ruby
 upload_symbols_to_sentry(
-  api_key: '...', # Do not use if using auth_token
-  auth_token: '...', # Do not use if using api_key
+  auth_token: '...',
   org_slug: '...',
   project_slug: '...',
   dsym_path: './App.dSYM.zip'
 )
 ```
 
-`auth_token` is the preferred way to authentication method with Sentry. `api_key` will eventually become deprecated.
+`auth_token` is the preferred way to authentication method with Sentry.
 
-The following environment variables may be used in place of parameters: `SENTRY_API_KEY`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG`, and `SENTRY_DSYM_PATH`.
+The following environment variables may be used in place of parameters: `SENTRY_AUTH_TOKEN`, `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG`, and `SENTRY_DSYM_PATH`.
 
 
 ### AWS S3 Distribution

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
@@ -37,7 +37,7 @@ module Fastlane
         if has_api_key
           resource = RestClient::Resource.new(url, api_key, '')
         else
-          resource = RestClient::Resource.new(url, headers: {Authorization: "Bearer #{auth_token}"})
+          resource = RestClient::Resource.new(url, {headers: {Authorization: "Bearer #{auth_token}"}})
         end
 
         UI.message "Will upload dSYM(s) to #{url}"

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
@@ -2,6 +2,11 @@ module Fastlane
   module Actions
     class UploadSymbolsToSentryAction < Action
       def self.run(params)
+
+        UI.important("It's recommended to use the official Sentry Fastlane plugin")
+        UI.important("Github: https://github.com/getsentry/fastlane-plugin-sentry")
+        UI.important("Installation: fastlane add_plugin sentry")
+
         Actions.verify_gem!('rest-client')
         require 'rest-client'
 

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
@@ -8,6 +8,7 @@ module Fastlane
         # Params - API
         host = params[:api_host]
         api_key = params[:api_key]
+        auth_token = params[:auth_token]
         org = params[:org_slug]
         project = params[:project_slug]
 
@@ -15,9 +16,24 @@ module Fastlane
         dsym_path = params[:dsym_path]
         dsym_paths = params[:dsym_paths] || []
 
+        has_api_key = !api_key.to_s.empty?
+        has_auth_token = !auth_token.to_s.empty?
+
+        # Will fail if none or both authentication methods are provided
+        if !has_api_key && !has_auth_token
+          UI.user_error!("No API key or authentication token found for SentryAction given, pass using `api_key: 'key'` or `auth_token: 'token'`")
+        elsif has_api_key && has_auth_token
+          UI.user_error!("Both API key and authentication token found for SentryAction given, please only give one")
+        end
+
         # Url to post dSYMs to
         url = "#{host}/projects/#{org}/#{project}/files/dsyms/"
-        resource = RestClient::Resource.new(url, api_key, '')
+
+        if has_api_key
+          resource = RestClient::Resource.new(url, api_key, '')
+        else
+          resource = RestClient::Resource.new(url, headers: {Authorization: "Bearer #{auth_token}"})
+        end
 
         UI.message "Will upload dSYM(s) to #{url}"
 
@@ -67,10 +83,12 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :api_key,
                                        env_name: "SENTRY_API_KEY",
-                                       description: "API Key for Sentry",
-                                       verify_block: proc do |value|
-                                         UI.user_error!("No API token for SentryAction given, pass using `api_key: 'key'`") unless value and !value.empty?
-                                       end),
+                                       description: "API key for Sentry",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :auth_token,
+                                       env_name: "SENTRY_AUTH_TOKEN",
+                                       description: "Authentication token for Sentry",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :org_slug,
                                        env_name: "SENTRY_ORG_SLUG",
                                        description: "Organization slug for Sentry project",

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class UploadSymbolsToSentryAction < Action
       def self.run(params)
-
+        # Warning about usinging new plugin
         UI.important("It's recommended to use the official Sentry Fastlane plugin")
         UI.important("Github: https://github.com/getsentry/fastlane-plugin-sentry")
         UI.important("Installation: fastlane add_plugin sentry")

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
@@ -37,7 +37,7 @@ module Fastlane
         if has_api_key
           resource = RestClient::Resource.new(url, api_key, '')
         else
-          resource = RestClient::Resource.new(url, {headers: {Authorization: "Bearer #{auth_token}"}})
+          resource = RestClient::Resource.new(url, headers: { Authorization: "Bearer #{auth_token}" })
         end
 
         UI.message "Will upload dSYM(s) to #{url}"

--- a/fastlane/spec/actions_specs/upload_symbols_to_sentry_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_sentry_spec.rb
@@ -1,12 +1,54 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "sentry" do
-      it "returns uploaded dSYM path" do
+      it "fails with no API key or auth token" do
+        dsym_path_1 = './fastlane/spec/fixtures/dSYM/Themoji.dSYM.zip'
+
+        expect do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            upload_symbols_to_sentry(
+              org_slug: 'some_org',
+              project_slug: 'some_project',
+              dsym_path: '#{dsym_path_1}')
+          end").runner.execute(:test)
+        end.to raise_error("No API key or authentication token found for SentryAction given, pass using `api_key: 'key'` or `auth_token: 'token'`")
+      end
+
+      it "fails with API key and auth token" do
+        dsym_path_1 = './fastlane/spec/fixtures/dSYM/Themoji.dSYM.zip'
+
+        expect do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            upload_symbols_to_sentry(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              auth_token: 'something123',
+              project_slug: 'some_project',
+              dsym_path: '#{dsym_path_1}')
+          end").runner.execute(:test)
+        end.to raise_error("Both API key and authentication token found for SentryAction given, please only give one")
+      end
+
+      it "returns uploaded dSYM path using API key" do
         dsym_path_1 = './fastlane/spec/fixtures/dSYM/Themoji.dSYM.zip'
 
         result = Fastlane::FastFile.new.parse("lane :test do
           upload_symbols_to_sentry(
             api_key: 'something123',
+            org_slug: 'some_org',
+            project_slug: 'some_project',
+            dsym_path: '#{dsym_path_1}')
+        end").runner.execute(:test)
+
+        expect(result).to include(dsym_path_1)
+      end
+
+      it "returns uploaded dSYM path using auth token" do
+        dsym_path_1 = './fastlane/spec/fixtures/dSYM/Themoji.dSYM.zip'
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          upload_symbols_to_sentry(
+            auth_token: 'something123',
             org_slug: 'some_org',
             project_slug: 'some_project',
             dsym_path: '#{dsym_path_1}')


### PR DESCRIPTION
…cation token

Sentry introduced a new form of API authentication using bearer authentication - https://docs.getsentry.com/hosted/clients/javascript/sourcemaps/#uploading-source-maps-to-sentry

This PR adds support for `auth_token` while still supporting `api_key`.

fastlane4life ❤️ 
