### PR TITLE
Fix Sticker category by adding correct Apps prefix

### DIFF
--- a/deliver/Reference.md
+++ b/deliver/Reference.md
@@ -23,6 +23,7 @@ You can always prefix the category using `MZGenre.` (e.g. `MZGenre.Book`). `deli
 - `Apps.Shopping`
 - `SocialNetworking`
 - `Sports`
+- `Stickers`
 - `Travel`
 - `Utilities`
 - `Weather`

--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -63,7 +63,7 @@ module Deliver
         c.description = 'Create the initial `deliver` configuration based on an existing app'
         c.action do |args, options|
           if File.exist?("Deliverfile") or File.exist?("fastlane/Deliverfile")
-            UI.important("You already got a running deliver setup in this directory")
+            UI.important("You already have a running deliver setup in this directory")
             return 0
           end
 

--- a/spaceship/lib/spaceship/tunes/app_details.rb
+++ b/spaceship/lib/spaceship/tunes/app_details.rb
@@ -84,32 +84,38 @@ module Spaceship
       # Custom Setters
       #
       def primary_category=(value)
-        value = "MZGenre.#{value}" unless value.include? "MZGenre"
+        value = prefix_apps(value)
+        value = prefix_mzgenre(value)
         super(value)
       end
 
       def primary_first_sub_category=(value)
-        value = "MZGenre.#{value}" unless value.include? "MZGenre"
+        value = prefix_apps(value)
+        value = prefix_mzgenre(value)
         super(value)
       end
 
       def primary_second_sub_category=(value)
-        value = "MZGenre.#{value}" unless value.include? "MZGenre"
+        value = prefix_apps(value)
+        value = prefix_mzgenre(value)
         super(value)
       end
 
       def secondary_category=(value)
-        value = "MZGenre.#{value}" unless value.include? "MZGenre"
+        value = prefix_apps(value)
+        value = prefix_mzgenre(value)
         super(value)
       end
 
       def secondary_first_sub_category=(value)
-        value = "MZGenre.#{value}" unless value.include? "MZGenre"
+        value = prefix_apps(value)
+        value = prefix_mzgenre(value)
         super(value)
       end
 
       def secondary_second_sub_category=(value)
-        value = "MZGenre.#{value}" unless value.include? "MZGenre"
+        value = prefix_apps(value)
+        value = prefix_mzgenre(value)
         super(value)
       end
 
@@ -117,6 +123,17 @@ module Spaceship
       # @!group General
       #####################################################
       def setup
+      end
+
+      private
+
+      def prefix_mzgenre(value)
+        (value.include? "MZGenre") ? value : "MZGenre.#{value}"
+      end
+
+      def prefix_apps(value)
+        return value unless value.include? "Stickers"
+        (value.include? "Apps") ? value : "Apps.#{value}"
       end
     end
   end

--- a/spaceship/spec/tunes/app_details_spec.rb
+++ b/spaceship/spec/tunes/app_details_spec.rb
@@ -17,7 +17,7 @@ describe Spaceship::Tunes::AppDetails do
   end
 
   describe "Modifying the app category" do
-    it "prefixes the category with the correct value for all category types" do
+    it "prefixes the category with MZGenre for all category types" do
       details = app.details
 
       details.primary_category = "Weather"
@@ -39,11 +39,39 @@ describe Spaceship::Tunes::AppDetails do
       expect(details.secondary_second_sub_category).to eq("MZGenre.Weather")
     end
 
+    it "prefixes the category with MZGenre.Apps for Stickers types" do
+      details = app.details
+
+      details.primary_category = "Stickers"
+      expect(details.primary_category).to eq("MZGenre.Apps.Stickers")
+
+      details.primary_first_sub_category = "Stickers.Art"
+      expect(details.primary_first_sub_category).to eq("MZGenre.Apps.Stickers.Art")
+
+      details.primary_second_sub_category = "Stickers.Art"
+      expect(details.primary_second_sub_category).to eq("MZGenre.Apps.Stickers.Art")
+
+      details.secondary_category = "Stickers"
+      expect(details.secondary_category).to eq("MZGenre.Apps.Stickers")
+
+      details.secondary_first_sub_category = "Stickers.Art"
+      expect(details.secondary_first_sub_category).to eq("MZGenre.Apps.Stickers.Art")
+
+      details.secondary_second_sub_category = "Stickers.Art"
+      expect(details.secondary_second_sub_category).to eq("MZGenre.Apps.Stickers.Art")
+
+      details.primary_category = "Apps.Stickers"
+      expect(details.primary_category).to eq("MZGenre.Apps.Stickers")
+    end
+
     it "doesn't prefix if the prefix is already there" do
       details = app.details
 
       details.primary_category = "MZGenre.Weather"
       expect(details.primary_category).to eq("MZGenre.Weather")
+
+      details.primary_category = "MZGenre.Apps.Stickers"
+      expect(details.primary_category).to eq("MZGenre.Apps.Stickers")
     end
   end
 end


### PR DESCRIPTION
- The full category for stickers is MZGenre.Apps.Stickers.
- Fix wording in _deliver_ output
- Add "Stickers" to Reference.md
