### PR TITLE
Version Bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.52.0".freeze
+  VERSION = "0.52.1".freeze
 end


### PR DESCRIPTION
Changes since release 0.52.0:
- Don’t show error message when importing provisioning profile
- Update excon dependency
- Add `rake update_dependencies` to automatically update internal dependencies (#6326)
