### PR TITLE
[sigh] expand_path on resign

### DIFF
--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -27,7 +27,10 @@ module Sigh
       # validate that we have valid values for all these params, we don't need to check signing_identity because `find_signing_identity` will only ever return a valid value
       validate_params(resign_path, ipa, provisioning_profiles)
       entitlements = "-e #{entitlements.shellescape}" if entitlements
-      provisioning_options = provisioning_profiles.map { |fst, snd| "-p #{[fst, snd].compact.map(&:shellescape).join('=')}" }.join(' ')
+      provisioning_options = provisioning_profiles.map do |fst, snd|
+        fst = File.expand_path(fst)
+        "-p #{[fst, snd].compact.map(&:shellescape).join('=')}"
+      end.join(' ')
       version = "-n #{version}" if version
       display_name = "-d #{display_name.shellescape}" if display_name
       short_version = "--short-version #{short_version}" if short_version

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -35,7 +35,7 @@ module Sigh
       #     "at.fastlane.today" => "/folder/mobile.mobileprovision"
       #   }
       # or an array
-      # ( resign.sh also takes "-p /folder/mobile.mobileprovision" as a param
+      # (resign.sh also takes "-p /folder/mobile.mobileprovision" as a param)
       #   [
       #        "/folder/mobile.mobileprovision"
       #   ]

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -28,11 +28,17 @@ module Sigh
       validate_params(resign_path, ipa, provisioning_profiles)
       entitlements = "-e #{entitlements.shellescape}" if entitlements
 
-      # provisioning_profiles is passed as a hash:
+      # provisioning_profiles is passed either a hash (to be able to resign extensions/nested apps):
+      # (in that case the underlying resign.sh expects values given as "-p at.fastlane=/folder/mobile.mobileprovision -p at.fastlane.today=/folder/mobile.mobileprovision")
       #   {
       #     "at.fastlane" => "/folder/mobile.mobileprovision",
       #     "at.fastlane.today" => "/folder/mobile.mobileprovision"
       #   }
+      # or an array
+      # ( resign.sh also takes "-p /folder/mobile.mobileprovision" as a param
+      #   [ 
+      #        "/folder/mobile.mobileprovision"
+      #   ] 
       provisioning_options = provisioning_profiles.map do |app_id, app_id_prov|
         app_id = File.expand_path(app_id)
         "-p #{[app_id, app_id_prov].compact.map(&:shellescape).join('=')}"

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -27,9 +27,15 @@ module Sigh
       # validate that we have valid values for all these params, we don't need to check signing_identity because `find_signing_identity` will only ever return a valid value
       validate_params(resign_path, ipa, provisioning_profiles)
       entitlements = "-e #{entitlements.shellescape}" if entitlements
-      provisioning_options = provisioning_profiles.map do |fst, snd|
-        fst = File.expand_path(fst)
-        "-p #{[fst, snd].compact.map(&:shellescape).join('=')}"
+
+      # provisioning_profiles is passed as a hash:
+      #   {
+      #     "at.fastlane" => "/folder/mobile.mobileprovision",
+      #     "at.fastlane.today" => "/folder/mobile.mobileprovision"
+      #   }
+      provisioning_options = provisioning_profiles.map do |app_id, app_id_prov|
+        app_id = File.expand_path(app_id)
+        "-p #{[app_id, app_id_prov].compact.map(&:shellescape).join('=')}"
       end.join(' ')
       version = "-n #{version}" if version
       display_name = "-d #{display_name.shellescape}" if display_name

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -36,9 +36,9 @@ module Sigh
       #   }
       # or an array
       # ( resign.sh also takes "-p /folder/mobile.mobileprovision" as a param
-      #   [ 
+      #   [
       #        "/folder/mobile.mobileprovision"
-      #   ] 
+      #   ]
       provisioning_options = provisioning_profiles.map do |app_id, app_id_prov|
         app_id = File.expand_path(app_id)
         "-p #{[app_id, app_id_prov].compact.map(&:shellescape).join('=')}"


### PR DESCRIPTION
expand_path on resign so `~/Downloads/1.mobileprovision` will work.

as discussed here: https://github.com/fastlane/fastlane/issues/6986