### PR TITLE
Fix typo / wrong bracket in readme

### DIFF
--- a/screengrab/README.md
+++ b/screengrab/README.md
@@ -35,7 +35,7 @@ screengrab
 
 ###### Automated localized screenshots of your Android app on every device
 
-`screengrab` generates localized screenshots of your Android app for different device types and languages for Google Play and can be uploaded using ([`supply`](https://github.com/fastlane/fastlane/tree/master/supply).
+`screengrab` generates localized screenshots of your Android app for different device types and languages for Google Play and can be uploaded using [`supply`](https://github.com/fastlane/fastlane/tree/master/supply).
 
 <img src="assets/running-screengrab.gif" width="640">
 


### PR DESCRIPTION
This PR fixes a simple typo in the screengrab/README.md ;)
