### PR TITLE
Add parameter to user_error! to not look for GitHub issues

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -40,7 +40,7 @@ module Commander
         abort e.to_s
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         collector.did_raise_error(@program[:name])
-        show_github_issues(e.message)
+        show_github_issues(e.message) if e.show_github_issues
         display_user_error!(e, e.message)
       rescue => e # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
         collector.did_crash(@program[:name])

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -141,7 +141,7 @@ module FastlaneCore
     # Basically this should be used when you actively catch the error
     # and want to show a nice error message to the user
     def user_error!(error_message, options = {})
-      options[:show_github_issues] = true unless options.key?(:show_github_issues)
+      options = { show_github_issues: true }.merge(options)
       raise FastlaneError.new(show_github_issues: options[:show_github_issues]), error_message.to_s
     end
 

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -117,6 +117,11 @@ module FastlaneCore
 
     # raised from user_error!
     class FastlaneError < StandardError
+      attr_reader :show_github_issues
+
+      def initialize(show_github_issues: true)
+        @show_github_issues = show_github_issues
+      end
     end
 
     # Pass an exception to this method to exit the program
@@ -135,8 +140,9 @@ module FastlaneCore
     #   stack trace
     # Basically this should be used when you actively catch the error
     # and want to show a nice error message to the user
-    def user_error!(error_message)
-      raise FastlaneError.new, error_message.to_s
+    def user_error!(error_message, options = {})
+      options[:show_github_issues] = true unless options.key?(:show_github_issues)
+      raise FastlaneError.new(show_github_issues: options[:show_github_issues]), error_message.to_s
     end
 
     #####################################################


### PR DESCRIPTION
This will be used when running tests with `scan`, as “Tests failed” is not something we want to search on GitHub for
