### PR TITLE
Update gradle and Android plugin versions

### DIFF
--- a/screengrab/build.gradle
+++ b/screengrab/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
     }
 }
 

--- a/screengrab/gradle/wrapper/gradle-wrapper.properties
+++ b/screengrab/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 03 15:15:30 EDT 2016
+#Fri Aug 26 13:15:01 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
This is an important update as it fixes a security vulnerability
https://docs.gradle.org/2.14/release-notes#local-privilege-escalation-when-using-the-daemon
