### PR TITLE
Proper escaping of codesigning identity

### DIFF
--- a/gym/lib/gym/generators/package_command_generator_legacy.rb
+++ b/gym/lib/gym/generators/package_command_generator_legacy.rb
@@ -30,7 +30,7 @@ module Gym
         end
 
         if Gym.config[:codesigning_identity]
-          options << "--sign '#{Gym.config[:codesigning_identity]}'"
+          options << "--sign #{Gym.config[:codesigning_identity].shellescape}"
         end
 
         options


### PR DESCRIPTION
Related to #5089

If a codesigning identity contains apostrophes, the build will fail.
