### PR TITLE
[spaceship] Change order of ensure_csrf_token

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -155,6 +155,8 @@ module Spaceship
     end
 
     def create_app!(type, name, bundle_id, mac: false)
+      ensure_csrf
+
       ident_params = case type.to_sym
                      when :explicit
                        {
@@ -178,7 +180,6 @@ module Spaceship
 
       params.merge!(ident_params)
 
-      ensure_csrf
       r = request(:post, "account/#{platform_slug(mac)}/identifiers/addAppId.action", params)
       parse_response(r, 'appId')
     end

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -155,6 +155,9 @@ module Spaceship
     end
 
     def create_app!(type, name, bundle_id, mac: false)
+      # We moved the ensure_csrf to the top of this method
+      # as we got some users with issues around creating new apps
+      # https://github.com/fastlane/fastlane/issues/5813
       ensure_csrf
 
       ident_params = case type.to_sym


### PR DESCRIPTION
Maybe by calling `self.team` before calling `ensure_csrf` it doesn't work for everyone
