### PR TITLE
Add documentation to the `cocoapods` action

### DIFF
--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -48,7 +48,7 @@ cocoapods(
   clean: true,                                    # Remove SCM directories
   integrate: true,                                # Integrate the Pods libraries into the Xcode project(s)
   repo_update: false,                             # Run `pod repo update` before install
-  silent: false,                                  # Show nothing
+  silent: false,                                  # Execute command without logging output
   verbose: false,                                 # Show more debugging information
   ansi: true,                                     # Show output with ANSI codes
   use_bundle_exec: true,                          # Use bundle exec when there is a Gemfile presented

--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -41,6 +41,21 @@ If you use [CocoaPods](http://cocoapods.org) you can use the `cocoapods` integra
 cocoapods # this will run pod install
 ```
 
+More options are available:
+
+```ruby
+cocoapods(
+  clean: true,                                    # Remove SCM directories
+  integrate: true,                                # Integrate the Pods libraries into the Xcode project(s)
+  repo_update: false,                             # Run `pod repo update` before install
+  silent: false,                                  # Show nothing
+  verbose: false,                                 # Show more debugging information
+  ansi: true,                                     # Show output with ANSI codes
+  use_bundle_exec: true,                          # Use bundle exec when there is a Gemfile presented
+  podfile: 'path/to/Podfile'                      # Explicitly specify the path to the Cocoapods' Podfile. You can either set it to the Podfile's path or to the folder containing the Podfile file
+)
+```
+
 ### [Carthage](https://github.com/Carthage/Carthage)
 
 This will execute `carthage bootstrap`

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -50,7 +50,7 @@ module Fastlane
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :silent,
                                        env_name: "FL_COCOAPODS_SILENT",
-                                       description: "Show nothing",
+                                       description: "Execute command without logging output",
                                        is_string: false,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :verbose,


### PR DESCRIPTION
Documentation for the available options/params that can be passed to the `cocoapods` fastlane action
