### PR TITLE
Skip GitHub issues by default for user_error!

### DIFF
--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -7,7 +7,7 @@ module Cert
 
       installed = FastlaneCore::CertChecker.installed?(ENV["CER_FILE_PATH"])
       UI.message "Verifying the certificate is properly installed locally..."
-      UI.user_error!("Could not find the newly generated certificate installed") unless installed
+      UI.user_error!("Could not find the newly generated certificate installed", show_github_issues: true) unless installed
       UI.success "Successfully installed certificate #{ENV['CER_CERTIFICATE_ID']}"
       return ENV["CER_FILE_PATH"]
     end
@@ -137,7 +137,7 @@ module Cert
         certificate = certificate_type.create!(csr: csr)
       rescue => ex
         if ex.to_s.include?("You already have a current")
-          UI.user_error!("Could not create another certificate, reached the maximum number of available certificates.")
+          UI.user_error!("Could not create another certificate, reached the maximum number of available certificates.", show_github_issues: true)
         end
 
         raise ex

--- a/deliver/lib/deliver/html_generator.rb
+++ b/deliver/lib/deliver/html_generator.rb
@@ -24,7 +24,7 @@ module Deliver
       if okay
         UI.success("HTML file confirmed...") # print this to give feedback to the user immediately
       else
-        UI.user_error!("Did not upload the metadata, because the HTML file was rejected by the user", show_github_issues: false)
+        UI.user_error!("Did not upload the metadata, because the HTML file was rejected by the user")
       end
     end
 

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -80,7 +80,7 @@ module Deliver
 
       transporter = FastlaneCore::ItunesTransporter.new(options[:username], nil, false, options[:itc_provider])
       result = transporter.upload(options[:app].apple_id, package_path)
-      UI.user_error!("Could not upload binary to iTunes Connect. Check out the error above") unless result
+      UI.user_error!("Could not upload binary to iTunes Connect. Check out the error above", show_github_issues: true) unless result
     end
 
     def submit_for_review

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -163,7 +163,7 @@ module Deliver
     def set_review_information(v, options)
       return unless options[:app_review_information]
       info = options[:app_review_information]
-      UI.user_error!("`app_review_information` must be a hash") unless info.kind_of?(Hash)
+      UI.user_error!("`app_review_information` must be a hash", show_github_issues: true) unless info.kind_of?(Hash)
 
       v.review_first_name = info[:first_name] if info[:first_name]
       v.review_last_name = info[:last_name] if info[:last_name]

--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -104,13 +104,13 @@ module Fastlane
           else
             UI.error "Could not find method 'run' in class #{class_name}."
             UI.error 'For more information, check out the docs: https://github.com/fastlane/fastlane/tree/master/fastlane'
-            UI.user_error!("Action '#{file_name}' is damaged!")
+            UI.user_error!("Action '#{file_name}' is damaged!", show_github_issues: true)
           end
         rescue NameError
           # Action not found
           UI.error "Could not find '#{class_name}' class defined."
           UI.error 'For more information, check out the docs: https://github.com/fastlane/fastlane/tree/master/fastlane'
-          UI.user_error!("Action '#{file_name}' is damaged!")
+          UI.user_error!("Action '#{file_name}' is damaged!", show_github_issues: true)
         end
       end
     end

--- a/fastlane/spec/actions_helper_spec.rb
+++ b/fastlane/spec/actions_helper_spec.rb
@@ -43,7 +43,7 @@ describe Fastlane do
       end
 
       it "can throws an error if plugin is damaged" do
-        expect(UI).to receive(:user_error!).with("Action 'broken_action' is damaged!")
+        expect(UI).to receive(:user_error!).with("Action 'broken_action' is damaged!", { show_github_issues: true })
         Fastlane::Actions.load_external_actions("spec/fixtures/broken_actions")
       end
     end

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -141,7 +141,7 @@ module FastlaneCore
     # Basically this should be used when you actively catch the error
     # and want to show a nice error message to the user
     def user_error!(error_message, options = {})
-      options = { show_github_issues: true }.merge(options)
+      options = { show_github_issues: false }.merge(options)
       raise FastlaneError.new(show_github_issues: options[:show_github_issues]), error_message.to_s
     end
 

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -50,7 +50,7 @@ module Gym
           print "For more information visit this stackoverflow answer:"
           print "https://stackoverflow.com/a/17031697/445598"
         end
-        UI.user_error!("Error building the application - see the log above", show_github_issues: false)
+        UI.user_error!("Error building the application - see the log above")
       end
 
       # @param [Array] The output of the errored build (line by line)
@@ -91,7 +91,7 @@ module Gym
           print "Unfortunately the new Xcode export API is unstable and causes problems on some projects"
           print "You can temporary use the :use_legacy_build_api option to get the build to work again"
         end
-        UI.user_error!("Error packaging up the application", show_github_issues: false)
+        UI.user_error!("Error packaging up the application")
       end
 
       def handle_empty_archive

--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -34,7 +34,7 @@ module Match
 
         c.action do |args, options|
           if args.count > 0
-            FastlaneCore::UI.user_error!("Please run `match [type]`, allowed values: development, adhoc or appstore", show_github_issues: false)
+            FastlaneCore::UI.user_error!("Please run `match [type]`, allowed values: development, adhoc or appstore")
           end
 
           params = FastlaneCore::Configuration.create(Match::Options.available_options, options.__hash__)
@@ -65,7 +65,7 @@ module Match
           path = File.join(containing, "Matchfile")
 
           if File.exist?(path)
-            FastlaneCore::UI.user_error!("You already got a Matchfile in this directory", show_github_issues: false)
+            FastlaneCore::UI.user_error!("You already got a Matchfile in this directory")
             return 0
           end
 
@@ -100,7 +100,7 @@ module Match
         c.syntax = "match nuke"
         c.description = "Delete all certificates and provisioning profiles from the Apple Dev Portal"
         c.action do |args, options|
-          FastlaneCore::UI.user_error!("Please run `match nuke [type], allowed values: distribution and development. For the 'adhoc' type, please use 'distribution' instead.", show_github_issues: false)
+          FastlaneCore::UI.user_error!("Please run `match nuke [type], allowed values: distribution and development. For the 'adhoc' type, please use 'distribution' instead.")
         end
       end
 

--- a/scan/lib/scan/error_handler.rb
+++ b/scan/lib/scan/error_handler.rb
@@ -21,7 +21,7 @@ module Scan
           print "For more information visit this stackoverflow answer:"
           print "https://stackoverflow.com/a/17031697/445598"
         when /Testing failed/
-          UI.user_error!("Error building the application - see the log above", show_github_issues: false)
+          UI.user_error!("Error building the application - see the log above")
         when /Executed/
           # this is *really* important:
           # we don't want to raise an exception here

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -83,11 +83,11 @@ module Scan
       report_collector.parse_raw_file(TestCommandGenerator.xcodebuild_log_path)
 
       unless tests_exit_status == 0
-        UI.user_error!("Test execution failed. Exit status: #{tests_exit_status}", show_github_issues: false)
+        UI.user_error!("Test execution failed. Exit status: #{tests_exit_status}")
       end
 
       unless result[:failures] == 0
-        UI.user_error!("Tests failed", show_github_issues: false)
+        UI.user_error!("Tests failed")
       end
     end
 

--- a/screengrab/lib/screengrab/dependency_checker.rb
+++ b/screengrab/lib/screengrab/dependency_checker.rb
@@ -25,7 +25,7 @@ module Screengrab
         UI.error 'Please ensure that the Android SDK is installed and the platform-tools directory is present and on your PATH'
       end
 
-      UI.user_error! 'adb command not found'
+      UI.user_error!('adb command not found')
     end
 
     def self.check_aapt(android_env)


### PR DESCRIPTION
As suggested by @mfurtak, we should skip GitHub issues by default for `user_error!`, and show it for actual crashes.

Work in progress:
- [x] Pass build
- [x] Go through all UI.user_error! and check where we should show GitHub issues
