### PR TITLE
Refactor scan and snapshot to launch Simulator.app via fastlane_core

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -97,16 +97,7 @@ module Scan
       UI.message("Killing all running simulators")
       `killall Simulator &> /dev/null`
 
-      # As a second level of feature switching, see if we want to try the xcode-select variant
-      if ENV['FASTLANE_EXPLICIT_OPEN_SIMULATOR'] == '2'
-        simulator_path = File.join(FastlaneCore::Helper.xcode_path, 'Applications', 'Simulator.app')
-        UI.message("Explicitly opening simulator at #{simulator_path} for device: #{device.name}")
-      else
-        simulator_path = 'Simulator'
-        UI.message("Explicitly opening simulator for device: #{device.name}")
-      end
-
-      `open -a #{simulator_path} --args -CurrentDeviceUDID #{device.udid}`
+      FastlaneCore::Simulator.launch(device)
     end
   end
 end

--- a/scan/scan.gemspec
+++ b/scan/scan.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.49.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.50.0', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'xcpretty', '>= 0.2.1' # pretty xcodebuild output
   spec.add_dependency 'xcpretty-travis-formatter', '>= 0.0.3'
   spec.add_dependency 'slack-notifier', '~> 1.3'

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -198,19 +198,11 @@ module Snapshot
     end
     # rubocop:enable Metrics/AbcSize
 
-    def open_simulator_for_device(device)
+    def open_simulator_for_device(device_name)
       return unless ENV['FASTLANE_EXPLICIT_OPEN_SIMULATOR']
 
-      # As a second level of feature switching, see if we want to try the xcode-select variant
-      if ENV['FASTLANE_EXPLICIT_OPEN_SIMULATOR'] == '2'
-        simulator_path = File.join(FastlaneCore::Helper.xcode_path, 'Applications', 'Simulator.app')
-        UI.message("Explicitly opening simulator at #{simulator_path} for device: #{device}")
-      else
-        simulator_path = 'Simulator'
-        UI.message("Explicitly opening simulator for device: #{device}")
-      end
-
-      `open -a #{simulator_path} --args -CurrentDeviceUDID #{TestCommandGenerator.device_udid(device)}`
+      device = TestCommandGenerator.find_device(device_name)
+      FastlaneCore::Simulator.launch(device) if device
     end
 
     def uninstall_app(device_type)

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -64,21 +64,23 @@ module Snapshot
         ["| tee #{xcodebuild_log_path.shellescape} | xcpretty #{Snapshot.config[:xcpretty_args]}"]
       end
 
-      def device_udid(device)
-        # we now fetch the device's udid. Why? Because we might get this error message
+      def find_device(device_name)
+        # We might get this error message
         # > The requested device could not be found because multiple devices matched the request.
         #
         # This happens when you have multiple simulators for a given device type / iOS combination
         #   { platform:iOS Simulator, id:1685B071-AFB2-4DC1-BE29-8370BA4A6EBD, OS:9.0, name:iPhone 5 }
         #   { platform:iOS Simulator, id:A141F23B-96B3-491A-8949-813B376C28A7, OS:9.0, name:iPhone 5 }
         #
-
-        device_udid = nil
-        FastlaneCore::Simulator.all.each do |sim|
-          device_udid = sim.udid if sim.name.strip == device.strip and sim.ios_version == Snapshot.config[:ios_version]
+        FastlaneCore::Simulator.all.detect do |sim|
+          sim.name.strip == device_name.strip && sim.ios_version == Snapshot.config[:ios_version]
         end
+      end
 
-        return device_udid
+      def device_udid(device_name)
+        device = find_device(device_name)
+
+        device ? device.udid : nil
       end
 
       def destination(device)

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -72,7 +72,7 @@ module Snapshot
         #   { platform:iOS Simulator, id:1685B071-AFB2-4DC1-BE29-8370BA4A6EBD, OS:9.0, name:iPhone 5 }
         #   { platform:iOS Simulator, id:A141F23B-96B3-491A-8949-813B376C28A7, OS:9.0, name:iPhone 5 }
         #
-        FastlaneCore::Simulator.all.detect do |sim|
+        FastlaneCore::Simulator.all.find do |sim|
           sim.name.strip == device_name.strip && sim.ios_version == Snapshot.config[:ios_version]
         end
       end

--- a/snapshot/snapshot.gemspec
+++ b/snapshot/snapshot.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'fastimage', '~> 1.6.3' # fetch the image sizes from the screenshots
-  spec.add_dependency 'fastlane_core', '>= 0.43.3', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.50.0', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'xcpretty', '>= 0.2.1' # beautiful Xcode output
   spec.add_dependency 'plist', '~> 3.1.0' # parsing the Xcode output plist
 


### PR DESCRIPTION
Builds upon #5584

This refactoring removes the two-layer feature switch behavior for `FASTLANE_EXPLICIT_OPEN_SIMULATOR` that was introduced previously. The `fastlane_core` behavior we delegate to now always uses the `xcode-select -p` method for referring to the Simulator.app to launch. The `FASTLANE_EXPLICIT_OPEN_SIMULATOR` feature switch is still required to trigger this behavior in general.
- Refactor `TestCommandGenerator` in `snapshot` to be able to return the `Device` object for a given device name
- Bump the minimum version for `fastlane_core` in both gemspecs to depend on the latest version which includes this functionality
