### PR TITLE
Fix destination directory when device internal storage is used

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -286,7 +286,7 @@ module Screengrab
         # directory for the screenshots, so we'll try to remove that path from the directory name when
         # creating the destination path.
         # See: https://github.com/fastlane/fastlane/pull/4915#issuecomment-236368649
-        dest_dir = dest_dir.gsub('screengrab/', '')
+        dest_dir = dest_dir.gsub(%r{(app_)?screengrab/}, '')
 
         # We then replace the last segment of the screenshots directory path with the device_type
         # specific name, as expected by supply


### PR DESCRIPTION
- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)
---
When screenshots are saved into internal storage, the directory is `app_screengrab` instead of `screengrab`, see determine_internal_screenshots_path in screengrab/lib/screengrab/runner.rb

The screenshots would end up in fastlane/metadata/android/app_en-US instead of fastlane/metadata/android/en-US