### PR TITLE
Version Bump

### DIFF
--- a/screengrab/version.properties
+++ b/screengrab/version.properties
@@ -1,3 +1,3 @@
 major=0
 minor=5
-patch=0
+patch=1


### PR DESCRIPTION
Changes since release 0.5.0:
- Update gradle and Android plugin versions (#5906)
- Add a ROOT path constant for screengrab (#5846)
- Skip GitHub issues by default for user_error! (#5622)
- Fix illegal > char in JavaDoc (#5722)
