### PR TITLE
Disable the rubocop rules for MethodLength and AbcSize

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,9 +47,13 @@ Style/SpecialGlobalVars:
   Enabled: false
 
 Metrics/AbcSize:
-  Max: 60
-  Exclude:
-    - '**/lib/*/options.rb'
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
 
 # The %w might be confusing for new users
 Style/WordArray:
@@ -75,8 +79,6 @@ Style/AndOr:
 Metrics/ClassLength:
   Max: 320
 
-Metrics/CyclomaticComplexity:
-  Max: 17
 
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:
@@ -130,13 +132,6 @@ Style/PerlBackrefs:
 Style/SpaceAroundOperators:
   Exclude:
     - '**/spec/actions_specs/xcodebuild_spec.rb'
-
-Metrics/MethodLength:
-  Exclude:
-    - '**/lib/fastlane/actions/*.rb'
-    - '**/bin/fastlane'
-    - '**/lib/*/options.rb'
-  Max: 60
 
 AllCops:
   Include:

--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -14,8 +14,6 @@ module Deliver
       FastlaneCore::UpdateChecker.show_update_status('deliver', Deliver::VERSION)
     end
 
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def run
       program :version, Deliver::VERSION
       program :description, Deliver::DESCRIPTION
@@ -124,8 +122,6 @@ module Deliver
           end
         end
       end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
 
       default_command :run
 

--- a/fastlane/lib/fastlane/actions/bundle_install.rb
+++ b/fastlane/lib/fastlane/actions/bundle_install.rb
@@ -1,7 +1,6 @@
 module Fastlane
   module Actions
     class BundleInstallAction < Action
-      # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         if gemfile_exists?(params)
@@ -31,7 +30,6 @@ module Fastlane
           UI.message("No Gemfile found")
         end
       end
-      # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/PerceivedComplexity
 
       def self.gemfile_exists?(params)

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/AbcSize
 module Fastlane
   module Actions
     # Commits the current changes in the repo as a version bump, checking to make sure only files which contain version information have been changed.
@@ -153,4 +152,3 @@ module Fastlane
     end
   end
 end
-# rubocop:enable Metrics/AbcSize

--- a/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/AbcSize
 module Fastlane
   module Actions
     # Commits version bump.
@@ -155,4 +154,3 @@ module Fastlane
     end
   end
 end
-# rubocop:enable Metrics/AbcSize

--- a/fastlane/lib/fastlane/actions/oclint.rb
+++ b/fastlane/lib/fastlane/actions/oclint.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 module Fastlane
   module Actions
     module SharedValues
@@ -6,6 +5,7 @@ module Fastlane
     end
 
     class OclintAction < Action
+      # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         oclint_path = params[:oclint_path]
         if `which #{oclint_path}`.to_s.empty? and !Helper.test?
@@ -190,6 +190,7 @@ module Fastlane
                                        default_value: false)
         ]
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       def self.output
         [
@@ -207,4 +208,3 @@ module Fastlane
     end
   end
 end
-# rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/fastlane/lib/fastlane/actions/s3.rb
+++ b/fastlane/lib/fastlane/actions/s3.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/AbcSize
 require 'fastlane/erb_template_helper'
 require 'ostruct'
 
@@ -351,4 +350,3 @@ module Fastlane
     end
   end
 end
-# rubocop:enable Metrics/AbcSize

--- a/fastlane/lib/fastlane/actions/set_github_release.rb
+++ b/fastlane/lib/fastlane/actions/set_github_release.rb
@@ -1,5 +1,3 @@
-# rubocop:disable Metrics/AbcSize
-
 module Fastlane
   module Actions
     module SharedValues

--- a/fastlane/lib/fastlane/actions/update_fastlane.rb
+++ b/fastlane/lib/fastlane/actions/update_fastlane.rb
@@ -26,7 +26,6 @@ module Fastlane
         "match"
       ]
 
-      # rubocop:disable Metrics/AbcSize
       def self.run(options)
         if options[:no_update]
           return
@@ -103,7 +102,6 @@ module Fastlane
           exec "FL_NO_UPDATE=true #{$PROGRAM_NAME} #{ARGV.join ' '}"
         end
       end
-      # rubocop:enable Metrics/AbcSize
 
       def self.all_installed_tools
         Gem::Specification.select { |s| ALL_TOOLS.include? s.name }.map(&:name).uniq

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -1,5 +1,4 @@
 # coding: utf-8
-# rubocop:disable Metrics/AbcSize
 module Fastlane
   module Actions
     module SharedValues
@@ -133,4 +132,3 @@ module Fastlane
     end
   end
 end
-# rubocop:enable Metrics/AbcSize

--- a/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
+++ b/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/AbcSize
 module Fastlane
   module Actions
     module SharedValues
@@ -293,4 +292,3 @@ module Fastlane
     end
   end
 end
-# rubocop:enable Metrics/AbcSize

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -23,8 +23,6 @@ module Fastlane
       Fastlane::PluginUpdateManager.show_update_status
     end
 
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def run
       program :version, Fastlane::VERSION
       program :description, [
@@ -265,8 +263,5 @@ module Fastlane
       UI.important("Instead please submit an issue on GitHub: https://github.com/fastlane/fastlane/issues")
       UI.important("This command will be removed in one of the next releases")
     end
-
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -18,7 +18,6 @@ module Fastlane
     # @param lane_name The name of the lane to execute
     # @param platform The name of the platform to execute
     # @param parameters [Hash] The parameters passed from the command line to the lane
-    # rubocop:disable Metrics/AbcSize
     def execute(lane, platform = nil, parameters = nil)
       UI.crash!("No lane given") unless lane
 
@@ -68,7 +67,6 @@ module Fastlane
         raise ex
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     # @param filter_platform: Filter, to only show the lanes of a given platform
     # @return an array of lanes (platform lane_name) to print them out to the user

--- a/frameit/lib/frameit/offsets.rb
+++ b/frameit/lib/frameit/offsets.rb
@@ -2,7 +2,6 @@ module Frameit
   class Offsets
     # Returns the image offset needed for a certain device type for a given orientation
     # uses deliver to detect the screen size
-    # rubocop:disable Metrics/MethodLength
     def self.image_offset(screenshot)
       size = Deliver::AppScreenshot::ScreenSize
       case screenshot.orientation_name
@@ -88,6 +87,5 @@ module Frameit
         end
       end
     end
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -14,8 +14,6 @@ module Match
       FastlaneCore::UpdateChecker.show_update_status('match', Match::VERSION)
     end
 
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
     def run
       program :version, Match::VERSION
       program :description, Match::DESCRIPTION
@@ -120,7 +118,5 @@ module Match
 
       run!
     end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/pem/lib/pem/manager.rb
+++ b/pem/lib/pem/manager.rb
@@ -37,7 +37,6 @@ module PEM
         UI.message "Successfully logged in"
       end
 
-      # rubocop:disable Metrics/AbcSize
       def create_certificate
         UI.important "Creating a new push certificate for app '#{PEM.config[:app_identifier]}'."
 
@@ -81,7 +80,6 @@ module PEM
         UI.message("PEM: ".green + Pathname.new(x509_cert_path).realpath.to_s)
         return x509_cert_path
       end
-      # rubocop:enable Metrics/AbcSize
 
       def certificate
         if PEM.config[:development]

--- a/pilot/lib/pilot/commands_generator.rb
+++ b/pilot/lib/pilot/commands_generator.rb
@@ -1,5 +1,3 @@
-# rubocop:disable Metrics/MethodLength
-# rubocop:disable Metrics/AbcSize
 require "commander"
 require "pilot/options"
 require "fastlane_core"
@@ -138,5 +136,3 @@ module Pilot
     end
   end
 end
-# rubocop:enable Metrics/MethodLength
-# rubocop:enable Metrics/AbcSize

--- a/produce/lib/produce/commands_generator.rb
+++ b/produce/lib/produce/commands_generator.rb
@@ -13,8 +13,6 @@ module Produce
       FastlaneCore::UpdateChecker.show_update_status('produce', Produce::VERSION)
     end
 
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def run
       program :version, Produce::VERSION
       program :description, 'CLI for \'produce\''
@@ -126,7 +124,5 @@ module Produce
 
       run!
     end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/produce/lib/produce/service.rb
+++ b/produce/lib/produce/service.rb
@@ -39,9 +39,6 @@ module Produce
     end
 
     # rubocop:disable Metrics/PerceivedComplexity
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/AbcSize
     def update(on, app, options)
       updated = valid_services_for(options).count
 

--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -13,7 +13,6 @@ module Sigh
       FastlaneCore::UpdateChecker.show_update_status('sigh', Sigh::VERSION)
     end
 
-    # rubocop:disable Metrics/MethodLength
     def run
       program :version, Sigh::VERSION
       program :description, 'CLI for \'sigh\' - Because you would rather spend your time building stuff than fighting provisioning'
@@ -96,7 +95,6 @@ module Sigh
 
       run!
     end
-    # rubocop:enable Metrics/MethodLength
 
     def multiple_values_option_proc(command, name)
       proc do |value|

--- a/sigh/lib/sigh/local_manage.rb
+++ b/sigh/lib/sigh/local_manage.rb
@@ -41,7 +41,6 @@ module Sigh
       return command, clean_expired, clean_pattern, force
     end
 
-    # rubocop:disable Metrics/AbcSize
     def self.list_profiles
       profiles = load_profiles
 
@@ -84,7 +83,6 @@ module Sigh
 
       UI.message "You can remove all expired profiles using `sigh manage -e`" if profiles_expired.count > 0
     end
-    # rubocop:enable Metrics/AbcSize
 
     def self.profile_info(profile)
       if $verbose

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -117,7 +117,6 @@ module Sigh
     end
 
     # Certificate to use based on the current distribution mode
-    # rubocop:disable Metrics/AbcSize
     def certificate_to_use
       if profile_type == Spaceship.provisioning_profile.Development
         certificates = Spaceship.certificate.development.all
@@ -170,7 +169,6 @@ module Sigh
       return certificates if Sigh.config[:development] # development profiles support multiple certificates
       return certificates.first
     end
-    # rubocop:enable Metrics/AbcSize
 
     # Downloads and stores the provisioning profile
     def download_profile(profile)

--- a/snapshot/lib/snapshot/commands_generator.rb
+++ b/snapshot/lib/snapshot/commands_generator.rb
@@ -13,7 +13,6 @@ module Snapshot
       FastlaneCore::UpdateChecker.show_update_status('snapshot', Snapshot::VERSION)
     end
 
-    # rubocop:disable Metrics/MethodLength
     def run
       program :version, Snapshot::VERSION
       program :description, 'CLI for \'snapshot\' - Automate taking localized screenshots of your iOS app on every device'

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -9,7 +9,6 @@ module Snapshot
     # All the errors we experience while running snapshot
     attr_accessor :collected_errors
 
-    # rubocop:disable Metrics/AbcSize
     def work
       if File.exist?("./fastlane/snapshot.js") or File.exist?("./snapshot.js")
         UI.error "Found old snapshot configuration file 'snapshot.js'"
@@ -64,7 +63,6 @@ module Snapshot
         FileUtils.rm_rf(TestCommandGenerator.derived_data_path)
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     # This is its own method so that it can re-try if the tests fail randomly
     # @return true/false depending on if the tests succeded
@@ -117,7 +115,6 @@ module Snapshot
     end
 
     # Returns true if it succeded
-    # rubocop:disable Metrics/AbcSize
     def launch(language, locale, device_type, launch_arguments)
       screenshots_path = TestCommandGenerator.derived_data_path
       FileUtils.rm_rf(File.join(screenshots_path, "Logs"))
@@ -196,7 +193,6 @@ module Snapshot
 
       return Collector.fetch_screenshots(raw_output, dir_name, device_type, launch_arguments.first)
     end
-    # rubocop:enable Metrics/AbcSize
 
     def open_simulator_for_device(device_name)
       return unless ENV['FASTLANE_EXPLICIT_OPEN_SIMULATOR']

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -126,9 +126,7 @@ module Spaceship
       send_shared_login_request(user, password)
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
-    # rubocop:disable Metrics/AbcSize
     def handle_itc_response(raw)
       return unless raw
       return unless raw.kind_of? Hash
@@ -186,9 +184,7 @@ module Spaceship
 
       return data
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
-    # rubocop:enable Metrics/AbcSize
 
     #####################################################
     # @!group Applications


### PR DESCRIPTION
Disabled `Metrics/AbcSize`, `Metrics/MethodLength` and `Metrics/CyclomaticComplexity`, as it didn't change the way we write our code cc @mfurtak 
