### PR TITLE
Fix some info in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ If you're considering contributing new functionality, please open a new issue ex
 - Adding automated tests that cover your changes and/or new functionality is important!
     - `fastlane` has a lot of moving parts and receives contributions from many developers. The best way to ensure that your contributions keep working is to ensure that there will be failing tests if something accidentally gets broken.
     - You can run the tests by executing `bundle install`, then:
-        - Run tests only for a given too by `cd` in that tool subdirectory (e.g. `cd pilot`) then running `bundle exec rspec`,
+        - Run tests only for a given tool by `cd` in that tool subdirectory (e.g. `cd pilot`) then running `bundle exec rspec`,
         - Or test all the Fastlane tools by running `rake test_all` from the root of your working copy.
 - Your code editor should indent using spaces with a tab size of 2 spaces.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ If you're considering contributing new functionality, please open a new issue ex
 
 To submit the changes to the fastlane repo, you have to do the following:
 
-- Run `git push origin master`.
+- Run `git push origin master` (replace `master` with the name of the branch you made your modifications onto in your fork when appropriate).
 - Open `https://github.com/fastlane/fastlane` in your browser and click the green "Create Pull Request" button
 
 ## What Do All These Labels Mean?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ If you're considering contributing new functionality, please open a new issue ex
     - `fastlane` has a lot of moving parts and receives contributions from many developers. The best way to ensure that your contributions keep working is to ensure that there will be failing tests if something accidentally gets broken.
     - You can run the tests by executing `bundle install`, then:
         - Run tests only for a given tool by `cd` in that tool subdirectory (e.g. `cd pilot`) then running `bundle exec rspec`,
-        - Or test all the Fastlane tools by running `rake test_all` from the root of your working copy.
+        - Or test all `fastlane` tools by running `rake test_all` from the root of your working copy.
 - Your code editor should indent using spaces with a tab size of 2 spaces.
 
 To submit the changes to the fastlane repo, you have to do the following:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,12 +80,14 @@ If you're considering contributing new functionality, please open a new issue ex
 
 - Adding automated tests that cover your changes and/or new functionality is important!
     - `fastlane` has a lot of moving parts and receives contributions from many developers. The best way to ensure that your contributions keep working is to ensure that there will be failing tests if something accidentally gets broken.
-    - You can run the tests by executing `bundle install` and then `bundle exec rspec`.
+    - You can run the tests by executing `bundle install`, then:
+        - Run tests only for a given too by `cd` in that tool subdirectory (e.g. `cd pilot`) then running `bundle exec rspec`,
+        - Or test all the Fastlane tools by running `rake test_all` from the root of your working copy.
 - Your code editor should indent using spaces with a tab size of 2 spaces.
 
 To submit the changes to the fastlane repo, you have to do the following:
 
-- Run `git push upstream master`.
+- Run `git push origin master`.
 - Open `https://github.com/fastlane/fastlane` in your browser and click the green "Create Pull Request" button
 
 ## What Do All These Labels Mean?


### PR DESCRIPTION
When reading the CONTRIBUTING.md file while submitting my first PR to Fastlane, I found some inconsistencies, especially:
- The `remote` mentioned when we want to submit a PR seems wrong.
  - Typically contributors not having push access will fork so they'll push to `origin`, not to `upstream`
  - _and people having push access and pushing directly on Fastlane's repo (`upstream`) will create branches to be merged and thus will not push onto the `master` branch anyway_
- The explanations on how to run the specs are misleading.
  - First time I tried, I ran `bundle exec rspec` in the root directory and had an error with ruby stacktrace not finding `spec_helper`, and wondered in my rspec installation was broken, whereas I just was in the root dir instead of one of the tool's subdirectory.
