### PR TITLE
add shared logs base directory

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -66,6 +66,11 @@ module FastlaneCore
       !!ENV["ITERM_SESSION_ID"]
     end
 
+    # Logs base directory
+    def self.buildlog_path
+      return ENV["FL_BUILDLOG_PATH"] || "~/Library/Logs"
+    end
+
     # All Xcode Related things
     #
 


### PR DESCRIPTION
Adds `FL_BUILDLOG_PATH` environment variable to override the default base log path of `~/Library/Logs`.

Half Implements #4989

---

Another PR will include changes to:
- gym
- scan
- snapshot
- fastlane/actions/xcodebuild

https://github.com/fastlane/fastlane/compare/master...Ashton-W:aw-common-buildlog_path
