### PR TITLE
Version Bump

### DIFF
--- a/match/lib/match/version.rb
+++ b/match/lib/match/version.rb
@@ -1,4 +1,4 @@
 module Match
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
   DESCRIPTION = "Easily sync your certificates and profiles across your team using git"
 end


### PR DESCRIPTION
Changes since release 0.8.0:
- Fix Keychain handling on macOS Sierra (#6389)
- Don’t hang when git credentials are not there
- Add error message to make it more clear enterprise profiles are not supported (#6328)
