### PR TITLE
Fix missing last_git_commit_message to last_git_commit (ref #5213)

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -1775,12 +1775,13 @@ import_from_git(
 )
 ```
 
-### last_git_commit_message (was: last_git_commit)
+### last_git_commit
 
 Get information about the last git commit, returns the commit hash, the abbreviated commit hash, the author and the git message.
 
 ```ruby
-crashlytics(notes: last_git_commit_message)
+commit = last_git_commit
+crashlytics(notes: commit[:message])
 ```
 
 ### create_pull_request


### PR DESCRIPTION
Please refer https://github.com/fastlane/fastlane/issues/5213#issuecomment-230962062

`last_git_commit_message` action is missing.
I revert to `last_git_commit`.
