### PR TITLE
Move 3rd party require statements into supplemental task definitions

### DIFF
--- a/rakelib/issue_stats.rake
+++ b/rakelib/issue_stats.rake
@@ -1,9 +1,3 @@
-require 'date'
-require 'json'
-require 'faraday'
-require 'terminal-table'
-require 'colored'
-
 QUERY_DAYS = (ENV["DAYS"] || 4).to_i
 
 FASTLANE_MEMBERS = %w(asfalcone chaselatta fastlane-bot hemal i2amsam kimyoutora KrauseFx mfurtak MichaelDoyle mpirri ohwutup samrobbins snatchev vpolouchkine)
@@ -53,6 +47,12 @@ end
 
 desc "Display issue opening and closing statistics from GitHub"
 task :issue_stats do
+  require 'date'
+  require 'json'
+  require 'faraday'
+  require 'terminal-table'
+  require 'colored'
+
   raise "Please set GITHUB_SCRIPT_TOKEN in your environment with a GitHub personal access token value".red if GITHUB_TOKEN.to_s.empty?
 
   conn = Faraday.new(:url => BASE_URL)

--- a/rakelib/release_stats.rake
+++ b/rakelib/release_stats.rake
@@ -1,8 +1,3 @@
-require 'date'
-require 'terminal-table'
-require 'colored'
-require 'shellwords'
-
 RED_COMMIT_COUNT = 5
 RED_DAY_COUNT = 14
 
@@ -26,6 +21,11 @@ end
 
 desc 'Print stats about how much time has passed and work has happened since the last release of each tool'
 task :release_stats do
+  require 'date'
+  require 'terminal-table'
+  require 'colored'
+  require 'shellwords'
+
   `git pull --tags`
 
   now = Time.now


### PR DESCRIPTION
This prevents the scenario where a first-time developer can't run `rake` commands because they do not yet have a 3rd party gem installed locally
