### PR TITLE
Add option to log output for `import_certificate` per #1314

### DIFF
--- a/fastlane/lib/fastlane/actions/import_certificate.rb
+++ b/fastlane/lib/fastlane/actions/import_certificate.rb
@@ -8,8 +8,13 @@ module Fastlane
         command << " -P #{params[:certificate_password].shellescape}" if params[:certificate_password]
         command << " -T /usr/bin/codesign"
         command << " -T /usr/bin/security"
+        
+        log_output = false
+        if params[:log_output]
+            log_output = params[:log_output]
+        end
 
-        Fastlane::Actions.sh(command, log: false)
+        Fastlane::Actions.sh(command, log: log_output)
       end
 
       def self.description
@@ -27,6 +32,10 @@ module Fastlane
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :certificate_password,
                                        description: "Certificate password",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :log_output,
+                                       description: "If output should be logged to the console",
+                                       default_value: false,
                                        optional: true)
         ]
       end

--- a/fastlane/lib/fastlane/actions/import_certificate.rb
+++ b/fastlane/lib/fastlane/actions/import_certificate.rb
@@ -9,12 +9,7 @@ module Fastlane
         command << " -T /usr/bin/codesign"
         command << " -T /usr/bin/security"
 
-        log_output = false
-        if params[:log_output]
-          log_output = params[:log_output]
-        end
-
-        Fastlane::Actions.sh(command, log: log_output)
+        Fastlane::Actions.sh(command, log: params[:log_output])
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/import_certificate.rb
+++ b/fastlane/lib/fastlane/actions/import_certificate.rb
@@ -8,10 +8,10 @@ module Fastlane
         command << " -P #{params[:certificate_password].shellescape}" if params[:certificate_password]
         command << " -T /usr/bin/codesign"
         command << " -T /usr/bin/security"
-        
+
         log_output = false
         if params[:log_output]
-            log_output = params[:log_output]
+          log_output = params[:log_output]
         end
 
         Fastlane::Actions.sh(command, log: log_output)


### PR DESCRIPTION
This allows the user to specify that the output of the `import_certificate` command should be logged to help diagnose what's going wrong with an import. The default value remains `false` so that the user has to actively opt-in to cause logging to occur, and the option is...optional, so it shouldn't break any existing code. 

I'll note that my ruby skills are [not awesome](http://i0.kym-cdn.com/photos/images/newsfeed/000/234/765/b7e.jpg), so any suggestions on how to make this better are most welcome. 
