### PR TITLE
Fix for missing dotfiles in new plugins

### DIFF
--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.files = Dir["lib/**/*"] + %w(bin/fastlane bin/🚀 README.md LICENSE)
+  spec.files = Dir.glob("lib/**/*", File::FNM_DOTMATCH) + %w(bin/fastlane bin/🚀 README.md LICENSE)
 
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
This happened only when using the packaged gem, because `Dir.glob` does not include dotfiles by default. Using `FNM_DOTMATCH` changes that behaviour. 

I didn't add a test for this, because the error doesn't surface when developing the gem.

cc @KrauseFx 🚢 
