### PR TITLE
Fixes #4912 pilot importer to process first row

### DIFF
--- a/pilot/lib/pilot/tester_importer.rb
+++ b/pilot/lib/pilot/tester_importer.rb
@@ -13,12 +13,7 @@ module Pilot
       tester_manager = Pilot::TesterManager.new
       imported_tester_count = 0
 
-      is_first = true
       CSV.foreach(file, "r") do |row|
-        if is_first
-          is_first = false
-          next
-        end
 
         first_name, last_name, email = row
 

--- a/pilot/lib/pilot/tester_importer.rb
+++ b/pilot/lib/pilot/tester_importer.rb
@@ -14,7 +14,6 @@ module Pilot
       imported_tester_count = 0
 
       CSV.foreach(file, "r") do |row|
-
         first_name, last_name, email = row
 
         unless email


### PR DESCRIPTION
The importer did not process the first row of the provided csv. I assume that it expected that the first row has header information in it but the example linked in the documentation does not.

Fixes #4912
