### PR TITLE
Update device_grid to work with the new danger

### DIFF
--- a/danger-device_grid/lib/device_grid/plugin.rb
+++ b/danger-device_grid/lib/device_grid/plugin.rb
@@ -23,7 +23,7 @@ module Danger
       # To use the local fastlane instead of bundle
       prefix_command = "./bin/" if FastlaneCore::Helper.test?
 
-      deep_link_matches = pr_body.match(/:link:\s(.*)/) # :link: emoji
+      deep_link_matches = github.pr_body.match(/:link:\s(.*)/) # :link: emoji
       deep_link = deep_link_matches[1] if deep_link_matches
 
       markdown("<table>")

--- a/danger-device_grid/spec/device_grid_spec.rb
+++ b/danger-device_grid/spec/device_grid_spec.rb
@@ -3,11 +3,17 @@ require File.expand_path('../spec_helper', __FILE__)
 module Danger
   class Dangerfile
     module DSL
+      class GitHubObj
+        def pr_body
+          ""
+        end
+      end
+
       class Plugin
         attr_accessor :current_markdown
 
-        def pr_body # needed for the action
-          ""
+        def github # needed for the action
+          GitHubObj.new
         end
 
         def markdown(str)


### PR DESCRIPTION
The new danger requires the user to prefix all GitHub related commands
