### PR TITLE
Fix the PluginInfoCollector to check RubyGems for the gem_name

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
@@ -37,9 +37,11 @@ module Fastlane
 
         break if plugin_name_valid?(plugin_name)
 
-        if plugin_name_taken?(plugin_name)
-          # Plugin name is already taken on RubyGems
-          @ui.message("\nPlugin name '#{plugin_name}' is already taken on RubyGems, please choose a different one.")
+        gem_name = PluginManager::FASTLANE_PLUGIN_PREFIX + plugin_name
+
+        if gem_name_taken?(gem_name)
+          # Gem name is already taken on RubyGems
+          @ui.message("\nThe gem name '#{gem_name}' is already taken on RubyGems, please choose a different plugin name.")
         else
           # That's a naming error
           @ui.message("\nPlugin names can only contain lower case letters, numbers, and underscores")
@@ -56,12 +58,12 @@ module Fastlane
         # Does not contain the words 'fastlane' or 'plugin' since those will become
         # part of the gem name
         [/fastlane/, /plugin/].none? { |regex| regex =~ name } &&
-        # Plugin name isn't taken on RubyGems yet
-        !plugin_name_taken?(name)
+        # Gem name isn't taken on RubyGems yet
+        !gem_name_taken?(PluginManager::FASTLANE_PLUGIN_PREFIX + name)
     end
 
-    # Checks if the plugin name is still free on RubyGems
-    def plugin_name_taken?(name)
+    # Checks if the gem name is still free on RubyGems
+    def gem_name_taken?(name)
       require 'open-uri'
       require 'json'
       url = "https://rubygems.org/api/v1/gems/#{name}.json"

--- a/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
@@ -37,7 +37,7 @@ module Fastlane
 
         break if plugin_name_valid?(plugin_name)
 
-        gem_name = PluginManager::FASTLANE_PLUGIN_PREFIX + plugin_name
+        gem_name = PluginManager.to_gem_name(plugin_name)
 
         if gem_name_taken?(gem_name)
           # Gem name is already taken on RubyGems
@@ -59,7 +59,7 @@ module Fastlane
         # part of the gem name
         [/fastlane/, /plugin/].none? { |regex| regex =~ name } &&
         # Gem name isn't taken on RubyGems yet
-        !gem_name_taken?(PluginManager::FASTLANE_PLUGIN_PREFIX + name)
+        !gem_name_taken?(PluginManager.to_gem_name(name))
     end
 
     # Checks if the gem name is still free on RubyGems

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -45,6 +45,10 @@ module Fastlane
       FASTLANE_PLUGIN_PREFIX
     end
 
+    def self.to_gem_name(plugin_name)
+      plugin_name.start_with?(plugin_prefix) ? plugin_name : (plugin_prefix + plugin_name)
+    end
+
     # Returns an array of gems that are added to the Gemfile or Pluginfile
     def available_gems
       return [] unless gemfile_path

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -17,9 +17,7 @@ describe Fastlane::PluginGenerator do
     let(:summary) { plugin_info.summary }
 
     before(:each) do
-      stub_request(:get, "https://rubygems.org/api/v1/gems/tester_thing.json").
-        with(headers: {'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent' => 'Ruby'}).
-        to_return(status: 200, body: nil, headers: {})
+      stub_plugin_exists_on_rubygems(plugin_name, false)
 
       unless initialized
         test_ui = Fastlane::PluginGeneratorUI.new

--- a/fastlane/spec/plugins_specs/plugin_info_collector_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_info_collector_spec.rb
@@ -9,9 +9,7 @@ describe Fastlane::PluginInfoCollector do
 
   before do
     ["my plugin", "test_name", "my_", "fastlane-whatever", "whatever"].each do |current|
-      stub_request(:get, "https://rubygems.org/api/v1/gems/#{current}.json").
-        with(headers: {'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent' => 'Ruby'}).
-        to_return(status: 200, body: nil, headers: {})
+      stub_plugin_exists_on_rubygems(current, false)
     end
   end
 
@@ -105,9 +103,8 @@ describe Fastlane::PluginInfoCollector do
     end
 
     it "detects if the plugin is already taken on RubyGems.org" do
-      stub_request(:get, "https://rubygems.org/api/v1/gems/already_taken.json").
-        with(headers: {'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent' => 'Ruby'}).
-        to_return(status: 200, body: {version: "1.0"}.to_json, headers: {})
+      stub_plugin_exists_on_rubygems('already_taken', true)
+
       expect(collector.plugin_name_valid?('already_taken')).to be_falsey
     end
   end

--- a/fastlane/spec/spec_helper.rb
+++ b/fastlane/spec/spec_helper.rb
@@ -46,6 +46,6 @@ end
 
 def stub_plugin_exists_on_rubygems(plugin_name, exists)
   stub_request(:get, "https://rubygems.org/api/v1/gems/fastlane-plugin-#{plugin_name}.json").
-      with(headers: {'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent' => 'Ruby'}).
-      to_return(status: 200, body: (exists ? {version: "1.0"}.to_json : nil), headers: {})
+    with(headers: {'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent' => 'Ruby'}).
+    to_return(status: 200, body: (exists ? {version: "1.0"}.to_json : nil), headers: {})
 end

--- a/fastlane/spec/spec_helper.rb
+++ b/fastlane/spec/spec_helper.rb
@@ -43,3 +43,9 @@ def with_verbose(verbose)
 ensure
   $verbose = orig_verbose
 end
+
+def stub_plugin_exists_on_rubygems(plugin_name, exists)
+  stub_request(:get, "https://rubygems.org/api/v1/gems/fastlane-plugin-#{plugin_name}.json").
+      with(headers: {'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent' => 'Ruby'}).
+      to_return(status: 200, body: (exists ? {version: "1.0"}.to_json : nil), headers: {})
+end


### PR DESCRIPTION
Previously this was checking RubyGems to see if the `plugin_name` was already taken, but this does not contain the 'fastlane-plugin-' prefix, and is not the full final name of the gem.

Fixes up the tests to match this behavior, and provides a helper method for setting up the stubbed web request.
