### PR TITLE
Adding danger_id and dangerfile params to Danger action

### DIFF
--- a/fastlane/lib/fastlane/actions/danger.rb
+++ b/fastlane/lib/fastlane/actions/danger.rb
@@ -5,9 +5,14 @@ module Fastlane
         Actions.verify_gem!('danger')
         cmd = []
 
-        cmd << ['bundle exec'] if File.exist?('Gemfile') && params[:use_bundle_exec]
-        cmd << ['danger']
-        cmd << ['--verbose'] if params[:verbose]
+        cmd << 'bundle exec' if File.exist?('Gemfile') && params[:use_bundle_exec]
+        cmd << 'danger'
+        cmd << '--verbose' if params[:verbose]
+
+        danger_id = params[:danger_id]
+        dangerfile = params[:dangerfile]
+        cmd << "--danger_id=#{danger_id}" if danger_id
+        cmd << "--dangerfile=#{dangerfile}" if dangerfile
 
         ENV['DANGER_GITHUB_API_TOKEN'] = params[:github_api_token] if params[:github_api_token]
 
@@ -34,6 +39,16 @@ module Fastlane
                                        description: "Show more debugging information",
                                        is_string: false,
                                        default_value: false),
+          FastlaneCore::ConfigItem.new(key: :danger_id,
+                                       env_name: "FL_DANGER_ID",
+                                       description: "The identifier of this Danger instance",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :dangerfile,
+                                       env_name: "FL_DANGER_DANGERFILE",
+                                       description: "The location of your Dangerfile",
+                                       is_string: true,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :github_api_token,
                                        env_name: "FL_DANGER_GITHUB_API_TOKEN",
                                        description: "GitHub API token for danger",

--- a/fastlane/spec/actions_specs/danger_spec.rb
+++ b/fastlane/spec/actions_specs/danger_spec.rb
@@ -33,6 +33,22 @@ describe Fastlane do
         expect(result).to eq("bundle exec danger")
         expect(ENV['DANGER_GITHUB_API_TOKEN']).to eq("1234")
       end
+
+      it "appends danger_id" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          danger(danger_id: 'unit-tests')
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec danger --danger_id=unit-tests")
+      end
+
+      it "appends dangerfile" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          danger(dangerfile: 'test/OtherDangerfile')
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec danger --dangerfile=test/OtherDangerfile")
+      end
     end
   end
 end


### PR DESCRIPTION
This adds support to `danger_id` and `dangerfile` parameters in Danger action.
