### PR TITLE
Added exporting to PKCS12

### DIFF
--- a/cert/lib/cert/options.rb
+++ b/cert/lib/cert/options.rb
@@ -54,7 +54,14 @@ module Cert
                                      verify_block: proc do |value|
                                        value = File.expand_path(value)
                                        UI.user_error!("Keychain not found at path '#{value}'") unless File.exist?(value)
-                                     end)
+                                     end),
+
+        FastlaneCore::ConfigItem.new(key: :p12_password,
+                                     short_option: "-p",
+                                     env_name: "CERT_P12_PASSWORD",
+                                     description: "The password that will be used in PKCS #12 keypair container",
+                                     optional: true,
+                                     default_value: "")
       ]
     end
   end

--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -160,7 +160,7 @@ module Cert
 
       # Generate p12 file
       p12_key_path = File.expand_path(File.join(Cert.config[:output_path], "#{certificate.id}.p12"))
-      p12 = OpenSSL::PKCS12.create(ENV['CERT_P12_PASSWORD'], certificate.name, pkey, cert, public)
+      p12 = OpenSSL::PKCS12.create(ENV['CERT_P12_PASSWORD'], certificate.name, pkey, cert)
       File.write(p12_key_path, p12.to_der)
 
       # Environment variables for the fastlane action

--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -158,7 +158,6 @@ module Cert
       KeychainImporter.import_file(private_key_path)
       KeychainImporter.import_file(cert_path)
 
-
       # Generate p12 file
       p12_key_path = File.expand_path(File.join(Cert.config[:output_path], "#{certificate.id}.p12"))
       p12 = OpenSSL::PKCS12.create(ENV['CERT_P12_PASSWORD'], certificate.name, pkey, cert, public)


### PR DESCRIPTION
Cert stores private key with `.p12` extension. But `.p12` is not used to store raw private keys. p12 means PKCS12. It's secure archive which stores private key and cert. https://en.wikipedia.org/wiki/PKCS_12

I think that cert can make 3 files: private key and certificate for importing to key-chain, storing and pkcs12. The last one for secure sending to another mac, storing in a cloud like s3 or some public storage. PKCS12 is common standard of sending private keys and digital certificate in the web. 
