### PR TITLE
Add a ROOT path constant for scan

### DIFF
--- a/scan/lib/scan.rb
+++ b/scan/lib/scan.rb
@@ -35,4 +35,5 @@ module Scan
 
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
+  ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 end

--- a/scan/lib/scan/commands_generator.rb
+++ b/scan/lib/scan/commands_generator.rb
@@ -49,7 +49,7 @@ module Scan
           containing = (Helper.fastlane_enabled? ? 'fastlane' : '.')
           path = File.join(containing, Scan.scanfile_name)
           UI.user_error!("Scanfile already exists").yellow if File.exist?(path)
-          template = File.read("#{Helper.gem_path('scan')}/lib/assets/ScanfileTemplate")
+          template = File.read("#{Scan::ROOT}/lib/assets/ScanfileTemplate")
           File.write(path, template)
           UI.success("Successfully created '#{path}'. Open the file using a code editor.")
         end


### PR DESCRIPTION
Continuation of work on concerns raised in #5770

Replace use of `Helper.gem_path` with `Scan::ROOT`
