### PR TITLE
bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.95.0'.freeze
+  VERSION = '1.96.0'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end


### PR DESCRIPTION
- Crashlytics Beta Initialization
- Dont generate empty platform docs when there are no lanes (#5196)
- [fastlane] Updated fastlane_core dependency (#5172)
- Merge test results and send to coveralls (#5091)
