### PR TITLE
Update settings bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ rspec_logs.json
 test_output/
 .DS_STORE
 .keys
+*.swp
 
 ## Specific to Android
 .gradle/

--- a/fastlane/docs/Actions.md
+++ b/fastlane/docs/Actions.md
@@ -2345,10 +2345,37 @@ Key | Description
 
 </details>
 
+### update_settings_bundle
 
+Updates a key in a plist file in the Settings.bundle to the current version
+and build number.
 
+> Run after increment_version_number and/or increment_build_number. Takes the updated version number and modifies the app's settings bundle.
 
+update_settings_bundle |
+-----|----
+Supported platforms | ios
+Author | @jdee
 
+<details>
+<summary>1 Example</summary>
+
+```ruby
+udpate_settings_bundle(
+  path: "Resources/Settings.bundle/Root.plist",
+  setting_key: "CurrentAppVersion"
+)
+```
+</details>
+
+<details>
+<summary>Parameters</summary>
+Key | Description
+----|------------
+  `path` | The path to the plist file in the Settings.bundle. Does not have to be the Root.plist.
+  `setting_key` | The identifier of the preference specifier to update
+
+</details>
 
 # Code Signing
 

--- a/fastlane/lib/fastlane/actions/update_settings_bundle.rb
+++ b/fastlane/lib/fastlane/actions/update_settings_bundle.rb
@@ -14,7 +14,7 @@ module Fastlane
           # Load Root.plist (raises)
           root_plist = Plist::parse_xml options[:path]
       
-          # Find the preference specifier for CurrentAppVersion
+          # Find the preference specifier for the setting key
           preference_specifiers = root_plist["PreferenceSpecifiers"]
 
           raise "#{update_params.settings_plist_path} is not a valid preferences plist" unless preference_specifiers.is_a? Array

--- a/fastlane/lib/fastlane/actions/update_settings_bundle.rb
+++ b/fastlane/lib/fastlane/actions/update_settings_bundle.rb
@@ -11,20 +11,22 @@ module Fastlane
         def update(options)
           require 'plist'
 
+          path = options[:path]
+          setting_key = options[:setting_key]
+
           # Load Root.plist (raises)
-          root_plist = Plist.parse_xml options[:path]
+          root_plist = Plist.parse_xml path
 
           # Find the preference specifier for the setting key
           preference_specifiers = root_plist["PreferenceSpecifiers"]
 
-          raise "#{update_params.settings_plist_path} is not a valid preferences plist" unless preference_specifiers.kind_of? Array
+          raise "#{path} is not a valid preferences plist" unless preference_specifiers.kind_of? Array
 
-          setting_key = options[:setting_key]
           current_app_version_specifier = preference_specifiers.find do |specifier|
             specifier["Key"] == setting_key
           end
 
-          raise "#{update_params.version_key} not found in #{update_params.settings_plist_path}" if current_app_version_specifier.nil?
+          raise "#{setting_key} not found in #{update_params.settings_plist_path}" if current_app_version_specifier.nil?
 
           # Formatted app version for settings bundle:
           # version (build)
@@ -34,7 +36,7 @@ module Fastlane
           current_app_version_specifier["DefaultValue"] = formatted_version
 
           # Save (raises)
-          Plist::Emit.save_plist root_plist, update_params.settings_plist_path
+          Plist::Emit.save_plist root_plist, path
         end
       end
     end

--- a/fastlane/lib/fastlane/actions/update_settings_bundle.rb
+++ b/fastlane/lib/fastlane/actions/update_settings_bundle.rb
@@ -1,13 +1,13 @@
 module Fastlane
   module Actions
     module SharedValues
+      SETTINGS_PLIST_PATH = :SETTINGS_PLIST_PATH
     end
 
+    # SettingsBundle utility module
     module SettingsBundle
       class UpdateParameters
-        attr_accessor :root_plist_path
-        attr_accessor :version_number
-        attr_accessor :build_number
+        attr_accessor :settings_plist_path
         attr_accessor :version_key
 
         # options is a Hash with keys corresponding to the
@@ -15,26 +15,20 @@ module Fastlane
         def initialize(options)
           symbolized_options = options.symbolize_keys
 
-          self.root_plist_path = symbolized_options[:root_plist_path]
-          self.version_number = symbolized_options[:version_number]
-          self.build_number = symbolized_options[:build_number]
+          self.settings_plist_path = symbolized_options[:settings_plist_path]
           self.version_key = symbolized_options[:version_key]
 
           raise "invalid options: #{error_message}" unless valid?
         end
 
         def valid?
-          not (root_plist_path.nil? or
-            version_number.nil? or
-            build_number.nil? or
+          not (settings_plist_path.nil? or
             version_key.nil?)
         end
 
         def error_message
           message = ""
-          message << "no root_plist_path. " if root_plist_path.nil?
-          message << "no version_number. " if version_number.nil?
-          message << "no build_number. " if build_number.nil?
+          message << "no settings_plist_path. " if settings_plist_path.nil?
           message << "no version_key. " if version_key.nil?
           message
         end
@@ -46,54 +40,81 @@ module Fastlane
           update_params = UpdateParameters.new options
 
           require 'plist'
-
-          # Formatted app version for settings bundle
-          current_app_version = "#{update_params.version_number} (#{update_params.build_number})"
       
           # Load Root.plist (raises)
-          root_plist = Plist::parse_xml update_params.root_plist_path
+          root_plist = Plist::parse_xml update_params.settings_plist_path
       
           # Find the preference specifier for CurrentAppVersion
           preference_specifiers = root_plist["PreferenceSpecifiers"]
 
-          raise "#{update_params.root_plist_path} is not a valid preferences plist" unless preference_specifiers.is_a? Array
+          raise "#{update_params.settings_plist_path} is not a valid preferences plist" unless preference_specifiers.is_a? Array
 
           current_app_version_specifier = preference_specifiers.find do |specifier|
             specifier["Key"] == update_params.version_key
           end
 
-          raise "#{update_params.version_key} not found in #{update_params.root_plist_path}" if current_app_version_specifier.nil?
+          raise "#{update_params.version_key} not found in #{update_params.settings_plist_path}" if current_app_version_specifier.nil?
+
+          Actions.lane_context[SharedValues::SETTINGS_PLIST_PATH] = settings_plist_path
+
+          # Formatted app version for settings bundle:
+          # version (build)
+          formatted_version = "#{Actions.lane_context[SharedValues::VERSION_NUMBER]} (#{Actions.lane_context[SharedValues::BUILD_NUMBER]})"
       
           # Update to the new value
-          current_app_version_specifier["DefaultValue"] = current_app_version
+          current_app_version_specifier["DefaultValue"] = formatted_version
       
           # Save (raises)
-          Plist::Emit.save_plist root_plist, update_params.root_plist_path
+          Plist::Emit.save_plist root_plist, update_params.settings_plist_path
         end
       end
     end
 
-=begin
-    version_key option is required, e.g.:
-    update_settings_bundle version_key: "CurrentAppVersion"
-    This key must already exist in the Root.plist
-=end
-    def update_settings_bundle(options)
-      version_key = options.symbolize_keys[:version_key]
-      raise "version_key option is required" if version_key.nil?
+    # UpdateSettingsBundle action
+    class UpdateSettingsBundle < Action
+      class << self
+        def description
+          <<-EOF
+          Update the current version and build number in the settings bundle.
+          EOF
+        end
 
-      # Get the Root.plist path from the project file or allow override.
-      root_plist_path = ""
+        def details
+          <<-EOF
+          After updating the marketing version and/or build number,
+          update a key in the settings bundle to reflect this information.
+          EOF
+        end
 
-      # Get the current version and build number from the project file,
-      # Info.plist, agvtool or elsewhere.
-      current_version = "1.0"
-      current_build = "1"
+        def available_options
+          # TODO
+          [
+          ]
+        end
 
-      SettingsBundle.update root_plist_path: root_plist_path,
-        version_number: current_version,
-        build_number: current_build,
-        version_key: version_key
+        def author
+          <<-EOF
+            Jimmy Dee (https://github.com/jdee)
+          EOF
+        end
+
+        def is_supported?(platform)
+          # TODO: Review Mac
+          platform == :ios
+        end
+
+        def output
+          [
+            [
+              'SETTINGS_PLIST_PATH',
+              'The plist path specified or taken from the project file'
+            ]
+          ]
+        end
+
+        def run(params)
+        end
+      end
     end
   end
 end

--- a/fastlane/lib/fastlane/actions/update_settings_bundle.rb
+++ b/fastlane/lib/fastlane/actions/update_settings_bundle.rb
@@ -1,5 +1,8 @@
 module Fastlane
   module Actions
+    module SharedValues
+    end
+
     module SettingsBundle
       class UpdateParameters
         attr_accessor :root_plist_path

--- a/fastlane/lib/fastlane/actions/update_settings_bundle.rb
+++ b/fastlane/lib/fastlane/actions/update_settings_bundle.rb
@@ -72,7 +72,7 @@ module Fastlane
             current_app_version_specifier["DefaultValue"] = formatted_version
 
             # Save (raises)
-            Plist::Emit.save_plist root_plist, update_params.settings_plist_path
+            Plist::Emit.save_plist root_plist, params[:path]
           end
         end
       end

--- a/fastlane/lib/fastlane/actions/update_settings_bundle.rb
+++ b/fastlane/lib/fastlane/actions/update_settings_bundle.rb
@@ -1,5 +1,9 @@
 module Fastlane
   module Actions
+    module SharedValues
+      SETTINGS_PLIST_PATH = :SETTINGS_PLIST_PATH
+    end
+
     # SettingsBundle utility module
     module SettingsBundle
       class << self
@@ -21,8 +25,6 @@ module Fastlane
           end
 
           raise "#{update_params.version_key} not found in #{update_params.settings_plist_path}" if current_app_version_specifier.nil?
-
-          Actions.lane_context[SharedValues::SETTINGS_PLIST_PATH] = settings_plist_path
 
           # Formatted app version for settings bundle:
           # version (build)
@@ -83,12 +85,17 @@ module Fastlane
 
         def output
           [
+            [
+              'SETTINGS_PLIST_PATH',
+              'The path to the updated plist file'
+            ]
           ]
         end
 
         def run(params)
           # raises if can't parse the file
           SettingsBundle.update params
+          Actions.lane_context[SharedValues::SETTINGS_PLIST_PATH] = params[:path]
         end
       end
     end

--- a/fastlane/lib/fastlane/actions/update_settings_bundle.rb
+++ b/fastlane/lib/fastlane/actions/update_settings_bundle.rb
@@ -72,7 +72,7 @@ module Fastlane
             current_app_version_specifier["DefaultValue"] = formatted_version
 
             # Save (raises)
-            Plist::Emit.save_plist root_plist, params[:path]
+            Plist::Emit.save_plist root_plist, options[:path]
           end
         end
       end
@@ -98,7 +98,7 @@ module Fastlane
                                          description: "(required) you must specify the path to the plist file in the settings bundle, e.g. Resources/Settings.Bundle/Root.plist",
                                          optional: false,
                                          verify_block: proc do |value|
-                                           UI.user_error!("The supplied path is not to a plist file") if value.end_with? ".plist"
+                                           UI.user_error!("The supplied path is not to a plist file") unless value.end_with? ".plist"
                                            UI.user_error!("Could not find plist file") if !File.exist?(value) and !Helper.is_test?
                                          end),
             # Not sure if there's any limitation on the setting key to validate

--- a/fastlane/lib/fastlane/actions/update_settings_bundle.rb
+++ b/fastlane/lib/fastlane/actions/update_settings_bundle.rb
@@ -1,0 +1,96 @@
+module Fastlane
+  module Actions
+    module SettingsBundle
+      class UpdateParameters
+        attr_accessor :root_plist_path
+        attr_accessor :version_number
+        attr_accessor :build_number
+        attr_accessor :version_key
+
+        # options is a Hash with keys corresponding to the
+        # attrs of this class
+        def initialize(options)
+          symbolized_options = options.symbolize_keys
+
+          self.root_plist_path = symbolized_options[:root_plist_path]
+          self.version_number = symbolized_options[:version_number]
+          self.build_number = symbolized_options[:build_number]
+          self.version_key = symbolized_options[:version_key]
+
+          raise "invalid options: #{error_message}" unless valid?
+        end
+
+        def valid?
+          not (root_plist_path.nil? or
+            version_number.nil? or
+            build_number.nil? or
+            version_key.nil?)
+        end
+
+        def error_message
+          message = ""
+          message << "no root_plist_path. " if root_plist_path.nil?
+          message << "no version_number. " if version_number.nil?
+          message << "no build_number. " if build_number.nil?
+          message << "no version_key. " if version_key.nil?
+          message
+        end
+      end
+
+      class << self
+        # options is a Hash
+        def update(options)
+          update_params = UpdateParameters.new options
+
+          require 'plist'
+
+          # Formatted app version for settings bundle
+          current_app_version = "#{update_params.version_number} (#{update_params.build_number})"
+      
+          # Load Root.plist (raises)
+          root_plist = Plist::parse_xml update_params.root_plist_path
+      
+          # Find the preference specifier for CurrentAppVersion
+          preference_specifiers = root_plist["PreferenceSpecifiers"]
+
+          raise "#{update_params.root_plist_path} is not a valid preferences plist" unless preference_specifiers.is_a? Array
+
+          current_app_version_specifier = preference_specifiers.find do |specifier|
+            specifier["Key"] == update_params.version_key
+          end
+
+          raise "#{update_params.version_key} not found in #{update_params.root_plist_path}" if current_app_version_specifier.nil?
+      
+          # Update to the new value
+          current_app_version_specifier["DefaultValue"] = current_app_version
+      
+          # Save (raises)
+          Plist::Emit.save_plist root_plist, update_params.root_plist_path
+        end
+      end
+    end
+
+=begin
+    version_key option is required, e.g.:
+    update_settings_bundle version_key: "CurrentAppVersion"
+    This key must already exist in the Root.plist
+=end
+    def update_settings_bundle(options)
+      version_key = options.symbolize_keys[:version_key]
+      raise "version_key option is required" if version_key.nil?
+
+      # Get the Root.plist path from the project file or allow override.
+      root_plist_path = ""
+
+      # Get the current version and build number from the project file,
+      # Info.plist, agvtool or elsewhere.
+      current_version = "1.0"
+      current_build = "1"
+
+      SettingsBundle.update root_plist_path: root_plist_path,
+        version_number: current_version,
+        build_number: current_build,
+        version_key: version_key
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/update_settings_bundle.rb
+++ b/fastlane/lib/fastlane/actions/update_settings_bundle.rb
@@ -80,7 +80,7 @@ module Fastlane
         end
 
         def is_supported?(platform)
-          [:ios, :mac].include? platform
+          platform == :ios
         end
 
         def output

--- a/fastlane/lib/fastlane/actions/update_settings_bundle.rb
+++ b/fastlane/lib/fastlane/actions/update_settings_bundle.rb
@@ -10,14 +10,14 @@ module Fastlane
         # options is a Hash
         def update(options)
           require 'plist'
-      
+
           # Load Root.plist (raises)
-          root_plist = Plist::parse_xml options[:path]
-      
+          root_plist = Plist.parse_xml options[:path]
+
           # Find the preference specifier for the setting key
           preference_specifiers = root_plist["PreferenceSpecifiers"]
 
-          raise "#{update_params.settings_plist_path} is not a valid preferences plist" unless preference_specifiers.is_a? Array
+          raise "#{update_params.settings_plist_path} is not a valid preferences plist" unless preference_specifiers.kind_of? Array
 
           setting_key = options[:setting_key]
           current_app_version_specifier = preference_specifiers.find do |specifier|
@@ -29,10 +29,10 @@ module Fastlane
           # Formatted app version for settings bundle:
           # version (build)
           formatted_version = "#{Actions.lane_context[SharedValues::VERSION_NUMBER]} (#{Actions.lane_context[SharedValues::BUILD_NUMBER]})"
-      
+
           # Update to the new value
           current_app_version_specifier["DefaultValue"] = formatted_version
-      
+
           # Save (raises)
           Plist::Emit.save_plist root_plist, update_params.settings_plist_path
         end
@@ -41,7 +41,6 @@ module Fastlane
 
     # UpdateSettingsBundle action
     class UpdateSettingsBundleAction < Action
-
       # SettingsBundle utility module
       module SettingsBundle
         class << self
@@ -50,12 +49,12 @@ module Fastlane
             require 'plist'
 
             # Load Root.plist (raises)
-            root_plist = Plist::parse_xml options[:path]
+            root_plist = Plist.parse_xml options[:path]
 
             # Find the preference specifier for the setting key
             preference_specifiers = root_plist["PreferenceSpecifiers"]
 
-            raise "#{update_params.settings_plist_path} is not a valid preferences plist" unless preference_specifiers.is_a? Array
+            raise "#{update_params.settings_plist_path} is not a valid preferences plist" unless preference_specifiers.kind_of? Array
 
             setting_key = options[:setting_key]
             current_app_version_specifier = preference_specifiers.find do |specifier|

--- a/fastlane/lib/fastlane/actions/update_settings_bundle.rb
+++ b/fastlane/lib/fastlane/actions/update_settings_bundle.rb
@@ -41,41 +41,6 @@ module Fastlane
 
     # UpdateSettingsBundle action
     class UpdateSettingsBundleAction < Action
-      # SettingsBundle utility module
-      module SettingsBundle
-        class << self
-          # options is a Hash
-          def update(options)
-            require 'plist'
-
-            # Load Root.plist (raises)
-            root_plist = Plist.parse_xml options[:path]
-
-            # Find the preference specifier for the setting key
-            preference_specifiers = root_plist["PreferenceSpecifiers"]
-
-            raise "#{update_params.settings_plist_path} is not a valid preferences plist" unless preference_specifiers.kind_of? Array
-
-            setting_key = options[:setting_key]
-            current_app_version_specifier = preference_specifiers.find do |specifier|
-              specifier["Key"] == setting_key
-            end
-
-            raise "#{update_params.version_key} not found in #{update_params.settings_plist_path}" if current_app_version_specifier.nil?
-
-            # Formatted app version for settings bundle:
-            # version (build)
-            formatted_version = "#{Actions.lane_context[SharedValues::VERSION_NUMBER]} (#{Actions.lane_context[SharedValues::BUILD_NUMBER]})"
-
-            # Update to the new value
-            current_app_version_specifier["DefaultValue"] = formatted_version
-
-            # Save (raises)
-            Plist::Emit.save_plist root_plist, options[:path]
-          end
-        end
-      end
-
       class << self
         def description
           <<-EOF

--- a/fastlane/spec/actions_specs/update_settings_bundle_action_spec.rb
+++ b/fastlane/spec/actions_specs/update_settings_bundle_action_spec.rb
@@ -1,10 +1,22 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Update Settings Bundle Integration" do
-      require 'shellwords'
 
       it "updates the current app version in the settings bundle" do
+        pending "Not finished yet"
+
         require 'plist'
+
+        plist = {
+          "PreferenceSpecifiers" => [
+            {
+              "Key" => "CurrentAppVersion"
+            }
+          ]
+        }
+
+        allow(Plist).to receive(:parse_xml).and_return plist
+        allow(Plist::Emit).to receive(:save_plist)
 
         lane = <<-EOF
           lane :test do

--- a/fastlane/spec/actions_specs/update_settings_bundle_action_spec.rb
+++ b/fastlane/spec/actions_specs/update_settings_bundle_action_spec.rb
@@ -5,10 +5,13 @@ describe Fastlane do
       it "updates the current app version in the settings bundle" do
         require 'plist'
 
+        path = "Resources/Settings.bundle/Root.plist"
+        setting_key = "CurrentAppVersion"
+
         plist = {
           "PreferenceSpecifiers" => [
             {
-              "Key" => "CurrentAppVersion"
+              "Key" => setting_key
             }
           ]
         }
@@ -16,13 +19,11 @@ describe Fastlane do
         expected = {
           "PreferenceSpecifiers" => [
             {
-              "Key" => "CurrentAppVersion",
+              "Key" => setting_key,
               "DefaultValue" => "1.0.0 (1)"
             }
           ]
         }
-
-        path = "Resources/Settings.bundle/Root.plist"
 
         allow(Plist).to receive(:parse_xml).and_return plist
         allow(Plist::Emit).to receive(:save_plist).with(expected, path)
@@ -32,7 +33,7 @@ describe Fastlane do
             Actions.lane_context[:VERSION_NUMBER] = "1.0.0"
             Actions.lane_context[:BUILD_NUMBER] = "1"
             update_settings_bundle path: "#{path}",
-              setting_key: "CurrentAppVersion"
+              setting_key: "#{setting_key}"
           end
         EOF
 

--- a/fastlane/spec/actions_specs/update_settings_bundle_action_spec.rb
+++ b/fastlane/spec/actions_specs/update_settings_bundle_action_spec.rb
@@ -1,0 +1,21 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Update Settings Bundle Integration" do
+      require 'shellwords'
+
+      it "updates the current app version in the settings bundle" do
+        require 'plist'
+
+        lane = <<-EOF
+          lane :test do
+            update_settings_bundle path: "Resources/Settings.bundle/Root.plist",
+              setting_key: "CurrentAppVersion"
+          end
+        EOF
+
+        Fastlane::FastFile.new.parse(lane).runner.execute(:test)
+
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/update_settings_bundle_action_spec.rb
+++ b/fastlane/spec/actions_specs/update_settings_bundle_action_spec.rb
@@ -3,8 +3,6 @@ describe Fastlane do
     describe "Update Settings Bundle Integration" do
 
       it "updates the current app version in the settings bundle" do
-        pending "Not finished yet"
-
         require 'plist'
 
         plist = {
@@ -15,12 +13,25 @@ describe Fastlane do
           ]
         }
 
+        expected = {
+          "PreferenceSpecifiers" => [
+            {
+              "Key" => "CurrentAppVersion",
+              "DefaultValue" => "1.0.0 (1)"
+            }
+          ]
+        }
+
+        path = "Resources/Settings.bundle/Root.plist"
+
         allow(Plist).to receive(:parse_xml).and_return plist
-        allow(Plist::Emit).to receive(:save_plist)
+        allow(Plist::Emit).to receive(:save_plist).with(expected, path)
 
         lane = <<-EOF
           lane :test do
-            update_settings_bundle path: "Resources/Settings.bundle/Root.plist",
+            Actions.lane_context[:VERSION_NUMBER] = "1.0.0"
+            Actions.lane_context[:BUILD_NUMBER] = "1"
+            update_settings_bundle path: "#{path}",
               setting_key: "CurrentAppVersion"
           end
         EOF

--- a/fastlane/spec/actions_specs/update_settings_bundle_action_spec.rb
+++ b/fastlane/spec/actions_specs/update_settings_bundle_action_spec.rb
@@ -1,7 +1,6 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Update Settings Bundle Integration" do
-
       it "updates the current app version in the settings bundle" do
         require 'plist'
 
@@ -38,7 +37,6 @@ describe Fastlane do
         EOF
 
         Fastlane::FastFile.new.parse(lane).runner.execute(:test)
-
       end
     end
   end


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [ x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [ x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x ] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x ] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

Please see https://github.com/fastlane/fastlane/issues/5758

This seems like a candidate for core Fastlane functionality, closely related to increment_version_number, increment_build_number and commit_version_bump. It basically just extends agvtool. It writes a new parameter to the lane context for the benefit of commit_version_bump. I had the impression from the discussion in the issue that this should be a new action for Fastlane, or possibly even an option to increment_version_number and/or increment_build_number. So while I understand you're not accepting new actions, I'm opening this PR anyway. Please close it if this is not the right thing to do, and I'll set it up as a plugin.

This just supports some basic functionality:

```ruby
update_settings_bundle path: "Resources/Settings.bundle/Root.plist, setting_key: "CurrentAppVersion"
```

See the spec example.

It takes the current version and build numbers from the lane context and formats them as "#{version} (#{build})", updating the key in the specified plist file. It also records the supplied path in the SharedValues::SETTINGS_PLIST_PATH variable in the lane context.

Still to do:

[ ] Modify the commit_version_bump action to read the SETTINGS_PLIST_PATH from the lane context and include it in expected changes.
[ ] Finish off unit tests.

Some possible improvements:

- Use the xcodeproj gem to get the Settings.bundle location from the project file.
- Support other formats or possibly just allow overriding the values from the lane context, like:

```ruby
version = Actions.lane_context[Actions::SharedValues::VERSION_NUMBER]
build = Actions.lane_context[Actions::SharedValues::BUILD_NUMBER]
setting_value = "#{version}-#{build}"
update_settings_bundle path: ".../Root.plist", key: "CurrentAppVersion", value: setting_value
```