### PR TITLE
Add documentation for multiuser configuration

### DIFF
--- a/fastlane/docs/Appfile.md
+++ b/fastlane/docs/Appfile.md
@@ -66,22 +66,42 @@ team_id = CredentialsManager::AppfileConfig.try_fetch_value(:team_id)
 
 ### Multiple users configuration
 
+#### Using environment vairables
+
 In big teams instead of specifying one email for `apple_id`, you can get `apple_id` from environment variable instead. 
 Doing this will allow different developers to specify their own apple ids, and won't affect others
 In case if this enviroment variable won't be setup - then it will be asked by fastlane on any command that requires apple_id
 
 ```ruby
+# Appfile
 # without default fallback user will be asked to input apple_id
 apple_id ENV["MY_APP_NAME_APPLE_ID"] 
 
 # In case if environment variable isn't set up, fallback email will be used
-apple_id ENV["MY_APP_NAME_APPLE_ID"] || "defaultintegratoremail@gmail.com"
+apple_id ENV["MY_APP_NAME_APPLE_ID"] || "default@email.com"
 ```
 
 ```bash
 # ~/.bashrc of some user
-export MY_APP_NAME_APPLE_ID="someuser@gmail.com"
+export MY_APP_NAME_APPLE_ID="some_user@gmail.com"
 
 # ~/.bashrc of some another user
-export MY_APP_NAME_APPLE_ID="someanotheruser@gmail.com"
+export MY_APP_NAME_APPLE_ID="another_user@gmail.com"
+```
+
+#### Using file check and .gitignore
+
+As an another option, you can use use file checking and .gitignore combination:
+```ruby
+# Appfile
+if File.exist?("apple_id.txt")
+  apple_id File.read("apple_id.txt")
+else
+  apple_id "default@email.com"
+end
+```
+
+```sh
+# .gitignore
+apple_id.txt
 ```

--- a/fastlane/docs/Appfile.md
+++ b/fastlane/docs/Appfile.md
@@ -63,3 +63,25 @@ If you want to access those values from within your `Fastfile` use
 identifier = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
 team_id = CredentialsManager::AppfileConfig.try_fetch_value(:team_id)
 ```
+
+### Multiple users configuration
+
+In big teams instead of specifying one email for `apple_id`, you can get `apple_id` from environment variable instead. 
+Doing this will allow different developers to specify their own apple ids, and won't affect others
+In case if this enviroment variable won't be setup - then it will be asked by fastlane on any command that requires apple_id
+
+```ruby
+# without default fallback user will be asked to input apple_id
+apple_id ENV["MY_APP_NAME_APPLE_ID"] 
+
+# In case if environment variable isn't set up, fallback email will be used
+apple_id ENV["MY_APP_NAME_APPLE_ID"] || "defaultintegratoremail@gmail.com"
+```
+
+```bash
+# ~/.bashrc of some user
+export MY_APP_NAME_APPLE_ID="someuser@gmail.com"
+
+# ~/.bashrc of some another user
+export MY_APP_NAME_APPLE_ID="someanotheruser@gmail.com"
+```

--- a/fastlane/docs/Appfile.md
+++ b/fastlane/docs/Appfile.md
@@ -68,25 +68,22 @@ team_id = CredentialsManager::AppfileConfig.try_fetch_value(:team_id)
 
 #### Using environment vairables
 
-In big teams instead of specifying one email for `apple_id`, you can get `apple_id` from environment variable instead. 
+In big teams you can override `apple_id` variable with `FASTLANE_USER` environment variable. 
 Doing this will allow different developers to specify their own apple ids, and won't affect others
-In case if this enviroment variable won't be setup - then it will be asked by fastlane on any command that requires apple_id
+In case if `FASTLANE_USER` enviroment variable won't be setup - then email from the `Appfile` will be used
 
 ```ruby
 # Appfile
-# without default fallback user will be asked to input apple_id
-apple_id ENV["MY_APP_NAME_APPLE_ID"] 
-
-# In case if environment variable isn't set up, fallback email will be used
-apple_id ENV["MY_APP_NAME_APPLE_ID"] || "default@email.com"
+# This is the apple id that will be used in case if FASTLANE_USER is undefined
+apple_id "default@email.com"
 ```
 
 ```bash
 # ~/.bashrc of some user
-export MY_APP_NAME_APPLE_ID="some_user@gmail.com"
+export FASTLANE_USER="some_user@gmail.com"
 
 # ~/.bashrc of some another user
-export MY_APP_NAME_APPLE_ID="another_user@gmail.com"
+export FASTLANE_USER="another_user@gmail.com"
 ```
 
 #### Using file check and .gitignore

--- a/fastlane/docs/Appfile.md
+++ b/fastlane/docs/Appfile.md
@@ -95,7 +95,7 @@ As an another option, you can use use file checking and .gitignore combination:
 ```ruby
 # Appfile
 if File.exist?("apple_id.txt")
-  apple_id File.read("apple_id.txt")
+  apple_id File.read("apple_id.txt").strip
 else
   apple_id "default@email.com"
 end


### PR DESCRIPTION
🔑 Documentation for multiuser team configuration

This is an example how Appfile can be configured in case if your team is big enough and multiple users can submit application to the AppStore
