### PR TITLE
[fastlane_core] Add support for platform detection for refresher service

### DIFF
--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -71,6 +71,7 @@ module FastlaneCore
 
       project_hash = p_hash(ARGV, gem_name)
       params["p_hash"] = project_hash if project_hash
+      params["platform"] = @platform if @platform # this has to be called after `p_hash`
 
       url += "?" + URI.encode_www_form(params) if params.count > 0
       return url
@@ -148,10 +149,17 @@ module FastlaneCore
       require 'credentials_manager'
 
       # check if this is an android project first because some of the same params exist for iOS and Android tools
-      value = android_app_identifier(args, gem_name) || ios_app_identifier(args)
+      app_identifier = android_app_identifier(args, gem_name)
+      @platform = nil # since have a state in-between runs
+      if app_identifier
+        @platform = :android
+      else
+        app_identifier = ios_app_identifier(args)
+        @platform = :ios if app_identifier
+      end
 
-      if value
-        return Digest::SHA256.hexdigest("p#{value}fastlan3_SAlt") # hashed + salted the bundle identifier
+      if app_identifier
+        return Digest::SHA256.hexdigest("p#{app_identifier}fastlan3_SAlt") # hashed + salted the bundle identifier
       end
 
       return nil

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -66,6 +66,7 @@ describe FastlaneCore do
     describe "#generate_fetch_url" do
       before do
         ENV.delete("FASTLANE_OPT_OUT_USAGE")
+        expect(FastlaneCore::Helper).to receive(:is_ci?).and_return(false)
       end
 
       it "generated the correct URL with no parameters, no platform value and no p_hash" do

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -62,5 +62,32 @@ describe FastlaneCore do
         expect(FastlaneCore::UpdateChecker.p_hash(args, 'gym')).to eq(hash_of(package_name))
       end
     end
+
+    describe "#generate_fetch_url" do
+      before do
+        ENV.delete("FASTLANE_OPT_OUT_USAGE")
+      end
+
+      it "generated the correct URL with no parameters, no platform value and no p_hash" do
+        expect(FastlaneCore::UpdateChecker.generate_fetch_url("fastlane")).to eq("https://fastlane-refresher.herokuapp.com/fastlane")
+      end
+
+      it "uses the bundle identifier and hashes the value if available" do
+        ENV["PILOT_APP_IDENTIFIER"] = "com.krausefx.app"
+        expect(FastlaneCore::UpdateChecker.generate_fetch_url("fastlane")).to eq("https://fastlane-refresher.herokuapp.com/fastlane?p_hash=50925b8f18defc356dad507b1729bc185f9582513537346424b0be09b1f12b2f&platform=ios")
+      end
+
+      describe "#platform" do
+        it "ios" do
+          ARGV = ["--app_identifier", "yolo.app"]
+          expect(FastlaneCore::UpdateChecker.generate_fetch_url("sigh")).to eq("https://fastlane-refresher.herokuapp.com/sigh?p_hash=52629c9a0eebe49c58db83c94c090bd790a101ff2a70ab9514f6a6427644375a&platform=ios")
+        end
+
+        it "android" do
+          ARGV = ["--app_package_name", "yolo.android.app"]
+          expect(FastlaneCore::UpdateChecker.generate_fetch_url("supply")).to eq("https://fastlane-refresher.herokuapp.com/supply?p_hash=6a8b842e4a75d2a2bc4bdf584406a68eab8cabcc7b7a396c283b390fff30b59b&platform=android")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This is used to get a feeling of how many people use fastlane with iOS or with Android projects. The data is being sent to [refresher](https://github.com/fastlane/refresher)
