### PR TITLE
Add missing device names for iPhone7 and iPhone7Plus

### DIFF
--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -53,6 +53,8 @@ module Snapshot
       # and the iPhone 6 is inlucded in the iPhone 6 Plus
       {
         'AppleTV1080p' => 'Apple TV',
+        'iPhone7Plus' => "iPhone7Plus (5.5-Inch)",
+        'iPhone7' => "iPhone7 (4.7-Inch)",
         'iPhone6sPlus' => "iPhone6sPlus (5.5-Inch)",
         'iPhone6Plus' => "iPhone6Plus (5.5-Inch)",
         'iPhone6s' => "iPhone6s (4.7-Inch)",


### PR DESCRIPTION
Fix issue #6376 - Screenshots on iPhone 7 and iPhone 7 Plus aren't working.

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:
- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:
