### PR TITLE
(feat/actions): Add new action 'Upload symbols to new relic'

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -973,6 +973,19 @@ This action allows you to upload symbolication files to Crashlytics. It's extra 
 upload_symbols_to_crashlytics(dsym_path: "./App.dSYM.zip")
 ```
 
+### `upload_symbols_to_new_relic`
+
+This action allows you to upload symbolication files to New Relic.
+
+```ruby
+upload_symbols_to_new_relic(
+            dsym_path: "./App.dSYM.zip",
+            new_relic_license_key: 'something123',
+            new_relic_app_name: 'appname',
+            new_relic_upload_libs: 'applib,otherlib'
+)
+```
+
 ### [upload_symbols_to_sentry](https://getsentry.com)
 
 This action allows you to upload symbolication files to Sentry.

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_new_relic.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_new_relic.rb
@@ -1,0 +1,148 @@
+module Fastlane
+  module Actions
+    class UploadSymbolsToNewRelicAction < Action
+      def self.run(params)
+        dsym_paths = get_all_dsym_paths(params)
+
+        if dsym_paths.count == 0
+          UI.error("Couldn't find any dSYMs, please pass them using the dsym_path option")
+          return nil
+        end
+
+        dsym_paths.each do |current_path|
+          handle_dsym(params, current_path)
+        end
+      end
+
+      def self.get_all_dsym_paths(params)
+        dsym_paths = []
+        dsym_paths << params[:dsym_path] if params[:dsym_path]
+        dsym_paths += Actions.lane_context[SharedValues::DSYM_PATHS] if Actions.lane_context[SharedValues::DSYM_PATHS]
+
+        # Get rid of duplicates (which might occur when both passed and detected)
+        dsym_paths = dsym_paths.collect { |a| File.expand_path(a) }
+        dsym_paths.uniq!
+
+        return dsym_paths
+      end
+
+      # @param current_path this is a path to either a dSYM or a zipped dSYM
+      #   this might also be either nested or not, we're flexible
+      def self.handle_dsym(params, current_path)
+        if current_path.end_with?(".dSYM")
+          dwarf_dump = Actions.sh("xcrun dwarfdump --uuid #{current_path}")
+          upload_dsym(params, current_path, dwarf_dump)
+        elsif current_path.end_with?(".zip")
+          UI.message("Extracting '#{current_path}'...")
+
+          current_path = File.expand_path(current_path)
+          Dir.mktmpdir do |dir|
+            Dir.chdir(dir) do
+              Actions.sh("unzip -qo #{current_path.shellescape}")
+              Dir["*.dSYM"].each do |path|
+                handle_dsym(params, path)
+              end
+            end
+          end
+        else
+          UI.error "Don't know how to handle '#{current_path}'"
+        end
+      end
+
+      def self.upload_dsym(params, path, dwarf_dump)
+        if dwarf_dump.nil?
+          return
+        end
+
+        app_name = params[:new_relic_app_name]
+        uploadable_lib_names = (params[:new_relic_upload_libs] || "").split(",")
+        new_relic_key = params[:new_relic_license_key]
+
+        all_included_architecture_info = dwarf_dump.split("\n").map { |line| transform_architecture_symbol_info(line) }
+        lib_name = all_included_architecture_info[0][:lib_name]
+
+        # if we haven't specified any upload libs, we'll upload them all
+        # otherwise, check that the lib+name from the dwarfdump is in our list
+        if uploadable_lib_names.count == 0 || uploadable_lib_names.include?(lib_name)
+          build_ids = all_included_architecture_info.map { |info| info[:uuid] } .join(",")
+          zip_file_name = "#{path}.zip"
+          sh "zip --recurse-paths --quiet '#{zip_file_name}' '#{path}'"
+          sh "curl -F dsym=@'#{zip_file_name}' -F buildId='#{build_ids}' -F appName='#{app_name}' -H 'X-APP-LICENSE-KEY: #{new_relic_key}' https://mobile-symbol-upload.newrelic.com/symbol"
+        end
+      end
+
+      def self.transform_architecture_symbol_info(architecture_symbol_info)
+        # dwarfdump returns lines in the format "UUID: THE-dSYM-UUID-HERE (architecture) path/to/lib"
+        dsym_info_components = architecture_symbol_info.split(" ")
+        uuid = dsym_info_components[1]
+        uuid.delete! '-'
+        uuid = uuid.downcase
+
+        lib_path = dsym_info_components.last
+        lib_name = lib_path.split("/").last
+
+        return { uuid: uuid, lib_name: lib_name }
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Upload all dsyms (possibly in a zip file) to new relic"
+      end
+
+      def self.details
+        "Upload all dsyms (possibly in a zip file) to new relic"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :new_relic_app_name,
+                                       env_name: "FL_UPLOAD_SYMBOLS_TO_NEW_RELIC_APP_NAME",
+                                       description: "The name of your app",
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No app name for New Relic given, pass using `new_relic_app_name: 'app name'`") if value.to_s.length == 0
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :new_relic_license_key,
+                                       env_name: "FL_UPLOAD_SYMBOLS_TO_NEW_RELIC_LICENSE_KEY",
+                                       description: "Your New Relic app license key",
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No license key for New Relic given, pass using `new_relic_license_key: 'key'`") if value.to_s.length == 0
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :dsym_path,
+                                       env_name: "FL_UPLOAD_SYMBOLS_TO_NEW_RELIC_DSYM_PATH",
+                                       description: "Path to the DSYM file or zip to upload",
+                                       default_value: ENV[SharedValues::DSYM_OUTPUT_PATH.to_s] || (Dir["./**/*.dSYM"] + Dir["./**/*.dSYM.zip"]).first,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Couldn't find file at path '#{File.expand_path(value)}'") unless File.exist?(value)
+                                         UI.user_error!("Symbolication file needs to be dSYM or zip") unless value.end_with?(".zip", ".dSYM")
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :new_relic_upload_libs,
+                                       env_name: "FL_UPLOAD_SYMBOLS_TO_NEW_RELIC_UPLOAD_LIBS",
+                                       description: "The library names to upload",
+                                       optional: true)
+        ]
+      end
+
+      def self.output
+        []
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.authors
+        ["bitwit"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/upload_symbols_to_new_relic_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_new_relic_spec.rb
@@ -1,0 +1,43 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "upload_symbols_to_new_relic" do
+      it "converts dwarf dump output to hash map" do
+        action = Fastlane::Actions::UploadSymbolsToNewRelicAction
+        test_dwarf_dump_line = "UUID: ABC-123-DEF-4G56-HIJ (amv7s) path/to/TestLibName"
+        result = action.transform_architecture_symbol_info(test_dwarf_dump_line)
+        expect(result[:uuid]).to eq("abc123def4g56hij")
+        expect(result[:lib_name]).to eq("TestLibName")
+      end
+
+      it "extracts zip files" do
+        binary_path = './spec/fixtures/screenshots/screenshot1.png'
+        dsym_path = './spec/fixtures/dSYM/Themoji.dSYM.zip'
+
+        expect(Fastlane::Actions).to receive(:sh).with("unzip -qo #{File.expand_path(dsym_path)}")
+
+        Fastlane::FastFile.new.parse("lane :test do
+          upload_symbols_to_new_relic(
+            dsym_path: 'fastlane/#{dsym_path}',
+            new_relic_license_key: 'something123',
+            new_relic_app_name: 'TestAppName',
+            new_relic_upload_libs: 'TestAppName')
+        end").runner.execute(:test)
+      end
+
+      it "uploads dSYM files" do
+        binary_path = './spec/fixtures/screenshots/screenshot1.png'
+        dsym_path = './spec/fixtures/dSYM/Themoji.dSYM'
+
+        expect(Fastlane::Actions).to receive(:sh).with("xcrun dwarfdump --uuid #{File.expand_path(dsym_path)}")
+
+        Fastlane::FastFile.new.parse("lane :test do
+          upload_symbols_to_new_relic(
+            dsym_path: 'fastlane/#{dsym_path}',
+            new_relic_license_key: 'something123',
+            new_relic_app_name: 'TestAppName',
+            new_relic_upload_libs: 'todoappgame')
+        end").runner.execute(:test)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Related to #5399]

This PR is near ready for merging but I would like to expand just a little bit on the tests before merging. I'm new to ruby and fastlane so I think it's best to state my intentions and criticisms of what is here so far because a little feedback will probably go a long way.

What I see in the specs folder is mostly what we would probably call 'integration tests' rather than 'unit tests' since most are kicked off with the `Fastlane::FastFile.new.parse("action")` format and the crashlytics tests simply set expectations for what `sh` should execute. There were no direct method tests or dependency injections going on, from what I could see.

The biggest criticism of what I have right now is [this nil check on line 53](https://github.com/fastlane/fastlane/compare/master...bitwit:feat/upload-symbols-new-relic?expand=1#diff-cf71198d0bcc8c2ffb8c61a7b32c7f89R53) which really only exists to satisfy the tests so far.

Is there a way to either A. execute sh commands for real or B. stub sh somehow so I can mock the return value? I think this would help me get the best coverage

On a related note, I also found it hard to execute static method directly in tests if they contained any other calls to other actions, such as sh. Only my first test seems to work that way since it has no outside dependencies. Is there a way to get around that problem?

If I can get some feedback on a good way to approach some of these sorts of tests I think it will be more robust and easier for people to provide failing test examples if there are any issues in the future.
