### PR TITLE
[frameit] Add Nexus 6P support.

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -23,6 +23,8 @@ module Deliver
       MAC = "Mac"
       # Apple TV
       APPLE_TV = "Apple-TV"
+      # Android Nexus 6P
+      ANDROID_NEXUS_6P = "Android-Nexus-6P"
     end
 
     # @return [Deliver::ScreenSize] the screen size (device type)
@@ -74,7 +76,8 @@ module Deliver
         ScreenSize::IOS_IPAD_PRO => "iPad Pro",
         ScreenSize::MAC => "Mac",
         ScreenSize::IOS_APPLE_WATCH => "Watch",
-        ScreenSize::APPLE_TV => "Apple TV"
+        ScreenSize::APPLE_TV => "Apple TV",
+        ScreenSize::ANDROID_NEXUS_6P => "Nexus 6P"
       }
       return matching[self.screen_size]
     end
@@ -130,6 +133,10 @@ module Deliver
         ],
         ScreenSize::APPLE_TV => [
           [1920, 1080]
+        ],
+        ScreenSize::ANDROID_NEXUS_6P => [
+          [1440, 2560],
+          [2560, 1440]
         ]
       }
     end

--- a/frameit/lib/frameit/offsets.rb
+++ b/frameit/lib/frameit/offsets.rb
@@ -44,6 +44,11 @@ module Frameit
             'offset' => '+48+90',
             'width' => 805
           }
+        when size::ANDROID_NEXUS_6P
+          return {
+              'offset' => '+62+329',
+              'width' => 1440
+          }
         end
       when Orientation::LANDSCAPE
         case screenshot.screen_size
@@ -83,6 +88,11 @@ module Frameit
           return {
             'offset' => '+88+48',
             'width' => 1075
+          }
+        when size::ANDROID_NEXUS_6P
+          return {
+            'offset' => '+329+71',
+            'width' => 2560
           }
         end
       end

--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -35,6 +35,8 @@ module Frameit
         return 'iPad-Pro'
       when sizes::MAC
         return 'Mac'
+      when sizes::ANDROID_NEXUS_6P
+        return 'Nexus_6P'
       else
         UI.error "Unknown device type for size #{@screen_size} for path '#{path}'"
       end


### PR DESCRIPTION
- [x] Run `rspec` for all tools you modified
- [x] Run `rubocop -a` to ensure the code style is valid
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

This pull request adds support for Android device (Nexus 6P). The need of it discussed in https://github.com/fastlane/fastlane/issues/4077.
Nexus 6P is used as one of the most popular and current Android device.
