### PR TITLE
Add Xcode 8 support: rename "OS X" to "macOS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you experience slow launch times of fastlane, try running:
 
     gem cleanup
 
-**System Requirements:** `fastlane` requires Mac OS X or Linux with Ruby 2.0.0 or above
+**System Requirements:** `fastlane` requires macOS or Linux with Ruby 2.0.0 or above
 
 If you'd like to take a look at a project already using `fastlane` check out [fastlane-examples](https://github.com/fastlane/examples) which includes `fastlane` setups by Wikipedia, Product Hunt, MindNode, and more.
 

--- a/credentials_manager/README.md
+++ b/credentials_manager/README.md
@@ -23,7 +23,7 @@ password has been deleted.
 
 ## Storing in the keychain
 
-By default, your Apple credentials are stored in the OS X Keychain.
+By default, your Apple credentials are stored in the macOS Keychain.
 
 Your password is only stored locally on your computer.
 

--- a/deliver/README.md
+++ b/deliver/README.md
@@ -110,7 +110,7 @@ Provide the path to an `ipa` file to upload and submit your app for review:
 deliver --ipa "App.ipa" --submit_for_review
 ```
 
-or you can specify path to `pkg` file for Mac OS X apps:
+or you can specify path to `pkg` file for macOS apps:
 
 ```
 deliver --pkg "MacApp.pkg"
@@ -149,7 +149,7 @@ A detailed description about how your credentials are handled is available in a 
 
 ### How does this thing even work? Is magic involved? 🎩###
 
-Your password will be stored in the Mac OS X keychain, but can also be passed using environment variables. (More information available on [CredentialsManager](https://github.com/fastlane/fastlane/tree/master/credentials_manager))
+Your password will be stored in the macOS keychain, but can also be passed using environment variables. (More information available on [CredentialsManager](https://github.com/fastlane/fastlane/tree/master/credentials_manager))
 
 Before actually uploading anything to iTunes, ```deliver``` will generate a HTML summary of the collected data.
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -114,7 +114,7 @@ If you experience slow launch times of fastlane, try running
 
 to clean up outdated gems.
 
-System Requirements: `fastlane` requires Mac OS X or Linux with Ruby 2.0.0 or above.
+System Requirements: `fastlane` requires macOS or Linux with Ruby 2.0.0 or above.
 
 
 If you want to take a look at a project, already using `fastlane`, check out the [fastlane-examples](https://github.com/fastlane/examples) with `fastlane` setups by Wikipedia, Product Hunt, MindNode and more.

--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -1959,7 +1959,7 @@ Post a message to a **group chat**.
 ```
 
 ### Notification
-Display a notification using the OS X notification centre. Uses [terminal-notifier](https://github.com/alloy/terminal-notifier).
+Display a notification using the macOS notification center. Uses [terminal-notifier](https://github.com/alloy/terminal-notifier).
 
 ```ruby
   notification(subtitle: "Finished Building", message: "Ready to upload...")

--- a/fastlane/docs/Platforms.md
+++ b/fastlane/docs/Platforms.md
@@ -1,6 +1,6 @@
 # Support for multiple platforms
 
-`fastlane` can handle multiple app platforms in one `Fastfile`. This is super useful for projects supporting iPhone, Mac OS X and Android apps.
+`fastlane` can handle multiple app platforms in one `Fastfile`. This is super useful for projects supporting iPhone, macOS and Android apps.
 
 Watch this magic:
 

--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'slack-notifier', '~> 1.3' # Slack notifications
   spec.add_dependency 'xcodeproj', '>= 0.20', '< 2.0.0' # Needed for commit_version_bump action
   spec.add_dependency 'xcpretty', '>= 0.2.1' # prettify xcodebuild output
-  spec.add_dependency 'terminal-notifier', '~> 1.6.2' # Mac OS X notifications
+  spec.add_dependency 'terminal-notifier', '~> 1.6.2' # macOS notifications
   spec.add_dependency 'terminal-table', '~> 1.4.5' # Actions documentation
   spec.add_dependency 'plist', '~> 3.1.0' # Needed for set_build_number_repository and get_info_plist_value actions
   spec.add_dependency 'addressable', '~> 2.3' # Support for URI templates

--- a/fastlane/lib/fastlane/actions/clipboard.rb
+++ b/fastlane/lib/fastlane/actions/clipboard.rb
@@ -12,7 +12,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Copies a given string into the clipboard. Works only on Mac OS X computers"
+        "Copies a given string into the clipboard. Works only on macOS"
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/actions/notification.rb
+++ b/fastlane/lib/fastlane/actions/notification.rb
@@ -18,7 +18,7 @@ module Fastlane
       end
 
       def self.description
-        "Display a Mac OS X notification with custom message and title"
+        "Display a macOS notification with custom message and title"
       end
 
       def self.author

--- a/fastlane/lib/fastlane/actions/notify.rb
+++ b/fastlane/lib/fastlane/actions/notify.rb
@@ -10,7 +10,7 @@ module Fastlane
       end
 
       def self.description
-        "Shows a Mac OS X notification"
+        "Shows a macOS notification"
       end
 
       def self.author

--- a/fastlane/lib/fastlane/plugins/template/.travis.yml
+++ b/fastlane/lib/fastlane/plugins/template/.travis.yml
@@ -1,4 +1,4 @@
-# os: osx # enable this if you need OS X support
+# os: osx # enable this if you need macOS support
 language: ruby
 rvm:
   - 2.2.4

--- a/fastlane/lib/fastlane/plugins/template/circle.yml
+++ b/fastlane/lib/fastlane/plugins/template/circle.yml
@@ -4,6 +4,6 @@ test:
 machine:
   ruby:
     version: 2.2.4
-# Enable xcode below if you need OS X
+# Enable xcode below if you need macOS
 #   xcode:
 #     version: "7.3"

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -166,6 +166,7 @@ module FastlaneCore
     def mac?
       # Some projects have different values... we have to look for all of them
       return true if build_settings(key: "PLATFORM_NAME") == "macosx"
+      return true if build_settings(key: "PLATFORM_DISPLAY_NAME") == "macOS"
       return true if build_settings(key: "PLATFORM_DISPLAY_NAME") == "OS X"
       false
     end

--- a/frameit/README.md
+++ b/frameit/README.md
@@ -36,7 +36,7 @@ frameit
 
 ###### Quickly put your screenshots into the right device frames
 
-`frameit` allows you to put a gorgeous device frame around your iOS screenshots just by running one simple command. Use `frameit` to prepare perfect screenshots for the App Store, your website, QA or emails. 
+`frameit` allows you to put a gorgeous device frame around your iOS screenshots just by running one simple command. Use `frameit` to prepare perfect screenshots for the App Store, your website, QA or emails.
 
 
 Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.com/FastlaneTools)
@@ -199,7 +199,7 @@ Use [deliver](https://github.com/fastlane/fastlane/tree/master/deliver) to uploa
 
 ### Mac
 
-With `frameit` 2.0 it's possible to also frame Mac OS X Application screenshots. You have to provide the following:
+With `frameit` 2.0 it's possible to also frame macOS Application screenshots. You have to provide the following:
 
 - The `offset` information so `frameit` knows where to put your screenshots
 - A path to a `background`, which should contain both the background and the Mac

--- a/gym/README.md
+++ b/gym/README.md
@@ -53,7 +53,7 @@ Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.c
 
 # What's gym?
 
-`gym` builds and packages iOS and OS X apps for you. It takes care of all the heavy lifting and makes it super easy to generate a signed `ipa` or `app` file :muscle:
+`gym` builds and packages iOS and macOS apps for you. It takes care of all the heavy lifting and makes it super easy to generate a signed `ipa` or `app` file :muscle:
 
 `gym` is a replacement for [shenzhen](https://github.com/nomad/shenzhen).
 

--- a/gym/examples/cocoapods/Pods/HexColors/README.md
+++ b/gym/examples/cocoapods/Pods/HexColors/README.md
@@ -7,7 +7,7 @@ HexColors
 HexColors is drop in category for HexColor Support for NSColor and UIColor. Support for HexColors with prefixed # and without.
 
 #RELEASE 2.3.0
-Attention the API has changed! 
+Attention the API has changed!
 
 #Example iOS
 ``` objective-c
@@ -21,7 +21,7 @@ UIColor *secondColorWithHex = [UIColor colorWithHexString:@"ff8942"];
 UIColor *shortColorWithHex = [UIColor colorWithHexString:@"fff"];
 ```
 
-#Example Mac OS X
+#Example macOS
 ``` objective-c
 // with hash
 NSColor *colorWithHex = [NSColor colorWithHexString:@"#ff8942"];
@@ -44,7 +44,7 @@ HexColors requires [iOS 5.0](http://developer.apple.com/library/ios/#releasenote
 ##Credits
 HexColors was created by [Marius Landwehr](https://github.com/mRs-) because of the pain recalculating Hex values to RGB.
 
-HexColors was ported to Mac OS X by [holgersindbaek](https://github.com/holgersindbaek).
+HexColors was ported to macOS by [holgersindbaek](https://github.com/holgersindbaek).
 
 ##Creator
 [Marius Landwehr](https://github.com/mRs-) [@mariusLAN](https://twitter.com/mariusLAN)

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -56,19 +56,15 @@ module Gym
       Gym.project.select_scheme
     end
 
-    def self.xcode_version
-      `xcodebuild -version`.match(/Xcode (.*)/)[1]
-    end
-
     def self.min_xcode8?
-      xcode_version.split(".").first.to_i >= 8
+      Helper.xcode_version.split(".").first.to_i >= 8
     end
 
     # Is it an iOS device or a Mac?
     def self.detect_platform
       return if Gym.config[:destination]
       platform = if Gym.project.mac?
-                   min_xcode8 ? "macOS" : "OS X"
+                   min_xcode8? ? "macOS" : "OS X"
                  elsif Gym.project.tvos?
                    "tvOS"
                  else

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -60,7 +60,7 @@ module Gym
     def self.detect_platform
       return if Gym.config[:destination]
       platform = if Gym.project.mac?
-                   "OS X"
+                   "macOS"
                  elsif Gym.project.tvos?
                    "tvOS"
                  else

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -56,11 +56,19 @@ module Gym
       Gym.project.select_scheme
     end
 
+    def self.xcode_version
+      `xcodebuild -version`.match(/Xcode (.*)/)[1]
+    end
+
+    def self.min_xcode8?
+      xcode_version.split(".").first.to_i >= 8
+    end
+
     # Is it an iOS device or a Mac?
     def self.detect_platform
       return if Gym.config[:destination]
       platform = if Gym.project.mac?
-                   "macOS"
+                   min_xcode8 ? "macOS" : "OS X"
                  elsif Gym.project.tvos?
                    "tvOS"
                  else

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -138,7 +138,7 @@ module Scan
       elsif Scan.project.tvos?
         Scan.config[:destination] = Scan.devices.map { |d| "platform=tvOS Simulator,id=#{d.udid}" }
       else
-        Scan.config[:destination] = ["platform=OS X"]
+        Scan.config[:destination] = ["platform=macOS"]
       end
     end
   end

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -122,6 +122,14 @@ module Scan
       end
     end
 
+    def self.xcode_version
+      `xcodebuild -version`.match(/Xcode (.*)/)[1]
+    end
+
+    def self.min_xcode8?
+      xcode_version.split(".").first.to_i >= 8
+    end
+
     # Is it an iOS, a tvOS or a MacOS device?
     def self.detect_destination
       if Scan.config[:destination]
@@ -138,7 +146,7 @@ module Scan
       elsif Scan.project.tvos?
         Scan.config[:destination] = Scan.devices.map { |d| "platform=tvOS Simulator,id=#{d.udid}" }
       else
-        Scan.config[:destination] = ["platform=macOS"]
+        Scan.config[:destination] = min_xcode8 ? ["platform=macOS"] : ["platform=OS X"]
       end
     end
   end

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -122,15 +122,11 @@ module Scan
       end
     end
 
-    def self.xcode_version
-      `xcodebuild -version`.match(/Xcode (.*)/)[1]
-    end
-
     def self.min_xcode8?
-      xcode_version.split(".").first.to_i >= 8
+      Helper.xcode_version.split(".").first.to_i >= 8
     end
 
-    # Is it an iOS, a tvOS or a MacOS device?
+    # Is it an iOS, a tvOS or a macOS device?
     def self.detect_destination
       if Scan.config[:destination]
         UI.important("It's not recommended to set the `destination` value directly")
@@ -146,7 +142,7 @@ module Scan
       elsif Scan.project.tvos?
         Scan.config[:destination] = Scan.devices.map { |d| "platform=tvOS Simulator,id=#{d.udid}" }
       else
-        Scan.config[:destination] = min_xcode8 ? ["platform=macOS"] : ["platform=OS X"]
+        Scan.config[:destination] = min_xcode8? ? ["platform=macOS"] : ["platform=OS X"]
       end
     end
   end

--- a/watchbuild/README.md
+++ b/watchbuild/README.md
@@ -39,7 +39,7 @@ As the [#iosprocessingtime](https://twitter.com/search?q=%23iosprocessingtime) v
 
 WatchBuild is a simple standalone tool that shows a notification once your newly uploaded build was successfully processed by iTunes Connect.
 
-Once the build is ready to be pushed to TestFlight or for review, you get a OS X notification. You can even directly click on the notification to open the build on iTunes Connect.
+Once the build is ready to be pushed to TestFlight or for review, you get a macOS notification. You can even directly click on the notification to open the build on iTunes Connect.
 
 ### Why use WatchBuild?
 


### PR DESCRIPTION
Most (but not all) of these changes are cosmetic. Xcode 8 changes the platform string to "macOS" (when used in a destination specification) and also uses macOS as PLATFORM_DISPLAY_NAME.
