### PR TITLE
Add a ROOT path constant for snapshot

### DIFF
--- a/snapshot/lib/snapshot.rb
+++ b/snapshot/lib/snapshot.rb
@@ -45,6 +45,7 @@ module Snapshot
 
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
+  ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 
   Snapshot::DependencyChecker.check_dependencies
 

--- a/snapshot/lib/snapshot/setup.rb
+++ b/snapshot/lib/snapshot/setup.rb
@@ -8,9 +8,8 @@ module Snapshot
         UI.user_error!("Snapfile already exists at path '#{snapfile_path}'. Run 'snapshot' to use snapshot.")
       end
 
-      gem_path = Helper.gem_path("snapshot")
-      File.write(snapfile_path, File.read("#{gem_path}/lib/assets/SnapfileTemplate"))
-      File.write(File.join(path, 'SnapshotHelper.swift'), File.read("#{gem_path}/lib/assets/SnapshotHelper.swift"))
+      File.write(snapfile_path, File.read("#{Snapshot::ROOT}/lib/assets/SnapfileTemplate"))
+      File.write(File.join(path, 'SnapshotHelper.swift'), File.read("#{Snapshot::ROOT}/lib/assets/SnapshotHelper.swift"))
 
       puts "Successfully created SnapshotHelper.swift '#{File.join(path, 'SnapshotHelper.swift')}'".green
       puts "Successfully created new Snapfile at '#{snapfile_path}'".green

--- a/snapshot/lib/snapshot/update.rb
+++ b/snapshot/lib/snapshot/update.rb
@@ -7,7 +7,6 @@ module Snapshot
     end
 
     def update
-      gem_path = Helper.gem_path("snapshot")
       paths = self.class.find_helper
 
       UI.message "Found the following SnapshotHelper:"
@@ -15,13 +14,13 @@ module Snapshot
       UI.important "Are you sure you want to automatically update the helpers listed above?"
       UI.message "This will overwrite all its content with the latest code."
       UI.message "The underlying API will not change. You can always migrate manually by looking at"
-      UI.message "https://github.com/fastlane/snapshot/blob/master/lib/assets/SnapshotHelper.swift"
+      UI.message "https://github.com/fastlane/fastlane/blob/master/snapshot/lib/assets/SnapshotHelper.swift"
 
       return 1 unless UI.confirm("Overwrite configuration files?")
 
       paths.each do |path|
         UI.message "Updating '#{path}'..."
-        File.write(path, File.read("#{gem_path}/lib/assets/SnapshotHelper.swift"))
+        File.write(path, File.read("#{Snapshot::ROOT}/lib/assets/SnapshotHelper.swift"))
       end
 
       UI.success "Successfully updated helper files"


### PR DESCRIPTION
Continuation of work on concerns raised in #5770
- Replace use of `Helper.gem_path` with `Snapshot::ROOT`
- Correct a GitHub link for the migrated project location
