### PR TITLE
Add `rubocop` to plugin template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,10 +43,11 @@ Gemfile.lock
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 
-# Added by Felix
+# fastlane specific
 /*.itmsp
 .idea
 spec/fixtures/*.itmsp/*.png
 /integration
 **/report.xml
 **/.bundle
+fastlane/lib/fastlane/plugins/template/.rubocop.yml

--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -3,6 +3,10 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fastlane/version'
 
+# Copy over the latest .rubocop.yml style guide
+rubocop_config = File.expand_path('../../.rubocop.yml', __FILE__)
+`cp #{rubocop_config} #{lib}/fastlane/plugins/template/.rubocop.yml`
+
 Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION

--- a/fastlane/lib/fastlane/plugins/template/%gem_name%.gemspec.erb
+++ b/fastlane/lib/fastlane/plugins/template/%gem_name%.gemspec.erb
@@ -22,5 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'fastlane', '>= <%= Fastlane::VERSION %>'
 end

--- a/fastlane/lib/fastlane/plugins/template/README.md.erb
+++ b/fastlane/lib/fastlane/plugins/template/README.md.erb
@@ -22,6 +22,19 @@ Check out the [example `Fastfile`](fastlane/Fastfile) to see how to use this plu
 
 **Note to author:** Please set up a sample project to make it easy for users to explore what your plugin does. Provide everything that is necessary to try out the plugin in this project (including a sample Xcode/Android project if necessary)
 
+## Run tests for this plugin
+
+To run both the tests, and code style validation, run
+
+````
+rake
+```
+
+To automatically fix many of the styling issues, use 
+```
+rubocop -a
+```
+
 ## Issues and Feedback
 
 For any other issues and feedback about this plugin, please submit it to this repository.

--- a/fastlane/lib/fastlane/plugins/template/Rakefile
+++ b/fastlane/lib/fastlane/plugins/template/Rakefile
@@ -1,1 +1,9 @@
 require 'bundler/gem_tasks'
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new
+
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new(:rubocop)
+
+task default: [:spec, :rubocop]

--- a/fastlane/lib/fastlane/plugins/template/fastlane/Fastfile.erb
+++ b/fastlane/lib/fastlane/plugins/template/fastlane/Fastfile.erb
@@ -1,3 +1,3 @@
 lane :test do
-  <%= plugin_name %>()
+  <%= plugin_name %>
 end

--- a/fastlane/lib/fastlane/plugins/template/lib/fastlane/plugin/%plugin_name%/actions/%plugin_name%_action.rb.erb
+++ b/fastlane/lib/fastlane/plugins/template/lib/fastlane/plugin/%plugin_name%/actions/%plugin_name%_action.rb.erb
@@ -6,11 +6,11 @@ module Fastlane
       end
 
       def self.description
-        %q{<%= summary %>}
+        "<%= summary.gsub('"', "'") %>"
       end
 
       def self.authors
-        [%q{<%= author %>}]
+        ["<%= author.gsub('"', "'") %>"]
       end
 
       def self.available_options

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -220,6 +220,8 @@ describe Fastlane::PluginGenerator do
           Gem::Dependency.new("pry", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("bundler", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("rspec", Gem::Requirement.new([">= 0"]), :development),
+          Gem::Dependency.new("rake", Gem::Requirement.new([">= 0"]), :development),
+          Gem::Dependency.new("rubocop", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("fastlane", Gem::Requirement.new([">= #{Fastlane::VERSION}"]), :development)
         )
       end
@@ -257,12 +259,6 @@ describe Fastlane::PluginGenerator do
     it "creates a action_spec.rb file" do
       action_spec_file = File.join(tmp_dir, gem_name, 'spec', "#{plugin_name}_action_spec.rb")
       expect(File.exist?(action_spec_file)).to be(true)
-
-      # Actually run our generated spec as part of this spec #yodawg
-      Dir.chdir(gem_name) do
-        `rspec &> /dev/null`
-        expect($?.exitstatus).to be(0)
-      end
     end
 
     it "creates a Rakefile" do
@@ -270,7 +266,34 @@ describe Fastlane::PluginGenerator do
       expect(File.exist?(rakefile)).to be(true)
 
       rakefile_contents = File.read(rakefile)
-      expect(rakefile_contents).to eq("require 'bundler/gem_tasks'\n")
+      expect(rakefile_contents).to eq("require 'bundler/gem_tasks'\n\nrequire 'rspec/core/rake_task'\nRSpec::Core::RakeTask.new\n\nrequire 'rubocop/rake_task'\nRuboCop::RakeTask.new(:rubocop)\n\ntask default: [:spec, :rubocop]\n")
+    end
+
+    describe "All tests and style validation of the new plugin are passing" do
+      it "rspec tests are passing" do
+        # Actually run our generated spec as part of this spec #yodawg
+        Dir.chdir(gem_name) do
+          `rspec &> /dev/null`
+          expect($?.exitstatus).to be(0)
+        end
+      end
+
+      it "rubocop validations are passing" do
+        # Actually run our generated spec as part of this spec #yodawg
+        Dir.chdir(gem_name) do
+          `rubocop &> /dev/null`
+          expect($?.exitstatus).to be(0)
+        end
+      end
+
+      it "`rake` runs both rspec and rubocop" do
+        Dir.chdir(gem_name) do
+          result = `rake`
+          expect($?.exitstatus).to be(0)
+          expect(result).to include("no offenses detected") # rubocop
+          expect(result).to include("example, 0 failures") # rspec
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- Adds symlink to shared `.rubocop.yml`
- Add `rake` and `rubocop` as development dependencies
- Add `rspec` and `rubocop` rake tasks
- Fix rubocop issues in the template

cc @KrauseFx 
