### PR TITLE
Provide more context for choosing your git URL

### DIFF
--- a/match/README.md
+++ b/match/README.md
@@ -118,7 +118,7 @@ match init
 
 <img src="assets/match_init.gif" width="550" />
 
-You'll be asked to enter the URL to your Git repo. This can be either a `https://` or a `git` URL. `match init` won't read or modify your certificates or profiles.
+You'll be asked to enter the URL to your Git repo. This can be either a `https://` or a `git` URL. (If your machine is currently using SSH to authenticate with Github, you'll want to use a `git` URL, otherwise you may see an authentication error when you attempt to use match.) `match init` won't read or modify your certificates or profiles.
 
 This will create a `Matchfile` in your current directory (or in your `./fastlane/` folder).
 


### PR DESCRIPTION
The user will receive an auth error if he/she uses the incorrect type of Git URL, i.e. if he/she is using SSH to authenticate but uses an HTTPS url. This change adds a note reminding the user of this.