### PR TITLE
Fix syntax error in Scanfile example

### DIFF
--- a/scan/README.md
+++ b/scan/README.md
@@ -168,7 +168,7 @@ Run `scan init` to create a new configuration file. Example:
 
 ```ruby
 scheme "Example"
-devices: ["iPhone 6s", "iPad Air"]
+devices ["iPhone 6s", "iPad Air"]
 
 clean true
 


### PR DESCRIPTION
Scanfile example cause following error.

```
[!] Syntax error in your configuration file './fastlane/Scanfile' on line 2: (eval):2: syntax error, unexpected ':', expecting end-of-input
devices: ["iPhone 6s", "iPad Air"]
```

I removed `:` 
