### PR TITLE
Version bump fastlane_core dependency for deliver and pilot

### DIFF
--- a/deliver/deliver.gemspec
+++ b/deliver/deliver.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # fastlane dependencies
-  spec.add_dependency 'fastlane_core', '>= 0.43.1', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.46.2', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'credentials_manager', '>= 0.16.0', '< 1.0.0'
   spec.add_dependency 'spaceship', '>= 0.26.2', '< 1.0.0' # Communication with iTunes Connect
 

--- a/pilot/pilot.gemspec
+++ b/pilot/pilot.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.41.2', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.46.2', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'spaceship', '>= 0.27.0', '< 1.0.0' # iTunes Connect communication
   spec.add_dependency 'credentials_manager', '>= 0.3.0'
 


### PR DESCRIPTION
Needed to use the `itc_provider` paramter to `ItunesTransporter`
