### PR TITLE
Scan Support for connected devices

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -51,12 +51,15 @@ module FastlaneCore
       def connected_devices(requested_os_type)
         UI.verbose("Fetching available connected devices")
 
+        tvos_devices = ["AppleTV"]
+        ios_devices = ["iPhone", "iPad", "iPod"]
+
         device_types = if requested_os_type == "tvOS"
-                         ["AppleTV"]
+                         tvos_devices
                        elsif requested_os_type == "iOS"
-                         ["iPhone", "iPad", "iPod"]
+                         ios_devices
                        else
-                         []
+                         ios_devices + tvos_devices
                        end
 
         devices = [] # Return early if no supported devices are being searched for

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -60,6 +60,18 @@ describe Scan do
 "
     FastlaneCore::Simulator.clear_cache
     response = "response"
+    device = "device"
+    system_profiler_output = '<?xml version="1.0" encoding="UTF-8"?>
+                                  <array>
+                                  	<dict>
+                                  		<key>_items</key>
+                                  		<array/>
+                                  	</dict>
+                                  </array>'
+
+    allow(device).to receive(:read).and_return(system_profiler_output)
+    allow(Open3).to receive(:popen3).with("system_profiler SPUSBDataType -xml").and_yield(nil, device, nil, nil)
+
     allow(response).to receive(:read).and_return(@valid_simulators)
     allow(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
 


### PR DESCRIPTION
Relates to #5160 

This adds support for testing using connected devices for scan.

I refactored the device selection to use DeviceManager so physical devices can be tested by adding the device name to list of devices.
