### PR TITLE
Add warnings when using Xcode's 7 build options with legacy build api

### DIFF
--- a/gym/lib/gym/generators/package_command_generator_legacy.rb
+++ b/gym/lib/gym/generators/package_command_generator_legacy.rb
@@ -11,6 +11,8 @@ module Gym
   class PackageCommandGeneratorLegacy
     class << self
       def generate
+        print_legacy_information
+
         parts = ["/usr/bin/xcrun #{XcodebuildFixes.patch_package_application.shellescape} -v"]
         parts += options
         parts += pipe
@@ -76,6 +78,24 @@ module Gym
 
       def apps_path
         ""
+      end
+
+      def print_legacy_information
+        if Gym.config[:include_bitcode]
+          UI.important "Lagacy build api is enabled, the `include_bitcode` value will be ignored"
+        end
+
+        if Gym.config[:include_symbols]
+          UI.important "Lagacy build api is enabled, the `include_symbols` value will be ignored"
+        end
+
+        if Gym.config[:export_team_id].to_s.length > 0
+          UI.important "Lagacy build api is enabled, the `export_team_id` value will be ignored"
+        end
+
+        if Gym.config[:export_method].to_s.length > 0
+          UI.important "Lagacy build api is enabled, the `export_method` value will be ignored"
+        end
       end
     end
   end


### PR DESCRIPTION
Add warnings when using Xcode's 7 build options with legacy build api

Fixes [#5225](https://github.com/fastlane/fastlane/issues/5225)
