### PR TITLE
[Carthage] Add option to pass in specific toolchain

### DIFF
--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -19,6 +19,7 @@ module Fastlane
         cmd << "--platform #{params[:platform]}" if params[:platform]
         cmd << "--configuration #{params[:configuration]}" if params[:configuration]
         cmd << "--derived-data #{params[:derived_data].shellescape}" if params[:derived_data]
+        cmd << "--toolchain #{params[:toolchain]}" if params[:toolchain]
 
         Actions.sh(cmd.join(' '))
       end
@@ -118,7 +119,11 @@ module Fastlane
                                          if value.chomp(' ').empty?
                                            UI.user_error!("Please pass a valid build configuration. You can review the list of configurations for this project using the command: xcodebuild -list")
                                          end
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :toolchain,
+                                       env_name: "FL_CARTHAGE_TOOLCHAIN",
+                                       description: "Define which xcodebuild toolchain to use when building",
+                                       optional: true)
         ]
       end
 

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -333,6 +333,16 @@ describe Fastlane do
         end.to raise_error("Please pass a valid build configuration. You can review the list of configurations for this project using the command: xcodebuild -list")
       end
 
+      it "sets the toolchain to Swift_2_3" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              toolchain: 'com.apple.dt.toolchain.Swift_2_3'
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap --toolchain com.apple.dt.toolchain.Swift_2_3")
+      end
+
       it "use custom derived data" do
         result = Fastlane::FastFile.new.parse("lane :test do
             carthage(


### PR DESCRIPTION
This enables the ability to pass in a specific xcodebuild toolchain to carthage for installing / updating / etc; closes #5526. 

An optional array of strings can now be passed into the carthage command as such:

``` ruby
carthage(
      toolchain: 'com.apple.dt.toolchain.Swift_2_3',
      use_binaries: false,
      use_ssh: true
)
```

in order to bootstrap the dependencies using Swift 2.3 toolchain.
