### PR TITLE
Version Bump

### DIFF
--- a/snapshot/lib/snapshot/version.rb
+++ b/snapshot/lib/snapshot/version.rb
@@ -1,4 +1,4 @@
 module Snapshot
-  VERSION = "1.12.3".freeze
+  VERSION = "1.13.0".freeze
   DESCRIPTION = "Automate taking localized screenshots of your iOS app on every device"
 end


### PR DESCRIPTION
Changes since release 1.12.3:
- Use the xcode-select path for FASTLANE_EXPLICIT_OPEN_SIMULATOR (#5529)
- Fix typo (#5447)
- Updated snapshot setup instructions (#5326)
- Update link to snapshot github repo (#5268)
- Fix missing close paren in README.md (#5204)
- Modified READMEs to provide clarity on what the tools do
- Use user_error! instead of raise for snapshot failure (#5146)
- Merge test results and send to coveralls (#5091)
- Fix tests that are failing due to shellescape changes (#5095)
- Add build setting to xcodebuild command so projects can detect snapshot during build (#5051)
- Improved code style
- Enabled fastlane plugins for all the tools (#4941)
