### PR TITLE
fastlane env

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -22,10 +22,5 @@ Fastfile:
 
 ### Environment
 
-fastlane version (run `fastlane -v`):
-
-Do you use bundler to execute fastlane (i.e. `bundle exec fastlane`)?
-
-Do you use a Ruby environment manager (e.g. `chruby`, `rbenv`, `rvm`)?
-
-What Xcode version do you use (e.g. 7.3, 8.0)
+Please replace this with the output of `fastlane env`.
+e.g. via `fastlane env | pbcopy`, if you are using bundler use: `bundle exec fastlane env | pbcopy`

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -14,7 +14,8 @@ module Fastlane
 
       FastlaneCore::UpdateChecker.start_looking_for_update('fastlane')
       Fastlane.load_actions
-      unless ARGV.include?("env")
+      # do not use "include" as it may be some where in the commandline where "env" is required, therefore explicit index->0
+      unless ARGV[0] == "env"
         # *after* loading the plugins
         Fastlane.plugin_manager.load_plugins
         Fastlane::PluginUpdateManager.start_looking_for_updates
@@ -244,10 +245,11 @@ module Fastlane
 
       command :env do |c|
         c.syntax = 'fastlane env'
-        c.description = 'Print your fastlane environment'
+        c.description = 'Print your fastlane environment, use this when you submit an issue on GitHub'
         c.action do |args, options|
           require "fastlane/environment_printer"
-          Fastlane::EnvironmentPrinter.print
+          env_info = Fastlane::EnvironmentPrinter.get
+          puts env_info
         end
       end
 

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -14,9 +14,11 @@ module Fastlane
 
       FastlaneCore::UpdateChecker.start_looking_for_update('fastlane')
       Fastlane.load_actions
-      Fastlane.plugin_manager.load_plugins
-      # *after* loading the plugins
-      Fastlane::PluginUpdateManager.start_looking_for_updates
+      unless ARGV.include?("env")
+        # *after* loading the plugins
+        Fastlane.plugin_manager.load_plugins
+        Fastlane::PluginUpdateManager.start_looking_for_updates
+      end
       self.new.run
     ensure
       FastlaneCore::UpdateChecker.show_update_status('fastlane', Fastlane::VERSION)
@@ -237,6 +239,15 @@ module Fastlane
         c.action do |args, options|
           search_query = args.last
           PluginSearch.print_plugins(search_query: search_query)
+        end
+      end
+
+      command :env do |c|
+        c.syntax = 'fastlane env'
+        c.description = 'Print your fastlane environment'
+        c.action do |args, options|
+          require "fastlane/environment_printer"
+          Fastlane::EnvironmentPrinter.print
         end
       end
 

--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -32,6 +32,7 @@ module Fastlane
         table << "| Plugin | Version | Update-Status |\n"
         table << "|--------|---------|\n"
         plugin_manager.available_plugins.each do |plugin|
+          begin
           installed_version = Fastlane::ActionCollector.determine_version(plugin)
           update_url = FastlaneCore::UpdateChecker.generate_fetch_url(plugin)
           latest_version = FastlaneCore::UpdateChecker.fetch_latest(update_url)
@@ -40,6 +41,9 @@ module Fastlane
           else
             update_status = "🚫 Update availaible"
           end
+        rescue
+          update_status = "💥 Check failed"
+        end
           table << "| #{plugin} | #{installed_version} | #{update_status} |\n"
         end
 
@@ -61,12 +65,16 @@ module Fastlane
         update_status = "N/A"
 
         next unless Fastlane::TOOLS.include?(x.name.to_sym)
-        update_url = FastlaneCore::UpdateChecker.generate_fetch_url(x.name)
-        latest_version = FastlaneCore::UpdateChecker.fetch_latest(update_url)
-        if Gem::Version.new(x.version) == Gem::Version.new(latest_version)
-          update_status = "✅ Up-To-Date"
-        else
-          update_status = "🚫 Update availaible"
+        begin
+          update_url = FastlaneCore::UpdateChecker.generate_fetch_url(x.name)
+          latest_version = FastlaneCore::UpdateChecker.fetch_latest(update_url)
+          if Gem::Version.new(x.version) == Gem::Version.new(latest_version)
+            update_status = "✅ Up-To-Date"
+          else
+            update_status = "🚫 Update availaible"
+          end
+        rescue
+          update_status = "💥 Check failed"
         end
         table << "| #{x.name} | #{x.version} | #{update_status} |\n"
       end

--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -1,100 +1,156 @@
 module Fastlane
   class EnvironmentPrinter
-    def self.print
-      puts "### Fastlane Environment"
-      puts ""
-      print_system_environment
-      print_fastlane_files
-      print_loaded_gems
-      print_loaded_plugins
-      print_instructions
+    def self.get
+      require "fastlane/markdown_table_formatter"
+      env_output = ""
+      env_output << "### fastlane Environment\n"
+      env_output << "\n"
+      env_output << print_system_environment
+      env_output << print_fastlane_files
+      env_output << print_loaded_fastlane_gems
+      env_output << print_loaded_plugins
+      env_output << print_loaded_gems
+      env_output << print_date
+      env_output
     end
 
-    def self.print_instructions
-      puts "Please file a new issue by going to: https://github.com/fastlane/fastlane/issues/new"
-      puts "and do fastlane env|pbcopy  to get the report into pasteboard"
+    def self.print_date
+      date = Time.now.strftime("%d/%m/%Y %H:%M")
+      "\n *generated at:* **#{date}** \n"
     end
 
     def self.print_loaded_plugins
       ENV["FASTLANE_ENV_PRINTER"] = "enabled"
-      puts "### Loaded Fastlane Plugins:"
-      puts ""
+      env_output =  "### Loaded fastlane Plugins:\n"
+      env_output << "\n"
       plugin_manager = Fastlane::PluginManager.new
       plugin_manager.load_plugins
       if plugin_manager.available_plugins.length <= 0
-        puts "**No Plugins Loaded***"
+        env_output << "**No Plugins Loaded***\n"
       else
-        puts "| Plugin | Version |"
-        puts "|--------|---------|"
+        table = ""
+        table << "| Plugin | Version | Update-Status |\n"
+        table << "|--------|---------|\n"
         plugin_manager.available_plugins.each do |plugin|
-          puts "| #{plugin} | #{Fastlane::ActionCollector.determine_version(plugin)} |"
+          installed_version = Fastlane::ActionCollector.determine_version(plugin)
+          update_url = FastlaneCore::UpdateChecker.generate_fetch_url(plugin)
+          latest_version = FastlaneCore::UpdateChecker.fetch_latest(update_url)
+          if Gem::Version.new(installed_version) == Gem::Version.new(latest_version)
+            update_status = "✅ Up-To-Date"
+          else
+            update_status = "🚫 Update availaible"
+          end
+          table << "| #{plugin} | #{installed_version} | #{update_status} |\n"
         end
+
+        rendered_table = MarkdownTableFormatter.new table
+        env_output << rendered_table.to_md
       end
 
-      puts " "
-      puts " "
+      env_output << "\n\n"
+      env_output
+    end
+
+    def self.print_loaded_fastlane_gems
+      # fastlanes own gems
+      env_output = "### fastlane gems\n\n"
+      table = ""
+      table << "| Gem | Version | Update-Status |\n"
+      table << "|-----|---------|------------|\n"
+      Gem.loaded_specs.values.each do |x|
+        update_status = "N/A"
+
+        next unless Fastlane::TOOLS.include?(x.name.to_sym)
+        update_url = FastlaneCore::UpdateChecker.generate_fetch_url(x.name)
+        latest_version = FastlaneCore::UpdateChecker.fetch_latest(update_url)
+        if Gem::Version.new(x.version) == Gem::Version.new(latest_version)
+          update_status = "✅ Up-To-Date"
+        else
+          update_status = "🚫 Update availaible"
+        end
+        table << "| #{x.name} | #{x.version} | #{update_status} |\n"
+      end
+
+      rendered_table = MarkdownTableFormatter.new table
+      env_output << rendered_table.to_md
+
+      env_output << "\n\n"
+
+      env_output
     end
 
     def self.print_loaded_gems
-      puts "### Loaded Gems"
-      puts ""
-      puts "| Gem | Version |"
-      puts "|-----|---------|"
-      puts Gem.loaded_specs.values.map { |x| "| #{x.name} | #{x.version} |" }
-      puts " "
-      puts " "
+      env_output = "### Loaded Gems\n\n"
+      table = ""
+      table << "| Gem | Version |\n"
+      table << "|-----|---------|\n"
+      Gem.loaded_specs.values.each do |x|
+        unless Fastlane::TOOLS.include?(x.name.to_sym)
+          table << "| #{x.name} | #{x.version} |\n"
+        end
+      end
+      rendered_table = MarkdownTableFormatter.new table
+      env_output << rendered_table.to_md
+
+      env_output << "\n\n"
+
+      env_output
     end
 
     def self.print_system_environment
-      puts "### Stack"
-      puts ""
-      puts "| Key |  Value |"
-      puts "|-----|---------|"
-      puts "| Fastlane | #{Fastlane::VERSION} |"
-      puts "| OS  | #{`sw_vers -productVersion`.strip}|"
-      puts "| Ruby  | #{RUBY_VERSION}|"
-      puts "| Xcode | #{`xcode-select -p`.strip.tr("\n", ' ')}|"
-      puts "| Xcode Version | #{`xcodebuild -version`.strip.tr("\n", ' ')}|"
-      puts "| Git | #{`git --version`.strip.split("\n").first} |"
-      puts "| Installation Source | #{$PROGRAM_NAME} |"
+      require "openssl"
 
+      env_output = "### Stack\n\n"
       product, version, build = `sw_vers`.strip.split("\n").map { |line| line.split(':').last.strip }
+      table = ""
+      table << "| Key |  Value |\n"
+      table << "|-----|---------|\n"
+      table << "| fastlane | #{Fastlane::VERSION} |\n"
+      table << "| OS  | #{`sw_vers -productVersion`.strip}|\n"
+      table << "| Ruby  | #{RUBY_VERSION}|\n"
+      table << "| Xcode | #{`xcode-select -p`.strip.tr("\n", ' ')}|\n"
+      table << "| Xcode Version | #{`xcodebuild -version`.strip.tr("\n", ' ')}|\n"
+      table << "| Git | #{`git --version`.strip.split("\n").first} |\n"
+      table << "| Installation Source | #{$PROGRAM_NAME} |\n"
+      table << "| Host | #{product} #{version} (#{build}) |\n"
+      table << "| Ruby Lib Dir | #{RbConfig::CONFIG['libdir']}|\n"
+      table << "| OpenSSL Version | #{OpenSSL::OPENSSL_VERSION} |\n"
 
-      puts "| Host | #{product} #{version} (#{build}) |"
-      puts "| Ruby Lib Dir | #{RbConfig::CONFIG['libdir']}|"
+      rendered_table = MarkdownTableFormatter.new table
+      env_output << rendered_table.to_md
 
-      puts " "
-      puts " "
+      env_output << "\n\n"
+      env_output
     end
 
     def self.print_fastlane_files
-      puts "### Fastlane Files:"
-      puts ""
+      env_output = "### fastlane Files:\n\n"
 
       fastlane_path = FastlaneFolder.fastfile_path
 
-      if File.exist?(fastlane_path)
-        puts "`Fastfile` located in #{fastlane_path}"
-        puts ""
-        puts "```"
-        puts File.read(fastlane_path)
-        puts "```"
+      if fastlane_path && File.exist?(fastlane_path)
+        env_output << "`Fastfile` located in #{fastlane_path}\n"
+        env_output << "\n"
+        env_output << "```\n"
+        env_output <<  File.read(fastlane_path)
+        env_output <<  "```\n"
       else
-        puts "No Fastfile found"
+        env_output << "**No Fastfile found**\n"
       end
-      puts ""
+      env_output << "\n\n"
 
       appfile_path = CredentialsManager::AppfileConfig.default_path
-      if File.exist?(appfile_path)
-        puts "`Appfile` located in #{appfile_path}"
-        puts ""
-        puts "```"
-        puts File.read(appfile_path)
-        puts "```"
+      if appfile_path && File.exist?(appfile_path)
+        env_output << "`Appfile` located in #{appfile_path}\n"
+        env_output << "\n"
+        env_output << "```\n"
+        env_output <<  File.read(appfile_path)
+        env_output <<  "```\n"
       else
-        puts "No Appfile found"
+        env_output <<  "**No Appfile found**\n"
       end
-      puts ""
+      env_output << "\n\n"
+      env_output
     end
   end
 end

--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -1,0 +1,100 @@
+module Fastlane
+  class EnvironmentPrinter
+    def self.print
+      puts "### Fastlane Environment"
+      puts ""
+      print_system_environment
+      print_fastlane_files
+      print_loaded_gems
+      print_loaded_plugins
+      print_instructions
+    end
+
+    def self.print_instructions
+      puts "Please file a new issue by going to: https://github.com/fastlane/fastlane/issues/new"
+      puts "and do fastlane env|pbcopy  to get the report into pasteboard"
+    end
+
+    def self.print_loaded_plugins
+      ENV["FASTLANE_ENV_PRINTER"] = "enabled"
+      puts "### Loaded Fastlane Plugins:"
+      puts ""
+      plugin_manager = Fastlane::PluginManager.new
+      plugin_manager.load_plugins
+      if plugin_manager.available_plugins.length <= 0
+        puts "**No Plugins Loaded***"
+      else
+        puts "| Plugin | Version |"
+        puts "|--------|---------|"
+        plugin_manager.available_plugins.each do |plugin|
+          puts "| #{plugin} | #{Fastlane::ActionCollector.determine_version(plugin)} |"
+        end
+      end
+
+      puts " "
+      puts " "
+    end
+
+    def self.print_loaded_gems
+      puts "### Loaded Gems"
+      puts ""
+      puts "| Gem | Version |"
+      puts "|-----|---------|"
+      puts Gem.loaded_specs.values.map { |x| "| #{x.name} | #{x.version} |" }
+      puts " "
+      puts " "
+    end
+
+    def self.print_system_environment
+      puts "### Stack"
+      puts ""
+      puts "| Key |  Value |"
+      puts "|-----|---------|"
+      puts "| Fastlane | #{Fastlane::VERSION} |"
+      puts "| OS  | #{`sw_vers -productVersion`.strip}|"
+      puts "| Ruby  | #{RUBY_VERSION}|"
+      puts "| Xcode | #{`xcode-select -p`.strip.tr("\n", ' ')}|"
+      puts "| Xcode Version | #{`xcodebuild -version`.strip.tr("\n", ' ')}|"
+      puts "| Git | #{`git --version`.strip.split("\n").first} |"
+      puts "| Installation Source | #{$PROGRAM_NAME} |"
+
+      product, version, build = `sw_vers`.strip.split("\n").map { |line| line.split(':').last.strip }
+
+      puts "| Host | #{product} #{version} (#{build}) |"
+      puts "| Ruby Lib Dir | #{RbConfig::CONFIG['libdir']}|"
+
+      puts " "
+      puts " "
+    end
+
+    def self.print_fastlane_files
+      puts "### Fastlane Files:"
+      puts ""
+
+      fastlane_path = FastlaneFolder.fastfile_path
+
+      if File.exist?(fastlane_path)
+        puts "`Fastfile` located in #{fastlane_path}"
+        puts ""
+        puts "```"
+        puts File.read(fastlane_path)
+        puts "```"
+      else
+        puts "No Fastfile found"
+      end
+      puts ""
+
+      appfile_path = CredentialsManager::AppfileConfig.default_path
+      if File.exist?(appfile_path)
+        puts "`Appfile` located in #{appfile_path}"
+        puts ""
+        puts "```"
+        puts File.read(appfile_path)
+        puts "```"
+      else
+        puts "No Appfile found"
+      end
+      puts ""
+    end
+  end
+end

--- a/fastlane/lib/fastlane/markdown_table_formatter.rb
+++ b/fastlane/lib/fastlane/markdown_table_formatter.rb
@@ -1,0 +1,62 @@
+module Fastlane
+  class MarkdownTableFormatter
+    # taken from: https://github.com/benbalter/markdown-table-formatter
+    def initialize(string, header = true)
+      @doc = string
+      @header = header
+    end
+
+    # converts the markdown string into an array of arrays
+    def parse
+      @table = []
+      rows = @doc.split(/\r?\n/)
+      rows.each do |row|
+        row_array = row.split("|")
+        row_array.each(&:strip!)
+        @table.push row_array
+      end
+      @table.delete_at(1) if @header # strip header separator
+      @table
+    end
+
+    def table
+      @table ||= parse
+    end
+
+    def column_width(column)
+      width = 0
+      table.each do |row|
+        length = row[column].strip.length
+        width = length if length > width
+      end
+      width
+    end
+
+    def pad(string, length)
+      string.strip.ljust(length, ' ')
+    end
+
+    def separator(length)
+      "".ljust(length, '-')
+    end
+
+    def header_separator_row
+      output = []
+      [*0...table.first.length].each do |column|
+        output.push separator(column_width(column))
+      end
+      output
+    end
+
+    def to_md
+      output = ""
+      t = table.clone
+      t.insert(1, header_separator_row) if @header
+      t.each_with_index do |row, index|
+        row.map!.with_index { |cell_row, index_row| pad(cell_row, column_width(index_row)) }
+        output += "#{row.join(' | ').lstrip} |\n"
+      end
+      output
+    end
+  end
+end

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -293,7 +293,7 @@ module Fastlane
         UI.error("Please follow the troubleshooting guide: #{TROUBLESHOOTING_URL}")
       end
 
-      skip_print_plugin_info = self.plugin_references.empty? || CLIToolsDistributor.running_version_command?
+      skip_print_plugin_info = self.plugin_references.empty? || CLIToolsDistributor.running_version_command? || ENV["FASTLANE_ENV_PRINTER"]
 
       # We want to avoid printing output other than the version number if we are running `fastlane -v`
       print_plugin_information(self.plugin_references) unless skip_print_plugin_info

--- a/fastlane/spec/env_spec.rb
+++ b/fastlane/spec/env_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require "fastlane/environment_printer"
+require "fastlane/cli_tools_distributor"
+
+describe Fastlane do
+  describe Fastlane::EnvironmentPrinter do
+    before do
+      stub_request(:post, %r{https:\/\/fastlane-refresher.herokuapp.com\/.*}).
+        with(headers: { 'Host' => 'fastlane-refresher.herokuapp.com:443', 'User-Agent' => 'excon/0.53.0' }).
+        to_return(status: 200, body: '{"version": "0.16.2",  "status": "ok"}', headers: {})
+    end
+
+    it "Prints Env Dump" do
+      expect(Fastlane::EnvironmentPrinter.get).to include("fastlane")
+      expect(Fastlane::EnvironmentPrinter.get).to include("Loaded fastlane Plugins")
+      expect(Fastlane::EnvironmentPrinter.get).to include("fastlane gems")
+      expect(Fastlane::EnvironmentPrinter.get).to include("generated at")
+    end
+  end
+end


### PR DESCRIPTION
- [x] atleast on unit test
- [x] documentation on how to use this feature, mostly in the ISSUE_TEMPLATE.md
- [x] Output should be nice markdown output, easy to copy and paste to GitHub
- [x] Instructions in the terminal on how to copy & paste to GitHub
- [x] Listing all the used Ruby gem versions (something similar to the Gemfile.lock, but has to be   fetched from the run time). It's easy to fetch the version of all gems that are being loaded
- [x] Xcode path (xcode-select -p)
- [x] Version of the Xcode installation on xcode-select -p
- [x] Print out the stack similar to CocoaPods (see below)
- [x] Executable path (similar to CocoaPods)
- [x] Loaded plugins (if any)

i took over https://github.com/fastlane/fastlane/pull/6252 - hope it is ok @KrauseFx 

Sample Output:
### Fastlane Environment
### Stack

| Key | Value |
| --- | --- |
| Fastlane | 1.105.2 |
| OS | 10.12 |
| Ruby | 2.2.1 |
| Xcode | /Applications/Xcode.app/Contents/Developer |
| Xcode Version | Xcode 8.0 Build version 8A218a |
| Git | git version 2.10.0 |
| Installation Source | /Users/hjanuschka/.rvm/gems/ruby-2.2.1/bin/fastlane |
| Host | Mac OS X 10.12 (16A323) |
| Ruby Lib Dir | /Users/hjanuschka/.rvm/rubies/ruby-2.2.1/lib |
### Fastlane Files:

`Fastfile` located in ./fastlane/Fastfile

```
lane :demo do
    puts "my fastfile"
end
```

`Appfile` located in ./fastlane/Appfile

```
my_app_file=1
```
### Fastlane Gems

| Gem | Version | Update-Status |
| --- | --- | --- |
| credentials_manager | 0.16.2 | 😇 Up-To-Date |
| fastlane_core | 0.52.1 | 😇 Up-To-Date |
| spaceship | 0.36.0 | 😇 Up-To-Date |
| cert | 1.4.3 | 😱 Update availaible |
| deliver | 1.14.2 | 😇 Up-To-Date |
| frameit | 2.8.0 | 😇 Up-To-Date |
| gym | 1.11.2 | 😇 Up-To-Date |
| sigh | 1.11.2 | 😇 Up-To-Date |
| match | 0.8.1 | 😇 Up-To-Date |
| pem | 1.3.2 | 😇 Up-To-Date |
| pilot | 1.10.1 | 😇 Up-To-Date |
| produce | 1.2.1 | 😇 Up-To-Date |
| scan | 0.13.1 | 😇 Up-To-Date |
| screengrab | 0.5.5 | 😇 Up-To-Date |
| snapshot | 1.16.2 | 😇 Up-To-Date |
| supply | 0.7.1 | 😇 Up-To-Date |
| fastlane | 1.105.2 | 😇 Up-To-Date |
### Loaded Fastlane Plugins:

| Plugin | Version | Update-Status |
| --- | --- | --- |
| fastlane-plugin-sharethemeal | 0.1.9 | 😇 Up-To-Date |
### Loaded Gems

| Gem | Version |
| --- | --- |
| rake | 11.3.0 |
| i18n | 0.7.0 |
| json | 1.8.3 |
| minitest | 5.9.1 |
| thread_safe | 0.3.5 |
| tzinfo | 1.2.2 |
| activesupport | 4.2.7.1 |
| addressable | 2.4.0 |
| ast | 2.3.0 |
| babosa | 1.0.2 |
| builder | 3.2.2 |
| bundler | 1.13.1 |
| byebug | 9.0.6 |
| colored | 1.2 |
| highline | 1.7.8 |
| commander | 4.4.0 |
| security | 0.1.3 |
| excon | 0.53.0 |
| gh_inspector | 1.0.2 |
| multi_json | 1.12.1 |
| plist | 3.1.0 |
| rubyzip | 1.1.7 |
| terminal-table | 1.4.5 |
| multipart-post | 2.0.0 |
| faraday | 0.9.2 |
| unf_ext | 0.0.7.2 |
| unf | 0.1.4 |
| domain_name | 0.5.20160826 |
| http-cookie | 1.0.3 |
| faraday-cookie_jar | 0.0.6 |
| faraday_middleware | 0.10.0 |
| fastimage | 1.6.8 |
| multi_xml | 0.5.5 |
| claide | 1.0.1 |
| cork | 0.2.0 |
| nap | 1.1.0 |
| open4 | 1.3.4 |
| claide-plugins | 0.9.2 |
| coderay | 1.1.1 |
| docile | 1.1.5 |
| simplecov-html | 0.10.0 |
| simplecov | 0.12.0 |
| tins | 1.12.0 |
| term-ansicolor | 1.4.0 |
| thor | 0.19.1 |
| coveralls | 0.8.15 |
| safe_yaml | 1.0.4 |
| crack | 0.4.3 |
| faraday-http-cache | 1.3.1 |
| git | 1.3.0 |
| sawyer | 0.7.0 |
| octokit | 4.3.0 |
| redcarpet | 3.3.4 |
| danger | 0.10.1 |
| diff-lcs | 1.2.5 |
| dotenv | 2.1.1 |
| fakefs | 0.8.1 |
| mini_magick | 4.5.1 |
| rouge | 1.11.1 |
| xcpretty | 0.2.4 |
| net-ssh | 3.2.0 |
| net-sftp | 2.1.2 |
| krausefx-shenzhen | 0.14.10 |
| slack-notifier | 1.5.1 |
| xcpretty-travis-formatter | 0.0.4 |
| jwt | 1.5.6 |
| little-plugger | 1.1.4 |
| logging | 2.1.0 |
| memoist | 0.15.0 |
| os | 0.9.6 |
| signet | 0.7.3 |
| googleauth | 0.5.1 |
| httpclient | 2.8.2.4 |
| hurley | 0.2 |
| mime-types | 1.25.1 |
| uber | 0.0.15 |
| representable | 2.3.0 |
| retriable | 2.1.0 |
| google-api-client | 0.9.15 |
| terminal-notifier | 1.7.1 |
| word_wrap | 1.0.0 |
| xcode-install | 2.0.7 |
| xcodeproj | 1.3.2 |
| rest-client | 1.6.9 |
| stm_api | 0.1.6 |
| fastlane-plugin-sharethemeal | 0.1.9 |
| method_source | 0.8.2 |
| parser | 2.3.1.4 |
| powerpack | 0.1.1 |
| slop | 3.6.0 |
| pry | 0.10.4 |
| pry-byebug | 3.4.0 |
| rainbow | 2.1.0 |
| rspec-support | 3.1.2 |
| rspec-core | 3.1.7 |
| rspec-expectations | 3.1.2 |
| rspec-mocks | 3.1.3 |
| rspec | 3.1.0 |
| rspec_junit_formatter | 0.2.3 |
| ruby-progressbar | 1.8.1 |
| unicode-display_width | 1.1.1 |
| rubocop | 0.38.0 |
| webmock | 1.19.0 |
| yard | 0.8.7.6 |
