### PR TITLE
Lock `activesupport` to < 5

### DIFF
--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -58,6 +58,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'match', '>= 0.6.0', '< 1.0.0'
   spec.add_dependency 'screengrab', '>= 0.3.2', '< 1.0.0'
 
+  # Lock `activesupport` (transitive depedency via `xcodeproj`) to keep supporting system ruby
+  spec.add_dependency 'activesupport', '< 5'
+
   # Development only
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.1.0'


### PR DESCRIPTION
The `activesupport` gem is a transitive dependency of `fastlane` through `xcodeproj`. With the new major version 5, installation on macOS is broken by default. Locking the dependency to older versions avoids this issue.

Fixes #5294
