### PR TITLE
[deliver] Version bump

### DIFF
--- a/deliver/lib/deliver/version.rb
+++ b/deliver/lib/deliver/version.rb
@@ -1,4 +1,4 @@
 module Deliver
-  VERSION = "1.14.4"
+  VERSION = "1.14.5"
   DESCRIPTION = 'Upload screenshots, metadata and your app to the App Store using a single command'
 end


### PR DESCRIPTION
Fix crash on `deliver init` when metadata was empty
