### PR TITLE
ActiveSupport 5.0 breaks fastlane installation

### DIFF
--- a/screengrab/screengrab.gemspec
+++ b/screengrab/screengrab.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'fastlane'
-  spec.add_development_dependency 'activesupport'
+  spec.add_development_dependency 'activesupport', '~> 4.2'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.1.0'


### PR DESCRIPTION
Because it requires a Ruby version that is not shipped with OS X.

Fixes #5294
