### PR TITLE
Version Bump

### DIFF
--- a/screengrab/version.properties
+++ b/screengrab/version.properties
@@ -1,3 +1,3 @@
 major=0
 minor=5
-patch=2
+patch=3


### PR DESCRIPTION
Changes since release 0.5.2:
- Fixes #6285 - improper handling of adb server out of date (#6286)
- Fix typo / wrong bracket in readme (#6150)
- Update internal dependencies (#6104)
- Remove version number from README(#6020)
