### PR TITLE
Allow Match::Utils.import to resolve a fully-qualified keychain path

### DIFF
--- a/match/lib/match/utils.rb
+++ b/match/lib/match/utils.rb
@@ -4,18 +4,19 @@ module Match
       # Existing code expects that a keychain name will be expanded into a default path to Libary/Keychains
       # in the user's home directory. However, this will not allow the user to pass an absolute path
       # for the keychain value
-      keychain_path = File.join(Dir.home, 'Library', 'Keychains', keychain)
-
+      #
       # So, if the passed value can't be resolved as a file in Library/Keychains, just use it as-is
       # as the keychain path.
-      keychain_path = keychain unless File.exist?(keychain_path)
+      keychain_paths = [File.join(Dir.home, 'Library', 'Keychains', keychain), keychain]
+
+      keychain_path = keychain_paths.detect { |path| File.exist?(path) }
+
+      UI.user_error!("Could not locate the provided keychain. Tried:\n\t#{keychain_paths.join("\n\t")}") unless keychain_path
 
       command = "security import #{item_path.shellescape} -k #{keychain_path.shellescape}"
       command << " -T /usr/bin/codesign" # to not be asked for permission when running a tool like `gym`
       command << " -T /usr/bin/security"
       command << " &> /dev/null" unless $verbose
-
-      return command if Helper.test?
 
       Helper.backticks(command, print: $verbose)
     end

--- a/match/lib/match/utils.rb
+++ b/match/lib/match/utils.rb
@@ -1,10 +1,21 @@
 module Match
   class Utils
     def self.import(item_path, keychain)
-      command = "security import #{item_path.shellescape} -k ~/Library/Keychains/#{keychain.shellescape}"
+      # Existing code expects that a keychain name will be expanded into a default path to Libary/Keychains
+      # in the user's home directory. However, this will not allow the user to pass an absolute path
+      # for the keychain value
+      keychain_path = File.join(Dir.home, 'Library', 'Keychains', keychain)
+
+      # So, if the passed value can't be resolved as a file in Library/Keychains, just use it as-is
+      # as the keychain path.
+      keychain_path = keychain unless File.exist?(keychain_path)
+
+      command = "security import #{item_path.shellescape} -k #{keychain_path.shellescape}"
       command << " -T /usr/bin/codesign" # to not be asked for permission when running a tool like `gym`
       command << " -T /usr/bin/security"
-      command << "&> /dev/null" # we couldn't care less about the output
+      command << " &> /dev/null" unless $verbose
+
+      return command if Helper.test?
 
       Helper.backticks(command, print: $verbose)
     end

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -1,5 +1,17 @@
 describe Match do
   describe Match::Utils do
+    describe 'import' do
+      it 'finds a normal keychain name relative to ~/Library/Keychains' do
+        expected_command = "security import item.path -k #{Dir.home}/Library/Keychains/login.keychain -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
+        expect(Match::Utils.import('item.path', 'login.keychain')).to eq(expected_command)
+      end
+
+      it 'treats a keychain name it cannot find in ~/Library/Keychains as the full keychain path' do
+        expected_command = "security import item.path -k /my/special.keychain -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
+        expect(Match::Utils.import('item.path', '/my/special.keychain')).to eq(expected_command)
+      end
+    end
+
     describe "fill_environment" do
       it "pre-fills the environment" do
         uuid = "my_uuid #{Time.now.to_i}"

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -3,12 +3,31 @@ describe Match do
     describe 'import' do
       it 'finds a normal keychain name relative to ~/Library/Keychains' do
         expected_command = "security import item.path -k #{Dir.home}/Library/Keychains/login.keychain -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
-        expect(Match::Utils.import('item.path', 'login.keychain')).to eq(expected_command)
+
+        expect(File).to receive(:exist?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
+        expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: $verbose)
+
+        Match::Utils.import('item.path', 'login.keychain')
       end
 
       it 'treats a keychain name it cannot find in ~/Library/Keychains as the full keychain path' do
         expected_command = "security import item.path -k /my/special.keychain -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
-        expect(Match::Utils.import('item.path', '/my/special.keychain')).to eq(expected_command)
+
+        expect(File).to receive(:exist?).with("#{Dir.home}/Library/Keychains/my/special.keychain").and_return(false)
+        expect(File).to receive(:exist?).with('/my/special.keychain').and_return(true)
+
+        expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: $verbose)
+
+        Match::Utils.import('item.path', '/my/special.keychain')
+      end
+
+      it 'shows a user error if the keychain path cannot be resolved' do
+        expect(File).to receive(:exist?).with("#{Dir.home}/Library/Keychains/my/special.keychain").and_return(false)
+        expect(File).to receive(:exist?).with('/my/special.keychain').and_return(false)
+
+        expect do
+          Match::Utils.import('item.path', '/my/special.keychain')
+        end.to raise_error(/Could not locate the provided keychain/)
       end
     end
 


### PR DESCRIPTION
Addresses #4866 

During import, first try to resolve the keychain value with the old assumptions about a ~/Library/Keychains location. If that path doesn't exist, now fall-back to using the provided value as the full path.

Suppresses redirection of the command output to `/dev/null` if verbose mode is enabled.
