### PR TITLE
Use the xcode-select path for FASTLANE_EXPLICIT_OPEN_SIMULATOR

### DIFF
--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -195,8 +195,16 @@ module Snapshot
     def open_simulator_for_device(device)
       return unless ENV['FASTLANE_EXPLICIT_OPEN_SIMULATOR']
 
-      UI.message("Explicitly opening simulator for device: #{device}")
-      `open -a Simulator --args -CurrentDeviceUDID #{TestCommandGenerator.device_udid(device)}`
+      # As a second level of feature switching, see if we want to try the xcode-select variant
+      if ENV['FASTLANE_EXPLICIT_OPEN_SIMULATOR'] == '2'
+        simulator_path = File.join(FastlaneCore::Helper.xcode_path, 'Applications', 'Simulator.app')
+        UI.message("Explicitly opening simulator at #{simulator_path} for device: #{device}")
+      else
+        simulator_path = 'Simulator'
+        UI.message("Explicitly opening simulator for device: #{device}")
+      end
+
+      `open -a #{simulator_path} --args -CurrentDeviceUDID #{TestCommandGenerator.device_udid(device)}`
     end
 
     def uninstall_app(device_type)


### PR DESCRIPTION
Experimental solution for https://github.com/fastlane/fastlane/issues/5128

Extend the `FASTLANE_EXPLICIT_OPEN_SIMULATOR` feature switch to possibly use the path returned by `xcode-select -p` to locate the Simulator.app to be launched.

My theory is that people are having trouble with this work-around when the **Simulator.app** resolved by `open Simulator` is different than the one in the developer tools path set by `xcode-select`.

This change adds a kind of second level to the `FASTLANE_EXPLICIT_OPEN_SIMULATOR` feature switch, by checking to see if its value is `"2"`. If so, we'll try this variation.
