### PR TITLE
hipchat: escape channel name if it is not escaped yet

### DIFF
--- a/fastlane/lib/fastlane/actions/hipchat.rb
+++ b/fastlane/lib/fastlane/actions/hipchat.rb
@@ -51,7 +51,8 @@ module Fastlane
             json_headers = { 'Content-Type' => 'application/json',
                              'Accept' => 'application/json', 'Authorization' => "Bearer #{api_token}" }
 
-            uri = URI.parse("https://#{api_host}/v2/user/#{channel}/message")
+            escaped_channel = URI.unescape(channel) == channel ? URI.escape(channel) : channel
+            uri = URI.parse("https://#{api_host}/v2/user/#{escaped_channel}/message")
             http = Net::HTTP.new(uri.host, uri.port)
             http.use_ssl = true
 


### PR DESCRIPTION
As mentioned in #302, if you have a channel name with whitespace in it, the action fails:

```
irb(main):003:0> URI.parse("https://api.hipchat.com/v2/user/Mobile Engineering/message")
URI::InvalidURIError: bad URI(is not URI?): https://api.hipchat.com/v2/user/Mobile Engineering/message
    from /Users/gustavo/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/uri/common.rb:176:in `split'
    from /Users/gustavo/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/uri/common.rb:211:in `parse'
    from /Users/gustavo/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/uri/common.rb:747:in `parse'
    from (irb):3
    from /Users/gustavo/.rbenv/versions/2.0.0-p247/bin/irb:12:in `<main>'
```

The current workaround is to set the channel name as an already escaped string, like `Mobile%20Engineering`.

This PR checks if the channel name is already escaped (so developers using the workaround won't be affected) and escapes it otherwise.

```
irb(main):004:0> channel = "Mobile Engineering"
=> "Mobile Engineering"
irb(main):005:0> escaped_channel = URI.unescape(channel) == channel ? URI.escape(channel) : channel
=> "Mobile%20Engineering"
irb(main):006:0> channel = "Mobile%20Engineering"
=> "Mobile%20Engineering"
irb(main):007:0> escaped_channel = URI.unescape(channel) == channel ? URI.escape(channel) : channel
=> "Mobile%20Engineering"
```

fixes #302
