### PR TITLE
Use the Simulator.app matching the currently selected Xcode Command Line Tools

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -92,7 +92,7 @@ module Scan
       `killall Simulator &> /dev/null`
 
       xcode_select_path = `xcode-select -p`.strip
-      
+
       UI.message("Explicitly opening simulator for device: #{device.name}")
       `open -a #{xcode_select_path}/Applications/Simulator.app --args -CurrentDeviceUDID #{device.udid}`
     end

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -101,7 +101,6 @@ module Scan
       end
 
       `open -a #{simulator_path} --args -CurrentDeviceUDID #{device.udid}`
-
     end
   end
 end

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -91,10 +91,17 @@ module Scan
       UI.message("Killing all running simulators")
       `killall Simulator &> /dev/null`
 
-      xcode_select_path = `xcode-select -p`.strip
+      # As a second level of feature switching, see if we want to try the xcode-select variant
+      if ENV['FASTLANE_EXPLICIT_OPEN_SIMULATOR'] == '2'
+        simulator_path = File.join(FastlaneCore::Helper.xcode_path, 'Applications', 'Simulator.app')
+        UI.message("Explicitly opening simulator at #{simulator_path} for device: #{device.name}")
+      else
+        simulator_path = 'Simulator'
+        UI.message("Explicitly opening simulator for device: #{device.name}")
+      end
 
-      UI.message("Explicitly opening simulator for device: #{device.name}")
-      `open -a #{xcode_select_path}/Applications/Simulator.app --args -CurrentDeviceUDID #{device.udid}`
+      `open -a #{simulator_path} --args -CurrentDeviceUDID #{device.udid}`
+
     end
   end
 end

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -91,8 +91,10 @@ module Scan
       UI.message("Killing all running simulators")
       `killall Simulator &> /dev/null`
 
+      xcode_select_path = `xcode-select -p`.strip
+      
       UI.message("Explicitly opening simulator for device: #{device.name}")
-      `open -a Simulator --args -CurrentDeviceUDID #{device.udid}`
+      `open -a #{xcode_select_path}/Applications/Simulator.app --args -CurrentDeviceUDID #{device.udid}`
     end
   end
 end


### PR DESCRIPTION
This solves issue #5375.

As discussed in the issue, `scan` uses `fastlane_core`, which uses `xcrun` to gather all simulators. Since `xcrun` is part of the Xcode Command Line Tools, I resolved the ambiguity of which Simulator to use by prepending the output of `xcode-select -p` in the `open -a Simulator ...` statement.

I tested the change in both scenarios described in my opening post in the issue and the errors are gone.
