### PR TITLE
Make commander great again

### DIFF
--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'krausefx-shenzhen', '>= 0.14.7' # to upload to Hockey and Crashlytics and build the app
+  spec.add_dependency 'krausefx-shenzhen', '>= 0.14.10' # to upload to Hockey and Crashlytics and build the app
   spec.add_dependency 'slack-notifier', '~> 1.3' # Slack notifications
   spec.add_dependency 'xcodeproj', '>= 0.20', '< 2.0.0' # Needed for commit_version_bump action
   spec.add_dependency 'xcpretty', '>= 0.2.1' # prettify xcodebuild output

--- a/fastlane_core/fastlane_core.gemspec
+++ b/fastlane_core/fastlane_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json' # Because sometimes it's just not installed
   spec.add_dependency 'highline', '>= 1.7.2' # user inputs (e.g. passwords)
   spec.add_dependency 'colored' # coloured terminal output
-  spec.add_dependency 'commander', '= 4.3.5' # CLI parser
+  spec.add_dependency 'commander', '= 4.4.0' # CLI parser
   spec.add_dependency 'babosa' # transliterate strings
   spec.add_dependency 'excon', '~> 0.45.0' # Great HTTP Client
   spec.add_dependency 'rubyzip', '~> 1.1.6' # needed for extracting the ipa file

--- a/fastlane_core/fastlane_core.gemspec
+++ b/fastlane_core/fastlane_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json' # Because sometimes it's just not installed
   spec.add_dependency 'highline', '>= 1.7.2' # user inputs (e.g. passwords)
   spec.add_dependency 'colored' # coloured terminal output
-  spec.add_dependency 'commander', '= 4.4.0' # CLI parser
+  spec.add_dependency 'commander', '= 4.3.5' # CLI parser
   spec.add_dependency 'babosa' # transliterate strings
   spec.add_dependency 'excon', '~> 0.45.0' # Great HTTP Client
   spec.add_dependency 'rubyzip', '~> 1.1.6' # needed for extracting the ipa file


### PR DESCRIPTION
This should finally update the commander dependency 🚀
- It was started by @ohwutup first with https://github.com/fastlane/fastlane/pull/5101 and https://github.com/fastlane/shenzhen/pull/8, but had to rolled back, since it caused version conflicts and people couldn't install `fastlane`
- @neonichu did a PR updating the dependency with https://github.com/fastlane/fastlane/pull/5116, however there were too many changes in just 1 PR, also the dependency to `shenzhen` was somehow wrong
#### Let's try the following
- [x] First release a new version of `shenzhen` that has a less strict dependency to `commander` (since we don't use the `commander` CLI in `shenzhen` anyway) with https://github.com/fastlane/shenzhen/pull/9 and https://github.com/fastlane/shenzhen/pull/10
- [x] After this was released, we can merge this PR that updates to the new `shenzhen` with the losened-up dependency to `commander`. 
- [x] This is a change in `fastlane_core`, so next up we'll merge and release a `fastlane_core` version with https://github.com/fastlane/fastlane/pull/5611
- [x] Only after this was done, we can finally update our `commander` dependency in `fastlane.gemspec` in combination with the `fastlane_core` dependency, since we now have the losened up dependency of commander (PR will follow)

**Note**: This PR is failing until we merged and released https://github.com/fastlane/shenzhen/pull/9 and https://github.com/fastlane/shenzhen/pull/10
