### PR TITLE
Adding groups support for external testers

### DIFF
--- a/spaceship/lib/spaceship/tunes/tester.rb
+++ b/spaceship/lib/spaceship/tunes/tester.rb
@@ -21,6 +21,16 @@ module Spaceship
       #   "Bennett"
       attr_accessor :last_name
 
+      # @return (Array) an array of associated groups
+      # @example
+      #    [{
+      #      "id": "e031e048-4f0f-4c1e-8d8a-a5341a267986",
+      #      "name": {
+      #        "value": "My App Testers"
+      #      }
+      #    }]
+      attr_accessor :groups
+
       # @return (Array) An array of registered devices for this user
       # @example
       #    [{
@@ -50,6 +60,7 @@ module Spaceship
         'emailAddress.value' => :email,
         'firstName.value' => :first_name,
         'lastName.value' => :last_name,
+        'groups' => :groups,
         'devices' => :devices,
         'latestInstalledAppAdamId' => :latest_install_app_id,
         'latestInstalledDate' => :latest_install_date,
@@ -83,18 +94,24 @@ module Spaceship
           end
         end
 
+        def groups
+          client.groups
+        end
+
         # Create new tester in iTunes Connect
         # @param email (String) (required): The email of the new tester
         # @param first_name (String) (optional): The first name of the new tester
         # @param last_name (String) (optional): The last name of the new tester
+        # @param groups (Array) (option): Names/IDs of existing groups for the new tester
         # @example
-        #   Spaceship::Tunes::Tester.external.create!(email: "tester@mathiascarignani.com", first_name: "Cary", last_name:"Bennett")
+        #   Spaceship::Tunes::Tester.external.create!(email: "tester@mathiascarignani.com", first_name: "Cary", last_name:"Bennett", groups:["Testers"])
         # @return (Tester): The newly created tester
-        def create!(email: nil, first_name: nil, last_name: nil)
+        def create!(email: nil, first_name: nil, last_name: nil, groups: nil)
           data = client.create_tester!(tester: self,
                                         email: email,
                                    first_name: first_name,
-                                    last_name: last_name)
+                                    last_name: last_name,
+                                       groups: groups)
           self.factory(data)
         end
 
@@ -186,6 +203,19 @@ module Spaceship
       # @param app_id (String) (required): The id of the application to which want to modify the list
       def remove_from_app!(app_id)
         client.remove_tester_from_app!(self, app_id)
+      end
+
+      #####################################################
+      # @!group Helpers
+      #####################################################
+
+      # Return a list of the Tester's group, if any
+      # @return
+      def groups_list(separator = ', ')
+        if groups
+          group_names = groups.map { |group| group["name"]["value"] }
+          group_names.join(separator)
+        end
       end
     end
 

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -541,7 +541,7 @@ module Spaceship
       return @cached if @cached
       r = request(:get, '/WebObjects/iTunesConnect.woa/ra/user/detail')
       data = parse_response(r, 'data')
-      @cached ||= Spaceship::Tunes::UserDetail.factory(data)
+      @cached = Spaceship::Tunes::UserDetail.factory(data)
     end
 
     #####################################################

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -788,7 +788,13 @@ module Spaceship
       parse_response(r, 'data')['users']
     end
 
-    def create_tester!(tester: nil, email: nil, first_name: nil, last_name: nil)
+    def groups
+      return @cached_groups if @cached_groups
+      r = request(:get, '/WebObjects/iTunesConnect.woa/ra/users/pre/ext')
+      @cached_groups ||= parse_response(r, 'data')['groups']
+    end
+
+    def create_tester!(tester: nil, email: nil, first_name: nil, last_name: nil, groups: nil)
       url = tester.url[:create]
       raise "Action not provided for this tester type." unless url
 
@@ -806,6 +812,9 @@ module Spaceship
               value: true
             }
           }
+      if groups
+        tester_data[:groups] = groups.map { |x| { "id" => x } }
+      end
 
       data = { testers: [tester_data] }
 

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -791,7 +791,7 @@ module Spaceship
     def groups
       return @cached_groups if @cached_groups
       r = request(:get, '/WebObjects/iTunesConnect.woa/ra/users/pre/ext')
-      @cached_groups ||= parse_response(r, 'data')['groups']
+      @cached_groups = parse_response(r, 'data')['groups']
     end
 
     def create_tester!(tester: nil, email: nil, first_name: nil, last_name: nil, groups: nil)

--- a/spaceship/spec/tunes/fixtures/testers/get_external.json
+++ b/spaceship/spec/tunes/fixtures/testers/get_external.json
@@ -44,7 +44,22 @@
       "hasAddedOrInvitedApp": null,
       "warnOnDelete": true,
       "itcUsername": null,
-      "groups": []
+      "groups": [
+          {
+            "id": "e031d021-4f0f-4c1e-8d8a-c3341a267986",
+            "name": {
+              "value": "App Testers Group",
+              "isEditable": false,
+              "isRequired": false,
+              "errorKeys": null,
+              "maxLength": 25,
+              "minLength": 1
+            },
+            "testerCount": null,
+            "testers": null,
+            "isDeleted": null
+          }
+        ]
     }, {
       "emailAddress": {
         "value": "ich@felixkrause.at",

--- a/spaceship/spec/tunes/testers_spec.rb
+++ b/spaceship/spec/tunes/testers_spec.rb
@@ -43,6 +43,7 @@ describe Spaceship::Tunes::Tester do
       expect(t.first_name).to eq("Detlef")
       expect(t.last_name).to eq("Müller")
       expect(t.devices).to eq([{ "model" => "iPhone 6", "os" => "iOS", "osVersion" => "8.3", "name" => nil }])
+      expect(t.groups[0]["id"]).to eq("e031d021-4f0f-4c1e-8d8a-c3341a267986")
     end
   end
 


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

In accordance to #6812 and @KrauseFx's request, pushing spaceship modification before merging pilot changes.
This change include storing groups for external testers, and allowing to add multiple groups for a new tester.