### PR TITLE
Don’t show error message when importing provisioning profile

### DIFF
--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -24,7 +24,7 @@ module FastlaneCore
       def parse(path)
         require 'plist'
 
-        plist = Plist.parse_xml(`security cms -D -i "#{path}"`)
+        plist = Plist.parse_xml(`security cms -D -i "#{path}" 2> /dev/null`) # /dev/null: https://github.com/fastlane/fastlane/issues/6387
         if (plist || []).count > 5
           plist
         else

--- a/sigh/lib/sigh/local_manage.rb
+++ b/sigh/lib/sigh/local_manage.rb
@@ -126,7 +126,7 @@ module Sigh
 
       profiles = []
       profile_paths.each do |profile_path|
-        profile = Plist.parse_xml(`security cms -D -i '#{profile_path}'`)
+        profile = Plist.parse_xml(`security cms -D -i '#{profile_path}' 2> /dev/null`) # /dev/null: https://github.com/fastlane/fastlane/issues/6387
         profile['Path'] = profile_path
         profiles << profile
       end


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/6387
