### PR TITLE
[spaceship] Version bump

### DIFF
--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,4 +1,4 @@
 module Spaceship
-  VERSION = "0.27.1".freeze
+  VERSION = "0.27.2".freeze
   DESCRIPTION = "Ruby library to access the Apple Dev Center and iTunes Connect".freeze
 end


### PR DESCRIPTION
- Print proper error message when new 2step is used (#4959)
- Fix broken urls in Spaceship docs (#4952)
- [spaceship] Add .jpeg to the set of recognized media extensions
- Sort team selections (#4794)
- Removed link to RubyDoc (#4705)
- [spaceship] Updated spaceship gem description (#4684)
- [spaceship] Add link to GitHub issue for Accept-Encoding fix
