### PR TITLE
Version Bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.52.1".freeze
+  VERSION = "0.52.2".freeze
 end


### PR DESCRIPTION
Changes since release 0.52.1:
- Update error handling for recent TLS 1.2 problems talking to Apple servers (#6593)
- Loosen up dependencies of subtools (#6461)
