### PR TITLE
Hide similar GitHub issues on user error

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -119,7 +119,7 @@ module FastlaneCore
     class FastlaneError < StandardError
       attr_reader :show_github_issues
 
-      def initialize(show_github_issues: true)
+      def initialize(show_github_issues: false)
         @show_github_issues = show_github_issues
       end
     end


### PR DESCRIPTION
I thought we already did that a while ago, but seems like https://github.com/fastlane/fastlane/commit/bc4178eefdfc586f5993806cdef477e969a21d68 was not correct
