### PR TITLE
Display error when parsing a .strings file returns empty results (#1747)

### DIFF
--- a/frameit/lib/frameit/strings_parser.rb
+++ b/frameit/lib/frameit/strings_parser.rb
@@ -25,6 +25,10 @@ module Frameit
         end
       end
 
+      if result.empty?
+        UI.error "Empty parsing result for #{path}. Please make sure the file is valid and UTF16 Big-endian encoded"
+      end
+
       result
     end
   end

--- a/frameit/spec/strings_parser_spec.rb
+++ b/frameit/spec/strings_parser_spec.rb
@@ -29,6 +29,7 @@ describe Frameit do
         it "logs a helpful message on a bad file" do
           expect(Frameit::UI).to receive(:error).with(/.*translations.bad.strings line 2:/)
           expect(Frameit::UI).to receive(:verbose).with(/undefined method .\[\]. for nil:NilClass/)
+          expect(Frameit::UI).to receive(:error).with(/Empty parsing result for .*translations.bad.strings/)
 
           translations = Frameit::StringsParser.parse("./spec/fixtures/translations.bad.strings")
           expect(translations). to eq({})


### PR DESCRIPTION
Display error messages when the parser can not read the strings file or the file contains empty data.
Related to this issue: #1747, fixed as discussed with @mfurtak in issue #5956
