### PR TITLE
Ignore SIGH_PROFILE_PATH when using newer api

### DIFF
--- a/fastlane/lib/fastlane/actions/gym.rb
+++ b/fastlane/lib/fastlane/actions/gym.rb
@@ -12,7 +12,9 @@ module Fastlane
         begin
           FastlaneCore::UpdateChecker.start_looking_for_update('gym') unless Helper.is_test?
 
-          if values[:provisioning_profile_path].to_s.length == 0
+          should_use_legacy_api = values[:use_legacy_build_api] || Gym::Xcode.pre7?
+
+          if values[:provisioning_profile_path].to_s.length == 0 || should_use_legacy_api
             sigh_path = Actions.lane_context[Actions::SharedValues::SIGH_PROFILE_PATH] || ENV["SIGH_PROFILE_PATH"]
             values[:provisioning_profile_path] = File.expand_path(sigh_path) if sigh_path
           end

--- a/fastlane/lib/fastlane/actions/gym.rb
+++ b/fastlane/lib/fastlane/actions/gym.rb
@@ -14,7 +14,7 @@ module Fastlane
 
           should_use_legacy_api = values[:use_legacy_build_api] || Gym::Xcode.pre7?
 
-          if values[:provisioning_profile_path].to_s.length == 0 || should_use_legacy_api
+          if values[:provisioning_profile_path].to_s.length.zero? && should_use_legacy_api
             sigh_path = Actions.lane_context[Actions::SharedValues::SIGH_PROFILE_PATH] || ENV["SIGH_PROFILE_PATH"]
             values[:provisioning_profile_path] = File.expand_path(sigh_path) if sigh_path
           end


### PR DESCRIPTION
- [x] Run `rspec` for all tools you modified
- [x] Run `rubocop -a` to ensure the code style is valid
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

For Xcode 7+, there is a error "You're using Xcode 7 or above, the `provisioning_profile_path` value will be ignored" that gym is outputting.  In my case, I am using `sigh` before `gym` and seeing this error pop up.  Originally this happened when some other issue appeared and this led me astray for a bit.

So this change will not forward the `SIGH_PROFILE_PATH` onto `gym` if the developer is not using the legacy api.

Note: It will still warn, if the developer explicitly defines `provisioning_profile_path` in the action options.

Lastly: There are no specs for gym action, that I can find.  I'd be happy to write some just wanted to get this up first.
