### PR TITLE
Update import_from_git :branch parameter documentation

### DIFF
--- a/fastlane/lib/fastlane/actions/import_from_git.rb
+++ b/fastlane/lib/fastlane/actions/import_from_git.rb
@@ -26,7 +26,7 @@ module Fastlane
                                        description: "The url of the repository to import the Fastfile from",
                                        default_value: nil),
           FastlaneCore::ConfigItem.new(key: :branch,
-                                       description: "The branch to check-out on the repository",
+                                       description: "The branch or tag to check-out on the repository",
                                        default_value: 'HEAD',
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :path,


### PR DESCRIPTION
Adds the information that import_from_git :branch argument can take
tags as well as branches.

This "fixes" issue #5420 
