### PR TITLE
[fastlane_core] Fix a regular expression for check the installed cert

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -33,7 +33,7 @@ module FastlaneCore
       available.split("\n").each do |current|
         next if current.include? "REVOKED"
         begin
-          (ids << current.match(/.*\) (.*) \".*/)[1])
+          (ids << current.match(/.*\) ([[:xdigit:]]*) \".*/)[1])
         rescue
           # the last line does not match
         end


### PR DESCRIPTION
The PR solve the problem with the certificate for which I came. The problem was that one of my certificate contains quotes in name. Because of this, it was considered that the certificate is not installed. I fixed the regular expression in the more correct given that the certificate fingerprint contains only hexadecimal characters.

Example:
List of certificates
`security find-identity -v -p codesigning`

```
1) AAAAC8FE25EB5CFF3D367D0A6C5859997B697A1B "iPhone Developer: CognitiveDisson (ABBDEF1234)"
2) BBBBAF37CBBCAE43A2B90FED1936F8F7AFAAFB "iPhone Distribution: FoolWhoUsesQuotes "JSC BlaBla" (SSSSRN1234)"
```

Current regular expression finds the following matches:
`.match(/.*\) (.*) \".*/)[1]`

```
AAAAC8FE25EB5CFF3D367D0A6C5859997B697A1B
BBBBAF37CBBCAE43A2B90FED1936F8F7AFAAFB "iPhone Distribution: FoolWhoUsesQuotes
```

Therefore, the verification of the certificate installation fails
`return ids.include? finger_print`

Please accept and merge PR. And released the new version as soon as possible.
