### PR TITLE
MAKE FASTLANE FAST AGAIN

### DIFF
--- a/fastlane/bin/fastlane
+++ b/fastlane/bin/fastlane
@@ -2,13 +2,15 @@
 $LOAD_PATH.push File.expand_path("../../lib", __FILE__)
 
 unless ENV['BUNDLE_BIN_PATH']
-  has_gemfile = File.exist?('Gemfile')
+  has_gemfile = File.exist?('Gemfile') && File.read('Gemfile').include?('fastlane')
 
   require 'tmpdir'
-  temp_gemfile = File.join(Dir.tmpdir, "Gemfile")
+  temp_gemfile = File.join(Dir.tmpdir, 'Gemfile')
   File.write(temp_gemfile, "gem 'fastlane'") unless has_gemfile
 
-  system("BUNDLE_GEMFILE=#{temp_gemfile} bundle exec fastlane #{ARGV.join(' ')}")
+  command = "bundle exec fastlane #{ARGV.join(' ')}"
+  command = "BUNDLE_GEMFILE=#{temp_gemfile} #{command}" unless has_gemfile
+  system(command)
   status = $?
 
   unless has_gemfile

--- a/fastlane/bin/fastlane
+++ b/fastlane/bin/fastlane
@@ -1,5 +1,23 @@
 #!/usr/bin/env ruby
 $LOAD_PATH.push File.expand_path("../../lib", __FILE__)
 
+unless ENV['BUNDLE_BIN_PATH']
+  has_gemfile = File.exist?('Gemfile')
+
+  require 'tmpdir'
+  temp_gemfile = "#{Dir.tmpdir}/Gemfile"
+  File.open(temp_gemfile, 'w') { |file| file.write("gem 'fastlane'") } unless has_gemfile
+
+  system("BUNDLE_GEMFILE=#{temp_gemfile} bundle exec fastlane #{ARGV.join(' ')}")
+  status = $?
+
+  unless has_gemfile
+    File.delete(temp_gemfile)
+    File.delete("#{temp_gemfile}.lock")
+  end
+
+  exit(status.exitstatus)
+end
+
 require "fastlane/cli_tools_distributor"
 Fastlane::CLIToolsDistributor.take_off

--- a/fastlane/bin/fastlane
+++ b/fastlane/bin/fastlane
@@ -5,8 +5,8 @@ unless ENV['BUNDLE_BIN_PATH']
   has_gemfile = File.exist?('Gemfile')
 
   require 'tmpdir'
-  temp_gemfile = "#{Dir.tmpdir}/Gemfile"
-  File.open(temp_gemfile, 'w') { |file| file.write("gem 'fastlane'") } unless has_gemfile
+  temp_gemfile = File.join(Dir.tmpdir, "Gemfile")
+  File.write(temp_gemfile, "gem 'fastlane'") unless has_gemfile
 
   system("BUNDLE_GEMFILE=#{temp_gemfile} bundle exec fastlane #{ARGV.join(' ')}")
   status = $?

--- a/fastlane/bin/fastlane
+++ b/fastlane/bin/fastlane
@@ -2,23 +2,13 @@
 $LOAD_PATH.push File.expand_path("../../lib", __FILE__)
 
 unless ENV['BUNDLE_BIN_PATH']
-  has_gemfile = File.exist?('Gemfile') && File.read('Gemfile').include?('fastlane')
+  require 'bundler'
+  gemfile = Bundler::SharedHelpers.in_bundle?
 
-  require 'tmpdir'
-  temp_gemfile = File.join(Dir.tmpdir, 'Gemfile')
-  File.write(temp_gemfile, "gem 'fastlane'") unless has_gemfile
-
-  command = "bundle exec fastlane #{ARGV.join(' ')}"
-  command = "BUNDLE_GEMFILE=#{temp_gemfile} #{command}" unless has_gemfile
-  system(command)
-  status = $?
-
-  unless has_gemfile
-    File.delete(temp_gemfile)
-    File.delete("#{temp_gemfile}.lock")
+  if gemfile && File.read(gemfile).include?('fastlane')
+    system("bundle exec fastlane #{ARGV.join(' ')}")
+    exit($?.exitstatus)
   end
-
-  exit(status.exitstatus)
 end
 
 require "fastlane/cli_tools_distributor"

--- a/fastlane/bin/🚀
+++ b/fastlane/bin/🚀
@@ -1,5 +1,2 @@
 #!/usr/bin/env ruby
-$LOAD_PATH.push File.expand_path("../../lib", __FILE__)
-
-require "fastlane/cli_tools_distributor"
-Fastlane::CLIToolsDistributor.take_off
+load(File.expand_path('../fastlane', __FILE__))


### PR DESCRIPTION
Turns out `fastlane` can be kinda slow if the user has a bunch of gems installed:

``` bash
$ time fastlane -v
real    1m36.253s
user    1m28.818s
sys 0m2.793s
```

with the changes in this branch:

``` bash
$ time fastlane -v
real    0m2.277s
user    0m1.704s
sys 0m0.295s
```

The approach is kinda hacky, it works by shelling out to `bundle exec fastlane` and generates a `Gemfile` on the fly if there isn't one already.

cc @KrauseFx 
