### PR TITLE
Spaceship improvements

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -310,6 +310,11 @@ module Spaceship
 
     def itc_service_key
       return @service_key if @service_key
+
+      # Check if we have a local cache of the key
+      itc_service_key_path = File.expand_path("~/Library/Caches/spaceship_itc_service_key.txt")
+      return File.read(itc_service_key_path) if File.exist?(itc_service_key_path)
+
       # Some customers in Asia have had trouble with the CDNs there that cache and serve this content, leading
       # to "buffer error (Zlib::BufError)" from deep in the Ruby HTTP stack. Setting this header requests that
       # the content be served only as plain-text, which seems to work around their problem, while not affecting
@@ -319,7 +324,12 @@ module Spaceship
       headers = { 'Accept-Encoding' => 'identity' }
       # We need a service key from a JS file to properly auth
       js = request(:get, "https://itunesconnect.apple.com/itc/static-resources/controllers/login_cntrl.js", nil, headers)
-      @service_key ||= js.body.match(/itcServiceKey = '(.*)'/)[1]
+      @service_key = js.body.match(/itcServiceKey = '(.*)'/)[1]
+
+      # Cache the key locally
+      File.write(itc_service_key_path, @service_key)
+
+      return @service_key
     end
 
     #####################################################

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -1,5 +1,4 @@
 module Spaceship
-  # rubocop:disable Metrics/ClassLength
   class PortalClient < Spaceship::Client
     #####################################################
     # @!group Init and Login
@@ -7,29 +6,6 @@ module Spaceship
 
     def self.hostname
       "https://developer.apple.com/services-account/#{PROTOCOL_VERSION}/"
-    end
-
-    # Fetches the latest API Key from the Apple Dev Portal
-    def api_key
-      cache_path = File.expand_path("~/Library/Caches/spaceship_api_key.txt")
-      begin
-        cached = File.read(cache_path)
-      rescue Errno::ENOENT
-      end
-      return cached if cached
-
-      landing_url = "https://developer.apple.com/account/"
-      logger.info("GET: " + landing_url)
-      headers = @client.get(landing_url).headers
-      results = headers['location'].match(/.*appIdKey=(\h+)/)
-      if (results || []).length > 1
-        api_key = results[1]
-        FileUtils.mkdir_p(File.dirname(cache_path))
-        File.write(cache_path, api_key) if api_key.length == 64
-        return api_key
-      else
-        raise "Could not find latest API Key from the Dev Portal - the server might be slow right now"
-      end
     end
 
     def send_login_request(user, password)
@@ -449,5 +425,4 @@ module Spaceship
       csrf_cache[klass] = self.csrf_tokens
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -6,29 +6,6 @@ describe Spaceship::Client do
   let(:username) { 'spaceship@krausefx.com' }
   let(:password) { 'so_secret' }
 
-  describe '#api_key' do
-    let(:path) { File.expand_path("~/Library/Caches/spaceship_api_key.txt") }
-    it 'returns the extracted api key from the login page' do
-      expect(subject.api_key).to eq('aaabd3417a7776362562d2197faaa80a8aaab108fd934911bcbea0110d07faaa')
-    end
-
-    it "stores a cached result in /tmp" do
-      File.delete(path) if File.exist?(path)
-      expect(subject.api_key).to eq('aaabd3417a7776362562d2197faaa80a8aaab108fd934911bcbea0110d07faaa')
-      expect(File.read(path)).to eq("aaabd3417a7776362562d2197faaa80a8aaab108fd934911bcbea0110d07faaa")
-    end
-
-    it "uses the cached api key if it exists" do
-      new_value = "NewValue"
-      File.write(path, new_value)
-      expect(subject.api_key).to eq(new_value)
-    end
-
-    after do
-      File.delete(path) if File.exist?(path)
-    end
-  end
-
   describe '#login' do
     it 'sets the session cookies' do
       response = subject.login(username, password)

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -23,11 +23,6 @@ end
 
 def adp_stub_login
   # Most stuff is stubbed in tunes_stubbing (since it's shared)
-
-  stub_request(:get, "https://developer.apple.com/account/").
-    to_return(status: 200, body: nil,
-    headers: { 'Location' => "https://idmsa.apple.com/IDMSWebAuth/login?&appIdKey=aaabd3417a7776362562d2197faaa80a8aaab108fd934911bcbea0110d07faaa&path=%2F%2Fmembercenter%2Findex.action" })
-
   stub_request(:post, 'https://developerservices2.apple.com/services/QH65B2/listTeams.action').
     to_return(status: 200, body: adp_read_fixture_file('listTeams.action.json'), headers: { 'Content-Type' => 'application/json' })
 end

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -24,11 +24,11 @@ end
 
 cache_paths = [
   File.expand_path("~/Library/Caches/spaceship_api_key.txt"),
-  "/tmp/spaceship_itc_login_url.txt"
+  File.expand_path("~/Library/Caches/spaceship_itc_service_key.txt")
 ]
 
 def try_delete(path)
-  FileUtils.rm_f path if File.exist? path
+  FileUtils.rm_f(path) if File.exist? path
 end
 
 RSpec.configure do |config|

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -6,6 +6,8 @@ end
 
 def itc_stub_login
   # Retrieving the current login URL
+  itc_service_key_path = File.expand_path("~/Library/Caches/spaceship_itc_service_key.txt")
+  File.delete(itc_service_key_path) if File.exist?(itc_service_key_path)
 
   stub_request(:get, 'https://itunesconnect.apple.com/itc/static-resources/controllers/login_cntrl.js').
     to_return(status: 200, body: itc_read_fixture_file('login_cntrl.js'))


### PR DESCRIPTION
Please don't squash
- Add caching of the `itc_service_key` which was requested on each login until now
- Remove old `api_key` method, which is not used any more since switching to the new two factor auth
