### PR TITLE
[fastlane] Fix slack action error when passing a custom payload option

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -156,7 +156,7 @@ module Fastlane
 
       def self.generate_slack_attachments(options)
         color = (options[:success] ? 'good' : 'danger')
-        should_add_payload = ->(payload_name) { options[:default_payloads].nil? || options[:default_payloads].include?(payload_name) }
+        should_add_payload = ->(payload_name) { options[:default_payloads].nil? || options[:default_payloads].include?(payload_name.to_s) }
 
         slack_attachment = {
           fallback: options[:message],

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -156,7 +156,7 @@ module Fastlane
 
       def self.generate_slack_attachments(options)
         color = (options[:success] ? 'good' : 'danger')
-        should_add_payload = ->(payload_name) { options[:default_payloads].nil? || options[:default_payloads].include?(payload_name.to_s) }
+        should_add_payload = ->(payload_name) { options[:default_payloads].nil? || options[:default_payloads].join(" ").include?(payload_name.to_s) }
 
         slack_attachment = {
           fallback: options[:message],


### PR DESCRIPTION
This would be failing later on when passing a string via the CLI. Using this PR we'll support both symbols and strings
