### PR TITLE
[PR Template] Add 'bundle exec' to instructions

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:
 
-- [ ] Run `bundle exec rspec` from the subdirectory of all tools you modified. Alternatively, run `rake test_all` from the root directory.
+- [ ] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
 - [ ] Run `bundle exec rubocop -a` to ensure the code style is valid
 - [ ] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
 - [ ] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:
 
-- [ ] Run `rspec` for all tools you modified
-- [ ] Run `rubocop -a` to ensure the code style is valid
+- [ ] Run `bundle exec rspec` from the subdirectory of all tools you modified. Alternatively, run `rake test_all` from the root directory.
+- [ ] Run `bundle exec rubocop -a` to ensure the code style is valid
 - [ ] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
 - [ ] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)
 


### PR DESCRIPTION
This is to ensure people use `bundle exec` when running `rspec` and `rubocop` when validating their PR, to be sure everybody use the same version.

Related to https://github.com/fastlane/fastlane/issues/6570#issuecomment-254134586
