### PR TITLE
Add new line at end of docs generator

### DIFF
--- a/fastlane/lib/fastlane/documentation/docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/docs_generator.rb
@@ -38,6 +38,7 @@ module Fastlane
       output << "This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run."
       output << "More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools)."
       output << "The documentation of fastlane can be found on [GitHub](https://github.com/fastlane/fastlane/tree/master/fastlane)."
+      output << ""
 
       File.write(output_path, output.join("\n"))
       UI.success "Successfully generated documentation at path '#{File.expand_path(output_path)}'" if $verbose


### PR DESCRIPTION
Sorry for the silly PR, but I find the lack of a newline at the end of the auto generated readme a bit distracting in most git tools and unfriendly to `cat`.

![newline](https://cloud.githubusercontent.com/assets/5181522/18162392/8da44824-7036-11e6-9e7b-c72c3feb311c.png)

This simply adds a newline at the end of file to remove the warning. Thanks!!
