### PR TITLE
[gym] Don’t detect and set provisioning profile if legacy API is disabled

### DIFF
--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -33,6 +33,8 @@ module Gym
     # Helper Methods
 
     def self.detect_provisioning_profile
+      return unless Gym.config[:use_legacy_build_api]
+
       unless Gym.config[:provisioning_profile_path]
         Dir.chdir(File.expand_path("..", Gym.project.path)) do
           profiles = Dir["*.mobileprovision"]

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -167,7 +167,7 @@ module Gym
       def print_legacy_information
         return if Gym.config[:provisioning_profile_path].to_s.length == 0
 
-        UI.error "You're using Xcode 7, the `provisioning_profile_path` value will be ignored"
+        UI.error "You're using Xcode 7 or above, the `provisioning_profile_path` value will be ignored"
         UI.error "Please follow the Code Signing Guide: https://codesigning.guide (for match) or https://github.com/fastlane/fastlane/tree/master/fastlane/docs/Codesigning"
       end
     end


### PR DESCRIPTION
Since this value isn’t being used with the Xcode 7 API anyway
