### PR TITLE
[pem] Hide :new_profile key from pem summary table

### DIFF
--- a/pem/lib/pem/manager.rb
+++ b/pem/lib/pem/manager.rb
@@ -6,7 +6,7 @@ module PEM
   class Manager
     class << self
       def start
-        FastlaneCore::PrintTable.print_values(config: PEM.config, hide_keys: [], title: "Summary for PEM #{PEM::VERSION}")
+        FastlaneCore::PrintTable.print_values(config: PEM.config, hide_keys: [:new_profile], title: "Summary for PEM #{PEM::VERSION}")
         login
 
         existing_certificate = certificate.all.detect do |c|


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/5228
