### PR TITLE
Trust Apple's status for validity check

### DIFF
--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -78,6 +78,8 @@ module Sigh
       end
 
       return results if Sigh.config[:skip_certificate_verification]
+      
+      results = results.find_all(&:certificate_valid?)
 
       return results.find_all do |a|
         # Also make sure we have the certificate installed on the local machine

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -78,7 +78,7 @@ module Sigh
       end
 
       return results if Sigh.config[:skip_certificate_verification]
-      
+
       results = results.find_all(&:certificate_valid?)
 
       return results.find_all do |a|

--- a/sigh/spec/stubbing.rb
+++ b/sigh/spec/stubbing.rb
@@ -8,6 +8,7 @@ def stub_spaceship
   expect(Spaceship.client).to receive(:in_house?).and_return(false)
 
   allow(profile).to receive(:valid?).and_return(true)
+  allow(profile).to receive(:certificate_valid?).and_return(true)
   allow(profile.class).to receive(:pretty_type).and_return("pretty")
   allow(profile).to receive(:download).and_return("FileContent")
 

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -379,7 +379,7 @@ module Spaceship
 
       # @return (Bool) Is the current provisioning profile valid?
       def valid?
-        return (status == 'Active' and certificate_valid?)
+        return status == 'Active'
       end
 
       # @return (Bool) Is this profile managed by Xcode?

--- a/spaceship/spec/provisioning_profile_spec.rb
+++ b/spaceship/spec/provisioning_profile_spec.rb
@@ -104,9 +104,9 @@ describe Spaceship::ProvisioningProfile do
 
   describe '#valid?' do
     it "Valid profile" do
-      p = Spaceship::ProvisioningProfile.all.last
-      expect(p).to receive(:certificate_valid?).and_return(true)
-      expect(p.valid?).to eq(true)
+      profile = Spaceship::ProvisioningProfile.all.first
+      profile.status = 'Active'
+      expect(profile.valid?).to eq(true)
     end
 
     it "Invalid profile" do


### PR DESCRIPTION
Resolves #6137 if using --skip_certificate_verification

This PR moves the certificate_valid? check to after the check for skip_certificate_verification.
