### PR TITLE
Fix require for gem jira-ruby

### DIFF
--- a/fastlane/lib/fastlane/actions/jira.rb
+++ b/fastlane/lib/fastlane/actions/jira.rb
@@ -3,7 +3,7 @@ module Fastlane
     class JiraAction < Action
       def self.run(params)
         Actions.verify_gem!('jira-ruby')
-        require 'jira'
+        require 'jira-ruby'
 
         site         = params[:url]
         context_path = ""


### PR DESCRIPTION
Hello guys,

Just a very little fix. I tried today to use the "jira" action to add a comment on a jira ticket.
And I got an error on the `require 'jira'`.

I looked at the `jira-ruby` documentation (https://github.com/sumoheavy/jira-ruby) and it seems we need to `require 'jira-ruby'`.

That's what I did and it worked.

Best regards.
