### PR TITLE
Disable verbose loggin in DEBUG mode

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -116,7 +116,6 @@ module Spaceship
         if ENV['DEBUG']
           # for debugging only
           # This enables tracking of networking requests using Charles Web Proxy
-          c.response :logger
           c.proxy "https://127.0.0.1:8888"
         end
       end


### PR DESCRIPTION
This made the output super spammy, we're using Charles anyway
