### PR TITLE
Add csrf token handling to repair_provisioning_profile

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -370,6 +370,8 @@ module Spaceship
     end
 
     def repair_provisioning_profile!(profile_id, name, distribution_method, app_id, certificate_ids, device_ids, mac: false)
+      ensure_csrf
+
       r = request(:post, "account/#{platform_slug(mac)}/profile/regenProvisioningProfile.action", {
         teamId: team_id,
         provisioningProfileId: profile_id,


### PR DESCRIPTION
Fixes repair_provision_profile as described in [this comment](https://github.com/fastlane/fastlane/issues/5813#issuecomment-241173861)
