### PR TITLE
Add additional json file with screenshot image

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -22,7 +22,7 @@ func setupSnapshot(app: XCUIApplication) {
 }
 
 func snapshot(name: String, waitForLoadingIndicator: Bool = true, additionalInfos:Dictionary<String,AnyObject>? = nil) {
-    Snapshot.snapshot(name, waitForLoadingIndicator: waitForLoadingIndicator,additionalInfos:additionalInfos)
+    Snapshot.snapshot(name, waitForLoadingIndicator: waitForLoadingIndicator, additionalInfos:additionalInfos)
 }
 
 public class Snapshot: NSObject {
@@ -93,7 +93,7 @@ public class Snapshot: NSObject {
         if waitForLoadingIndicator {
             waitForLoadingIndicatorToDisappear()
         }
-        var metaInfos = "";
+        var metaInfos = ""
         if let additionalInfos = additionalInfos {
             do {
                 let jsonData:NSData? = try NSJSONSerialization.dataWithJSONObject(additionalInfos,options:NSJSONWritingOptions.init(rawValue: 0))
@@ -105,7 +105,8 @@ public class Snapshot: NSObject {
             }
         }
 
-        print("snapshot: \(name) meta: \(metaInfos)") // more information about this, check out https://github.com/fastlane/snapshot
+        // more information about this, check out https://github.com/fastlane/snapshot
+        print("snapshot: \(name) meta: \(metaInfos)")
 
         sleep(1) // Waiting for the animation to be finished (kind of)
         XCUIDevice.sharedDevice().orientation = .Unknown

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -21,8 +21,8 @@ func setupSnapshot(app: XCUIApplication) {
     Snapshot.setupSnapshot(app)
 }
 
-func snapshot(name: String, waitForLoadingIndicator: Bool = true) {
-    Snapshot.snapshot(name, waitForLoadingIndicator: waitForLoadingIndicator)
+func snapshot(name: String, waitForLoadingIndicator: Bool = true, additionalInfos:Dictionary<String,AnyObject>? = nil) {
+    Snapshot.snapshot(name, waitForLoadingIndicator: waitForLoadingIndicator,additionalInfos:additionalInfos)
 }
 
 public class Snapshot: NSObject {
@@ -89,12 +89,23 @@ public class Snapshot: NSObject {
         }
     }
 
-    public class func snapshot(name: String, waitForLoadingIndicator: Bool = true) {
+    public class func snapshot(name: String, waitForLoadingIndicator: Bool = true, additionalInfos:Dictionary<String,AnyObject>? = nil) {
         if waitForLoadingIndicator {
             waitForLoadingIndicatorToDisappear()
         }
+        var metaInfos = "";
+        if let additionalInfos = additionalInfos {
+            do {
+                let jsonData:NSData? = try NSJSONSerialization.dataWithJSONObject(additionalInfos,options:NSJSONWritingOptions.init(rawValue: 0))
+                if let jsonData = jsonData {
+                    metaInfos = NSString(data: jsonData, encoding: NSUTF8StringEncoding) as! String
+                }
+            } catch {
+                print("Unable to serialize Additional Info ...")
+            }
+        }
 
-        print("snapshot: \(name)") // more information about this, check out https://github.com/fastlane/snapshot
+        print("snapshot: \(name) meta: \(metaInfos)") // more information about this, check out https://github.com/fastlane/snapshot
 
         sleep(1) // Waiting for the animation to be finished (kind of)
         XCUIDevice.sharedDevice().orientation = .Unknown

--- a/snapshot/lib/snapshot/collector.rb
+++ b/snapshot/lib/snapshot/collector.rb
@@ -34,10 +34,10 @@ module Snapshot
         json_output_path = File.join(language_folder, components.join("-") + ".json")
         if $verbose
           UI.success "Copying file '#{from_path}' to '#{output_path}'..."
-          UI.success "Create meta json file to '#{json_output_path}' ..."
+          UI.success "Creating meta json file to '#{json_output_path}' ..."
         else
           UI.success "Copying '#{output_path}'..."
-          UI.success "Create meta json file to '#{json_output_path}' ..."
+          UI.success "Creating '#{json_output_path}' ..."
         end
         FileUtils.cp(from_path, output_path)
         IO.write(json_output_path, meta, mode: 'w')

--- a/snapshot/lib/snapshot/collector.rb
+++ b/snapshot/lib/snapshot/collector.rb
@@ -8,7 +8,7 @@ module Snapshot
       attachments_path = File.join(containing, "Attachments")
 
       to_store = attachments(containing)
-      matches = output.scan(/snapshot: (.*)/)
+      matches = output.scan(/snapshot: (.*) meta: (.*)/)
 
       if to_store.count == 0 && matches.count == 0
         return false
@@ -20,6 +20,7 @@ module Snapshot
 
       matches.each_with_index do |current, index|
         name = current[0]
+        meta = current[1]
         filename = to_store[index]
 
         language_folder = File.join(Snapshot.config[:output_directory], dir_name)
@@ -30,12 +31,16 @@ module Snapshot
 
         output_path = File.join(language_folder, components.join("-") + ".png")
         from_path = File.join(attachments_path, filename)
+        json_output_path = File.join(language_folder, components.join("-") + ".json")
         if $verbose
           UI.success "Copying file '#{from_path}' to '#{output_path}'..."
+          UI.success "Create meta json file to '#{json_output_path}' ..."
         else
           UI.success "Copying '#{output_path}'..."
+          UI.success "Create meta json file to '#{json_output_path}' ..."
         end
         FileUtils.cp(from_path, output_path)
+        IO.write(json_output_path, meta, mode: 'w')
       end
 
       return true


### PR DESCRIPTION
I'm working on automated UI test with snapshot and send them to a comparison server (VisualReview). To be able to add some dynamic additional info to the screenshot, few small modifications had been done on the collector script and on the swift helper.

For more Info about the others tools needed to compare screens. See https://github.com/rgroult/fastlane-VisualReview-protractor
It would be great if you could had them in the mainstream.
Regards.
