### PR TITLE
[fastlane] Summary table show failed action in red

### DIFF
--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -94,6 +94,7 @@ module Fastlane
       rows = []
       actions.each_with_index do |current, i|
         name = current[:name][0..60]
+        name = name.red unless current[:error].to_s.empty?
         rows << [i + 1, name, current[:time].to_i]
       end
 


### PR DESCRIPTION
Makes it more clear on what step caused the error message

<img width="525" alt="screenshot 2016-08-09 18 46 54" src="https://cloud.githubusercontent.com/assets/869950/17539255/a712826c-5e61-11e6-81a5-9dd3059f7bd6.png">
