### PR TITLE
Set layout direction to match Locale on API 17+

### DIFF
--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
@@ -1,6 +1,7 @@
 package tools.fastlane.screengrab.locale;
 
 import android.content.res.Configuration;
+import android.os.Build;
 import android.support.test.InstrumentationRegistry;
 import android.util.Log;
 
@@ -30,6 +31,10 @@ public class LocaleUtil {
 
             config.getClass().getField("userSetLocale").setBoolean(config, true);
             config.locale = locale;
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                config.setLayoutDirection(locale);
+            }
 
             Method updateConfigurationMethod = amnClass.getMethod("updateConfiguration", Configuration.class);
             updateConfigurationMethod.setAccessible(true);


### PR DESCRIPTION
Problem:
Layout isn't mirrored when setting RTL language.

Solution:
Call Configuration#setLayoutDirection(Locale) when changing the configuration.

Fixes: https://github.com/fastlane/fastlane/issues/4906
