### PR TITLE
[spaceship] Version bump

### DIFF
--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,4 +1,4 @@
 module Spaceship
-  VERSION = "0.30.0".freeze
+  VERSION = "0.31.0".freeze
   DESCRIPTION = "Ruby library to access the Apple Dev Center and iTunes Connect".freeze
 end


### PR DESCRIPTION
- Add support for tvOS build trains in TestFlight
- Update `credentials_manager` dependency
