### PR TITLE
Fix typo in OneSignal action that cause the action to fail every time when creating apps with apns

### DIFF
--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -23,7 +23,7 @@ module Fastlane
         unless params[:apns_p12].nil?
           data = File.read(params[:apns_p12])
           apns_p12 = Base64.encode64(data)
-          payload["apns_env"] = [:apns_env]
+          payload["apns_env"] = params[:apns_env]
           payload["apns_p12"] = apns_p12
           # we need to have something for the p12 password, even if it's an empty string
           payload["apns_p12_password"] = apns_p12_password || ""


### PR DESCRIPTION
OneSignal action failed with 400 from onesignal server when providing APNS cert because a wrong signature is generated and sent to onesignal server. #4893
