### PR TITLE
Version Bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.48.1".freeze
+  VERSION = "0.48.2".freeze
 end


### PR DESCRIPTION
Changes since release 0.48.1:
- Provide options to make FastlaneCore::Project print less output (#5491)
- Add Xcode 8 support: rename "OS X" to "macOS" (#5385)
- Fix run-on sentence. (#5357)
- Fixed not duping env variables (#5304)
- Add error catching when ipa file is not found (#5323)
- Remove redundant use of `xcrun` (#5279)
