### PR TITLE
Improved action loading and error message on name conflicts

### DIFF
--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -61,6 +61,19 @@ module Fastlane
     end
     # rubocop:enable Style/AccessorMethodName
 
+    # Returns the class ref to the action based on the action name
+    # Returns nil if the action is not aailable
+    def self.action_class_ref(action_name)
+      class_name = action_name.to_s.fastlane_class + 'Action'
+      class_ref = nil
+      begin
+        class_ref = Fastlane::Actions.const_get(class_name)
+      rescue NameError
+        return nil
+      end
+      return class_ref
+    end
+
     def self.load_default_actions
       Dir[File.expand_path('*.rb', File.dirname(__FILE__))].each do |file|
         require file

--- a/fastlane/lib/fastlane/lane.rb
+++ b/fastlane/lib/fastlane/lane.rb
@@ -52,6 +52,8 @@ module Fastlane
           # We still allow it, because we're nice
           # Otherwise we might break existing setups
         end
+
+        self.ensure_name_not_conflicts(name.to_s)
       end
 
       def black_list
@@ -60,6 +62,12 @@ module Fastlane
 
       def gray_list
         Fastlane::TOOLS
+      end
+
+      def ensure_name_not_conflicts(name)
+        # First, check if there is a predefined method in the actions folder
+        return unless Actions.action_class_ref(name)
+        UI.error("Name of the lane '#{name}' is already taken by the action named '#{name}'")
       end
     end
   end

--- a/fastlane/lib/fastlane/one_off.rb
+++ b/fastlane/lib/fastlane/one_off.rb
@@ -26,11 +26,8 @@ module Fastlane
     def self.run(action: nil, parameters: nil)
       Fastlane.load_actions
 
-      class_name = action.fastlane_class + 'Action'
-      class_ref = nil
-      begin
-        class_ref = Fastlane::Actions.const_get(class_name)
-      rescue NameError
+      class_ref = Actions.action_class_ref(action)
+      unless class_ref
         if Fastlane::Actions.formerly_bundled_actions.include?(action)
           # This was a formerly bundled action which is now a plugin.
           UI.verbose(caller.join("\n"))

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -91,12 +91,7 @@ module Fastlane
       method_str.delete!('?') # as a `?` could be at the end of the method name
 
       # First, check if there is a predefined method in the actions folder
-      class_name = method_str.fastlane_class + 'Action'
-      class_ref = nil
-      begin
-        class_ref = Fastlane::Actions.const_get(class_name)
-      rescue NameError
-      end
+      class_ref = Actions.action_class_ref(method_str)
 
       # It's important to *not* have this code inside the rescue block
       # otherwise all NameErrors will be caught and the error message is

--- a/fastlane/spec/actions_helper_spec.rb
+++ b/fastlane/spec/actions_helper_spec.rb
@@ -24,6 +24,12 @@ describe Fastlane do
       end
     end
 
+    it "#action_class_ref" do
+      expect(Fastlane::Actions.action_class_ref("gym")).to eq(Fastlane::Actions::GymAction)
+      expect(Fastlane::Actions.action_class_ref(:cocoapods)).to eq(Fastlane::Actions::CocoapodsAction)
+      expect(Fastlane::Actions.action_class_ref('notExistentObv')).to eq(nil)
+    end
+
     it "#load_default_actions" do
       expect(Fastlane::Actions.load_default_actions.count).to be > 6
     end

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -155,6 +155,11 @@ describe Fastlane do
         expect(File.exist?('/tmp/fastlane/test')).to eq(true)
       end
 
+      it "prints a warning if a lane is called like an action" do
+        expect(UI).to receive(:error).with("Name of the lane 'cocoapods' is already taken by the action named 'cocoapods'")
+        Fastlane::FastFile.new('./spec/fixtures/fastfiles/FastfileLaneNameEqualsActionName')
+      end
+
       it "allows calling a lane directly even with a default_platform" do
         ff = Fastlane::FastFile.new('./spec/fixtures/fastfiles/FastfileGrouped')
         result = ff.runner.execute(:test)

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -38,7 +38,7 @@ describe Fastlane do
         @ff = Fastlane::FastFile.new('./spec/fixtures/fastfiles/Fastfile1')
       end
 
-      it "raises an error if block is missing", nower: true do
+      it "raises an error if block is missing" do
         expect(UI).to receive(:user_error!).with("You have to pass a block using 'do' for lane 'my_name'. Make sure you read the docs on GitHub.")
         @ff.lane(:my_name)
       end

--- a/fastlane/spec/fixtures/fastfiles/FastfileLaneNameEqualsActionName
+++ b/fastlane/spec/fixtures/fastfiles/FastfileLaneNameEqualsActionName
@@ -1,0 +1,3 @@
+lane :cocoapods do
+  
+end

--- a/fastlane/spec/tools_spec.rb
+++ b/fastlane/spec/tools_spec.rb
@@ -14,6 +14,7 @@ describe Fastlane do
       ff = Fastlane::FastFile.new('./spec/fixtures/fastfiles/Fastfile1')
       expect(UI).to receive(:error).with("Lane name 'gym' should not be used because it is the name of a fastlane tool")
       expect(UI).to receive(:error).with("It is recommended to not use 'gym' as the name of your lane")
+      expect(UI).to receive(:error).with("Name of the lane 'gym' is already taken by the action named 'gym'")
       ff.lane :gym do
       end
     end


### PR DESCRIPTION
- Refactored how actions are loaded to a central point
- Added warning when a lane name is already taken by an action
