### PR TITLE
Authorize location permission for the application prior to taking screenshots

### DIFF
--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -91,7 +91,7 @@ module Snapshot
                                      env_name: 'SNAPSHOT_APP_IDENTIFIER',
                                      short_option: "-a",
                                      optional: true,
-                                     description: "The bundle identifier of the app to uninstall (only needed when enabling reinstall_app)",
+                                     description: "The bundle identifier of the app to uninstall or authorize (only needed when enabling reinstall_app or authorize_location)",
                                      default_value: ENV["SNAPSHOT_APP_IDENTITIFER"] || CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)),
         FastlaneCore::ConfigItem.new(key: :add_photos,
                                      env_name: 'SNAPSHOT_PHOTOS',
@@ -105,6 +105,12 @@ module Snapshot
                                      description: "A list of videos that should be added to the simulator before running the application",
                                      type: Array,
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :authorize_location,
+                                     env_name: 'SNAPSHOT_AUTHORIZE_LOCATION',
+                                     short_option: "-z",
+                                     description: "Enabling this option will automatically authorize location permission on the simulator for the application",
+                                     default_value: false,
+                                     is_string: false),
 
         # Everything around building
         FastlaneCore::ConfigItem.new(key: :buildlog_path,

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -144,6 +144,7 @@ module Snapshot
 
       add_media(device_type, :photo, Snapshot.config[:add_photos]) if Snapshot.config[:add_photos]
       add_media(device_type, :video, Snapshot.config[:add_videos]) if Snapshot.config[:add_videos]
+      authorize_location(device_type) if Snapshot.config[:authorize_location]
 
       open_simulator_for_device(device_type)
 
@@ -247,6 +248,30 @@ module Snapshot
         UI.message "Adding '#{path}'"
         Helper.backticks("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape} &> /dev/null")
       end
+    end
+
+    def authorize_location(device_type)
+      UI.verbose "Authorizing location permission for #{device_type}..."
+      device_udid = TestCommandGenerator.device_udid(device_type)
+      Snapshot.config[:app_identifier] ||= UI.input("The Bundle Identifier of your App: ")
+
+      plist_path = "#{ENV['HOME']}/Library/Developer/CoreSimulator/Devices/#{device_udid}/data/Library/Caches/locationd"
+      FileUtils.mkpath(plist_path)
+      plist_file = File.join(plist_path, "clients.plist")
+      Helper.backticks("plutil -convert xml1 #{plist_file}") if File.file?(plist_file)
+      plist = Plist.parse_xml(plist_file) || {}
+
+      plist[Snapshot.config[:app_identifier]] = {
+        "SupportedAuthorizationMask" => 3,
+        "Authorization" => 4,
+        "Authorized" => true,
+        "Whitelisted" => false,
+        "Executable" => "",
+        "Registered" => "",
+        "BundleId" => Snapshot.config[:app_identifier]
+      }
+
+      File.write(plist_file, Plist::Emit.dump(plist))
     end
 
     def clear_previous_screenshots


### PR DESCRIPTION
Adds an option to pre-authorize location permission for the application prior to taking screenshots.

After losing hours to XCTest's flakey and unreliable `addUIInterruptionMonitorWithDescription` handler in order to allow location permission during snapshot I have implemented the option to have the application be 'pre-authorized' for location permission prior to launching the device.

`addUIInterruptionMonitorWithDescription` has an ongoing bug ([apple dev forums](https://forums.developer.apple.com/thread/15971), [stackoverflow](http://stackoverflow.com/questions/32148965/xcode-7-ui-testing-how-to-dismiss-a-series-of-system-alerts-in-code/32228033#32228033) and [stackoverflow](http://stackoverflow.com/a/33875994/387317)) that involves having to tap/interact with the interface after the permission alert is displayed in order for the handler to fire. My experience with this has been very inconsistent and found it is subject to timing issues and network speed. Using this handler I have snapshot tests intermittently fail without code changes.

This PR avoids this issue by having the app already authorized to use location and therefore not needing to request permission.

`snapshot --authorize_location`
`snapshot -z`

Snapfile: `authorize_location true`
ENV `SNAPSHOT_AUTHORIZE_LOCATION`
