### PR TITLE
[fastlane_core] Version bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.45.0".freeze
+  VERSION = "0.45.1".freeze
 end

--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.45.1".freeze
+  VERSION = "0.46.0".freeze
 end


### PR DESCRIPTION
- Preparing for fastlane plugins 🚀 
- Added new option to hide timestamps in fastlane outputs using `FASTLANE_HIDE_TIMESTAMP` (#4838)
- Fix `PkgFileAnalyser` to shell escape `xar` arguments
- `Helper.fastlane_enabled?` improvements (#4889)
- Continuing work on #3843
- Ads Apple Developer Id to `itunes_transporter.rb` - allows `deliver` to work with multiple iTunes Providers
