### PR TITLE
[produce] Allow `produce` to enable/disable additional services (apple-pay, gam…

### DIFF
--- a/produce/README.md
+++ b/produce/README.md
@@ -128,15 +128,19 @@ Get a list of all available options using
 
 ```
     --app-group          Enable App Groups
+    --apple-pay          Enable Apple Pay
     --associated-domains Enable Associated Domains
     --data-protection STRING Enable Data Protection, suitable values are "complete", "unlessopen" and "untilfirstauth"
+    --game-center        Enable Game Center
     --healthkit          Enable HealthKit
     --homekit            Enable HomeKit
     --wireless-conf      Enable Wireless Accessory Configuration
     --icloud STRING      Enable iCloud, suitable values are "legacy" and "cloudkit"
+    --in-app-purchase    Enable In-App Purchase
     --inter-app-audio    Enable Inter-App-Audio
     --passbook           Enable Passbook
     --push-notification  Enable Push notification (only enables the service, does not configure certificates)
+    --sirikit            Enable SiriKit
     --vpn-conf           Enable VPN Configuration
 ```
 
@@ -144,15 +148,19 @@ Get a list of all available options using
 
 ```
     --app-group          Disable App Groups
+    --apple-pay          Disable Apple Pay
     --associated-domains Disable Associated Domains
     --data-protection    Disable Data Protection
+    --game-center        Disable Game Center
     --healthkit          Disable HealthKit
     --homekit            Disable HomeKit
     --wireless-conf      Disable Wireless Accessory Configuration
     --icloud             Disable iCloud
+    --in-app-purchase    Disable In-App Purchase
     --inter-app-audio    Disable Inter-App-Audio
     --passbook           Disable Passbook
     --push-notification  Disable Push notifications
+    --sirikit            Disable SiriKit
     --vpn-conf           Disable VPN Configuration
 ```
 

--- a/produce/lib/produce/commands_generator.rb
+++ b/produce/lib/produce/commands_generator.rb
@@ -42,15 +42,19 @@ module Produce
         c.example 'Enable HealthKit, HomeKit and Passbook', 'produce enable_services -a com.example.app --healthkit --homekit --passbook'
 
         c.option '--app-group', 'Enable App Groups'
+        c.option '--apple-pay', 'Enable Apple Pay'
         c.option '--associated-domains', 'Enable Associated Domains'
         c.option '--data-protection STRING', String, 'Enable Data Protection, suitable values are "complete", "unlessopen" and "untilfirstauth"'
+        c.option '--game-center', 'Enable Game Center'
         c.option '--healthkit', 'Enable HealthKit'
         c.option '--homekit', 'Enable HomeKit'
         c.option '--wireless-conf', 'Enable Wireless Accessory Configuration'
         c.option '--icloud STRING', String, 'Enable iCloud, suitable values are "legacy" and "cloudkit"'
+        c.option '--in-app-purchase', 'Enable In-App Purchase'
         c.option '--inter-app-audio', 'Enable Inter-App-Audio'
         c.option '--passbook', 'Enable Passbook'
         c.option '--push-notification', 'Enable Push notification (only enables the service, does not configure certificates)'
+        c.option '--sirikit', 'Enable SiriKit'
         c.option '--vpn-conf', 'Enable VPN Configuration'
 
         c.action do |args, options|
@@ -69,15 +73,19 @@ module Produce
         c.example 'Disable HealthKit', 'produce disable_services -a com.example.app --healthkit'
 
         c.option '--app-group', 'Disable App Groups'
+        c.option '--apple-pay', 'Disable Apple Pay'
         c.option '--associated-domains', 'Disable Associated Domains'
         c.option '--data-protection', 'Disable Data Protection'
+        c.option '--game-center', 'Disable Game Center'
         c.option '--healthkit', 'Disable HealthKit'
         c.option '--homekit', 'Disable HomeKit'
         c.option '--wireless-conf', 'Disable Wireless Accessory Configuration'
         c.option '--icloud', 'Disable iCloud'
+        c.option '--in-app-purchase', 'Disable In-App Purchase'
         c.option '--inter-app-audio', 'Disable Inter-App-Audio'
         c.option '--passbook', 'Disable Passbook'
         c.option '--push-notification', 'Disable Push notifications'
+        c.option '--sirikit', 'Disable SiriKit'
         c.option '--vpn-conf', 'Disable VPN Configuration'
 
         c.action do |args, options|

--- a/produce/lib/produce/service.rb
+++ b/produce/lib/produce/service.rb
@@ -33,8 +33,8 @@ module Produce
     end
 
     def valid_services_for(options)
-      allowed_keys = [:app_group, :associated_domains, :data_protection, :healthkit, :homekit,
-                      :wireless_conf, :icloud, :inter_app_audio, :passbook, :push_notification, :vpn_conf]
+      allowed_keys = [:app_group, :apple_pay, :associated_domains, :data_protection, :game_center, :healthkit, :homekit,
+                      :wireless_conf, :icloud, :in_app_purchase, :inter_app_audio, :passbook, :push_notification, :sirikit, :vpn_conf]
       options.__hash__.select { |key, value| allowed_keys.include? key }
     end
 
@@ -49,6 +49,16 @@ module Produce
           app.update_service(Spaceship.app_service.app_group.on)
         else
           app.update_service(Spaceship.app_service.app_group.off)
+        end
+      end
+
+      if options.apple_pay
+        UI.message("\tApple Pay")
+
+        if on
+          app.update_service(Spaceship.app_service.apple_pay.on)
+        else
+          app.update_service(Spaceship.app_service.apple_pay.off)
         end
       end
 
@@ -78,6 +88,16 @@ module Produce
           end
         else
           app.update_service(Spaceship.app_service.data_protection.off)
+        end
+      end
+
+      if options.game_center
+        UI.message("\tGame Center")
+
+        if on
+          app.update_service(Spaceship.app_service.game_center.on)
+        else
+          app.update_service(Spaceship.app_service.game_center.off)
         end
       end
 
@@ -130,6 +150,16 @@ module Produce
         end
       end
 
+      if options.in_app_purchase
+        UI.message("\tIn-App Purchase")
+
+        if on
+          app.update_service(Spaceship.app_service.in_app_purchase.on)
+        else
+          app.update_service(Spaceship.app_service.in_app_purchase.off)
+        end
+      end
+
       if options.inter_app_audio
         UI.message("\tInter-App Audio")
 
@@ -157,6 +187,16 @@ module Produce
           app.update_service(Spaceship.app_service.push_notification.on)
         else
           app.update_service(Spaceship.app_service.push_notification.off)
+        end
+      end
+
+      if options.sirikit
+        UI.message("\tSiriKit")
+
+        if on
+          app.update_service(Spaceship.app_service.siri_kit.on)
+        else
+          app.update_service(Spaceship.app_service.siri_kit.off)
         end
       end
 

--- a/spaceship/docs/DeveloperPortal.md
+++ b/spaceship/docs/DeveloperPortal.md
@@ -41,16 +41,20 @@ Currently available services include (all require the `Spaceship.app_service.` p
 
 ```
 app_group.(on|off)
+apple_pay.(on|off)
 associated_domains.(on|off)
 data_protection.(complete|unless_open|until_first_auth|off)
+game_center.(on|off)
 health_kit.(on|off)
 home_kit.(on|off)
 wireless_accessory.(on|off)
 icloud.(on|off)
 cloud_kit.(xcode5_compatible|cloud_kit)
+in_app_purchase.(on|off)
 inter_app_audio.(on|off)
 passbook.(on|off)
 push_notification.(on|off)
+siri_kit.(on|off)
 vpn_configuration.(on|off)
 ```
 

--- a/spaceship/lib/spaceship/portal/app_service.rb
+++ b/spaceship/lib/spaceship/portal/app_service.rb
@@ -35,12 +35,20 @@ module Spaceship
           self::AppGroup
         end
 
+        def apple_pay
+          self::ApplePay
+        end
+
         def associated_domains
           self::AssociatedDomains
         end
 
         def data_protection
           self::DataProtection
+        end
+
+        def game_center
+          self::GameCenter
         end
 
         def health_kit
@@ -63,6 +71,10 @@ module Spaceship
           self::CloudKit
         end
 
+        def in_app_purchase
+          self::InAppPurchase
+        end
+
         def inter_app_audio
           self::InterAppAudio
         end
@@ -73,6 +85,10 @@ module Spaceship
 
         def push_notification
           self::PushNotification
+        end
+
+        def siri_kit
+          self::SiriKit
         end
 
         def vpn_configuration
@@ -97,6 +113,16 @@ module Spaceship
 
         def self.on
           AppService.new("APG3427HIY", true)
+        end
+      end
+
+      module ApplePay
+        def self.off
+          AppService.new("OM633U5T5G", false)
+        end
+
+        def self.on
+          AppService.new("OM633U5T5G", true)
         end
       end
 
@@ -125,6 +151,16 @@ module Spaceship
 
         def self.until_first_auth
           AppService.new("dataProtection", "untilfirstauth")
+        end
+      end
+
+      module GameCenter
+        def self.off
+          AppService.new("gameCenter", false)
+        end
+
+        def self.on
+          AppService.new("gameCenter", true)
         end
       end
 
@@ -178,6 +214,16 @@ module Spaceship
         end
       end
 
+      module InAppPurchase
+        def self.off
+          AppService.new("inAppPurchase", false)
+        end
+
+        def self.on
+          AppService.new("inAppPurchase", true)
+        end
+      end
+
       module InterAppAudio
         def self.off
           AppService.new("IAD53UNK2F", false)
@@ -205,6 +251,16 @@ module Spaceship
 
         def self.on
           AppService.new("push", true)
+        end
+      end
+
+      module SiriKit
+        def self.off
+          AppService.new("SI015DKUHP", false)
+        end
+
+        def self.on
+          AppService.new("SI015DKUHP", true)
         end
       end
 


### PR DESCRIPTION
Allow `produce` to enable/disable additional services (apple-pay, game-center, in-app-purchase, sirikit)

- Added services to spaceship.portal.app_service

- Added the following options to `produce enable_services`

```
    --apple-pay          Enable Apple Pay
    --game-center        Enable Game Center
    --in-app-purchase    Enable In-App Purchase
    --sirikit            Enable SiriKit

```

- Added the following options to `produce disable_services`

```
    --apple-pay          Disable Apple Pay
    --game-center        Disable Game Center
    --in-app-purchase    Disable In-App Purchase
    --sirikit            Disable SiriKit

```

Related to #5100

-----
Notes:

I've investigated into the requests for enabling/disabling services in the Dev Portal (via `/account/ios/identifiers/updateService.action` and found the following services maps to the `featureType` value

Service Name | `featureType` | Available in produce v1.2.1
--------------|---------------|-------------------
App Groups | `APG3427HIY` | :white_check_mark:
Apple Pay | `OM633U5T5G` | :no_entry_sign:
Associated Domains | `SKC3T5S89Y` | :white_check_mark:
Data Protection | `dataProtection`  | :white_check_mark:
Game Center | `gameCenter` | :no_entry_sign:
HealthKit | `HK421J6T7P` | :white_check_mark:
HomeKit | `homeKit` | :white_check_mark:
iCloud | `iCloud` | :white_check_mark:
In-App Purchase |` inAppPurchase` | :no_entry_sign:
Inter-App Audio | `IAD53UNK2F` | :white_check_mark:
Personal VPN | `V66P55NK2I` | :white_check_mark:
Push Notifications | `push` | :white_check_mark:
SiriKit | `SI015DKUHP` | :no_entry_sign:
Wallet / Passbook | `pass` | :white_check_mark:
Wireless Accessory Configuration | `WC421J6T7P` | :white_check_mark:
