### PR TITLE
Fixed issue where artefacts with parens () would not get copied

### DIFF
--- a/fastlane/lib/fastlane/actions/copy_artifacts.rb
+++ b/fastlane/lib/fastlane/actions/copy_artifacts.rb
@@ -1,5 +1,4 @@
 require 'fileutils'
-require 'shellwords'
 
 module Fastlane
   module Actions
@@ -17,8 +16,7 @@ module Fastlane
         # If any of the paths include "*", we assume that we are referring to the Unix entries
         # e.g /tmp/fastlane/* refers to all the files in /tmp/fastlane
         # We use Dir.glob to expand all those paths, this would create an array of arrays though, so flatten
-        # Lastly, we shell escape everything in case they contain incompatible symbols (e.g. spaces)
-        artifacts = artifacts_to_search.map { |f| f.include?("*") ? Dir.glob(f) : f }.flatten.map(&:shellescape)
+        artifacts = artifacts_to_search.map { |f| f.include?("*") ? Dir.glob(f) : f }.flatten
 
         UI.verbose("Copying artifacts #{artifacts.join(', ')} to #{target_path}")
         UI.verbose(params[:keep_original] ? "Keeping original files" : "Not keeping original files")


### PR DESCRIPTION
Regarding the `copy_artefacts` task, it was recently rewritten to use native Ruby methods instead of shell scripting magic via `cp`. 

It seems a part of the old code was left over which is unnecessary for the native Ruby based approach, namely shellescaping, which was causing files with parens in them e.g. `MyApp_v3.0_(3000).ipa`

This PR fixes the issue.
