### PR TITLE
[match] Version bump

### DIFF
--- a/match/lib/match/version.rb
+++ b/match/lib/match/version.rb
@@ -1,4 +1,4 @@
 module Match
-  VERSION = "0.8.1"
+  VERSION = "0.9.0"
   DESCRIPTION = "Easily sync your certificates and profiles across your team using git"
 end


### PR DESCRIPTION
- Match: support for supplying multiple app identifiers at once (#6635)
- Update internal dependencies (#6682)
- Improve team selection (#6444)
- Improve error message when user didn’t properly auth for git

You can now pass multiple app identifiers, and _match_ will clone the repo just once:

``` ruby
match(app_identifier: ["tools.fastlane.app", "tools.fastlane.sleepy"])
```
