### PR TITLE
No syntax highlighting for avaliable plugins

### DIFF
--- a/fastlane/lib/assets/AvailablePlugins.md.erb
+++ b/fastlane/lib/assets/AvailablePlugins.md.erb
@@ -2,13 +2,13 @@
 
 To get an up to date list of all available plugins run
 
-```
+```no-highlight
 fastlane search_plugins
 ```
 
 To search for a specific plugin
 
-```
+```no-highlight
 fastlane search_plugins [search_query]
 ```
 


### PR DESCRIPTION
Needed for docs.fastlane.tools
