### PR TITLE
Can automatically determine if the Swift 2.3 toolchain needs to be used

### DIFF
--- a/gym/lib/gym/xcodebuild_fixes/swift_fix.rb
+++ b/gym/lib/gym/xcodebuild_fixes/swift_fix.rb
@@ -70,13 +70,13 @@ module Gym
       # at some point
       # @return true if all build settings are configured as 2.3
       def is_swift_23
-
         project = Gym.project
         xcodeproj_path = project.is_workspace ? project.path.gsub('xcworkspace', 'xcodeproj') : project.path
 
         project = Xcodeproj::Project.open(xcodeproj_path)
 
         # Get array of unique swift versions
+        # rubocop:disable Style/MultilineBlockChain
         swift_versions = project.objects.select do |object|
           object.isa == 'XCBuildConfiguration'
         end.map(&:to_hash).map do |object_hash|

--- a/gym/lib/gym/xcodebuild_fixes/swift_fix.rb
+++ b/gym/lib/gym/xcodebuild_fixes/swift_fix.rb
@@ -86,6 +86,7 @@ module Gym
         end.map do |build_settings|
           build_settings['SWIFT_VERSION']
         end.uniq
+        # rubocop:enable Style/MultilineBlockChain
 
         # Warning and return false if multiple settings
         # This probably shouldn't ever happen so didn't want to spend a lot of

--- a/gym/lib/gym/xcodebuild_fixes/swift_fix.rb
+++ b/gym/lib/gym/xcodebuild_fixes/swift_fix.rb
@@ -95,7 +95,7 @@ module Gym
         # Developer can use the "toolchain" config to get something super specific setup
         # if (s)he wants :)
         if swift_versions.count > 1
-          UI.warning "Build settings don't have SWIFT_VERSION set to 2.3 for all configurations. Cannot determine which toolchaint to use."
+          UI.warning "Build settings don't have SWIFT_VERSION set to 2.3 for all configurations. Cannot determine which toolchain to use."
           return false
         end
 


### PR DESCRIPTION
@KrauseFx Here is the PR I told you I'd do 😊 
- I still allowed the `toolchain` config to be used first (if specified). I wanted to do this incase of some odd naming or custom toolchain they wanted to use.
- If legacy is set to `2.3`, we will use that toolchain automatically
