### PR TITLE
Fix Xcode 8 hung-up by making Helper.backticks retriable 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,6 +79,8 @@ Style/AndOr:
 Metrics/ClassLength:
   Max: 320
 
+Metrics/ModuleLength:
+  Max: 130
 
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:

--- a/fastlane_core/fastlane_core.gemspec
+++ b/fastlane_core/fastlane_core.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'plist', '~> 3.1' # needed for parsing provisioning profiles
   spec.add_dependency 'terminal-table', '~> 1.4.5' # options summary
   spec.add_dependency 'gh_inspector', '>= 1.0.1', '< 2.0.0' # search for issues on GitHub when something goes wrong
+  spec.add_dependency 'retriable', '~> 2.1' # simple DSL to retry failed code blocks
 
   spec.add_dependency 'credentials_manager', '>= 0.16.0', '< 1.0.0' # fastlane password manager
 

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -216,7 +216,14 @@ module FastlaneCore
     def build_settings(key: nil, optional: true)
       unless @build_settings
         command = build_xcodebuild_showbuildsettings_command
-        @build_settings = Helper.backticks(command, print: false)
+        # Workaround for Xcode 8 problem:
+        # `xcodebuild -showBuildSettings` will hang up sometimes
+        # By retrying with specific timeout, this problem can be avoided
+        options = {
+          tries:  (ENV['FASTLANE_XCODEBUILD_SETTINGS_TRIES'] || 3).to_i,
+          timeout: (ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] || 10).to_i
+        }
+        @build_settings = Helper.backticks(command, print: false, retriable_options: options)
       end
 
       begin


### PR DESCRIPTION
This is for https://github.com/fastlane/fastlane/issues/4059  https://github.com/fastlane/fastlane/issues/5163 https://github.com/fastlane/fastlane/issues/5603
This will solve these issues!

The problem is caused by Xcode 8 
Ref: https://forums.developer.apple.com/thread/50372
## How to reproduce

See sample project: https://github.com/nafu/Xcode8HungUpTestWithCoreData/tree/master
## Notes

I know there is already PR for this https://github.com/fastlane/fastlane/pull/5188, but I try to take another option.
