### PR TITLE
[fastlane] Version bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.104.0'.freeze
+  VERSION = '1.105.0'.freeze
   DESCRIPTION = "The easiest way to automate building and releasing your iOS and Android apps"
 end


### PR DESCRIPTION
- Improve documentation of all _fastlane_ actions
- New [actions docs](https://docs.fastlane.tools/actions)
- Improved support for macOS Sierra
- Improved support for Xcode 8
- Improve output of `fastlane_version` action (#6393)
- Add listing of plugins and their actions in Actions.md
- Switch to new Fastlane::ROOT method to fetch gem resources
- Update `xcpretty` dependency to 0.2.3 (#6323)
- Show 💥  when a fastlane step fails
- Ignore SIGH_PROFILE_PATH when using newer api (#6347)
- Add `rake update_dependencies` to automatically update internal dependencies (#6326)
- Update internal dependencies
