### PR TITLE
Adding bitrise.io git_branch ENV variable check

### DIFF
--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -7,6 +7,7 @@ module Fastlane
       def self.run(params)
         return ENV['GIT_BRANCH'] if ENV['GIT_BRANCH']
         return ENV["TRAVIS_BRANCH"] if ENV["TRAVIS_BRANCH"]
+        return ENV["BITRISE_GIT_BRANCH"] if ENV["BITRISE_GIT_BRANCH"]
         `git symbolic-ref HEAD --short 2>/dev/null`.strip
       end
 


### PR DESCRIPTION
The git_branch action seems to return an empty string when run in bitrise.io.
I added the ENV check for BITRISE_GIT_BRANCH (listed in BITRISE_GIT_BRANCH).