### PR TITLE
[scan] Fix crash when running scan on macOS projects

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -172,7 +172,7 @@ module Scan
       end
 
       # building up the destination now
-      if Scan.devices.count > 0
+      if Scan.devices && Scan.devices.count > 0
         Scan.config[:destination] = Scan.devices.map { |d| "platform=#{d.os_type} Simulator,id=#{d.udid}" }
       else
         Scan.config[:destination] = min_xcode8? ? ["platform=macOS"] : ["platform=OS X"]


### PR DESCRIPTION
- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

---
scan would crash if the --device option is not specified. This regression was introduced in #6637, sorry. It would also crash for single scheme projects when no --device option is specified.