### PR TITLE
Checking the default team_id value in the Appfile

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_team.rb
+++ b/fastlane/lib/fastlane/actions/update_project_team.rb
@@ -36,7 +36,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :teamid,
                                        env_name: "FL_PROJECT_TEAM_ID",
                                        description: "The Team ID  you want to use",
-                                       default_value: ENV["TEAM_ID"])
+                                       default_value: ENV["TEAM_ID"] || CredentialsManager::AppfileConfig.try_fetch_value(:team_id))
         ]
       end
 


### PR DESCRIPTION
Adding Appfile setting as an additional default value fallback for team id for issue #5477
