### PR TITLE
Improve plugin action discovery

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -343,9 +343,12 @@ module Fastlane
       references = Fastlane.const_get(module_name).all_classes.collect do |path|
         next unless File.dirname(path).end_with?("/actions") # we only want to match actions
 
-        File.basename(path).gsub("_action", "").gsub(".rb", "").to_sym # the _action is optional
+        File.readlines(path)
+          .map { |line| line.sub!(/class (.*) < Action/, '\1') }
+          .compact
+          .map { |line| line.strip.gsub('Action', '').fastlane_underscore }
       end
-      references.compact!
+      references.compact!.flatten(1)
 
       # Check if this overwrites a built-in action and
       # show a warning if that's the case


### PR DESCRIPTION
Previously, the action discovery was based on filenames which will always work for auto-generated actions, but can easily be wrong if users manually add their own actions. The new code scans the `.rb` with a regex to find `Action` subclasses and converts their names correctly for the action list.
