### PR TITLE
New action: Update Android package

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -1310,6 +1310,35 @@ update_project_team(
 )
 ```
 
+## update_android_package
+
+This action allows you to modify your `AndroidManifest.xml` and `build.gradle` file to change app name and app identifier before building. This may be useful if you want a separate build for alpha, beta or nightly builds, but don't want a separate target.
+
+```ruby
+# Update app identifier string
+update_android_package(
+  app_build_gradle_path: "path/to/app/build.gradle",
+  app_identifier: "com.example.newappidentifier"
+)
+
+# Change the Display Name of your app
+update_android_package(
+  manifest_path: "path/to/AndroidManifest.xml",
+  string_resource_path: "path/to/values/strings.xml",
+  display_name: "MyApp-Beta"
+)
+
+# Update both
+update_info_plist(
+  app_build_gradle_path: "path/to/app/build.gradle",
+  manifest_path: "path/to/AndroidManifest.xml",
+  string_resource_path: "path/to/res/values/strings.xml",
+  app_identifier: "com.example.newappidentifier",
+  display_name: "MyApp-Beta"
+)
+
+```
+
 ## update_info_plist
 
 This action allows you to modify your `Info.plist` file before building. This may be useful if you want a separate build for alpha, beta or nightly builds, but don't want a separate target.

--- a/fastlane/lib/fastlane/actions/update_android_package.rb
+++ b/fastlane/lib/fastlane/actions/update_android_package.rb
@@ -42,6 +42,8 @@ module Fastlane
                     File.write(manifest_path, manifest.to_xml)
                   end
                 end
+              else
+                next
               end
             end
             UI.success("Updated #{params[:manifest_path]} 💾.")

--- a/fastlane/lib/fastlane/actions/update_android_package.rb
+++ b/fastlane/lib/fastlane/actions/update_android_package.rb
@@ -26,21 +26,20 @@ module Fastlane
               # Find launcher activity
               if activity_node.at_css("intent-filter").to_s != ""
                 intent_filter_node = Nokogiri::XML(activity_node.at_css("intent-filter").to_s)
-                if intent_filter_node.at_css("action").to_s != "" && intent_filter_node.at_css("category").to_s != ""
-                  if intent_filter_node.at_css("action").attributes["android:name"].value == "android.intent.action.MAIN" && \
-                    intent_filter_node.at_css("category").attributes["android:name"].value == "android.intent.category.LAUNCHER"
-                    # Update manifest values
-                    if activity.attributes["label"].value.start_with? "@string"
-                      # If label is getting from strings.xml, change in strings.xml
-                      string_resource_name = activity.attributes["label"].value.sub("@string/","")
-                      app_name_resource = strings.search('string[name="' + string_resource_name + '"]')
-                      app_name_resource[0].content = params[:display_name]
-                      File.write(string_resource_path, strings.to_xml)
-                    else
-                      # If label is manually put in the attribute, change the attribute directly
-                      activity.attributes["label"].value = params[:display_name]
-                      File.write(manifest_path, manifest.to_xml)
-                    end
+                if intent_filter_node.at_css("action").to_s != "" && intent_filter_node.at_css("category").to_s != "" && \
+                intent_filter_node.at_css("action").attributes["android:name"].value == "android.intent.action.MAIN" && \
+                intent_filter_node.at_css("category").attributes["android:name"].value == "android.intent.category.LAUNCHER"
+                  # Update manifest values
+                  if activity.attributes["label"].value.start_with? "@string"
+                    # If label is getting from strings.xml, change in strings.xml
+                    string_resource_name = activity.attributes["label"].value.sub("@string/", "")
+                    app_name_resource = strings.search('string[name="' + string_resource_name + '"]')
+                    app_name_resource[0].content = params[:display_name]
+                    File.write(string_resource_path, strings.to_xml)
+                  else
+                    # If label is manually put in the attribute, change the attribute directly
+                    activity.attributes["label"].value = params[:display_name]
+                    File.write(manifest_path, manifest.to_xml)
                   end
                 end
               end

--- a/fastlane/lib/fastlane/actions/update_android_package.rb
+++ b/fastlane/lib/fastlane/actions/update_android_package.rb
@@ -3,7 +3,6 @@ module Fastlane
     module SharedValues
     end
 
-
     class UpdateAndroidPackageAction < Action
       def self.run(params)
         require 'nokogiri'
@@ -22,18 +21,18 @@ module Fastlane
             ## Change name
             # Find all activities inside the app
             activites = manifest.xpath("//application//activity")
-            for activity in activites do
+            activites.each do |activity|
               activity_node = Nokogiri::XML(activity.to_s)
               # Find launcher activity
-              if activity_node.at_css("intent-filter").to_s != "" then
+              if activity_node.at_css("intent-filter").to_s != ""
                 intent_filter_node = Nokogiri::XML(activity_node.at_css("intent-filter").to_s)
-                if (intent_filter_node.at_css("action").to_s != "" && intent_filter_node.at_css("category").to_s != "") then
+                if intent_filter_node.at_css("action").to_s != "" && intent_filter_node.at_css("category").to_s != ""
                   if intent_filter_node.at_css("action").attributes["android:name"].value == "android.intent.action.MAIN" && \
-                    intent_filter_node.at_css("category").attributes["android:name"].value == "android.intent.category.LAUNCHER" then
+                    intent_filter_node.at_css("category").attributes["android:name"].value == "android.intent.category.LAUNCHER"
                     # Update manifest values
-                    if activity.attributes["label"].value.start_with? "@string" then
+                    if activity.attributes["label"].value.start_with? "@string"
                       # If label is getting from strings.xml, change in strings.xml
-                      string_resource_name = activity.attributes["label"].value.sub("@string/","")                    
+                      string_resource_name = activity.attributes["label"].value.sub("@string/","")
                       app_name_resource = strings.search('string[name="' + string_resource_name + '"]')
                       app_name_resource[0].content = params[:display_name]
                       File.write(string_resource_path, strings.to_xml)
@@ -48,7 +47,7 @@ module Fastlane
             end
             UI.success("Updated #{params[:manifest_path]} 💾.")
           end
-          
+
           ## Change app identifier
           if params[:app_identifier]
             app_build_gradle_path = File.join(".", params[:app_build_gradle_path])
@@ -58,7 +57,7 @@ module Fastlane
             File.write(app_build_gradle_path, build_gradle)
 
           end
-          
+
         else
           UI.important("You haven't specified any parameters to update your package.")
           false

--- a/fastlane/lib/fastlane/actions/update_android_package.rb
+++ b/fastlane/lib/fastlane/actions/update_android_package.rb
@@ -24,26 +24,22 @@ module Fastlane
             activites.each do |activity|
               activity_node = Nokogiri::XML(activity.to_s)
               # Find launcher activity
-              if activity_node.at_css("intent-filter").to_s != ""
-                intent_filter_node = Nokogiri::XML(activity_node.at_css("intent-filter").to_s)
-                if intent_filter_node.at_css("action").to_s != "" && intent_filter_node.at_css("category").to_s != "" && \
+              next unless activity_node.at_css("intent-filter").to_s != ""
+              intent_filter_node = Nokogiri::XML(activity_node.at_css("intent-filter").to_s)
+              next unless intent_filter_node.at_css("action").to_s != "" && intent_filter_node.at_css("category").to_s != "" && \
                 intent_filter_node.at_css("action").attributes["android:name"].value == "android.intent.action.MAIN" && \
                 intent_filter_node.at_css("category").attributes["android:name"].value == "android.intent.category.LAUNCHER"
-                  # Update manifest values
-                  if activity.attributes["label"].value.start_with? "@string"
-                    # If label is getting from strings.xml, change in strings.xml
-                    string_resource_name = activity.attributes["label"].value.sub("@string/", "")
-                    app_name_resource = strings.search('string[name="' + string_resource_name + '"]')
-                    app_name_resource[0].content = params[:display_name]
-                    File.write(string_resource_path, strings.to_xml)
-                  else
-                    # If label is manually put in the attribute, change the attribute directly
-                    activity.attributes["label"].value = params[:display_name]
-                    File.write(manifest_path, manifest.to_xml)
-                  end
-                end
+              # Update manifest values
+              if activity.attributes["label"].value.start_with? "@string"
+                # If label is getting from strings.xml, change in strings.xml
+                string_resource_name = activity.attributes["label"].value.sub("@string/", "")
+                app_name_resource = strings.search('string[name="' + string_resource_name + '"]')
+                app_name_resource[0].content = params[:display_name]
+                File.write(string_resource_path, strings.to_xml)
               else
-                next
+                # If label is manually put in the attribute, change the attribute directly
+                activity.attributes["label"].value = params[:display_name]
+                File.write(manifest_path, manifest.to_xml)
               end
             end
             UI.success("Updated #{params[:manifest_path]} 💾.")

--- a/fastlane/lib/fastlane/actions/update_android_package.rb
+++ b/fastlane/lib/fastlane/actions/update_android_package.rb
@@ -100,8 +100,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :display_name,
                                        env_name: 'FL_UPDATE_ANDROID_MANIFEST_DISPLAY_NAME',
                                        description: 'The Display Name of your app',
-                                       optional: true),
-
+                                       optional: true)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/update_android_package.rb
+++ b/fastlane/lib/fastlane/actions/update_android_package.rb
@@ -1,0 +1,121 @@
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+
+    class UpdateAndroidPackageAction < Action
+      def self.run(params)
+        require 'nokogiri'
+        ## Check if parameters are set
+        if params[:app_identifier] or params[:display_name]
+          if params[:display_name]
+            manifest_path = File.join(".", params[:manifest_path])
+            string_resource_path = File.join(".", params[:string_resource_path])
+            UI.user_error!("Couldn't find manifest file at path '#{params[:manifest_path]}'") unless File.exist?(manifest_path)
+            UI.user_error!("Couldn't find string resource file at path '#{params[:string_resource_path]}'") unless File.exist?(string_resource_path)
+
+            ## Parse XML
+            manifest = Nokogiri::XML(File.open(manifest_path))
+            strings = Nokogiri::XML(File.open(string_resource_path))
+
+            ## Change name
+            # Find all activities inside the app
+            activites = manifest.xpath("//application//activity")
+            for activity in activites do
+              activity_node = Nokogiri::XML(activity.to_s)
+              # Find launcher activity
+              if activity_node.at_css("intent-filter").to_s != "" then
+                intent_filter_node = Nokogiri::XML(activity_node.at_css("intent-filter").to_s)
+                if (intent_filter_node.at_css("action").to_s != "" && intent_filter_node.at_css("category").to_s != "") then
+                  if intent_filter_node.at_css("action").attributes["android:name"].value == "android.intent.action.MAIN" && \
+                    intent_filter_node.at_css("category").attributes["android:name"].value == "android.intent.category.LAUNCHER" then
+                    # Update manifest values
+                    if activity.attributes["label"].value.start_with? "@string" then
+                      # If label is getting from strings.xml, change in strings.xml
+                      string_resource_name = activity.attributes["label"].value.sub("@string/","")                    
+                      app_name_resource = strings.search('string[name="' + string_resource_name + '"]')
+                      app_name_resource[0].content = params[:display_name]
+                      File.write(string_resource_path, strings.to_xml)
+                    else
+                      # If label is manually put in the attribute, change the attribute directly
+                      activity.attributes["label"].value = params[:display_name]
+                      File.write(manifest_path, manifest.to_xml)
+                    end
+                  end
+                end
+              end
+            end
+            UI.success("Updated #{params[:manifest_path]} 💾.")
+          end
+          
+          ## Change app identifier
+          if params[:app_identifier]
+            app_build_gradle_path = File.join(".", params[:app_build_gradle_path])
+            UI.user_error!("Couldn't find build.gradle file at path '#{params[:app_build_gradle_path]}'") unless File.exist?(app_build_gradle_path)
+            build_gradle = File.open(app_build_gradle_path).read
+            build_gradle = build_gradle.sub(/applicationId\s"(.+)"/.match(build_gradle)[1], params[:app_identifier])
+            File.write(app_build_gradle_path, build_gradle)
+
+          end
+          
+        else
+          UI.important("You haven't specified any parameters to update your package.")
+          false
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Update a Android packaging files with new information'
+      end
+
+      def self.details
+        "This action allows you to modify your AndroidManifest.xml and build.gradle file before building. This may be useful if you want a separate build for alpha, beta or nightly builds, but don't want a separate target."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :manifest_path,
+                                       env_name: "FL_UPDATE_ANDROID_MANIFEST_PATH",
+                                       description: "Path to AndroidManifest.xml",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Invalid manifest file") unless value.end_with? "AndroidManifest.xml"
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :app_build_gradle_path,
+                                       env_name: "FL_UPDATE_ANDROID_BUILD_GRADLE_PATH",
+                                       description: "Path to app/build.gradle",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Invalid build.gradle file") unless value.end_with? "build.gradle"
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :string_resource_path,
+                                       env_name: "FL_UPDATE_ANDROID_MANIFEST_STRING_RESOURCE_PATH",
+                                       description: "Path to res/values/strings.xml",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Invalid string resource path") unless value.end_with? "strings.xml"
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :app_identifier,
+                                       env_name: 'FL_UPDATE_ANDROID_MANIFEST_APP_IDENTIFIER',
+                                       description: 'The bundle identifier or application ID of your app',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :display_name,
+                                       env_name: 'FL_UPDATE_ANDROID_MANIFEST_DISPLAY_NAME',
+                                       description: 'The Display Name of your app',
+                                       optional: true),
+
+        ]
+      end
+
+      def self.authors
+        "ncnlinh"
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end


### PR DESCRIPTION
This action allows you to modify your AndroidManifest.xml and build.gradle file with new app name and app identifier before building. This may be useful if you want a separate build for alpha, beta or nightly builds, but don't want a separate target.
Similar to update_info_plist but for android
