### PR TITLE
[snapshot] support --force on reset_simulators

### DIFF
--- a/snapshot/lib/snapshot/commands_generator.rb
+++ b/snapshot/lib/snapshot/commands_generator.rb
@@ -64,13 +64,14 @@ module Snapshot
         c.syntax = 'snapshot reset_simulators'
         c.description = "This will remove all your existing simulators and re-create new ones"
         c.option '-i', '--ios String', String, 'The comma separated list of iOS Versions you want to use'
+        c.option '--force', 'Disables confirmation prompts'
 
         c.action do |args, options|
           options.default ios_version: Snapshot::LatestOsVersion.ios_version
           versions = options.ios_version.split(',') if options.ios_version
           require 'snapshot/reset_simulators'
 
-          Snapshot::ResetSimulators.clear_everything!(versions)
+          Snapshot::ResetSimulators.clear_everything!(versions, options.force)
         end
       end
 

--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -1,11 +1,11 @@
 module Snapshot
   class ResetSimulators
-    def self.clear_everything!(ios_versions)
+    def self.clear_everything!(ios_versions, force = false)
       # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       # !! Warning: This script will remove all your existing simulators !!
       # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-      sure = true if ENV["SNAPSHOT_FORCE_DELETE"]
+      sure = true if ENV["SNAPSHOT_FORCE_DELETE"] ||  force
       sure = agree("Are you sure? All your simulators will be DELETED and new ones will be created! (y/n)".red, true) unless sure
       UI.user_error!("User cancelled action") unless sure
 


### PR DESCRIPTION
as discussed here: https://github.com/fastlane/fastlane/issues/6927

enables: `snapshot reset_simulators --force`