### PR TITLE
Include the full path name in file not found error message. #5962

### DIFF
--- a/fastlane/lib/fastlane/actions/update_info_plist.rb
+++ b/fastlane/lib/fastlane/actions/update_info_plist.rb
@@ -33,7 +33,7 @@ module Fastlane
 
           # Read existing plist file
           info_plist_path = File.join(folder, "..", params[:plist_path])
-          UI.user_error!("Couldn't find info plist file at path '#{params[:plist_path]}'") unless File.exist?(info_plist_path)
+          UI.user_error!("Couldn't find info plist file at path '#{info_plist_path}'") unless File.exist?(info_plist_path)
           plist = Xcodeproj::Plist.read_from_path(info_plist_path)
 
           # Update plist values

--- a/fastlane/spec/actions_specs/update_info_plist_spec.rb
+++ b/fastlane/spec/actions_specs/update_info_plist_spec.rb
@@ -63,6 +63,9 @@ describe Fastlane do
       end
 
       it "throws an error when the info plist file does not exist" do
+        # This is path update_info_plist creates to locate the plist file.
+        full_path = [test_path, proj_file, '..', "NOEXIST-#{plist_path}"].join(File::SEPARATOR)
+
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             update_info_plist ({
@@ -72,7 +75,7 @@ describe Fastlane do
               display_name: '#{display_name}'
             })
           end").runner.execute(:test)
-        end.to raise_error("Couldn't find info plist file at path 'NOEXIST-#{plist_path}'")
+        end.to raise_error("Couldn't find info plist file at path '#{full_path}'")
       end
 
       it "throws an error when the scheme does not exist" do


### PR DESCRIPTION
🔑 

When the plist file cannot be found, include the full path name to the file in the error message to help in troubleshooting.
