### PR TITLE
Fix Info.plist key in option description

### DIFF
--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -68,9 +68,9 @@ module Sigh
         c.option '-d', '--display_name STRING', String, 'Display name to use'
         c.option '-e', '--entitlements PATH', String, 'The path to the entitlements file to use.'
         c.option '--short_version STRING', String, 'Short version string to force binary and all nested binaries to use (CFBundleShortVersionString).'
-        c.option '--bundle_version STRING', String, 'Bundle version to force binary and all nested binaries to use (CFBundleIdentifier).'
+        c.option '--bundle_version STRING', String, 'Bundle version to force binary and all nested binaries to use (CFBundleVersion).'
         c.option '--use_app_entitlements', 'Extract app bundle codesigning entitlements and combine with entitlements from new provisionin profile.'
-        c.option '-g', '--new_bundle_id STRING', String, 'New application bundle ID'
+        c.option '-g', '--new_bundle_id STRING', String, 'New application bundle ID (CFBundleIdentifier)'
         c.option '--keychain_path STRING', String, 'Path to the keychain that /usr/bin/codesign should use'
 
         c.action do |args, options|


### PR DESCRIPTION
I think there is a refactor in the code that could be made, as the correct key is in 2 of the 3 usage descriptions throughout the code.

sigh/lib/sigh/commands_generator.rb
sigh/lib/assets/resign.sh
fastlane/lib/fastlane/actions/resign.rb
