### PR TITLE
Version Bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.50.3".freeze
+  VERSION = "0.51.0".freeze
 end


### PR DESCRIPTION
Changes since release 0.50.3:
- Make small improvements to project run retry code and logging (#6030)
- Timeout and retry `xcodebuild -showBuildSettings` (#5188)
- Note reason for work-around (#6024)
- Add `clean` to `xcodebuild -showBuildSettings` to workaround hang with core data projects
- [fastlane] Refactor fastlane runner to make it easy to access from docs (#5951)
- Add a ROOT path constant for fastlane_core (#5854)
