### PR TITLE
Add version support to cocoapods action.

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -88,7 +88,7 @@ module Fastlane
                                        optional: true,
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         UI.user_error!("Cocoapods #{value} is not installed") unless !Actions.verify_gem('cocoapods', Gem::Requirement.create("= #{value}")) || Helper.test?
+                                         UI.user_error!("Cocoapods #{value} is not installed") unless Actions.verify_gem('cocoapods', Gem::Requirement.create(value)) || Helper.test?
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -15,7 +15,13 @@ module Fastlane
         end
 
         cmd << ['bundle exec'] if File.exist?('Gemfile') && params[:use_bundle_exec]
-        cmd << ['pod install']
+
+        version = params[:version]
+        unless version.nil?
+          cmd << ["pod _#{version}_ install"]
+        else
+          cmd << ['pod install']
+        end
 
         cmd << '--no-clean' unless params[:clean]
         cmd << '--no-integrate' unless params[:integrate]
@@ -75,6 +81,14 @@ module Fastlane
                                        is_string: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Could not find Podfile") unless File.exist?(value) || Helper.test?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       env_name: "FL_COCOAPODS_VERSION",
+                                       description: "Use a specific version of Cocoapods",
+                                       optional: true,
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Cocoapods #{value} is not installed") unless !Actions.verify_gem('cocoapods', Gem::Requirement.create("= #{value}")) || Helper.test?
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -17,10 +17,10 @@ module Fastlane
         cmd << ['bundle exec'] if File.exist?('Gemfile') && params[:use_bundle_exec]
 
         version = params[:version]
-        unless version.nil?
-          cmd << ["pod _#{version}_ install"]
-        else
+        if version.nil?
           cmd << ['pod install']
+        else
+          cmd << ["pod _#{version}_ install"]
         end
 
         cmd << '--no-clean' unless params[:clean]

--- a/fastlane/lib/fastlane/helper/gem_helper.rb
+++ b/fastlane/lib/fastlane/helper/gem_helper.rb
@@ -22,5 +22,16 @@ module Fastlane
       end
       true
     end
+
+    # check a gem with requirement is installed
+    # does not 'require' the gem
+    def self.verify_gem(gem_name, requirement)
+      begin
+        Gem::Specification.find_by_name(gem_name, requirement)
+      rescue Gem::LoadError
+        false
+      end
+      true
+    end
   end
 end

--- a/fastlane/spec/actions_specs/cocoapods_spec.rb
+++ b/fastlane/spec/actions_specs/cocoapods_spec.rb
@@ -96,6 +96,16 @@ describe Fastlane do
 
         expect(result).to eq("cd 'Project' && bundle exec pod install")
       end
+
+      it "adds Cocoapods version to command if version is set" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          cocoapods(
+            version: '0.38.2'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod _0.38.2_ install")
+      end
     end
   end
 end


### PR DESCRIPTION
In legacy iOS projects I frequently find it the case that I need to use an old version of Cocoapods using the following command: `pod _0.38.2_ install`.

I thought it would be nice if the cocoapods action supported this out the box, so I've added it here.

My only thought looking at the code is that perhaps I could rename my version of verify_gem to gem_installed? since it returns true or false rather than raising an exception. I thought it best to leave the existing verify_gem! implementation untouched - any opinions on this?
