### PR TITLE
Add a ROOT path constant for cert

### DIFF
--- a/cert/lib/cert.rb
+++ b/cert/lib/cert.rb
@@ -14,6 +14,7 @@ module Cert
 
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
+  ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 
   ENV['FASTLANE_TEAM_ID'] ||= ENV["CERT_TEAM_ID"]
 end


### PR DESCRIPTION
Continuation of work on concerns raised in #5770

`cert` does not have any local file references needing this constant yet, but I think it's good for all projects to have one for consistency and later use.
