### PR TITLE
Use Snapshot.config[:ios_version] if os_version is not given.

### DIFF
--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -64,7 +64,7 @@ module Snapshot
         ["| tee #{xcodebuild_log_path.shellescape} | xcpretty #{Snapshot.config[:xcpretty_args]}"]
       end
 
-      def find_device(device_name, os_version)
+      def find_device(device_name, os_version = Snapshot.config[:ios_version])
         # We might get this error message
         # > The requested device could not be found because multiple devices matched the request.
         #


### PR DESCRIPTION
Use Snapshot.config[:ios_version] if os_version is not given, #5976.
The call from runner.rb:200 only uses device_name.
