### PR TITLE
Version Bump

### DIFF
--- a/snapshot/lib/snapshot/version.rb
+++ b/snapshot/lib/snapshot/version.rb
@@ -1,4 +1,4 @@
 module Snapshot
-  VERSION = "1.14.0".freeze
+  VERSION = "1.15.0".freeze
   DESCRIPTION = "Automate taking localized screenshots of your iOS app on every device"
 end


### PR DESCRIPTION
Changes since release 1.14.0:
- Allow snapshot to match simulators with the right name but wrong OS version (#6204)
- Fix specs to work when simulators not installed (#6127)
- Update internal dependencies (#6104)
- Update fastlane code base to use UI.input instead of ask
- Use Snapshot.config[:ios_version] if os_version is not given. (#5985)
