### PR TITLE
Fix not to create ~ directory in current directory

### DIFF
--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -13,7 +13,7 @@ module Gym
       end
       verify_archive
 
-      FileUtils.mkdir_p(Gym.config[:output_directory])
+      FileUtils.mkdir_p(File.expand_path(Gym.config[:output_directory]))
 
       if Gym.project.ios? || Gym.project.tvos?
         fix_generic_archive # See https://github.com/fastlane/fastlane/pull/4325


### PR DESCRIPTION
Fix https://github.com/fastlane/fastlane/issues/5430 by passing `File.expand_path(Gym.config[:output_directory])` to `FileUtils.mkdir_p()`
