### PR TITLE
[ready for review] [scan] Refactor matching simulator devices for `device` flags and defaults.

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -39,103 +39,112 @@ module Scan
       Scan.config[:derived_data_path] = default_path
     end
 
-    def self.filter_simulators(simulators, deployment_target)
-      # Filter out any simulators that are not the same major and minor version of our deployment target
+    def self.filter_simulators(simulators, operator = :greater_than_or_equal, deployment_target)
       deployment_target_version = Gem::Version.new(deployment_target)
       simulators.select do |s|
-        sim_version = Gem::Version.new(s.ios_version)
-        (sim_version >= deployment_target_version)
+        sim_version = Gem::Version.new(s.os_version)
+        if operator == :greater_than_or_equal
+          sim_version >= deployment_target_version
+        elsif operator == :equal
+          sim_version == deployment_target_version
+        else
+          false # fail gracefully, I guess?
+        end
       end
+    end
+
+    def self.regular_expression_for_split_on_whitespace_followed_by_parenthesized_version
+      # %r{
+      #   \s # a whitespace character
+      #   (?= # followed by -- using lookahead
+      #   \( # open parenthesis
+      #   [\d\.]+ # our version -- one or more digits or full stops
+      #   \) # close parenthesis
+      #   $ # end of line
+      #   ) # end of lookahead
+      # }
+      /\s(?=\([\d\.]+\)$)/
     end
 
     def self.default_device_ios
-      devices = Scan.config[:devices] || Array(Scan.config[:device]) # important to use Array(nil) for when the value is nil
-      found_devices = []
-      xcode_target = Scan.project.build_settings(key: "IPHONEOS_DEPLOYMENT_TARGET")
-
-      if devices.any?
-        # Optionally, we only do this if the user specified a custom device or an array of devices
-        devices.each do |device|
-          lookup_device = device.to_s.strip
-          has_version = lookup_device.include?(xcode_target) || lookup_device.include?('(')
-          lookup_device = lookup_device.tr('()', '') # Remove parenthesis
-          # Default to Xcode target version if no device version is specified.
-          lookup_device = lookup_device + " " + xcode_target unless has_version
-
-          found = FastlaneCore::Simulator.all.detect do |d|
-            (d.name + " " + d.ios_version).include? lookup_device
-          end
-
-          if found
-            found_devices.push(found)
-          else
-            UI.error("Ignoring '#{device}', couldn't find matching simulator")
-          end
-        end
-
-        if found_devices.any?
-          Scan.devices = found_devices
-          return
-        else
-          UI.error("Couldn't find any matching simulators for '#{devices}' - falling back to default simulator")
-        end
-      end
-
-      sims = FastlaneCore::Simulator.all
-      sims = filter_simulators(sims, xcode_target)
-
-      # An iPhone 5s is reasonable small and useful for tests
-      found = sims.detect { |d| d.name == "iPhone 5s" }
-      found ||= sims.first # anything is better than nothing
-
-      if found
-        Scan.devices = [found]
-      else
-        UI.user_error!("No simulators found on local machine")
-      end
+      # An iPhone 5s is a reasonably small and useful default for tests
+      default_device('iOS', 'IPHONEOS_DEPLOYMENT_TARGET', 'iPhone 5s', nil)
     end
 
     def self.default_device_tvos
+      default_device('tvOS', 'TVOS_DEPLOYMENT_TARGET', 'Apple TV 1080p', 'TV')
+    end
+
+    def self.default_device(requested_os_type, deployment_target_key, default_device_name, simulator_type_descriptor)
+      require 'set'
       devices = Scan.config[:devices] || Array(Scan.config[:device]) # important to use Array(nil) for when the value is nil
-      found_devices = []
 
-      if devices.any?
-        # Optionally, we only do this if the user specified a custom device or an array of devices
-        devices.each do |device|
-          lookup_device = device.to_s.strip.tr('()', '') # Remove parenthesis
+      deployment_target_version = Scan.project.build_settings(key: deployment_target_key)
 
-          found = FastlaneCore::SimulatorTV.all.detect do |d|
-            (d.name + " " + d.os_version).include? lookup_device
-          end
+      simulators = filter_simulators(
+        FastlaneCore::DeviceManager.simulators(requested_os_type).tap do |array|
+          UI.user_error!(
+            ['No', simulator_type_descriptor, 'simulators found on local machine'].reject(&:nil?).join(' ')
+          ) if array.empty?
+        end,
+        :greater_than_or_equal,
+        deployment_target_version
+      ).tap do |sims|
+        UI.error("No simulators found that are greater than or equal to the version " \
+        "of deployment target (#{deployment_target_version})") if sims.empty?
+      end
 
-          if found
-            found_devices.push(found)
-          else
-            UI.error("Ignoring '#{device}', couldn't find matching simulator")
+      matches = lambda do
+        set_of_simulators = devices.inject(
+          Set.new # of simulators
+        ) do |set, device_string|
+          pieces = device_string.split(regular_expression_for_split_on_whitespace_followed_by_parenthesized_version)
+
+          selector = ->(sim) { pieces.count > 0 && sim.name == pieces.first }
+
+          set + (
+            if pieces.count == 0
+              [] # empty array
+            elsif pieces.count == 1
+              simulators
+                .select(&selector)
+                .reverse # more efficient, because `simctl` prints higher versions first
+                .sort_by! { |sim| Gem::Version.new(sim.os_version) }
+                .pop(1)
+            else # pieces.count == 2 -- mathematically, because of the 'end of line' part of our regular expression
+              version = pieces[1].tr('()', '')
+              potential_emptiness_error = lambda do |sims|
+                UI.error("No simulators found that are equal to the version " \
+                "of specifier (#{version}) and greater than or equal to the version " \
+                "of deployment target (#{deployment_target_version})") if sims.empty?
+              end
+              filter_simulators(simulators, :equal, version).tap(&potential_emptiness_error).select(&selector)
+            end
+          ).tap do |array|
+            UI.error("Ignoring '#{device_string}', couldn’t find matching simulator") if array.empty?
           end
         end
 
-        if found_devices.any?
-          Scan.devices = found_devices
-          return
-        else
-          UI.error("Couldn't find any matching simulators for '#{devices}' - falling back to default simulator")
-        end
+        set_of_simulators.to_a
       end
 
-      sims = FastlaneCore::SimulatorTV.all
-      xcode_target = Scan.project.build_settings(key: "TVOS_DEPLOYMENT_TARGET")
-      sims = filter_simulators(sims, xcode_target)
+      default = lambda do
+        UI.error("Couldn't find any matching simulators for '#{devices}' - falling back to default simulator")
 
-      # Apple TV 1080p is useful for tests
-      found = sims.detect { |d| d.name == "Apple TV 1080p" }
-      found ||= sims.first # anything is better than nothing
-
-      if found
-        Scan.devices = [found]
-      else
-        UI.user_error!("No TV simulators found on the local machine")
+        Array(
+          simulators
+            .select { |sim| sim.name == default_device_name }
+            .reverse # more efficient, because `simctl` prints higher versions first
+            .sort_by! { |sim| Gem::Version.new(sim.os_version) }
+            .last || simulators.first
+        )
       end
+
+      # grab the first unempty evaluated array
+      Scan.devices = [matches, default].lazy.map { |x|
+        arr = x.call
+        arr unless arr.empty?
+      }.reject(&:nil?).first
     end
 
     def self.min_xcode8?

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -130,13 +130,15 @@ module Scan
 
       default = lambda do
         UI.error("Couldn't find any matching simulators for '#{devices}' - falling back to default simulator")
+
         Array(
-          simulators.detect { |d| d.name == default_device_name } || simulators.first
-        ).tap do |array|
-          UI.user_error!(
-            ['No', simulator_type_descriptor, 'simulators found on local machine'].reject(&:nil?).join(' ')
-          ) if array.empty?
-        end
+          simulators
+            .select { |sim| sim.name == default_device_name }
+            .reverse # more efficient, because `simctl` prints higher versions first
+            .sort_by! { |sim| Gem::Version.new(sim.os_version) }
+            .last
+            || simulators.first
+        )
       end
 
       # grab the first unempty evaluated array

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -136,8 +136,7 @@ module Scan
             .select { |sim| sim.name == default_device_name }
             .reverse # more efficient, because `simctl` prints higher versions first
             .sort_by! { |sim| Gem::Version.new(sim.os_version) }
-            .last
-            || simulators.first
+            .last || simulators.first
         )
       end
 

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -90,7 +90,7 @@ module Scan
         :greater_than_or_equal,
         deployment_target_version
       ).tap do |sims|
-        UI.error("No simulators found that are greater than or equal to the version " +
+        UI.error("No simulators found that are greater than or equal to the version " \
         "of deployment target (#{deployment_target_version})") if sims.empty?
       end
 
@@ -113,11 +113,11 @@ module Scan
                 .pop(1)
             else # pieces.count == 2 -- mathematically, because of the 'end of line' part of our regular expression
               version = pieces[1].tr('()', '')
-              potential_emptiness_error = ->(sims) {
-                UI.error("No simulators found that are equal to the version " +
-                "of specifier (#{version}) and greater than or equal to the version " +
+              potential_emptiness_error = lambda do |sims|
+                UI.error("No simulators found that are equal to the version " \
+                "of specifier (#{version}) and greater than or equal to the version " \
                 "of deployment target (#{deployment_target_version})") if sims.empty?
-              }
+              end
               filter_simulators(simulators, :equal, version).tap(&potential_emptiness_error).select(&selector)
             end
           ).tap do |array|

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -51,9 +51,9 @@ module Scan
     def self.regular_expression_for_split_on_whitespace_followed_by_parenthesized_version
       # %r{
       #   \s # a whitespace character
-      #   (?= # followed by — using lookahead
+      #   (?= # followed by -- using lookahead
       #   \( # open parenthesis
-      #   [\d\.]+ # our version — one or more digits or full stops
+      #   [\d\.]+ # our version -- one or more digits or full stops
       #   \) # close parenthesis
       #   $ # end of line
       #   ) # end of lookahead
@@ -91,7 +91,7 @@ module Scan
               [] # empty array
             elsif pieces.count == 1
               simulators
-            else # pieces.count == 2 — mathematically, because of the ‘end of line’ part of our regular expression
+            else # pieces.count == 2 -- mathematically, because of the 'end of line' part of our regular expression
               filter_simulators(simulators, pieces[1].tr('()', ''))
             end
           ).select { |sim|

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -62,7 +62,7 @@ module Scan
 
     def self.default_device_ios
       # An iPhone 5s is a reasonably small and useful default for tests
-      default_device('iOS', 'IPHONEOS_DEPLOYMENT_TARGET', 'iPhone 5s')
+      default_device('iOS', 'IPHONEOS_DEPLOYMENT_TARGET', 'iPhone 5s', nil)
     end
 
     def self.default_device_tvos

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -49,15 +49,16 @@ module Scan
     end
 
     def self.regular_expression_for_split_on_whitespace_followed_by_parenthesized_version
-      %r{
-        \s # a whitespace character
-        (?= # followed by — using lookahead
-        \( # open parenthesis
-        [\d\.]+ # our version — one or more digits or full stops
-        \) # close parenthesis
-        $ # end of line
-        ) # end of lookahead
-      }
+      # %r{
+      #   \s # a whitespace character
+      #   (?= # followed by — using lookahead
+      #   \( # open parenthesis
+      #   [\d\.]+ # our version — one or more digits or full stops
+      #   \) # close parenthesis
+      #   $ # end of line
+      #   ) # end of lookahead
+      # }
+      /\s(?=\([\d\.]+\)$)/
     end
 
     def self.default_device_ios

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -93,8 +93,9 @@ module Scan
             else # pieces.count == 2 — mathematically, because of the ‘end of line’ part of our regular expression
               filter_simulators(simulators, pieces[1].tr('()', ''))
             end
-          ).select { |sim| sim.name == pieces.first }
-          .tap { |array| UI.error("Ignoring '#{device_string}', couldn’t find matching simulator") if array.empty? }
+          ).select { |sim|
+            pieces.count > 0 && sim.name == pieces.first
+          }.tap { |array| UI.error("Ignoring '#{device_string}', couldn’t find matching simulator") if array.empty? }
         }.to_a
       end
 

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -103,11 +103,11 @@ module Scan
         UI.error("Couldn't find any matching simulators for '#{devices}' - falling back to default simulator")
         Array(
           simulators.detect { |d| d.name == default_device_name } || simulators.first
-        ).tap { |array|
+        ).tap do |array|
           UI.user_error!(
             ['No', simulator_type_descriptor, 'simulators found on local machine'].reject(&:nil?).join(' ')
           ) if array.empty?
-        }
+        end
       end
 
       # grab the first unempty evaluated array

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -85,9 +85,9 @@ module Scan
           Set.new # of simulators
         ) do |set, device_string|
           pieces = device_string.split(regular_expression_for_split_on_whitespace_followed_by_parenthesized_version)
-          
-          selector = lambda { |sim| pieces.count > 0 && sim.name == pieces.first }
-          
+
+          selector = ->(sim) { pieces.count > 0 && sim.name == pieces.first }
+
           set + (
             if pieces.count == 0
               [] # empty array
@@ -100,7 +100,7 @@ module Scan
             UI.error("Ignoring '#{device_string}', couldn’t find matching simulator") if array.empty?
           end
         end
-        
+
         set_of_simulators.to_a
       end
 

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -81,8 +81,8 @@ module Scan
       matches = lambda do
         devices = Scan.config[:devices] || Array(Scan.config[:device]) # important to use Array(nil) for when the value is nil
 
-        devices.reduce(
-          Set.new() # of simulators
+        devices.inject(
+          Set.new # of simulators
         ) { |set, device_string|
           pieces = device_string.split(regular_expression_for_split_on_whitespace_followed_by_parenthesized_version)
 

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -86,7 +86,7 @@ module Scan
         ) { |set, device_string|
           pieces = device_string.split(regular_expression_for_split_on_whitespace_followed_by_parenthesized_version)
 
-          set += (
+          set + (
             if pieces.count == 0
               [] # empty array
             elsif pieces.count == 1

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -111,10 +111,10 @@ module Scan
       end
 
       # grab the first unempty evaluated array
-      Scan.devices = [matches, default].lazy.flat_map { |x|
+      Scan.devices = [matches, default].lazy.map { |x|
         arr = x.call
         arr unless arr.empty?
-      }.first
+      }.reject(&:nil?).first
     end
 
     def self.min_xcode8?

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -48,6 +48,18 @@ module Scan
       end
     end
 
+    def self.regular_expression_for_split_on_whitespace_followed_by_parenthesized_version
+      %r{
+        \s # a whitespace character
+        (?= # followed by — using lookahead
+        \( # open parenthesis
+        [\d\.]+ # our version — one or more digits or full stops
+        \) # close parenthesis
+        $ # end of line
+        ) # end of lookahead
+      }
+    end
+
     def self.default_device_ios
       # An iPhone 5s is a reasonably small and useful default for tests
       default_device('iOS', 'IPHONEOS_DEPLOYMENT_TARGET', 'iPhone 5s')
@@ -59,17 +71,6 @@ module Scan
 
     def self.default_device(requested_os_type, deployment_target_key, default_device_name, simulator_type_descriptor)
       require 'set'
-      def regular_expression_for_split_on_whitespace_followed_by_parenthesized_version
-        %r{
-          \s # a whitespace character
-          (?= # followed by — using lookahead
-          \( # open parenthesis
-          [\d\.]+ # our version — one or more digits or full stops
-          \) # close parenthesis
-          $ # end of line
-          ) # end of lookahead
-        }
-      end
 
       # Select only simulators that are greater than or equal to the version of our deployment target
       simulators = filter_simulators(

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -71,6 +71,7 @@ module Scan
 
     def self.default_device(requested_os_type, deployment_target_key, default_device_name, simulator_type_descriptor)
       require 'set'
+      devices = Scan.config[:devices] || Array(Scan.config[:device]) # important to use Array(nil) for when the value is nil
 
       # Select only simulators that are greater than or equal to the version of our deployment target
       simulators = filter_simulators(
@@ -79,8 +80,6 @@ module Scan
       )
 
       matches = lambda do
-        devices = Scan.config[:devices] || Array(Scan.config[:device]) # important to use Array(nil) for when the value is nil
-
         devices.inject(
           Set.new # of simulators
         ) { |set, device_string|

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -112,7 +112,7 @@ module Scan
 
       # grab the first unempty evaluated array
       Scan.devices = [matches, default].lazy.flat_map { |x|
-        arr = x.call()
+        arr = x.call
         arr unless arr.empty?
       }.first
     end

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -117,49 +117,6 @@ module Scan
       }.first
     end
 
-    def self.default_device_tvos
-      devices = Scan.config[:devices] || Array(Scan.config[:device]) # important to use Array(nil) for when the value is nil
-      found_devices = []
-
-      if devices.any?
-        # Optionally, we only do this if the user specified a custom device or an array of devices
-        devices.each do |device|
-          lookup_device = device.to_s.strip.tr('()', '') # Remove parenthesis
-
-          found = FastlaneCore::SimulatorTV.all.detect do |d|
-            (d.name + " " + d.os_version).include? lookup_device
-          end
-
-          if found
-            found_devices.push(found)
-          else
-            UI.error("Ignoring '#{device}', couldn't find matching simulator")
-          end
-        end
-
-        if found_devices.any?
-          Scan.devices = found_devices
-          return
-        else
-          UI.error("Couldn't find any matching simulators for '#{devices}' - falling back to default simulator")
-        end
-      end
-
-      sims = FastlaneCore::SimulatorTV.all
-      xcode_target = Scan.project.build_settings(key: "TVOS_DEPLOYMENT_TARGET")
-      sims = filter_simulators(sims, xcode_target)
-
-      # Apple TV 1080p is useful for tests
-      found = sims.detect { |d| d.name == "Apple TV 1080p" }
-      found ||= sims.first # anything is better than nothing
-
-      if found
-        Scan.devices = [found]
-      else
-        UI.user_error!("No TV simulators found on the local machine")
-      end
-    end
-
     def self.min_xcode8?
       Helper.xcode_version.split(".").first.to_i >= 8
     end

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -7,6 +7,19 @@ describe Scan do
 
   before(:each) do
     @valid_simulators = "== Devices ==
+-- iOS 10.0 --
+    iPhone 5 (5FF87891-D7CB-4C65-9F88-701A471223A9) (Shutdown)
+    iPhone 5s (E697990C-3A83-4C01-83D1-C367011B31EE) (Shutdown)
+    iPhone 6 (A35509F5-78A4-4B7D-B199-0F1244A5A7FC) (Shutdown)
+    iPhone 6 Plus (F8E78DE1-F715-46BE-B9FD-4909CC45C05F) (Shutdown)
+    iPhone 6s (021A465B-A294-4D9E-AD07-6BDC8E186343) (Shutdown)
+    iPhone 6s Plus (1891208D-477A-4399-83BE-7D57B176A32B) (Shutdown)
+    iPhone SE (B3D411C0-7FC4-4248-BEB8-7B09668023C8) (Shutdown)
+    iPad Retina (07773A11-417D-4D4C-BC25-1C3444D50836) (Shutdown)
+    iPad Air (2ABEAF08-E480-4617-894F-6BAB587E7963) (Shutdown)
+    iPad Air 2 (DA6C7D10-564B-4563-884D-834EF4F10FB9) (Shutdown)
+    iPad Pro (9.7 inch) (C051C63B-EDF7-4871-860A-BF975B517E94) (Shutdown)
+    iPad Pro (12.9 inch) (EED6BFB4-5DD9-48AB-8573-5172EF6F2A93) (Shutdown)
 -- iOS 9.3 --
     iPhone 4s (238767C4-AF29-4485-878C-7011B98DCB87) (Shutdown)
     iPhone 5 (B8E05CCB-B97A-41FC-A8A8-2771711690B5) (Shutdown)
@@ -20,6 +33,25 @@ describe Scan do
     iPad Air (DD134998-177F-47DA-99FA-D549D9305476) (Shutdown)
     iPad Air 2 (9B54C167-21A9-4AD7-97D4-21F2F1D7EAAF) (Shutdown)
     iPad Pro (61EEEF5C-EA64-47EF-9EED-3075E983FBCD) (Shutdown)
+-- iOS 9.0 --
+    iPhone 4s (88975B7F-DE3C-4680-8653-F4212E389E35) (Shutdown)
+    iPhone 5 (9905A018-9DC9-4DD8-BA14-B0B000CC8622) (Shutdown)
+    iPhone 5s (FD90588B-1020-45C5-8EE9-C5CF89A26A22) (Shutdown)
+    iPhone 6 (9A224332-DF90-4A30-BB7B-D0ABFE2A658F) (Shutdown)
+    iPhone 6 Plus (B12E4F8A-00DF-4DFA-AF0F-FCAD6C16CBDE) (Shutdown)
+    iPad 2 (A9B8647B-1C6C-41D5-8B51-B2D0A7FD4549) (Shutdown)
+    iPad Retina (39EAB2A5-FBF8-417C-9578-4C47125E6658) (Shutdown)
+    iPad Air (1D37AF01-FA0A-485A-86CD-A5F26845C528) (Shutdown)
+    iPad Air 2 (90FF95A9-CB0E-4670-B9C4-A9BC6500F4EA) (Shutdown)
+-- iOS 8.4 --
+    iPhone 4s (16764BF6-4E85-42CE-9C1E-E5B0185B49BD) (Shutdown)
+    iPhone 5 (6636AA80-6030-468A-8650-479A1A11899A) (Shutdown)
+    iPhone 5s (5E15A2AC-2787-4C8D-8FBA-DF09FD216326) (Shutdown)
+    iPhone 6 (9842E17B-F831-4CEE-BF7A-90EC14A346B7) (Shutdown)
+    iPhone 6 Plus (6B638BF3-773A-4604-BB4A-75C33138C371) (Shutdown)
+    iPad 2 (D15D74A7-338D-4CCC-9FE4-158917220903) (Shutdown)
+    iPad Retina (3482DB34-48FE-4166-9C85-C30042E82DFE) (Shutdown)
+    iPad Air (CF1146F7-9C3C-490A-B41C-38D0674333E6) (Shutdown)
 -- tvOS 9.2 --
     Apple TV 1080p (83C3BAF8-54AD-4403-A688-D0B6E58020AF) (Shutdown)
 -- watchOS 2.2 --
@@ -59,7 +91,7 @@ describe Scan do
                                      "-scheme app",
                                      "-project ./examples/standard/app.xcodeproj",
                                      "-sdk '9.0'",
-                                     "-destination 'platform=iOS Simulator,id=F48E1168-110C-4EC6-805C-6B03A03CAC2D'",
+                                     "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                      "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                      "DEBUG=1 BUNDLE_NAME=Example\\ App",
                                      :build,
@@ -90,7 +122,7 @@ describe Scan do
                                        "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./examples/standard/app.xcodeproj",
-                                       "-destination 'platform=iOS Simulator,id=F48E1168-110C-4EC6-805C-6B03A03CAC2D'",
+                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
                                        :test
@@ -136,7 +168,7 @@ describe Scan do
                                        "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./examples/standard/app.xcodeproj",
-                                       "-destination 'platform=iOS Simulator,id=F48E1168-110C-4EC6-805C-6B03A03CAC2D'",
+                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '/tmp/my/derived_data'",
                                        :build,
                                        :test
@@ -157,13 +189,39 @@ describe Scan do
                                        "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./examples/standard/app.xcodeproj",
-                                       "-destination 'platform=iOS Simulator,id=F48E1168-110C-4EC6-805C-6B03A03CAC2D'",
+                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        "-resultBundlePath './fastlane/test_output/app.test_result'",
                                        :build,
                                        :test
                                      ])
       end
+    end
+
+    it "uses a device without version specifier" do
+      options = { project: "./examples/standard/app.xcodeproj", device: "iPhone 6s" }
+      Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+      result = Scan::TestCommandGenerator.generate
+      expect(result).to start_with([
+                                     "set -o pipefail &&",
+                                     "env NSUnbufferedIO=YES xcodebuild",
+                                     "-scheme app",
+                                     "-project ./examples/standard/app.xcodeproj",
+                                     # expect the single highest versioned iOS simulator device available with matching name
+                                     "-destination 'platform=iOS Simulator,id=021A465B-A294-4D9E-AD07-6BDC8E186343'",
+                                     "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                     :build,
+                                     :test
+                                   ])
+    end
+
+    it "rejects devices with versions below deployment target" do
+      options = { project: "./examples/standard/app.xcodeproj", device: "iPhone 5 (8.4)" }
+      Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+      result = Scan::TestCommandGenerator.generate
+      # FIXME: expect UI error starting "No simulators found that are equal to the version of specifier"
     end
 
     describe "Multiple devices example" do
@@ -203,6 +261,26 @@ describe Scan do
                                        "-project ./examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=70E1E92F-A292-4980-BC3C-7770C5EEFCFD' " \
                                        "-destination 'platform=iOS Simulator,id=DD134998-177F-47DA-99FA-D549D9305476'",
+                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       :build,
+                                       :test
+                                     ])
+      end
+
+      it "de-duplicates devices matching same simulator" do
+        options = { project: "./examples/standard/app.xcodeproj", devices: [
+          "iPhone 5 (9.0)",
+          "iPhone 5 (9.0.0)"
+        ] }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = Scan::TestCommandGenerator.generate
+        expect(result).to start_with([
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "-scheme app",
+                                       "-project ./examples/standard/app.xcodeproj",
+                                       "-destination 'platform=iOS Simulator,id=9905A018-9DC9-4DD8-BA14-B0B000CC8622'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
                                        :test

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -7,19 +7,6 @@ describe Scan do
 
   before(:each) do
     @valid_simulators = "== Devices ==
--- iOS 10.0 --
-    iPhone 5 (5FF87891-D7CB-4C65-9F88-701A471223A9) (Shutdown)
-    iPhone 5s (E697990C-3A83-4C01-83D1-C367011B31EE) (Shutdown)
-    iPhone 6 (A35509F5-78A4-4B7D-B199-0F1244A5A7FC) (Shutdown)
-    iPhone 6 Plus (F8E78DE1-F715-46BE-B9FD-4909CC45C05F) (Shutdown)
-    iPhone 6s (021A465B-A294-4D9E-AD07-6BDC8E186343) (Shutdown)
-    iPhone 6s Plus (1891208D-477A-4399-83BE-7D57B176A32B) (Shutdown)
-    iPhone SE (B3D411C0-7FC4-4248-BEB8-7B09668023C8) (Shutdown)
-    iPad Retina (07773A11-417D-4D4C-BC25-1C3444D50836) (Shutdown)
-    iPad Air (2ABEAF08-E480-4617-894F-6BAB587E7963) (Shutdown)
-    iPad Air 2 (DA6C7D10-564B-4563-884D-834EF4F10FB9) (Shutdown)
-    iPad Pro (9.7 inch) (C051C63B-EDF7-4871-860A-BF975B517E94) (Shutdown)
-    iPad Pro (12.9 inch) (EED6BFB4-5DD9-48AB-8573-5172EF6F2A93) (Shutdown)
 -- iOS 9.3 --
     iPhone 4s (238767C4-AF29-4485-878C-7011B98DCB87) (Shutdown)
     iPhone 5 (B8E05CCB-B97A-41FC-A8A8-2771711690B5) (Shutdown)
@@ -33,25 +20,6 @@ describe Scan do
     iPad Air (DD134998-177F-47DA-99FA-D549D9305476) (Shutdown)
     iPad Air 2 (9B54C167-21A9-4AD7-97D4-21F2F1D7EAAF) (Shutdown)
     iPad Pro (61EEEF5C-EA64-47EF-9EED-3075E983FBCD) (Shutdown)
--- iOS 9.0 --
-    iPhone 4s (88975B7F-DE3C-4680-8653-F4212E389E35) (Shutdown)
-    iPhone 5 (9905A018-9DC9-4DD8-BA14-B0B000CC8622) (Shutdown)
-    iPhone 5s (FD90588B-1020-45C5-8EE9-C5CF89A26A22) (Shutdown)
-    iPhone 6 (9A224332-DF90-4A30-BB7B-D0ABFE2A658F) (Shutdown)
-    iPhone 6 Plus (B12E4F8A-00DF-4DFA-AF0F-FCAD6C16CBDE) (Shutdown)
-    iPad 2 (A9B8647B-1C6C-41D5-8B51-B2D0A7FD4549) (Shutdown)
-    iPad Retina (39EAB2A5-FBF8-417C-9578-4C47125E6658) (Shutdown)
-    iPad Air (1D37AF01-FA0A-485A-86CD-A5F26845C528) (Shutdown)
-    iPad Air 2 (90FF95A9-CB0E-4670-B9C4-A9BC6500F4EA) (Shutdown)
--- iOS 8.4 --
-    iPhone 4s (16764BF6-4E85-42CE-9C1E-E5B0185B49BD) (Shutdown)
-    iPhone 5 (6636AA80-6030-468A-8650-479A1A11899A) (Shutdown)
-    iPhone 5s (5E15A2AC-2787-4C8D-8FBA-DF09FD216326) (Shutdown)
-    iPhone 6 (9842E17B-F831-4CEE-BF7A-90EC14A346B7) (Shutdown)
-    iPhone 6 Plus (6B638BF3-773A-4604-BB4A-75C33138C371) (Shutdown)
-    iPad 2 (D15D74A7-338D-4CCC-9FE4-158917220903) (Shutdown)
-    iPad Retina (3482DB34-48FE-4166-9C85-C30042E82DFE) (Shutdown)
-    iPad Air (CF1146F7-9C3C-490A-B41C-38D0674333E6) (Shutdown)
 -- tvOS 9.2 --
     Apple TV 1080p (83C3BAF8-54AD-4403-A688-D0B6E58020AF) (Shutdown)
 -- watchOS 2.2 --
@@ -91,7 +59,7 @@ describe Scan do
                                      "-scheme app",
                                      "-project ./examples/standard/app.xcodeproj",
                                      "-sdk '9.0'",
-                                     "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                     "-destination 'platform=iOS Simulator,id=F48E1168-110C-4EC6-805C-6B03A03CAC2D'",
                                      "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                      "DEBUG=1 BUNDLE_NAME=Example\\ App",
                                      :build,
@@ -122,7 +90,7 @@ describe Scan do
                                        "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./examples/standard/app.xcodeproj",
-                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                       "-destination 'platform=iOS Simulator,id=F48E1168-110C-4EC6-805C-6B03A03CAC2D'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
                                        :test
@@ -168,7 +136,7 @@ describe Scan do
                                        "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./examples/standard/app.xcodeproj",
-                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                       "-destination 'platform=iOS Simulator,id=F48E1168-110C-4EC6-805C-6B03A03CAC2D'",
                                        "-derivedDataPath '/tmp/my/derived_data'",
                                        :build,
                                        :test
@@ -189,39 +157,13 @@ describe Scan do
                                        "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./examples/standard/app.xcodeproj",
-                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                       "-destination 'platform=iOS Simulator,id=F48E1168-110C-4EC6-805C-6B03A03CAC2D'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        "-resultBundlePath './fastlane/test_output/app.test_result'",
                                        :build,
                                        :test
                                      ])
       end
-    end
-
-    it "uses a device without version specifier" do
-      options = { project: "./examples/standard/app.xcodeproj", device: "iPhone 6s" }
-      Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
-
-      result = Scan::TestCommandGenerator.generate
-      expect(result).to start_with([
-                                     "set -o pipefail &&",
-                                     "env NSUnbufferedIO=YES xcodebuild",
-                                     "-scheme app",
-                                     "-project ./examples/standard/app.xcodeproj",
-                                     # expect the single highest versioned iOS simulator device available with matching name
-                                     "-destination 'platform=iOS Simulator,id=021A465B-A294-4D9E-AD07-6BDC8E186343'",
-                                     "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                     :build,
-                                     :test
-                                   ])
-    end
-
-    it "rejects devices with versions below deployment target" do
-      options = { project: "./examples/standard/app.xcodeproj", device: "iPhone 5 (8.4)" }
-      Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
-
-      result = Scan::TestCommandGenerator.generate
-      # FIXME: expect UI error starting "No simulators found that are equal to the version of specifier"
     end
 
     describe "Multiple devices example" do
@@ -261,26 +203,6 @@ describe Scan do
                                        "-project ./examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=70E1E92F-A292-4980-BC3C-7770C5EEFCFD' " \
                                        "-destination 'platform=iOS Simulator,id=DD134998-177F-47DA-99FA-D549D9305476'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                       :build,
-                                       :test
-                                     ])
-      end
-
-      it "de-duplicates devices matching same simulator" do
-        options = { project: "./examples/standard/app.xcodeproj", devices: [
-          "iPhone 5 (9.0)",
-          "iPhone 5 (9.0.0)"
-        ] }
-        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
-
-        result = Scan::TestCommandGenerator.generate
-        expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
-                                       "-scheme app",
-                                       "-project ./examples/standard/app.xcodeproj",
-                                       "-destination 'platform=iOS Simulator,id=9905A018-9DC9-4DD8-BA14-B0B000CC8622'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
                                        :test


### PR DESCRIPTION
- Replace untrue comment on `filter_simulators` to reflect function behavior.
- Match only simulators with versions ‘that are greater than or equal to the version of our deployment target.’
- Be less naïve with striping parentheses. Only match versions at end of line.
- Unify logic for iOS and tvOS.

Fixes #5742.
