### PR TITLE
Replace use of `Helper.gem_path` for locating assets

### DIFF
--- a/deliver/lib/deliver.rb
+++ b/deliver/lib/deliver.rb
@@ -23,4 +23,8 @@ module Deliver
 
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
+
+  # Constant that captures the root Pathname for the project. Should be used for building paths to assets or other
+  # resources that code needs to locate locally
+  ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 end

--- a/deliver/lib/deliver/html_generator.rb
+++ b/deliver/lib/deliver/html_generator.rb
@@ -31,8 +31,6 @@ module Deliver
     # Renders all data available to quickly see if everything was correctly generated.
     # @param export_path (String) The path to a folder where the resulting HTML file should be stored.
     def render(options, screenshots, export_path = nil)
-      lib_path = Helper.gem_path('deliver')
-
       @screenshots = screenshots || []
       @options = options
 
@@ -42,7 +40,7 @@ module Deliver
       @languages = options[:description].keys if options[:description]
       @languages ||= options[:app].latest_version.description.languages
 
-      html_path = File.join(lib_path, "lib/assets/summary.html.erb")
+      html_path = File.join(Deliver::ROOT, "lib/assets/summary.html.erb")
       html = ERB.new(File.read(html_path)).result(binding) # http://www.rrn.dk/rubys-erb-templating-system
 
       export_path = File.join(export_path, "Preview.html")

--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -15,7 +15,7 @@ module Deliver
 
         # Add a README to the screenshots folder
         FileUtils.mkdir_p File.join(deliver_path, 'screenshots') # just in case the fetching didn't work
-        File.write(File.join(deliver_path, 'screenshots', 'README.txt'), File.read("#{Helper.gem_path('deliver')}/lib/assets/ScreenshotsHelp"))
+        File.write(File.join(deliver_path, 'screenshots', 'README.txt'), File.read("#{Deliver::ROOT}/lib/assets/ScreenshotsHelp"))
       end
 
       UI.success("Successfully created new Deliverfile at path '#{file_path}'")
@@ -28,8 +28,7 @@ module Deliver
       generate_metadata_files(v, File.join(deliver_path, 'metadata'))
 
       # Generate the final Deliverfile here
-      gem_path = Helper.gem_path('deliver')
-      deliver = File.read("#{gem_path}/lib/assets/DeliverfileDefault")
+      deliver = File.read("#{Deliver::ROOT}/lib/assets/DeliverfileDefault")
       deliver.gsub!("[[APP_IDENTIFIER]]", options[:app].bundle_id)
       deliver.gsub!("[[USERNAME]]", Spaceship::Tunes.client.user)
       return deliver


### PR DESCRIPTION
Continuation of work on concerns raised in #5770

Here is a suggested pattern for replacing the use of `Helper.gem_path` for locating resource paths within our projects. It is inspired by `Rails.root`

This could be carried over to each project in turn.
