### PR TITLE
[gym] provision profile specifier

### DIFF
--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -37,7 +37,7 @@ module FastlaneCore
       def uuid(path)
         parse(path).fetch("UUID")
       end
-      
+
       # @return [String] The Name of the given provisioning profile
       def name(path)
         parse(path).fetch("Name")

--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -37,6 +37,11 @@ module FastlaneCore
       def uuid(path)
         parse(path).fetch("UUID")
       end
+      
+      # @return [String] The Name of the given provisioning profile
+      def name(path)
+        parse(path).fetch("Name")
+      end
 
       def profiles_path
         path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -51,7 +51,15 @@ module Gym
       end
 
       if Gym.config[:provisioning_profile_path]
-        FastlaneCore::ProvisioningProfile.install(Gym.config[:provisioning_profile_path])
+        provisioning_path = Gym.config[:provisioning_profile_path]
+        FastlaneCore::ProvisioningProfile.install(provisioning_path)
+
+        if Xcode.pre_8?
+          Gym.config[:provisioning_profile_uuid] = FastlaneCore::ProvisioningProfile.uuid(provisioning_path)
+        else
+          Gym.config[:provisioning_profile_specifier] = FastlaneCore::ProvisioningProfile.name(provisioning_path)
+        end
+
       end
     end
 

--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -57,12 +57,13 @@ module Gym
 
       def buildsettings
         config = Gym.config
-        
+
         buildsettings = []
         buildsettings << "CODE_SIGN_IDENTITY=#{config[:codesigning_identity].shellescape}" if config[:codesigning_identity]
         buildsettings << "PROVISIONING_PROFILE=#{config[:provisioning_profile_uuid].shellescape}" if config[:provisioning_profile_uuid]
         buildsettings << "PROVISIONING_PROFILE_SPECIFIER=#{config[:provisioning_profile_specifier].shellescape}" if config[:provisioning_profile_specifier]
         buildsettings << config[:xcargs] if config[:xcargs]
+
         buildsettings
       end
 

--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -8,8 +8,8 @@ module Gym
         parts = prefix
         parts << "xcodebuild"
         parts += options
+        parts += buildsettings
         parts += actions
-        parts += suffix
         parts += pipe
 
         parts
@@ -41,7 +41,6 @@ module Gym
         options << "-archivePath #{archive_path.shellescape}"
         options << "-derivedDataPath '#{config[:derived_data_path]}'" if config[:derived_data_path]
         options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
-        options << config[:xcargs] if config[:xcargs]
 
         options
       end
@@ -56,10 +55,13 @@ module Gym
         actions
       end
 
-      def suffix
-        suffix = []
-        suffix << "CODE_SIGN_IDENTITY=#{Gym.config[:codesigning_identity].shellescape}" if Gym.config[:codesigning_identity]
-        suffix
+      def buildsettings
+        config = Gym.config
+        
+        buildsettings = []
+        buildsettings << "CODE_SIGN_IDENTITY=#{config[:codesigning_identity].shellescape}" if config[:codesigning_identity]
+        buildsettings << config[:xcargs] if config[:xcargs]
+        buildsettings
       end
 
       def pipe

--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -60,6 +60,8 @@ module Gym
         
         buildsettings = []
         buildsettings << "CODE_SIGN_IDENTITY=#{config[:codesigning_identity].shellescape}" if config[:codesigning_identity]
+        buildsettings << "PROVISIONING_PROFILE=#{config[:provisioning_profile_uuid].shellescape}" if config[:provisioning_profile_uuid]
+        buildsettings << "PROVISIONING_PROFILE_SPECIFIER=#{config[:provisioning_profile_specifier].shellescape}" if config[:provisioning_profile_specifier]
         buildsettings << config[:xcargs] if config[:xcargs]
         buildsettings
       end

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -173,6 +173,14 @@ module Gym
                                      verify_block: proc do |value|
                                        UI.user_error!("Provisioning profile not found at path '#{File.expand_path(value)}'") unless File.exist?(File.expand_path(value))
                                      end),
+        FastlaneCore::ConfigItem.new(key: :provisioning_profile_uuid,
+                                     env_name: "GYM_PROVISIONING_PROFILE_UUID",
+                                     description: "The UUID of the provisioning profile (Xcode 7 and older)",
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :provisioning_profile_specifier,
+                                     env_name: "GYM_PROVISIONING_PROFILE_SPECIFIER",
+                                     description: "The name of the provision profile (Xcode 8 and above)",
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :destination,
                                      short_option: "-d",
                                      env_name: "GYM_DESTINATION",

--- a/gym/lib/gym/xcode.rb
+++ b/gym/lib/gym/xcode.rb
@@ -16,6 +16,14 @@ module Gym
         is_pre = v.split('.')[0].to_i < 7
         is_pre
       end
+
+      # Below Xcode 8 (which offers a new nice API to specify provision profiles)
+      def pre_8?
+        UI.user_error!("Unable to locate Xcode. Please make sure to have Xcode installed on your machine") if xcode_version.nil?
+        v = xcode_version
+        is_pre = v.split('.')[0].to_i < 8
+        is_pre
+      end
     end
   end
 end

--- a/gym/spec/package_command_generator_legacy_spec.rb
+++ b/gym/spec/package_command_generator_legacy_spec.rb
@@ -58,6 +58,7 @@ describe Gym do
     it "supports passing a path to a provisioning profile" do
       # Profile Installation
       expect(FastlaneCore::ProvisioningProfile).to receive(:install).with("./spec/fixtures/dummy.mobileprovision")
+      expect(FastlaneCore::ProvisioningProfile).to receive(:name).with("./spec/fixtures/dummy.mobileprovision")
       options = {
         project: "./examples/standard/Example.xcodeproj",
         provisioning_profile_path: "./spec/fixtures/dummy.mobileprovision"


### PR DESCRIPTION
- [x] Run `rspec` for all tools you modified
- [x] Run `rubocop -a` to ensure the code style is valid
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

I'd like to propose adding support for PROVISIONING_PROFILE (deprecated in Xcode 8) and PROVISIONING_PROFILE_SPECIFIER (added in Xcode 8).

I believe this will help many code signing issues, but I realize it does go against the fastlane recommended guidelines for code signing.

With these changes, reverting #6347, and removing the deprecated :provisioning_profile_path warning for Xcode 7 package generator the following would happen:

```
lane :beta do
   sigh
   gym
end
```

The provision profile selected by `sigh` would be passed to `gym`, which would explicitly use the UUID (in Xcode 7 and before) or the Name (in Xcode 8 and above).  This guarantees that the more obvious provision profile is used for `gym`, without requiring changes to the Xcode Project files.

This should also work with `match`, but I haven't tested it yet, as our project currently does not implement it.

I am happy to write more tests.

Without the changes described above related to reverting and removing deprecation messages, this PR is still valid and allows developers to do the following and get the same effect:

```
lane :beta do
   sigh
   gym( provisioning_profile_uuid: ENV["SIGH_UDID"] )
end
```

I do recognize that this is currently possible with `xcargs` parameter for `gym`, but I believe it would benefit the community and help alleviate the code signing hydra
