### PR TITLE
[match] make match pass the keychain name to cert

### DIFF
--- a/match/lib/match/generator.rb
+++ b/match/lib/match/generator.rb
@@ -10,7 +10,8 @@ module Match
         output_path: output_path,
         force: true, # we don't need a certificate without its private key, we only care about a new certificate
         username: params[:username],
-        team_id: params[:team_id]
+        team_id: params[:team_id],
+        keychain_path: Utils.keychain_path(params[:keychain_name])
       })
 
       Cert.config = arguments

--- a/match/lib/match/utils.rb
+++ b/match/lib/match/utils.rb
@@ -1,6 +1,11 @@
 module Match
   class Utils
     def self.import(item_path, keychain, password: "")
+      keychain_path = self.keychain_path(keychain)
+      FastlaneCore::KeychainImporter.import_file(item_path, keychain_path, keychain_password: password, output: $verbose)
+    end
+
+    def self.keychain_path(name)
       # Existing code expects that a keychain name will be expanded into a default path to Libary/Keychains
       # in the user's home directory. However, this will not allow the user to pass an absolute path
       # for the keychain value
@@ -13,18 +18,17 @@ module Match
       # We also try to append `-db` at the end of the file path, as with Sierra the default Keychain name
       # has changed for some users: https://github.com/fastlane/fastlane/issues/5649
       #
+
       keychain_paths = [
-        File.join(Dir.home, 'Library', 'Keychains', keychain),
-        File.join(Dir.home, 'Library', 'Keychains', "#{keychain}-db"),
-        keychain,
-        "#{keychain}-db"
+        File.join(Dir.home, 'Library', 'Keychains', name),
+        File.join(Dir.home, 'Library', 'Keychains', "#{name}-db"),
+        name,
+        "#{name}-db"
       ].map { |path| File.expand_path(path) }
 
       keychain_path = keychain_paths.find { |path| File.exist?(path) }
-
       UI.user_error!("Could not locate the provided keychain. Tried:\n\t#{keychain_paths.join("\n\t")}") unless keychain_path
-
-      FastlaneCore::KeychainImporter.import_file(item_path, keychain_path, keychain_password: password, output: $verbose)
+      keychain_path
     end
 
     # Fill in an environment variable, ready to be used in _xcodebuild_

--- a/match/spec/generator_spec.rb
+++ b/match/spec/generator_spec.rb
@@ -8,7 +8,8 @@ describe Match::Generator do
         output_path: 'workspace/certs/development',
         force: true,
         username: 'username',
-        team_id: 'team_id'
+        team_id: 'team_id',
+        keychain_path: Match::Utils.keychain_path("login.keychain")
       })
 
       # This is the important part. We need to see the right configuration come through
@@ -25,8 +26,10 @@ describe Match::Generator do
         type: 'development',
         workspace: 'workspace',
         username: 'username',
-        team_id: 'team_id'
+        team_id: 'team_id',
+        keychain_name: 'login.keychain'
       }
+
       Match::Generator.generate_certificate(params, 'development')
     end
 


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:
- [ x] Run `rspec` for all tools you modified
- [ x] Run `rubocop -a` to ensure the code style is valid
- [ x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

This fixes #6375 . Match looks up the keychain path by its name and passes it to cert. "== 0" has been replaced with ".zero?" by rubocop.
