### PR TITLE
Match enterprise type mismatch

### DIFF
--- a/match/lib/match.rb
+++ b/match/lib/match.rb
@@ -29,4 +29,21 @@ module Match
   def self.enterprise?
     ENV["MATCH_FORCE_ENTERPRISE"]
   end
+
+  def self.type_is_enterprise?(type)
+    Match.enterprise? && type != "development"
+  end
+
+  def self.profile_type_sym(type)
+    return :enterprise if self.type_is_enterprise? type
+    return :adhoc if type == "adhoc"
+    return :appstore if type == "appstore"
+    return :development
+  end
+
+  def self.cert_type_sym(type)
+    return :enterprise if self.type_is_enterprise? type
+    return :development if type == "development"
+    return :distribution
+  end
 end

--- a/match/lib/match.rb
+++ b/match/lib/match.rb
@@ -26,10 +26,12 @@ module Match
     return envs
   end
 
+  # @return [Boolean] returns true if the unsupported enterprise mode should be enabled
   def self.enterprise?
     ENV["MATCH_FORCE_ENTERPRISE"]
   end
 
+  # @return [Boolean] returns true if match should interpret the given [certificate|profile] type as an enterprise one
   def self.type_is_enterprise?(type)
     Match.enterprise? && type != "development"
   end

--- a/match/lib/match/generator.rb
+++ b/match/lib/match/generator.rb
@@ -36,7 +36,7 @@ module Match
     def self.generate_provisioning_profile(params: nil, prov_type: nil, certificate_id: nil, app_identifier: nil)
       require 'sigh'
 
-      prov_type = :enterprise if Match.enterprise? && ENV["SIGH_PROFILE_ENTERPRISE"] && !params[:type] == "development"
+      prov_type = Match.profile_type_sym(params[:type])
 
       profile_name = ["match", profile_type_name(prov_type), app_identifier].join(" ")
 

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -47,7 +47,7 @@ module Match
     # Collect all the certs/profiles
     def prepare_list
       UI.message "Fetching certificates and profiles..."
-      cert_type = type.to_sym
+      cert_type = Match.cert_type_sym type
 
       prov_types = [:development]
       prov_types = [:appstore, :adhoc] if cert_type == :distribution

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -47,7 +47,7 @@ module Match
     # Collect all the certs/profiles
     def prepare_list
       UI.message "Fetching certificates and profiles..."
-      cert_type = Match.cert_type_sym type
+      cert_type = Match.cert_type_sym(type)
 
       prov_types = [:development]
       prov_types = [:appstore, :adhoc] if cert_type == :distribution

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -60,9 +60,7 @@ module Match
     end
 
     def fetch_certificate(params: nil)
-      cert_type = :distribution
-      cert_type = :development if params[:type] == "development"
-      cert_type = :enterprise if Match.enterprise? && params[:type] == "enterprise"
+      cert_type = Match.cert_type_sym params[:type]
 
       certs = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.cer")]
       keys = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.p12")]
@@ -92,7 +90,7 @@ module Match
 
     # @return [String] The UUID of the provisioning profile so we can verify it with the Apple Developer Portal
     def fetch_provisioning_profile(params: nil, certificate_id: nil, app_identifier: nil)
-      prov_type = params[:type].to_sym
+      prov_type = Match.profile_type_sym params[:type]
 
       profile_name = [Match::Generator.profile_type_name(prov_type), app_identifier].join("_").gsub("*", '\*') # this is important, as it shouldn't be a wildcard
       base_dir = File.join(params[:workspace], "profiles", prov_type.to_s)
@@ -107,7 +105,7 @@ module Match
 
       if profile.nil? or params[:force]
         if params[:readonly]
-          all_profiles = Dir.entries(base_dir).reject {|f| f.start_with? "." }
+          all_profiles = Dir.entries(base_dir).reject { |f| f.start_with? "." }
           UI.error "No matching provisioning profiles found for '#{profile_name}'"
           UI.error "A new one cannot be created because you enabled `readonly`"
           UI.error "Certificates in your repo for type `#{prov_type}`:"

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -60,7 +60,7 @@ module Match
     end
 
     def fetch_certificate(params: nil)
-      cert_type = Match.cert_type_sym params[:type]
+      cert_type = Match.cert_type_sym(params[:type])
 
       certs = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.cer")]
       keys = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.p12")]
@@ -90,7 +90,7 @@ module Match
 
     # @return [String] The UUID of the provisioning profile so we can verify it with the Apple Developer Portal
     def fetch_provisioning_profile(params: nil, certificate_id: nil, app_identifier: nil)
-      prov_type = Match.profile_type_sym params[:type]
+      prov_type = Match.profile_type_sym(params[:type])
 
       profile_name = [Match::Generator.profile_type_name(prov_type), app_identifier].join("_").gsub("*", '\*') # this is important, as it shouldn't be a wildcard
       base_dir = File.join(params[:workspace], "profiles", prov_type.to_s)
@@ -108,7 +108,7 @@ module Match
           all_profiles = Dir.entries(base_dir).reject { |f| f.start_with? "." }
           UI.error "No matching provisioning profiles found for '#{profile_name}'"
           UI.error "A new one cannot be created because you enabled `readonly`"
-          UI.error "Certificates in your repo for type `#{prov_type}`:"
+          UI.error "Provisioning profiles in your repo for type `#{prov_type}`:"
           all_profiles.each { |p| UI.error "- '#{p}'" }
           UI.error "If you are certain that a profile should exist, double-check the recent changes to your match repository"
           UI.user_error! "No matching provisioning profiles found and can not create a new one because you enabled `readonly`. Check the output above for more information."


### PR DESCRIPTION
There was a mismatch in comparing the types of provisioning profiles when `type: "appstore"` was used with the `MATCH_FORCE_ENTERPRISE`. Generating the profiles would work, but when cloning on a different machine it would try to generate a new certificate or error out in `readonly` mode. 

The error now includes more useful information on why no provisioning profile was found. Conversion of type strings to symbols is now centralized, so the above error doesn't happen anymore. 
