### PR TITLE
Add a ROOT path constant for gym

### DIFF
--- a/gym/lib/gym.rb
+++ b/gym/lib/gym.rb
@@ -43,6 +43,7 @@ module Gym
 
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
+  ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 
   Gym.init_libs
 end

--- a/gym/lib/gym/commands_generator.rb
+++ b/gym/lib/gym/commands_generator.rb
@@ -50,7 +50,7 @@ module Gym
           containing = (File.directory?("fastlane") ? 'fastlane' : '.')
           path = File.join(containing, Gym.gymfile_name)
           UI.user_error! "Gymfile already exists" if File.exist?(path)
-          template = File.read("#{Helper.gem_path('gym')}/lib/assets/GymfileTemplate")
+          template = File.read("#{Gym::ROOT}/lib/assets/GymfileTemplate")
           File.write(path, template)
           UI.success "Successfully created '#{path}'. Open the file using a code editor."
         end

--- a/gym/lib/gym/xcodebuild_fixes/package_application_fix.rb
+++ b/gym/lib/gym/xcodebuild_fixes/package_application_fix.rb
@@ -14,7 +14,7 @@ module Gym
           # Check current set of PackageApplication MD5 hashes
           require 'digest'
 
-          path = File.join(Helper.gem_path("gym"), "lib/assets/package_application_patches/PackageApplication_MD5")
+          path = File.join(Gym::ROOT, "lib/assets/package_application_patches/PackageApplication_MD5")
           expected_md5_hashes = File.read(path).split("\n")
 
           # If that location changes, search it using xcrun --sdk iphoneos -f PackageApplication
@@ -26,7 +26,7 @@ module Gym
           FileUtils.copy_file(package_application_path, @patched_package_application_path)
 
           # Apply patches to PackageApplication4Gym from patches folder
-          Dir[File.join(Helper.gem_path("gym"), "lib/assets/package_application_patches/*.diff")].each do |patch|
+          Dir[File.join(Gym::ROOT, "lib/assets/package_application_patches/*.diff")].each do |patch|
             UI.verbose "Applying Package Application patch: #{File.basename(patch)}"
             command = ["patch '#{@patched_package_application_path}' < '#{patch}'"]
             Runner.new.print_command(command, "Applying Package Application patch: #{File.basename(patch)}") if $verbose
@@ -46,7 +46,7 @@ module Gym
       # Wrap xcodebuild to work-around ipatool dependecy to system ruby
       def wrap_xcodebuild
         require 'fileutils'
-        @wrapped_xcodebuild_path ||= File.join(Helper.gem_path("gym"), "lib/assets/wrap_xcodebuild/xcbuild-safe.sh")
+        @wrapped_xcodebuild_path ||= File.join(Gym::ROOT, "lib/assets/wrap_xcodebuild/xcbuild-safe.sh")
       end
     end
   end


### PR DESCRIPTION
Continuation of work on concerns raised in #5770

Replace use of `Helper.gem_path` with `Gym::ROOT`
