### PR TITLE
[spaceship] Version bump

### DIFF
--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,4 +1,4 @@
 module Spaceship
-  VERSION = "0.34.3".freeze
+  VERSION = "0.35.0".freeze
   DESCRIPTION = "Ruby library to access the Apple Dev Center and iTunes Connect".freeze
 end


### PR DESCRIPTION
- Add ability to delete iCloud Sandbox Testers (#6395)
- Validate team ID and show nice error message (#6442)
- Add more debugging information when providing a wrong team (#6443)
- adding in `pendingDeveloperRelease` status (#6436)
- Losen up dependencies of subtools (#6461)
