### PR TITLE
Pass generated Fastfile ID through to enhancer

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -190,6 +190,8 @@ module Fastlane
     end
 
     def generated_fastfile_id(id)
+      # This value helps us track success/failure metrics for Fastfiles we
+      # generate as part of an automated process.
       ENV['GENERATED_FASTFILE_ID'] = id
     end
 

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -189,6 +189,10 @@ module Fastlane
       FastlaneRequire.install_gem_if_needed(gem_name: gem_name, require_gem: true)
     end
 
+    def generated_fastfile_id(id)
+      ENV['GENERATED_FASTFILE_ID'] = id
+    end
+
     def import(path = nil)
       UI.user_error!("Please pass a path to the `import` action") unless path
 

--- a/fastlane_core/lib/fastlane_core/tool_collector.rb
+++ b/fastlane_core/lib/fastlane_core/tool_collector.rb
@@ -67,7 +67,8 @@ module FastlaneCore
         versions: versions.to_json,
         steps: launches.to_json,
         error: @error,
-        crash: @crash ? @error : nil
+        crash: @crash ? @error : nil,
+        fastfile_id: ENV["GENERATED_FASTFILE_ID"]
       )
 
       if Helper.is_test? # don't send test data

--- a/fastlane_core/lib/fastlane_core/tool_collector.rb
+++ b/fastlane_core/lib/fastlane_core/tool_collector.rb
@@ -61,6 +61,8 @@ module FastlaneCore
         show_message
       end
 
+      # `fastfile_id` helps us track success/failure metrics for Fastfiles we
+      # generate as part of an automated process.
       require 'excon'
       url = HOST_URL + '/did_launch?'
       url += URI.encode_www_form(


### PR DESCRIPTION
`generated_fastfile_id` will be a special "action" used to track Fastfiles which are automatically generated by tools. This will allow us to understand how often they succeed vs. fail through enhancer