### PR TITLE
Suppress command output for git queries during plugin info collection

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
@@ -73,7 +73,7 @@ module Fastlane
     #
 
     def detect_author
-      git_name = Helper.backticks('git config --get user.name').strip
+      git_name = Helper.backticks('git config --get user.name', print: $verbose).strip
       return git_name.empty? ? nil : git_name
     end
 
@@ -99,7 +99,7 @@ module Fastlane
     #
 
     def detect_email
-      git_email = Helper.backticks('git config --get user.email').strip
+      git_email = Helper.backticks('git config --get user.email', print: $verbose).strip
       return git_email.empty? ? nil : git_email
     end
 

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -30,8 +30,8 @@ describe Fastlane::PluginGenerator do
         oldwd = Dir.pwd
         Dir.chdir(tmp_dir)
 
-        expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.email').and_return('')
-        expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.name').and_return('')
+        expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.email', print: $verbose).and_return('')
+        expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.name', print: $verbose).and_return('')
 
         expect(test_ui).to receive(:input).and_return(plugin_name)
         expect(test_ui).to receive(:input).and_return(author)

--- a/fastlane/spec/plugins_specs/plugin_info_collector_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_info_collector_spec.rb
@@ -157,12 +157,12 @@ describe Fastlane::PluginInfoCollector do
 
   describe "author detection" do
     it "has an email from git config" do
-      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.name').and_return('Fabricio Devtoolio')
+      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.name', print: $verbose).and_return('Fabricio Devtoolio')
       expect(collector.detect_author).to eq('Fabricio Devtoolio')
     end
 
     it "does not have an email from git config" do
-      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.name').and_return('')
+      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.name', print: $verbose).and_return('')
       expect(collector.detect_author).to be(nil)
     end
   end
@@ -202,12 +202,12 @@ describe Fastlane::PluginInfoCollector do
 
   describe "email detection" do
     it "has an email from git config" do
-      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.email').and_return('fabric.devtools@gmail.com')
+      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.email', print: $verbose).and_return('fabric.devtools@gmail.com')
       expect(collector.detect_email).to eq('fabric.devtools@gmail.com')
     end
 
     it "does not have email in git config" do
-      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.email').and_return('')
+      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.email', print: $verbose).and_return('')
       expect(collector.detect_email).to be(nil)
     end
   end
@@ -247,8 +247,8 @@ describe Fastlane::PluginInfoCollector do
       expect(test_ui).to receive(:input).and_return('Fabricio Devtoolio')
       expect(test_ui).to receive(:input).and_return('fabric.devtools@gmail.com')
       expect(test_ui).to receive(:input).and_return('summary')
-      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.email').and_return('')
-      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.name').and_return('')
+      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.email', print: $verbose).and_return('')
+      expect(FastlaneCore::Helper).to receive(:backticks).with('git config --get user.name', print: $verbose).and_return('')
 
       info = Fastlane::PluginInfo.new('test_name', 'Fabricio Devtoolio', 'fabric.devtools@gmail.com', 'summary')
       expect(collector.collect_info).to eq(info)


### PR DESCRIPTION
Add `print: $verbose` to the `Helper.backticks` calls in the `PluginInfoCollector` so that the calls are not printed by default

```
[15:00:55]: $ git config --get user.name
[15:00:55]: ▸ Michael Furtak
[15:00:55]: $ git config --get user.email
[15:00:55]: ▸ mfurtak@twitter.com
```
