### PR TITLE
Add a ROOT path constant for spaceship

### DIFF
--- a/spaceship/lib/spaceship.rb
+++ b/spaceship/lib/spaceship.rb
@@ -13,6 +13,8 @@ require 'spaceship/tunes/spaceship'
 
 # To support legacy code
 module Spaceship
+  ROOT = Pathname.new(File.expand_path('../..', __FILE__))
+
   # Dev Portal
   Certificate = Spaceship::Portal::Certificate
   ProvisioningProfile = Spaceship::Portal::ProvisioningProfile

--- a/spaceship/lib/spaceship/tunes/language_converter.rb
+++ b/spaceship/lib/spaceship/tunes/language_converter.rb
@@ -29,22 +29,13 @@ module Spaceship
 
         private
 
-        # Path to the gem to fetch resoures
-        def spaceship_gem_path
-          if Gem::Specification.find_all_by_name('spaceship').any?
-            return Gem::Specification.find_by_name('spaceship').gem_dir
-          else
-            return './'
-          end
-        end
-
         # Get the mapping JSON parsed
         def mapping
-          @languages ||= JSON.parse(File.read(File.join(spaceship_gem_path, "lib", "assets", "languageMapping.json")))
+          @languages ||= JSON.parse(File.read(File.join(Spaceship::ROOT, "lib", "assets", "languageMapping.json")))
         end
 
         def readable_mapping
-          @readable ||= JSON.parse(File.read(File.join(spaceship_gem_path, "lib", "assets", "languageMappingReadable.json")))
+          @readable ||= JSON.parse(File.read(File.join(Spaceship::ROOT, "lib", "assets", "languageMappingReadable.json")))
         end
       end
     end


### PR DESCRIPTION
Continuation of work on concerns raised in #5770

Replace use of `spaceship_gem_path` with `Spaceship::ROOT`
