### PR TITLE
JIRA Transition Action

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -2029,6 +2029,20 @@ jira(
 )
 ```
 
+### [JIRA Transition](https://www.atlassian.com/software/jira)
+Apply a JIRA transition to issues mentioned in the changelog.
+
+```ruby
+jira_transition(
+  url: "https://bugs.yourdomain.com",
+  username: "Your username",
+  password: "Your password",
+  project_key: "Project Key, i.e. IOS",
+  transition_id: "Transition ID, i.e. 730",  
+  comment: "Optional text to post as a comment"
+)
+```
+
 ## Other
 
 ### update_fastlane

--- a/fastlane/lib/fastlane/actions/jira_transition.rb
+++ b/fastlane/lib/fastlane/actions/jira_transition.rb
@@ -88,13 +88,13 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("No transition id specified") if value.to_s.length == 0
                                        end),
-        FastlaneCore::ConfigItem.new(key: :comment,
-                                     env_name: "FL_JIRA_TRANSITION_COMMENT",
-                                     description: "Comment to add if the transition is applied",
-                                     optional: true,
-                                     verify_block: proc do |value|
-                                       UI.user_error!("No transition id specified") if value.to_s.length == 0
-                                     end)
+          FastlaneCore::ConfigItem.new(key: :comment,
+                                       env_name: "FL_JIRA_TRANSITION_COMMENT",
+                                       description: "Comment to add if the transition is applied",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No transition id specified") if value.to_s.length == 0
+                                       end)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/jira_transition.rb
+++ b/fastlane/lib/fastlane/actions/jira_transition.rb
@@ -53,7 +53,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Apply JIRA transitions to issues mentioned in the changelog"
+        "Apply a JIRA transition to issues mentioned in the changelog"
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/actions/jira_transition.rb
+++ b/fastlane/lib/fastlane/actions/jira_transition.rb
@@ -42,7 +42,7 @@ module Fastlane
               comment = issue.comments.build
               comment.save({"body" => comment_text})
             end
-          rescue Exception => e
+          rescue JIRA::HTTPError
             "Skipping issue #{issue_id}"
           end
         end

--- a/fastlane/lib/fastlane/actions/jira_transition.rb
+++ b/fastlane/lib/fastlane/actions/jira_transition.rb
@@ -38,7 +38,7 @@ module Fastlane
             transition = issue.transitions.build
             transition.save!("transition" => { "id" => transition_id })
 
-            if !comment_text.nil?
+            if comment_text
               comment = issue.comments.build
               comment.save({"body" => comment_text})
             end
@@ -53,7 +53,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Applies the defined JIRA transition to all the tickets mentioned in the changelog."
+        "Apply JIRA transitions to issues mentioned in the changelog"
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/actions/jira_transition.rb
+++ b/fastlane/lib/fastlane/actions/jira_transition.rb
@@ -1,0 +1,91 @@
+module Fastlane
+  module Actions
+    class JiraTransitionAction < Action
+
+      def self.run(params)
+        Actions.verify_gem!('jira-ruby')
+        require 'jira'
+
+        site         = params[:url]
+        context_path = ""
+        auth_type    = :basic
+        username     = params[:username]
+        password     = params[:password]
+        project_key  = params[:project_key]
+        transition   = params[:transition]
+
+        options = {
+                    site: site,
+                    context_path: context_path,
+                    auth_type: auth_type,
+                    username: username,
+                    password: password
+                  }
+
+        client = JIRA::Client.new(options)
+        project = client.Project.find(project_key)
+        puts Actions.lane_context[SharedValues::FL_CHANGELOG]
+        #issue = client.Issue.find(ticket_id)
+        #comment = issue.comments.build
+        #comment.save({ 'body' => comment_text })
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Applies the defined JIRA transition to all the tickets mentioned in the changelog."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :url,
+                                      env_name: "FL_JIRA_SITE",
+                                      description: "URL for Jira instance",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No url for Jira given, pass using `url: 'url'`") if value.to_s.length == 0
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :username,
+                                       env_name: "FL_JIRA_USERNAME",
+                                       description: "Username for JIRA instance",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No username") if value.to_s.length == 0
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :password,
+                                       env_name: "FL_JIRA_PASSWORD",
+                                       description: "Password for Jira",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No password") if value.to_s.length == 0
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :project_key,
+                                       env_name: "FL_JIRA_PROJECT_KEY",
+                                       description: "Project Key for Jira, i.e. IOS",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No Project Key specified") if value.to_s.length == 0
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :transition,
+                                       env_name: "FL_JIRA_TRANSITION",
+                                       description: "Transition to apply to the tickets referenced in the changelog",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No transition specified") if value.to_s.length == 0
+                                       end)
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+      end
+
+      def self.authors
+        ["Valerio Mazzeo", "Tiziano Bruni"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/jira_transition.rb
+++ b/fastlane/lib/fastlane/actions/jira_transition.rb
@@ -6,13 +6,14 @@ module Fastlane
         Actions.verify_gem!('jira-ruby')
         require 'jira'
 
-        site         = params[:url]
-        context_path = ""
-        auth_type    = :basic
-        username     = params[:username]
-        password     = params[:password]
-        project_key  = params[:project_key]
-        transition   = params[:transition]
+        site          = params[:url]
+        context_path  = ""
+        auth_type     = :basic
+        username      = params[:username]
+        password      = params[:password]
+        project_key   = params[:project_key]
+        transition_id = params[:transition_id]
+        comment_text  = params[:comment]
 
         options = {
                     site: site,
@@ -23,11 +24,28 @@ module Fastlane
                   }
 
         client = JIRA::Client.new(options)
-        project = client.Project.find(project_key)
-        puts Actions.lane_context[SharedValues::FL_CHANGELOG]
-        #issue = client.Issue.find(ticket_id)
-        #comment = issue.comments.build
-        #comment.save({ 'body' => comment_text })
+
+        if Actions.lane_context[SharedValues::FL_CHANGELOG].nil?
+          changelog_configuration = FastlaneCore::Configuration.create(Actions::ChangelogFromGitCommitsAction.available_options, {})
+          Actions::ChangelogFromGitCommitsAction.run(changelog_configuration)
+        end
+
+        issue_ids = Actions.lane_context[SharedValues::FL_CHANGELOG].scan(/#{project_key}-\d+/i).uniq
+
+        issue_ids.each do |issue_id|
+          begin
+            issue = client.Issue.find(issue_id)
+            transition = issue.transitions.build
+            transition.save!("transition" => { "id" => transition_id })
+
+            if !comment_text.nil?
+              comment = issue.comments.build
+              comment.save({"body" => comment_text})
+            end
+          rescue Exception => e
+            "Skipping issue #{issue_id}"
+          end
+        end
       end
 
       #####################################################
@@ -59,17 +77,24 @@ module Fastlane
                                          UI.user_error!("No password") if value.to_s.length == 0
                                        end),
           FastlaneCore::ConfigItem.new(key: :project_key,
-                                       env_name: "FL_JIRA_PROJECT_KEY",
+                                       env_name: "FL_JIRA_TRANSITION_PROJECT_KEY",
                                        description: "Project Key for Jira, i.e. IOS",
                                        verify_block: proc do |value|
                                          UI.user_error!("No Project Key specified") if value.to_s.length == 0
                                        end),
-          FastlaneCore::ConfigItem.new(key: :transition,
-                                       env_name: "FL_JIRA_TRANSITION",
+          FastlaneCore::ConfigItem.new(key: :transition_id,
+                                       env_name: "FL_JIRA_TRANSITION_TRANSITION_ID",
                                        description: "Transition to apply to the tickets referenced in the changelog",
                                        verify_block: proc do |value|
-                                         UI.user_error!("No transition specified") if value.to_s.length == 0
-                                       end)
+                                         UI.user_error!("No transition id specified") if value.to_s.length == 0
+                                       end),
+        FastlaneCore::ConfigItem.new(key: :comment,
+                                     env_name: "FL_JIRA_TRANSITION_COMMENT",
+                                     description: "Comment to add if the transition is applied",
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       UI.user_error!("No transition id specified") if value.to_s.length == 0
+                                     end)
         ]
       end
 


### PR DESCRIPTION
Implemented custom action to automate JIRA issues transitions based on issue ids found in the changelog.

This is particularly useful when running fastlane on a CI, for example when deploying to HockeyApp / Crashlytics, to move all the deployed issues to another state (for example: Ready For Testing).
