### PR TITLE
Version Bump

### DIFF
--- a/sigh/lib/sigh/version.rb
+++ b/sigh/lib/sigh/version.rb
@@ -1,3 +1,3 @@
 module Sigh
-  VERSION = "1.11.1"
+  VERSION = "1.11.2"
 end


### PR DESCRIPTION
Changes since release 1.11.1:
- Don’t show error message when importing provisioning profile
- Add `rake update_dependencies` to automatically update internal dependencies (#6326)
