### PR TITLE
gym now supports a skip_export option

### DIFF
--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -127,7 +127,21 @@ module Gym
                                      env_name: "GYM_SKIP_BUILD_ARCHIVE",
                                      description: "Export ipa from previously build xarchive. Uses archive_path as source",
                                      is_string: false,
-                                     optional: true),
+                                     optional: true,
+                                     conflicting_options: [:skip_export],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("'#{value.key}' must be false to use 'skip_build_archive'")
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :skip_export,
+                                     env_name: "GYM_SKIP_EXPORT",
+                                     description: "Builds and generates an archive, but does not export",
+                                     is_string: false,
+                                     optional: true,
+                                     conflicting_options: [:skip_build_archive],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("'#{value.key}' must be false to use 'skip_export'")
+                                     end),
+
         # Very optional
         FastlaneCore::ConfigItem.new(key: :build_path,
                                      env_name: "GYM_BUILD_PATH",

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -15,21 +15,23 @@ module Gym
 
       FileUtils.mkdir_p(File.expand_path(Gym.config[:output_directory]))
 
-      if Gym.project.ios? || Gym.project.tvos?
-        fix_generic_archive # See https://github.com/fastlane/fastlane/pull/4325
-        package_app
-        fix_package
-        compress_and_move_dsym
-        path = move_ipa
-        move_manifest
-        move_app_thinning
-        move_app_thinning_size_report
-        move_apps_folder
+      unless Gym.config[:skip_export]
+        if Gym.project.ios? || Gym.project.tvos?
+          fix_generic_archive # See https://github.com/fastlane/fastlane/pull/4325
+          package_app
+          fix_package
+          compress_and_move_dsym
+          path = move_ipa
+          move_manifest
+          move_app_thinning
+          move_app_thinning_size_report
+          move_apps_folder
 
-        path
-      elsif Gym.project.mac?
-        compress_and_move_dsym
-        copy_mac_app
+          path
+        elsif Gym.project.mac?
+          compress_and_move_dsym
+          copy_mac_app
+        end
       end
     end
 

--- a/gym/spec/options_spec.rb
+++ b/gym/spec/options_spec.rb
@@ -7,6 +7,13 @@ describe Gym do
       end.to raise_error "You can only pass either a 'project' or a 'workspace', not both"
     end
 
+    it "raises an exception when skip_build_archive and skip_export are both specified" do
+      expect do
+        options = { workspace: "./examples/cocoapods/Example.xcworkspace", skip_build_archive: true, skip_export: true }
+        Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+      end.to raise_error "'skip_export' must be false to use 'skip_build_archive'"
+    end
+
     it "removes the `ipa` from the output name if given" do
       options = { output_name: "Example.ipa", project: "./examples/standard/Example.xcodeproj" }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:
- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

Relates to #5824. I ended up only adding the skip_archive option. The project dependency was just too ingrained to take out for such a small feature.
