### PR TITLE
Preventing actions called from another action to show in summary

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -143,7 +143,7 @@ module Fastlane
 
     # Is used to look if the method is implemented as an action
     def method_missing(method_sym, *arguments, &_block)
-      self.runner.trigger_action_by_name(method_sym, nil, *arguments)
+      self.runner.trigger_action_by_name(method_sym, nil, false, *arguments)
     end
 
     #####################################################

--- a/fastlane/lib/fastlane/other_action.rb
+++ b/fastlane/lib/fastlane/other_action.rb
@@ -22,6 +22,7 @@ module Fastlane
 
       self.runner.trigger_action_by_name(method_sym,
                                          "./fastlane",
+                                         true,
                                          *arguments)
     end
   end

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -109,7 +109,9 @@ module Fastlane
 
     # This is being called from `method_missing` from the Fastfile
     # It's also used when an action is called from another action
-    def trigger_action_by_name(method_sym, custom_dir, *arguments)
+    # @param from_action Indicates if this action is being trigged by another action.
+    #                    If so, it won't show up in summary.
+    def trigger_action_by_name(method_sym, custom_dir, from_action, *arguments)
       # First, check if there is a predefined method in the actions folder
       class_ref = class_reference_from_action_name(method_sym)
       unless class_ref
@@ -130,7 +132,7 @@ module Fastlane
       if class_ref
         if class_ref.respond_to?(:run)
           # Action is available, now execute it
-          return self.execute_action(method_sym, class_ref, arguments, custom_dir: custom_dir)
+          return self.execute_action(method_sym, class_ref, arguments, custom_dir: custom_dir, from_action: from_action)
         else
           UI.user_error!("Action '#{method_sym}' of class '#{class_name}' was found, but has no `run` method.")
         end
@@ -197,7 +199,7 @@ module Fastlane
       end
     end
 
-    def execute_action(method_sym, class_ref, arguments, custom_dir: nil)
+    def execute_action(method_sym, class_ref, arguments, custom_dir: nil, from_action: false)
       if custom_dir.nil?
         custom_dir ||= "." if Helper.test?
         custom_dir ||= ".."
@@ -209,7 +211,10 @@ module Fastlane
 
       begin
         Dir.chdir(custom_dir) do # go up from the fastlane folder, to the project folder
-          Actions.execute_action(class_ref.step_text) do
+          # If another action is calling this action, we shouldn't show it in the summary
+          # (see https://github.com/fastlane/fastlane/issues/4546)
+          action_name = from_action ? nil : class_ref.step_text
+          Actions.execute_action(action_name) do
             # arguments is an array by default, containing an hash with the actual parameters
             # Since we usually just need the passed hash, we'll just use the first object if there is only one
             if arguments.count == 0

--- a/fastlane/spec/action_spec.rb
+++ b/fastlane/spec/action_spec.rb
@@ -58,12 +58,23 @@ describe Fastlane do
       it "allows the user to call it using `other_action.rocket`" do
         Fastlane::Actions.load_external_actions("./fastlane/spec/fixtures/actions")
         ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileActionFromAction')
+        Fastlane::Actions.executed_actions.clear
 
         response = {
           rocket: "🚀",
           pwd: File.join(Dir.pwd, "fastlane")
         }
         expect(ff.runner.execute(:something, :ios)).to eq(response)
+        expect(Fastlane::Actions.executed_actions.map { |a| a[:name] }).to eq(['from'])
+      end
+
+      it "shows only actions called from Fastfile" do
+        Fastlane::Actions.load_external_actions("./fastlane/spec/fixtures/actions")
+        ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileActionFromActionWithOtherAction')
+        Fastlane::Actions.executed_actions.clear
+
+        ff.runner.execute(:something, :ios)
+        expect(Fastlane::Actions.executed_actions.map { |a| a[:name] }).to eq(['from', 'example'])
       end
 
       it "shows an appropriate error message when trying to directly call an action" do

--- a/fastlane/spec/fixtures/fastfiles/FastfileActionFromActionWithOtherAction
+++ b/fastlane/spec/fixtures/fastfiles/FastfileActionFromActionWithOtherAction
@@ -1,0 +1,6 @@
+platform :ios do
+  lane :something do
+    action_from_action
+    example_action
+  end
+end


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:
- [x] Run `rspec` for all tools you modified
- [x] Run `rubocop -a` to ensure the code style is valid
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

This should fix #4546. We probably should add at least a test to make sure we don't have regressions on this, but just wanted to see it the implementation makes sense first.

Just to make clear, this hides the "inner actions" from the summary:

```
+------+-------------------------------------+-------------+
|                     fastlane summary                     |
+------+-------------------------------------+-------------+
| Step | Action                              | Time (in s) |
+------+-------------------------------------+-------------+
| 1    | opt_out_usage                       | 0           |
| 2    | Verifying required fastlane version | 0           |
| 3    | default_platform                    | 0           |
| 4    | is_ci                               | 0           |
| 5    | bundle_install                      | 0           |
| 6    | is_ci                               | 0           |
| 7    | cocoapods_if_needed                 | 98          |
+------+-------------------------------------+-------------+
```

You can compare to the behavior before this PR below:

```
$ fastlane pod_install

...
+------+-------------------------------------+-------------+
|                     fastlane summary                     |
+------+-------------------------------------+-------------+
| Step | Action                              | Time (in s) |
+------+-------------------------------------+-------------+
| 1    | opt_out_usage                       | 0           |
| 2    | Verifying required fastlane version | 0           |
| 3    | default_platform                    | 0           |
| 4    | is_ci                               | 0           |
| 5    | bundle_install                      | 0           |
| 6    | is_ci                               | 0           |
| 7    | cocoapods                           | 51          |
| 8    | cocoapods_if_needed                 | 62          |
+------+-------------------------------------+-------------+
```
