### PR TITLE
[spaceship] Version Bump

### DIFF
--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,4 +1,4 @@
 module Spaceship
-  VERSION = "0.36.2".freeze
+  VERSION = "0.37.0".freeze
   DESCRIPTION = "Ruby library to access the Apple Dev Center and iTunes Connect".freeze
 end


### PR DESCRIPTION
- Adding groups support for external testers (#6829)
- Allow `produce` to enable/disable additional services (apple-pay, game-center, in-app-purchase, sirikit)
- Add update check to ensure people are running the latest release (#6800)
- Show instructions on how to solve common TestFlight error (#6766)
- Replace step with factor, so that users that use CMD F find it either way (#6762)
- Add `SPACESHIP_TIMEOUT` environment variable to change the default timeout (#6712)