### PR TITLE
Update spaceship version

### DIFF
--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,4 +1,4 @@
 module Spaceship
-  VERSION = "0.36.0".freeze
+  VERSION = "0.36.1".freeze
   DESCRIPTION = "Ruby library to access the Apple Dev Center and iTunes Connect".freeze
 end


### PR DESCRIPTION
[13:28:06]: Changes since release 0.36.0:
- Fix upload of app icon for app and watch (#6652)
- Update fastlane tagline (#6645)
- Remove build status from spaceship README (#6622)
- Update rubocop and update styling rules (#6573)
