### PR TITLE
Spaceship csrf fix

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -349,6 +349,7 @@ module Spaceship
 
     def do_login(user, password)
       @loggedin = false
+      @requested_csrf_token = nil
       ret = send_login_request(user, password) # different in subclasses
       @loggedin = true
       ret

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -412,15 +412,20 @@ module Spaceship
       # as we always want to request something at least once
       return unless @requested_csrf_token.nil?
 
+      # Update 23rd August 2016
+      # Instead of calling `Certificate::Production.all` we call `App.all`
+      # We've had issues when we only requested certificates, instead of apps, we don't know why
+      # Source: https://github.com/fastlane/fastlane/issues/5827
+
       # If we directly create a new resource (e.g. app) without querying anything before
       # we don't have a valid csrf token, that's why we have to do at least one request
-      Certificate::Production.all
+      App.all
 
       # Update 18th August 2016
       # For some reason, we have to query the resource twice to actually get a valid csrf_token
       # I couldn't find out why, the first response does have a valid Set-Cookie header
       # But it still needs this second request
-      Certificate::Production.all
+      App.all
 
       @requested_csrf_token = true if csrf_tokens.count > 0
     end

--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,4 +1,4 @@
 module Spaceship
-  VERSION = "0.31.7".freeze
+  VERSION = "0.31.8".freeze
   DESCRIPTION = "Ruby library to access the Apple Dev Center and iTunes Connect".freeze
 end


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/5827#issuecomment-241626739

Please don't squash the commits, they should stay separate

This PR includes:
- Fix setting the `csrf_token` when creating a new application
- Clearing of `csrf_token` when logging in again in `spaceship`
- Version bump

🌴 
