### PR TITLE
Hide skip-docs step from output

### DIFF
--- a/fastlane/lib/fastlane/actions/skip_docs.rb
+++ b/fastlane/lib/fastlane/actions/skip_docs.rb
@@ -5,6 +5,10 @@ module Fastlane
         ENV["FASTLANE_SKIP_DOCS"] = "1"
       end
 
+      def self.step_text
+        nil
+      end
+
       #####################################################
       # @!group Documentation
       #####################################################


### PR DESCRIPTION
Before
<img width="360" alt="screenshot 2016-06-27 07 38 04" src="https://cloud.githubusercontent.com/assets/869950/16369733/1c219556-3c3a-11e6-8829-5887ff823301.png">

After
<img width="512" alt="screenshot 2016-06-27 07 38 09" src="https://cloud.githubusercontent.com/assets/869950/16369735/202caaf0-3c3a-11e6-8754-50786802783f.png">
