### PR TITLE
Handle iTMSTransporter failure/retry loop

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -73,7 +73,15 @@ module FastlaneCore
         UI.error(@errors.join("\n"))
       end
 
-      @errors.count.zero?
+      # this is to handle GitHub issue #1896, which occurs when an
+      #  iTMSTransporter file transfer fails; iTMSTransporter will log an error
+      #  but will then retry; if that retry is successful, we will see the error
+      #  logged, but since the status code is zero, we want to return success
+      if @errors.count > 0 && exit_status.zero?
+        UI.important("Although errors occurred during execution of iTMSTransporter, it returned success status.")
+      end
+
+      exit_status.zero?
     end
 
     private


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

When iTMSTransporter logs errors, but returns success status, log a message and return success.

This addresses Issue #1896 