### PR TITLE
Also check for a default value from the Appfile

### DIFF
--- a/fastlane/lib/fastlane/actions/update_app_identifier.rb
+++ b/fastlane/lib/fastlane/actions/update_app_identifier.rb
@@ -78,7 +78,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        env_name: 'FL_UPDATE_APP_IDENTIFIER',
                                        description: 'The app Identifier you want to set',
-                                       default_value: ENV['PRODUCE_APP_IDENTIFIER'])
+                                       default_value: ENV['PRODUCE_APP_IDENTIFIER'] || CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier))
         ]
       end
 


### PR DESCRIPTION
Adding Appfile setting as an additional default value fallback for app identifier for issue #5464 
