### PR TITLE
Version Bump

### DIFF
--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,4 +1,4 @@
 module Spaceship
-  VERSION = "0.34.1".freeze
+  VERSION = "0.34.2".freeze
   DESCRIPTION = "Ruby library to access the Apple Dev Center and iTunes Connect".freeze
 end


### PR DESCRIPTION
Changes since release 0.34.1:
- [spaceship] Show language of metadata failure next to error message (#6392)
- Remove duplicate line in spaceship Rakefile
- [spaceship] Rename DEBUG to SPACESHIP_DEBUG to avoid name conflicts (#6312)
- Add support for iCloud Sandbox testers (#6258)
