### PR TITLE
Improve output of changelog

### DIFF
--- a/fastlane/fastlane/Fastfile
+++ b/fastlane/fastlane/Fastfile
@@ -193,8 +193,10 @@ private_lane :print_release_changelog do |options|
   tool_name = options[:tool]
   old_version = options[:old_version]
 
-  changes = sh("git log --pretty='* %s' #{tool_name}/#{old_version}...HEAD --no-merges ..").gsub("\n\n", "\n")
-  puts "Changes since release #{old_version}:\n#{changes}"
+  changes = Actions.sh("git log --pretty='* %s' #{tool_name}/#{old_version}...HEAD --no-merges ..", log: false).gsub("\n\n", "\n")
+  changes.gsub!("[#{tool_name}] ", "") # some commits are pre-fixed with the tool name in [ ]
+
+  puts "Changes since release #{old_version}:\n\n#{changes.cyan}"
 end
 
 desc "Add a git tag in the fastlane repo for this release"


### PR DESCRIPTION
- Don’t show command output
- Use of colors
- Remove [tool] prefix if there

From 

![screenshot 2016-10-06 12 45 08](https://cloud.githubusercontent.com/assets/869950/19167983/d9dc3b46-8bc2-11e6-9ba9-d5d6a9bb5885.png)

to

![screenshot 2016-10-06 12 45 00](https://cloud.githubusercontent.com/assets/869950/19167987/e20ac648-8bc2-11e6-8bc7-177e13231b62.png)
