### PR TITLE
Version bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.46.1".freeze
+  VERSION = "0.46.2".freeze
 end


### PR DESCRIPTION
Changes since release 0.46.1:
- Re-implement -itc_provider support for ItunesTransporter
- Ads Apple Developer Id to itunes_transporter.rb. Allows deliver to work with multiple iTunes Providers
