### PR TITLE
Make download_dsyms work for appletvos

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -16,6 +16,7 @@ module Fastlane
 
         version = params[:version]
         build_number = params[:build_number]
+        platform = params[:platform]
 
         message = []
         message << "Looking for dSYM files for #{params[:app_identifier]}"
@@ -33,11 +34,11 @@ module Fastlane
           UI.user_error!("Could not find app with bundle identifier '#{params[:app_identifier]}' on account #{params[:username]}")
         end
 
-        app.all_build_train_numbers.each do |train_number|
+        app.all_build_train_numbers(platform: platform).each do |train_number|
           if version && version != train_number
             next
           end
-          app.all_builds_for_train(train: train_number).each do |build|
+          app.all_builds_for_train(train: train_number, platform: platform).each do |build|
             if build_number && build.build_version != build_number
               next
             end
@@ -125,6 +126,11 @@ module Fastlane
                                        verify_block: proc do |value|
                                          ENV["FASTLANE_ITC_TEAM_NAME"] = value
                                        end),
+          FastlaneCore::ConfigItem.new(key: :platform,
+                                       short_option: "-p",
+                                       env_name: "DOWNLOAD_DSYMS_PLATFORM",
+                                       description: "The app platform for dSYMs you wish to download",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :version,
                                        short_option: "-v",
                                        env_name: "DOWNLOAD_DSYMS_VERSION",

--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -201,8 +201,8 @@ module Spaceship
 
       # The numbers of all build trains that were uploaded
       # @return [Array] An array of train version numbers
-      def all_build_train_numbers
-        client.all_build_trains(app_id: self.apple_id).fetch("trains").collect do |current|
+      def all_build_train_numbers(platform: nil)
+        client.all_build_trains(app_id: self.apple_id, platform: platform).fetch("trains").collect do |current|
           current["versionString"]
         end
       end
@@ -211,8 +211,8 @@ module Spaceship
       # useful if the app is not listed in the TestFlight build list
       # which might happen if you don't use TestFlight
       # This is used to receive dSYM files from Apple
-      def all_builds_for_train(train: nil)
-        client.all_builds_for_train(app_id: self.apple_id, train: train).fetch("items", []).collect do |attrs|
+      def all_builds_for_train(train: nil, platform: nil)
+        client.all_builds_for_train(app_id: self.apple_id, train: train, platform: platform).fetch("items", []).collect do |attrs|
           attrs[:apple_id] = self.apple_id
           Tunes::Build.factory(attrs)
         end

--- a/spaceship/lib/spaceship/tunes/build.rb
+++ b/spaceship/lib/spaceship/tunes/build.rb
@@ -130,7 +130,8 @@ module Spaceship
       def details
         response = client.build_details(app_id: self.apple_id,
                                          train: self.train_version,
-                                  build_number: self.build_version)
+                                  build_number: self.build_version,
+                                      platform: self.platform)
         response['apple_id'] = self.apple_id
         BuildDetails.factory(response)
       end

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -540,18 +540,18 @@ module Spaceship
     end
 
     # All build trains, even if there is no TestFlight
-    def all_build_trains(app_id: nil, platform: "ios")
-      r = request(:get, "ra/apps/#{app_id}/buildHistory?platform=#{platform}")
+    def all_build_trains(app_id: nil, platform: nil)
+      r = request(:get, "ra/apps/#{app_id}/buildHistory?platform=#{platform || 'ios'}")
       handle_itc_response(r.body)
     end
 
-    def all_builds_for_train(app_id: nil, train: nil, platform: "ios")
-      r = request(:get, "ra/apps/#{app_id}/trains/#{train}/buildHistory?platform=#{platform}")
+    def all_builds_for_train(app_id: nil, train: nil, platform: nil)
+      r = request(:get, "ra/apps/#{app_id}/trains/#{train}/buildHistory?platform=#{platform || 'ios'}")
       handle_itc_response(r.body)
     end
 
-    def build_details(app_id: nil, train: nil, build_number: nil, platform: "ios")
-      r = request(:get, "ra/apps/#{app_id}/platforms/#{platform}/trains/#{train}/builds/#{build_number}/details")
+    def build_details(app_id: nil, train: nil, build_number: nil, platform: nil)
+      r = request(:get, "ra/apps/#{app_id}/platforms/#{platform || 'ios'}/trains/#{train}/builds/#{build_number}/details")
       handle_itc_response(r.body)
     end
 

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -540,18 +540,18 @@ module Spaceship
     end
 
     # All build trains, even if there is no TestFlight
-    def all_build_trains(app_id: nil)
-      r = request(:get, "ra/apps/#{app_id}/buildHistory?platform=ios")
+    def all_build_trains(app_id: nil, platform: "ios")
+      r = request(:get, "ra/apps/#{app_id}/buildHistory?platform=#{platform}")
       handle_itc_response(r.body)
     end
 
-    def all_builds_for_train(app_id: nil, train: nil)
-      r = request(:get, "ra/apps/#{app_id}/trains/#{train}/buildHistory?platform=ios")
+    def all_builds_for_train(app_id: nil, train: nil, platform: "ios")
+      r = request(:get, "ra/apps/#{app_id}/trains/#{train}/buildHistory?platform=#{platform}")
       handle_itc_response(r.body)
     end
 
-    def build_details(app_id: nil, train: nil, build_number: nil)
-      r = request(:get, "ra/apps/#{app_id}/platforms/ios/trains/#{train}/builds/#{build_number}/details")
+    def build_details(app_id: nil, train: nil, build_number: nil, platform: "ios")
+      r = request(:get, "ra/apps/#{app_id}/platforms/#{platform}/trains/#{train}/builds/#{build_number}/details")
       handle_itc_response(r.body)
     end
 


### PR DESCRIPTION
I added a `DOWNLOAD_DSYMS_PLATFORM` option, but maybe it's better to use `FASTLANE_PLATFORM_NAME` or the `DEFAULT_PLATFORM` instead?

cc @KrauseFx 
