### PR TITLE
[WIP] add troubleshoot option 🔫

### DIFF
--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -48,6 +48,13 @@ module Fastlane
     end
 
     def self.confirm_troubleshoot
+      if Helper.is_ci?
+        UI.error "---"
+        UI.error "You are trying to use '--troubleshoot' on CI"
+        UI.error "this option is not usable in CI, as it is insecure"
+        UI.error "---"
+        UI.user_error!("Do not use --troubleshoot in CI")
+      end
       # maybe already set by 'start'
       return if $troubleshoot
       UI.error "---"

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -12,6 +12,7 @@ module Fastlane
       # however we do want to log verbose information in the PluginManager
       $verbose = true if ARGV.include?("--verbose")
       $capture_output = true if ARGV.include?("--capture_output")
+      $troubleshoot = true if ARGV.include?("--troubleshoot")
 
       if $capture_output
         # Trace mode is enabled
@@ -56,6 +57,10 @@ module Fastlane
 
       global_option('--verbose') { $verbose = true }
       global_option('--capture_output', 'Captures the output of the current run, and generates a markdown issue template') { $capture_output = true }
+      global_option('--troubleshoot', 'Enables extended verbose mode, beware this eventually includes passwords, should not be run on CI') do
+        $verbose = true
+        $troubleshoot = true
+      end
 
       always_trace!
 

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -58,9 +58,9 @@ module Fastlane
       # maybe already set by 'start'
       return if $troubleshoot
       UI.error "---"
-      UI.error "Are you sure to enable '--troubleshoot'."
+      UI.error "Are you sure you want to enable '--troubleshoot'?"
       UI.error "All commmands will run in full unfiltered output mode."
-      UI.error "Beware that there maybe passwords printed to the console/log."
+      UI.error "Sensitive data, like passwords, could be printed to the log."
       UI.error "---"
       if UI.confirm("Do you really want to enable --troubleshoot")
         $troubleshoot = true
@@ -81,7 +81,7 @@ module Fastlane
 
       global_option('--verbose') { $verbose = true }
       global_option('--capture_output', 'Captures the output of the current run, and generates a markdown issue template') { $capture_output = true }
-      global_option('--troubleshoot', 'Enables extended verbose mode, beware this eventually includes passwords, should not be run on CI')
+      global_option('--troubleshoot', 'Enables extended verbose mode. Use with caution, as this even includes ALL sensitive data. Cannot be used on CI.')
 
       always_trace!
 

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -62,7 +62,7 @@ module Fastlane
       UI.error "All commmands will run in full unfiltered output mode."
       UI.error "Beware that there maybe passwords printed to the console/log."
       UI.error "---"
-      if agree("(y/n)", true)
+      if UI.confirm("Do you really want to enable --troubleshoot")
         $troubleshoot = true
       end
     end

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -12,7 +12,11 @@ module Fastlane
       # however we do want to log verbose information in the PluginManager
       $verbose = true if ARGV.include?("--verbose")
       $capture_output = true if ARGV.include?("--capture_output")
-      $troubleshoot = true if ARGV.include?("--troubleshoot")
+
+      # has to be checked here - in case we wan't to troubleshoot plugin related issues
+      if ARGV.include?("--troubleshoot")
+        self.confirm_troubleshoot
+      end
 
       if $capture_output
         # Trace mode is enabled
@@ -43,6 +47,19 @@ module Fastlane
       end
     end
 
+    def self.confirm_troubleshoot
+      # maybe already set by 'start'
+      return if $troubleshoot
+      UI.error "---"
+      UI.error "Are you sure to enable '--troubleshoot'"
+      UI.error "all commmands will run in full unfiltered output"
+      UI.error "beware that there maybe passwords printed to the console/log"
+      UI.error "---"
+      if agree("(y/n)", true)
+        $troubleshoot = true
+      end
+    end
+
     def run
       program :version, Fastlane::VERSION
       program :description, [
@@ -57,10 +74,7 @@ module Fastlane
 
       global_option('--verbose') { $verbose = true }
       global_option('--capture_output', 'Captures the output of the current run, and generates a markdown issue template') { $capture_output = true }
-      global_option('--troubleshoot', 'Enables extended verbose mode, beware this eventually includes passwords, should not be run on CI') do
-        $verbose = true
-        $troubleshoot = true
-      end
+      global_option('--troubleshoot', 'Enables extended verbose mode, beware this eventually includes passwords, should not be run on CI')
 
       always_trace!
 

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -51,9 +51,9 @@ module Fastlane
       # maybe already set by 'start'
       return if $troubleshoot
       UI.error "---"
-      UI.error "Are you sure to enable '--troubleshoot'"
-      UI.error "all commmands will run in full unfiltered output"
-      UI.error "beware that there maybe passwords printed to the console/log"
+      UI.error "Are you sure to enable '--troubleshoot'."
+      UI.error "All commmands will run in full unfiltered output mode."
+      UI.error "Beware that there maybe passwords printed to the console/log."
       UI.error "---"
       if agree("(y/n)", true)
         $troubleshoot = true

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -19,6 +19,7 @@ module Fastlane
     # @param print_command_output [Boolean] Should we print the command output during execution
     # @param error_callback [Block] A block that's called if the command exits with a non-zero status
     def self.sh_control_output(command, print_command: true, print_command_output: true, error_callback: nil)
+      print_command = print_command_output = true if $troubleshoot
       # Set the encoding first, the user might have set it wrong
       previous_encoding = [Encoding.default_external, Encoding.default_internal]
       Encoding.default_external = Encoding::UTF_8


### PR DESCRIPTION
as proposed here - to help debugging/troubleshooting.
https://github.com/fastlane/fastlane/issues/6878

adds `--troubleshoot`  enables `log:true`  on all `.sh` calls.
this should not be run on CI, existing setups using `--verbose` on CI - should not be affected, therefore not passwords in ci log