### PR TITLE
[fastlane_core] Version bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.51.0".freeze
+  VERSION = "0.52.0".freeze
 end


### PR DESCRIPTION
- Update tests to mock the FastlaneCore::UI.input method
- Print questions in yellow
- Update fastlane code base to use UI.input instead of ask
- [fastlane_core] Add support for platform detection for refresher service (#6087)

The platform detection is used to get a feeling of how many people use fastlane with iOS or with Android projects. The data is being sent to [refresher](https://github.com/fastlane/refresher). You can opt out by setting the `FASTLANE_OPT_OUT_USAGE` environment variable.
