### PR TITLE
Show 💥 when a fastlane step fails

### DIFF
--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -93,9 +93,13 @@ module Fastlane
 
       rows = []
       actions.each_with_index do |current, i|
+        is_error_step = !current[:error].to_s.empty?
+
         name = current[:name][0..60]
-        name = name.red unless current[:error].to_s.empty?
-        rows << [i + 1, name, current[:time].to_i]
+        name = name.red if is_error_step 
+        index = i + 1
+        index = "💥" if is_error_step
+        rows << [index, name, current[:time].to_i]
       end
 
       puts ""

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -96,7 +96,7 @@ module Fastlane
         is_error_step = !current[:error].to_s.empty?
 
         name = current[:name][0..60]
-        name = name.red if is_error_step 
+        name = name.red if is_error_step
         index = i + 1
         index = "💥" if is_error_step
         rows << [index, name, current[:time].to_i]


### PR DESCRIPTION
As @taquitos pointed out, there is not enough 💥 when _fastlane_ fails. This PR fixes this

<img width="371" alt="screenshot 2016-09-30 14 16 21" src="https://cloud.githubusercontent.com/assets/869950/19007682/13542070-871b-11e6-8c08-346da433852e.png">
