### PR TITLE
Fixed bug 2 step auth login

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -293,7 +293,8 @@ module Spaceship
       when 200
         return response
       else
-        if response["Location"] == "/auth" # redirect to 2 step auth page
+        location = response["Location"]
+        if location && URI.parse(location).path == "/auth" # redirect to 2 step auth page
           handle_two_step(response)
           return true
         elsif (response.body || "").include?('invalid="true"')


### PR DESCRIPTION
- [x] Run `rspec` for all tools you modified
- [x] Run `rubocop -a` to ensure the code style is valid
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Fixed #6129
In my environment had become response["Location"] is '/auth?ro=w'
