### PR TITLE
[Carthage] Add option to pass in specific dependencies to update

### DIFF
--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -35,7 +35,9 @@ module Fastlane
         %w(all iOS Mac tvOS watchOS)
       end
 
+      # rubocop:disable Metrics/AbcSize
       def self.available_options
+        # rubocop:enable Metrics/AbcSize
         [
           FastlaneCore::ConfigItem.new(key: :command,
                                        env_name: "FL_CARTHAGE_COMMAND",

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -5,6 +5,11 @@ module Fastlane
         cmd = ["carthage"]
 
         cmd << params[:command]
+
+        if params[:command] == "update" && params[:dependencies].count > 0
+          cmd.concat params[:dependencies]
+        end
+
         cmd << "--use-ssh" if params[:use_ssh]
         cmd << "--use-submodules" if params[:use_submodules]
         cmd << "--no-use-binaries" if params[:use_binaries] == false
@@ -38,6 +43,13 @@ module Fastlane
                                        default_value: 'bootstrap',
                                        verify_block: proc do |value|
                                          UI.user_error!("Please pass a valid command. Use one of the following: #{available_commands.join(', ')}") unless available_commands.include? value
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :dependencies,
+                                       description: "Carthage dependencies to update",
+                                       default_value: [],
+                                       is_string: false,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Please pass an array of carthage dependencies") unless value.kind_of?(Array)
                                        end),
           FastlaneCore::ConfigItem.new(key: :use_ssh,
                                        env_name: "FL_CARTHAGE_USE_SSH",
@@ -117,7 +129,7 @@ module Fastlane
       end
 
       def self.authors
-        ["bassrock", "petester42", "jschmid", "JaviSoto", "uny", "phatblat"]
+        ["bassrock", "petester42", "jschmid", "JaviSoto", "uny", "phatblat", "bfcrampton"]
       end
     end
   end

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -334,6 +334,30 @@ describe Fastlane do
           eq("carthage bootstrap --derived-data ../derived\\ data")
       end
 
+      it "updates with a single dependency" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              command: 'update',
+              dependencies: ['TestDependency']
+            )
+          end").runner.execute(:test)
+
+        expect(result).to \
+          eq("carthage update TestDependency")
+      end
+
+      it "updates with multiple dependencies" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              command: 'update',
+              dependencies: ['TestDependency1', 'TestDependency2']
+            )
+          end").runner.execute(:test)
+
+        expect(result).to \
+          eq("carthage update TestDependency1 TestDependency2")
+      end
+
       it "works with no parameters" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
This enables the ability to pass in particular dependencies to `carthage update`, and closes https://github.com/fastlane/fastlane/issues/5499.

An optional array of strings can now be passed into the `carthage` command as such:

``` ruby
carthage(
      command: 'update',
      dependencies: ['Alamofire', 'Notice'],
)
```

This enables a lane in the Fastfile to update particular dependencies under different circumstances.
