### PR TITLE
[device_grid] Post a single markdown to Github (#6181)

### DIFF
--- a/danger-device_grid/lib/device_grid/plugin.rb
+++ b/danger-device_grid/lib/device_grid/plugin.rb
@@ -26,15 +26,16 @@ module Danger
       deep_link_matches = github.pr_body.match(/:link:\s(.*)/) # :link: emoji
       deep_link = deep_link_matches[1] if deep_link_matches
 
-      markdown("<table>")
+      html = ""
+      html << "<table>"
       languages.each do |current_language|
-        markdown("<tr>")
-        markdown("<td>")
-        markdown("<b>#{current_language[0..1]}</b>")
-        markdown("</td>")
+        html << "<tr>"
+        html << "<td>"
+        html << "<b>#{current_language[0..1]}</b>"
+        html << "</td>"
 
         devices.each do |current_device|
-          markdown("<td>")
+          html << "<td>"
 
           params = {
             public_key: public_key,
@@ -46,19 +47,20 @@ module Danger
           url = Fastlane::Helper.backticks("#{prefix_command}fastlane run appetize_viewing_url_generator #{params_str}")
           url = url.match(%r{Result:.*(https\:\/\/.*)})[1].strip
 
-          markdown("<a href='#{url}'>")
-          markdown("<p align='center'>")
-          markdown("<img height='130' src='#{url_for_device(current_device)}' />")
-          markdown("<br />")
-          markdown(beautiful_device_name(current_device))
-          markdown("</p>")
-          markdown("</a>")
+          html << "<a href='#{url}'>"
+          html << "<p align='center'>"
+          html << "<img height='130' src='#{url_for_device(current_device)}' />"
+          html << "<br />"
+          html << beautiful_device_name(current_device)
+          html << "</p>"
+          html << "</a>"
 
-          markdown("</td>")
+          html << "</td>"
         end
-        markdown("</tr>")
+        html << "</tr>"
       end
-      markdown("</table>")
+      html << "</table>"
+      markdown(html)
     ensure
       ENV.delete(fastlane_colors_env) unless fastlane_colors_were_disabled
     end

--- a/danger-device_grid/spec/device_grid_spec.rb
+++ b/danger-device_grid/spec/device_grid_spec.rb
@@ -18,7 +18,7 @@ module Danger
 
         def markdown(str)
           @current_markdown ||= ""
-          @current_markdown += "#{str}\n"
+          @current_markdown += str.to_s
         end
       end
     end
@@ -31,12 +31,17 @@ module Danger
 
     it "works" do
       public_key = "1461233806"
+      correct = File.read("spec/fixtures/device_grid_results.html")
+                    .gsub("[[version]]", Fastlane::VERSION)
+                    .delete("\n")
+
       dg = Danger::DangerDeviceGrid.new(Danger::Dangerfile::DSL::Plugin.new)
+      allow(dg).to receive(:markdown).once.with(correct).and_call_original
+
       dg.run(languages: ['en', 'de'],
              devices: ['iphone4s'],
              public_key: public_key)
 
-      correct = File.read("spec/fixtures/device_grid_results.html").gsub("[[version]]", Fastlane::VERSION)
       expect(dg.current_markdown).to eq(correct)
     end
   end


### PR DESCRIPTION
Update device_grid plugin to send all the markdown content as a single message to Github.

See #6181 
