### PR TITLE
Losen up fastlane dependencies

### DIFF
--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -25,14 +25,14 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'krausefx-shenzhen', '>= 0.14.10' # to upload to Hockey and Crashlytics and build the app
-  spec.add_dependency 'slack-notifier', '~> 1.3' # Slack notifications
+  spec.add_dependency 'krausefx-shenzhen', '>= 0.14.10', '< 1.0.0' # to upload to Hockey and Crashlytics and build the app
+  spec.add_dependency 'slack-notifier', '>= 1.3', '< 2.0.0' # Slack notifications
   spec.add_dependency 'xcodeproj', '>= 0.20', '< 2.0.0' # Needed for commit_version_bump action
   spec.add_dependency 'xcpretty', '>= 0.2.3' # prettify xcodebuild output
-  spec.add_dependency 'terminal-notifier', '~> 1.6.2' # macOS notifications
+  spec.add_dependency 'terminal-notifier', '>= 1.6.2', '< 2.0.0' # macOS notifications
   spec.add_dependency 'terminal-table', '>= 1.4.5', '< 2.0.0' # Actions documentation
   spec.add_dependency 'plist', '>= 3.1.0', '< 4.0.0' # Needed for set_build_number_repository and get_info_plist_value actions
-  spec.add_dependency 'addressable', '~> 2.3' # Support for URI templates
+  spec.add_dependency 'addressable', '>= 2.3', '< 3.0.0' # Support for URI templates
   spec.add_dependency 'multipart-post', '~> 2.0.0' # Needed for uploading builds to appetize
   spec.add_dependency 'xcode-install', '~> 2.0.0' # Needed for xcversion and xcode_install actions
   spec.add_dependency 'word_wrap', '~> 1.0.0'  # to add line breaks for tables with long strings


### PR DESCRIPTION
Using `~>` leads to installation issues for many users, it's better to be less strict about the required versions
