### PR TITLE
Handle empty screenhosts and trailers

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -557,8 +557,10 @@ module Spaceship
 
       # generates the nested data structure to represent screenshots
       def setup_screenshots_for(row)
+        return if row.nil?
+
         display_families_hash = row.fetch("displayFamilies", {})
-        return [] unless display_families_hash
+        return {} unless display_families_hash
 
         display_families = display_families_hash.fetch("value", nil)
         return [] unless display_families
@@ -631,8 +633,10 @@ module Spaceship
 
       # generates the nested data structure to represent trailers
       def setup_trailers_for(row)
+        return if row.nil?
+
         display_families_hash = row.fetch("displayFamilies", {})
-        return [] unless display_families_hash
+        return {} unless display_families_hash
 
         display_families = display_families_hash.fetch("value", nil)
         return [] unless display_families

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -557,7 +557,10 @@ module Spaceship
 
       # generates the nested data structure to represent screenshots
       def setup_screenshots_for(row)
-        display_families = row.fetch("displayFamilies", {}).fetch("value", nil)
+        display_families_hash = row.fetch("displayFamilies", {})
+        return [] unless display_families_hash
+
+        display_families = display_families_hash.fetch("value", nil)
         return [] unless display_families
 
         result = []
@@ -628,7 +631,10 @@ module Spaceship
 
       # generates the nested data structure to represent trailers
       def setup_trailers_for(row)
-        display_families = row.fetch("displayFamilies", {}).fetch("value", nil)
+        display_families_hash = row.fetch("displayFamilies", {})
+        return [] unless display_families_hash
+
+        display_families = display_families_hash.fetch("value", nil)
         return [] unless display_families
 
         result = []


### PR DESCRIPTION
If bundle has no screenshots and/or trailers attached parsing fails
with "undefined method `fetch' for nil:NilClass". I added a couple
of nil checks to handle this corner case properly.

Related issue: https://github.com/fastlane/fastlane/issues/5701
