### PR TITLE
Improve error message when user didn’t properly auth for git

### DIFF
--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -14,7 +14,7 @@ module Match
         FastlaneCore::CommandExecutor.execute(command: "GIT_TERMINAL_PROMPT=0 #{command}",
                                             print_all: $verbose,
                                         print_command: $verbose)
-      rescue => ex
+      rescue
         UI.error("Error cloning certificates repo, please make sure you have read access to the repository you want to use")
         UI.error("Run the following command manually to make sure you're properly authenticated:")
         UI.command(command)

--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -5,14 +5,21 @@ module Match
 
       @dir = Dir.mktmpdir
 
-      # GIT_TERMINAL_PROMPT will fail the `git clone` command if user credentials are missing
-      command = "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{@dir}'"
+      command = "git clone '#{git_url}' '#{@dir}'"
       command << " --depth 1" if shallow_clone
 
       UI.message "Cloning remote git repo..."
-      FastlaneCore::CommandExecutor.execute(command: command,
-                                          print_all: $verbose,
-                                      print_command: $verbose)
+      begin
+        # GIT_TERMINAL_PROMPT will fail the `git clone` command if user credentials are missing
+        FastlaneCore::CommandExecutor.execute(command: "GIT_TERMINAL_PROMPT=0 #{command}",
+                                            print_all: $verbose,
+                                        print_command: $verbose)
+      rescue => ex
+        UI.error("Error cloning certificates repo, please make sure you have read access to the repository you want to use")
+        UI.error("Run the following command manually to make sure you're properly authenticated:")
+        UI.command(command)
+        UI.user_error!("Error cloning certificates git repo, please make sure you have access to the repository - see instructions above")
+      end
 
       UI.user_error!("Error cloning repo, make sure you have access to it '#{git_url}'") unless File.directory?(@dir)
 


### PR DESCRIPTION
This should get us less tickets like 
- https://github.com/fastlane/fastlane/issues/6341#issuecomment-251627860
- https://github.com/fastlane/fastlane/issues/6248
- and [12 more](https://github.com/fastlane/fastlane/issues?utf8=%E2%9C%93&q=%22Exit%20status%3A%20128%22)

![screen shot 2016-10-05 at 2 42 26 pm](https://cloud.githubusercontent.com/assets/869950/19132801/29ecc128-8b0a-11e6-8672-deb6c879b5d4.png)

💥 
