### PR TITLE
[spaceship] get current build_number from AppVersion 🚀🤘

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -30,6 +30,9 @@ module Spaceship
       # @return (String) App Status (e.g. 'readyForSale'). You should use `app_status` instead
       attr_accessor :raw_status
 
+      # @return (String) Build Version
+      attr_accessor :build_version
+
       # @return (Bool)
       attr_accessor :can_reject_version
 
@@ -133,6 +136,7 @@ module Spaceship
         'largeAppIcon.value.url' => :app_icon_url,
         'releaseOnApproval.value' => :release_on_approval,
         'status' => :raw_status,
+        'preReleaseBuild.buildVersion' => :build_version,
         'supportsAppleWatch' => :supports_apple_watch,
         'versionId' => :version_id,
         'version.value' => :version,
@@ -213,6 +217,16 @@ module Spaceship
           self.languages << new_language
         end
         nil
+      end
+
+      def current_build_number
+        if self.is_live?
+          build_version
+        else
+          if candidate_builds.length > 0
+            candidate_builds.first.build_version
+          end
+        end
       end
 
       # Returns an array of all builds that can be sent to review

--- a/spaceship/spec/tunes/app_version_spec.rb
+++ b/spaceship/spec/tunes/app_version_spec.rb
@@ -16,6 +16,7 @@ describe Spaceship::AppVersion, all: true do
 
       expect(version.application).to eq(app)
       expect(version.is_live?).to eq(false)
+      expect(version.current_build_number).to eq("9")
       expect(version.copyright).to eq("2015 SunApps GmbH")
       expect(version.version_id).to eq(812_106_519)
       expect(version.raw_status).to eq('readyForSale')
@@ -162,6 +163,7 @@ describe Spaceship::AppVersion, all: true do
         version = app.live_version
 
         expect(version.app_status).to eq("Ready for Sale")
+        expect(version.current_build_number).to eq("9")
         expect(version.app_status).to eq(Spaceship::Tunes::AppStatus::READY_FOR_SALE)
       end
 

--- a/spaceship/spec/tunes/fixtures/app_version.json
+++ b/spaceship/spec/tunes/fixtures/app_version.json
@@ -754,6 +754,9 @@
             "isRequired": true,
             "errorKeys": null
         },
+        "preReleaseBuild": {
+          "buildVersion": "9"
+        },
         "preReleaseBuildTrainVersionString": "0.9.13",
         "preReleaseBuildIconUrl": "https://is3-ssl.mzstatic.com/image/thumb/Newsstand3/v4/2d/eb/52/2deb529b-63ad-d456-017b-b379bac333dc/Icon-60@2x.png.png/150x150bb-80.png",
         "preReleaseBuildUploadDate": 1427833468000,


### PR DESCRIPTION
return build_number on AppVersion.

as supposed to be required here: https://github.com/fastlane/fastlane/issues/6770
if this one is merged - i ll add a custom action to retrieve the current build number.

adds method `current_build_number` to appVersion class.

e.g.:

``` ruby
app = Spaceship::Tunes::Application.find("krone.at-fivexfive")
[2] pry(main)> version = app.live_version.current_build_number
=> "7"
[3] pry(main)> version = app.edit_version.current_build_number
=> "14"

```
