### PR TITLE
[spaceship] Fixes on the documentation

### DIFF
--- a/spaceship/docs/iTunesConnect.md
+++ b/spaceship/docs/iTunesConnect.md
@@ -267,7 +267,7 @@ There are 3 types of testers:
 
 - **External testers**: usually not part of your team. You can invite up to 1000/2000 external testers. Before distributing a build to those testers you need to submit your app to beta review.
 - **Internal testers**: Employees that are registered in your iTunes Connect team. They get access to all builds without having to wait for review.
-**Sandbox testers**: Dummy accounts to test development-mode apps with in-app purchase or Apple Pay.
+- **Sandbox testers**: Dummy accounts to test development-mode apps with in-app purchase or Apple Pay.
 
 ```ruby
 # Find an internal tester based on the email address
@@ -296,9 +296,12 @@ app.add_external_tester!(email: "github@krausefx.com", first_name: "Felix", last
 Right now, `spaceship` can't modify or create internal testers.
 
 # Load all sandbox testers
+```ruby
 testers = Spaceship::Tunes::SandboxTester.all
+```
 
 # Create a sandbox tester
+```ruby
 testers = Spaceship::Tunes::SandboxTester.create!(
   email: 'sandbox@test.com', # required
   password: 'Passwordtest1', # required. Must contain >=8 characters, >=1 uppercase, >=1 lowercase, >=1 numeric.
@@ -306,12 +309,17 @@ testers = Spaceship::Tunes::SandboxTester.create!(
   first_name: 'Steve', # optional, defaults to 'Test'
   last_name: 'Brule', # optional, defaults to 'Test'
 )
+```
 
 # Delete sandbox testers by email
+```ruby
 Spaceship::Tunes::SandboxTester.delete!(['sandbox@test.com', 'sandbox2@test.com'])
+```
 
 # Delete all sandbox testers
+```ruby
 Spaceship::Tunes::SandboxTester.delete_all!
+```
 
 ## App ratings & reviews
 


### PR DESCRIPTION
🤓 Just some markdown format fixes on the documentation of spaceship

- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1: