### PR TITLE
Ensure csrf_token when downloading a provisioning profile

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -372,6 +372,10 @@ module Spaceship
     end
 
     def download_provisioning_profile(profile_id, mac: false)
+      # Calling provisioning_profiles uses a different api end point than creating or deleting them so we
+      # use a different entity to gather the csrf token
+      ensure_csrf(Spaceship::App)
+
       r = request(:get, "account/#{platform_slug(mac)}/profile/downloadProfileContent", {
         teamId: team_id,
         provisioningProfileId: profile_id


### PR DESCRIPTION
Fixes the comment https://github.com/fastlane/fastlane/issues/5827#issuecomment-242281199
