### PR TITLE
Fix update_project_team with Xcode 8

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_team.rb
+++ b/fastlane/lib/fastlane/actions/update_project_team.rb
@@ -12,7 +12,9 @@ module Fastlane
         UI.message("Updating development team (#{params[:teamid]}) for the given project '#{path}'")
 
         p = File.read(path)
-        File.write(path, p.gsub(/DevelopmentTeam = .*;/, "DevelopmentTeam = #{params[:teamid]};"))
+        p = p.gsub(/DevelopmentTeam = .*;/, "DevelopmentTeam = #{team_id};")
+        p = p.gsub(/DEVELOPMENT_TEAM = .*;/, "DEVELOPMENT_TEAM = #{team_id};")
+        File.write(path, p)
 
         UI.success("Successfully updated project settings to use Developer Team ID '#{params[:teamid]}'")
       end

--- a/fastlane/lib/fastlane/actions/update_project_team.rb
+++ b/fastlane/lib/fastlane/actions/update_project_team.rb
@@ -12,8 +12,8 @@ module Fastlane
         UI.message("Updating development team (#{params[:teamid]}) for the given project '#{path}'")
 
         p = File.read(path)
-        p = p.gsub(/DevelopmentTeam = .*;/, "DevelopmentTeam = #{team_id};")
-        p = p.gsub(/DEVELOPMENT_TEAM = .*;/, "DEVELOPMENT_TEAM = #{team_id};")
+        p.gsub!(/DevelopmentTeam = .*;/, "DevelopmentTeam = #{team_id};")
+        p.gsub!(/DEVELOPMENT_TEAM = .*;/, "DEVELOPMENT_TEAM = #{team_id};")
         File.write(path, p)
 
         UI.success("Successfully updated project settings to use Developer Team ID '#{params[:teamid]}'")


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:
- [x] Run `rspec` for all tools you modified (didn't have any spec)
- [x] Run `rubocop -a` to ensure the code style is valid
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Xcode now update DEVELOPMENT_TEAM in addition to DevelopmentTeam.

Fixes https://github.com/fastlane/fastlane/issues/6452
