### PR TITLE
enhance env printing + add  `--capture_output`  option

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -6,13 +6,13 @@
 ### Issue Description
 
 ##### Complete output when running fastlane, including the stack trace and command used
+> You can use: `--capture_output` as the last commandline argument to get that collected for you
 
-```
 [INSERT OUTPUT HERE]
-```
 
 ### Environment
 
 Please run `fastlane env` and copy the output below. This will help us help you :+1:
+If you used `--capture_output` option please remove this block - as it is already included there.
 
 [INSERT OUTPUT HERE]

--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -1,5 +1,15 @@
 module Fastlane
   class EnvironmentPrinter
+    def self.output
+      env_info = get
+      puts env_info
+      if FastlaneCore::Helper.mac? && UI.interactive? && UI.confirm("🙄  Wow, that's a lot of markdown text... should fastlane put it into your clipboard, so you can easily paste it on GitHub?")
+        copy_to_clipboard(env_info)
+        UI.success("Successfully copied markdown into your clipboard 🎨")
+      end
+      UI.success("Open https://github.com/fastlane/fastlane/issues/new to submit a new issue ✅")
+    end
+
     def self.get
       UI.important("Generating fastlane environment output, this might take a few seconds...")
       require "fastlane/markdown_table_formatter"
@@ -10,13 +20,20 @@ module Fastlane
       env_output << print_loaded_plugins
       env_output << print_loaded_gems
       env_output << print_date
-      env_output << "</details>"
 
       # Adding title
       status = (env_output.include?("🚫") ? "🚫" : "✅")
       env_header = "<details><summary>#{status} fastlane environment #{status}</summary>\n\n"
+      env_tail = "</details>"
+      final_output = ""
 
-      return env_header + env_output
+      if $captured_output
+        final_output << "### Captured Output\n\n"
+        final_output << "Command Used: `#{ARGV.join(' ')}`\n"
+        final_output << "<details><summary>Output/Log</summary>\n\n```\n\n#{$captured_output}\n\n```\n\n</details>\n\n"
+      end
+
+      final_output << env_header + env_output + env_tail
     end
 
     def self.print_date

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -25,6 +25,11 @@ module FastlaneCore
       defined? SpecHelper
     end
 
+    # removes ANSI colors from string
+    def self.strip_ansi_colors(str)
+      str.gsub(/\e\[([;\d]+)?m/, '')
+    end
+
     # @return [boolean] true if executing with bundler (like 'bundle exec fastlane [action]')
     def self.bundler?
       # Bundler environment variable


### PR DESCRIPTION
this one refactors the :env  a little bit, and adds a global parameter `--trace` - to capture all fastlane output.

so if users having trouble using fastlane they just run their failing command with the `--trace` 

e.g.:

```
fastlane demo --capture_output

```

sample:
### Trace Info

Command Used: `demo`
<details><summary>

Output/Log</summary>



```

[16:56:31]: Driving the lane 'demo' 🚀
[16:56:32]: fastlane.tools finished successfully 🎉


```

</details>

<details><summary>

✅ fastlane environment ✅</summary>


### Stack

| Key | Value |
| --- | --- |
| OS | 10.12 |
| Ruby | 2.3.1 |
| Bundler? | true |
| Xcode Path | /Applications/Xcode.app/Contents/Developer/ |
| Xcode Version | 8.0 |
| Git | git version 2.8.4 (Apple Git-73) |
| Installation Source | /usr/local/lib/ruby/gems/2.3.0/bin/fastlane |
| Host | Mac OS X 10.12 (16A323) |
| Ruby Lib Dir | /usr/local/Cellar/ruby/2.3.1_2/lib |
| OpenSSL Version | OpenSSL 1.0.2j  26 Sep 2016 |
### fastlane files:

<details><summary>

`./fastlane/Fastfile`</summary>



``` ruby
lane :demo do
demo=1
end
```

</details>

**No Appfile found**
### fastlane gems

| Gem | Version | Update-Status |
| --- | --- | --- |
| credentials_manager | 0.16.2 | ✅ Up-To-Date |
| fastlane_core | 0.53.0 | ✅ Up-To-Date |
| spaceship | 0.36.1 | ✅ Up-To-Date |
| cert | 1.4.3 | ✅ Up-To-Date |
| deliver | 1.14.3 | ✅ Up-To-Date |
| frameit | 3.0.0 | ✅ Up-To-Date |
| gym | 1.11.3 | ✅ Up-To-Date |
| sigh | 1.11.2 | ✅ Up-To-Date |
| match | 0.9.0 | ✅ Up-To-Date |
| pem | 1.3.2 | ✅ Up-To-Date |
| pilot | 1.11.0 | ✅ Up-To-Date |
| produce | 1.2.1 | ✅ Up-To-Date |
| scan | 0.13.1 | ✅ Up-To-Date |
| screengrab | 0.5.5 | ✅ Up-To-Date |
| snapshot | 1.16.2 | ✅ Up-To-Date |
| supply | 0.7.1 | ✅ Up-To-Date |
| fastlane | 1.106.1 | ✅ Up-To-Date |
### Loaded fastlane plugins:

**No plugins Loaded***

<details><summary>

<b>Loaded gems</b></summary>



| Gem | Version |
| --- | --- |
| did_you_mean | 1.0.0 |
| bundler | 1.13.6 |
| io-console | 0.4.5 |
| rake | 11.3.0 |
| i18n | 0.7.0 |
| json | 1.8.3 |
| minitest | 5.9.1 |
| thread_safe | 0.3.5 |
| tzinfo | 1.2.2 |
| activesupport | 4.2.7.1 |
| addressable | 2.4.0 |
| ast | 2.3.0 |
| babosa | 1.0.2 |
| builder | 3.2.2 |
| byebug | 9.0.6 |
| colored | 1.2 |
| highline | 1.7.8 |
| commander | 4.4.0 |
| security | 0.1.3 |
| credentials_manager | 0.16.2 |
| excon | 0.54.0 |
| gh_inspector | 1.0.2 |
| multi_json | 1.12.1 |
| plist | 3.1.0 |
| rubyzip | 1.1.7 |
| terminal-table | 1.4.5 |
| fastlane_core | 0.53.0 |
| multipart-post | 2.0.0 |
| faraday | 0.9.2 |
| unf_ext | 0.0.7.2 |
| unf | 0.1.4 |
| domain_name | 0.5.20160826 |
| http-cookie | 1.0.3 |
| faraday-cookie_jar | 0.0.6 |
| faraday_middleware | 0.10.0 |
| fastimage | 1.6.8 |
| multi_xml | 0.5.5 |
| claide | 1.0.1 |
| cork | 0.2.0 |
| nap | 1.1.0 |
| open4 | 1.3.4 |
| claide-plugins | 0.9.2 |
| coderay | 1.1.1 |
| docile | 1.1.5 |
| simplecov-html | 0.10.0 |
| simplecov | 0.12.0 |
| tins | 1.12.0 |
| term-ansicolor | 1.4.0 |
| thor | 0.19.1 |
| coveralls | 0.8.15 |
| safe_yaml | 1.0.4 |
| crack | 0.4.3 |
| faraday-http-cache | 1.3.1 |
| git | 1.3.0 |
| sawyer | 0.7.0 |
| octokit | 4.4.0 |
| redcarpet | 3.3.4 |
| danger | 0.10.1 |
| diff-lcs | 1.2.5 |
| dotenv | 2.1.1 |
| fakefs | 0.8.1 |
| mini_magick | 4.5.1 |
| rouge | 1.11.1 |
| xcpretty | 0.2.4 |
| net-ssh | 3.2.0 |
| net-sftp | 2.1.2 |
| krausefx-shenzhen | 0.14.10 |
| slack-notifier | 1.5.1 |
| xcpretty-travis-formatter | 0.0.4 |
| jwt | 1.5.6 |
| little-plugger | 1.1.4 |
| logging | 2.1.0 |
| memoist | 0.15.0 |
| os | 0.9.6 |
| signet | 0.7.3 |
| googleauth | 0.5.1 |
| httpclient | 2.8.2.4 |
| hurley | 0.2 |
| mime-types | 1.25.1 |
| uber | 0.0.15 |
| representable | 2.3.0 |
| retriable | 2.1.0 |
| google-api-client | 0.9.19 |
| terminal-notifier | 1.7.1 |
| word_wrap | 1.0.0 |
| xcode-install | 2.0.7 |
| xcodeproj | 1.3.3 |
| method_source | 0.8.2 |
| parser | 2.3.1.4 |
| powerpack | 0.1.1 |
| slop | 3.6.0 |
| pry | 0.10.4 |
| pry-byebug | 3.4.0 |
| rainbow | 2.1.0 |
| rest-client | 1.6.9 |
| rspec-support | 3.1.2 |
| rspec-core | 3.1.7 |
| rspec-expectations | 3.1.2 |
| rspec-mocks | 3.1.3 |
| rspec | 3.1.0 |
| rspec_junit_formatter | 0.2.3 |
| ruby-progressbar | 1.8.1 |
| unicode-display_width | 1.1.1 |
| rubocop | 0.44.1 |
| webmock | 1.19.0 |
| yard | 0.8.7.6 |

</details>

_generated on:_ **2016-10-24**
</details>
