### PR TITLE
Update outdated dependencies

### DIFF
--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "fastlane_core", ">= 0.52.1", "< 1.0.0" # all shared code and dependencies
 
-  spec.add_dependency 'bundler', "~> 1.13" # Used for fastlane plugins
+  spec.add_dependency 'bundler', "~> 1.12" # Used for fastlane plugins
   spec.add_dependency "credentials_manager", ">= 0.16.1", "< 1.0.0" # Password Manager
   spec.add_dependency "spaceship", ">= 0.34.3", "< 1.0.0" # communication layer with Apple's web services
 

--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -26,20 +26,20 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'krausefx-shenzhen', '>= 0.14.10' # to upload to Hockey and Crashlytics and build the app
-  spec.add_dependency 'slack-notifier', '~> 1.3' # Slack notifications
+  spec.add_dependency 'slack-notifier', '~> 1.5' # Slack notifications
   spec.add_dependency 'xcodeproj', '>= 0.20', '< 2.0.0' # Needed for commit_version_bump action
   spec.add_dependency 'xcpretty', '>= 0.2.3' # prettify xcodebuild output
-  spec.add_dependency 'terminal-notifier', '~> 1.6.2' # macOS notifications
-  spec.add_dependency 'terminal-table', '~> 1.4.5' # Actions documentation
-  spec.add_dependency 'plist', '~> 3.1.0' # Needed for set_build_number_repository and get_info_plist_value actions
-  spec.add_dependency 'addressable', '~> 2.3' # Support for URI templates
+  spec.add_dependency 'terminal-notifier', '~> 1.7.1' # macOS notifications
+  spec.add_dependency 'terminal-table', '>= 1.4.5' # Actions documentation
+  spec.add_dependency 'plist', '>= 3.1.0' # Needed for set_build_number_repository and get_info_plist_value actions
+  spec.add_dependency 'addressable', '~> 2.4' # Support for URI templates
   spec.add_dependency 'multipart-post', '~> 2.0.0' # Needed for uploading builds to appetize
   spec.add_dependency 'xcode-install', '~> 2.0.0' # Needed for xcversion and xcode_install actions
   spec.add_dependency 'word_wrap', '~> 1.0.0'  # to add line breaks for tables with long strings
 
   spec.add_dependency "fastlane_core", ">= 0.52.1", "< 1.0.0" # all shared code and dependencies
 
-  spec.add_dependency 'bundler', "~> 1.12" # Used for fastlane plugins
+  spec.add_dependency 'bundler', "~> 1.13" # Used for fastlane plugins
   spec.add_dependency "credentials_manager", ">= 0.16.1", "< 1.0.0" # Password Manager
   spec.add_dependency "spaceship", ">= 0.34.3", "< 1.0.0" # communication layer with Apple's web services
 


### PR DESCRIPTION
Updated outdated dependencies listed in https://libraries.io/rubygems/fastlane#license

This does not update the dependencies of terminal-table and plist, since we first have to losen up the dependencies from the sub-tools: https://github.com/fastlane/fastlane/pull/6461
