### PR TITLE
[fastlane_core] Add an `os_type` property to the `Device` class

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -40,7 +40,7 @@ module FastlaneCore
             end
 
             if match && !match[4] && (os_type == requested_os_type || requested_os_type == "")
-              @devices << Device.new(name: match[1], os_version: os_version, udid: match[2], state: match[3], is_simulator: true)
+              @devices << Device.new(name: match[1], os_type: os_type, os_version: os_version, udid: match[2], state: match[3], is_simulator: true)
             end
           end
         end
@@ -90,7 +90,7 @@ module FastlaneCore
             device_uuids.each do |device_uuid|
               match = instruments_device.match(/(.+) \(([0-9.]+)\) \[([0-9a-f]+)\]?/)
               if match && match[3] == device_uuid
-                devices << Device.new(name: match[1], udid: match[3], os_version: match[2], state: "Booted", is_simulator: false)
+                devices << Device.new(name: match[1], udid: match[3], os_type: requested_os_type, os_version: match[2], state: "Booted", is_simulator: false)
                 UI.verbose("USB Device Found - \"" + match[1] + "\" (" + match[2] + ") UUID:" + match[3])
               end
             end
@@ -124,7 +124,7 @@ module FastlaneCore
       #       next unless os_version.include?(requested_os_type)
 
       #       os = os_version.gsub(requested_os_type + " ", "").strip
-      #       @devices << Device.new(name: device['name'], os_version: os, udid: device['udid'])
+      #       @devices << Device.new(name: device['name'], os_type: requested_os_type, os_version: os, udid: device['udid'])
       #     end
       #   end
 
@@ -145,14 +145,16 @@ module FastlaneCore
     class Device
       attr_accessor :name
       attr_accessor :udid
+      attr_accessor :os_type
       attr_accessor :os_version
       attr_accessor :ios_version # Preserved for backwards compatibility
       attr_accessor :state
       attr_accessor :is_simulator
 
-      def initialize(name: nil, udid: nil, os_version: nil, state: nil, is_simulator: nil)
+      def initialize(name: nil, udid: nil, os_type: nil, os_version: nil, state: nil, is_simulator: nil)
         self.name = name
         self.udid = udid
+        self.os_type = os_type
         self.os_version = os_version
         self.ios_version = os_version
         self.state = state

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -30,37 +30,37 @@ describe FastlaneCore do
         expect(devices.count).to eq(6)
 
         expect(devices[0]).to have_attributes(
-          name: "iPhone 4s", os_version: "8.1",
+          name: "iPhone 4s", os_type: "iOS", os_version: "8.1",
           udid: "DBABD2A2-0144-44B0-8F93-263EB656FC13",
           state: "Shutdown",
           is_simulator: true
         )
         expect(devices[1]).to have_attributes(
-          name: "iPhone 5", os_version: "8.1",
+          name: "iPhone 5", os_type: "iOS", os_version: "8.1",
           udid: "0D80C781-8702-4156-855E-A9B737FF92D3",
           state: "Booted",
           is_simulator: true
         )
         expect(devices[2]).to have_attributes(
-          name: "iPhone 6s Plus", os_version: "9.1",
+          name: "iPhone 6s Plus", os_type: "iOS", os_version: "9.1",
           udid: "BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0",
           state: "Shutdown",
           is_simulator: true
         )
         expect(devices[3]).to have_attributes(
-          name: "iPad Air", os_version: "9.1",
+          name: "iPad Air", os_type: "iOS", os_version: "9.1",
           udid: "B61CB41D-354B-4991-992A-80AFFF1062E6",
           state: "Shutdown",
           is_simulator: true
         )
         expect(devices[4]).to have_attributes(
-          name: "iPad Air 2", os_version: "9.1",
+          name: "iPad Air 2", os_type: "iOS", os_version: "9.1",
           udid: "57836FE1-5443-4433-B164-A6C9EADAB3F9",
           state: "Shutdown",
           is_simulator: true
         )
         expect(devices[5]).to have_attributes(
-          name: "iPad Pro", os_version: "9.1",
+          name: "iPad Pro", os_type: "iOS", os_version: "9.1",
           udid: "B1DDED8D-E449-461A-94A5-4146A1F58B20",
           state: "Shutdown",
           is_simulator: true
@@ -77,19 +77,19 @@ describe FastlaneCore do
         expect(devices.count).to eq(12)
 
         expect(devices[-3]).to have_attributes(
-          name: "iPad Air 2", os_version: "10.0",
+          name: "iPad Air 2", os_type: "iOS", os_version: "10.0",
           udid: "0FDEB396-0582-438A-B09E-8F8F889DB632",
           state: "Shutdown",
           is_simulator: true
         )
         expect(devices[-2]).to have_attributes(
-          name: "iPad Pro (9.7 inch)", os_version: "10.0",
+          name: "iPad Pro (9.7 inch)", os_type: "iOS", os_version: "10.0",
           udid: "C03658EC-1362-4D8D-A40A-45B1D7D5405E",
           state: "Shutdown",
           is_simulator: true
         )
         expect(devices[-1]).to have_attributes(
-          name: "iPad Pro (12.9 inch)", os_version: "10.0",
+          name: "iPad Pro (12.9 inch)", os_type: "iOS", os_version: "10.0",
           udid: "CEF11EB3-79DF-43CB-896A-0F33916C8BDE",
           state: "Shutdown",
           is_simulator: true
@@ -106,7 +106,7 @@ describe FastlaneCore do
       expect(devices.count).to eq(1)
 
       expect(devices[0]).to have_attributes(
-        name: "Apple TV 1080p", os_version: "9.0",
+        name: "Apple TV 1080p", os_type: "tvOS", os_version: "9.0",
         udid: "D239A51B-A61C-4B60-B4D6-B7EC16595128",
         state: "Shutdown",
         is_simulator: true
@@ -122,13 +122,13 @@ describe FastlaneCore do
       expect(devices.count).to eq(2)
 
       expect(devices[0]).to have_attributes(
-        name: "Apple Watch - 38mm", os_version: "2.0",
+        name: "Apple Watch - 38mm", os_type: "watchOS", os_version: "2.0",
         udid: "FE0C82A5-CDD2-4062-A62C-21278EEE32BB",
         state: "Shutdown",
         is_simulator: true
       )
       expect(devices[1]).to have_attributes(
-        name: "Apple Watch - 38mm", os_version: "2.0",
+        name: "Apple Watch - 38mm", os_type: "watchOS", os_version: "2.0",
         udid: "66D1BF17-3003-465F-A165-E6E3A565E5EB",
         state: "Booted",
         is_simulator: true
@@ -144,43 +144,43 @@ describe FastlaneCore do
       expect(devices.count).to eq(9)
 
       expect(devices[0]).to have_attributes(
-        name: "iPhone 4s", os_version: "8.1",
+        name: "iPhone 4s", os_type: "iOS", os_version: "8.1",
         udid: "DBABD2A2-0144-44B0-8F93-263EB656FC13",
         state: "Shutdown",
         is_simulator: true
       )
       expect(devices[1]).to have_attributes(
-        name: "iPhone 5", os_version: "8.1",
+        name: "iPhone 5", os_type: "iOS", os_version: "8.1",
         udid: "0D80C781-8702-4156-855E-A9B737FF92D3",
         state: "Booted",
         is_simulator: true
       )
       expect(devices[2]).to have_attributes(
-        name: "iPhone 6s Plus", os_version: "9.1",
+        name: "iPhone 6s Plus", os_type: "iOS", os_version: "9.1",
         udid: "BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0",
         state: "Shutdown",
         is_simulator: true
       )
       expect(devices[3]).to have_attributes(
-        name: "iPad Air", os_version: "9.1",
+        name: "iPad Air", os_type: "iOS", os_version: "9.1",
         udid: "B61CB41D-354B-4991-992A-80AFFF1062E6",
         state: "Shutdown",
         is_simulator: true
       )
       expect(devices[6]).to have_attributes(
-        name: "Apple TV 1080p", os_version: "9.0",
+        name: "Apple TV 1080p", os_type: "tvOS", os_version: "9.0",
         udid: "D239A51B-A61C-4B60-B4D6-B7EC16595128",
         state: "Shutdown",
         is_simulator: true
       )
       expect(devices[7]).to have_attributes(
-        name: "Apple Watch - 38mm", os_version: "2.0",
+        name: "Apple Watch - 38mm", os_type: "watchOS", os_version: "2.0",
         udid: "FE0C82A5-CDD2-4062-A62C-21278EEE32BB",
         state: "Shutdown",
         is_simulator: true
       )
       expect(devices[8]).to have_attributes(
-        name: "Apple Watch - 38mm", os_version: "2.0",
+        name: "Apple Watch - 38mm", os_type: "watchOS", os_version: "2.0",
         udid: "66D1BF17-3003-465F-A165-E6E3A565E5EB",
         state: "Booted",
         is_simulator: true
@@ -199,7 +199,7 @@ describe FastlaneCore do
       expect(devices.count).to eq(1)
 
       expect(devices[0]).to have_attributes(
-        name: "Matthew's iPhone", os_version: "9.3",
+        name: "Matthew's iPhone", os_type: "iOS", os_version: "9.3",
         udid: "f0f9f44e7c2dafbae53d1a83fe27c37418ffffff",
         state: "Booted",
         is_simulator: false
@@ -218,7 +218,7 @@ describe FastlaneCore do
       expect(devices.count).to eq(1)
 
       expect(devices[0]).to have_attributes(
-        name: "Matthew's Apple TV", os_version: "9.1",
+        name: "Matthew's Apple TV", os_type: "tvOS", os_version: "9.1",
         udid: "82f1fb5c8362ee9eb89a9c2c6829fa0563ffffff",
         state: "Booted",
         is_simulator: false
@@ -240,31 +240,31 @@ describe FastlaneCore do
       expect(devices.count).to eq(7)
 
       expect(devices[0]).to have_attributes(
-        name: "Matthew's iPhone", os_version: "9.3",
+        name: "Matthew's iPhone", os_type: "iOS", os_version: "9.3",
         udid: "f0f9f44e7c2dafbae53d1a83fe27c37418ffffff",
         state: "Booted",
         is_simulator: false
       )
       expect(devices[1]).to have_attributes(
-        name: "iPhone 4s", os_version: "8.1",
+        name: "iPhone 4s", os_type: "iOS", os_version: "8.1",
         udid: "DBABD2A2-0144-44B0-8F93-263EB656FC13",
         state: "Shutdown",
         is_simulator: true
       )
       expect(devices[2]).to have_attributes(
-        name: "iPhone 5", os_version: "8.1",
+        name: "iPhone 5", os_type: "iOS", os_version: "8.1",
         udid: "0D80C781-8702-4156-855E-A9B737FF92D3",
         state: "Booted",
         is_simulator: true
       )
       expect(devices[3]).to have_attributes(
-        name: "iPhone 6s Plus", os_version: "9.1",
+        name: "iPhone 6s Plus", os_type: "iOS", os_version: "9.1",
         udid: "BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0",
         state: "Shutdown",
         is_simulator: true
       )
       expect(devices[4]).to have_attributes(
-        name: "iPad Air", os_version: "9.1",
+        name: "iPad Air", os_type: "iOS", os_version: "9.1",
         udid: "B61CB41D-354B-4991-992A-80AFFF1062E6",
         state: "Shutdown",
         is_simulator: true
@@ -286,13 +286,13 @@ describe FastlaneCore do
       expect(devices.count).to eq(2)
 
       expect(devices[0]).to have_attributes(
-        name: "Matthew's Apple TV", os_version: "9.1",
+        name: "Matthew's Apple TV", os_type: "tvOS", os_version: "9.1",
         udid: "82f1fb5c8362ee9eb89a9c2c6829fa0563ffffff",
         state: "Booted",
         is_simulator: false
       )
       expect(devices[1]).to have_attributes(
-        name: "Apple TV 1080p", os_version: "9.0",
+        name: "Apple TV 1080p", os_type: "tvOS", os_version: "9.0",
         udid: "D239A51B-A61C-4B60-B4D6-B7EC16595128",
         state: "Shutdown",
         is_simulator: true

--- a/fastlane_core/spec/simulator_spec.rb
+++ b/fastlane_core/spec/simulator_spec.rb
@@ -26,6 +26,7 @@ describe FastlaneCore do
     it "can launch Simulator.app for a simulator device" do
       device = FastlaneCore::DeviceManager::Device.new(name: 'iPhone 5s',
                                                        udid: '3E67398C-AF70-4D77-A22C-D43AA8623FE3',
+                                                    os_type: 'iOS',
                                                  os_version: '10.0',
                                                       state: 'Shutdown',
                                                is_simulator: true)
@@ -40,6 +41,7 @@ describe FastlaneCore do
     it "does not launch Simulator.app for a non-simulator device" do
       device = FastlaneCore::DeviceManager::Device.new(name: 'iPhone 5s',
                                                        udid: '3E67398C-AF70-4D77-A22C-D43AA8623FE3',
+                                                    os_type: 'iOS',
                                                  os_version: '10.0',
                                                       state: 'Shutdown',
                                                is_simulator: false)


### PR DESCRIPTION
- [x] Run `rspec` for all tools you modified
- [x] Run `rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

---

This will be required for an upcoming change to `scan` for handling projects supporting multiple platforms with a single scheme as described in http://promisekit.org/news/2016/08/Multiplatform-Single-Scheme-Xcode-Projects/
