### PR TITLE
Update badge description

### DIFF
--- a/fastlane/lib/fastlane/actions/badge.rb
+++ b/fastlane/lib/fastlane/actions/badge.rb
@@ -24,7 +24,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Automatically add a badge to your iOS app icon"
+        "Automatically add a badge to your app icon"
       end
 
       def self.details


### PR DESCRIPTION
Remove ios from the description because this action lists 'android' as a platform it supports
