### PR TITLE
[snapshot] Version bump

### DIFF
--- a/snapshot/lib/snapshot/version.rb
+++ b/snapshot/lib/snapshot/version.rb
@@ -1,4 +1,4 @@
 module Snapshot
-  VERSION = "1.16.1".freeze
+  VERSION = "1.16.2".freeze
   DESCRIPTION = "Automate taking localized screenshots of your iOS app on every device"
 end


### PR DESCRIPTION
- Update snapshot reporter to work with the new iPad Pro
- Remove iPhone 4s from default Snapfile and update iPad
- Move launch_arguments to bottom of sample Snapfile
