### PR TITLE
Use HTTPS to download root certificate in UpdateProjectProvisioningAction 🔒

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -5,7 +5,7 @@ module Fastlane
     end
 
     class UpdateProjectProvisioningAction < Action
-      ROOT_CERTIFICATE_URL = "http://www.apple.com/appleca/AppleIncRootCertificate.cer"
+      ROOT_CERTIFICATE_URL = "https://www.apple.com/appleca/AppleIncRootCertificate.cer"
       def self.run(params)
         UI.message("You’re updating provisioning profiles directly in your project, but have you considered easier ways to do code signing?")
         UI.message("https://docs.fastlane.tools/codesigning/GettingStarted/")


### PR DESCRIPTION
This root certificate path is hardcoded to http://www.apple.com/appleca/AppleIncRootCertificate.cer currently, which is also available over HTTPS. It's almost always better to fetch over HTTPS if available.

- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)