### PR TITLE
Change handling of xcode silent options to params instead of hash lookup

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -73,12 +73,12 @@ module FastlaneCore
     # Gets rid of annoying plugin info warnings.
     attr_accessor :xcodebuild_suppress_stderr
 
-    def initialize(options)
+    def initialize(options, xcodebuild_list_silent: false, xcodebuild_suppress_stderr: false)
       self.options = options
       self.path = File.expand_path(options[:workspace] || options[:project])
       self.is_workspace = (options[:workspace].to_s.length > 0)
-      self.xcodebuild_list_silent = options[:xcodebuild_list_silent]
-      self.xcodebuild_suppress_stderr = options[:xcodebuild_suppress_stderr]
+      self.xcodebuild_list_silent = xcodebuild_list_silent
+      self.xcodebuild_suppress_stderr = xcodebuild_suppress_stderr
 
       if !path or !File.directory?(path)
         UI.user_error!("Could not find project at path '#{path}'")

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -163,12 +163,8 @@ describe FastlaneCore do
 
     describe "Valid Standard Project" do
       before do
-        options = {
-          project: "./spec/fixtures/projects/Example.xcodeproj",
-          xcodebuild_list_silent: true,
-          xcodebuild_suppress_stderr: true
-        }
-        @project = FastlaneCore::Project.new(options)
+        options = { project: "./spec/fixtures/projects/Example.xcodeproj" }
+        @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
       end
 
       it "#path" do
@@ -212,11 +208,9 @@ describe FastlaneCore do
       before do
         options = {
           workspace: "./spec/fixtures/projects/cocoapods/Example.xcworkspace",
-          scheme: "Example",
-          xcodebuild_list_silent: true,
-          xcodebuild_suppress_stderr: true
+          scheme: "Example"
         }
-        @workspace = FastlaneCore::Project.new(options)
+        @workspace = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
       end
 
       it "#schemes returns all schemes" do
@@ -230,12 +224,8 @@ describe FastlaneCore do
 
     describe "Mac Project" do
       before do
-        options = {
-          project: "./spec/fixtures/projects/Mac.xcodeproj",
-          xcodebuild_list_silent: true,
-          xcodebuild_suppress_stderr: true
-        }
-        @project = FastlaneCore::Project.new(options)
+        options = { project: "./spec/fixtures/projects/Mac.xcodeproj" }
+        @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
       end
 
       it "#mac?" do
@@ -257,12 +247,8 @@ describe FastlaneCore do
 
     describe "TVOS Project" do
       before do
-        options = {
-          project: "./spec/fixtures/projects/ExampleTVOS.xcodeproj",
-          xcodebuild_list_silent: true,
-          xcodebuild_suppress_stderr: true
-        }
-        @project = FastlaneCore::Project.new(options)
+        options = { project: "./spec/fixtures/projects/ExampleTVOS.xcodeproj" }
+        @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
       end
 
       it "#mac?" do
@@ -284,12 +270,8 @@ describe FastlaneCore do
 
     describe "Build Settings" do
       before do
-        options = {
-          project: "./spec/fixtures/projects/Example.xcodeproj",
-          xcodebuild_list_silent: true,
-          xcodebuild_suppress_stderr: true
-        }
-        @project = FastlaneCore::Project.new(options)
+        options = { project: "./spec/fixtures/projects/Example.xcodeproj" }
+        @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
       end
 
       it "IPHONEOS_DEPLOYMENT_TARGET should be 9.0" do
@@ -354,21 +336,22 @@ describe FastlaneCore do
 
     describe 'xcodebuild_list_silent option' do
       it 'is not silent by default' do
-        project = FastlaneCore::Project.new({
-          project: "./spec/fixtures/projects/Example.xcodeproj",
+        project = FastlaneCore::Project.new(
+          { project: "./spec/fixtures/projects/Example.xcodeproj" },
           xcodebuild_suppress_stderr: true
-        })
-        expect(project).to receive(:raw_info).with(silent: nil).and_call_original
+        )
+
+        expect(project).to receive(:raw_info).with(silent: false).and_call_original
 
         project.configurations
       end
 
       it 'makes the raw_info method be silent if configured' do
-        project = FastlaneCore::Project.new({
-          project: "./spec/fixtures/projects/Example.xcodeproj",
+        project = FastlaneCore::Project.new(
+          { project: "./spec/fixtures/projects/Example.xcodeproj" },
           xcodebuild_list_silent: true,
           xcodebuild_suppress_stderr: true
-        })
+        )
         expect(project).to receive(:raw_info).with(silent: true).and_call_original
 
         project.configurations
@@ -377,32 +360,28 @@ describe FastlaneCore do
 
     describe 'xcodebuild_suppress_stderr option' do
       it 'generates an xcodebuild -list command without stderr redirection by default' do
-        project = FastlaneCore::Project.new({
-          project: "./spec/fixtures/projects/Example.xcodeproj"
-        })
+        project = FastlaneCore::Project.new({ project: "./spec/fixtures/projects/Example.xcodeproj" })
         expect(project.build_xcodebuild_list_command).not_to match(%r{2> /dev/null})
       end
 
       it 'generates an xcodebuild -list command that redirects stderr to /dev/null' do
-        project = FastlaneCore::Project.new({
-          project: "./spec/fixtures/projects/Example.xcodeproj",
+        project = FastlaneCore::Project.new(
+          { project: "./spec/fixtures/projects/Example.xcodeproj" },
           xcodebuild_suppress_stderr: true
-        })
+        )
         expect(project.build_xcodebuild_list_command).to match(%r{2> /dev/null})
       end
 
       it 'generates an xcodebuild -showBuildSettings command without stderr redirection by default' do
-        project = FastlaneCore::Project.new({
-          project: "./spec/fixtures/projects/Example.xcodeproj"
-        })
+        project = FastlaneCore::Project.new({ project: "./spec/fixtures/projects/Example.xcodeproj" })
         expect(project.build_xcodebuild_showbuildsettings_command).not_to match(%r{2> /dev/null})
       end
 
       it 'generates an xcodebuild -showBuildSettings command that redirects stderr to /dev/null' do
-        project = FastlaneCore::Project.new({
-          project: "./spec/fixtures/projects/Example.xcodeproj",
+        project = FastlaneCore::Project.new(
+          { project: "./spec/fixtures/projects/Example.xcodeproj" },
           xcodebuild_suppress_stderr: true
-        })
+        )
         expect(project.build_xcodebuild_showbuildsettings_command).to match(%r{2> /dev/null})
       end
     end


### PR DESCRIPTION
Because in most cases that options passed in is actually a `Configuration` from `gym` or `scan` and we can't look up random values in it
