### PR TITLE
[fastlane_core] Version bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.50.0".freeze
+  VERSION = "0.50.1".freeze
 end


### PR DESCRIPTION
- Update `device_manager` to work with Xcode 8 simulators
