### PR TITLE
adds keychain_path parameter to method calls

### DIFF
--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -12,8 +12,8 @@ module Sigh
       end
     end
 
-    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements)
-      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements)
+    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path)
+      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path)
     end
 
     def resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path)


### PR DESCRIPTION
Fixes a bug where the `resign` command fails to execute with the following error message:

```
13:20:46 /usr/local/lib/ruby/gems/2.3.0/gems/sigh-1.10.0/lib/sigh/resign.rb:15:in `resign': [!] wrong number of arguments (given 11, expected 10) (ArgumentError)
13:20:46    from /usr/local/lib/ruby/gems/2.3.0/gems/fastlane-1.102.0/lib/fastlane/actions/resign.rb:9:in `run'
```

This is a fix for an error introduced in https://github.com/fastlane/fastlane/pull/5934
