### PR TITLE
Update fastlane version

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.101.0'.freeze
+  VERSION = '1.102.0'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end


### PR DESCRIPTION
[13:44:59]: Changes since release 1.101.0:
- Added --keychain-path to sigh (#5934)
- Sigh/4397 extract entitlements from app (#5130)
- [fastlane] Switching lane shouldn't be green (#5914)
- Adds SCAN_GENERATED_PLIST_FILES variable to report all test summaries. (#5740)
- Adding danger_id and dangerfile params to Danger action (#5894)
- Updated tools with build logs to use common configured Logs directory. (#5881)
- [slack] Don't post the lane when using slack as one-off action (#5899)
- Fix lane name conflict when creating a new Fastfile (#5895)
- Cocoapods now recommends json file formats, so fastlane should support it (#5869)
- [fastlane][verify_xcode] Add an additional set of accepted codesign details for Xcode 8 (#5821) (#5822)
- Add shell escaping to Crashlytics path (#5870)
- Add a ROOT path constant for fastlane (#5855)
- Fixed issue where artefacts with parens () would not get copied because of the shell escaping (#5812)
- Remove new action link (#5814)
- Add link to Circle docs (#5801)
