### PR TITLE
Add nicer error message when API key can’t be received

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -331,6 +331,9 @@ module Spaceship
       File.write(itc_service_key_path, @service_key)
 
       return @service_key
+    rescue => ex
+      puts ex.to_s
+      raise AppleTimeoutError.new, "Could not receive latest API key from iTunes Connect, this might be a server issue."
     end
 
     #####################################################


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/6167
