### PR TITLE
Initial Attempt at Crashlytics Beta Initialization

### DIFF
--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'xcode-install', '~> 1.4.0' # Needed for xcversion and xcode_install actions
   spec.add_dependency 'word_wrap', '~> 1.0.0'  # to add line breaks for tables with long strings
 
-  spec.add_dependency 'fastlane_core', '>= 0.47.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.48.0', '< 1.0.0' # all shared code and dependencies
 
   spec.add_dependency 'bundler', "~> 1.12" # Used for fastlane plugins
   spec.add_dependency 'credentials_manager', '>= 0.16.0', '< 1.0.0' # Password Manager

--- a/fastlane/lib/fastlane.rb
+++ b/fastlane/lib/fastlane.rb
@@ -1,6 +1,7 @@
 require 'fastlane_core'
 
 require 'fastlane/version'
+require 'fastlane/features'
 require 'fastlane/tools'
 require 'fastlane/actions/actions_helper' # has to be before fast_file
 require 'fastlane/fast_file'

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -58,7 +58,12 @@ module Fastlane
         c.description = 'Helps you with your initial fastlane setup'
 
         c.action do |args, options|
-          Fastlane::Setup.new.run
+          if args[0] == 'beta' && FastlaneCore::Feature.enabled?('FASTLANE_ENABLE_CRASHLYTICS_BETA_INITIALIZATION')
+            require 'fastlane/setup/crashlytics_beta'
+            Fastlane::CrashlyticsBeta.new.run
+          else
+            Fastlane::Setup.new.run
+          end
         end
       end
 

--- a/fastlane/lib/fastlane/features.rb
+++ b/fastlane/lib/fastlane/features.rb
@@ -1,0 +1,2 @@
+FastlaneCore::Feature.register(env_var: 'FASTLANE_ENABLE_CRASHLYTICS_BETA_INITIALIZATION',
+                           description: 'Allow beta_init command to setup Beta by Crashlytics')

--- a/fastlane/lib/fastlane/features.rb
+++ b/fastlane/lib/fastlane/features.rb
@@ -1,2 +1,2 @@
 FastlaneCore::Feature.register(env_var: 'FASTLANE_ENABLE_CRASHLYTICS_BETA_INITIALIZATION',
-                           description: 'Allow beta_init command to setup Beta by Crashlytics')
+                           description: 'Allow `init beta` command to setup Beta by Crashlytics')

--- a/fastlane/lib/fastlane/setup/crashlytics_beta.rb
+++ b/fastlane/lib/fastlane/setup/crashlytics_beta.rb
@@ -1,6 +1,7 @@
 module Fastlane
   class CrashlyticsBeta
     def run
+      UI.user_error!('Beta by Crashlytics configuration is currently only available for iOS projects.') unless Setup.new.is_ios?
       config = {}
       FastlaneCore::Project.detect_projects(config)
       project = FastlaneCore::Project.new(config)

--- a/fastlane/lib/fastlane/setup/crashlytics_beta.rb
+++ b/fastlane/lib/fastlane/setup/crashlytics_beta.rb
@@ -1,0 +1,88 @@
+module Fastlane
+  class CrashlyticsBeta
+    def run
+      config = {}
+      FastlaneCore::Project.detect_projects(config)
+      project = FastlaneCore::Project.new(config)
+      keys = keys_from_project(project)
+
+      if FastlaneFolder.setup?
+        UI.header('Copy and paste the following lane into your Fastfile to use Crashlytics Beta!')
+        puts lane_template(keys[:api_key], keys[:build_secret], project.schemes.first).cyan
+      else
+        fastfile = fastfile_template(keys[:api_key], keys[:build_secret], project.schemes.first)
+        FileUtils.mkdir_p('fastlane')
+        File.write('fastlane/Fastfile', fastfile)
+      end
+    end
+
+    def keys_from_project(project)
+      require 'xcodeproj'
+      target_name = project.default_build_settings(key: 'TARGETNAME')
+      path = project.is_workspace ? project.path.gsub('xcworkspace', 'xcodeproj') : project.path
+      UI.crash!("No project available at path #{path}") unless File.exist?(path)
+      xcode_project = Xcodeproj::Project.open(path)
+      target = xcode_project.targets.find { |t| t.name == target_name }
+      scripts = target.build_phases.select { |t| t.class == Xcodeproj::Project::Object::PBXShellScriptBuildPhase }
+      crash_script = scripts.find { |s| includes_run_script?(s.shell_script) }
+      UI.user_error!("Unable to find Crashlytics Run Script Build Phase") if crash_script.nil?
+      script_array = crash_script.shell_script.split('\n').find { |l| includes_run_script?(l) }.split(' ')
+      if script_array.count == 3 && api_key_valid?(script_array[1]) && build_secret_valid?(script_array[2])
+        {
+          api_key: script_array[1],
+          build_secret: script_array[2]
+        }
+      else
+        UI.important('Please enter your API Key and Build Secret:')
+        keys = {}
+        loop do
+          keys[:api_key] = UI.input('API Key:')
+          break if api_key_valid?(keys[:api_key])
+          UI.important "Invalid API Key, Please Try Again!"
+        end
+        loop do
+          keys[:build_secret] = UI.input('Build Secret:')
+          break if build_secret_valid?(keys[:build_secret])
+          UI.important "Invalid Build Secret, Please Try Again!"
+        end
+        keys
+      end
+    end
+
+    def api_key_valid?(key)
+      key.to_s.length == 40
+    end
+
+    def build_secret_valid?(secret)
+      secret.to_s.length == 64
+    end
+
+    def includes_run_script?(string)
+      string.include?('Fabric/run') || string.include?('Crashlytics/run') || string.include?('Fabric.framework/run') || string.include?('Crashlytics.framework/run')
+    end
+
+    def lane_template(api_key, build_secret, scheme)
+      %{
+  lane :beta do
+    gym(scheme: '#{scheme}')
+    crashlytics(api_token: '#{api_key}',
+             build_secret: '#{build_secret}')
+  end
+      }
+    end
+
+    def fastfile_template(api_key, build_secret, scheme)
+      <<-eos
+fastlane_version "1.93.0"
+default_platform :ios
+platform :ios do
+  lane :beta do
+    gym(scheme: '#{scheme}')
+    crashlytics(api_token: '#{api_key}',
+             build_secret: '#{build_secret}')
+  end
+end
+eos
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a feature-gated (by the 'FASTLANE_ENABLE_CRASHLYTICS_BETA_INITIALIZATION' env var) command, `beta_init` (open to changing the name of this). 

This will detect your project, parse your API Key and Secret from the RSBP or prompt the user for them to be entered and generate the MVF (Minimum Viable Fastfile) or lane to be copy and pasted if a Fastfile already exists.
