### PR TITLE
Remove iPhone 4s from default Snapfile and update iPad

### DIFF
--- a/snapshot/lib/assets/SnapfileTemplate
+++ b/snapshot/lib/assets/SnapfileTemplate
@@ -5,9 +5,8 @@
 #   "iPhone 6",
 #   "iPhone 6 Plus",
 #   "iPhone 5",
-#   "iPhone 4s",
-#   "iPad Retina",
-#   "iPad Pro"
+#   "iPad Pro (12.9 inch)",
+#   "iPad Pro (9.7 inch)"
 # ])
 
 languages([


### PR DESCRIPTION
Since Xcode 8, there is no more iPhone 4s :cry: RIP
Also, updated to the new required iPad sizes

```
[!] Device 'iPhone 4s' not in list of available simulators 'iPhone 5, iPhone 5s, iPhone 6, iPhone 6 Plus, iPhone 6s, iPhone 6s Plus, iPhone 7, iPhone 7 Plus, iPhone SE, iPad Retina, iPad Air, iPad Air 2, iPad Pro (9.7 inch), iPad Pro (12.9 inch), Apple TV 1080p, Apple Watch - 38mm, Apple Watch - 42mm, Apple Watch Series 2 - 38mm, Apple Watch Series 2 - 42mm'
```
