### PR TITLE
Display error when unable to parse strings file #1747

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -286,7 +286,20 @@ module Frameit
       if File.exist? strings_path
         parsed = StringsParser.parse(strings_path)
         result = parsed.find { |k, v| screenshot.path.upcase.include? k.upcase }
-        return result.last if result
+        if result 
+          return result.last
+        else
+          File.open(strings_path, "rb") do |file|
+            num = file.read(2).unpack("n")
+            file.close
+
+            if num != 65279  # FEFF - 16bit Big-endian BOM
+              UI.error("Could not parse #{strings_path}. Please make sure it is UTF16, Big Endian Encoded")
+            else
+              UI.error("Could not parse #{strings_path}")
+            end
+          end 
+        end
       end
 
       # No string files, fallback to Framefile config

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -286,19 +286,19 @@ module Frameit
       if File.exist? strings_path
         parsed = StringsParser.parse(strings_path)
         result = parsed.find { |k, v| screenshot.path.upcase.include? k.upcase }
-        if result 
+        if result
           return result.last
         else
           File.open(strings_path, "rb") do |file|
             num = file.read(2).unpack("n")
             file.close
 
-            if num != 65279  # FEFF - 16bit Big-endian BOM
+            if num != 65_279 # FEFF - 16bit Big-endian BOM
               UI.error("Could not parse #{strings_path}. Please make sure it is UTF16, Big Endian Encoded")
             else
               UI.error("Could not parse #{strings_path}")
             end
-          end 
+          end
         end
       end
 


### PR DESCRIPTION
Display error messages when the parser can not read the strings file. (non-utf16 encoding or generic error).
Related to this issue: https://github.com/fastlane/fastlane/issues/1747
