### PR TITLE
Don't `shift` for `--use-app-entitlements`

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -195,7 +195,6 @@ while [ "$1" != "" ]; do
             BUNDLE_VERSION="$1"
             ;;
         --use-app-entitlements )
-            shift
             USE_APP_ENTITLEMENTS="YES"
             ;;
         --keychain-path )


### PR DESCRIPTION
This change in #5934 broke the `--use-app-entitlements` option that was added in #5130. Because there's no parameter to the `--use-app-entitlements`, we shouldn't `shift` for it.
