### PR TITLE
Fix incorrect docs for last_git_commit_message

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -1788,9 +1788,7 @@ import_from_git(
 Get information about the last git commit, returns the commit hash, the abbreviated commit hash, the author and the git message.
 
 ```ruby
-commit = last_git_commit_message
-crashlytics(notes: commit[:message])
-puts commit[:author]
+crashlytics(notes: last_git_commit_message)
 ```
 
 ### create_pull_request


### PR DESCRIPTION
`last_git_commit_message` returns a string that's just the message from the commit. The example was showing that it returned a hash representing the commit as a whole. This addresses #5213
