### PR TITLE
Add a ROOT path constant for frameit

### DIFF
--- a/frameit/lib/frameit.rb
+++ b/frameit/lib/frameit.rb
@@ -22,6 +22,7 @@ module Frameit
 
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
+  ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 end
 
 # rubocop:disable all

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -231,7 +231,7 @@ module Frameit
       results = {}
       words.each do |key|
         # Create empty background
-        empty_path = File.join(Helper.gem_path('frameit'), "lib/assets/empty.png")
+        empty_path = File.join(Frameit::ROOT, "lib/assets/empty.png")
         title_image = MiniMagick::Image.open(empty_path)
         image_height = max_height # gets trimmed afterwards anyway, and on the iPad the `y` would get cut
         title_image.combine_options do |i|


### PR DESCRIPTION
Continuation of work on concerns raised in #5770

Replace use of `Helper.gem_path` with `Frameit::ROOT`
