### PR TITLE
[snapshot] Move launch_arguments to bottom of sample Snapfile

### DIFF
--- a/snapshot/lib/assets/SnapfileTemplate
+++ b/snapshot/lib/assets/SnapfileTemplate
@@ -17,9 +17,6 @@ languages([
   ["pt", "pt_BR"] # Portuguese with Brazilian locale
 ])
 
-# Arguments to pass to the app on launch. See https://github.com/fastlane/snapshot#launch-arguments
-# launch_arguments(["-favColor red"])
-
 # The name of the scheme which contains the UI Tests
 # scheme "SchemeName"
 
@@ -31,6 +28,9 @@ languages([
 # Choose which project/workspace to use
 # project "./Project.xcodeproj"
 # workspace "./Project.xcworkspace"
+
+# Arguments to pass to the app on launch. See https://github.com/fastlane/snapshot#launch-arguments
+# launch_arguments(["-favColor red"])
 
 # For more information about all available options run
 # snapshot --help


### PR DESCRIPTION
Less people will probably use `launch_arguments`
