### PR TITLE
Fix for plist encoding error

### DIFF
--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -174,7 +174,7 @@ module Gym
 
         to_plist(hash)
       end
-      
+
       # Avoids a Hash#to_plist conflict between CFPropertyList and plist gems
       def to_plist(hash)
         Plist::Emit.dump(hash, true)

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -168,11 +168,15 @@ module Gym
         if $verbose
           UI.message("This results in the following plist file:")
           UI.command_output("-----------------------------------------")
-          UI.command_output(hash.to_plist)
+          UI.command_output(to_plist(hash))
           UI.command_output("-----------------------------------------")
         end
 
-        hash.to_plist
+        to_plist(hash)
+      end
+
+      def to_plist(hash)
+        Plist::Emit.dump(hash, true)
       end
 
       def print_legacy_information

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -174,7 +174,8 @@ module Gym
 
         to_plist(hash)
       end
-
+      
+      # Avoids a Hash#to_plist conflict between CFPropertyList and plist gems
       def to_plist(hash)
         Plist::Emit.dump(hash, true)
       end


### PR DESCRIPTION
- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Fix for: #6784

It looks like the `config_content` method is expecting to use the `plist` gem, and is actually getting the `CFPropertyList` gem due to a conflicting `Hash#to_plist` monkey patch.

`CFPropertyList` is used by `xcodeproj`, which is a Fastlane dependency.