### PR TITLE
Consider using a subshell rather than a pseudo-terminal

### DIFF
--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -43,7 +43,7 @@ module FastlaneCore
         end
 
         begin
-          PTY.spawn(command) do |stdin, stdout, pid|
+          system(ENV, command) do |stdin, stdout, pid|
             begin
               stdin.each do |l|
                 line = l.strip # strip so that \n gets removed


### PR DESCRIPTION
I wanted to open the MR to discuss potentially using a different system for launching commands as we have been having a lot of trouble on our build machines with environment variables and the 'famous' "invalid byte sequence in US-ASCII (ArgumentError)" problem.

We don't want to globally set these locale variables on machines, so I've tried to use the Fastlane environment variables feature (https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Advanced.md#environment-variables) to pass in the `LC_ALL`, `LANG` & `LANGUAGE` variables in when my script runs. 

This has had limited success and it seems that when PTY.spawn is used, the environment variables are lost!

Obviously there are a lot of consequences to a change like this, but I wanted to open a discussion and see what you think and ask if you are aware of issues relating to this?
