### PR TITLE
[fastlane] Version bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.94.1'.freeze
+  VERSION = '1.95.0'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end


### PR DESCRIPTION
- Added error handling when dSYM download failed
- Added update checker for plugins (#5039)
- Generate empty JSON if there is no `Fastfile` (#5056)
- Updated fastlane.gemspec to include fastlane team (#5026)
- Updating `upload_symbols_to_sentry` action to allow for bearer auth (#4884)
- Changed Helper.is_ci? to UI.interactive? (#5037)
- [fastlane] Show error message when plugin name has _ in the name when adding a plugin (#5034)
- Reduce gem size by 70% by excluding device grid assets from .gem (#5024)
- Improved error handling for `download_dsyms` action
- Fixed `fastlane action` table design for legacy actions (#5052)
