### PR TITLE
[fastlane_core] Convert value type of ConfigItems earlier

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -87,14 +87,14 @@ module FastlaneCore
 
     # Returns an updated value type (if necessary)
     def auto_convert_value(value)
-      # Weird because of https://stackoverflow.com/questions/9537895/using-a-class-object-in-case-statement
-      case
-      when data_type == Array
+      return nil if value.nil?
+
+      if data_type == Array
         return value.split(',') if value.kind_of?(String)
-      when data_type == Integer
-        return value.to_i unless value.nil?
-      when data_type == Float
-        return value.to_f unless value.nil?
+      elsif data_type == Integer
+        return value.to_i if value.to_i.to_s == value.to_s
+      elsif data_type == Float
+        return value.to_f if value.to_f.to_s == value.to_s
       else
         # Special treatment if the user specified true, false or YES, NO
         # There is no boolean type, so we just do it here

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -54,11 +54,11 @@ module FastlaneCore
       # Make sure the given value keys exist
       @values.each do |key, value|
         next if key == :trace # special treatment
-
         option = option_for_key(key)
         if option
+          @values[key] = option.auto_convert_value(value)
           UI.deprecated("Using deprecated option: '--#{key}' (#{option.deprecated})") if option.deprecated
-          option.verify!(value) # Call the verify block for it too
+          option.verify!(@values[key]) # Call the verify block for it too
         else
           UI.user_error!("Could not find option '#{key}' in the list of available options: #{@available_options.collect(&:key).join(', ')}")
         end

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -217,11 +217,12 @@ describe FastlaneCore do
 
         it "auto converts booleans as strings to booleans" do
           c = [
-            FastlaneCore::ConfigItem.new(key: :true_value),
-            FastlaneCore::ConfigItem.new(key: :true_value2),
-            FastlaneCore::ConfigItem.new(key: :false_value),
-            FastlaneCore::ConfigItem.new(key: :false_value2)
+            FastlaneCore::ConfigItem.new(key: :true_value, is_string: false),
+            FastlaneCore::ConfigItem.new(key: :true_value2, is_string: false),
+            FastlaneCore::ConfigItem.new(key: :false_value, is_string: false),
+            FastlaneCore::ConfigItem.new(key: :false_value2, is_string: false)
           ]
+
           config = FastlaneCore::Configuration.create(c, {
             true_value: "true",
             true_value2: "YES",
@@ -233,6 +234,30 @@ describe FastlaneCore do
           expect(config[:true_value2]).to eq(true)
           expect(config[:false_value]).to eq(false)
           expect(config[:false_value2]).to eq(false)
+        end
+
+        it "auto converts strings to integers" do
+          c = [
+            FastlaneCore::ConfigItem.new(key: :int_value,
+                                         type: Integer)
+          ]
+          config = FastlaneCore::Configuration.create(c, {
+            int_value: "10"
+          })
+
+          expect(config[:int_value]).to eq(10)
+        end
+
+        it "auto converts '0' to the integer 0" do
+          c = [
+            FastlaneCore::ConfigItem.new(key: :int_value,
+                                         type: Integer)
+          ]
+          config = FastlaneCore::Configuration.create(c, {
+            int_value: "0"
+          })
+
+          expect(config[:int_value]).to eq(0)
         end
       end
 


### PR DESCRIPTION
So that command line values (specifically from OneOff) are converted to their proper type correctly.

Example:

``` ruby
fastlane run changelog_from_git_commits commits_count:10
```

Now works correctly and the Integer 10 is provided to the action

This will fix all instances where actions are being called from the command line. It was prompted by this issue: https://github.com/fastlane/fastlane/issues/4862
