### PR TITLE
Fix bootstrap for missing task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,6 @@ SECONDS_PER_DAY = 60 * 60 * 24
 desc 'Setup the fastlane development environment'
 task :bootstrap do
   system('gem install bundler') unless system('which bundle')
-  Rake::Task[:clone].invoke
   Rake::Task[:install].invoke
 
   box 'You are up and running'


### PR DESCRIPTION
dbc324955ff4b4f9eb2b37dfe7216450570da2e1 removed the task, but didn’t delete this.
