### PR TITLE
Improve instructions for publishing plugin

### DIFF
--- a/fastlane/docs/Plugins.md
+++ b/fastlane/docs/Plugins.md
@@ -127,8 +127,12 @@ All you have to do if you have an exiting gem:
 
 ##### RubyGems
 
-The recommended way to publish your plugin is to publish it on [RubyGems.org](https://rubygems.org). You'll first have to create an account, and then push a new release using
+The recommended way to publish your plugin is to publish it on [RubyGems.org](https://rubygems.org). Follow the steps below to publish your plugin.
 
+1. Create an account at [RubyGems.org](https://rubygems.org)
+2. Publish your plugin to a [GitHub](https://github.com) repo
+3. Update the `fastlane-plugin-[plugin_name].gemspec` file so that the `spec.homepage` points to your github repo.
+4. Publish the first release of your plugin:
 ```sh
 bundle install
 rake install


### PR DESCRIPTION
Add some steps to the instructions for publishing a plugin. This addresses the [issues](https://github.com/fastlane/fastlane/pull/5016#issuecomment-230281341) I faced when following the original instructions.
