### PR TITLE
[match] Version Bump

### DIFF
--- a/match/lib/match/version.rb
+++ b/match/lib/match/version.rb
@@ -1,4 +1,4 @@
 module Match
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
   DESCRIPTION = "Easily sync your certificates and profiles across your team using git"
 end


### PR DESCRIPTION
* Fix hang on CI on macOS Sierra (#6935)
* New `keychain_password` parameter to avoid system keychain prompt 
* support force on nuke (#6886, #6894)
* Provide more context for choosing your git URL (#6856)
* Update internal dependencies 