### PR TITLE
Issue with screengrab looking for images in the wrong folder

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -294,7 +294,7 @@ module Screengrab
       unless @config[:skip_open_summary]
         UI.message "Opening screenshots summary"
         # MCF: this isn't OK on any platform except Mac
-        @executor.execute(command: "open #{@config[:output_directory]}/*/images/#{device_type_dir_name}/*.png",
+        @executor.execute(command: "open #{@config[:output_directory]}/screengrab/*/images/#{device_type_dir_name}/*.png",
                           print_all: false,
                           print_command: true)
       end


### PR DESCRIPTION
Screengrab creates an additional folder screengrab on emulator/device and this line does not handle this folder.
