### PR TITLE
new actions to access service on bugly.qq.com

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -2611,3 +2611,44 @@ set_pod_key(
   project: 'MyProject'
 )
 ```
+
+### upload_app_to_bugly
+
+upload your app to [bugly](http://beta.qq.com/).
+
+```ruby
+  lane :upload do
+    upload_app_to_bugly(
+      file_path:"file_path",
+      app_key:"app_key",
+      app_id:"app_id",
+      pid:"pid",
+      title:"title",
+      desc:"description",
+      secret:"secret",
+      users:"users",
+      password:"password",
+      download_limit:"download_limit"
+    )
+  end
+```
+
+### update_app_to_bugly
+
+update your  exp on [bugly](http://beta.qq.com/).
+
+```ruby
+  lane :update do 
+    update_app_to_bugly(
+      file_path:"file_path",
+      app_key:"app_key",
+      exp_id:"exp_id",
+      title:"title",
+      desc:"description",
+      secret:"secret",
+      users:"users",
+      password:"password",
+      download_limit:"download_limit"
+    )
+  end
+```

--- a/fastlane/lib/fastlane/actions/update_app_to_bugly.rb
+++ b/fastlane/lib/fastlane/actions/update_app_to_bugly.rb
@@ -1,0 +1,164 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      UPDATE_APP_TO_BUGLY_DOWNLOAD_URL = :UPDATE_APP_TO_BUGLY_DOWNLOAD_URL
+    end
+
+    # To share this integration with the other fastlane users:
+    # - Fork https://github.com/fastlane/fastlane/tree/master/fastlane
+    # - Clone the forked repository
+    # - Move this integration into lib/fastlane/actions
+    # - Commit, push and submit the pull request
+
+    class UpdateAppToBuglyAction < Action
+      def self.run(params)
+        require 'json'
+        UI.message "file path: #{params[:file_path]}"
+        result_file = File.new('update_app_to_bugly_result.json', 'w+')
+        result_file.close
+        json_file = 'update_app_to_bugly_result.json'
+        secret = ''
+        if !params[:secret].nil? && !params[:secret].empty?
+          secret = " -F \"secret=#{params[:secret]}\" "
+          UI.message "secret:#{secret}"
+        end
+        title = ''
+        if !params[:title].nil? && !params[:title].to_s.empty?
+          title = " -F \"title=#{params[:title]}\" "
+          UI.message "title:#{title}"
+        end
+        desc = ''
+        if !params[:desc].nil? && !params[:desc].to_s.empty?
+          desc = " -F \"description=#{params[:desc]}\" "
+          UI.message "desc:#{desc}"
+        end
+        users = ''
+        if !params[:users].nil? && !params[:users].empty?
+          users = " -F \"users=#{params[:users]}\" "
+          UI.message "users:#{users}"
+        end
+        password = ''
+        if !params[:password].nil? && !params[:password].empty?
+          password = " -F \"password=#{params[:password]}\" "
+          UI.message "password:#{password}"
+        end
+        download_limit = ''
+        if !params[:download_limit].nil? && params[:download_limit] > 0
+          download_limit = " -F \"download_limit=#{params[:download_limit]}\" "
+          UI.message "download_limit:#{download_limit}"
+        end
+        cmd = "curl --insecure -X \"PUT\" -F \"file=@#{params[:file_path]}\" -F \"exp_id=#{params[:exp_id]}\"" + title + desc + secret + users + password + download_limit + "https://api.bugly.qq.com/beta/apiv1/exp?app_key=#{params[:app_key]} -o " + json_file
+        sh(cmd)
+        obj = JSON.parse(File.read(json_file))
+        ret = obj['rtcode']
+        if ret == 0
+          url = obj['data']['url']
+          Actions.lane_context[SharedValues::UPDATE_APP_TO_BUGLY_DOWNLOAD_URL] = url
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'A short description with <= 80 characters of what this action does'
+      end
+
+      def self.details
+        # Optional:
+        # this is your chance to provide a more detailed description of this action
+        'You can use this action to do cool things...'
+      end
+
+      def self.available_options
+        # Define all options your action supports.
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(key: :file_path,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_FILE_PATH',
+                                       description: 'file path for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No file path for UploadAppToBuglyAction given, pass using `file_path: 'path'`") unless value && !value.empty?
+                                         UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :app_key,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_APP_KEY',
+                                       description: 'app key for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("NO app_key for UploadAppToBuglyAction given, pass using `app_key: 'app_key'`") unless value && !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :exp_id,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_EXP_ID',
+                                       description: 'exp id for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No exp_id for UploadAppToBuglyAction given, pass using `exp_id: 'exp_id'`") unless value && !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :title,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_TITLE',
+                                       description: 'title for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       default_value: ''),
+          FastlaneCore::ConfigItem.new(key: :desc,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_DESC',
+                                       description: 'desc for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       default_value: 'description'),
+          FastlaneCore::ConfigItem.new(key: :secret,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_DESCRIPTION',
+                                       description: 'secret for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       default_value: ''),
+          FastlaneCore::ConfigItem.new(key: :users,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_DESCRIPTION',
+                                       description: 'users for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       default_value: ''),
+          FastlaneCore::ConfigItem.new(key: :password,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_DESCRIPTION',
+                                       description: 'password for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       default_value: ''),
+          FastlaneCore::ConfigItem.new(key: :download_limit,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_DESCRIPTION',
+                                       description: 'download_limit for UploadAppToBuglyAction',
+                                       is_string: false,
+                                       default_value: 10_000)
+        ]
+      end
+
+      def self.output
+        # Define the shared values you are going to provide
+        # Example
+        [
+          ['UPDATE_APP_TO_BUGLY_DOWNLOAD_URL', 'download url']
+        ]
+      end
+
+      def self.return_value
+        # If you method provides a return value, you can describe here what it does
+      end
+
+      def self.authors
+        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+        ["sexiong306"]
+      end
+
+      def self.is_supported?(platform)
+        # you can do things like
+        #
+        #  true
+        #
+        #  platform == :ios
+        #
+        #  [:ios, :mac].include?(platform)
+        #
+
+        platform == :ios
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/upload_app_to_bugly.rb
+++ b/fastlane/lib/fastlane/actions/upload_app_to_bugly.rb
@@ -1,0 +1,156 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      UPLOAD_APP_TO_BUGLY_DOWNLOAD_URL = :UPLOAD_APP_TO_BUGLY_DOWNLOAD_URL
+    end
+
+    # To share this integration with the other fastlane users:
+    # - Fork https://github.com/fastlane/fastlane/tree/master/fastlane
+    # - Clone the forked repository
+    # - Move this integration into lib/fastlane/actions
+    # - Commit, push and submit the pull request
+
+    class UploadAppToBuglyAction < Action
+      def self.run(params)
+        require 'json'
+        # fastlane will take care of reading in the parameter and fetching the environment variable:
+        UI.message "file path: #{params[:file_path]}"
+        result_file = File.new('upload_result.json', 'w+')
+        result_file.close
+        json_file = 'upload_app_to_bugly_result.json'
+        secret = ''
+        if !params[:secret].to_s.nil? && !params[:secret].empty?
+          secret = " -F \"secret=#{params[:secret]}\" "
+          UI.message "secret:#{secret}"
+        end
+        users = ''
+        if !params[:users].nil? && !params[:users].empty?
+          users = " -F \"users=#{params[:users]}\" "
+          UI.message "users:#{users}"
+        end
+        password = ''
+        if !params[:password].nil? && !params[:password].empty?
+          password = " -F \"password=#{params[:password]}\" "
+          UI.message "password:#{password}"
+        end
+        download_limit = ''
+        if !params[:download_limit].nil? && params[:download_limit] > 0
+          download_limit = " -F \"download_limit=#{params[:download_limit]}\" "
+          UI.message "download_limit:#{download_limit}"
+        end
+        cmd = "curl --insecure -F \"file=@#{params[:file_path]}\" -F \"app_id=#{params[:app_id]}\" -F \"pid=#{params[:pid]}\" -F \"title=#{params[:title]}\" -F \"description=#{params[:desc]}\"" + secret + users + password + download_limit + " https://api.bugly.qq.com/beta/apiv1/exp?app_key=#{params[:app_key]} -o " + json_file
+        sh(cmd)
+        obj = JSON.parse(File.read(json_file))
+        ret = obj['rtcode']
+        if ret == 0
+          url = obj['data']['url']
+          Actions.lane_context[SharedValues::UPLOAD_APP_TO_BUGLY_DOWNLOAD_URL] = url
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'A short description with <= 80 characters of what this action does'
+      end
+
+      def self.details
+        # Optional:
+        # this is your chance to provide a more detailed description of this action
+        'You can use this action to do cool things...'
+      end
+
+      def self.available_options
+        # Define all options your action supports.
+
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(key: :file_path,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_FILE_PATH',
+                                       description: 'file path for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No file path for UploadAppToBuglyAction given, pass using `file_path: 'path'`") unless value && !value.empty?
+                                         UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :app_key,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_APP_KEY',
+                                       description: 'app key for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("NO app_key for UploadAppToBuglyAction given, pass using `app_key: 'app_key'`") unless value && !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :app_id,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_APP_ID',
+                                       description: 'app id for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No app_id for UploadAppToBuglyAction given, pass using `app_id: 'app_id'`") unless value && !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :pid,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_PID',
+                                       description: 'pid for UploadToBuglyAction',
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No pid for UploadAppToBuglyAction given, pass using `pid: 'pid'`") unless value && !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :title,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_TITLE',
+                                       description: 'title for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       default_value: 'title',
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No title for UploadAppToBuglyAction given, pass using `title: 'title'`") unless value && !value.empty?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :desc,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_DESC',
+                                       description: 'desc for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       default_value: 'desc'),
+          FastlaneCore::ConfigItem.new(key: :secret,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_DESCRIPTION',
+                                       description: 'secret for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       default_value: ''),
+          FastlaneCore::ConfigItem.new(key: :users,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_DESCRIPTION',
+                                       description: 'users for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       default_value: ''),
+          FastlaneCore::ConfigItem.new(key: :password,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_DESCRIPTION',
+                                       description: 'password for UploadAppToBuglyAction',
+                                       is_string: true,
+                                       default_value: ''),
+          FastlaneCore::ConfigItem.new(key: :download_limit,
+                                       env_name: 'FL_UPLOAD_APP_TO_BUGLY_DESCRIPTION',
+                                       description: 'download_limit for UploadAppToBuglyAction',
+                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       default_value: 10_000)
+        ]
+      end
+
+      def self.output
+        # Define the shared values you are going to provide
+        [
+          ['UPLOAD_APP_TO_BUGLY_DOWNLOAD_URL', 'download url']
+        ]
+      end
+
+      def self.return_value
+        # If you method provides a return value, you can describe here what it does
+      end
+
+      def self.authors
+        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+        ["sexiong306"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end


### PR DESCRIPTION
hi, @KrauseFx, 
Sorry to pull it again as I've pulled it sevral days ago which is closed.
It's obviously that I shold have introduced our service which named bugly to you.You can experience it by visiting https://bugly.qq.com.
We provide services for mobile app developers(mostly in China) to collect,analysis crashes apps report and distribute apps to target users. We have such a large amount of users that we should provide various plugins to access our services.It sounds like the way crashlytics works.
The action I commited is just an easy way for developers to upload/update their apks to bugly.
I've add the way in which the integration goes to the end of /doc/Actions.md as required.
I think it meets the standard you required for an action to add to your main repo.I'm looking forward to it so that developers can access our service in their fastlane process .
