### PR TITLE
Update s3 action to be more clever about finding the v1.x AWS SDK

### DIFF
--- a/fastlane/lib/fastlane/actions/s3.rb
+++ b/fastlane/lib/fastlane/actions/s3.rb
@@ -200,9 +200,56 @@ module Fastlane
         return true
       end
 
+      # @return true if loading the AWS SDK from the 'aws-sdk' gem yields the expected v1 API, or false otherwise
+      def self.load_from_original_gem_name
+        begin
+          # We don't use `Actions.verify_gem!` here, because we want to silently be OK with this gem not being
+          # present, in case the user has already migrated to 'aws-sdk-v1' (see #load_from_v1_gem_name)
+          Gem::Specification.find_by_name('aws-sdk')
+          require 'aws-sdk'
+        rescue Gem::LoadError
+          UI.verbose("The 'aws-sdk' gem is not present")
+          return false
+        end
+
+        UI.verbose("The 'aws-sdk' gem is present")
+        true
+      end
+
+      def self.load_from_v1_gem_name
+        Actions.verify_gem!('aws-sdk-v1')
+        require 'aws-sdk-v1'
+      end
+
+      def self.v1_sdk_module_present?
+        begin
+          # Here we'll make sure that the `AWS` module is defined. If it is, the gem is the v1.x API.
+          Object.const_get("AWS")
+        rescue NameError
+          UI.verbose("Couldn't find the needed `AWS` module in the 'aws-sdk' gem")
+          return false
+        end
+
+        UI.verbose("Found the needed `AWS` module in the 'aws-sdk' gem")
+        true
+      end
+
       def self.s3_client(s3_access_key, s3_secret_access_key, s3_region)
-        Actions.verify_gem!('aws-sdk')
-        require 'aws-sdk'
+        # The AWS SDK API changed completely in v2.x. The most stable way to keep using the V1 API is to
+        # require the 'aws-sdk-v1' gem directly. However, for those customers who are using the 'aws-sdk'
+        # gem at v1.x, we don't want to break their setup which currently works.
+        #
+        # Therefore, we will attempt to load the v1 API from the original gem name, but go on to load
+        # from the aws-sdk-v1 gem name if necessary
+        loaded_original_gem = load_from_original_gem_name
+
+        if !loaded_original_gem || !v1_sdk_module_present?
+          load_from_v1_gem_name
+          UI.verbose("Loaded AWS SDK v1.x from the `aws-sdk-v1` gem")
+        else
+          UI.verbose("Loaded AWS SDK v1.x from the `aws-sdk` gem")
+        end
+
         if s3_region
           s3_client = AWS::S3.new(
             access_key_id: s3_access_key,


### PR DESCRIPTION
Addresses #4295

The API of the AWS SDK has changed dramatically in v2.x. The _fastlane_ `s3` action was written against the v1.x API.

This improves the S3 action to be able to work under the following conditions:
- The `aws-sdk` gem is installed, and is v1.x
- The `aws-sdk` gem is installed at v2.x, but the `aws-sdk-v1` gem is installed
- The `aws-sdk` gem is _not_ installed but the `aws-sdk-v1` gem is installed

This allows current customers who have the older `aws-sdk` version installed to continue to work with no changes. For people who have wound up having the `aws-sdk` gem updated to v2.x, or have no suitable AWS SDK gems installed, they will be notified that they need to install the `aws-sdk-v1` gem via the usual messaging.

```
Could not find gem 'aws-sdk-v1'

If you installed fastlane using `sudo gem install fastlane` run
  $ sudo gem install aws-sdk-v1
to install the missing gem

If you use a Gemfile add this to your Gemfile:
  gem 'aws-sdk-v1'
and run `bundle install`
```
