### PR TITLE
Escape code signing identity

### DIFF
--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -57,7 +57,7 @@ module Gym
 
       def suffix
         suffix = []
-        suffix << "CODE_SIGN_IDENTITY='#{Gym.config[:codesigning_identity]}'" if Gym.config[:codesigning_identity]
+        suffix << "CODE_SIGN_IDENTITY=#{Gym.config[:codesigning_identity].shellescape}" if Gym.config[:codesigning_identity]
         suffix
       end
 


### PR DESCRIPTION
Attempting to build gym with a --codesigning_identity value that has an apostrophe (e.g. `gym --scheme "My App" --codesigning_identity "iPhone Distribution: Mark's Company (ABCDE123456)"`) will fail with the error:

``` bash
sh: -c: line 0: syntax error near unexpected token `('
```

Escaping the value instead of quoting fixes the problem.
