### PR TITLE
Add option to clear existing screenshots

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -159,6 +159,11 @@ module Deliver
                                      env_name: "DELIVER_ITC_PROVIDER",
                                      description: "The provider short name to be used with the iTMSTransporter to identify your team",
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :overwrite_screenshots,
+                                     env_name: "DELIVER_OVERWRITE_SCREENSHOTS",
+                                     description: "Clear all previously uploaded screenshots",
+                                     is_string: false,
+                                     default_value: false),
 
         # App Metadata
         # Non Localised

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -161,7 +161,7 @@ module Deliver
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :overwrite_screenshots,
                                      env_name: "DELIVER_OVERWRITE_SCREENSHOTS",
-                                     description: "Clear all previously uploaded screenshots",
+                                     description: "Clear all previously uploaded screenshots before uploading the new ones",
                                      is_string: false,
                                      default_value: false),
 

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -10,20 +10,21 @@ module Deliver
       UI.user_error!("Could not find a version to edit for app '#{app.name}'") unless v
 
       UI.message("Starting with the upload of screenshots...")
+      screenshots_per_language = screenshots.group_by(&:language)
 
-      # First, clear all previously uploaded screenshots, but only where we have new ones
-      # screenshots.each do |screenshot|
-      #   to_remove = v.screenshots[screenshot.language].find_all do |current|
-      #     current.device_type == screenshot.device_type
-      #   end
-      #   to_remove.each { |t| t.reset! }
-      # end
-      # This part is not working yet...
+      if options[:overwrite_screenshots]
+        UI.message("Removing all previously uploaded screenshots...")
+        # First, clear all previously uploaded screenshots
+        screenshots_per_language.keys.each do |language|
+          v.screenshots[language].each_with_index do |t, index|
+            v.upload_screenshot!(nil, index, t.language, t.device_type)
+          end
+        end
+      end
 
       # Now, fill in the new ones
       indized = {} # per language and device type
 
-      screenshots_per_language = screenshots.group_by(&:language)
       enabled_languages = screenshots_per_language.keys
       if enabled_languages.count > 0
         v.create_languages(enabled_languages)


### PR DESCRIPTION
- [x] Run `rspec` for all tools you modified
- [x] Run `rubocop -a` to ensure the code style is valid
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Formerly, I had been uploaded screenshots of all available sizes via deliver.
Thanks to recent iTunes Connect updates, we have only to upload the largest size.
So I dropped other sizes and submitted via deliver. But these are not removed and old ones published onto App Store.

So I added the new option for deliver to remove all existing screenshots forcibly.
