### PR TITLE
Anonymize paths in `fastlane env` output

### DIFF
--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -207,15 +207,15 @@ module Fastlane
         "Ruby" => RUBY_VERSION,
         "Bundler?" => Helper.bundler?,
         "Git" => `git --version`.strip.split("\n").first,
-        "Installation Source" => $PROGRAM_NAME,
+        "Installation Source" => anonymized_path($PROGRAM_NAME),
         "Host" => "#{product} #{version} (#{build})",
-        "Ruby Lib Dir" => RbConfig::CONFIG['libdir'],
+        "Ruby Lib Dir" => anonymized_path(RbConfig::CONFIG['libdir']),
         "OpenSSL Version" => OpenSSL::OPENSSL_VERSION,
         "Is contained" => Helper.contained_fastlane?.to_s
       }
 
       if Helper.mac?
-        table_content["Xcode Path"] = Helper.xcode_path
+        table_content["Xcode Path"] = anonymized_path(Helper.xcode_path)
         table_content["Xcode Version"] = Helper.xcode_version
       end
 
@@ -268,6 +268,10 @@ module Fastlane
       end
       env_output << "\n\n"
       env_output
+    end
+
+    def self.anonymized_path(path, home = ENV['HOME'])
+      return home ? path.gsub(%r{^#{home}(?=/(.*)|$)}, '~\2') : path
     end
 
     # Copy a given string into the clipboard

--- a/fastlane/spec/env_spec.rb
+++ b/fastlane/spec/env_spec.rb
@@ -34,5 +34,12 @@ describe Fastlane do
       expect(env).to include("Xcode Version")
       expect(env).to include("OpenSSL")
     end
+
+    it "anonymizes a path containing the user’s home" do
+      expect(Fastlane::EnvironmentPrinter.anonymized_path('/Users/john/.fastlane/bin/bundle/bin/fastlane', '/Users/john')).to eq('~/.fastlane/bin/bundle/bin/fastlane')
+      expect(Fastlane::EnvironmentPrinter.anonymized_path('/Users/john', '/Users/john')).to eq('~')
+      expect(Fastlane::EnvironmentPrinter.anonymized_path('/Users/john/', '/Users/john')).to eq('~/')
+      expect(Fastlane::EnvironmentPrinter.anonymized_path('/workspace/project/test', '/work')).to eq('/workspace/project/test')
+    end
   end
 end


### PR DESCRIPTION
- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

---

This way, the username is not leaked. Also, it makes it easy to visually spot when a path is in the user’s home directory.