### PR TITLE
[WIP] Hemal add environment printer for GitHub issues

### DIFF
--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -242,6 +242,16 @@ module Fastlane
         end
       end
 
+      command :env do |c|
+        c.syntax = 'fastlane env'
+        c.description = 'Print your fastlane environment'
+
+        c.action do |args, options|
+          require "fastlane/environment_printer"
+          Fastlane::EnvironmentPrinter.print
+        end
+      end
+
       default_command :trigger
       run!
     end

--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -1,6 +1,5 @@
 module Fastlane
   class EnvironmentPrinter
-
     def self.print
       puts "My fastlane environment"
       print_system_environment
@@ -18,15 +17,16 @@ module Fastlane
     end
 
     def self.print_fastlane_properties
-      #prints the fastfile
+      # prints the fastfile
       fastlane_path = FastlaneFolder.fastfile_path
       puts "fastfile located at: #{fastlane_path}"
       puts "```"
       puts File.read(fastlane_path)
       puts "```"
     end
+
     def self.print_appfile
-      #prints the fastfile
+      # prints the fastfile
       appfile_path = CredentialsManager::AppfileConfig.default_path
       puts "appfile located at: #{appfile_path}"
       puts "```"

--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -1,0 +1,37 @@
+module Fastlane
+  class EnvironmentPrinter
+
+    def self.print
+      puts "My fastlane environment"
+      print_system_environment
+      print_ruby_environment
+      print_fastlane_properties
+      print_appfile
+    end
+
+    def self.print_system_environment
+      puts "My OS version is: #{`sw_vers -productVersion`.strip}"
+    end
+
+    def self.print_ruby_environment
+      puts "Ruby version #{RUBY_VERSION}"
+    end
+
+    def self.print_fastlane_properties
+      #prints the fastfile
+      fastlane_path = FastlaneFolder.fastfile_path
+      puts "fastfile located at: #{fastlane_path}"
+      puts "```"
+      puts File.read(fastlane_path)
+      puts "```"
+    end
+    def self.print_appfile
+      #prints the fastfile
+      appfile_path = CredentialsManager::AppfileConfig.default_path
+      puts "appfile located at: #{appfile_path}"
+      puts "```"
+      puts File.read(appfile_path)
+      puts "```"
+    end
+  end
+end


### PR DESCRIPTION
This will make it easy for people to submit their GitHub issues via @hemal 

Missing things:
- [ ] Output should be nice markdown output, easy to copy and paste to GitHub
- [ ] Instructions in the terminal on how to copy & paste to GitHub
- [ ] Listing all the used Ruby gem versions (something similar to the Gemfile.lock, but has to be fetched from the run time). It's easy to fetch the version of all gems that are being loaded
- [ ] documentation on how to use this feature, mostly in the ISSUE_TEMPLATE.md
- [ ] Xcode path (`xcode-select -p`)
- [ ] Version of the Xcode installation on `xcode-select -p`
- [ ] Print out the stack similar to CocoaPods (see below)
- [ ] Executable path (similar to CocoaPods)
- [ ] Loaded plugins (if any)
- [ ] At least one unit test

```
   CocoaPods : 1.0.1
        Ruby : ruby 2.2.1p85 (2015-02-26 revision 49769) [x86_64-darwin14]
    RubyGems : 2.6.6
        Host : Mac OS X 10.11.6 (15G1004)
       Xcode : 8.0 (8A218a)
         Git : git version 2.4.11.781.g446a618-twtrsrc
Ruby lib dir : /Users/fkrause/.rbenv/versions/2.2.1/lib
```
