### PR TITLE
Add a test for error shown with a UTF-8 encoded strings file

### DIFF
--- a/frameit/spec/fixtures/translations.utf8.strings
+++ b/frameit/spec/fixtures/translations.utf8.strings
@@ -1,0 +1,8 @@
+/* No comment provided by engineer. */
+"Cancel" = "Abbrechen";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
+
+/* No comment provided by engineer. */
+"Multiple words working" = "einlangesdeutshceswort mit Abstand";

--- a/frameit/spec/strings_parser_spec.rb
+++ b/frameit/spec/strings_parser_spec.rb
@@ -1,5 +1,5 @@
 describe Frameit do
-  describe Frameit::ConfigParser do
+  describe Frameit::StringsParser do
     describe "parse" do
       it "raise error when file can't be found" do
         expect do
@@ -32,6 +32,13 @@ describe Frameit do
           expect(Frameit::UI).to receive(:error).with(/Empty parsing result for .*translations.bad.strings/)
 
           translations = Frameit::StringsParser.parse("./spec/fixtures/translations.bad.strings")
+          expect(translations). to eq({})
+        end
+
+        it "explains that only UTF-16 is allowed if a UTF-8 encoded, but otherwise valid file is parsed" do
+          expect(Frameit::UI).to receive(:error).with(/.*translations.utf8.strings.*UTF16/)
+
+          translations = Frameit::StringsParser.parse("./spec/fixtures/translations.utf8.strings")
           expect(translations). to eq({})
         end
       end


### PR DESCRIPTION
Follow-on to #5958 to add another test
