### PR TITLE
Add a ROOT path constant for fastlane_core

### DIFF
--- a/fastlane_core/lib/fastlane_core.rb
+++ b/fastlane_core/lib/fastlane_core.rb
@@ -34,4 +34,5 @@ require 'commander'
 require 'fastlane_core/ui/fastlane_runner' # monkey patch
 
 module FastlaneCore
+  ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 end

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -140,8 +140,13 @@ module FastlaneCore
       @enabled ||= (File.directory?("./fastlane") || File.directory?("./.fastlane"))
     end
 
+    # <b>DEPRECATED:</b> Use the `ROOT` constant from the appropriate tool module instead
+    # e.g. File.join(Sigh::ROOT, 'lib', 'assets', 'resign.sh')
+    #
     # Path to the installed gem to load resources (e.g. resign.sh)
     def self.gem_path(gem_name)
+      UI.deprecated('`Helper.gem_path` is deprecated. Use the `ROOT` constant from the appropriate tool module instead.')
+
       if !Helper.is_test? and Gem::Specification.find_all_by_name(gem_name).any?
         return Gem::Specification.find_by_name(gem_name).gem_dir
       else

--- a/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -12,8 +12,6 @@ module FastlaneCore
       FileUtils.rm_rf self.package_path if File.directory?(self.package_path)
       FileUtils.mkdir_p self.package_path
 
-      lib_path = Helper.gem_path("fastlane_core")
-
       ipa_path = copy_ipa(ipa_path)
       @data = {
         apple_id: app_id,
@@ -24,7 +22,7 @@ module FastlaneCore
         platform: (platform || "ios") # pass "appletvos" for Apple TV's IPA
       }
 
-      xml_path = File.join(lib_path, "lib/assets/XMLTemplate.xml.erb")
+      xml_path = File.join(FastlaneCore::ROOT, "lib/assets/XMLTemplate.xml.erb")
       xml = ERB.new(File.read(xml_path)).result(binding) # http://www.rrn.dk/rubys-erb-templating-system
 
       File.write(File.join(self.package_path, METADATA_FILE_NAME), xml)

--- a/fastlane_core/lib/fastlane_core/pkg_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/pkg_upload_package_builder.rb
@@ -12,8 +12,6 @@ module FastlaneCore
       FileUtils.rm_rf(self.package_path) if File.directory?(self.package_path)
       FileUtils.mkdir_p self.package_path
 
-      lib_path = Helper.gem_path('fastlane_core')
-
       pkg_path = copy_pkg(pkg_path)
       @data = {
         apple_id: app_id,
@@ -24,7 +22,7 @@ module FastlaneCore
         platform: 'osx'
       }
 
-      xml_path = File.join(lib_path, 'lib/assets/XMLTemplate.xml.erb')
+      xml_path = File.join(FastlaneCore::ROOT, 'lib/assets/XMLTemplate.xml.erb')
       xml = ERB.new(File.read(xml_path)).result(binding) # http://www.rrn.dk/rubys-erb-templating-system
 
       File.write(File.join(self.package_path, METADATA_FILE_NAME), xml)


### PR DESCRIPTION
Continuation of work on concerns raised in #5770
- Replace use of `Helper.gem_path` with `FastlaneCore::ROOT`
- Deprecate `Helper.gem_path`
