### PR TITLE
Remove extra call to iTunesConnect web objects that invalidates myacinfo cookie

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -284,7 +284,6 @@ module Spaceship
 
       # get woinst, wois, and itctx cookie values
       request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/wa/route?noext")
-      request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa")
 
       case response.status
       when 403


### PR DESCRIPTION
For dev portal accounts that don't have iTunesConnect accounts associated with them, this call was invalidating the `myacinfo` cookie that is required to make authenticated calls. This call doesn't appear neccessary as it doesn't provide any additional cookies as compared with [line 286](https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/client.rb#L286).

This PR allows accounts that only have dev portal access to use tools like `sigh`, `cert` and `produce` 

Fixes #3901 
Fixes #5386
Fixes #5384
