### PR TITLE
Let FastlaneCore::Simulator launch Simulator.app for a device

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -186,6 +186,16 @@ module FastlaneCore
       def clear_cache
         @devices = nil
       end
+
+      def launch(device)
+        return unless device.is_simulator
+
+        simulator_path = File.join(Helper.xcode_path, 'Applications', 'Simulator.app')
+
+        UI.verbose "Launching #{simulator_path} for device: #{device.name} (#{device.udid})"
+
+        Helper.backticks("open -a #{simulator_path} --args -CurrentDeviceUDID #{device.udid}", print: $verbose)
+      end
     end
   end
 

--- a/fastlane_core/spec/simulator_spec.rb
+++ b/fastlane_core/spec/simulator_spec.rb
@@ -23,6 +23,20 @@ describe FastlaneCore do
       FastlaneCore::Simulator.clear_cache
     end
 
+    it "can launch Simulator.app for a simulator device" do
+      device = FastlaneCore::DeviceManager::Device.new(name: 'iPhone 5s',
+                                                       udid: '3E67398C-AF70-4D77-A22C-D43AA8623FE3',
+                                                 os_version: '10.0',
+                                                      state: 'Shutdown',
+                                               is_simulator: true)
+
+      expected_command = "open -a #{FastlaneCore::Helper.xcode_path}Applications/Simulator.app --args -CurrentDeviceUDID #{device.udid}"
+
+      expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: $verbose)
+
+      FastlaneCore::Simulator.launch(device)
+    end
+
     it "raises an error if xcrun CLI prints garbage" do
       response = "response"
       expect(response).to receive(:read).and_return("💩")

--- a/fastlane_core/spec/simulator_spec.rb
+++ b/fastlane_core/spec/simulator_spec.rb
@@ -37,6 +37,18 @@ describe FastlaneCore do
       FastlaneCore::Simulator.launch(device)
     end
 
+    it "does not launch Simulator.app for a non-simulator device" do
+      device = FastlaneCore::DeviceManager::Device.new(name: 'iPhone 5s',
+                                                       udid: '3E67398C-AF70-4D77-A22C-D43AA8623FE3',
+                                                 os_version: '10.0',
+                                                      state: 'Shutdown',
+                                               is_simulator: false)
+
+      expect(FastlaneCore::Helper).not_to receive(:backticks)
+
+      FastlaneCore::Simulator.launch(device)
+    end
+
     it "raises an error if xcrun CLI prints garbage" do
       response = "response"
       expect(response).to receive(:read).and_return("💩")


### PR DESCRIPTION
To be used as common code for `snapshot` and `scan`
