### PR TITLE
Improve adb output handling to ignore warning lines

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -77,11 +77,15 @@ module Screengrab
     end
 
     def select_device
-      devices = @executor.execute(command: "adb devices -l", print_all: true, print_command: true).split("\n")
+      devices = run_adb_command("adb devices -l", print_all: true, print_command: true).split("\n")
       # the first output by adb devices is "List of devices attached" so remove that and any adb startup output
-      # devices.reject! { |d| d.include?("List of devices attached") || d.include?("* daemon") || d.include?("unauthorized") || d.include?("offline") }
       devices.reject! do |device|
-        ['unauthorized', 'offline', '* daemon', 'List of devices attached'].any? { |status| device.include? status }
+        [
+          'unauthorized',            # The device has not yet accepted ADB control
+          'offline',                 # The device is offline, skip it
+          '* daemon',                # Messages printed when the daemon is starting up
+          'List of devices attached' # Header of table for data we want
+        ].any? { |status| device.include? status }
       end
 
       UI.user_error! 'There are no connected and authorized devices or emulators' if devices.empty?
@@ -130,9 +134,9 @@ module Screengrab
     end
 
     def determine_external_screenshots_path(device_serial)
-      device_ext_storage = @executor.execute(command: "adb -s #{device_serial} shell echo \\$EXTERNAL_STORAGE",
-                                             print_all: true,
-                                             print_command: true)
+      device_ext_storage = run_adb_command("adb -s #{device_serial} shell echo \\$EXTERNAL_STORAGE",
+                                           print_all: true,
+                                           print_command: true)
       File.join(device_ext_storage, @config[:app_package_name], 'screengrab')
     end
 
@@ -145,9 +149,9 @@ module Screengrab
 
       device_screenshots_paths.each do |device_path|
         if_device_path_exists(device_serial, device_path) do |path|
-          @executor.execute(command: "adb -s #{device_serial} shell rm -rf #{path}",
-                            print_all: true,
-                            print_command: true)
+          run_adb_command("adb -s #{device_serial} shell rm -rf #{path}",
+                          print_all: true,
+                          print_command: true)
         end
       end
     end
@@ -172,36 +176,36 @@ module Screengrab
 
     def install_apks(device_serial, app_apk_path, tests_apk_path)
       UI.message 'Installing app APK'
-      apk_install_output = @executor.execute(command: "adb -s #{device_serial} install -r #{app_apk_path}",
-                        print_all: true,
-                        print_command: true)
+      apk_install_output = run_adb_command("adb -s #{device_serial} install -r #{app_apk_path}",
+                                           print_all: true,
+                                           print_command: true)
       UI.user_error! "App APK could not be installed" if apk_install_output.include?("Failure [")
 
       UI.message 'Installing tests APK'
-      apk_install_output = @executor.execute(command: "adb -s #{device_serial} install -r #{tests_apk_path}",
-                        print_all: true,
-                        print_command: true)
+      apk_install_output = run_adb_command("adb -s #{device_serial} install -r #{tests_apk_path}",
+                                           print_all: true,
+                                           print_command: true)
       UI.user_error! "Tests APK could not be installed" if apk_install_output.include?("Failure [")
     end
 
     def grant_permissions(device_serial)
       UI.message 'Granting the permission necessary to change locales on the device'
-      @executor.execute(command: "adb -s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.CHANGE_CONFIGURATION",
-                        print_all: true,
-                        print_command: true)
+      run_adb_command("adb -s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.CHANGE_CONFIGURATION",
+                      print_all: true,
+                      print_command: true)
 
-      device_api_version = @executor.execute(command: "adb -s #{device_serial} shell getprop ro.build.version.sdk",
-                                             print_all: true,
-                                             print_command: true).to_i
+      device_api_version = run_adb_command("adb -s #{device_serial} shell getprop ro.build.version.sdk",
+                                           print_all: true,
+                                           print_command: true).to_i
 
       if device_api_version >= 23
         UI.message 'Granting the permissions necessary to access device external storage'
-        @executor.execute(command: "adb -s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.WRITE_EXTERNAL_STORAGE",
-                          print_all: true,
-                          print_command: true)
-        @executor.execute(command: "adb -s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.READ_EXTERNAL_STORAGE",
-                          print_all: true,
-                          print_command: true)
+        run_adb_command("adb -s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.WRITE_EXTERNAL_STORAGE",
+                        print_all: true,
+                        print_command: true)
+        run_adb_command("adb -s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.READ_EXTERNAL_STORAGE",
+                        print_all: true,
+                        print_command: true)
       end
     end
 
@@ -216,9 +220,9 @@ module Screengrab
         instrument_command << "-e package #{test_packages_to_use.join(',')}" if test_packages_to_use
         instrument_command << "#{@config[:tests_package_name]}/#{@config[:test_instrumentation_runner]}"
 
-        test_output = @executor.execute(command: instrument_command.join(" \\\n"),
-                                        print_all: true,
-                                        print_command: true)
+        test_output = run_adb_command(instrument_command.join(" \\\n"),
+                                      print_all: true,
+                                      print_command: true)
 
         UI.user_error!("Tests failed", show_github_issues: false) if test_output.include?("FAILURES!!!")
       end
@@ -235,9 +239,9 @@ module Screengrab
       Dir.mktmpdir do |tempdir|
         device_screenshots_paths.each do |device_path|
           if_device_path_exists(device_serial, device_path) do |path|
-            @executor.execute(command: "adb -s #{device_serial} pull #{path} #{tempdir}",
-                              print_all: false,
-                              print_command: true)
+            run_adb_command("adb -s #{device_serial} pull #{path} #{tempdir}",
+                            print_all: false,
+                            print_command: true)
           end
         end
 
@@ -298,9 +302,9 @@ module Screengrab
     # Some device commands fail if executed against a device path that does not exist, so this helper method
     # provides a way to conditionally execute a block only if the provided path exists on the device.
     def if_device_path_exists(device_serial, device_path)
-      return if @executor.execute(command: "adb -s #{device_serial} shell ls #{device_path}",
-                                  print_all: false,
-                                  print_command: false).include?('No such file')
+      return if run_adb_command("adb -s #{device_serial} shell ls #{device_path}",
+                                print_all: false,
+                                print_command: false).include?('No such file')
 
       yield device_path
     rescue
@@ -312,10 +316,20 @@ module Screengrab
       unless @config[:skip_open_summary]
         UI.message "Opening screenshots summary"
         # MCF: this isn't OK on any platform except Mac
-        @executor.execute(command: "open #{@config[:output_directory]}/*/images/#{device_type_dir_name}/*.png",
-                          print_all: false,
-                          print_command: true)
+        run_adb_command("open #{@config[:output_directory]}/*/images/#{device_type_dir_name}/*.png",
+                        print_all: false,
+                        print_command: true)
       end
+    end
+
+    def run_adb_command(command, print_all: false, print_command: false)
+      output = @executor.execute(command: command,
+                                 print_all: print_all,
+                                 print_command: print_command) || ''
+      output.lines.reject do |line|
+        # Debug/Warning output from ADB}
+        line.start_with?('adb: ')
+      end.join('') # Lines retain their newline chars
     end
   end
 end

--- a/screengrab/spec/runner_spec.rb
+++ b/screengrab/spec/runner_spec.rb
@@ -97,4 +97,19 @@ describe Screengrab::Runner do
       end
     end
   end
+
+  describe :run_adb_command do
+    it 'filters out lines which are ADB warnings' do
+      adb_response = <<-ADB_OUTPUT.strip_heredoc
+            adb: /home/me/rubystack-2.3.1-4/common/lib/libcrypto.so.1.0.0: no version information available (required by adb)
+            List of devices attached
+            e1dbf228               device usb:1-1.2 product:a33gdd model:SM_A300H device:a33g
+
+          ADB_OUTPUT
+
+      set_mock_adb_response("test", adb_response)
+
+      expect(@runner.run_adb_command("test").lines.any? { |line| line.start_with?('adb: ') }).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Addresses #5928 by filtering out `adb` output lines beginning with "adb: "
