### PR TITLE
Version bump

### DIFF
--- a/deliver/lib/deliver/version.rb
+++ b/deliver/lib/deliver/version.rb
@@ -1,4 +1,4 @@
 module Deliver
-  VERSION = "1.12.0"
+  VERSION = "1.13.0"
   DESCRIPTION = 'Upload screenshots, metadata and your app to the App Store using a single command'
 end


### PR DESCRIPTION
Changes since release 1.12.0:
- Add :itc_provider option for deliver and pilot
- Ads Apple Developer Id to itunes_transporter.rb. Allows deliver to work with multiple iTunes Providers
- Revert "Allow deliver to work with multiple iTunes Providers" (#4961)
- Enabled fastlane plugins for all the tools (#4941)
- Make deliver setup honor the skip_screenshots flag (#4919)
