### PR TITLE
Fix copy_to_clipboard for ruby 2.0.0

### DIFF
--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -231,11 +231,8 @@ module Fastlane
     # Make sure to ask the user first, as some people don't
     # use a clipboard manager, so they might lose something important
     def self.copy_to_clipboard(string)
-      require 'tempfile'
-      Tempfile.create('environment_printer') do |tmp_file|
-        File.write(tmp_file, string)
-        `cat '#{tmp_file.path}' | pbcopy`
-      end
+      require 'open3'
+      Open3.popen3('pbcopy') { |input, _, _| input << string }
     end
   end
 end


### PR DESCRIPTION
Tempfile::create was introduced in ruby 2.1.0

Using popen3 instead works on ruby 2.0.0 and is simpler since it doesn’t involve a temporary file at all.

Fixes #6945