### PR TITLE
Print out summary of config files to make debugging easier

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -37,7 +37,7 @@ module FastlaneCore
 
       # Show message when self.modified_values is empty
       if self.modified_values.empty?
-        UI.important("No values defined in #{path}")
+        UI.important("No values defined in '#{path}'")
         return
       end
 

--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -23,22 +23,44 @@ module FastlaneCore
         # rubocop:disable Lint/Eval
         eval(content) # this is okay in this case
         # rubocop:enable Lint/Eval
+
+        print_resulting_config_values(path)
       rescue SyntaxError => ex
         line = ex.to_s.match(/\(eval\):(\d+)/)[1]
         UI.user_error!("Syntax error in your configuration file '#{path}' on line #{line}: #{ex}")
       end
     end
 
+    def print_resulting_config_values(path)
+      require 'terminal-table'
+      UI.success("Successfully loaded #{path}")
+
+      # require 'pry'
+      # binding.pry
+      # Show message when self.modified_values is empty
+      return if self.modified_values.empty?
+      rows = self.modified_values.collect do |key, value|
+        [key, value] if value.to_s.length > 0
+      end.compact
+      puts Terminal::Table.new(rows: rows, title: "Detected Values from '#{path}'")
+    end
+
+    def modified_values
+      @modified_values ||= {}
+    end
+
     def method_missing(method_sym, *arguments, &block)
       # First, check if the key is actually available
-      if self.config.all_keys.include? method_sym
+      if self.config.all_keys.include?(method_sym)
         # This silently prevents a value from having its value set more than once.
         return unless self.config._values[method_sym].to_s.empty?
 
         value = arguments.first
         value = yield if value.nil? && block_given?
 
-        self.config[method_sym] = value unless value.nil?
+        return if value.nil?
+        self.modified_values[method_sym] = value
+        self.config[method_sym] = value
       else
         # We can't set this value, maybe the tool using this configuration system has its own
         # way of handling this block, as this might be a special block (e.g. ipa block) that's only

--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -24,7 +24,7 @@ module FastlaneCore
         eval(content) # this is okay in this case
         # rubocop:enable Lint/Eval
 
-        print_resulting_config_values(path)
+        print_resulting_config_values(path) # only on success
       rescue SyntaxError => ex
         line = ex.to_s.match(/\(eval\):(\d+)/)[1]
         UI.user_error!("Syntax error in your configuration file '#{path}' on line #{line}: #{ex}")
@@ -33,18 +33,24 @@ module FastlaneCore
 
     def print_resulting_config_values(path)
       require 'terminal-table'
-      UI.success("Successfully loaded #{path}")
+      UI.success("Successfully loaded '#{File.expand_path(path)}' 📄")
 
-      # require 'pry'
-      # binding.pry
       # Show message when self.modified_values is empty
-      return if self.modified_values.empty?
+      if self.modified_values.empty?
+        UI.important("No values defined in #{path}")
+        return
+      end
+
       rows = self.modified_values.collect do |key, value|
         [key, value] if value.to_s.length > 0
       end.compact
+
+      puts ""
       puts Terminal::Table.new(rows: rows, title: "Detected Values from '#{path}'")
+      puts ""
     end
 
+    # This is used to display only the values that have changed in the summary table
     def modified_values
       @modified_values ||= {}
     end

--- a/fastlane_core/spec/configuration_file_spec.rb
+++ b/fastlane_core/spec/configuration_file_spec.rb
@@ -86,6 +86,25 @@ describe FastlaneCore do
         end
       end
 
+      describe "Prints out a table of summary" do
+        it "shows a warning when no values were found" do
+          expect(FastlaneCore::UI).to receive(:important).with("No values defined in './spec/fixtures/ConfigFileEmpty'")
+
+          config = FastlaneCore::Configuration.create(options, {})
+          config.load_configuration_file('ConfigFileEmpty')
+        end
+
+        it "prints out a table of all the set values" do
+          expect(Terminal::Table).to receive(:new).with({
+            rows: [[:app_identifier, "com.krausefx.app"], [:apple_id, "from_le_block"]],
+            title: "Detected Values from './spec/fixtures/ConfigFileValid'"
+          })
+
+          config = FastlaneCore::Configuration.create(options, {})
+          config.load_configuration_file('ConfigFileValid')
+        end
+      end
+
       it "allows using a custom block to handle special callbacks" do
         config = FastlaneCore::Configuration.create(options, {})
         config.load_configuration_file('ConfigFileUnhandledBlock', proc do |method_sym, arguments, block|


### PR DESCRIPTION
This will print out a nice table of values that were collected from a config file

<img width="742" alt="screenshot 2016-10-17 18 05 05" src="https://cloud.githubusercontent.com/assets/869950/19460878/beb66a14-9494-11e6-97b3-f615e7af38cb.png">
<img width="755" alt="screenshot 2016-10-17 18 04 55" src="https://cloud.githubusercontent.com/assets/869950/19460877/beb1a52e-9494-11e6-8d3d-95b419313593.png">
