### PR TITLE
Add easier access to lane context from actions

### DIFF
--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -75,6 +75,10 @@ module Fastlane
       self.name.split('::').last.gsub('Action', '').fastlane_underscore
     end
 
+    def self.lane_context
+      Actions.lane_context
+    end
+
     # Allows the user to call an action from an action
     def self.method_missing(method_sym, *arguments, &_block)
       UI.error("Unknown method '#{method_sym}'")

--- a/fastlane/spec/action_spec.rb
+++ b/fastlane/spec/action_spec.rb
@@ -7,6 +7,13 @@ describe Fastlane do
       end
     end
 
+    describe "Easy access to the lane context" do
+      it "redirects to the correct class and method" do
+        Fastlane::Actions.lane_context[:something] = 1
+        expect(Fastlane::Action.lane_context).to eq({ something: 1 })
+      end
+    end
+
     describe "Call another action from an action" do
       it "allows the user to call it using `other_action.rocket`" do
         Fastlane::Actions.load_external_actions("spec/fixtures/actions")


### PR DESCRIPTION
Instead of

`Actions.lane_context[Actions::SharedValues::SCAN_DERIVED_DATA_PATH]`
you can now use
`lane_context[Actions::SharedValues::SCAN_DERIVED_DATA_PATH]`
also from actions
