### PR TITLE
[fastlane] Update `fastlane_version` action to show new update message

### DIFF
--- a/fastlane/lib/fastlane/actions/fastlane_version.rb
+++ b/fastlane/lib/fastlane/actions/fastlane_version.rb
@@ -12,12 +12,8 @@ module Fastlane
         UI.user_error!("Please pass minimum fastlane version as parameter to fastlane_version") unless defined_version
 
         if Gem::Version.new(Fastlane::VERSION) < defined_version
-          error_message = "The Fastfile requires a fastlane version of >= #{defined_version}. You are on #{Fastlane::VERSION}. "
-          if Helper.bundler?
-            error_message += "Please update using `bundle update fastlane`."
-          else
-            error_message += "Please update using `sudo gem update fastlane`."
-          end
+          FastlaneCore::UpdateChecker.show_update_message('fastlane', Fastlane::VERSION)
+          error_message = "The Fastfile requires a fastlane version of >= #{defined_version}. You are on #{Fastlane::VERSION}."
           UI.user_error!(error_message)
         end
 

--- a/fastlane/lib/fastlane/actions/update_fastlane.rb
+++ b/fastlane/lib/fastlane/actions/update_fastlane.rb
@@ -53,7 +53,7 @@ module Fastlane
           return
         end
 
-        unless updater.respond_to? :highest_installed_gems
+        unless updater.respond_to?(:highest_installed_gems)
           UI.important "The update_fastlane action requires rubygems version 2.1.0 or greater."
           UI.important "Please update your version of ruby gems before proceeding."
           UI.command "gem install rubygems-update"

--- a/fastlane/spec/actions_specs/fastlane_version_spec.rb
+++ b/fastlane/spec/actions_specs/fastlane_version_spec.rb
@@ -19,20 +19,24 @@ describe Fastlane do
         expect do
           # We have to clean ENV to be sure that Bundler environement is not defined.
           stub_const('ENV', {})
+          expect(FastlaneCore::Changelog).to receive(:show_changes).with("fastlane", Fastlane::VERSION)
+
           Fastlane::FastFile.new.parse("lane :test do
             fastlane_version '9999'
           end").runner.execute(:test)
-        end.to raise_error("The Fastfile requires a fastlane version of >= 9999. You are on #{Fastlane::VERSION}. Please update using `sudo gem update fastlane`.")
+        end.to raise_error("The Fastfile requires a fastlane version of >= 9999. You are on #{Fastlane::VERSION}.")
       end
 
       it "raises an exception if it's an old version in a bundler environement" do
         expect do
+          expect(FastlaneCore::Changelog).to receive(:show_changes).with("fastlane", Fastlane::VERSION)
+
           # Let's define BUNDLE_BIN_PATH in ENV to simulate a bundler environement
           stub_const('ENV', { 'BUNDLE_BIN_PATH' => '/fake/elsewhere' })
           Fastlane::FastFile.new.parse("lane :test do
             fastlane_version '9999'
           end").runner.execute(:test)
-        end.to raise_error("The Fastfile requires a fastlane version of >= 9999. You are on #{Fastlane::VERSION}. Please update using `bundle update fastlane`.")
+        end.to raise_error("The Fastfile requires a fastlane version of >= 9999. You are on #{Fastlane::VERSION}.")
       end
 
       it "raises an error if no team ID is given" do


### PR DESCRIPTION
Related to https://github.com/fastlane/fastlane/pull/6953, but no dependency

<img width="631" alt="screenshot 2016-11-10 17 19 21" src="https://cloud.githubusercontent.com/assets/869950/20201455/1c12b0e2-a76d-11e6-99ee-469a82561dd8.png">
<img width="581" alt="screenshot 2016-11-10 17 17 41" src="https://cloud.githubusercontent.com/assets/869950/20201457/1c135330-a76d-11e6-84ab-ff111b72649f.png">
<img width="592" alt="screenshot 2016-11-10 17 17 25" src="https://cloud.githubusercontent.com/assets/869950/20201456/1c133a26-a76d-11e6-995e-68db1fba38bc.png">
<img width="587" alt="screenshot 2016-11-10 17 16 39" src="https://cloud.githubusercontent.com/assets/869950/20201458/1c136e6a-a76d-11e6-8bcb-cd2a92e8c83a.png">
