### PR TITLE
Truncate all values, not just strings

### DIFF
--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -35,7 +35,7 @@ module FastlaneCore
         max_allowed_value_length = max_length - max_key_length - 7
         rows.map do |e|
           value = e[1]
-          value = value.truncate(max_allowed_value_length) if value.kind_of? String
+          value = value.to_s.truncate(max_allowed_value_length) unless value.nil?
           [e[0], value]
         end
       end

--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -35,7 +35,7 @@ module FastlaneCore
         max_allowed_value_length = max_length - max_key_length - 7
         rows.map do |e|
           value = e[1]
-          value = value.to_s.truncate(max_allowed_value_length) unless value.nil? || [true, false].include?(value)
+          value = value.to_s.truncate(max_allowed_value_length) unless [true, false].include?(value)
           [e[0], value]
         end
       end

--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -35,7 +35,7 @@ module FastlaneCore
         max_allowed_value_length = max_length - max_key_length - 7
         rows.map do |e|
           value = e[1]
-          value = value.to_s.truncate(max_allowed_value_length) unless value.nil?
+          value = value.to_s.truncate(max_allowed_value_length) unless value.nil? || [true, false].include?(value)
           [e[0], value]
         end
       end


### PR DESCRIPTION
Reason being that config options can also be arrays
