### PR TITLE
Add :itc_provider option for deliver and pilot

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -146,6 +146,10 @@ module Deliver
                                      verify_block: proc do |value|
                                        ENV["FASTLANE_TEAM_ID"] = value.to_s
                                      end),
+        FastlaneCore::ConfigItem.new(key: :itc_provider,
+                                     env_name: "DELIVER_ITC_PROVIDER",
+                                     description: "The provider short name to be used with the iTMSTransporter to identify your team",
+                                     optional: true),
 
         # App Metadata
         # Non Localised

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -78,7 +78,7 @@ module Deliver
         )
       end
 
-      transporter = FastlaneCore::ItunesTransporter.new(options[:username])
+      transporter = FastlaneCore::ItunesTransporter.new(options[:username], nil, false, options[:itc_provider])
       result = transporter.upload(options[:app].apple_id, package_path)
       UI.user_error!("Could not upload binary to iTunes Connect. Check out the error above") unless result
     end

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -15,7 +15,7 @@ module Pilot
                                                                   package_path: "/tmp",
                                                                       platform: platform)
 
-      transporter = FastlaneCore::ItunesTransporter.new(options[:username])
+      transporter = FastlaneCore::ItunesTransporter.new(options[:username], nil, false, options[:itc_provider])
       result = transporter.upload(app.apple_id, package_path)
 
       unless result

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -117,7 +117,11 @@ module Pilot
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:team_id),
                                      verify_block: proc do |value|
                                        ENV["FASTLANE_TEAM_ID"] = value.to_s
-                                     end)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :itc_provider,
+                                     env_name: "PILOT_ITC_PROVIDER",
+                                     description: "The provider short name to be used with the iTMSTransporter to identify your team",
+                                     optional: true)
       ]
     end
   end


### PR DESCRIPTION
Addresses https://github.com/fastlane/fastlane/issues/4936

This provides an explicit option for controlling use of the `-itc_provider` option in the iTMSTransporter through `deliver` and `pilot`
