### PR TITLE
[fastlane] Version bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.105.3'.freeze
+  VERSION = '1.106.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps"
 end


### PR DESCRIPTION
- New `fastlane env` command to print out the fastlane environment
- Docs: describe using next to stop executing a lane (#6674)
- Update dependencies (#6682)
- Remove old crash reporter code from fastlane (#6623)
