### PR TITLE
[spaceship] Add update check to ensure people are running the latest release

### DIFF
--- a/spaceship/lib/spaceship.rb
+++ b/spaceship/lib/spaceship.rb
@@ -2,6 +2,7 @@ require 'spaceship/version'
 require 'spaceship/base'
 require 'spaceship/client'
 require 'spaceship/launcher'
+require 'spaceship/update_checker'
 
 # Dev Portal
 require 'spaceship/portal/portal'
@@ -27,4 +28,6 @@ module Spaceship
   AppVersion = Spaceship::Tunes::AppVersion
   AppSubmission = Spaceship::Tunes::AppSubmission
   Application = Spaceship::Tunes::Application
+
+  UpdateChecker.ensure_spaceship_version
 end

--- a/spaceship/lib/spaceship/update_checker.rb
+++ b/spaceship/lib/spaceship/update_checker.rb
@@ -18,7 +18,7 @@ module Spaceship
 
       show_update_message(Spaceship::VERSION, version)
     rescue => ex
-      puts "#{ex}" if $verbose
+      puts ex.to_s if $verbose
       puts "Couldn't verify that spaceship is up to date"
     end
 

--- a/spaceship/lib/spaceship/update_checker.rb
+++ b/spaceship/lib/spaceship/update_checker.rb
@@ -31,8 +31,8 @@ module Spaceship
       puts ""
       puts "or `bundle update` if you use bundler."
       puts ""
-      puts "You're on spaceship: #{local_version}".yedllow
-      puts "Latest spaceship   : #{live_version}".yellow
+      puts "You're on spaceship version: #{local_version}".yellow
+      puts "Latest spaceship version  : #{live_version}".yellow
       puts ""
     end
   end

--- a/spaceship/lib/spaceship/update_checker.rb
+++ b/spaceship/lib/spaceship/update_checker.rb
@@ -17,6 +17,9 @@ module Spaceship
       return if Gem::Version.new(version) <= Gem::Version.new(Spaceship::VERSION)
 
       show_update_message(Spaceship::VERSION, version)
+    rescue => ex
+      puts "#{ex}" if $verbose
+      puts "Couldn't verify that spaceship is up to date"
     end
 
     def self.show_update_message(local_version, live_version)

--- a/spaceship/lib/spaceship/update_checker.rb
+++ b/spaceship/lib/spaceship/update_checker.rb
@@ -1,0 +1,39 @@
+module Spaceship
+  class UpdateChecker
+    UPDATE_URL = "https://fastlane-refresher.herokuapp.com/spaceship"
+
+    def self.ensure_spaceship_version
+      return if defined?(SpecHelper) # is this running via tests
+      return if ENV["FASTLANE_SKIP_UPDATE_CHECK"]
+
+      require 'faraday'
+      require 'json'
+
+      response = Faraday.get(UPDATE_URL)
+      return if response.nil? || response.body.to_s.length == 0
+
+      version = JSON.parse(response.body)["version"]
+      puts "Comparing spaceship version (remote #{version} - local #{Spaceship::VERSION})" if $verbose
+      return if Gem::Version.new(version) <= Gem::Version.new(Spaceship::VERSION)
+
+      show_update_message(Spaceship::VERSION, version)
+    end
+
+    def self.show_update_message(local_version, live_version)
+      puts "---------------------------------------------".red
+      puts "-------------------WARNING-------------------".red
+      puts "---------------------------------------------".red
+      puts "You're using an old version of spaceship"
+      puts "To ensure spaceship and fastlane works"
+      puts "update to the latest version."
+      puts ""
+      puts "Run `[sudo] gem update spaceship`"
+      puts ""
+      puts "or `bundle update` if you use bundler."
+      puts ""
+      puts "You're on spaceship: #{local_version}".yedllow
+      puts "Latest spaceship   : #{live_version}".yellow
+      puts ""
+    end
+  end
+end


### PR DESCRIPTION
<img width="388" alt="screenshot 2016-10-30 15 31 17" src="https://cloud.githubusercontent.com/assets/869950/19841611/920dc5ca-9ecb-11e6-911e-67eae9407eb7.png">

We’ve had many issues around users not using the latest version of spaceship.
While we show update messages in the tools themselves, spaceship didn’t show a warning before. This way we also had to push new releases for all tools depending on spaceship

We don't use the update manager from _fastlane_core_ as _spaceship_ doesn't have a dependency to it. 
