### PR TITLE
[fastlane] Version bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.91.0'.freeze
+  VERSION = '1.92.0'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end


### PR DESCRIPTION
- Improved handling of new lines in `increment_build_number` (#4837)
- Fix bug in `OneSignal` action (#4892)
- Escape Gradle properties (#4897)
- `slather` fix `--decimals` flag type
- Output changelog in `changelog_from_git_commits` (#4860)
- Verify `rest-client` dependency for `sentry` (#4871)
- Removed `appium` development dependency and therefore `nokogiri` (#4852)
