### PR TITLE
[fastlane_core] Version bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.48.0".freeze
+  VERSION = "0.48.1".freeze
 end


### PR DESCRIPTION
- Use the exception handler in the inspector when you don't have a specific message (#5235)
- [fastlane_core] Added missing prefix when printing out GH issue errors (#5215)

Fixes https://github.com/fastlane/fastlane/issues/5272
