### PR TITLE
Fix documentation about zip action

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -2550,7 +2550,7 @@ Compress a file or directory
 ```ruby
 zip(path: "MyApp.app")
 
-zip(path: "MyApp.app", output_name: "Latest.app.zip")
+zip(path: "MyApp.app", output_path: "Latest.app.zip")
 ```
 
 ### ifttt

--- a/fastlane/lib/fastlane/actions/zip.rb
+++ b/fastlane/lib/fastlane/actions/zip.rb
@@ -34,8 +34,8 @@ module Fastlane
                                          UI.user_error!("Couldn't find file/folder at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :output_path,
-                                       env_name: "FL_ZIP_OUTPUT_PATH",
-                                       description: "The path of the resulting zip file",
+                                       env_name: "FL_ZIP_OUTPUT_NAME",
+                                       description: "The name of the resulting zip file",
                                        optional: true)
         ]
       end

--- a/fastlane/lib/fastlane/actions/zip.rb
+++ b/fastlane/lib/fastlane/actions/zip.rb
@@ -34,8 +34,8 @@ module Fastlane
                                          UI.user_error!("Couldn't find file/folder at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :output_path,
-                                       env_name: "FL_ZIP_OUTPUT_NAME",
-                                       description: "The name of the resulting zip file",
+                                       env_name: "FL_ZIP_OUTPUT_PATH",
+                                       description: "The path of the resulting zip file",
                                        optional: true)
         ]
       end


### PR DESCRIPTION
I found miss on documentation about `zip` action.

| Documented | Actual |
| --- | --- |
| `output_name` | `output_path` |

 https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/zip.rb#L36

Additionally, I prefer to change `env_name` also.
