### PR TITLE
Don’t hang on git clone command when user credentials are missing

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -217,7 +217,7 @@ module Fastlane
         branch_option = ""
         branch_option = "--branch #{branch}" if branch != 'HEAD'
 
-        clone_command = "git clone '#{url}' '#{clone_folder}' --depth 1 -n #{branch_option}"
+        clone_command = "GIT_TERMINAL_PROMPT=0 git clone '#{url}' '#{clone_folder}' --depth 1 -n #{branch_option}"
 
         UI.message "Cloning remote git repo..."
         Actions.sh(clone_command)

--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -4,7 +4,9 @@ module Match
       return @dir if @dir
 
       @dir = Dir.mktmpdir
-      command = "git clone '#{git_url}' '#{@dir}'"
+
+      # GIT_TERMINAL_PROMPT will fail the `git clone` command if user credentials are missing
+      command = "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{@dir}'"
       command << " --depth 1" if shallow_clone
 
       UI.message "Cloning remote git repo..."

--- a/match/spec/git_helper_spec.rb
+++ b/match/spec/git_helper_spec.rb
@@ -17,7 +17,7 @@ describe Match do
         expect(Dir).to receive(:mktmpdir).and_return(path)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         shallow_clone = false
-        command = "git clone '#{git_url}' '#{path}'"
+        command = "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{path}'"
         to_params = {
           command: command,
           print_all: nil,
@@ -39,7 +39,7 @@ describe Match do
         expect(Dir).to receive(:mktmpdir).and_return(path)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         shallow_clone = true
-        command = "git clone '#{git_url}' '#{path}' --depth 1"
+        command = "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{path}' --depth 1"
         to_params = {
           command: command,
           print_all: nil,
@@ -61,7 +61,7 @@ describe Match do
         expect(Dir).to receive(:mktmpdir).and_return(path)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         shallow_clone = false
-        command = "git clone '#{git_url}' '#{path}'"
+        command = "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{path}'"
         to_params = {
           command: command,
           print_all: nil,
@@ -84,7 +84,7 @@ describe Match do
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         git_branch = "test"
         shallow_clone = false
-        command = "git clone '#{git_url}' '#{path}'"
+        command = "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{path}'"
         to_params = {
           command: command,
           print_all: nil,


### PR DESCRIPTION
Using the `GIT_TERMINAL_PROMPT` env variable the command will fail instead of prompting for the user’s credentials, it’s like magic
