### PR TITLE
Add project_directory option to carthage action

### DIFF
--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -20,6 +20,7 @@ module Fastlane
         cmd << "--configuration #{params[:configuration]}" if params[:configuration]
         cmd << "--derived-data #{params[:derived_data].shellescape}" if params[:derived_data]
         cmd << "--toolchain #{params[:toolchain]}" if params[:toolchain]
+        cmd << "--project-directory #{params[:project_directory]}" if params[:project_directory]
 
         Actions.sh(cmd.join(' '))
       end
@@ -123,6 +124,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :toolchain,
                                        env_name: "FL_CARTHAGE_TOOLCHAIN",
                                        description: "Define which xcodebuild toolchain to use when building",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :project_directory,
+                                       env_name: "FL_CARTHAGE_PROJECT_DIRECTORY",
+                                       description: "Define the directory containing the Carthage project",
                                        optional: true)
         ]
       end

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -342,6 +342,30 @@ describe Fastlane do
 
         expect(result).to eq("carthage bootstrap --toolchain com.apple.dt.toolchain.Swift_2_3")
       end
+      
+      it "sets the project directory to other" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          carthage(project_directory: 'other')
+        end").runner.execute(:test)
+        
+        expect(result).to eq("carthage bootstrap --project-directory other")
+      end
+      
+      it "sets the project directory to other and the toolchain to Swift_2_3" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          carthage(toolchain: 'com.apple.dt.toolchain.Swift_2_3', project_directory: 'other')
+        end").runner.execute(:test)
+        
+        expect(result).to eq("carthage bootstrap --toolchain com.apple.dt.toolchain.Swift_2_3 --project-directory other")
+      end
+      
+      it "does not set the project directory if none is provided" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          carthage
+        end").runner.execute(:test)
+        
+        expect(result).to eq("carthage bootstrap")
+      end
 
       it "use custom derived data" do
         result = Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -342,28 +342,28 @@ describe Fastlane do
 
         expect(result).to eq("carthage bootstrap --toolchain com.apple.dt.toolchain.Swift_2_3")
       end
-      
+
       it "sets the project directory to other" do
         result = Fastlane::FastFile.new.parse("lane :test do
           carthage(project_directory: 'other')
         end").runner.execute(:test)
-        
+
         expect(result).to eq("carthage bootstrap --project-directory other")
       end
-      
+
       it "sets the project directory to other and the toolchain to Swift_2_3" do
         result = Fastlane::FastFile.new.parse("lane :test do
           carthage(toolchain: 'com.apple.dt.toolchain.Swift_2_3', project_directory: 'other')
         end").runner.execute(:test)
-        
+
         expect(result).to eq("carthage bootstrap --toolchain com.apple.dt.toolchain.Swift_2_3 --project-directory other")
       end
-      
+
       it "does not set the project directory if none is provided" do
         result = Fastlane::FastFile.new.parse("lane :test do
           carthage
         end").runner.execute(:test)
-        
+
         expect(result).to eq("carthage bootstrap")
       end
 


### PR DESCRIPTION
Accept an option of project_directory that adds a `--project-directory` flag to
the executed carthage command.

Related to issue #6052.
