### PR TITLE
Frameit: fixed portrait orientation offsets for iPad Pro.

### DIFF
--- a/frameit/lib/frameit/offsets.rb
+++ b/frameit/lib/frameit/offsets.rb
@@ -42,8 +42,8 @@ module Frameit
           }
         when size::IOS_IPAD_PRO
           return {
-            'offset' => '+48+90',
-            'width' => 805
+            'offset' => '+88+150',
+            'width' => 897
           }
         end
       when Orientation::LANDSCAPE


### PR DESCRIPTION
Fixes #4108 for portrait orientation on iPad Pro.
