### PR TITLE
Version Bump

### DIFF
--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,4 +1,4 @@
 module Spaceship
-  VERSION = "0.33.0".freeze
+  VERSION = "0.34.0".freeze
   DESCRIPTION = "Ruby library to access the Apple Dev Center and iTunes Connect".freeze
 end


### PR DESCRIPTION
Changes since release 0.33.0:
- Add tests for recent Mac provisioning profile enhancements (#6250)
- [spaceship] Add basic support for Developer ID profiles (#6232)
- [spaceship] Fix fetching devices/certificates on Mac profiles (#6231)
- Disable verbose loggin in DEBUG mode (#6210)
