### PR TITLE
Move `ensure_csrf` call to just after login

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -171,7 +171,6 @@ module Spaceship
       params.merge!(ident_params)
 
       ensure_csrf
-
       r = request(:post, "account/#{platform_slug(mac)}/identifiers/addAppId.action", params)
       parse_response(r, 'appId')
     end
@@ -384,19 +383,17 @@ module Spaceship
       parse_response(r, 'provisioningProfile')
     end
 
-    private
-
     def ensure_csrf
       if csrf_tokens.count == 0
         # If we directly create a new resource (e.g. app) without querying anything before
         # we don't have a valid csrf token, that's why we have to do at least one request
-        apps
+        Certificate::Production.all
 
         # Update 18th August 2016
         # For some reason, we have to query the resource twice to actually get a valid csrf_token
         # I couldn't find out why, the first response does have a valid Set-Cookie header
         # But it still needs this second request
-        apps
+        Certificate::Production.all
       end
     end
   end

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -383,18 +383,24 @@ module Spaceship
       parse_response(r, 'provisioningProfile')
     end
 
-    def ensure_csrf
-      if csrf_tokens.count == 0
-        # If we directly create a new resource (e.g. app) without querying anything before
-        # we don't have a valid csrf token, that's why we have to do at least one request
-        Certificate::Production.all
+    private
 
-        # Update 18th August 2016
-        # For some reason, we have to query the resource twice to actually get a valid csrf_token
-        # I couldn't find out why, the first response does have a valid Set-Cookie header
-        # But it still needs this second request
-        Certificate::Production.all
-      end
+    def ensure_csrf
+      # It's important we store this state here
+      # as we always want to request something at least once
+      return unless @requested_csrf_token.nil?
+
+      # If we directly create a new resource (e.g. app) without querying anything before
+      # we don't have a valid csrf token, that's why we have to do at least one request
+      Certificate::Production.all
+
+      # Update 18th August 2016
+      # For some reason, we have to query the resource twice to actually get a valid csrf_token
+      # I couldn't find out why, the first response does have a valid Set-Cookie header
+      # But it still needs this second request
+      Certificate::Production.all
+
+      @requested_csrf_token = true if csrf_tokens.count > 0
     end
   end
 end

--- a/spaceship/lib/spaceship/portal/spaceship.rb
+++ b/spaceship/lib/spaceship/portal/spaceship.rb
@@ -20,6 +20,7 @@ module Spaceship
       # @return (Spaceship::Client) The client the login method was called for
       def login(user = nil, password = nil)
         @client = PortalClient.login(user, password)
+        @client.ensure_csrf
       end
 
       # Open up the team selection for the user (if necessary).

--- a/spaceship/lib/spaceship/portal/spaceship.rb
+++ b/spaceship/lib/spaceship/portal/spaceship.rb
@@ -20,7 +20,6 @@ module Spaceship
       # @return (Spaceship::Client) The client the login method was called for
       def login(user = nil, password = nil)
         @client = PortalClient.login(user, password)
-        @client.ensure_csrf
       end
 
       # Open up the team selection for the user (if necessary).


### PR DESCRIPTION
Fixes #5797 

Move `ensure_csrf` call to just after login so that no other queries are made that would improperly set csrf tokens (because we need to do these two in a row...) Also switch to using all production certifications because this should be limited to 2 instead of all apps.
