### PR TITLE
Version Bump

### DIFF
--- a/screengrab/version.properties
+++ b/screengrab/version.properties
@@ -1,3 +1,3 @@
 major=0
 minor=5
-patch=1
+patch=2


### PR DESCRIPTION
Changes since release 0.5.1:
- Improve adb output handling to ignore adb warning lines (#6016)
- Update version (#5968)
