### PR TITLE
[spaceship] Handle empty screenshots and trailers

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -557,6 +557,8 @@ module Spaceship
 
       # generates the nested data structure to represent screenshots
       def setup_screenshots_for(row)
+        return [] if row.nil? || row["displayFamilies"].nil?
+
         display_families = row.fetch("displayFamilies", {}).fetch("value", nil)
         return [] unless display_families
 
@@ -628,6 +630,8 @@ module Spaceship
 
       # generates the nested data structure to represent trailers
       def setup_trailers_for(row)
+        return [] if row.nil? || row["displayFamilies"].nil?
+
         display_families = row.fetch("displayFamilies", {}).fetch("value", nil)
         return [] unless display_families
 


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/5701
Fixes https://github.com/fastlane/fastlane/pull/5702

Hey @olegoid, since I can't reproduce, could you help me test the following PR locally https://github.com/fastlane/fastlane/pull/5741

```
git fetch origin
git checkout -b handle-empty-screenshots-and-trailers origin/handle-empty-screenshots-and-trailers
```

And then install spaceship locally using

```
bundle update
rake install
```

and try running spaceship again 👍 
