### PR TITLE
Updated cocoapods action to correctly update repo when using cocoapods 1.0

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -19,7 +19,7 @@ module Fastlane
 
         cmd << '--no-clean' unless params[:clean]
         cmd << '--no-integrate' unless params[:integrate]
-        cmd << '--no-repo-update' unless params[:repo_update]
+        cmd << '--repo-update' if params[:repo_update]
         cmd << '--silent' if params[:silent]
         cmd << '--verbose' if params[:verbose]
         cmd << '--no-ansi' unless params[:ansi]
@@ -47,7 +47,7 @@ module Fastlane
                                        env_name: "FL_COCOAPODS_REPO_UPDATE",
                                        description: "Run `pod repo update` before install",
                                        is_string: false,
-                                       default_value: true),
+                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :silent,
                                        env_name: "FL_COCOAPODS_SILENT",
                                        description: "Show nothing",

--- a/fastlane/spec/actions_specs/cocoapods_spec.rb
+++ b/fastlane/spec/actions_specs/cocoapods_spec.rb
@@ -37,14 +37,14 @@ describe Fastlane do
         expect(result).to eq("bundle exec pod install --no-integrate")
       end
 
-      it "adds no-repo-update to command if repo_update is set to false" do
+      it "adds repo-update to command if repo_update is set to true" do
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
-            repo_update: false
+            repo_update: true
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("bundle exec pod install --no-repo-update")
+        expect(result).to eq("bundle exec pod install --repo-update")
       end
 
       it "adds silent to command if silent is set to true" do


### PR DESCRIPTION
cocoapods 1.0 by default does not run `pod repo update` on `pod install` unless `--repo-update` is set. I'm wondering if I should check the gem version to handle both behaviors? I'm not an experienced ruby developer or familiar with fastlane code, so let me know :)

Linked issue: https://github.com/fastlane/fastlane/issues/4965
