### PR TITLE
Sigh/recreate profiles

### DIFF
--- a/sigh/spec/manager_spec.rb
+++ b/sigh/spec/manager_spec.rb
@@ -14,5 +14,25 @@ describe Sigh do
       expect(val).to eq(File.expand_path("./AppStore_com.krausefx.app.mobileprovision"))
       File.delete(val)
     end
+
+    it "Invalid profile not force run" do
+      sigh_stub_spaceship(valid_profile = false, expect_create = true)
+      options = { app_identifier: "com.krausefx.app", skip_install: true, skip_certificate_verification: true }
+      Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
+
+      val = Sigh::Manager.start
+      expect(val).to eq(File.expand_path("./AppStore_com.krausefx.app.mobileprovision"))
+      File.delete(val)
+    end
+
+    it "Invalid profile force run" do
+      sigh_stub_spaceship(valid_profile = false, expect_create = true, expect_delete = true)
+      options = { app_identifier: "com.krausefx.app", skip_install: true, skip_certificate_verification: true, force: true }
+      Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
+
+      val = Sigh::Manager.start
+      expect(val).to eq(File.expand_path("./AppStore_com.krausefx.app.mobileprovision"))
+      File.delete(val)
+    end
   end
 end

--- a/sigh/spec/stubbing.rb
+++ b/sigh/spec/stubbing.rb
@@ -1,4 +1,4 @@
-def sigh_stub_spaceship
+def sigh_stub_spaceship(valid_profile = true, expect_create = false, expect_delete = false)
   profile = "profile"
   certificate = "certificate"
 
@@ -6,16 +6,27 @@ def sigh_stub_spaceship
   allow(Spaceship).to receive(:client).and_return("client")
   expect(Spaceship).to receive(:select_team).and_return(nil)
   expect(Spaceship.client).to receive(:in_house?).and_return(false)
+  allow(Spaceship.app).to receive(:find).and_return(true)
+  allow(Spaceship.provisioning_profile).to receive(:all).and_return([])
 
-  allow(profile).to receive(:valid?).and_return(true)
+  allow(profile).to receive(:valid?).and_return(valid_profile)
   allow(profile.class).to receive(:pretty_type).and_return("pretty")
   allow(profile).to receive(:download).and_return("FileContent")
   allow(profile).to receive(:is_adhoc?).and_return(false)
+  allow(profile).to receive(:name).and_return("profile name")
+  if expect_delete
+    expect(profile).to receive(:delete!)
+  else
+    expect(profile).to_not receive(:delete!)
+  end
 
-  types = [Spaceship.provisioning_profile, Spaceship.provisioning_profile.app_store]
-  types.each do |current|
-    allow(current).to receive(:find_by_bundle_id).and_return([profile])
-    allow(current).to receive(:all).and_return([profile])
+  profile_type = Spaceship.provisioning_profile.app_store
+  allow(profile_type).to receive(:find_by_bundle_id).and_return([profile])
+  allow(profile_type).to receive(:all).and_return([profile])
+  if expect_create
+    expect(profile_type).to receive(:create!).and_return(profile)
+  else
+    expect(profile_type).to_not receive(:create!)
   end
 
   certs = [Spaceship.certificate.production]


### PR DESCRIPTION
Delete and recreate the profiles instead of simply updating it to include new devices.  This ensures the profile matches all of the parameters' requirements.
