### PR TITLE
Add a ROOT path constant for sigh

### DIFF
--- a/sigh/lib/sigh.rb
+++ b/sigh/lib/sigh.rb
@@ -13,6 +13,7 @@ module Sigh
 
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
+  ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 
   ENV['FASTLANE_TEAM_ID'] ||= ENV["SIGH_TEAM_ID"]
   ENV['DELIVER_USER'] ||= ENV["SIGH_USERNAME"]

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -82,7 +82,7 @@ module Sigh
     end
 
     def find_resign_path
-      File.join(Helper.gem_path('sigh'), 'lib', 'assets', 'resign.sh')
+      File.join(Sigh::ROOT, 'lib', 'assets', 'resign.sh')
     end
 
     def find_ipa


### PR DESCRIPTION
Continuation of work on concerns raised in #5770

Replace use of `Helper.gem_path` with `Sigh::ROOT`
