### PR TITLE
Add a flag dry_run flag to lane generated by init beta

### DIFF
--- a/fastlane/lib/fastlane/setup/crashlytics_beta.rb
+++ b/fastlane/lib/fastlane/setup/crashlytics_beta.rb
@@ -50,23 +50,25 @@ module Fastlane
         crashlytics_path_arg = "\n         crashlytics_path: '#{@beta_info.crashlytics_path}',"
       end
 
-      groups = @beta_info.groups if @beta_info.groups_valid?
-      unless groups
-        groups = ['group_alias_1', 'group_alias_2']
-      end
+      beta_info_groups = @beta_info.groups_valid? ? "['#{@beta_info.groups.join("', '")}']" : "nil"
+      beta_info_emails = @beta_info.emails_valid? ? "['#{@beta_info.emails.join("', '")}']" : "nil"
 
 # rubocop:disable Style/IndentationConsistency
 %{  #
   # Learn more here: https://github.com/fastlane/setups/blob/master/samples-ios/distribute-beta-build.md 🚀
   #
-  lane :beta do
+  lane :beta do |values|
+
     # set 'export_method' to 'ad-hoc' if your Crashlytics Beta distribution uses ad-hoc provisioning
     gym(scheme: '#{@beta_info.schemes.first}', export_method: '#{@beta_info.export_method}')
 
+    emails = values[:dry_run_email] ? values[:dry_run_email] : #{beta_info_emails} # You can list more emails here
+    groups = values[:dry_run_email] ? nil : #{beta_info_groups} # You can define groups on the web and reference them here
+
     crashlytics(api_token: '#{@beta_info.api_key}',
              build_secret: '#{@beta_info.build_secret}',#{crashlytics_path_arg}
-                   emails: ['#{@beta_info.emails.join("', '")}'], # You can list more emails here
-                 # groups: ['#{groups.join("', '")}'], # You can define groups on the web and reference them here
+                   emails: emails,
+                   groups: groups,
                     notes: 'Distributed with fastlane', # Check out the changelog_from_git_commits action!
             notifications: true) # Should this distribution notify your testers via email?
 

--- a/fastlane/lib/fastlane/setup/crashlytics_beta_info_collector.rb
+++ b/fastlane/lib/fastlane/setup/crashlytics_beta_info_collector.rb
@@ -88,7 +88,7 @@ module Fastlane
         prompt_for_build_secret(info)
       end
 
-      if !info.emails || !info.emails_valid?
+      if (!info.emails || !info.emails_valid?) && !info.groups
         @ui.important "Your email address couldn't be discovered from your project 🔍"
         prompt_for_email(info)
       end

--- a/fastlane/spec/setup/crashlytics_beta_info_collector_spec.rb
+++ b/fastlane/spec/setup/crashlytics_beta_info_collector_spec.rb
@@ -34,12 +34,12 @@ describe Fastlane::CrashlyticsBetaInfoCollector do
       info.export_method = valid_export_method
     end
 
-    def validate_info
+    def validate_info(expected_emails: valid_emails, expected_groups: valid_groups)
       expect(info.api_key).to eq(valid_api_key)
       expect(info.build_secret).to eq(valid_build_secret)
       expect(info.crashlytics_path).to eq(valid_crashlytics_path)
-      expect(info.emails).to eq(valid_emails)
-      expect(info.groups).to eq(valid_groups)
+      expect(info.emails).to eq(expected_emails)
+      expect(info.groups).to eq(expected_groups)
       expect(info.schemes).to eq(valid_schemes)
       expect(info.export_method).to eq(valid_export_method)
     end
@@ -209,19 +209,34 @@ describe Fastlane::CrashlyticsBetaInfoCollector do
       validate_info
     end
 
-    it 'prompts for user input with invalid emails provided' do
+    it 'prompts for user input with invalid emails and no groups provided' do
       allow(project_parser).to receive(:parse).and_return(valid_project_parser_result)
 
       expect(email_fetcher).to receive(:fetch).and_return(nil)
 
       info.emails = nil
+      info.groups = nil
 
       allow(ui).to receive(:important)
       expect(ui).to receive(:input).with(/email/).and_return(valid_emails.first)
 
       collector.collect_info_into(info)
 
-      validate_info
+      validate_info(expected_groups: nil)
+    end
+
+    it 'does not prompt for user input with groups and invalid emails provided' do
+      allow(project_parser).to receive(:parse).and_return(valid_project_parser_result)
+
+      expect(email_fetcher).to receive(:fetch).and_return(nil)
+
+      info.emails = nil
+
+      expect(ui).not_to receive(:input)
+
+      collector.collect_info_into(info)
+
+      validate_info(expected_emails: nil)
     end
 
     it 'continues to prompt for user input with invalid emails provided' do
@@ -230,6 +245,7 @@ describe Fastlane::CrashlyticsBetaInfoCollector do
       expect(email_fetcher).to receive(:fetch).and_return(nil)
 
       info.emails = nil
+      info.groups = nil
 
       allow(ui).to receive(:important)
       expect(ui).to receive(:input).with(/email/).and_return('')
@@ -237,7 +253,7 @@ describe Fastlane::CrashlyticsBetaInfoCollector do
 
       collector.collect_info_into(info)
 
-      validate_info
+      validate_info(expected_groups: nil)
     end
 
     it 'has the user choose from a list when there are multiple schemes' do


### PR DESCRIPTION
This allows users to try `fastlane beta dry_run_email:my@email.com` after running `fastlane init beta` to test it before sending out a build to all their testers/groups

Also makes emails an optional param when groups are passed
