### PR TITLE
Add a 'raw' output style

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -82,10 +82,10 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :output_style,
                                      short_option: "-b",
                                      env_name: "SCAN_OUTPUT_STYLE",
-                                     description: "Define how the output should look like (standard, basic or rspec)",
+                                     description: "Define how the output should look like (standard, basic, rspec or raw)",
                                      optional: true,
                                      verify_block: proc do |value|
-                                       UI.user_error!("Invalid output_style #{value}") unless ['standard', 'basic', "rspec"].include?(value)
+                                       UI.user_error!("Invalid output_style #{value}") unless ['standard', 'basic', 'rspec', 'raw'].include?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :output_types,
                                      short_option: "-f",

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -63,6 +63,12 @@ module Scan
       def pipe
         # During building we just show the output in the terminal
         # Check out the ReportCollector class for more xcpretty things
+        pipe = ["| tee '#{xcodebuild_log_path}'"]
+
+        if Scan.config[:output_style] == 'raw'
+          return pipe
+        end
+
         formatter = []
         if Scan.config[:formatter]
           formatter << "-f `#{Scan.config[:formatter]}`"
@@ -83,7 +89,7 @@ module Scan
           formatter << "--test"
         end
 
-        ["| tee '#{xcodebuild_log_path}' | xcpretty #{formatter.join(' ')}"]
+        return pipe << ["| xcpretty #{formatter.join(' ')}"]
       end
 
       # Store the raw file

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -104,7 +104,7 @@ describe Scan do
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
       result = Scan::TestCommandGenerator.generate
-      expect(result.last).to include(" | xcpretty -f `custom-formatter`")
+      expect(result.last).to include("| xcpretty -f `custom-formatter`")
     end
 
     describe "Standard Example" do


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:
- [x] Run `rspec` for all tools you modified
- [x] Run `rubocop -a` to ensure the code style is valid
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

The 'raw' output style bypasses xcpretty. This will help diagnosing stalled Travis jobs such as https://travis-ci.org/AFNetworking/AFNetworking/jobs/161185973 where xcpretty misses the actual error message.
