### PR TITLE
Add `pilot distribute` to release latest build to testflight

### DIFF
--- a/pilot/lib/pilot/commands_generator.rb
+++ b/pilot/lib/pilot/commands_generator.rb
@@ -1,4 +1,5 @@
 # rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/AbcSize
 require "commander"
 require "pilot/options"
 require "fastlane_core"
@@ -58,6 +59,16 @@ module Pilot
         c.action do |args, options|
           config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
           Pilot::BuildManager.new.upload(config)
+        end
+      end
+
+      command :distribute do |c|
+        c.syntax = "pilot distribute"
+        c.description = "Distribute a previously uploaded binary to Apple TestFlight"
+        c.action do |args, options|
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
+          config[:distribute_external] = true
+          Pilot::BuildManager.new.distribute(config)
         end
       end
 


### PR DESCRIPTION
```
$ export PILOT_CHANGELOG="..."
$ pilot distribute
[16:19:40]: Login to iTunes Connect
[16:19:42]: Login successful
[16:19:49]: Distributing build 1.0.0(6.16.2055) from Internal -> External
[16:19:50]: Successfully set the changelog for build
[16:19:50]: Distributing new build to testers
[16:20:01]: Successfully distributed build to beta testers 🚀
```

```
$ pilot distribute
[16:20:40]: Login to iTunes Connect
[16:20:43]: Login successful

[!] Build 1.0.0(6.16.2055) has already been distributed.
```
