### PR TITLE
[gym] Replace separator in output name to prevent directory creation #5909

### DIFF
--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -63,7 +63,8 @@ module Gym
                                      description: "The name of the resulting ipa file",
                                      optional: true,
                                      verify_block: proc do |value|
-                                       value.gsub!(".ipa", "").gsub!(File::SEPARATOR, "_")
+                                       value.gsub!(".ipa", "")
+                                       value.gsub!(File::SEPARATOR, "_")
                                      end),
         FastlaneCore::ConfigItem.new(key: :configuration,
                                      short_option: "-q",

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -63,7 +63,7 @@ module Gym
                                      description: "The name of the resulting ipa file",
                                      optional: true,
                                      verify_block: proc do |value|
-                                       value.gsub!(".ipa", "").gsub!(File::SEPARATOR,"_")
+                                       value.gsub!(".ipa", "").gsub!(File::SEPARATOR, "_")
                                      end),
         FastlaneCore::ConfigItem.new(key: :configuration,
                                      short_option: "-q",

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -63,7 +63,7 @@ module Gym
                                      description: "The name of the resulting ipa file",
                                      optional: true,
                                      verify_block: proc do |value|
-                                       value.gsub!(".ipa", "")
+                                       value.gsub!(".ipa", "").gsub!(File::SEPARATOR,"_")
                                      end),
         FastlaneCore::ConfigItem.new(key: :configuration,
                                      short_option: "-q",

--- a/gym/spec/options_spec.rb
+++ b/gym/spec/options_spec.rb
@@ -20,5 +20,12 @@ describe Gym do
 
       expect(Gym.config[:scheme]).to eq("Example")
     end
+
+    it "replaces SEPARATOR (i.e. /) character with underscore(_) in output name" do
+      options = { output_name: "feature" + File::SEPARATOR + "Example.ipa", project: "./examples/standard/Example.xcodeproj" }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      expect(Gym.config[:output_name]).to eq("feature_Example")
+    end
   end
 end


### PR DESCRIPTION
#5909

This replaces any File::SEPARATOR occurrences in output name to prevent directories being created when output name is used in a path for file creation.
