### PR TITLE
Always wait for new build trains (remove feature flag to enable behavior)

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -121,7 +121,7 @@ module Pilot
         #  build trains right away, and if we don't do this check, we will
         #  get break out of this loop and then generate an error later when we
         #  have a nil build
-        if FastlaneCore::Feature.enabled?('PILOT_WAIT_FOR_NEW_BUILD_TRAINS_ON_ITUNES_CONNECT') && app.build_trains.count == 0
+        if app.build_trains.count == 0
           UI.message("New application; waiting for build train to appear on iTunes Connect")
         else
           builds = app.all_processing_builds

--- a/pilot/lib/pilot/features.rb
+++ b/pilot/lib/pilot/features.rb
@@ -1,2 +1,0 @@
-FastlaneCore::Feature.register(env_var: 'PILOT_WAIT_FOR_NEW_BUILD_TRAINS_ON_ITUNES_CONNECT',
-                           description: 'When submitting a build, wait for the build train to appear on iTunes Connect if not present yet (will be default eventually)')


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:
- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:
