### PR TITLE
[Pilot] Add feature to wait for a build train to appear on iTunes Connect if not present

### DIFF
--- a/pilot/lib/pilot.rb
+++ b/pilot/lib/pilot.rb
@@ -1,5 +1,9 @@
+# fastlane_core must be required before 'pilot/features' which depends on it for FastlaneCore::Feature
+require "fastlane_core"
+
 require "json"
 require "pilot/version"
+require 'pilot/features'
 require "pilot/options"
 require "pilot/manager"
 require "pilot/build_manager"
@@ -7,7 +11,6 @@ require "pilot/tester_manager"
 require "pilot/tester_importer"
 require "pilot/tester_exporter"
 
-require "fastlane_core"
 require "spaceship"
 require "terminal-table"
 

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -109,17 +109,26 @@ module Pilot
     def wait_for_processing_build
       # the upload date of the new buid
       # we use it to identify the build
-
       start = Time.now
       wait_processing_interval = config[:wait_processing_interval].to_i
       latest_build = nil
       UI.message("Waiting for iTunes Connect to process the new build")
       loop do
         sleep wait_processing_interval
-        builds = app.all_processing_builds
-        break if builds.count == 0
-        latest_build = builds.last
-        UI.message("Waiting for iTunes Connect to finish processing the new build (#{latest_build.train_version} - #{latest_build.build_version})")
+
+        # before we look for processing builds, we need to ensure that there
+        #  is a build train for this application; new applications don't
+        #  build trains right away, and if we don't do this check, we will
+        #  get break out of this loop and then generate an error later when we
+        #  have a nil build
+        if FastlaneCore::Feature.enabled?('PILOT_WAIT_FOR_NEW_BUILD_TRAINS_ON_ITUNES_CONNECT') && app.build_trains.count == 0
+          UI.message("New application; waiting for build train to appear on iTunes Connect")
+        else
+          builds = app.all_processing_builds
+          break if builds.count == 0
+          latest_build = builds.last
+          UI.message("Waiting for iTunes Connect to finish processing the new build (#{latest_build.train_version} - #{latest_build.build_version})")
+        end
       end
 
       UI.user_error!("Error receiving the newly uploaded binary, please check iTunes Connect") if latest_build.nil?

--- a/pilot/lib/pilot/features.rb
+++ b/pilot/lib/pilot/features.rb
@@ -1,0 +1,2 @@
+FastlaneCore::Feature.register(env_var: 'PILOT_WAIT_FOR_NEW_BUILD_TRAINS_ON_ITUNES_CONNECT',
+                           description: 'When submitting a build, wait for the build train to appear on iTunes Connect if not present yet (will be default eventually)')


### PR DESCRIPTION
To fix issue #5125
