### PR TITLE
Prompt for json_key if it and legacy option are both missing

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -23,7 +23,8 @@ module Supply
     # instantiate a client given the supplied configuration
     def self.make_from_config
       unless Supply.config[:json_key] || (Supply.config[:key] && Supply.config[:issuer])
-        UI.user_error! "Missing auth credentials: You must specify either 'json_key' or 'key' and 'issuer'"
+        UI.important("To not be asked about this value, you can specify it using 'json_key'")
+        Supply.config[:json_key] = UI.input("The service account json file used to authenticate with Google: ")
       end
 
       return Client.new(path_to_key: Supply.config[:key],


### PR DESCRIPTION
Previously an error message was displayed, but we would prefer that the user is prompted for a value, since one is required
