### PR TITLE
Generate empty JSON if there is no `Fastfile`

### DIFF
--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -79,9 +79,9 @@ module Fastlane
         c.option "-j", "--json", "Output the lanes in JSON instead of text"
 
         c.action do |args, options|
-          if ensure_fastfile
+          if options.json || ensure_fastfile
             require 'fastlane/lane_list'
-            path = File.join(Fastlane::FastlaneFolder.fastfile_path)
+            path = Fastlane::FastlaneFolder.fastfile_path
 
             if options.json
               Fastlane::LaneList.output_json(path)

--- a/fastlane/lib/fastlane/lane_list.rb
+++ b/fastlane/lib/fastlane/lane_list.rb
@@ -45,8 +45,9 @@ module Fastlane
 
     # Returns a hash
     def self.generate_json(path)
-      ff = Fastlane::FastFile.new(path)
       output = {}
+      return output if path.nil?
+      ff = Fastlane::FastFile.new(path)
 
       all_keys = ff.runner.lanes.keys
 

--- a/fastlane/spec/lane_list_spec.rb
+++ b/fastlane/spec/lane_list_spec.rb
@@ -31,5 +31,10 @@ describe Fastlane do
  }
  })
     end
+
+    it "generates empty JSON if there is no Fastfile" do
+      result = Fastlane::LaneList.generate_json(nil)
+      expect(result).to eq({})
+    end
   end
 end


### PR DESCRIPTION
The `--json` option should not prompt the user to setup a `Fastfile`.

cc @KrauseFx 
