### PR TITLE
Add a ROOT path constant for fastlane

### DIFF
--- a/fastlane/lib/fastlane.rb
+++ b/fastlane/lib/fastlane.rb
@@ -24,6 +24,7 @@ require 'fastlane/plugins/plugins'
 module Fastlane
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
+  ROOT = Pathname.new(File.expand_path('../..', __FILE__))
 
   class << self
     def load_actions

--- a/fastlane/lib/fastlane/auto_complete.rb
+++ b/fastlane/lib/fastlane/auto_complete.rb
@@ -13,7 +13,7 @@ module Fastlane
       FileUtils.mkdir_p fastlane_conf_dir
 
       # then copy all of the completions files into it from the gem
-      completion_script_path = File.join(Fastlane::Helper.gem_path('fastlane'), 'lib', 'assets', 'completions')
+      completion_script_path = File.join(Fastlane::ROOT, 'lib', 'assets', 'completions')
       FileUtils.cp_r completion_script_path, fastlane_conf_dir
 
       UI.success "Copied! To use auto complete for fastlane, add the following line to your favorite rc file (e.g. ~/.bashrc)"

--- a/fastlane/lib/fastlane/erb_template_helper.rb
+++ b/fastlane/lib/fastlane/erb_template_helper.rb
@@ -2,7 +2,7 @@ module Fastlane
   class ErbTemplateHelper
     require "erb"
     def self.load(template_name)
-      path = "#{Helper.gem_path('fastlane')}/lib/assets/#{template_name}.erb"
+      path = "#{Fastlane::ROOT}/lib/assets/#{template_name}.erb"
       load_from_path(path)
     end
 

--- a/fastlane/lib/fastlane/junit_generator.rb
+++ b/fastlane/lib/fastlane/junit_generator.rb
@@ -9,7 +9,7 @@ module Fastlane
       path = File.join(containing_folder, 'report.xml')
 
       @steps = results
-      xml_path = File.join(Helper.gem_path("fastlane"), "lib/assets/report_template.xml.erb")
+      xml_path = File.join(Fastlane::ROOT, "lib/assets/report_template.xml.erb")
       xml = ERB.new(File.read(xml_path)).result(binding) # http://www.rrn.dk/rubys-erb-templating-system
 
       xml = xml.gsub('system_', 'system-').delete("\e") # Jenkins can not parse 'ESC' symbol

--- a/fastlane/lib/fastlane/new_action.rb
+++ b/fastlane/lib/fastlane/new_action.rb
@@ -18,7 +18,7 @@ module Fastlane
     end
 
     def self.generate_action(name)
-      template = File.read("#{Helper.gem_path('fastlane')}/lib/assets/custom_action_template.rb")
+      template = File.read("#{Fastlane::ROOT}/lib/assets/custom_action_template.rb")
       template.gsub!('[[NAME]]', name)
       template.gsub!('[[NAME_UP]]', name.upcase)
       template.gsub!('[[NAME_CLASS]]', name.fastlane_class + 'Action')

--- a/fastlane/lib/fastlane/plugins/plugin_fetcher.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_fetcher.rb
@@ -26,8 +26,7 @@ module Fastlane
     def self.update_md_file!
       @plugins = fetch_gems
 
-      lib_path = FastlaneCore::Helper.gem_path('fastlane')
-      template_path = File.join(lib_path, "lib/assets/AvailablePlugins.md.erb")
+      template_path = File.join(Fastlane::ROOT, "lib/assets/AvailablePlugins.md.erb")
       md = ERB.new(File.read(template_path), nil, '<>').result(binding) # http://www.rrn.dk/rubys-erb-templating-system
 
       puts md

--- a/fastlane/lib/fastlane/setup/setup_android.rb
+++ b/fastlane/lib/fastlane/setup/setup_android.rb
@@ -31,7 +31,7 @@ module Fastlane
       puts "Follow the Setup Guide on how to get the Json file: https://github.com/fastlane/fastlane/tree/master/supply#setup".yellow
       json_key_file = ask('Path to the json secret file: '.yellow)
 
-      template = File.read("#{Helper.gem_path('fastlane')}/lib/assets/AppfileTemplateAndroid")
+      template = File.read("#{Fastlane::ROOT}/lib/assets/AppfileTemplateAndroid")
       template.gsub!('[[JSON_KEY_FILE]]', json_key_file)
       template.gsub!('[[PACKAGE_NAME]]', package_name)
       path = File.join(folder, 'Appfile')
@@ -40,7 +40,7 @@ module Fastlane
     end
 
     def generate_fastfile
-      template = File.read("#{Helper.gem_path('fastlane')}/lib/assets/FastfileTemplateAndroid")
+      template = File.read("#{Fastlane::ROOT}/lib/assets/FastfileTemplateAndroid")
 
       template.gsub!('[[FASTLANE_VERSION]]', Fastlane::VERSION)
 

--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -156,7 +156,7 @@ module Fastlane
     end
 
     def generate_appfile(manually: false)
-      template = File.read("#{Helper.gem_path('fastlane')}/lib/assets/AppfileTemplate")
+      template = File.read("#{Fastlane::ROOT}/lib/assets/AppfileTemplate")
       if manually
         ask_for_app_identifier
         ask_for_apple_id
@@ -233,7 +233,7 @@ module Fastlane
     def generate_fastfile(manually: false)
       scheme = self.project.schemes.first unless manually
 
-      template = File.read("#{Helper.gem_path('fastlane')}/lib/assets/DefaultFastfileTemplate")
+      template = File.read("#{Fastlane::ROOT}/lib/assets/DefaultFastfileTemplate")
 
       scheme = ask("Optional: The scheme name of your app (If you don't need one, just hit Enter): ").to_s.strip unless scheme
       if scheme.length > 0

--- a/fastlane/spec/erb_template_helper_spec.rb
+++ b/fastlane/spec/erb_template_helper_spec.rb
@@ -4,7 +4,7 @@ describe Fastlane do
       it "raises an error if file does not exist" do
         expect do
           Fastlane::ErbTemplateHelper.load('invalid_name')
-        end.to raise_exception("Could not find template at path './/lib/assets/invalid_name.erb'")
+        end.to raise_exception("Could not find template at path '#{Fastlane::ROOT}/lib/assets/invalid_name.erb'")
       end
 
       it "should load file if exists" do

--- a/fastlane/spec/setup_spec.rb
+++ b/fastlane/spec/setup_spec.rb
@@ -27,8 +27,6 @@ describe Fastlane do
       it "setup is successful and generated inital Fastfile" do
         require 'produce'
 
-        allow(FastlaneCore::Helper).to receive(:gem_path).with('fastlane').and_return(File.expand_path(".")) # since we chdir later on
-
         app = "app"
 
         dev_team_id = "123123"


### PR DESCRIPTION
Continuation of work on concerns raised in #5770

Replace use of `Helper.gem_path` with `Fastlane::ROOT`
