### PR TITLE
Change pod lib lint platform support

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_lib_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_lib_lint.rb
@@ -97,7 +97,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        true
+        [:ios, :mac].include?(platform)
       end
     end
   end


### PR DESCRIPTION
This action only supports ios or mac projects
