### PR TITLE
Install latest release for an Xcode plugin

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -2438,6 +2438,12 @@ Install an Xcode plugin for the current user
 install_xcode_plugin(url: 'https://github.com/contentful/ContentfulXcodePlugin/releases/download/0.5/ContentfulPlugin.xcplugin.zip')
 ```
 
+You can also let fastlane pick the latest version of a plugin automatically, if it is hosted on GitHub
+
+```ruby
+install_xcode_plugin(github: 'https://github.com/contentful/ContentfulXcodePlugin')
+```
+
 ### opt_out_usage
 
 Add this your `Fastfile` to not send any data to the fastlane web service. You can also use the `FASTLANE_OPT_OUT_USAGE` environment variable. No personal data is shared, more information on [https://github.com/fastlane/enhancer](https://github.com/fastlane/enhancer)

--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -2435,10 +2435,10 @@ fastlane_version "1.50.0"
 Install an Xcode plugin for the current user
 
 ```ruby
-install_xcode_plugin(url: 'https://github.com/contentful/ContentfulXcodePlugin/releases/download/0.5/ContentfulPlugin.xcplugin.zip')
+install_xcode_plugin(url: 'https://example.com/clubmate/plugin.zip')
 ```
 
-You can also let fastlane pick the latest version of a plugin automatically, if it is hosted on GitHub
+You can also let `fastlane` pick the latest version of a plugin automatically, if it is hosted on GitHub
 
 ```ruby
 install_xcode_plugin(github: 'https://github.com/contentful/ContentfulXcodePlugin')

--- a/fastlane/lib/fastlane/actions/install_xcode_plugin.rb
+++ b/fastlane/lib/fastlane/actions/install_xcode_plugin.rb
@@ -4,9 +4,10 @@ module Fastlane
       def self.run(params)
         require 'fileutils'
 
-        if params.fetch(:github, ask: false)
+        unless params[:github].nil?
           github_api_url = params[:github].sub('https://github.com', 'https://api.github.com/repos')
           release = self.fetch_json(github_api_url + '/releases/latest')
+          return if release.nil?
           params[:url] = release['assets'][0]['browser_download_url']
         end
 
@@ -23,7 +24,19 @@ module Fastlane
       def self.fetch_json(url)
         require 'excon'
         require 'json'
-        JSON.parse(Excon.get(url).body)
+
+        response = Excon.get(url)
+
+        if response[:status] != 200
+          if response[:status] == 404
+            UI.error("No latest release found for the specified GitHub repository")
+          else
+            UI.error("GitHub responded with #{response[:status]}:#{response[:body]}")
+          end
+          return nil
+        end
+
+        JSON.parse(response.body)
       end
 
       #####################################################
@@ -46,6 +59,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :github,
                                        env_name: "FL_XCODE_PLUGIN_GITHUB",
                                        description: "GitHub repository URL for Xcode plugin",
+                                       optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("No GitHub URL for InstallXcodePluginAction given, pass using `github: 'url'`") if value.to_s.length == 0
                                          UI.user_error!("URL doesn't use HTTPS") unless value.start_with?("https://")


### PR DESCRIPTION
Using the `github` option instead of `url`, fastlane can now determine the URL for the latest version of a plugin automatically.
