### PR TITLE
[fastlane] Version bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.107.0'.freeze
+  VERSION = '1.108.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps"
 end


### PR DESCRIPTION
* Implement `fastlane_require` to automatically install gems into bundle (#6858)
* Add new `fastlane update_fastlane` action (#6896)
* Support keychains in custom paths and fix non-existing default keychain crash 🔐 (#6887)
* Hide options with no description in docs (#6919)
* Fix commit_version_bump could not find a .xcodeproj (#6676)