### PR TITLE
Add a ROOT path constant for screengrab

### DIFF
--- a/screengrab/lib/screengrab.rb
+++ b/screengrab/lib/screengrab.rb
@@ -28,4 +28,5 @@ module Screengrab
 
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
+  ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 end

--- a/screengrab/lib/screengrab/setup.rb
+++ b/screengrab/lib/screengrab/setup.rb
@@ -8,8 +8,7 @@ module Screengrab
         UI.user_error!("Screengrabfile already exists at path '#{screengrabfile_path}'. Run 'screengrab' to use screengrab.")
       end
 
-      gem_path = Helper.gem_path("screengrab")
-      File.write(screengrabfile_path, File.read("#{gem_path}/lib/assets/ScreengrabfileTemplate"))
+      File.write(screengrabfile_path, File.read("#{Screengrab::ROOT}/lib/assets/ScreengrabfileTemplate"))
 
       UI.success("Successfully created new Screengrabfile at '#{screengrabfile_path}'")
     end


### PR DESCRIPTION
Continuation of work on concerns raised in #5770

Replace use of `Helper.gem_path` with `Screengrab::ROOT`
