### PR TITLE
Bump deliver version and update all dependencies

### DIFF
--- a/cert/cert.gemspec
+++ b/cert/cert.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fastlane_core", ">= 0.52.1", "< 1.0.0" # all shared code and dependencies
-  spec.add_dependency "spaceship", ">= 0.34.2", "< 1.0.0" # access to the Dev Portal
+  spec.add_dependency "spaceship", ">= 0.34.3", "< 1.0.0" # access to the Dev Portal
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/danger-device_grid/danger-device_grid.gemspec
+++ b/danger-device_grid/danger-device_grid.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency "fastlane", ">= 1.104.0", "< 2.0.0"
+  spec.add_dependency "fastlane", ">= 1.105.0", "< 2.0.0"
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/deliver/deliver.gemspec
+++ b/deliver/deliver.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   # fastlane dependencies
   spec.add_dependency "fastlane_core", ">= 0.52.1", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency "credentials_manager", ">= 0.16.1", "< 1.0.0"
-  spec.add_dependency "spaceship", ">= 0.34.2", "< 1.0.0" # Communication with iTunes Connect
+  spec.add_dependency "spaceship", ">= 0.34.3", "< 1.0.0" # Communication with iTunes Connect
 
   # third party dependencies
   spec.add_dependency 'fastimage', '~> 1.6' # fetch the image sizes from the screenshots

--- a/deliver/lib/deliver/version.rb
+++ b/deliver/lib/deliver/version.rb
@@ -1,4 +1,4 @@
 module Deliver
-  VERSION = "1.14.0"
+  VERSION = "1.14.1"
   DESCRIPTION = 'Upload screenshots, metadata and your app to the App Store using a single command'
 end

--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bundler', "~> 1.12" # Used for fastlane plugins
   spec.add_dependency "credentials_manager", ">= 0.16.1", "< 1.0.0" # Password Manager
-  spec.add_dependency "spaceship", ">= 0.34.2", "< 1.0.0" # communication layer with Apple's web services
+  spec.add_dependency "spaceship", ">= 0.34.3", "< 1.0.0" # communication layer with Apple's web services
 
   # All the fastlane tools
   spec.add_dependency "deliver", ">= 1.14.0", "< 2.0.0"

--- a/match/match.gemspec
+++ b/match/match.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "fastlane_core", ">= 0.52.1", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency "credentials_manager", ">= 0.16.1", "< 1.0.0" # fastlane password manager
-  spec.add_dependency "spaceship", ">= 0.34.2", "< 1.0.0" # communication layer with Apple's web services
+  spec.add_dependency "spaceship", ">= 0.34.3", "< 1.0.0" # communication layer with Apple's web services
   spec.add_dependency "sigh", ">= 1.11.2", "< 2.0.0"
   spec.add_dependency "cert", ">= 1.4.3", "< 2.0.0"
 

--- a/pem/pem.gemspec
+++ b/pem/pem.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fastlane_core", ">= 0.52.1", "< 1.0.0" # all shared code and dependencies
-  spec.add_dependency "spaceship", ">= 0.34.2", "< 1.0.0" # Communicating with the Apple Dev Portal
+  spec.add_dependency "spaceship", ">= 0.34.3", "< 1.0.0" # Communicating with the Apple Dev Portal
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/pilot/pilot.gemspec
+++ b/pilot/pilot.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fastlane_core", ">= 0.52.1", "< 1.0.0" # all shared code and dependencies
-  spec.add_dependency "spaceship", ">= 0.34.2", "< 1.0.0" # iTunes Connect communication
+  spec.add_dependency "spaceship", ">= 0.34.3", "< 1.0.0" # iTunes Connect communication
   spec.add_dependency 'credentials_manager', '>= 0.16.0'
 
   spec.add_dependency 'terminal-table', '~> 1.4.5' # User's information

--- a/produce/produce.gemspec
+++ b/produce/produce.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fastlane_core", ">= 0.52.1", "< 1.0.0" # all shared code and dependencies
-  spec.add_dependency "spaceship", ">= 0.34.2", "< 1.0.0" # Apple Dev Portal and iTunes Connect Access
+  spec.add_dependency "spaceship", ">= 0.34.3", "< 1.0.0" # Apple Dev Portal and iTunes Connect Access
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/sigh/sigh.gemspec
+++ b/sigh/sigh.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "fastlane_core", ">= 0.52.1", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'plist', '~> 3.1' # for reading the provisioning profile
-  spec.add_dependency "spaceship", ">= 0.34.2", "< 1.0.0" # communication with Apple
+  spec.add_dependency "spaceship", ">= 0.34.3", "< 1.0.0" # communication with Apple
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/watchbuild/watchbuild.gemspec
+++ b/watchbuild/watchbuild.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fastlane_core", ">= 0.52.1", "< 1.0.0" # all shared code and dependencies
-  spec.add_dependency "spaceship", ">= 0.34.2", "< 1.0.0" # communication with Apple
+  spec.add_dependency "spaceship", ">= 0.34.3", "< 1.0.0" # communication with Apple
   spec.add_dependency 'terminal-notifier' # show a notification once the build is ready
 
   # Development only


### PR DESCRIPTION
Changes since release 1.14.0:
- Bump deliver version and update all dependencies
- [deliver] Show language next to screenshot download (#6424)
- Version bump dependencies on fastlane_core and spaceship (#6407)
- Add `rake update_dependencies` to automatically update internal dependencies (#6326)
