### PR TITLE
[fastlane] support keychains in custom paths and fix non-existing default keychain crash🔐

### DIFF
--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -14,7 +14,7 @@ module Fastlane
           escaped_name = params[:name].shellescape
           keychain_path = "~/Library/Keychains/#{escaped_name}"
         else
-          keychain_path = params[:path]
+          keychain_path = params[:path].shellescape
         end
 
         if keychain_path.nil?

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -8,30 +8,44 @@ module Fastlane
 
     class CreateKeychainAction < Action
       def self.run(params)
-        escaped_name = params[:name].shellescape
         escaped_password = params[:password].shellescape
 
-        commands = []
-        commands << Fastlane::Actions.sh("security create-keychain -p #{escaped_password} #{escaped_name}", log: false)
-
-        if params[:default_keychain]
-          Actions.lane_context[Actions::SharedValues::ORIGINAL_DEFAULT_KEYCHAIN] = Fastlane::Actions.sh("security default-keychain", log: false).strip
-          commands << Fastlane::Actions.sh("security default-keychain -s #{escaped_name}", log: false)
+        if params[:name]
+          escaped_name = params[:name].shellescape
+          keychain_path = "~/Library/Keychains/#{escaped_name}"
+        else
+          keychain_path = params[:path]
         end
 
-        commands << Fastlane::Actions.sh("security unlock-keychain -p #{escaped_password} #{escaped_name}", log: false) if params[:unlock]
+        if keychain_path.nil?
+          UI.user_error!("You either have to set :name or :path")
+        end
+
+        commands = []
+        commands << Fastlane::Actions.sh("security create-keychain -p #{escaped_password} #{keychain_path}", log: false)
+
+        if params[:default_keychain]
+          # if there is no default keychain - setting the original will fail - silent this error
+          begin
+            Actions.lane_context[Actions::SharedValues::ORIGINAL_DEFAULT_KEYCHAIN] = Fastlane::Actions.sh("security default-keychain", log: false).strip
+          rescue
+          end
+          commands << Fastlane::Actions.sh("security default-keychain -s #{keychain_path}", log: false)
+        end
+
+        commands << Fastlane::Actions.sh("security unlock-keychain -p #{escaped_password} #{keychain_path}", log: false) if params[:unlock]
 
         command = "security set-keychain-settings"
         command << " -t #{params[:timeout]}" if params[:timeout]
         command << " -l" if params[:lock_when_sleeps]
         command << " -u" if params[:lock_after_timeout]
-        command << " ~/Library/Keychains/#{escaped_name}"
+        command << " #{keychain_path}"
 
         commands << Fastlane::Actions.sh(command, log: false)
 
         if params[:add_to_search_list]
           keychains = Action.sh("security list-keychains -d user").shellsplit
-          keychains << File.expand_path(params[:name], "~/Library/Keychains")
+          keychains << File.expand_path(keychain_path)
           commands << Fastlane::Actions.sh("security list-keychains -s #{keychains.shelljoin}", log: false)
         end
 
@@ -47,7 +61,15 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :name,
                                        env_name: "KEYCHAIN_NAME",
                                        description: "Keychain name",
-                                       optional: false),
+                                       conflicting_options: [:path],
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: "KEYCHAIN_PATH",
+                                       description: "Path to Keychain",
+                                       is_string: true,
+                                       conflicting_options: [:name],
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :password,
                                        env_name: "KEYCHAIN_PASSWORD",
                                        description: "Password for the keychain",

--- a/fastlane/spec/actions_specs/create_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/create_keychain_spec.rb
@@ -10,7 +10,7 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result.size).to eq 3
-        expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
+        expect(result[0]).to eq 'security create-keychain -p testpassword ~/Library/Keychains/test.keychain'
 
         expect(result[1]).to start_with 'security set-keychain-settings'
         expect(result[1]).to include '-t 300'
@@ -30,7 +30,7 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result.size).to eq 3
-        expect(result[0]).to eq %(security create-keychain -p \\\"test\\ password\\\" test.keychain)
+        expect(result[0]).to eq %(security create-keychain -p \\\"test\\ password\\\" ~/Library/Keychains/test.keychain)
       end
 
       it "works with keychain-settings and name and password" do
@@ -45,7 +45,7 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result.size).to eq 3
-        expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
+        expect(result[0]).to eq 'security create-keychain -p testpassword ~/Library/Keychains/test.keychain'
 
         expect(result[1]).to start_with 'security set-keychain-settings'
         expect(result[1]).to include '-t 600'
@@ -64,9 +64,9 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result.size).to eq 4
-        expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
+        expect(result[0]).to eq 'security create-keychain -p testpassword ~/Library/Keychains/test.keychain'
 
-        expect(result[1]).to eq 'security default-keychain -s test.keychain'
+        expect(result[1]).to eq 'security default-keychain -s ~/Library/Keychains/test.keychain'
 
         expect(result[2]).to start_with 'security set-keychain-settings'
         expect(result[2]).to include '-t 300'
@@ -85,15 +85,41 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result.size).to eq 4
-        expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
+        expect(result[0]).to eq 'security create-keychain -p testpassword ~/Library/Keychains/test.keychain'
 
-        expect(result[1]).to eq 'security unlock-keychain -p testpassword test.keychain'
+        expect(result[1]).to eq 'security unlock-keychain -p testpassword ~/Library/Keychains/test.keychain'
 
         expect(result[2]).to start_with 'security set-keychain-settings'
         expect(result[2]).to include '-t 300'
         expect(result[2]).to_not include '-l'
         expect(result[2]).to_not include '-u'
         expect(result[2]).to include '~/Library/Keychains/test.keychain'
+      end
+
+      it "works with :path param" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          create_keychain ({
+            path: '/tmp/test.keychain',
+            password: 'testpassword',
+            default_keychain: true,
+            unlock: true,
+            timeout: 600,
+            lock_when_sleeps: true,
+            lock_after_timeout: true,
+            add_to_search_list: false,
+          })
+        end").runner.execute(:test)
+        expect(result.size).to eq 4
+        expect(result[0]).to eq 'security create-keychain -p testpassword /tmp/test.keychain'
+
+        expect(result[1]).to eq 'security default-keychain -s /tmp/test.keychain'
+        expect(result[2]).to eq 'security unlock-keychain -p testpassword /tmp/test.keychain'
+
+        expect(result[3]).to start_with 'security set-keychain-settings'
+        expect(result[3]).to include '-t 600'
+        expect(result[3]).to include '-l'
+        expect(result[3]).to include '-u'
+        expect(result[3]).to include '/tmp/test.keychain'
       end
 
       it "works with all params" do
@@ -111,10 +137,10 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result.size).to eq 4
-        expect(result[0]).to eq 'security create-keychain -p testpassword test.keychain'
+        expect(result[0]).to eq 'security create-keychain -p testpassword ~/Library/Keychains/test.keychain'
 
-        expect(result[1]).to eq 'security default-keychain -s test.keychain'
-        expect(result[2]).to eq 'security unlock-keychain -p testpassword test.keychain'
+        expect(result[1]).to eq 'security default-keychain -s ~/Library/Keychains/test.keychain'
+        expect(result[2]).to eq 'security unlock-keychain -p testpassword ~/Library/Keychains/test.keychain'
 
         expect(result[3]).to start_with 'security set-keychain-settings'
         expect(result[3]).to include '-t 600'


### PR DESCRIPTION
as discussed here: https://github.com/fastlane/fastlane/issues/6880

adds parameter `path` - so `create_keychain` either accepts `path` (full path to keychain)  - or `name` (name inside `~/Libarary/Keychains/`)


  * also fixes issue with `set-default` - when there is no default keychain

sample:
```
lane :demo do
        create_keychain(path: "/tmp/11131.keychain")
end
```