### PR TITLE
[deliver] Support iMessage Screenshots

### DIFF
--- a/deliver/lib/assets/ScreenshotsHelp
+++ b/deliver/lib/assets/ScreenshotsHelp
@@ -1,7 +1,7 @@
 Put all screenshots you want to use inside the folder of its language (e.g. en-US).
 The device type will automatically be recognized using the image resolution. Apple TV screenshots
 should be stored in a subdirectory named appleTV with language folders inside of it. iMessage
-screenshots, like Apple TV screenshots, should also be stored in a subdirectory name iMessage
+screenshots, like Apple TV screenshots, should also be stored in a subdirectory named iMessage
 with language folders inside of it.
 
 The screenshots can be named whatever you want, but keep in mind they are sorted alphabetically.

--- a/deliver/lib/assets/ScreenshotsHelp
+++ b/deliver/lib/assets/ScreenshotsHelp
@@ -1,5 +1,7 @@
 Put all screenshots you want to use inside the folder of its language (e.g. en-US).
 The device type will automatically be recognized using the image resolution. Apple TV screenshots
-should be stored in a subdirectory named appleTV with language folders inside of it.
+should be stored in a subdirectory named appleTV with language folders inside of it. iMessage
+screenshots, like Apple TV screenshots, should also be stored in a subdirectory name iMessage
+with language folders inside of it.
 
 The screenshots can be named whatever you want, but keep in mind they are sorted alphabetically.

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -17,6 +17,16 @@ module Deliver
       IOS_IPAD = "iOS-iPad"
       # iPad Pro
       IOS_IPAD_PRO = "iOS-iPad-Pro"
+      # iPhone 5 iMessage
+      IOS_40_MESSAGES = "iOS-4-in-Messages"
+      # iPhone 6 iMessage
+      IOS_47_MESSAGES = "iOS-4.7-in-Messages"
+      # iPhone 6 Plus iMessage
+      IOS_55_MESSAGES = "iOS-5.5-in-Messages"
+      # iPad iMessage
+      IOS_IPAD_MESSAGES = "iOS-iPad-Messages"
+      # iPad Pro iMessage
+      IOS_IPAD_PRO_MESSAGES = "iOS-iPad-Pro-Messages"
       # Apple Watch
       IOS_APPLE_WATCH = "iOS-Apple-Watch"
       # Mac
@@ -56,6 +66,11 @@ module Deliver
         ScreenSize::IOS_55 => "iphone6Plus",
         ScreenSize::IOS_IPAD => "ipad",
         ScreenSize::IOS_IPAD_PRO => "ipadPro",
+        ScreenSize::IOS_40_MESSAGES => "iphone4Messages",
+        ScreenSize::IOS_47_MESSAGES => "iphone6Messages",
+        ScreenSize::IOS_55_MESSAGES => "iphone6PlusMessages",
+        ScreenSize::IOS_IPAD_MESSAGES => "ipadMessages",
+        ScreenSize::IOS_IPAD_PRO_MESSAGES => "ipadProMessages",
         ScreenSize::MAC => "desktop",
         ScreenSize::IOS_APPLE_WATCH => "watch",
         ScreenSize::APPLE_TV => "appleTV"
@@ -72,6 +87,11 @@ module Deliver
         ScreenSize::IOS_55 => "iPhone 6 Plus",
         ScreenSize::IOS_IPAD => "iPad",
         ScreenSize::IOS_IPAD_PRO => "iPad Pro",
+        ScreenSize::IOS_40_MESSAGES => "iPhone 5 (iMessage)",
+        ScreenSize::IOS_47_MESSAGES => "iPhone 6 (iMessage)",
+        ScreenSize::IOS_55_MESSAGES => "iPhone 6 Plus (iMessage)",
+        ScreenSize::IOS_IPAD_MESSAGES => "iPad (iMessage)",
+        ScreenSize::IOS_IPAD_PRO_MESSAGES => "iPad Pro (iMessage)",
         ScreenSize::MAC => "Mac",
         ScreenSize::IOS_APPLE_WATCH => "Watch",
         ScreenSize::APPLE_TV => "Apple TV"
@@ -84,6 +104,37 @@ module Deliver
       return false unless ["png", "PNG", "jpg", "JPG", "jpeg", "JPEG"].include?(self.path.split(".").last)
 
       return self.screen_size == self.class.calculate_screen_size(self.path)
+    end
+
+    def self.device_messages
+      return {
+        ScreenSize::IOS_55_MESSAGES => [
+          [1080, 1920],
+          [1242, 2208]
+        ],
+        ScreenSize::IOS_47_MESSAGES => [
+          [750, 1334]
+        ],
+        ScreenSize::IOS_40_MESSAGES => [
+          [640, 1136],
+          [640, 1096],
+          [1136, 600] # landscape status bar is smaller
+        ],
+        ScreenSize::IOS_IPAD_MESSAGES => [
+          [1024, 748],
+          [1024, 768],
+          [2048, 1496],
+          [2048, 1536],
+          [768, 1004],
+          [768, 1024],
+          [1536, 2008],
+          [1536, 2048]
+        ],
+        ScreenSize::IOS_IPAD_PRO_MESSAGES => [
+          [2732, 2048],
+          [2048, 2732]
+        ]
+      }
     end
 
     def self.devices
@@ -145,7 +196,10 @@ module Deliver
         skip_landscape = true
       end
 
-      self.devices.each do |device_type, array|
+      # iMessage screenshots have same resolution as app screenshots so we need to distinguish them
+      devices = path_component.eql?("iMessage") ? self.device_messages : self.devices
+
+      devices.each do |device_type, array|
         array.each do |resolution|
           if skip_landscape
             if size[0] == resolution[0] and size[1] == resolution[1] # portrait

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -18,15 +18,15 @@ module Deliver
       # iPad Pro
       IOS_IPAD_PRO = "iOS-iPad-Pro"
       # iPhone 5 iMessage
-      IOS_40_MESSAGES = "iOS-4-in-Messages"
+      IOS_40_MESSAGES = "iOS-4-in"
       # iPhone 6 iMessage
-      IOS_47_MESSAGES = "iOS-4.7-in-Messages"
+      IOS_47_MESSAGES = "iOS-4.7-in"
       # iPhone 6 Plus iMessage
-      IOS_55_MESSAGES = "iOS-5.5-in-Messages"
+      IOS_55_MESSAGES = "iOS-5.5-in"
       # iPad iMessage
-      IOS_IPAD_MESSAGES = "iOS-iPad-Messages"
+      IOS_IPAD_MESSAGES = "iOS-iPad"
       # iPad Pro iMessage
-      IOS_IPAD_PRO_MESSAGES = "iOS-iPad-Pro-Messages"
+      IOS_IPAD_PRO_MESSAGES = "iOS-iPad-Pro"
       # Apple Watch
       IOS_APPLE_WATCH = "iOS-Apple-Watch"
       # Mac
@@ -66,11 +66,11 @@ module Deliver
         ScreenSize::IOS_55 => "iphone6Plus",
         ScreenSize::IOS_IPAD => "ipad",
         ScreenSize::IOS_IPAD_PRO => "ipadPro",
-        ScreenSize::IOS_40_MESSAGES => "iphone4Messages",
-        ScreenSize::IOS_47_MESSAGES => "iphone6Messages",
-        ScreenSize::IOS_55_MESSAGES => "iphone6PlusMessages",
-        ScreenSize::IOS_IPAD_MESSAGES => "ipadMessages",
-        ScreenSize::IOS_IPAD_PRO_MESSAGES => "ipadProMessages",
+        ScreenSize::IOS_40_MESSAGES => "iphone4",
+        ScreenSize::IOS_47_MESSAGES => "iphone6",
+        ScreenSize::IOS_55_MESSAGES => "iphone6Plus",
+        ScreenSize::IOS_IPAD_MESSAGES => "ipad",
+        ScreenSize::IOS_IPAD_PRO_MESSAGES => "ipadPro",
         ScreenSize::MAC => "desktop",
         ScreenSize::IOS_APPLE_WATCH => "watch",
         ScreenSize::APPLE_TV => "appleTV"
@@ -104,6 +104,10 @@ module Deliver
       return false unless ["png", "PNG", "jpg", "JPG", "jpeg", "JPEG"].include?(self.path.split(".").last)
 
       return self.screen_size == self.class.calculate_screen_size(self.path)
+    end
+
+    def is_messages?
+      return [ScreenSize::IOS_40_MESSAGES, ScreenSize::IOS_47_MESSAGES, ScreenSize::IOS_55_MESSAGES, ScreenSize::IOS_IPAD_MESSAGES, ScreenSize::IOS_IPAD_PRO_MESSAGES].include?(self.screen_size)
     end
 
     def self.device_messages

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -18,15 +18,15 @@ module Deliver
       # iPad Pro
       IOS_IPAD_PRO = "iOS-iPad-Pro"
       # iPhone 5 iMessage
-      IOS_40_MESSAGES = "iOS-4-in"
+      IOS_40_MESSAGES = "iOS-4-in-messages"
       # iPhone 6 iMessage
-      IOS_47_MESSAGES = "iOS-4.7-in"
+      IOS_47_MESSAGES = "iOS-4.7-in-messages"
       # iPhone 6 Plus iMessage
-      IOS_55_MESSAGES = "iOS-5.5-in"
+      IOS_55_MESSAGES = "iOS-5.5-in-messages"
       # iPad iMessage
-      IOS_IPAD_MESSAGES = "iOS-iPad"
+      IOS_IPAD_MESSAGES = "iOS-iPad-messages"
       # iPad Pro iMessage
-      IOS_IPAD_PRO_MESSAGES = "iOS-iPad-Pro"
+      IOS_IPAD_PRO_MESSAGES = "iOS-iPad-Pro-messages"
       # Apple Watch
       IOS_APPLE_WATCH = "iOS-Apple-Watch"
       # Mac

--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -2,11 +2,12 @@ require 'fastlane_core/languages'
 
 module Deliver
   module Loader
-    # The directory 'appleTV' is a special folder that will cause our screenshot gathering code to iterate
+    # The directory 'appleTV' and `iMessage` are special folders that will cause our screenshot gathering code to iterate
     # through it as well searching for language folders.
     APPLE_TV_DIR_NAME = "appleTV".freeze
+    IMESSAGE_DIR_NAME = "iMessage".freeze
     DEFAULT_DIR_NAME = "default".freeze
-    ALL_LANGUAGES = (FastlaneCore::Languages::ALL_LANGUAGES + [APPLE_TV_DIR_NAME, APPLE_TV_DIR_NAME, DEFAULT_DIR_NAME]).map(&:downcase).freeze
+    ALL_LANGUAGES = (FastlaneCore::Languages::ALL_LANGUAGES + [APPLE_TV_DIR_NAME, APPLE_TV_DIR_NAME, IMESSAGE_DIR_NAME, DEFAULT_DIR_NAME]).map(&:downcase).freeze
 
     def self.language_folders(root)
       Dir.glob(File.join(root, '*')).select do |path|

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -39,13 +39,14 @@ module Deliver
         UI.message("Uploading #{screenshots_for_language.length} screenshots for language #{language}")
         screenshots_for_language.each do |screenshot|
           indized[screenshot.language] ||= {}
-          indized[screenshot.language][screenshot.device_type] ||= 0
-          indized[screenshot.language][screenshot.device_type] += 1 # we actually start with 1... wtf iTC
+          indized[screenshot.language][screenshot.formatted_name] ||= 0
+          indized[screenshot.language][screenshot.formatted_name] += 1 # we actually start with 1... wtf iTC
 
-          index = indized[screenshot.language][screenshot.device_type]
+
+          index = indized[screenshot.language][screenshot.formatted_name]
 
           if index > 5
-            UI.error("Too many screenshots found for device '#{screenshot.device_type}' in '#{screenshot.language}', skipping this one (#{screenshot.path})")
+            UI.error("Too many screenshots found for device '#{screenshot.formatted_name}' in '#{screenshot.language}', skipping this one (#{screenshot.path})")
             next
           end
 

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -42,7 +42,6 @@ module Deliver
           indized[screenshot.language][screenshot.formatted_name] ||= 0
           indized[screenshot.language][screenshot.formatted_name] += 1 # we actually start with 1... wtf iTC
 
-
           index = indized[screenshot.language][screenshot.formatted_name]
 
           if index > 5

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -76,7 +76,7 @@ module Deliver
         language = File.basename(lng_folder)
 
         # Check to see if we need to traverse multiple platforms or just a single platform
-        if language == Loader::APPLE_TV_DIR_NAME
+        if language == Loader::APPLE_TV_DIR_NAME || language == Loader::IMESSAGE_DIR_NAME
           screenshots.concat(collect_screenshots_for_languages(File.join(path, language)))
           next
         end

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -53,7 +53,8 @@ module Deliver
           v.upload_screenshot!(screenshot.path,
                                index,
                                screenshot.language,
-                               screenshot.device_type)
+                               screenshot.device_type,
+                               screenshot.is_messages?)
         end
         # ideally we should only save once, but itunes server can't cope it seems
         # so we save per language. See issue #349

--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -78,15 +78,15 @@ module Spaceship
     def picture_type_map
       # rubocop:enable Style/ExtraSpacing
       {
-        watch:        "MZPFT.SortedN27ScreenShot",
-        ipad:         "MZPFT.SortedTabletScreenShot",
-        ipadPro:      "MZPFT.SortedJ99ScreenShot",
-        iphone6:      "MZPFT.SortedN61ScreenShot",
-        iphone6Plus:  "MZPFT.SortedN56ScreenShot",
-        iphone4:      "MZPFT.SortedN41ScreenShot",
-        iphone35:     "MZPFT.SortedScreenShot",
-        appleTV:      "MZPFT.SortedATVScreenShot",
-        desktop:      "MZPFT.SortedDesktopScreenShot"
+        watch:       "MZPFT.SortedN27ScreenShot",
+        ipad:        "MZPFT.SortedTabletScreenShot",
+        ipadPro:     "MZPFT.SortedJ99ScreenShot",
+        iphone6:     "MZPFT.SortedN61ScreenShot",
+        iphone6Plus: "MZPFT.SortedN56ScreenShot",
+        iphone4:     "MZPFT.SortedN41ScreenShot",
+        iphone35:    "MZPFT.SortedScreenShot",
+        appleTV:     "MZPFT.SortedATVScreenShot",
+        desktop:     "MZPFT.SortedDesktopScreenShot"
       }
     end
 

--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -78,15 +78,15 @@ module Spaceship
     def picture_type_map
       # rubocop:enable Style/ExtraSpacing
       {
-        watch:       "MZPFT.SortedN27ScreenShot",
-        ipad:        "MZPFT.SortedTabletScreenShot",
-        ipadPro:     "MZPFT.SortedJ99ScreenShot",
-        iphone6:     "MZPFT.SortedN61ScreenShot",
-        iphone6Plus: "MZPFT.SortedN56ScreenShot",
-        iphone4:     "MZPFT.SortedN41ScreenShot",
-        iphone35:    "MZPFT.SortedScreenShot",
-        appleTV:     "MZPFT.SortedATVScreenShot",
-        desktop:     "MZPFT.SortedDesktopScreenShot"
+        watch:        "MZPFT.SortedN27ScreenShot",
+        ipad:         "MZPFT.SortedTabletScreenShot",
+        ipadPro:      "MZPFT.SortedJ99ScreenShot",
+        iphone6:      "MZPFT.SortedN61ScreenShot",
+        iphone6Plus:  "MZPFT.SortedN56ScreenShot",
+        iphone4:      "MZPFT.SortedN41ScreenShot",
+        iphone35:     "MZPFT.SortedScreenShot",
+        appleTV:      "MZPFT.SortedATVScreenShot",
+        desktop:      "MZPFT.SortedDesktopScreenShot"
       }
     end
 


### PR DESCRIPTION
- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid.

Because iMessage screenshots and normal screenshots have same image resolution, we need to put all iMessage screenshots into an `iMessage` subdirectory. Currently `deliver` needs Apple TV screenshots be in the `appleTV` subdirectory, so I think this is the right approach.

This can be merged after #6823 being merged.