### PR TITLE
add linux/unix/windows helper - fix env printer usage of sw_vers

### DIFF
--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -132,10 +132,24 @@ module Fastlane
       require "openssl"
 
       env_output = "### Stack\n\n"
-      product, version, build = `sw_vers`.strip.split("\n").map { |line| line.split(':').last.strip }
+      product, version, build = "Unkown"
+      os_version = "UNKOWN"
+
+      if FastlaneCore::Helper.mac?
+        product, version, build = `sw_vers`.strip.split("\n").map { |line| line.split(':').last.strip }
+        os_version = `sw_vers -productVersion`.strip
+      end
+
+      if FastlaneCore::Helper.linux?
+        os_version = `uname -a`.strip.split("\n").map { |line| line.split(':').last.strip }
+        version = ""
+        build = ""
+        product = `cat /etc/issue`
+      end
+
       table_content = {
         "fastlane" => Fastlane::VERSION,
-        "OS" => `sw_vers -productVersion`.strip,
+        "OS" => os_version,
         "Ruby" => RUBY_VERSION,
         "Bundler?" => Helper.bundler?,
         "Xcode Path" => Helper.xcode_path,

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -48,6 +48,18 @@ module FastlaneCore
       return false
     end
 
+    def self.unix?
+      !windows?
+    end
+
+    def self.windows?
+      (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+    end
+
+    def self.linux?
+      unix? and !mac?
+    end
+
     # Is the currently running computer a Mac?
     def self.mac?
       (/darwin/ =~ RUBY_PLATFORM) != nil


### PR DESCRIPTION
fix issues with `sw_ver` in env printer, on non mac OS.
