### PR TITLE
Improve junit template reference style

### DIFF
--- a/fastlane/lib/fastlane/junit_generator.rb
+++ b/fastlane/lib/fastlane/junit_generator.rb
@@ -9,7 +9,7 @@ module Fastlane
       path = File.join(containing_folder, 'report.xml')
 
       @steps = results
-      xml_path = File.join(Helper.gem_path("fastlane"), "lib/assets/report_template.xml.erb")
+      xml_path = File.expand_path("../../assets/report_template.xml.erb", __FILE__)
       xml = ERB.new(File.read(xml_path)).result(binding) # http://www.rrn.dk/rubys-erb-templating-system
 
       xml = xml.gsub('system_', 'system-').delete("\e") # Jenkins can not parse 'ESC' symbol


### PR DESCRIPTION
The previous style would return './' for the starting location if the fastlane gem was not installed. When running fastlane relative to another project directory in that scenario, that value does not work.

The change uses what I believe to be the more common Ruby style for referencing needed files at a relative path.
