### PR TITLE
Fixed Scan `destination` parameter

### DIFF
--- a/fastlane/lib/fastlane/actions/scan.rb
+++ b/fastlane/lib/fastlane/actions/scan.rb
@@ -10,14 +10,15 @@ module Fastlane
         require 'scan'
 
         begin
+          destination = values[:destination] # save destination value which can be later overridden
           Scan.config = values # we set this here to auto-detect missing values, which we need later on
           unless values[:derived_data_path].to_s.empty?
             plist_files_before = Dir["#{values[:derived_data_path]}/**/Logs/Test/*TestSummaries.plist"]
-            Scan.config[:destination] = nil # we have to do this, as otherwise a warning is shown to the user to not set this value
           end
 
           FastlaneCore::UpdateChecker.start_looking_for_update('scan') unless Helper.is_test?
 
+          values[:destination] = destination # restore destination value
           Scan::Manager.new.work(values)
 
           return true


### PR DESCRIPTION
Bug was described in task #5731.

Destination parameter, provided in the `Fastfile`, was always removed by [line](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/scan.rb#L16):

```
Scan.config[:destination] = nil # we have to do this, as otherwise a warning is shown to the user to not set this value
```

My suggestion is to save `values[:destination]` and restore it just before running Scan action instead of setting it always to `nil`.
