### PR TITLE
[add_git_tag] Add commit option

### DIFF
--- a/fastlane/lib/fastlane/actions/add_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/add_git_tag.rb
@@ -13,6 +13,7 @@ module Fastlane
         cmd << ["-am #{message.shellescape}"]
         cmd << '--force' if options[:force]
         cmd << "'#{tag}'"
+        cmd << options[:commit].to_s if options[:commit]
 
         UI.message "Adding git tag '#{tag}' 🎯."
         Actions.sh(cmd.join(' '))
@@ -44,6 +45,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :message,
                                        env_name: "FL_GIT_TAG_MESSAGE",
                                        description: "The tag message. Defaults to the tag's name",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :commit,
+                                       env_name: "FL_GIT_TAG_COMMIT",
+                                       description: "The commit or object where the tag will be set. Defaults to the current HEAD",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :force,
                                        env_name: "FL_GIT_TAG_FORCE",

--- a/fastlane/spec/actions_specs/add_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/add_git_tag_spec.rb
@@ -113,6 +113,22 @@ describe Fastlane do
 
         expect(result).to eq("git tag -am message --force \'#{tag}\'")
       end
+
+      it "allows you to specify the commit where to add the tag" do
+        tag = '2.0.0'
+        commit = 'beta_tag'
+        message = "message"
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          add_git_tag ({
+            tag: '#{tag}',
+            message: '#{message}',
+            commit: '#{commit}'
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("git tag -am #{message} \'#{tag}\' #{commit}")
+      end
     end
   end
 end


### PR DESCRIPTION
This option allows one to specify the commit/object where to put the
tag in the git history.

This is an implementation for issue #5459 
