### PR TITLE
[match] Implement auto-repair of provisioning profiles

### DIFF
--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -54,13 +54,25 @@ module Match
       found = Spaceship.provisioning_profile.all.find do |profile|
         profile.uuid == uuid
       end
-      return if found
 
-      UI.error("Provisioning profile '#{uuid}' is not available on the Developer Portal")
-      UI.error("for the user #{username}")
-      UI.error("Make sure to use the same user and team every time you run 'match' for this")
-      UI.error("Git repository. This might be caused by deleting the provisioning profile on the Dev Portal")
-      UI.user_error!("To reset the provisioning profiles of your Apple account, you can use the `match nuke` feature, more information on https://github.com/fastlane/fastlane/tree/master/match")
+      unless found
+        UI.error("Provisioning profile '#{uuid}' is not available on the Developer Portal")
+        UI.error("for the user #{username}")
+        UI.error("Make sure to use the same user and team every time you run 'match' for this")
+        UI.error("Git repository. This might be caused by deleting the provisioning profile on the Dev Portal")
+        UI.user_error!("To reset the provisioning profiles of your Apple account, you can use the `match nuke` feature, more information on https://github.com/fastlane/fastlane/tree/master/match")
+      end
+
+      if found.valid?
+        return found
+      else
+        UI.important("'#{found.name}' is available on the Developer Portal, however it's 'Invalid', fixing this now for you 🔨")
+        # it's easier to just create a new one, than to repair an existing profile
+        # it has the same effects anyway, including a new UUID of the provisioning profile
+        found.delete!
+        # return nil to re-download the new profile in runner.rb
+        return nil
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/5379 caused by https://openradar.appspot.com/radar?id=4956030156931072

> [15:19:45]: 'match Development tools.fastlane.app' is available on the Developer Portal, however it's 'Invalid', fixing this now for you 🔨
