### PR TITLE
Re-implement -itc_provider support for ItunesTransporter

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -136,6 +136,16 @@ module Deliver
                                      verify_block: proc do |value|
                                        ENV["FASTLANE_ITC_TEAM_NAME"] = value
                                      end),
+        FastlaneCore::ConfigItem.new(key: :dev_portal_team_id,
+                                     short_option: "-s",
+                                     env_name: "DELIVER_DEV_PORTAL_TEAM_ID",
+                                     description: "The short ID of your team in the developer portal, if you're in multiple teams. Different from your iTC team ID!",
+                                     optional: true,
+                                     is_string: true,
+                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:team_id),
+                                     verify_block: proc do |value|
+                                       ENV["FASTLANE_TEAM_ID"] = value.to_s
+                                     end),
 
         # App Metadata
         # Non Localised

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -133,7 +133,7 @@ module FastlaneCore
 
   # Generates commands and executes the iTMSTransporter through the shell script it provides by the same name
   class ShellScriptTransporterExecutor < TransporterExecutor
-    def build_upload_command(username, password, source = "/tmp")
+    def build_upload_command(username, password, source = "/tmp", team_id = "")
       [
         '"' + Helper.transporter_path + '"',
         "-m upload",
@@ -142,19 +142,21 @@ module FastlaneCore
         "-f '#{source}'",
         ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
         "-t 'Signiant'",
-        "-k 100000"
-      ].join(' ')
+        "-k 100000",
+        ("-itc_provider #{team_id}" if team_id.length > 0)
+      ].compact.join(' ')
     end
 
-    def build_download_command(username, password, apple_id, destination = "/tmp")
+    def build_download_command(username, password, apple_id, destination = "/tmp", team_id = "")
       [
         '"' + Helper.transporter_path + '"',
         "-m lookupMetadata",
         "-u \"#{username}\"",
         "-p #{shell_escaped_password(password)}",
         "-apple_id #{apple_id}",
-        "-destination '#{destination}'"
-      ].join(' ')
+        "-destination '#{destination}'",
+        ("-itc_provider #{team_id}" if team_id.length > 0)
+      ].compact.join(' ')
     end
 
     def handle_error(password)
@@ -190,7 +192,7 @@ module FastlaneCore
   # Generates commands and executes the iTMSTransporter by invoking its Java app directly, to avoid the crazy parameter
   # escaping problems in its accompanying shell script.
   class JavaTransporterExecutor < TransporterExecutor
-    def build_upload_command(username, password, source = "/tmp")
+    def build_upload_command(username, password, source = "/tmp", team_id = "")
       [
         Helper.transporter_java_executable_path.shellescape,
         "-Djava.ext.dirs=#{Helper.transporter_java_ext_dir.shellescape}",
@@ -209,11 +211,12 @@ module FastlaneCore
         ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
         '-t Signiant',
         '-k 100000',
+        ("-itc_provider #{team_id}" if team_id.length > 0),
         '2>&1' # cause stderr to be written to stdout
       ].compact.join(' ') # compact gets rid of the possibly nil ENV value
     end
 
-    def build_download_command(username, password, apple_id, destination = "/tmp")
+    def build_download_command(username, password, apple_id, destination = "/tmp", team_id = "")
       [
         Helper.transporter_java_executable_path.shellescape,
         "-Djava.ext.dirs=#{Helper.transporter_java_ext_dir.shellescape}",
@@ -230,8 +233,9 @@ module FastlaneCore
         "-p #{password.shellescape}",
         "-apple_id #{apple_id.shellescape}",
         "-destination #{destination.shellescape}",
+        ("-itc_provider #{team_id}" if team_id.length > 0),
         '2>&1' # cause stderr to be written to stdout
-      ].join(' ')
+      ].compact.join(' ')
     end
 
     def handle_error(password)
@@ -270,7 +274,10 @@ module FastlaneCore
     # @param use_shell_script if true, forces use of the iTMSTransporter shell script.
     #                         if false, allows a direct call to the iTMSTransporter Java app (preferred).
     #                         see: https://github.com/fastlane/fastlane/pull/4003
-    def initialize(user = nil, password = nil, use_shell_script = false)
+    # @param team_id Represents the developer team id (not the iTC id). If provided, will add the correct
+    #                flag to the upload command.
+    #                see: https://github.com/fastlane/fastlane/issues/1524
+    def initialize(user = nil, password = nil, use_shell_script = false, team_id = nil)
       # Xcode 6.x doesn't have the same iTMSTransporter Java setup as later Xcode versions, so
       # we can't default to using the better direct Java invocation strategy for those versions.
       use_shell_script ||= Helper.is_mac? && Helper.xcode_version.start_with?('6.')
@@ -292,6 +299,7 @@ module FastlaneCore
       end
 
       @transporter_executor = use_shell_script ? ShellScriptTransporterExecutor.new : JavaTransporterExecutor.new
+      @team_id = team_id || (ENV['FASTLANE_TEAM_ID'] || '').strip
     end
 
     # Downloads the latest version of the app metadata package from iTC.
@@ -304,8 +312,8 @@ module FastlaneCore
       dir ||= "/tmp"
 
       UI.message("Going to download app metadata from iTunes Connect")
-      command = @transporter_executor.build_download_command(@user, @password, app_id, dir)
-      UI.verbose(@transporter_executor.build_download_command(@user, 'YourPassword', app_id, dir))
+      command = @transporter_executor.build_download_command(@user, @password, app_id, dir, @team_id)
+      UI.verbose(@transporter_executor.build_download_command(@user, 'YourPassword', app_id, dir, @team_id))
 
       begin
         result = @transporter_executor.execute(command, ItunesTransporter.hide_transporter_output?)
@@ -340,8 +348,14 @@ module FastlaneCore
       UI.message("Going to upload updated app to iTunes Connect")
       UI.success("This might take a few minutes, please don't interrupt the script")
 
+<<<<<<< 4d22f03f0181e6085053d9e4d1cd5da23b3758e5
       command = @transporter_executor.build_upload_command(@user, @password, actual_dir)
       UI.verbose(@transporter_executor.build_upload_command(@user, 'YourPassword', actual_dir))
+=======
+      command = @transporter_executor.build_upload_command(@user, @password, dir, @team_id)
+
+      UI.verbose(@transporter_executor.build_upload_command(@user, 'YourPassword', dir, @team_id))
+>>>>>>> Ads Apple Developer Id to itunes_transporter.rb. Allows deliver to work with multiple iTunes Providers
 
       begin
         result = @transporter_executor.execute(command, ItunesTransporter.hide_transporter_output?)

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -3,31 +3,32 @@ require 'credentials_manager'
 
 describe FastlaneCore do
   describe FastlaneCore::ItunesTransporter do
-    let(:shell_upload_command) do
+    def shell_upload_command(provider_short_name = nil)
       [
         '"' + FastlaneCore::Helper.transporter_path + '"',
         "-m upload",
         '-u "fabric.devtools@gmail.com"',
         "-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'",
         "-f '/tmp/my.app.id.itmsp'",
-        nil, # This represents the environment variable which is not set
         "-t 'Signiant'",
-        "-k 100000"
-      ].join(' ')
+        "-k 100000",
+        ("-itc_provider #{provider_short_name}" if provider_short_name)
+      ].compact.join(' ')
     end
 
-    let(:shell_download_command) do
+    def shell_download_command(provider_short_name = nil)
       [
         '"' + FastlaneCore::Helper.transporter_path + '"',
         '-m lookupMetadata',
         '-u "fabric.devtools@gmail.com"',
         "-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'",
         "-apple_id my.app.id",
-        "-destination '/tmp'"
-      ].join(' ')
+        "-destination '/tmp'",
+        ("-itc_provider #{provider_short_name}" if provider_short_name)
+      ].compact.join(' ')
     end
 
-    let(:java_upload_command) do
+    def java_upload_command(provider_short_name = nil)
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
         "-Djava.ext.dirs=#{FastlaneCore::Helper.transporter_java_ext_dir.shellescape}",
@@ -45,11 +46,12 @@ describe FastlaneCore do
         "-f /tmp/my.app.id.itmsp",
         "-t Signiant",
         "-k 100000",
+        ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
-      ].join(' ')
+      ].compact.join(' ')
     end
 
-    let(:java_download_command) do
+    def java_download_command(provider_short_name = nil)
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
         "-Djava.ext.dirs=#{FastlaneCore::Helper.transporter_java_ext_dir.shellescape}",
@@ -66,8 +68,9 @@ describe FastlaneCore do
         "-p \\!\\>\\ p@\\$s_-\\+\\=w\\'o\\%rd\\\"\\&\\#\\*\\<",
         '-apple_id my.app.id',
         '-destination /tmp',
+        ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
-      ].join(' ')
+      ].compact.join(' ')
     end
 
     describe "with Xcode 7.x installed" do
@@ -85,6 +88,38 @@ describe FastlaneCore do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<")
             expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
+          end
+        end
+      end
+
+      describe "use_shell_script is false with a itc_provider short name set" do
+        describe "upload command generation" do
+          it 'generates a call to java directly' do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false, 'abcd1234')
+            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command('abcd1234'))
+          end
+        end
+
+        describe "download command generation" do
+          it 'generates a call to java directly' do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false, 'abcd1234')
+            expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command('abcd1234'))
+          end
+        end
+      end
+
+      describe "use_shell_script is true with a itc_provider short name set" do
+        describe "upload command generation" do
+          it 'generates a call to java directly' do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true, 'abcd1234')
+            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command('abcd1234'))
+          end
+        end
+
+        describe "download command generation" do
+          it 'generates a call to java directly' do
+            transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", true, 'abcd1234')
+            expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command('abcd1234'))
           end
         end
       end


### PR DESCRIPTION
The major difference between this and the implementation we shipped previously in https://github.com/fastlane/fastlane/pull/4746 is that this one will not take the value from `ENV['FASTLANE_TEAM_ID']`.

We have learned that the `-itc_provider` short name is _often_ the same as your Developer Portal team ID, [but **not always**](https://github.com/fastlane/fastlane/issues/4936#issuecomment-223267068).

The `provider_short_name` parameter is therefore not connected to anything yet, as of this commit. It will be wired up to new options in `deliver` and `pilot` in follow-up PRs
