### PR TITLE
Fix to_json method signature

### DIFF
--- a/spaceship/lib/spaceship/base.rb
+++ b/spaceship/lib/spaceship/base.rb
@@ -46,10 +46,10 @@ module Spaceship
         end
       end
 
-      def to_json
+      def to_json(*a)
         h = @hash.dup
         h.delete(:application)
-        h.to_json
+        h.to_json(*a)
       end
     end
 


### PR DESCRIPTION
Calling `to_json` on an array containing objects which inherit from `Spaceship::Base::DataHash` results in the following problem:

```
Exception: ArgumentError: wrong number of arguments (1 for 0)
--
0: /home/lo/src/fastlane/spaceship/lib/spaceship/base.rb:49:in `to_json'
```

This can be fixed by using the correct method signature (See [to_json docs](http://ruby-doc.org/stdlib-2.0.0/libdoc/json/rdoc/JSON/GenericObject.html#method-i-to_json)).
