### PR TITLE
[spaceship] Support iMessage Screenshots

### DIFF
--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -86,7 +86,7 @@ module Spaceship
         iphone4:      "MZPFT.SortedN41ScreenShot",
         iphone35:     "MZPFT.SortedScreenShot",
         appleTV:      "MZPFT.SortedATVScreenShot",
-        desktop:      "MZPFT.SortedDesktopScreenShot",
+        desktop:      "MZPFT.SortedDesktopScreenShot"
       }
     end
 

--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -78,15 +78,20 @@ module Spaceship
     def picture_type_map
       # rubocop:enable Style/ExtraSpacing
       {
-        watch:        "MZPFT.SortedN27ScreenShot",
-        ipad:         "MZPFT.SortedTabletScreenShot",
-        ipadPro:      "MZPFT.SortedJ99ScreenShot",
-        iphone6:      "MZPFT.SortedN61ScreenShot",
-        iphone6Plus:  "MZPFT.SortedN56ScreenShot",
-        iphone4:      "MZPFT.SortedN41ScreenShot",
-        iphone35:     "MZPFT.SortedScreenShot",
-        appleTV:      "MZPFT.SortedATVScreenShot",
-        desktop:      "MZPFT.SortedDesktopScreenShot"
+        watch:               "MZPFT.SortedN27ScreenShot",
+        ipad:                "MZPFT.SortedTabletScreenShot",
+        ipadPro:             "MZPFT.SortedJ99ScreenShot",
+        iphone6:             "MZPFT.SortedN61ScreenShot",
+        iphone6Plus:         "MZPFT.SortedN56ScreenShot",
+        iphone4:             "MZPFT.SortedN41ScreenShot",
+        iphone35:            "MZPFT.SortedScreenShot",
+        appleTV:             "MZPFT.SortedATVScreenShot",
+        desktop:             "MZPFT.SortedDesktopScreenShot",
+        ipadMessages:        "MZPFT.SortedTabletMessagesScreenShot",
+        ipadProMessages:     "MZPFT.SortedJ99MessagesScreenShot",
+        iphone6Messages:     "MZPFT.SortedN61MessagesScreenShot",
+        iphone6PlusMessages: "MZPFT.SortedN56MessagesScreenShot",
+        iphone4Messages:     "MZPFT.SortedN41MessagesScreenShot"
       }
     end
 

--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -93,8 +93,8 @@ module Spaceship
     def messages_picture_type_map
       # rubocop:enable Style/ExtraSpacing
       {
-        iPad:         "MZPFT.SortedTabletMessagesScreenShot",
-        iPadPro:      "MZPFT.SortedJ99MessagesScreenShot",
+        ipad:         "MZPFT.SortedTabletMessagesScreenShot",
+        ipadPro:      "MZPFT.SortedJ99MessagesScreenShot",
         iphone6:      "MZPFT.SortedN61MessagesScreenShot",
         iphone6Plus:  "MZPFT.SortedN56MessagesScreenShot",
         iphone4:      "MZPFT.SortedN41MessagesScreenShot"

--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -14,8 +14,8 @@ module Spaceship
     # @!group Images
     #####################################################
 
-    def upload_screenshot(app_version, upload_file, content_provider_id, sso_token_for_image, device)
-      upload_file(app_version, upload_file, '/upload/image', content_provider_id, sso_token_for_image, screenshot_picture_type(device))
+    def upload_screenshot(app_version, upload_file, content_provider_id, sso_token_for_image, device, is_messages)
+      upload_file(app_version, upload_file, '/upload/image', content_provider_id, sso_token_for_image, screenshot_picture_type(device, is_messages))
     end
 
     def upload_large_icon(app_version, upload_file, content_provider_id, sso_token_for_image)
@@ -78,27 +78,34 @@ module Spaceship
     def picture_type_map
       # rubocop:enable Style/ExtraSpacing
       {
-        watch:               "MZPFT.SortedN27ScreenShot",
-        ipad:                "MZPFT.SortedTabletScreenShot",
-        ipadPro:             "MZPFT.SortedJ99ScreenShot",
-        iphone6:             "MZPFT.SortedN61ScreenShot",
-        iphone6Plus:         "MZPFT.SortedN56ScreenShot",
-        iphone4:             "MZPFT.SortedN41ScreenShot",
-        iphone35:            "MZPFT.SortedScreenShot",
-        appleTV:             "MZPFT.SortedATVScreenShot",
-        desktop:             "MZPFT.SortedDesktopScreenShot",
-        ipadMessages:        "MZPFT.SortedTabletMessagesScreenShot",
-        ipadProMessages:     "MZPFT.SortedJ99MessagesScreenShot",
-        iphone6Messages:     "MZPFT.SortedN61MessagesScreenShot",
-        iphone6PlusMessages: "MZPFT.SortedN56MessagesScreenShot",
-        iphone4Messages:     "MZPFT.SortedN41MessagesScreenShot"
+        watch:        "MZPFT.SortedN27ScreenShot",
+        ipad:         "MZPFT.SortedTabletScreenShot",
+        ipadPro:      "MZPFT.SortedJ99ScreenShot",
+        iphone6:      "MZPFT.SortedN61ScreenShot",
+        iphone6Plus:  "MZPFT.SortedN56ScreenShot",
+        iphone4:      "MZPFT.SortedN41ScreenShot",
+        iphone35:     "MZPFT.SortedScreenShot",
+        appleTV:      "MZPFT.SortedATVScreenShot",
+        desktop:      "MZPFT.SortedDesktopScreenShot",
       }
     end
 
-    def screenshot_picture_type(device)
+    def messages_picture_type_map
+      # rubocop:enable Style/ExtraSpacing
+      {
+        iPad:         "MZPFT.SortedTabletMessagesScreenShot",
+        iPadPro:      "MZPFT.SortedJ99MessagesScreenShot",
+        iphone6:      "MZPFT.SortedN61MessagesScreenShot",
+        iphone6Plus:  "MZPFT.SortedN56MessagesScreenShot",
+        iphone4:      "MZPFT.SortedN41MessagesScreenShot"
+      }
+    end
+
+    def screenshot_picture_type(device, is_messages)
+      map = is_messages ? messages_picture_type_map : picture_type_map
       device = device.to_sym
-      raise "Unknown picture type for device: #{device}" unless picture_type_map.key? device
-      picture_type_map[device]
+      raise "Unknown picture type for device: #{device}" unless map.key? device
+      map[device]
     end
 
     def parse_upload_response(response)

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -692,7 +692,9 @@ module Spaceship
         result = []
 
         display_families.each do |display_family|
-          display_family.fetch("messagesScreenshots", {}).fetch("value", []).each do |screenshot|
+          display_family_screenshots = display_family.fetch("messagesScreenshots", {})
+          next unless display_family_screenshots
+          display_family_screenshots.fetch("value", []).each do |screenshot|
             screenshot_data = screenshot["value"]
             data = {
                 device_type: display_family['name'],

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -484,13 +484,27 @@ module Spaceship
     # @param app_version (AppVersion): The version of your app
     # @param upload_image (UploadFile): The image to upload
     # @param device (string): The target device
+    # @param is_messages (Bool): True if the screenshot is for iMessage
     # @return [JSON] the response
-    def upload_screenshot(app_version, upload_image, device)
+    def upload_screenshot(app_version, upload_image, device, is_messages)
       raise "app_version is required" unless app_version
       raise "upload_image is required" unless upload_image
       raise "device is required" unless device
 
-      du_client.upload_screenshot(app_version, upload_image, content_provider_id, sso_token_for_image, device)
+      du_client.upload_screenshot(app_version, upload_image, content_provider_id, sso_token_for_image, device, is_messages)
+    end
+
+    # Uploads an iMessage screenshot
+    # @param app_version (AppVersion): The version of your app
+    # @param upload_image (UploadFile): The image to upload
+    # @param device (string): The target device
+    # @return [JSON] the response
+    def upload_messages_screenshot(app_version, upload_image, device)
+      raise "app_version is required" unless app_version
+      raise "upload_image is required" unless upload_image
+      raise "device is required" unless device
+
+      du_client.upload_messages_screenshot(app_version, upload_image, content_provider_id, sso_token_for_image, device)
     end
 
     # Uploads the transit app file

--- a/spaceship/spec/du/du_stubbing.rb
+++ b/spaceship/spec/du/du_stubbing.rb
@@ -132,6 +132,22 @@ def du_upload_screenshot_success
     to_return(status: 201, body: du_read_upload_screenshot_response_success, headers: { 'Content-Type' => 'application/json' })
 end
 
+def du_upload_messages_screenshot_success
+  stub_request(:post, "https://du-itc.itunes.apple.com/upload/image").
+    with(body: "the screenshot...",
+           headers: { 'Accept' => 'application/json, text/plain, */*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Content-Length' => '1234520', 'Content-Type' => 'image/jpeg', 'Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088',
+                     'X-Apple-Jingle-Correlation-Key' => 'iOS App:AdamId=898536088:Version=0.9.13', 'X-Apple-Upload-Appleid' => '898536088', 'X-Apple-Upload-Contentproviderid' => '1234567', 'X-Apple-Upload-Itctoken' => 'the_sso_token_for_image',
+                     'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Apple-Upload-Validation-Rulesets' => 'MZPFT.SortedN41MessagesScreenShot', 'X-Original-Filename' => 'ftl_FAKEMD5_screenshot1024.jpg' }).
+    to_return(status: 201, body: du_read_upload_screenshot_response_success, headers: { 'Content-Type' => 'application/json' })
+
+  stub_request(:post, "https://du-itc.itunes.apple.com/upload/image").
+    with(body: "the screenshot...",
+           headers: { 'Accept' => 'application/json, text/plain, */*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Content-Length' => '1234520', 'Content-Type' => 'image/jpeg', 'Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088',
+                     'User-Agent' => "Spaceship #{Spaceship::VERSION}", 'X-Apple-Jingle-Correlation-Key' => 'iOS App:AdamId=898536088:Version=0.9.13', 'X-Apple-Upload-Appleid' => '898536088', 'X-Apple-Upload-Contentproviderid' => '1234567',
+                     'X-Apple-Upload-Itctoken' => 'the_sso_token_for_image', 'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Apple-Upload-Validation-Rulesets' => 'MZPFT.SortedScreenShot', 'X-Original-Filename' => 'ftl_FAKEMD5_screenshot1024.jpg' }).
+    to_return(status: 201, body: du_read_upload_screenshot_response_success, headers: { 'Content-Type' => 'application/json' })
+end
+
 # def du_upload_video_preview_success
 #  stub_request(:post, "https://du-itc.itunes.apple.com/upload/app-screenshot-image").
 #      with(body: "trailer preview...",

--- a/spaceship/spec/tunes/app_version_spec.rb
+++ b/spaceship/spec/tunes/app_version_spec.rb
@@ -455,44 +455,44 @@ describe Spaceship::AppVersion, all: true do
       describe "Parameter checks" do
         it "prevents from using negative sort_order" do
           expect do
-            version.upload_screenshot!(screenshot_path, -1, "English", 'iphone4')
+            version.upload_screenshot!(screenshot_path, -1, "English", 'iphone4', false)
           end.to raise_error "sort_order must be higher than 0"
         end
 
         it "prevents from using sort_order 0" do
           expect do
-            version.upload_screenshot!(screenshot_path, 0, "English", 'iphone4')
+            version.upload_screenshot!(screenshot_path, 0, "English", 'iphone4', false)
           end.to raise_error "sort_order must be higher than 0"
         end
 
         it "prevents from using too large sort_order" do
           expect do
-            version.upload_screenshot!(screenshot_path, 6, "English", 'iphone4')
+            version.upload_screenshot!(screenshot_path, 6, "English", 'iphone4', false)
           end.to raise_error "sort_order must not be > 5"
         end
 
         # not really sure if we want to enforce that
         # it "prevents from letting holes in sort_orders" do
         #  expect do
-        #    version.upload_screenshot!(screenshot_path, 4, "English", 'iphone4')
+        #    version.upload_screenshot!(screenshot_path, 4, "English", 'iphone4', false)
         #  end.to raise_error "FIXME"
         # end
 
         it "prevent from using invalid language" do
           expect do
-            version.upload_screenshot!(screenshot_path, 1, "NotALanguage", 'iphone4')
+            version.upload_screenshot!(screenshot_path, 1, "NotALanguage", 'iphone4', false)
           end.to raise_error "iTunes Connect error: NotALanguage isn't an activated language"
         end
 
         it "prevent from using invalid language" do
           expect do
-            version.upload_screenshot!(screenshot_path, 1, "English_CA", 'iphone4')
+            version.upload_screenshot!(screenshot_path, 1, "English_CA", 'iphone4', false)
           end.to raise_error "iTunes Connect error: English_CA isn't an activated language"
         end
 
         it "prevent from using invalid device" do
           expect do
-            version.upload_screenshot!(screenshot_path, 1, "English", :android)
+            version.upload_screenshot!(screenshot_path, 1, "English", :android, false)
           end.to raise_error "iTunes Connect error: android isn't a valid device name"
         end
       end
@@ -506,7 +506,15 @@ describe Spaceship::AppVersion, all: true do
           du_upload_screenshot_success
 
           count = version.screenshots["English"].count
-          version.upload_screenshot!(screenshot_path, 4, "English", 'iphone4')
+          version.upload_screenshot!(screenshot_path, 4, "English", 'iphone4', false)
+          expect(version.screenshots["English"].count).to eq(count + 1)
+        end
+
+        it "can add a new imessage screenshot to the list" do
+          du_upload_screenshot_success
+
+          count = version.screenshots["English"].count
+          version.upload_screenshot!(screenshot_path, 4, "English", 'iphone4', true)
           expect(version.screenshots["English"].count).to eq(count + 1)
         end
 
@@ -524,7 +532,7 @@ describe Spaceship::AppVersion, all: true do
           family = fetch_family(device_type, language)
           expect(family["scaled"]["value"]).to eq(true)
 
-          version.upload_screenshot!(screenshot_path, 1, language, device_type)
+          version.upload_screenshot!(screenshot_path, 1, language, device_type, false)
 
           family = fetch_family(device_type, language)
           expect(family["scaled"]["value"]).to eq(false)
@@ -534,19 +542,19 @@ describe Spaceship::AppVersion, all: true do
           du_upload_screenshot_success
 
           count = version.screenshots["English"].count
-          version.upload_screenshot!(screenshot_path, 2, "English", 'iphone4')
+          version.upload_screenshot!(screenshot_path, 2, "English", 'iphone4', false)
           expect(version.screenshots["English"].count).to eq(count)
         end
 
         it "can remove existing screenshot" do
           count = version.screenshots["English"].count
-          version.upload_screenshot!(nil, 2, "English", 'iphone4')
+          version.upload_screenshot!(nil, 2, "English", 'iphone4', false)
           expect(version.screenshots["English"].count).to eq(count - 1)
         end
 
         it "fails with error if the screenshot to remove doesn't exist" do
           expect do
-            version.upload_screenshot!(nil, 5, "English", 'iphone4')
+            version.upload_screenshot!(nil, 5, "English", 'iphone4', false)
           end.to raise_error "cannot remove screenshot with non existing sort_order"
         end
       end

--- a/spaceship/spec/tunes/app_version_spec.rb
+++ b/spaceship/spec/tunes/app_version_spec.rb
@@ -190,7 +190,7 @@ describe Spaceship::AppVersion, all: true do
         expect(s1.original_file_name).to eq('ftl_250ec6b31ba0da4c4e8e22fdf83d71a1_65ea94f6b362563260a5742b93659729.png')
         expect(s1.language).to eq("English")
 
-        expect(v.screenshots["English"].count).to eq(10)
+        expect(v.screenshots["English"].count).to eq(13)
 
         # 2 iPhone 6 Plus Screenshots
         expect(v.screenshots["English"].count { |s| s.device_type == 'iphone6Plus' }).to eq(3)
@@ -510,8 +510,8 @@ describe Spaceship::AppVersion, all: true do
           expect(version.screenshots["English"].count).to eq(count + 1)
         end
 
-        it "can add a new imessage screenshot to the list" do
-          du_upload_screenshot_success
+        it "can add a new iMessage screenshot to the list" do
+          du_upload_messages_screenshot_success
 
           count = version.screenshots["English"].count
           version.upload_screenshot!(screenshot_path, 4, "English", 'iphone4', true)
@@ -536,6 +536,26 @@ describe Spaceship::AppVersion, all: true do
 
           family = fetch_family(device_type, language)
           expect(family["scaled"]["value"]).to eq(false)
+        end
+
+        it "auto-sets the 'scaled' parameter when the user provides an iMessage screenshot" do
+          def fetch_family(device_type, language)
+            lang_details = version.raw_data["details"]["value"].find { |a| a["language"] == language }
+            return lang_details["displayFamilies"]["value"].find { |value| value["name"] == device_type }
+          end
+
+          device_type = "iphone4"
+          language = "English"
+
+          du_upload_messages_screenshot_success
+
+          family = fetch_family(device_type, language)
+          expect(family["messagesScaled"]["value"]).to eq(true)
+
+          version.upload_screenshot!(screenshot_path, 1, language, device_type, true)
+
+          family = fetch_family(device_type, language)
+          expect(family["messagesScaled"]["value"]).to eq(false)
         end
 
         it "can replace an existing screenshot with existing sort_order" do

--- a/spaceship/spec/tunes/fixtures/app_version.json
+++ b/spaceship/spec/tunes/fixtures/app_version.json
@@ -352,6 +352,52 @@
                                     "isRequired": false,
                                     "errorKeys": null
                                 },
+                                "messagesScaled": {
+                                    "value": false,
+                                    "isEditable": true,
+                                    "isRequired": false,
+                                    "errorKeys": null
+                                },
+                                "messagesScreenshots": {
+                                    "value": [
+                                        {
+                                            "value": {
+                                                "assetToken": "Purple62/v4/4f/26/50/4f265065-b11d-857b-6232-d219ad4791d2/pr_source.png",
+                                                "sortOrder": 1,
+                                                "type": null,
+                                                "originalFileName": "ftl_250ec6b31ba0da4c4e8e22fdf83d71a1_65ea94f6b362563260a5742b93659729.png"
+                                            },
+                                            "isEditable": true,
+                                            "isRequired": false,
+                                            "errorKeys": null
+                                        },
+                                        {
+                                            "value": {
+                                                "assetToken": "Purple71/v4/6d/bc/94/6dbc946c-90f2-cfa1-02ea-993c2cb89733/pr_source.png",
+                                                "sortOrder": 2,
+                                                "type": null,
+                                                "originalFileName": "ftl_e9ea3f152ae51e75c08f458729c4ec03_bbd0825584e9df0c5fba89f15e207978.png"
+                                            },
+                                            "isEditable": true,
+                                            "isRequired": false,
+                                            "errorKeys": null
+                                        },
+                                        {
+                                            "value": {
+                                                "assetToken": "Purple71/v4/ed/06/26/ed06263d-d158-8d96-fc97-42f97e06386c/pr_source.png",
+                                                "sortOrder": 3,
+                                                "type": null,
+                                                "originalFileName": "ftl_66ee8db4eeaed4f4f4c28a5299e6e3ca_f00ce35bfeb953204a37e39b2ee10417.png"
+                                            },
+                                            "isEditable": true,
+                                            "isRequired": false,
+                                            "errorKeys": null
+                                        }
+                                    ],
+                                    "isEditable": true,
+                                    "isRequired": false,
+                                    "errorKeys": null
+                                },
                                 "trailer": {
                                     "value": null,
                                     "isEditable": true,

--- a/spaceship/spec/tunes/fixtures/app_version.json
+++ b/spaceship/spec/tunes/fixtures/app_version.json
@@ -353,7 +353,7 @@
                                     "errorKeys": null
                                 },
                                 "messagesScaled": {
-                                    "value": false,
+                                    "value": true,
                                     "isEditable": true,
                                     "isRequired": false,
                                     "errorKeys": null


### PR DESCRIPTION
- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid.

This pull request allows `spaceship` to upload iMessage screenshots to iTunes Connect.