### PR TITLE
[snapshot] remove encoding from screenshot names

### DIFF
--- a/snapshot/lib/snapshot/page.html.erb
+++ b/snapshot/lib/snapshot/page.html.erb
@@ -147,7 +147,7 @@
             imageDisplay.dataset.counter = img.dataset.counter;
             
             imageInfo.innerHTML          = '<h3>'+img.alt+'</h3>';
-            imageInfo.innerHTML         += img.src.split("/").pop();
+            imageInfo.innerHTML         += decodeURI(img.src.split("/").pop());
             imageInfo.innerHTML         += '<br />'+tmpImg.height+'&times;'+tmpImg.width+'px';
                     
             overlay.style.display        = "block";


### PR DESCRIPTION
The image name displayed when expanding a screenshot should not be
percent encoded when displayed to the user.

Before: iPhone6-1%20First%20Screen.png
After:  iPhone6-1 First Screen.png

Example:
![screen shot 2016-08-16 at 8 06 06 am](https://cloud.githubusercontent.com/assets/619602/17698453/4e7700b0-6389-11e6-92de-5285e42699ed.png)
