### PR TITLE
Allow commit_version_bump to find the Settings.bundle in the project

### DIFF
--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -146,7 +146,7 @@ module Fastlane
                                        optional: true,
                                        default_value: false,
                                        is_string: false),
-          FastlaneCore::ConfigItem.new(key: :include_settings,
+          FastlaneCore::ConfigItem.new(key: :settings,
                                        env_name: "FL_COMMIT_INCLUDE_SETTINGS",
                                        description: "Include Settings.bundle/Root.plist with version bump",
                                        optional: true,

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -206,6 +206,7 @@ module Fastlane
 
       class << self
         private
+
         def settings_bundle_file_path(xcodeproj_path, settings_file_name)
           require 'xcodeproj'
           project = Xcodeproj::Project.open xcodeproj_path

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -68,8 +68,8 @@ module Fastlane
         expected_changed_files << pbxproj_path
         expected_changed_files << info_plist_files
 
-        if params[:settings]
-          settings_plists_from_param(params[:settings]).each do |file|
+        if params[:include_settings]
+          settings_plists_from_param(params[:include_settings]).each do |file|
             settings_file_pathname = Pathname.new settings_bundle_file_path(project, file)
             expected_changed_files << settings_file_pathname.relative_path_from(repo_pathname).to_s
           end

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -146,7 +146,7 @@ module Fastlane
                                        optional: true,
                                        default_value: false,
                                        is_string: false),
-          FastlaneCore::ConfigItem.new(key: :settings,
+          FastlaneCore::ConfigItem.new(key: :include_settings,
                                        env_name: "FL_COMMIT_INCLUDE_SETTINGS",
                                        description: "Include Settings.bundle/Root.plist with version bump",
                                        optional: true,

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -70,7 +70,7 @@ module Fastlane
 
         if params[:settings]
           settings_plists_from_param(params[:settings]).each do |file|
-            settings_file_pathname = Pathname.new settings_bundle_file_path(xcodeproj_path, file)
+            settings_file_pathname = Pathname.new settings_bundle_file_path(project, file)
             expected_changed_files << settings_file_pathname.relative_path_from(repo_pathname).to_s
           end
         end
@@ -212,13 +212,11 @@ module Fastlane
           ["Root.plist"]
         end
 
-        def settings_bundle_file_path(xcodeproj_path, settings_file_name)
-          require 'xcodeproj'
-          project = Xcodeproj::Project.open xcodeproj_path
+        def settings_bundle_file_path(project, settings_file_name)
           settings_bundle = project.files.find { |f| f.path =~ /Settings.bundle/ }
           raise "No Settings.bundle in project" if settings_bundle.nil?
 
-          project_parent = File.dirname xcodeproj_path
+          project_parent = File.dirname project.path
           File.join(project_parent, settings_bundle.path, settings_file_name)
         end
       end

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -68,8 +68,8 @@ module Fastlane
         expected_changed_files << pbxproj_path
         expected_changed_files << info_plist_files
 
-        if params[:include_settings]
-          settings_plists_from_param(params[:include_settings]).each do |file|
+        if params[:settings]
+          settings_plists_from_param(params[:settings]).each do |file|
             settings_file_pathname = Pathname.new settings_bundle_file_path(project, file)
             expected_changed_files << settings_file_pathname.relative_path_from(repo_pathname).to_s
           end

--- a/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
+++ b/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
@@ -33,7 +33,7 @@ describe Fastlane::Actions::CommitVersionBumpAction do
 
       expect do
         action.settings_bundle_file_path xcodeproj, "Root.plist"
-      end.to raise_error
+      end.to raise_error RuntimeError
     end
   end
 end

--- a/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
+++ b/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
@@ -1,0 +1,39 @@
+describe Fastlane::Actions::CommitVersionBumpAction do
+  let (:action) { Fastlane::Actions::CommitVersionBumpAction }
+
+  describe 'settings_plists_from_param' do
+    it 'returns the param in an array if a String' do
+      settings_plists = action.settings_plists_from_param "About.plist"
+      expect(settings_plists).to eq ["About.plist"]
+    end
+
+    it 'returns the param if an Array' do
+      settings_plists = action.settings_plists_from_param ["About.plist", "Root.plist"]
+      expect(settings_plists).to eq ["About.plist", "Root.plist"]
+    end
+
+    it 'returns ["Root.plist"] for any other input' do
+      settings_plists = action.settings_plists_from_param true
+      expect(settings_plists).to eq ["Root.plist"]
+    end
+  end
+
+  describe 'settings_bundle_file_path' do
+    it 'returns the path of a file in the settings bundle from an Xcodeproj::Project' do
+      settings_bundle = double "file", path: "MyApp/Settings.bundle"
+      xcodeproj = double "xcodeproj", files: [settings_bundle], path: "./MyApp.xcodeproj"
+
+      file_path = action.settings_bundle_file_path xcodeproj, "Root.plist"
+
+      expect(file_path).to eq "./MyApp/Settings.bundle/Root.plist"
+    end
+
+    it 'raises if no settings bundle in the project' do
+      xcodeproj = double "xcodeproj", files: []
+
+      expect do
+        action.settings_bundle_file_path xcodeproj, "Root.plist"
+      end.to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x ] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
 Some tests are failing in master and continue to fail here. This action actually has no tests. I may add some.
- [x ] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x ] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x ] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:


Please see issue #5758.

This change allows the `commit_version_bump` action to infer the location of the Settings.bundle from the project. It also adds a new optional :settings_file parameter that allows the user to specify a plist file in the Settings.bundle other than Root.plist.
