### PR TITLE
[fastlane] Version bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.102.0'.freeze
+  VERSION = '1.103.0'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end


### PR DESCRIPTION
- Remove testmunk integration (#6102)
- Don’t hang on git clone command when user credentials are missing (#6068)
- Fix an issue with multi team ids and latest_test_flight_build_number (#6076)
- Add project_directory option to carthage action (#6072)
- add ability to pass in specific file name for plist file (#6035)
- Update docs for resign.rb (#5994)
- Add `SKIP_SLOW_FASTLANE_WARNING` env var (#6048)
- Change pod lib lint platform support (#6049)
- Update fastlane code base to use UI.input instead of ask
- Only set ipa path for iOS builds (non Mac) (#6036)
- `xcode_select` improve instructions on how to use action when failing (#6019)
- Include the full path name in file not found error message (#5979, #5962)
- Add paging support for plugins to list all available plugins (#5977)
- Add parameter for output path for available plugins (#5970)
- Refactor fastlane runner to make it easy to access from docs (#5951)
- Improve docs (#5947, #5950, #5937, #6046)
- Update internal dependencies (#6104, #6063)

The platform detection is used to get a feeling of how many people use fastlane with iOS or with Android projects. The data is being sent to [refresher](https://github.com/fastlane/refresher). You can opt out by setting the `FASTLANE_OPT_OUT_USAGE` environment variable.
