### PR TITLE
Fix commit_version_bump could not find a .xcodeproj, this closes #6675

### DIFF
--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -19,7 +19,7 @@ module Fastlane
           UI.user_error!("Could not find the specified xcodeproj: #{xcodeproj_path}") unless File.directory?(xcodeproj_path)
         else
           # find an xcodeproj (ignoring the Cocoapods one)
-          xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))].reject { |path| %r{Pods\/.*.xcodeproj} =~ path }
+          xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))].reject { |path| %r{/Pods/[^/]*.xcodeproj} =~ path }
 
           # no projects found: error
           UI.user_error!('Could not find a .xcodeproj in the current repository\'s working directory.') if xcodeproj_paths.count == 0

--- a/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
@@ -24,8 +24,9 @@ module Fastlane
             UI.user_error!("Could not find the specified xcodeproj: #{xcodeproj_path}") unless File.directory?(xcodeproj_path)
           end
         else
+          all_xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))]
           # find an xcodeproj (ignoring the Cocoapods one)
-          xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))].reject { |path| %r{/Pods/[^/]*.xcodeproj} =~ path }
+          xcodeproj_paths = ignore_cocoapods_path(all_xcodeproj_paths)
 
           # no projects found: error
           UI.user_error!('Could not find a .xcodeproj in the current repository\'s working directory.') if xcodeproj_paths.count == 0
@@ -104,6 +105,10 @@ module Fastlane
           UI.error(ex)
           UI.important("Didn't commit any changes. 😐")
         end
+      end
+
+      def self.ignore_cocoapods_path(all_xcodeproj_paths)
+        all_xcodeproj_paths.reject { |path| %r{/Pods/[^/]*.xcodeproj} =~ path }
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
@@ -25,7 +25,7 @@ module Fastlane
           end
         else
           # find an xcodeproj (ignoring the Cocoapods one)
-          xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))].reject { |path| %r{Pods\/.*.xcodeproj} =~ path }
+          xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))].reject { |path| %r{/Pods/[^/]*.xcodeproj} =~ path }
 
           # no projects found: error
           UI.user_error!('Could not find a .xcodeproj in the current repository\'s working directory.') if xcodeproj_paths.count == 0

--- a/fastlane/spec/actions_specs/hg_commit_version_bump_spec.rb
+++ b/fastlane/spec/actions_specs/hg_commit_version_bump_spec.rb
@@ -15,6 +15,12 @@ describe Fastlane do
         expect(result).to eq("hg commit -m 'Version Bump'")
       end
 
+      it 'return the project path when ignoring the cocoapods path' do
+        all_xcodeproj_paths = ["/Users/tmp/Developer/iOS/MyPods/MyProject/MyProject.xcodeproj", "/Users/tmp/Developer/iOS/MyPods/MyProject/Pods/Pods.xcodeproj"]
+        project_path = Fastlane::Actions::HgCommitVersionBumpAction.ignore_cocoapods_path(all_xcodeproj_paths)
+        expect(project_path).to eq(all_xcodeproj_paths[0..0])
+      end
+
       it "passes when modified files are not a subset of expected files, but :force is true" do
         dirty_files = "file1,file3,file5"
         expected_files = "file1"


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:
- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

…pository's working directory when the current repository is under something like xxxPods/myProjectName
