### PR TITLE
[fastlane_core] Move update command to its own method

### DIFF
--- a/fastlane_core/lib/fastlane_core/update_checker/changelog.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/changelog.rb
@@ -19,7 +19,8 @@ module FastlaneCore
           break
         end
 
-        puts "\nPlease update using `#{UpdateChecker.update_command(gem_name: gem_name)}`".green if did_show_changelog
+        puts ""
+        puts "Please update using `#{UpdateChecker.update_command(gem_name: gem_name)}`".green if did_show_changelog
       rescue
         # Something went wrong, we don't care so much about this
       end

--- a/fastlane_core/lib/fastlane_core/update_checker/changelog.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/changelog.rb
@@ -4,18 +4,22 @@ module FastlaneCore
   class Changelog
     class << self
       def show_changes(gem_name, current_version)
+        did_show_changelog = false
+
         self.releases(gem_name).each_with_index do |release, index|
           next unless Gem::Version.new(release['tag_name']) > Gem::Version.new(current_version)
           puts ""
           puts release['name'].green
           puts release['body']
+          did_show_changelog = true
 
           next unless index == 2
           puts ""
           puts "To see all new releases, open https://github.com/fastlane/#{gem_name}/releases".green
           break
         end
-        puts "\nUpdate using 'sudo gem update #{gem_name.downcase}'".green
+
+        puts "\nPlease update using `#{UpdateChecker.update_command(gem_name: gem_name)}`".green if did_show_changelog
       rescue
         # Something went wrong, we don't care so much about this
       end

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -74,8 +74,7 @@ module FastlaneCore
     end
 
     # The command that the user should use to update their mac
-    def self.update_command(gem_name: nil)
-      gem_name ||= "fastlane"
+    def self.update_command(gem_name: "fastlane")
 
       if Helper.bundler?
         "bundle update #{gem_name.downcase}"

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -75,7 +75,6 @@ module FastlaneCore
 
     # The command that the user should use to update their mac
     def self.update_command(gem_name: "fastlane")
-
       if Helper.bundler?
         "bundle update #{gem_name.downcase}"
       elsif Helper.contained_fastlane?

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -47,25 +47,43 @@ module FastlaneCore
       end
     end
 
+    # Show a message to the user to update to a new version of fastlane (or a sub-gem)
+    # Use this method, as this will detect the current Ruby environment and show an
+    # appropriate message to the user
     def self.show_update_message(gem_name, current_version)
       available = server_results[gem_name]
       puts ""
       puts '#######################################################################'.green
-      puts "# #{gem_name} #{available} is available. You are on #{current_version}.".green
-      puts "# It is recommended to use the latest version.".green
-      if Helper.bundler?
-        puts "# Update using 'bundle update #{gem_name.downcase}'.".green
+      if available
+        puts "# #{gem_name} #{available} is available. You are on #{current_version}.".green
       else
-        puts "# Update using 'sudo gem update #{gem_name.downcase}'.".green
+        puts "# An update for #{gem_name} is available. You are on #{current_version}.".green
       end
+      puts "# It is recommended to use the latest version.".green
+      puts "# Please update using `#{self.update_command(gem_name: gem_name)}`.".green
+
       puts "# To see what's new, open https://github.com/fastlane/#{gem_name}/releases.".green if ENV["FASTLANE_HIDE_CHANGELOG"]
 
-      if Random.rand(5) == 1 && !Helper.bundler?
+      if !Helper.bundler? && !Helper.contained_fastlane? && Random.rand(5) == 1
+        # We want to show this message from time to time, if the user doesn't use bundler, nor bundled fastlane
         puts '#######################################################################'.green
         puts "# Run `sudo gem cleanup` from time to time to speed up fastlane".green
       end
       puts '#######################################################################'.green
       Changelog.show_changes(gem_name, current_version) unless ENV["FASTLANE_HIDE_CHANGELOG"]
+    end
+
+    # The command that the user should use to update their mac
+    def self.update_command(gem_name: nil)
+      gem_name ||= "fastlane"
+
+      if Helper.bundler?
+        "bundle update #{gem_name.downcase}"
+      elsif Helper.contained_fastlane?
+        "fastlane update_fastlane"
+      else
+        "sudo gem update #{gem_name.downcase}"
+      end
     end
 
     # Generate the URL on the main thread (since we're switching directory)

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -36,6 +36,31 @@ describe FastlaneCore do
       end
     end
 
+    describe "#update_command" do
+      before do
+        ENV.delete("BUNDLE_BIN_PATH")
+        ENV.delete("BUNDLE_GEMFILE")
+      end
+
+      it "works a custom gem name" do
+        expect(FastlaneCore::UpdateChecker.update_command(gem_name: "gym")).to eq("sudo gem update gym")
+      end
+
+      it "works with system ruby" do
+        expect(FastlaneCore::UpdateChecker.update_command).to eq("sudo gem update fastlane")
+      end
+
+      it "works with bundler" do
+        ENV["BUNDLE_BIN_PATH"] = "/tmp"
+        expect(FastlaneCore::UpdateChecker.update_command).to eq("bundle update fastlane")
+      end
+
+      it "works with bundled fastlane" do
+        ENV["SELF_CONTAINED"] = "true"
+        expect(FastlaneCore::UpdateChecker.update_command).to eq("fastlane update_fastlane")
+      end
+    end
+
     describe "#p_hash?" do
       let (:package_name) { 'com.test.app' }
 


### PR DESCRIPTION
- Better support for bundled fastlane update command
- Little refactoring to make the code nicer
- Don’t show `gem cleanup` message for bundled fastlane
- Add tests for that

Related to https://github.com/fastlane/fastlane/pull/6952, but no dependency

<img width="631" alt="screenshot 2016-11-10 17 19 21" src="https://cloud.githubusercontent.com/assets/869950/20201455/1c12b0e2-a76d-11e6-99ee-469a82561dd8.png">
<img width="581" alt="screenshot 2016-11-10 17 17 41" src="https://cloud.githubusercontent.com/assets/869950/20201457/1c135330-a76d-11e6-84ab-ff111b72649f.png">
<img width="592" alt="screenshot 2016-11-10 17 17 25" src="https://cloud.githubusercontent.com/assets/869950/20201456/1c133a26-a76d-11e6-995e-68db1fba38bc.png">
<img width="587" alt="screenshot 2016-11-10 17 16 39" src="https://cloud.githubusercontent.com/assets/869950/20201458/1c136e6a-a76d-11e6-8bcb-cd2a92e8c83a.png">
