### PR TITLE
Update error handling for recent TLS 1.2 problems talking to Apple servers

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -1,17 +1,19 @@
+unless Object.const_defined?("Faraday")
+  # We create these empty error classes if we didn't require Faraday
+  # so that we can use it in the rescue block below even if we didn't
+  # require Faraday or didn't use it
+  module Faraday
+    class Error < StandardError; end
+    class ClientError < Error; end
+    class SSLError < ClientError; end
+    class ConnectionFailed < ClientError; end
+  end
+end
+
 module Commander
   # This class override the run method with our custom stack trace handling
   # In particular we want to distinguish between user_error! and crash! (one with, one without stack trace)
   class Runner
-    unless Object.const_defined?("Faraday")
-      module Faraday
-        class SSLError < StandardError
-          # We create this empty error class if we didn't require Faraday
-          # so that we can use it in the rescue block below
-          # even if we didn't require Faraday or didn't use it
-        end
-      end
-    end
-
     # Code taken from https://github.com/commander-rb/commander/blob/master/lib/commander/runner.rb#L50
     def run!
       require_program :version, :description
@@ -53,28 +55,64 @@ module Commander
         show_github_issues(e.message) if e.show_github_issues
         display_user_error!(e, e.message)
       rescue Faraday::SSLError => e # SSL issues are very common
-        # SSL errors are very common when the Ruby or OpenSSL installation is somehow broken
-        # We want to show a nice error message to the user here
-        # We have over 20 GitHub issues just for this one error:
-        #   https://github.com/fastlane/fastlane/search?q=errno%3D0+state%3DSSLv3+read+server&type=Issues
-        ui = FastlaneCore::UI
-        ui.error "-----------------------------------------------------------------------"
-        ui.error e.to_s
-        ui.error "SSL errors can be caused by various components on your local machine"
-        ui.error "- Make sure OpenSSL is installed with Homebrew: `brew update && brew upgrade openssl`"
-        ui.error "- If you use rvm:"
-        ui.error "  - First run `rvm osx-ssl-certs update all`"
-        ui.error "  - Then run `rvm reinstall ruby-2.2.3 --with-openssl-dir=/usr/local"
-        ui.error "- If that doesn't fix your issue, please google for the following error message:"
-        ui.error "  '#{e}'"
-        ui.error "-----------------------------------------------------------------------"
-        display_user_error!(e, e.to_s)
+        handle_ssl_error!(e)
+      rescue Faraday::ConnectionFailed => e
+        if e.message.include? 'Connection reset by peer - SSL_connect'
+          handle_tls_error!(e)
+        else
+          handle_unknown_error!(e)
+        end
       rescue => e # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
         collector.did_crash(@program[:name])
         handle_unknown_error!(e)
       ensure
         collector.did_finish
       end
+    end
+
+    def handle_tls_error!(e)
+      # Apple has upgraded its iTunes Connect servers to require TLS 1.2, but
+      # system Ruby 2.0 does not support it. We want to suggest that users upgrade
+      # their Ruby version
+      suggest_ruby_reinstall(e)
+      display_user_error!(e, e.to_s)
+    end
+
+    def handle_ssl_error!(e)
+      # SSL errors are very common when the Ruby or OpenSSL installation is somehow broken
+      # We want to show a nice error message to the user here
+      # We have over 20 GitHub issues just for this one error:
+      #   https://github.com/fastlane/fastlane/search?q=errno%3D0+state%3DSSLv3+read+server&type=Issues
+      suggest_ruby_reinstall(e)
+      display_user_error!(e, e.to_s)
+    end
+
+    def suggest_ruby_reinstall(e)
+      ui = FastlaneCore::UI
+      ui.error "-----------------------------------------------------------------------"
+      ui.error e.to_s
+      ui.error ""
+      ui.error "SSL errors can be caused by various components on your local machine."
+      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1')
+        ui.error "Apple has recently changed their servers to require TLS 1.2, which may"
+        ui.error "not be available to your system installed Ruby (#{RUBY_VERSION})"
+      end
+      ui.error ""
+      ui.error "The best solution is to install a new version of Ruby"
+      ui.error ""
+      ui.error "- Make sure OpenSSL is installed with Homebrew: `brew update && brew upgrade openssl`"
+      ui.error "- If you use system Ruby:"
+      ui.error "  - Run `brew update && brew install ruby`"
+      ui.error "- If you use rbenv with ruby-build:"
+      ui.error "  - Run `brew update && brew upgrade ruby-build && rbenv install ruby-2.3.1`"
+      ui.error "  - Run `rbenv global ruby-2.3.1` to make it the new global default Ruby version"
+      ui.error "- If you use rvm:"
+      ui.error "  - First run `rvm osx-ssl-certs update all`"
+      ui.error "  - Then run `rvm reinstall ruby-2.3.1 --with-openssl-dir=/usr/local"
+      ui.error ""
+      ui.error "If that doesn't fix your issue, please google for the following error message:"
+      ui.error "  '#{e}'"
+      ui.error "-----------------------------------------------------------------------"
     end
 
     def handle_unknown_error!(e)


### PR DESCRIPTION
Help users towards the solution for #6553 by providing better error messaging when Ruby can't make an SSL connection to Apple's servers.

I needed to move the local Faraday error class creation outside of the `Commander` module in order to have the correct shadowing happen if/when `Faraday` is later defined.

I knew I was on the right track with that when Ruby complained that the `ConnectionFailed` class supertypes did not match (I originally started with `StandardError`, like in the previous code). [Looking at the Faraday code](https://github.com/lostisland/faraday/blob/a712938071bb0997410b5de4a4f2517d30fc4d3d/lib/faraday/error.rb), those extra super classes are now also defined locally so that the class hierarchies can match correctly.

![image](https://cloud.githubusercontent.com/assets/343134/19456220/6754fbf6-948e-11e6-8221-92e0170c1103.png)
