### PR TITLE
The depedency on `fastlane` should be more lenient

### DIFF
--- a/danger-device_grid/danger-device_grid.gemspec
+++ b/danger-device_grid/danger-device_grid.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'fastlane', '~> 1.94.0'
+  spec.add_dependency 'fastlane', '>= 1.94.0', '< 2.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
The old dependency definition would only accept bugfix releases of `fastlane`, but we should accept minor version bumps as well.
