### PR TITLE
Reduce output when running fastlane -v

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -4,13 +4,17 @@ module Fastlane
   # tool or fastlane itself
   class CLIToolsDistributor
     class << self
+      def running_version_command?
+        ARGV.include?('-v') || ARGV.include?('--version')
+      end
+
       def take_off
         before_import_time = Time.now
 
         require "fastlane" # this might take a long time if there is no Gemfile :(
 
         # We want to avoid printing output other than the version number if we are running `fastlane -v`
-        if Time.now - before_import_time > 3 && !ARGV.include?('-v')
+        if Time.now - before_import_time > 3 && !running_version_command?
           print_slow_fastlane_warning
         end
 

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -9,7 +9,8 @@ module Fastlane
 
         require "fastlane" # this might take a long time if there is no Gemfile :(
 
-        if Time.now - before_import_time > 3
+        # We want to avoid printing output other than the version number if we are running `fastlane -v`
+        if Time.now - before_import_time > 3 && !ARGV.include?('-v')
           print_slow_fastlane_warning
         end
 

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -293,8 +293,10 @@ module Fastlane
         UI.error("Please follow the troubleshooting guide: #{TROUBLESHOOTING_URL}")
       end
 
+      skip_print_plugin_info = self.plugin_references.empty? || CLIToolsDistributor.running_version_command?
+
       # We want to avoid printing output other than the version number if we are running `fastlane -v`
-      print_plugin_information(self.plugin_references) unless self.plugin_references.empty? || ARGV.include?('-v')
+      print_plugin_information(self.plugin_references) unless skip_print_plugin_info
     end
 
     # Prints a table all the plugins that were loaded

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -293,7 +293,8 @@ module Fastlane
         UI.error("Please follow the troubleshooting guide: #{TROUBLESHOOTING_URL}")
       end
 
-      print_plugin_information(self.plugin_references) unless self.plugin_references.empty?
+      # We want to avoid printing output other than the version number if we are running `fastlane -v`
+      print_plugin_information(self.plugin_references) unless self.plugin_references.empty? || ARGV.include?('-v')
     end
 
     # Prints a table all the plugins that were loaded


### PR DESCRIPTION
It is traditional for command line tools to only output a version number, and maybe the tool name, when responding to a `-v` request. `fastlane` used to do exactly this as well, but other recent improvements have made this command potentially print out a lot of extra information:
- Loading plugins causes the table of plugin information to be printed, if a Gemfile/Pluginfile are present
- Slow loading messaging can output a lot of text with suggestions for improvements

```
[16:38:46]: Seems like launching fastlane takes a while
[16:38:46]: fastlane detected a Gemfile in this directory
[16:38:46]: however it seems like you don't use `bundle exec`
[16:38:46]: to launch fastlane faster, please use
[16:38:46]: 
[16:38:46]: $ bundle exec fastlane -v
[16:38:46]: For more information, check out https://guides.cocoapods.org/using/a-gemfile.html
+--------------------------+---------+----------+
|                 Used plugins                  |
+--------------------------+---------+----------+
| Plugin                   | Version | Action   |
+--------------------------+---------+----------+
| fastlane-plugin-ruby     | 0.1.3   | rspec    |
|                          |         | rubocop  |
| fastlane-plugin-clubmate | 0.1.0   | clubmate |
+--------------------------+---------+----------+

fastlane 1.100.0
```

**This breaks the Fabric Mac app, which uses `fastlane -v` to determine whether `fastlane` is currently installed, and at what version.**

`Commander` gives `-v` a very high priority, so even running something like `fastlane -v lanes` causes the version info to be printed, and nothing else is executed. Therefore this PR attempts to suppress this output by detecting whether we're running with the `-v` flag present. 

I'm open to other ideas on how to make this decision!
