### PR TITLE
[gym] Version bump

### DIFF
--- a/gym/lib/gym/version.rb
+++ b/gym/lib/gym/version.rb
@@ -1,4 +1,4 @@
 module Gym
-  VERSION = "1.6.4"
+  VERSION = "1.7.0"
   DESCRIPTION = "Building your iOS apps has never been easier"
 end


### PR DESCRIPTION
- Added new code [signing guide](https://github.com/fastlane/fastlane/tree/master/fastlane/docs/Codesigning) (#5178)
- Support patching of signing script in Xcode 8 (#5391)
- Support relative path like `~/file` (#5350)
- Add warnings when using Xcode's 7 build options with legacy build api (#5229)
- Deprecated provisioning_profile_path (#5106)
- Proper escaping of codesigning identity (#5148)
- Escape code signing identity
- Add support for `rbenv` in `wrap_xcodebuild/xcbuild-safe.sh` (#4625)
- Print out legacy information every time you run gym (#4890)
- Fix gym with path with spaces (#4721)
