### PR TITLE
Show nice error message when there are OpenSSL issues

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -2,6 +2,16 @@ module Commander
   # This class override the run method with our custom stack trace handling
   # In particular we want to distinguish between user_error! and crash! (one with, one without stack trace)
   class Runner
+    unless Object.const_defined?("Faraday")
+      module Faraday
+        class SSLError < StandardError
+          # We create this empty error class if we didn't require Faraday
+          # so that we can use it in the rescue block below
+          # even if we didn't require Faraday or didn't use it
+        end
+      end
+    end
+
     # Code taken from https://github.com/commander-rb/commander/blob/master/lib/commander/runner.rb#L50
     def run!
       require_program :version, :description

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -42,6 +42,23 @@ module Commander
         collector.did_raise_error(@program[:name])
         show_github_issues(e.message) if e.show_github_issues
         display_user_error!(e, e.message)
+      rescue Faraday::SSLError => e # SSL issues are very common
+        # SSL errors are very common when the Ruby or OpenSSL installation is somehow broken
+        # We want to show a nice error message to the user here
+        # We have over 20 GitHub issues just for this one error:
+        #   https://github.com/fastlane/fastlane/search?q=errno%3D0+state%3DSSLv3+read+server&type=Issues
+        ui = FastlaneCore::UI
+        ui.error "-----------------------------------------------------------------------"
+        ui.error e.to_s
+        ui.error "SSL errors can be caused by various components on your local machine"
+        ui.error "- Make sure OpenSSL is installed with Homebrew: `brew update && brew upgrade openssl`"
+        ui.error "- If you use rvm:"
+        ui.error "  - First run `rvm osx-ssl-certs update all`"
+        ui.error "  - Then run `rvm reinstall ruby-2.2.3 --with-openssl-dir=/usr/local"
+        ui.error "- If that doesn't fix your issue, please google for the following error message:"
+        ui.error "  '#{e}'"
+        ui.error "-----------------------------------------------------------------------"
+        display_user_error!(e, e.to_s)
       rescue => e # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
         collector.did_crash(@program[:name])
         handle_unknown_error!(e)


### PR DESCRIPTION
**Before:**
<img width="1118" alt="screenshot 2016-08-02 23 48 25" src="https://cloud.githubusercontent.com/assets/869950/17356404/20458040-590c-11e6-8dc1-31069c7511b1.png">

**Now:**
<img width="983" alt="screenshot 2016-08-02 23 47 54" src="https://cloud.githubusercontent.com/assets/869950/17356400/1de29e5a-590c-11e6-9dab-a999ed51c907.png">

First I wanted to add this to the spaceship code, but I faced a few issues
- It doesn't have access to FastlaneCore::UI, making it look less nice
- It doesn't have access to `colored`, making it look less nice
- It would still raise the exception, so we'd need to handle it in `fastlane_runner` anyway. By catching the general `Faraday::SSLError` class, we should handle this for not only spaceship, but also for other actions or plugins.

We've had over 20 issues submitted with this particular error, and probably a few hundred people who had to manually google for the error message.

Since I ran into this on my local machine I figured, why not add this message, as I can reproduce it right now. 
