### PR TITLE
Add a ROOT path constant for match

### DIFF
--- a/match/lib/match.rb
+++ b/match/lib/match.rb
@@ -18,6 +18,7 @@ require 'spaceship'
 module Match
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
+  ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 
   def self.environments
     envs = %w(appstore adhoc development)

--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -122,7 +122,7 @@ module Match
 
     # Copies the README.md into the git repo
     def self.copy_readme(directory)
-      template = File.read("#{Helper.gem_path('match')}/lib/assets/READMETemplate.md")
+      template = File.read("#{Match::ROOT}/lib/assets/READMETemplate.md")
       File.write(File.join(directory, "README.md"), template)
     end
   end

--- a/match/lib/match/setup.rb
+++ b/match/lib/match/setup.rb
@@ -1,7 +1,7 @@
 module Match
   class Setup
     def run(path)
-      template = File.read("#{Helper.gem_path('match')}/lib/assets/MatchfileTemplate")
+      template = File.read("#{Match::ROOT}/lib/assets/MatchfileTemplate")
 
       UI.important "Please create a new, private git repository"
       UI.important "to store the certificates and profiles there"


### PR DESCRIPTION
Continuation of work on concerns raised in #5770

Replace use of `Helper.gem_path` with `Match::ROOT`
