### PR TITLE
Add type for log_output param

### DIFF
--- a/fastlane/lib/fastlane/actions/import_certificate.rb
+++ b/fastlane/lib/fastlane/actions/import_certificate.rb
@@ -30,6 +30,7 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :log_output,
                                        description: "If output should be logged to the console",
+                                       type: TrueClass,
                                        default_value: false,
                                        optional: true)
         ]

--- a/fastlane/spec/actions_specs/import_certificate_spec.rb
+++ b/fastlane/spec/actions_specs/import_certificate_spec.rb
@@ -50,6 +50,41 @@ describe Fastlane do
         expect(result).to include '-T /usr/bin/codesign'
         expect(result).to include '-T /usr/bin/security'
       end
+
+      it "works with a boolean for log_output" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          import_certificate ({
+            keychain_name: '\" test \".keychain',
+            certificate_path: '\" test \".cer',
+            certificate_password: '\"test password\"',
+            log_output: true
+          })
+        end").runner.execute(:test)
+
+        expect(result).to start_with 'security'
+        expect(result).to include %(import \\\"\\ test\\ \\\".cer)
+        expect(result).to include %(-k ~/Library/Keychains/\\\"\\ test\\ \\\".keychain)
+        expect(result).to include %(-P \\\"test\\ password\\\")
+        expect(result).to include '-T /usr/bin/codesign'
+        expect(result).to include '-T /usr/bin/security'
+      end
+
+      it "does not work with a string for log_output" do
+        import_certificate_fastfile = "lane :test do
+          import_certificate ({
+            keychain_name: '\" test \".keychain',
+            certificate_path: '\" test \".cer',
+            certificate_password: '\"test password\"',
+            log_output: '\"true\"'
+          })
+        end"
+
+        expect { Fastlane::FastFile.new.parse(import_certificate_fastfile).runner.execute(:test) }.to(
+          raise_error(FastlaneCore::Interface::FastlaneError) do |error|
+            expect(error.message).to match(/'log_output' value must be a TrueClass! Found String instead/)
+          end
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes a problem where the parameter is a boolean, but not specified as such, so it picks up the default parameter type which is string. If one actually tries to use this, you get an error when you try to pass in the default parameter type or the boolean type.

As it is being used as a boolean later on, I changed the type to boolean.

---

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:
- [x] Run `rspec` for all tools you modified
- [x] Run `rubocop -a` to ensure the code style is valid
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:
