### PR TITLE
Escape Gradle properties

### DIFF
--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -35,7 +35,7 @@ module Fastlane
         # Construct our flags
         flags = []
         flags << "-p #{project_dir.shellescape}"
-        flags << params[:properties].map { |k, v| "-P#{k}=#{v}" }.join(' ') unless params[:properties].nil?
+        flags << params[:properties].map { |k, v| "-P#{k.shellescape}=#{v.shellescape}" }.join(' ') unless params[:properties].nil?
         flags << params[:flags] unless params[:flags].nil?
 
         # Run the actual gradle task

--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -35,7 +35,7 @@ module Fastlane
         # Construct our flags
         flags = []
         flags << "-p #{project_dir.shellescape}"
-        flags << params[:properties].map { |k, v| "-P#{k.shellescape}=#{v.to_s.shellescape}" }.join(' ') unless params[:properties].nil?
+        flags << params[:properties].map { |k, v| "-P#{k.to_s.shellescape}=#{v.to_s.shellescape}" }.join(' ') unless params[:properties].nil?
         flags << params[:flags] unless params[:flags].nil?
 
         # Run the actual gradle task

--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -35,7 +35,7 @@ module Fastlane
         # Construct our flags
         flags = []
         flags << "-p #{project_dir.shellescape}"
-        flags << params[:properties].map { |k, v| "-P#{k.shellescape}=#{v.shellescape}" }.join(' ') unless params[:properties].nil?
+        flags << params[:properties].map { |k, v| "-P#{k.shellescape}=#{v.to_s.shellescape}" }.join(' ') unless params[:properties].nil?
         flags << params[:flags] unless params[:flags].nil?
 
         # Run the actual gradle task

--- a/fastlane/spec/actions_specs/gradle_spec.rb
+++ b/fastlane/spec/actions_specs/gradle_spec.rb
@@ -80,6 +80,16 @@ describe Fastlane do
         expect(result).to eq("ANDROID_SERIAL=abc123 #{gradle_path.shellescape} assembleWorldDominationRelease -p . -PversionCode=200")
       end
 
+      it "correctly escapes multiple properties and types" do
+        notes_key = 'Release Notes' # this value is interesting because it contains a space in the key
+        notes_result = 'World Domination Achieved!' # this value is interesting because it contains multiple spaces
+        result = Fastlane::FastFile.new.parse("lane :build do
+          gradle(task: 'assemble', flavor: 'WorldDomination', build_type: 'Release', properties: { 'versionCode' => 200, '#{notes_key}' => '#{notes_result}'}, gradle_path: './fastlane/README.md')
+        end").runner.execute(:build)
+
+        expect(result).to eq("#{File.expand_path('README.md')} assembleWorldDominationRelease -p . -PversionCode=200 -P#{notes_key.shellescape}=#{notes_result.shellescape}")
+      end
+
       it "correctly uses the serial" do
         result = Fastlane::FastFile.new.parse("lane :build do
           gradle(task: 'assemble', flavor: 'WorldDomination', build_type: 'Release', properties: { 'versionCode' => 200}, serial: 'abc123', gradle_path: './fastlane/README.md')


### PR DESCRIPTION
Gradle Action - Properties with special characters not supported #4700

Convert values and keys explicitly to strings and then shell escape them for use in the command. In addition there's a new expectation which includes multiple values in properties for a single invocation with a mix of escaped types to ensure consistent behavior.
