### PR TITLE
Update README.md

### DIFF
--- a/fastlane/lib/fastlane/actions/device_grid/README.md
+++ b/fastlane/lib/fastlane/actions/device_grid/README.md
@@ -44,7 +44,7 @@ fastlane init
 ### Setup `danger`
 
 ```
-danger init
+bundle exec danger init
 ```
 
 Follow the `danger` guide to authenticate with GitHub


### PR DESCRIPTION
Running `danger init` yields an error.

![image](https://cloud.githubusercontent.com/assets/390817/15984817/d575a772-2fd8-11e6-9391-f8550ffd6fd6.png)

Documentation says `bundle exec danger init`
https://github.com/danger/danger
