### PR TITLE
[scan] Properly handle report generation failures

### DIFF
--- a/scan/lib/scan/report_collector.rb
+++ b/scan/lib/scan/report_collector.rb
@@ -16,8 +16,11 @@ module Scan
 
       commands = generate_commands(path)
       commands.each do |output_path, command|
-        system(command)
-        UI.success("Successfully generated report at '#{output_path}'")
+        if system(command)
+          UI.success("Successfully generated report at '#{output_path}'")
+        else
+          UI.user_error!("Failed to generate report at '#{output_path}'")
+        end
 
         if @open_report and output_path.end_with?(".html")
           # Open the HTML file


### PR DESCRIPTION
- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

---

A failing report generation (e.g. when given a non-writable path) was erroneously reported as successful.

Now, an error is properly reported and the scan process exits with a non 0 status code.
