### PR TITLE
Update docs only after the complete release is done

### DIFF
--- a/fastlane/fastlane/Fastfile
+++ b/fastlane/fastlane/Fastfile
@@ -112,13 +112,13 @@ lane :release do |options|
     )
   end
 
-  update_docs
-
   clubmate
 
   puts "You can now tweet:".green
   tag_url = "https://github.com/fastlane/fastlane/releases/tag/#{tool_name}/#{version}"
   puts "[#{tool_name}] #{github_release['name']} #{tag_url}"
+
+  update_docs
 end
 
 desc "Makes sure the tests on https://docs.fastlane.tools still work with the latest version"


### PR DESCRIPTION
Updating docs might fail, and we don't want that the release to block, as it's optional
