### PR TITLE
[scan] Fixed reference to simulator os_version

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -89,7 +89,7 @@ module Scan
           lookup_device = device.to_s.strip.tr('()', '') # Remove parenthesis
 
           found = FastlaneCore::SimulatorTV.all.detect do |d|
-            (d.name + " " + d.tvos_version).include? lookup_device
+            (d.name + " " + d.os_version).include? lookup_device
           end
 
           if found


### PR DESCRIPTION
This (hopefully) fixes: https://github.com/fastlane/fastlane/issues/5359

Previously code was trying to call tvos_version instead of os_version which
caused an exception to be thrown.
