### PR TITLE
[fastlane] latest_testflight_build_number use itc_team_id

### DIFF
--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -80,7 +80,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :team_id,
                                        env_name: "FASTLANE_TEAM_ID",
                                        description: "Your team ID if you're in multiple teams",
-                                       default_value: CredentialsManager::AppfileConfig.try_fetch_value(:team_id),
+                                       default_value: CredentialsManager::AppfileConfig.try_fetch_value(:itc_team_id),
                                        optional: true)
         ]
       end


### PR DESCRIPTION
We fetched the Dev Portal Team ID instead of the itc team id
Fixes https://github.com/fastlane/fastlane/issues/5366
