### PR TITLE
Dont generate empty platform docs when there are no lanes

### DIFF
--- a/fastlane/lib/fastlane/documentation/docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/docs_generator.rb
@@ -17,12 +17,15 @@ module Fastlane
       all_keys.unshift(nil) # because we want root elements on top. always! They have key nil
 
       all_keys.each do |platform|
+        lanes = ff.runner.lanes[platform]
+
+        if lanes.nil? || lanes.empty? || lanes.all? { |_, lane| lane.is_private }
+          next
+        end
+
         output << "## #{formatted_platform(platform)}" if platform
 
-        value = ff.runner.lanes[platform]
-        next unless value
-
-        value.each do |lane_name, lane|
+        lanes.each do |lane_name, lane|
           next if lane.is_private
           output << render(platform, lane_name, lane.description.join("\n\n"))
         end

--- a/fastlane/spec/docs_generator_spec.rb
+++ b/fastlane/spec/docs_generator_spec.rb
@@ -21,5 +21,25 @@ describe Fastlane do
       expect(output).to include('https://fastlane.tools')
       expect(output).to include('https://github.com/')
     end
+
+    it "generates new markdown docs but skips empty platforms" do
+      output_path = "/tmp/documentation.md"
+      ff = Fastlane::FastFile.new('./spec/fixtures/fastfiles/FastfilePlatformDocumentation')
+      Fastlane::DocsGenerator.run(ff, output_path)
+
+      output = File.read(output_path)
+
+      expect(output).to include('sudo gem install fastlane')
+      expect(output).to include('# Available Actions')
+      expect(output).to include('## Android')
+      expect(output).to include('### android lane')
+      expect(output).to include('fastlane android lane')
+      expect(output).to include("I'm a lane")
+
+      expect(output).not_to include('## iOS')
+      expect(output).not_to include('## Mac')
+      expect(output).not_to include('mac_lane')
+      expect(output).not_to include("I'm a mac private_lane")
+    end
   end
 end

--- a/fastlane/spec/fixtures/fastfiles/FastfilePlatformDocumentation
+++ b/fastlane/spec/fixtures/fastfiles/FastfilePlatformDocumentation
@@ -1,0 +1,18 @@
+# Needs to have this name
+
+platform :ios do
+end
+
+platform :android do
+  desc "I'm a lane"
+  lane :lane do
+    UI.message("I'm a lane")
+  end
+end
+
+platform :mac do
+  desc "I'm a mac private_lane"
+  private_lane :mac_lane do
+    UI.message("I'm a lane")
+  end
+end


### PR DESCRIPTION
## Problem
- If all lanes in a platform are private, or there are no lanes, then documentation should not be generated for that platform. It was though.
## How?
- This was occurring because we have a shared git repo containing a master Fastfile that contains lanes and actions for iOS and Android. However, through use of environment variables (some things are only defined on CI for logging purposes) and private lanes (to be used in project specific Fastfiles), we ended up with an empty iOS platform for our Android projects
- This meant lovely docs like so:
  ![image](https://cloud.githubusercontent.com/assets/3074765/16282542/32207cce-3897-11e6-8ff8-443a17cbbd37.png)
## Fix
- If lanes for a given platform are `nil`, `empty?`, or are all private, then we skip.
- We also don't output a header until this check as well

Fixes #5195
