### PR TITLE
[fastlane] Version bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.106.0'.freeze
+  VERSION = '1.106.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps"
 end


### PR DESCRIPTION
- Losen up _frameit_ dependency
- Add `env` to black_list for valid lane names (#6693)
- Markdown docs generator: only print on verbose (#6694)
