### PR TITLE
[spaceship] Version bump

### DIFF
--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,4 +1,4 @@
 module Spaceship
-  VERSION = "0.32.4".freeze
+  VERSION = "0.33.0".freeze
   DESCRIPTION = "Ruby library to access the Apple Dev Center and iTunes Connect".freeze
 end


### PR DESCRIPTION
This release changes the way App Store and Ad Hoc profiles are handled due to a recent API change. If you're using _spaceship_ directly make sure to update your code to consider the following changes:
- `Spaceship::ProvisioningProfile::AppStore.all` and `Spaceship::ProvisioningProfile::AdHoc.all` now return the same array of both App Store and Ad Hoc profiles
- To distinguish between those profiles at a later point, you can use the new `profile.is_adhoc?` method
- The reason for this change is that it's now required to send an additional request per provisioning profile just to get the list of associated certificates and devices. The list of devices is required to detect if it's an Ad Hoc profile. 
- The _first time_ you call either `.devices`, `.certificates` or `.certificate_valid?` the details request will be sent. Make sure to only call this on profiles you're interested in, as it will take about 400ms per profile
- `profile.valid` now doesn't verify the certificate by default any more, you have to call `certificate_valid?` directly, which will take about 400ms to complete unless the certificate is cached

---
- This release also fixed a bug that `spaceauth` wasn't included in the Ruby gem
