### PR TITLE
add support for provisioning_profile_specifier

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -113,7 +113,7 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :provisioning_profile_specifier,
                                        env_name: "FL_PROJECT_PROVISIONING_PROFILE_SPECIFIER",
-                                       description: "A filter for the target name. Use a standard regex",
+                                       description: "The provisioning profile specifier (e.g: 'app.sample AppStore')",
                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :build_configuration_filter,
                                        env_name: "FL_PROJECT_PROVISIONING_PROFILE_FILTER",


### PR DESCRIPTION
this one adds the ability to set the new `PROVISIONING_PROFILE_SPECIFIER`

quick test:

```
bundle exec fastlane run update_project_provisioning provisioning_profile_specifier:asda xcodeproj:/Users/hja/Desktop/fastlane/fastlane-plugin-update_project_codesigning/demo-project/demo/demo.xcodeproj
```
