### PR TITLE
[scan] Add option to specify JUnit report output file name

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -178,8 +178,8 @@ module Scan
                                     description: "Generate the json compilation database with clang naming convention (compile_commands.json)",
                                     is_string: false,
                                     default_value: false),
-        FastlaneCore::ConfigItem.new(key: :custom_report_extension,
-                                    description: "Sets custom file extension for report file",
+        FastlaneCore::ConfigItem.new(key: :custom_report_file_name,
+                                    description: "Sets custom full report file name",
                                     optional: true,
                                     is_string: true)
       ]

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -177,7 +177,11 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :use_clang_report_name,
                                     description: "Generate the json compilation database with clang naming convention (compile_commands.json)",
                                     is_string: false,
-                                    default_value: false)
+                                    default_value: false),
+        FastlaneCore::ConfigItem.new(key: :custom_report_extension,
+                                    description: "Sets custom file extension for report file",
+                                    optional: true,
+                                    is_string: true)
       ]
     end
   end

--- a/scan/lib/scan/report_collector.rb
+++ b/scan/lib/scan/report_collector.rb
@@ -3,11 +3,12 @@ module Scan
     SUPPORTED = %w(html junit json-compilation-database)
 
     # Intialize with values from Scan.config matching these param names
-    def initialize(open_report, output_types, output_directory, use_clang_report_name)
+    def initialize(open_report, output_types, output_directory, use_clang_report_name, custom_report_extension)
       @open_report = open_report
       @output_types = output_types
       @output_directory = output_directory
       @use_clang_report_name = use_clang_report_name
+      @custom_report_extension = custom_report_extension
     end
 
     def parse_raw_file(path)
@@ -56,8 +57,8 @@ module Scan
     def determine_output_file_name(type)
       if @use_clang_report_name && type == "json-compilation-database"
         "compile_commands.json"
-      elsif type == "junit"
-        "report.xml"
+      elsif @custom_report_extension !=nil
+         "report.#{@custom_report_extension}"
       else
         "report.#{type}"
       end

--- a/scan/lib/scan/report_collector.rb
+++ b/scan/lib/scan/report_collector.rb
@@ -3,7 +3,7 @@ module Scan
     SUPPORTED = %w(html junit json-compilation-database)
 
     # Intialize with values from Scan.config matching these param names
-    def initialize(open_report, output_types, output_directory, use_clang_report_name, custom_report_extension)
+    def initialize(open_report, output_types, output_directory, use_clang_report_name, custom_report_extension = nil)
       @open_report = open_report
       @output_types = output_types
       @output_directory = output_directory

--- a/scan/lib/scan/report_collector.rb
+++ b/scan/lib/scan/report_collector.rb
@@ -57,7 +57,7 @@ module Scan
     def determine_output_file_name(type)
       if @use_clang_report_name && type == "json-compilation-database"
         "compile_commands.json"
-      elsif @custom_report_extension != nil
+      elsif !@custom_report_extension.nil?
         "report.#{@custom_report_extension}"
       else
         "report.#{type}"

--- a/scan/lib/scan/report_collector.rb
+++ b/scan/lib/scan/report_collector.rb
@@ -3,12 +3,12 @@ module Scan
     SUPPORTED = %w(html junit json-compilation-database)
 
     # Intialize with values from Scan.config matching these param names
-    def initialize(open_report, output_types, output_directory, use_clang_report_name, custom_report_extension = nil)
+    def initialize(open_report, output_types, output_directory, use_clang_report_name, custom_report_file_name = nil)
       @open_report = open_report
       @output_types = output_types
       @output_directory = output_directory
       @use_clang_report_name = use_clang_report_name
-      @custom_report_extension = custom_report_extension
+      @custom_report_file_name = custom_report_file_name
     end
 
     def parse_raw_file(path)
@@ -57,8 +57,8 @@ module Scan
     def determine_output_file_name(type)
       if @use_clang_report_name && type == "json-compilation-database"
         "compile_commands.json"
-      elsif !@custom_report_extension.nil?
-        "report.#{@custom_report_extension}"
+      elsif !@custom_report_file_name.nil?
+        @custom_report_file_name
       else
         "report.#{type}"
       end

--- a/scan/lib/scan/report_collector.rb
+++ b/scan/lib/scan/report_collector.rb
@@ -57,8 +57,8 @@ module Scan
     def determine_output_file_name(type)
       if @use_clang_report_name && type == "json-compilation-database"
         "compile_commands.json"
-      elsif @custom_report_extension !=nil
-         "report.#{@custom_report_extension}"
+      elsif @custom_report_extension != nil
+        "report.#{@custom_report_extension}"
       else
         "report.#{type}"
       end

--- a/scan/lib/scan/report_collector.rb
+++ b/scan/lib/scan/report_collector.rb
@@ -56,6 +56,8 @@ module Scan
     def determine_output_file_name(type)
       if @use_clang_report_name && type == "json-compilation-database"
         "compile_commands.json"
+      elsif type == "junit"
+        "report.xml"
       else
         "report.#{type}"
       end

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -54,7 +54,8 @@ module Scan
       report_collector = ReportCollector.new(Scan.config[:open_report],
                                              Scan.config[:output_types],
                                              Scan.config[:output_directory],
-                                             Scan.config[:use_clang_report_name])
+                                             Scan.config[:use_clang_report_name],
+                                             Scan.config[:custom_report_extension])
 
       cmd = report_collector.generate_commands(TestCommandGenerator.xcodebuild_log_path,
                                                types: 'junit',

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -55,7 +55,7 @@ module Scan
                                              Scan.config[:output_types],
                                              Scan.config[:output_directory],
                                              Scan.config[:use_clang_report_name],
-                                             Scan.config[:custom_report_extension])
+                                             Scan.config[:custom_report_file_name])
 
       cmd = report_collector.generate_commands(TestCommandGenerator.xcodebuild_log_path,
                                                types: 'junit',

--- a/scan/spec/report_collector_spec.rb
+++ b/scan/spec/report_collector_spec.rb
@@ -28,5 +28,14 @@ describe Scan do
                                  "/tmp/report.json-compilation-database" => "cat './spec/fixtures/boring.log' |  xcpretty --report json-compilation-database --output '/tmp/report.json-compilation-database' &> /dev/null "
                               })
     end
+
+    it "use user specified report file type" do
+      commands = Scan::ReportCollector.new(false, "junit", "/tmp", false, "xml").generate_commands(path)
+
+      expect(commands.count).to eq(1)
+      expect(commands).to eq({
+                                 "/tmp/report.xml" => "cat './spec/fixtures/boring.log' |  xcpretty --report junit --output '/tmp/report.xml' &> /dev/null "
+                             })
+    end
   end
 end

--- a/scan/spec/report_collector_spec.rb
+++ b/scan/spec/report_collector_spec.rb
@@ -29,12 +29,12 @@ describe Scan do
                               })
     end
 
-    it "use user specified report file type" do
-      commands = Scan::ReportCollector.new(false, "junit", "/tmp", false, "xml").generate_commands(path)
+    it "use user specified report file name" do
+      commands = Scan::ReportCollector.new(false, "junit", "/tmp", false, "custom.xml").generate_commands(path)
 
       expect(commands.count).to eq(1)
       expect(commands).to eq({
-                                 "/tmp/report.xml" => "cat './spec/fixtures/boring.log' |  xcpretty --report junit --output '/tmp/report.xml' &> /dev/null "
+                                 "/tmp/custom.xml" => "cat './spec/fixtures/boring.log' |  xcpretty --report junit --output '/tmp/custom.xml' &> /dev/null "
                              })
     end
   end


### PR DESCRIPTION
Scan junit report file had .junit extension, so it was not possible to use with some CI, fe. Bamboo. 

It was bugging me for a long time, in the end it was the reason to write my first line of ruby code ever. Hope it didn't breake anything 😁 

This solves #1942
