### PR TITLE
Fixed OneOff actions not loading the built-in fastlane actions

### DIFF
--- a/fastlane/lib/fastlane/one_off.rb
+++ b/fastlane/lib/fastlane/one_off.rb
@@ -2,6 +2,8 @@ module Fastlane
   # Call actions without triggering a full lane
   class OneOff
     def self.execute(args: nil)
+      Fastlane.load_actions
+
       action_parameters = {}
       action_name = nil
 

--- a/fastlane/lib/fastlane/one_off.rb
+++ b/fastlane/lib/fastlane/one_off.rb
@@ -2,8 +2,6 @@ module Fastlane
   # Call actions without triggering a full lane
   class OneOff
     def self.execute(args: nil)
-      Fastlane.load_actions
-
       action_parameters = {}
       action_name = nil
 
@@ -26,6 +24,8 @@ module Fastlane
     end
 
     def self.run(action: nil, parameters: nil)
+      Fastlane.load_actions
+
       class_name = action.fastlane_class + 'Action'
       class_ref = nil
       begin

--- a/fastlane/spec/one_off_spec.rb
+++ b/fastlane/spec/one_off_spec.rb
@@ -8,6 +8,16 @@ describe Fastlane do
         expect(Fastlane::Runner).to receive(:new).and_return(@runner)
       end
 
+      it "calls load_actions to load all built-in actions" do
+        action = 'increment_build_number'
+        expect(Fastlane).to receive(:load_actions)
+
+        expect(@runner).to receive(:execute_action).with(
+          action, Fastlane::Actions::IncrementBuildNumberAction, [{}], { custom_dir: "." }
+        )
+        Fastlane::OneOff.execute(args: [action])
+      end
+
       it "works with no parameters" do
         action = 'increment_build_number'
 


### PR DESCRIPTION
After the update to the plugins, this wasn't working
