### PR TITLE
Update gym version

### DIFF
--- a/gym/lib/gym/version.rb
+++ b/gym/lib/gym/version.rb
@@ -1,4 +1,4 @@
 module Gym
-  VERSION = "1.7.0"
+  VERSION = "1.8.0"
   DESCRIPTION = "Building your iOS apps has never been easier"
 end


### PR DESCRIPTION
[14:51:34]: Changes since release 1.7.0:
- [gym] Add option to pass in specific toolchain (#5864)
- Switch from xctool to scan (#5923)
- Updated tools with build logs to use common configured Logs directory. (#5881)
- Add a ROOT path constant for gym (#5842)
- [gym] add options to configure or disable xcpretty (#5751)
- Skip GitHub issues by default for user_error! (#5622)
- [gym] Skip showing GitHub issues for build errors (#5610)
- Update code signing URL across the fastlane code base (#5451)
- Add Xcode 8 support: rename "OS X" to "macOS" (#5385)
