### PR TITLE
Updated tools with build logs to use common configured Logs directory.

### DIFF
--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -146,7 +146,7 @@ module Fastlane
         end
 
         # By default we put xcodebuild.log in the Logs folder
-        buildlog_path ||= File.expand_path("~/Library/Logs/fastlane/xcbuild/#{Time.now.strftime('%F')}/#{Process.pid}")
+        buildlog_path ||= File.expand_path("#{FastlaneCore::Helper.buildlog_path}/fastlane/xcbuild/#{Time.now.strftime('%F')}/#{Process.pid}")
 
         # Joins args into space delimited string
         xcodebuild_args = xcodebuild_args.join(" ")

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -152,7 +152,7 @@ module Gym
                                      short_option: "-l",
                                      env_name: "GYM_BUILDLOG_PATH",
                                      description: "The directory where to store the build log",
-                                     default_value: "~/Library/Logs/gym"),
+                                     default_value: "#{FastlaneCore::Helper.buildlog_path}/gym"),
         FastlaneCore::ConfigItem.new(key: :sdk,
                                      short_option: "-k",
                                      env_name: "GYM_SDK",

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -96,7 +96,7 @@ module Scan
                                      short_option: "-l",
                                      env_name: "SCAN_BUILDLOG_PATH",
                                      description: "The directory were to store the raw log",
-                                     default_value: "~/Library/Logs/scan"),
+                                     default_value: "#{FastlaneCore::Helper.buildlog_path}/scan"),
         FastlaneCore::ConfigItem.new(key: :formatter,
                                      short_option: "-n",
                                      env_name: "SCAN_FORMATTER",

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -111,7 +111,7 @@ module Snapshot
                                      short_option: "-l",
                                      env_name: "SNAPSHOT_BUILDLOG_PATH",
                                      description: "The directory where to store the build log",
-                                     default_value: "~/Library/Logs/snapshot"),
+                                     default_value: "#{FastlaneCore::Helper.buildlog_path}/snapshot"),
         FastlaneCore::ConfigItem.new(key: :clean,
                                      short_option: "-c",
                                      env_name: "SNAPSHOT_CLEAN",


### PR DESCRIPTION
Continuing where #5409 left off (required a `fastlane_core` release before the tools change)

Second half of #4989 implementation.
