### PR TITLE
[Gym] Add reminder of the full log path when erroring

### DIFF
--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -6,7 +6,7 @@ module Gym
       # @param [String] The output of the errored build
       # This method should raise an exception in any case, as the return code indicated a failed build
       def handle_build_error(output)
-        # The order of the handling below is import
+        # The order of the handling below is important
         case output
         when /Your build settings specify a provisioning profile with the UUID/
           print "Invalid code signing settings"
@@ -50,6 +50,7 @@ module Gym
           print "For more information visit this stackoverflow answer:"
           print "https://stackoverflow.com/a/17031697/445598"
         end
+        print_full_log_path
         UI.user_error!("Error building the application - see the log above")
       end
 
@@ -91,6 +92,7 @@ module Gym
           print "Unfortunately the new Xcode export API is unstable and causes problems on some projects"
           print "You can temporary use the :use_legacy_build_api option to get the build to work again"
         end
+        print_full_log_path
         UI.user_error!("Error packaging up the application")
       end
 
@@ -119,6 +121,13 @@ module Gym
       # Just to make things easier
       def print(text)
         UI.error text
+      end
+
+      def print_full_log_path
+        return if Gym.config[:disable_xcpretty]
+        log_path = Gym::BuildCommandGenerator.xcodebuild_log_path
+        UI.error("📋  For a more detailed error log, check the full log at:")
+        UI.error("📋  #{log_path}")
       end
     end
   end


### PR DESCRIPTION
## The problem

Lately I have had multiple cases of build failed where the `xcpretty` output wasn't really helpful as it filtered out some important info
- Last time I encountered this, `xcpretty` filtered out some code signing errors, making it hard to figure out what was wrong (it has since been fixed by @mgrebenets in supermarin/xcpretty#247)
- Today I got an "Interaction is not allowed" error when driving our build via a headless CI, but was only able to see that error and understand it was the cause by reading the unfiltered log as well

Reading the full log unfiltered by `xcpretty` instead of the filtered stdout helped me a lot figuring out what the real problem was, so I think it's useful to mention it more clearly in case of failure.
## Solution

This PR aims at reminding the path where you can read the full log (not filtered by `xcpretty`) at the end of a `gym` failure, so users are incited to read it to get more info about the error, and have a quick way to find its path.

<img width="500" alt="gym_failure" src="https://cloud.githubusercontent.com/assets/216089/19443108/00f92c4e-948c-11e6-85d1-f9ed424a6e15.png">
