### PR TITLE
Markdown docs generator: only print on verbose

### DIFF
--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -98,7 +98,7 @@ module Fastlane
       template = File.join(Fastlane::ROOT, "lib/assets/Actions.md.erb")
 
       result = ERB.new(File.read(template), 0, '-').result(binding) # http://www.rrn.dk/rubys-erb-templating-system
-      puts result
+      UI.verbose(result)
 
       File.write(target_path, result)
       UI.success(target_path)


### PR DESCRIPTION
This was spamming our output a lot
