### PR TITLE
Device specific warnings in S3 HTML template

### DIFF
--- a/fastlane/lib/assets/s3_html_template.erb
+++ b/fastlane/lib/assets/s3_html_template.erb
@@ -63,7 +63,7 @@
       </span> -->
     </div>
 
-    <h3 id="desktop">Please open this page on your iPhone!</h3>
+    <h3 id="invalid-device">Please open this page on your iPhone!</h3>
 
     <p id="finished">
       App is being installed. Close Safari using the home button.
@@ -75,21 +75,29 @@
     <img src="https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane_medium.png" id="fastlaneLogo" />
   </body>
 
-  <script type='text/javascript'>
-    // if (/Android/i.test(navigator.userAgent))
-    // {
-    //   document.getElementById("ios").remove()
-    //   document.getElementById("desktop").remove()
-    // }
-    if (/iPhone|iPad|iPod/i.test(navigator.userAgent))
-    {
-      // document.getElementById("android").remove()
-      document.getElementById("desktop").remove()
-    }
-    else
-    {
-      document.getElementById("ios").remove()
-      // document.getElementById("android").remove()
-    }
-  </script>
+    <script type='text/javascript'>
+      // Array of supported devices, 1 is iPhone, 2 is iPad
+      var deviceFamily = <%= device_family %>;
+
+      function isIphoneValid() {
+        return deviceFamily.indexOf(1) != -1;
+      }
+
+      if (/iPhone|iPod/i.test(navigator.userAgent)) {
+        if (isIphoneValid()) {
+          document.getElementById("invalid-device").remove();
+        } else {
+          document.getElementById("ios").remove();
+          document.getElementById("invalid-device").innerHTML = "Please open this page on your iPad!";
+        }
+      } else if (/iPad/i.test(navigator.userAgent)) {
+        // iPhone only apps can still be installed on an iPad
+        document.getElementById("invalid-device").remove();
+      } else {
+        document.getElementById("ios").remove();
+
+        var validDeviceName = isIphoneValid() ? "iOS device" : "iPad";
+        document.getElementById("invalid-device").innerHTML = "Please open this page on your " + validDeviceName + "!";
+      }
+    </script>
 </html>

--- a/fastlane/lib/assets/s3_html_template.erb
+++ b/fastlane/lib/assets/s3_html_template.erb
@@ -75,29 +75,31 @@
     <img src="https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane_medium.png" id="fastlaneLogo" />
   </body>
 
-    <script type='text/javascript'>
-      // Array of supported devices, 1 is iPhone, 2 is iPad
-      var deviceFamily = <%= device_family %>;
+  <script type='text/javascript'>
+    // Array of supported devices, 1 is iPhone, 2 is iPad
+    var deviceFamily = <%= device_family %>;
 
-      function isIphoneValid() {
-        return deviceFamily.indexOf(1) != -1;
-      }
+    function isIphoneValid() {
+      return deviceFamily.indexOf(1) != -1;
+    }
 
-      if (/iPhone|iPod/i.test(navigator.userAgent)) {
-        if (isIphoneValid()) {
-          document.getElementById("invalid-device").remove();
-        } else {
-          document.getElementById("ios").remove();
-          document.getElementById("invalid-device").innerHTML = "Please open this page on your iPad!";
-        }
-      } else if (/iPad/i.test(navigator.userAgent)) {
-        // iPhone only apps can still be installed on an iPad
-        document.getElementById("invalid-device").remove();
-      } else {
-        document.getElementById("ios").remove();
+    function showError(error) {
+      document.getElementById("ios").remove();
+      document.getElementById("invalid-device").innerHTML = error;
+    }
 
-        var validDeviceName = isIphoneValid() ? "iOS device" : "iPad";
-        document.getElementById("invalid-device").innerHTML = "Please open this page on your " + validDeviceName + "!";
-      }
-    </script>
+    function showInstallLink() {
+      document.getElementById("invalid-device").remove();
+    }
+
+    if (/iPhone|iPod/i.test(navigator.userAgent) && isIphoneValid() ) {
+      showInstallLink();
+    } else if (/iPad/i.test(navigator.userAgent)) {
+      // All apps (even "iPhone only") can be installed on iPads
+      showInstallLink()
+    } else {
+      var validDeviceName = isIphoneValid() ? "iOS device" : "iPad";
+      showError("Please open this page on your " + validDeviceName + "!");
+    }
+  </script>
 </html>

--- a/fastlane/lib/fastlane/actions/s3.rb
+++ b/fastlane/lib/fastlane/actions/s3.rb
@@ -110,7 +110,9 @@ module Fastlane
         build_num = info['CFBundleVersion']
         bundle_id = info['CFBundleIdentifier']
         bundle_version = info['CFBundleShortVersionString']
-        title = info['CFBundleName']
+        title = info['CFBundleName']        
+        device_family = info['UIDeviceFamily']
+
         full_version = "#{bundle_version}.#{build_num}"
 
         # Creating plist and html names
@@ -145,6 +147,10 @@ module Fastlane
         else
           html_template = eth.load("s3_html_template")
         end
+        
+        print html_template_path
+        print html_template
+
         html_render = eth.render(html_template, {
           url: plist_url,
           plist_url: plist_url,
@@ -152,7 +158,8 @@ module Fastlane
           build_num: build_num,
           bundle_id: bundle_id,
           bundle_version: bundle_version,
-          title: title
+          title: title,
+          device_family: device_family
         })
 
         # Creates version from template

--- a/fastlane/lib/fastlane/actions/s3.rb
+++ b/fastlane/lib/fastlane/actions/s3.rb
@@ -110,9 +110,8 @@ module Fastlane
         build_num = info['CFBundleVersion']
         bundle_id = info['CFBundleIdentifier']
         bundle_version = info['CFBundleShortVersionString']
-        title = info['CFBundleName']        
+        title = info['CFBundleName']
         device_family = info['UIDeviceFamily']
-
         full_version = "#{bundle_version}.#{build_num}"
 
         # Creating plist and html names
@@ -147,9 +146,6 @@ module Fastlane
         else
           html_template = eth.load("s3_html_template")
         end
-        
-        print html_template_path
-        print html_template
 
         html_render = eth.render(html_template, {
           url: plist_url,


### PR DESCRIPTION
This PR does two things:
- Identifies supported device types from the .ipa plist file
- Adds device specific warnings into the default S3 HTML template

Discussed in issue #5774 
