### PR TITLE
[frameit] Version bump

### DIFF
--- a/frameit/lib/frameit/version.rb
+++ b/frameit/lib/frameit/version.rb
@@ -1,3 +1,3 @@
 module Frameit
-  VERSION = "2.7.0".freeze
+  VERSION = "2.8.0".freeze
 end


### PR DESCRIPTION
- Update internal dependencies (#6104)
- Add a test for error shown with a UTF-8 encoded strings file (#5960)
- Display error when parsing a .strings file returns empty results fixing #1747 (#5958)
- Add a ROOT path constant for frameit (#5843)
- Escape single quotes in frameit title strings (#4849)
- Added interline spacing to frameit titles (#3989)
