### PR TITLE
Don't expand keychain_path in setup_jenkins action

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/setup_jenkins.rb
@@ -31,7 +31,7 @@ module Fastlane
 
         # Keychain
         if params[:unlock_keychain] && params[:keychain_path]
-          keychain_path = File.expand_path(params[:keychain_path])
+          keychain_path = params[:keychain_path]
           UI.message "Unlocking keychain: \"#{keychain_path}\"."
           Actions::UnlockKeychainAction.run(
             path: keychain_path,


### PR DESCRIPTION
Specifying `keychain_path: "jenkins.keychain"` to `setup_jenkins` results in the output below (formatted for readability) . This is because `setup_jenkins` expands the path before passing it to `unlock_keychain`. This PR removes that `File.expand_path` call, allowing the unlock keychain action to expand it itself and perform its own logic for finding the keychain.

```
Could not find the keychain file in: 
["/Users/Jenkins/Documents/jenkins/workspace/project/jenkins.keychain", 
"~/Library/Keychains//Users/Jenkins/Documents/jenkins/workspace/project/jenkins.keychain", 
"~/Library/Keychains//Users/Jenkins/Documents/jenkins/workspace/project/jenkins.keychain.keychain"]
```
