### PR TITLE
Add `rake update_dependencies` to automatically update internal dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,19 +48,17 @@ task :update_dependencies do
     content = File.read(current_gemspec_path)
 
     content.gsub!(regex) do |full_match|
-      matched = full_match.match(regex)
-      gem_name = matched[1]
-      current_version_number = Gem::Version.new(matched[2]) # used to detect if we actually changed something
-
+      gem_name = $1
+      current_version_number = Gem::Version.new($2) # used to detect if we actually changed something
 
       version_path = "./#{gem_name}/lib/#{gem_name}/version.rb"
       if File.exist?(version_path) && gem_name != "screengrab" # internal dependency
         version = Gem::Version.new(File.read(version_path).match(/VERSION.=..(\d+\.\d+\.\d+)./)[1])
-        major_version = Gem::Version.new("#{version.segments[0] + 1}.0.0")
+        next_major_version = Gem::Version.new("#{version.segments[0] + 1}.0.0")
 
         puts "🚀  Updating #{gem_name} from #{current_version_number} to #{version} for #{gem_name}" if version != current_version_number
 
-        "spec.add_dependency \"#{gem_name}\", \">= #{version}\", \"< #{major_version}\""
+        "spec.add_dependency \"#{gem_name}\", \">= #{version}\", \"< #{next_major_version}\""
       else
         full_match # external dependency
       end

--- a/Rakefile
+++ b/Rakefile
@@ -39,6 +39,38 @@ task :rubygems_admins do
   end
 end
 
+task :update_dependencies do
+  puts "Updating all internal fastlane dependencies"
+
+  regex = %r{spec.add_dependency .(.+).\, .\>\= (\d+\.\d+\.\d+).\, .\< \d+\.\d+\.\d+.}
+
+  Dir["./**/*.gemspec"].each do |current_gemspec_path|
+    content = File.read(current_gemspec_path)
+
+    content.gsub!(regex) do |full_match|
+      matched = full_match.match(regex)
+      gem_name = matched[1]
+      current_version_number = Gem::Version.new(matched[2]) # used to detect if we actually changed something
+
+
+      version_path = "./#{gem_name}/lib/#{gem_name}/version.rb"
+      if File.exist?(version_path) && gem_name != "screengrab" # internal dependency
+        version = Gem::Version.new(File.read(version_path).match(/VERSION.=..(\d+\.\d+\.\d+)./)[1])
+        major_version = Gem::Version.new("#{version.segments[0] + 1}.0.0")
+
+        puts "🚀  Updating #{gem_name} from #{current_version_number} to #{version} for #{gem_name}" if version != current_version_number
+
+        "spec.add_dependency \"#{gem_name}\", \">= #{version}\", \"< #{major_version}\""
+      else
+        full_match # external dependency
+      end
+    end
+
+    puts "✅   Writing to #{current_gemspec_path}"
+    File.write(current_gemspec_path, content)
+  end
+end
+
 #####################################################
 # @!group Helper Methods
 #####################################################

--- a/Rakefile
+++ b/Rakefile
@@ -42,6 +42,7 @@ end
 task :update_dependencies do
   puts "Updating all internal fastlane dependencies"
 
+  # This requires all version numbers to be x.x.x (3 components)
   regex = %r{spec.add_dependency .(.+).\, .\>\= (\d+\.\d+\.\d+).\, .\< \d+\.\d+\.\d+.}
 
   Dir["./**/*.gemspec"].each do |current_gemspec_path|

--- a/cert/cert.gemspec
+++ b/cert/cert.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
-  spec.add_dependency 'spaceship', '>= 0.32.1', '< 1.0.0' # access to the Dev Portal
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "spaceship", ">= 0.34.1", "< 1.0.0" # access to the Dev Portal
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/danger-device_grid/danger-device_grid.gemspec
+++ b/danger-device_grid/danger-device_grid.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'fastlane', '>= 1.94.0', '< 2.0.0'
+  spec.add_dependency "fastlane", ">= 1.104.0", "< 2.0.0"
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/deliver/deliver.gemspec
+++ b/deliver/deliver.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # fastlane dependencies
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
-  spec.add_dependency 'credentials_manager', '>= 0.16.0', '< 1.0.0'
-  spec.add_dependency 'spaceship', '>= 0.34.1', '< 1.0.0' # Communication with iTunes Connect
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "credentials_manager", ">= 0.16.1", "< 1.0.0"
+  spec.add_dependency "spaceship", ">= 0.34.1", "< 1.0.0" # Communication with iTunes Connect
 
   # third party dependencies
   spec.add_dependency 'fastimage', '~> 1.6' # fetch the image sizes from the screenshots

--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -37,25 +37,25 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'xcode-install', '~> 2.0.0' # Needed for xcversion and xcode_install actions
   spec.add_dependency 'word_wrap', '~> 1.0.0'  # to add line breaks for tables with long strings
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
 
   spec.add_dependency 'bundler', "~> 1.12" # Used for fastlane plugins
-  spec.add_dependency 'credentials_manager', '>= 0.16.0', '< 1.0.0' # Password Manager
-  spec.add_dependency 'spaceship', '>= 0.33.0', '< 1.0.0' # communication layer with Apple's web services
+  spec.add_dependency "credentials_manager", ">= 0.16.1", "< 1.0.0" # Password Manager
+  spec.add_dependency "spaceship", ">= 0.34.1", "< 1.0.0" # communication layer with Apple's web services
 
   # All the fastlane tools
-  spec.add_dependency 'deliver', '>= 1.13.3', '< 2.0.0'
-  spec.add_dependency 'snapshot', '>= 1.16.0', '< 2.0.0'
-  spec.add_dependency 'frameit', '>= 2.7.0', '< 3.0.0'
-  spec.add_dependency 'pem', '>= 1.3.2', '< 2.0.0'
-  spec.add_dependency 'cert', '>= 1.4.1', '< 2.0.0'
-  spec.add_dependency 'sigh', '>= 1.11.1', '< 2.0.0'
-  spec.add_dependency 'produce', '>= 1.2.0', '< 2.0.0'
-  spec.add_dependency 'gym', '>= 1.9.0', '< 2.0.0'
-  spec.add_dependency 'pilot', '>= 1.10.0', '< 2.0.0'
-  spec.add_dependency 'scan', '>= 0.13.0', '< 2.0.0'
-  spec.add_dependency 'supply', '>= 0.7.1', '< 1.0.0'
-  spec.add_dependency 'match', '>= 0.8.0', '< 1.0.0'
+  spec.add_dependency "deliver", ">= 1.14.0", "< 2.0.0"
+  spec.add_dependency "snapshot", ">= 1.16.0", "< 2.0.0"
+  spec.add_dependency "frameit", ">= 2.7.0", "< 3.0.0"
+  spec.add_dependency "pem", ">= 1.3.2", "< 2.0.0"
+  spec.add_dependency "cert", ">= 1.4.2", "< 2.0.0"
+  spec.add_dependency "sigh", ">= 1.11.1", "< 2.0.0"
+  spec.add_dependency "produce", ">= 1.2.0", "< 2.0.0"
+  spec.add_dependency "gym", ">= 1.10.0", "< 2.0.0"
+  spec.add_dependency "pilot", ">= 1.10.0", "< 2.0.0"
+  spec.add_dependency "scan", ">= 0.13.0", "< 1.0.0"
+  spec.add_dependency "supply", ">= 0.7.1", "< 1.0.0"
+  spec.add_dependency "match", ">= 0.8.0", "< 1.0.0"
   spec.add_dependency 'screengrab', '>= 0.5.2', '< 1.0.0'
 
   # Lock `activesupport` (transitive depedency via `xcodeproj`) to keep supporting system ruby

--- a/fastlane_core/fastlane_core.gemspec
+++ b/fastlane_core/fastlane_core.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'terminal-table', '~> 1.4.5' # options summary
   spec.add_dependency 'gh_inspector', '>= 1.0.1', '< 2.0.0' # search for issues on GitHub when something goes wrong
 
-  spec.add_dependency 'credentials_manager', '>= 0.16.0', '< 1.0.0' # fastlane password manager
+  spec.add_dependency "credentials_manager", ">= 0.16.1", "< 1.0.0" # fastlane password manager
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/frameit/frameit.gemspec
+++ b/frameit/frameit.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'fastimage', '~> 1.6.3' # fetch the image sizes from the screenshots
   spec.add_dependency 'mini_magick', '~> 4.5.1' # To open, edit and export PSD files
   spec.add_dependency 'deliver', '> 0.3' # To determine the device type based on a screenshot file

--- a/gym/gym.gemspec
+++ b/gym/gym.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'xcpretty', '>= 0.2.3' # pretty xcodebuild output
   spec.add_dependency 'terminal-table' # print out build information
   spec.add_dependency 'plist' # Generate the Xcode config plist file

--- a/gym/gym.gemspec
+++ b/gym/gym.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'xcpretty', '>= 0.2.1' # pretty xcodebuild output
   spec.add_dependency 'terminal-table' # print out build information
   spec.add_dependency 'plist' # Generate the Xcode config plist file

--- a/match/match.gemspec
+++ b/match/match.gemspec
@@ -23,11 +23,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'security' # Mac OS Keychain manager
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
-  spec.add_dependency 'credentials_manager', '>= 0.16.0', '< 1.0.0' # fastlane password manager
-  spec.add_dependency 'spaceship', '>= 0.33.0', '< 1.0.0' # communication layer with Apple's web services
-  spec.add_dependency 'sigh', '>= 1.11.0', '< 2.0.0'
-  spec.add_dependency 'cert', '>= 1.4.2', '< 2.0.0'
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "credentials_manager", ">= 0.16.1", "< 1.0.0" # fastlane password manager
+  spec.add_dependency "spaceship", ">= 0.34.1", "< 1.0.0" # communication layer with Apple's web services
+  spec.add_dependency "sigh", ">= 1.11.1", "< 2.0.0"
+  spec.add_dependency "cert", ">= 1.4.2", "< 2.0.0"
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/pem/pem.gemspec
+++ b/pem/pem.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
-  spec.add_dependency 'spaceship', '>= 0.32.1', '< 1.0.0' # Communicating with the Apple Dev Portal
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "spaceship", ">= 0.34.1", "< 1.0.0" # Communicating with the Apple Dev Portal
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/pilot/pilot.gemspec
+++ b/pilot/pilot.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
-  spec.add_dependency 'spaceship', '>= 0.32.1', '< 1.0.0' # iTunes Connect communication
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "spaceship", ">= 0.34.1", "< 1.0.0" # iTunes Connect communication
   spec.add_dependency 'credentials_manager', '>= 0.16.0'
 
   spec.add_dependency 'terminal-table', '~> 1.4.5' # User's information

--- a/produce/produce.gemspec
+++ b/produce/produce.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
-  spec.add_dependency 'spaceship', '>= 0.32.1', '< 1.0.0' # Apple Dev Portal and iTunes Connect Access
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "spaceship", ">= 0.34.1", "< 1.0.0" # Apple Dev Portal and iTunes Connect Access
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/scan/scan.gemspec
+++ b/scan/scan.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'xcpretty', '>= 0.2.1' # pretty xcodebuild output
   spec.add_dependency 'xcpretty-travis-formatter', '>= 0.0.3'
   spec.add_dependency 'slack-notifier', '~> 1.3'

--- a/scan/scan.gemspec
+++ b/scan/scan.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'xcpretty', '>= 0.2.3' # pretty xcodebuild output
   spec.add_dependency 'xcpretty-travis-formatter', '>= 0.0.3'
   spec.add_dependency 'slack-notifier', '~> 1.3'

--- a/screengrab/screengrab.gemspec
+++ b/screengrab/screengrab.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/sigh/sigh.gemspec
+++ b/sigh/sigh.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'plist', '~> 3.1' # for reading the provisioning profile
-  spec.add_dependency 'spaceship', '>= 0.33.0', '< 1.0.0' # communication with Apple
+  spec.add_dependency "spaceship", ">= 0.34.1", "< 1.0.0" # communication with Apple
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/snapshot/snapshot.gemspec
+++ b/snapshot/snapshot.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'fastimage', '~> 1.6.3' # fetch the image sizes from the screenshots
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'xcpretty', '>= 0.2.3' # beautiful Xcode output
   spec.add_dependency 'plist', '~> 3.1.0' # parsing the Xcode output plist
 

--- a/snapshot/snapshot.gemspec
+++ b/snapshot/snapshot.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'fastimage', '~> 1.6.3' # fetch the image sizes from the screenshots
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'xcpretty', '>= 0.2.1' # beautiful Xcode output
   spec.add_dependency 'plist', '~> 3.1.0' # parsing the Xcode output plist
 

--- a/watchbuild/watchbuild.gemspec
+++ b/watchbuild/watchbuild.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.52.0', '< 1.0.0' # all shared code and dependencies
-  spec.add_dependency 'spaceship', '>= 0.32.1', '< 1.0.0' # communication with Apple
+  spec.add_dependency "fastlane_core", ">= 0.52.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "spaceship", ">= 0.34.1", "< 1.0.0" # communication with Apple
   spec.add_dependency 'terminal-notifier' # show a notification once the build is ready
 
   # Development only


### PR DESCRIPTION
We’ve spent enough time doing this manually, time for the bots to take over
