### PR TITLE
Allow snapshot to match simulators with the right name but wrong OS v…

### DIFF
--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -72,10 +72,13 @@ module Snapshot
         #   { platform:iOS Simulator, id:1685B071-AFB2-4DC1-BE29-8370BA4A6EBD, OS:9.0, name:iPhone 5 }
         #   { platform:iOS Simulator, id:A141F23B-96B3-491A-8949-813B376C28A7, OS:9.0, name:iPhone 5 }
         #
-
-        FastlaneCore::DeviceManager.simulators.find do |sim|
-          sim.name.strip == device_name.strip and sim.os_version == os_version
-        end
+        simulators = FastlaneCore::DeviceManager.simulators
+        # Sort devices with matching names by OS version, largest first, so that we can
+        # pick the device with the newest OS in case an exact OS match is not available
+        name_matches = simulators.find_all { |sim| sim.name.strip == device_name.strip }
+                                 .sort_by { |sim| Gem::Version.new(sim.os_version) }
+                                 .reverse
+        name_matches.find { |sim| sim.os_version == os_version } || name_matches.first
       end
 
       def device_udid(device_name, os_version = Snapshot.config[:ios_version])
@@ -92,6 +95,8 @@ module Snapshot
         if device.nil?
           UI.user_error!("No device found named '#{device_name}' for version '#{os_version}'")
           return
+        elsif device.os_version != os_version
+          UI.important("Using device named '#{device_name}' with version '#{device.os_version}' because no match was found for version '#{os_version}'")
         end
         value = "platform=#{os} Simulator,id=#{device.udid},OS=#{os_version}"
 

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -1,15 +1,32 @@
 describe Snapshot do
   describe Snapshot::TestCommandGenerator do
+    let(:os_version) { "9.3" }
+    let(:iphone6_9_3) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 6", os_version: os_version, udid: "11111", state: "Don't Care", is_simulator: true) }
+    let(:iphone6_9_0) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 6", os_version: '9.0', udid: "11111", state: "Don't Care", is_simulator: true) }
+    let(:iphone6_9_2) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 6", os_version: '9.2', udid: "11111", state: "Don't Care", is_simulator: true) }
+    let(:appleTV) { FastlaneCore::DeviceManager::Device.new(name: "Apple TV 1080p", os_version: os_version, udid: "22222", state: "Don't Care", is_simulator: true) }
+
     before do
-      mock_os_version = "6.6"
-      allow(Snapshot::LatestOsVersion).to receive(:version).and_return(mock_os_version)
-      allow(FastlaneCore::DeviceManager).to receive(:simulators).and_return(
-        [
-          FastlaneCore::DeviceManager::Device.new(name: "iPhone 6", os_version: mock_os_version, udid: "11111", state: "Don't Care", is_simulator: true),
-          FastlaneCore::DeviceManager::Device.new(name: "Apple TV 1080p", os_version: mock_os_version, udid: "22222", state: "Don't Care", is_simulator: true)
-        ]
-      )
+      allow(Snapshot::LatestOsVersion).to receive(:version).and_return(os_version)
+      allow(FastlaneCore::DeviceManager).to receive(:simulators).and_return([iphone6_9_0, iphone6_9_3, iphone6_9_2, appleTV])
       fake_out_xcode_project_loading
+    end
+
+    describe '#find_device' do
+      it 'finds a device that has a matching name and OS version' do
+        found = Snapshot::TestCommandGenerator.find_device('iPhone 6', '9.0')
+        expect(found).to eq(iphone6_9_0)
+      end
+
+      it 'does not find a device that has a different name' do
+        found = Snapshot::TestCommandGenerator.find_device('iPhone 5', '9.0')
+        expect(found).to be(nil)
+      end
+
+      it 'finds a device with the same name, but a different OS version, picking the highest available OS version' do
+        found = Snapshot::TestCommandGenerator.find_device('iPhone 6', '10.0')
+        expect(found).to be(iphone6_9_3)
+      end
     end
 
     describe "Valid Configuration" do


### PR DESCRIPTION
Addresses #6058 

Using Xcode 8 (which defaults to iOS version 10.0)... Now, instead of failing with:

```
No device found named 'iPhone 4s' for version '10.0'
```

It will proceed, warning:

```
Using device named 'iPhone 4s' with version '9.3' because no match was found for version '10.0'
```

assuming you still have a iPhone 4s (9.3) simulator present.
