### PR TITLE
Disable CollectionMethods rubocop preferences

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -155,3 +155,7 @@ Style/ZeroLengthPredicate:
 # Adds complexity
 Style/IfInsideElse:
   Enabled: false
+
+# Sometimes we just want to 'collect'
+Style/CollectionMethods:
+  Enabled: false

--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -31,7 +31,7 @@ module FastlaneCore
       def limit_row_size(rows, max_length = 100)
         require 'fastlane_core/string_filters'
 
-        max_key_length = rows.map { |e| e[0].length }.max || 0
+        max_key_length = rows.collect { |e| e[0].length }.max || 0
         max_allowed_value_length = max_length - max_key_length - 7
         rows.map do |e|
           value = e[1]

--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -31,7 +31,7 @@ module FastlaneCore
       def limit_row_size(rows, max_length = 100)
         require 'fastlane_core/string_filters'
 
-        max_key_length = rows.collect { |e| e[0].length }.max || 0
+        max_key_length = rows.map { |e| e[0].length }.max || 0
         max_allowed_value_length = max_length - max_key_length - 7
         rows.map do |e|
           value = e[1]


### PR DESCRIPTION
I'll remove the change to `print_table` once I see that hound ignores it 👍 
