### PR TITLE
Add printing out of snapshot progress

### DIFF
--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -43,7 +43,9 @@ module Snapshot
             end
             results[device] ||= {}
 
-            UI.message("snapshot run #{device_index * Snapshot.config[:languages].count + language_index + 1} of #{Snapshot.config[:languages].count * Snapshot.config[:devices].count}")
+            current_run = device_index * Snapshot.config[:languages].count + language_index + 1
+            number_of_runs = Snapshot.config[:languages].count * Snapshot.config[:devices].count
+            UI.message("snapshot run #{current_run} of #{number_of_runs}")
 
             results[device][language] = run_for_device_and_language(language, locale, device, launch_arguments)
           end

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -32,15 +32,17 @@ module Snapshot
       self.collected_errors = []
       results = {} # collect all the results for a nice table
       launch_arguments_set = config_launch_arguments
-      Snapshot.config[:devices].each do |device|
+      Snapshot.config[:devices].each_with_index do |device, device_index|
         launch_arguments_set.each do |launch_arguments|
-          Snapshot.config[:languages].each do |language|
+          Snapshot.config[:languages].each_with_index do |language, language_index|
             locale = nil
             if language.kind_of?(Array)
               locale = language[1]
               language = language[0]
             end
             results[device] ||= {}
+
+            UI.message("snapshot run #{device_index * Snapshot.config[:languages].count + language_index + 1} of #{Snapshot.config[:languages].count * Snapshot.config[:devices].count}")
 
             results[device][language] = run_for_device_and_language(language, locale, device, launch_arguments)
           end

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -9,6 +9,7 @@ module Snapshot
     # All the errors we experience while running snapshot
     attr_accessor :collected_errors
 
+    # rubocop:disable Metrics/AbcSize
     def work
       if File.exist?("./fastlane/snapshot.js") or File.exist?("./snapshot.js")
         UI.error "Found old snapshot configuration file 'snapshot.js'"
@@ -61,6 +62,7 @@ module Snapshot
         FileUtils.rm_rf(TestCommandGenerator.derived_data_path)
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     # This is its own method so that it can re-try if the tests fail randomly
     # @return true/false depending on if the tests succeded


### PR DESCRIPTION
This way it’s easy for the user to see how many runs were already done and how many are left

This will print out the following

```
...
[19:10:12]: snapshot run 5 of 6
...
```
