### PR TITLE
[match] Add information about readonly mode when spaceship request fails

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -31,6 +31,12 @@ module Match
       TablePrinter.print_summary(params, uuid)
 
       UI.success "All required keys, certificates and provisioning profiles are installed 🙌".green
+    rescue Spaceship::Client::UnexpectedResponse, Spaceship::Client::InvalidUserCredentialsError, Spaceship::Client::NoUserCredentialsError => ex
+      UI.error("An error occured while verifying your certificates and profiles with the Apple Developer Portal")
+      UI.error("If you already have your certificates stored in git, you can run `match` in readonly mode")
+      UI.error("To just install the certificates and profiles without accessing the Dev Portal")
+      UI.error("To do so, just pass `readonly: true` to your match call.")
+      raise ex
     ensure
       GitHelper.clear_changes
     end

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -32,9 +32,9 @@ module Match
 
       UI.success "All required keys, certificates and provisioning profiles are installed 🙌".green
     rescue Spaceship::Client::UnexpectedResponse, Spaceship::Client::InvalidUserCredentialsError, Spaceship::Client::NoUserCredentialsError => ex
-      UI.error("An error occured while verifying your certificates and profiles with the Apple Developer Portal")
+      UI.error("An error occured while verifying your certificates and profiles with the Apple Developer Portal.")
       UI.error("If you already have your certificates stored in git, you can run `match` in readonly mode")
-      UI.error("To just install the certificates and profiles without accessing the Dev Portal")
+      UI.error("to just install the certificates and profiles without accessing the Dev Portal.")
       UI.error("To do so, just pass `readonly: true` to your match call.")
       raise ex
     ensure


### PR DESCRIPTION
This will detect if match was failing due to a spaceship error, and if so, tell the user about using the readonly mode.

<img width="1108" alt="screenshot 2016-08-28 12 22 24" src="https://cloud.githubusercontent.com/assets/869950/18036237/25cedb52-6d1a-11e6-8643-88b32e03a4be.png">

This should make things clearer, fixes:
- https://github.com/fastlane/fastlane/issues/5123
- https://github.com/fastlane/fastlane/issues/5917
- https://github.com/fastlane/fastlane/issues/5921
