### PR TITLE
Fix spaceship caching on Linux

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -312,7 +312,7 @@ module Spaceship
       return @service_key if @service_key
 
       # Check if we have a local cache of the key
-      itc_service_key_path = File.expand_path("~/Library/Caches/spaceship_itc_service_key.txt")
+      itc_service_key_path = "/tmp/spaceship_itc_service_key.txt"
       return File.read(itc_service_key_path) if File.exist?(itc_service_key_path)
 
       # Some customers in Asia have had trouble with the CDNs there that cache and serve this content, leading

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -23,8 +23,7 @@ unless ENV["DEBUG"]
 end
 
 cache_paths = [
-  File.expand_path("~/Library/Caches/spaceship_api_key.txt"),
-  File.expand_path("~/Library/Caches/spaceship_itc_service_key.txt")
+  File.expand_path("/tmp/spaceship_itc_service_key.txt")
 ]
 
 def try_delete(path)


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/5952 which was introduced with https://github.com/fastlane/fastlane/pull/5887, since the ~/Library/Caches doesn’t exist on Linux
