### PR TITLE
Add the ability to specify a strategy for hockey action

### DIFF
--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -178,7 +178,14 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :owner_id,
                                       env_name: "FL_HOCKEY_OWNER_ID",
                                       description: "ID for the owner of the app",
-                                      optional: true)
+                                      optional: true),
+          FastlaneCore::ConfigItem.new(key: :strategy,
+                                       env_name: "FL_HOCKEY_STRATEGY",
+                                       description: "Strategy: \"add\" = to add the build as a new build  even if it has the same build number (default); \"replace\" = to replace a build with the same build number",
+                                       default_value: "add",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Invalid value '#{value}' for key 'strategy'. Allowed values are 'add', 'replace'.") unless ["add", "replace"].include?(value)
+                                       end)
         ]
       end
 

--- a/fastlane/spec/actions_specs/hockey_spec.rb
+++ b/fastlane/spec/actions_specs/hockey_spec.rb
@@ -88,6 +88,7 @@ describe Fastlane do
         expect(values[:mandatory]).to eq(0.to_s)
         expect(values[:notes_type]).to eq(1.to_s)
         expect(values[:upload_dsym_only]).to eq(false)
+        expect(values[:strategy]).to eq("add")
       end
 
       it "can use a generated changelog as release notes" do
@@ -184,6 +185,41 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(values[:owner_id]).to eq('123')
+      end
+
+      it "has the correct default strategy value" do
+        values = Fastlane::FastFile.new.parse("lane :test do
+          hockey({
+            api_token: 'xxx',
+            ipa: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+          })
+        end").runner.execute(:test)
+
+        expect(values[:strategy]).to eq("add")
+      end
+
+      it "can change the strategy" do
+        values = Fastlane::FastFile.new.parse("lane :test do
+          hockey({
+            api_token: 'xxx',
+            ipa: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+            strategy: 'replace'
+          })
+        end").runner.execute(:test)
+
+        expect(values[:strategy]).to eq("replace")
+      end
+
+      it "raises an error if supplied dsym file was not found" do
+        expect do
+          values = Fastlane::FastFile.new.parse("lane :test do
+            hockey({
+              api_token: 'xxx',
+              ipa: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+              strategy: 'wrongvalue'
+            })
+          end").runner.execute(:test)
+        end.to raise_error("Invalid value 'wrongvalue' for key 'strategy'. Allowed values are 'add', 'replace'.")
       end
     end
   end


### PR DESCRIPTION
Hello there,

I know I have not opened an issue before making this pull request but it's a very little change, so since the work was already done, I'm opening the PR anyway.
I sincerely apologize for not following the contribution process. 😞 

The thing I'm trying to solve is very simple. When I'm working on a feature branch on my project, I make a build and upload it to hockeyapp. If I need to do some more work on the feature branch, I will need to upload a new build to hockeyapp. And for now, the hockey action will create a new build on hockeyapp, and I would like to update the previous build instead of having a new one with a new download URL.

Fortunately, hockeyapp supports this out of the box. It's the "strategy" parameter in their upload version api. See here: https://support.hockeyapp.net/kb/api/api-versions#upload-version

All I did was to add an option to specify this.
It's my first time programming in Ruby so, feel free to tell me if there is anything wrong.
