### PR TITLE
[fastlane] Anonymize capture_output and env 👻

### DIFF
--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -21,6 +21,7 @@ module Fastlane
       if $capture_output
         # Trace mode is enabled
         # redirect STDOUT and STDERR
+        puts "Capturing Output.....".yellow
         out_channel = StringIO.new
         $stdout = out_channel
         $stderr = out_channel

--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -2,6 +2,17 @@ module Fastlane
   class EnvironmentPrinter
     def self.output
       env_info = get
+      # UI.important is not working here, as it does not survive the $stdout/$stderr redirect,
+      # so use .yellow directly here :)
+      puts "To protect your privacy".yellow
+      puts "Enter strings that you want to be removed/replaced - one by each line, end input with: END".yellow
+      puts "e.g.:".yellow
+      puts "      my.app.id".yellow
+      puts "      my-company-name".yellow
+      user_input = STDIN.gets("END\n").gsub("END\n", "").strip
+      user_input.split("\n").each do |privacy_word|
+        env_info.gsub!(privacy_word, "_-removed-_")
+      end
       puts env_info
       if FastlaneCore::Helper.mac? && UI.interactive? && UI.confirm("🙄  Wow, that's a lot of markdown text... should fastlane put it into your clipboard, so you can easily paste it on GitHub?")
         copy_to_clipboard(env_info)
@@ -29,6 +40,7 @@ module Fastlane
       final_output = ""
 
       if $captured_output
+        $captured_output.delete!("`") # just in case strip out `
         final_output << "### Captured Output\n\n"
         final_output << "Command Used: `#{ARGV.join(' ')}`\n"
         final_output << "<details><summary>Output/Log</summary>\n\n```\n\n#{$captured_output}\n\n```\n\n</details>\n\n"


### PR DESCRIPTION
This one - asks the user for input after `env`  - or `--capture_output`
to enter strings, one by each line - ending with `END`

this strings will later on removed from the output.

sample:
![bildschirmfoto 2016-11-16 um 14 24 03](https://cloud.githubusercontent.com/assets/2891702/20349049/d827a6a8-ac08-11e6-98d0-8162d186c1ee.png)


inspired by: https://github.com/fastlane/fastlane/pull/7037

hopefully this - helps users get their private info not leaked (e.g: fastfile) - and not having to edit the output by hand (which leads to many errors)


this PR also does:
  * add output when capturing is started
  * strips backticks out of `capture_output` - to prevent possible break of markdown.

output looks like: 

### Captured Output

Command Used: `demo`
<details><summary>Output/Log</summary>

```

[14:23:50]: You require a gem, please call fastlane_require 'spaceship' before to ensure the gem is installed
[14:23:50]: Driving the lane 'demo' 🚀
[14:23:50]: Building: 
[14:23:50]: fastlane.tools finished successfully 🎉


```

</details>

<details><summary>✅ fastlane environment ✅</summary>

### Stack

| Key                 | Value                                               |
| ------------------- | --------------------------------------------------- |
| OS                  | 10.12.1                                             |
| Ruby                | 2.2.1                                               |
| Bundler?            | true                                                |
| Git                 | git version 2.10.0                                  |
| Installation Source | /Users/_-removed-_/.rvm/gems/ruby-2.2.1/bin/fastlane |
| Host                | Mac OS X 10.12.1 (16B2555)                          |
| Ruby Lib Dir        | /Users/_-removed-_/.rvm/rubies/ruby-2.2.1/lib        |
| OpenSSL Version     | OpenSSL 1.0.2h  3 May 2016                          |
| Is contained        | false                                               |
| Xcode Path          | /Applications/Xcode.app/Contents/Developer/         |
| Xcode Version       | 8.1                                                 |


### System Locale

| Variable | Value       |   |
| -------- | ----------- | - |
| LANG     | de_AT.UTF-8 | ✅ |
| LC_ALL   |             |   |
| LANGUAGE |             |   |


### fastlane files:

<details><summary>`./fastlane/Fastfile`</summary>

```ruby
$self_idfs = ['_-removed-_.sticker-test', '_-removed-_.sticker-test.sticker-extension']
$cert_repo = 'ssh://git@_-removed-_._-removed-_/mobile/IOS-CERTIFICATES.git'

lane :dd do
	match(git_url: $cert_repo,
        type: 'appstore',
        app_identifier: $self_idfs)


end

lane :commandline do
	 #gym(scheme: "commandline", output_name: "commandline", project: "gym/examples/commandline/commandline.xcodeproj", clean: false)	
	 gym(scheme: "library", output_name: "commandline", project: "gym/examples/commandline/commandline.xcodeproj", clean: false)	
end

lane :get_prod_build_nr do
    require 'spaceship'
    Spaceship::Tunes.login
    app = Spaceship::Tunes::Application.find("_-removed-_-fivexfive")
    version = app.live_version
    latest_prod_build_nr = version.raw_data["preReleaseBuild"]["buildVersion"]
    puts "#{latest_prod_build_nr}"
end

lane :demo do | options | 
	puts "Building: #{options[:app_identifier]}"
end
```
</details>

<details><summary>`./fastlane/Appfile`</summary>

```ruby
app_identifier "_-removed-_.sticker-test" # The bundle identifier of your app
apple_id "helmut@januschka.com" # Your Apple email address
```
</details>

### fastlane gems

| Gem                 | Version | Update-Status |
| ------------------- | ------- | ------------- |
| credentials_manager | 0.16.2  | ✅ Up-To-Date  |
| fastlane_core       | 0.55.1  | ✅ Up-To-Date  |
| spaceship           | 0.37.0  | ✅ Up-To-Date  |
| cert                | 1.4.4   | ✅ Up-To-Date  |
| deliver             | 1.15.0  | ✅ Up-To-Date  |
| frameit             | 3.0.0   | ✅ Up-To-Date  |
| gym                 | 1.12.0  | ✅ Up-To-Date  |
| sigh                | 1.11.2  | ✅ Up-To-Date  |
| match               | 0.11.0  | ✅ Up-To-Date  |
| pem                 | 1.4.0   | ✅ Up-To-Date  |
| pilot               | 1.12.0  | ✅ Up-To-Date  |
| produce             | 1.3.0   | ✅ Up-To-Date  |
| scan                | 0.14.1  | ✅ Up-To-Date  |
| screengrab          | 0.5.6   | ✅ Up-To-Date  |
| snapshot            | 1.16.3  | ✅ Up-To-Date  |
| supply              | 0.7.1   | ✅ Up-To-Date  |
| fastlane            | 1.109.0 | ✅ Up-To-Date  |


### Loaded fastlane plugins:

**No plugins Loaded**


<details><summary><b>Loaded gems</b></summary>

| Gem                       | Version      |
| ------------------------- | ------------ |
| rake                      | 11.3.0       |
| CFPropertyList            | 2.3.3        |
| i18n                      | 0.7.0        |
| json                      | 1.8.3        |
| minitest                  | 5.9.1        |
| thread_safe               | 0.3.5        |
| tzinfo                    | 1.2.2        |
| activesupport             | 4.2.7.1      |
| public_suffix             | 2.0.4        |
| addressable               | 2.5.0        |
| ast                       | 2.3.0        |
| babosa                    | 1.0.2        |
| builder                   | 3.2.2        |
| bundler                   | 1.13.6       |
| byebug                    | 9.0.6        |
| colored                   | 1.2          |
| highline                  | 1.7.8        |
| commander                 | 4.4.0        |
| security                  | 0.1.3        |
| credentials_manager       | 0.16.2       |
| excon                     | 0.54.0       |
| gh_inspector              | 1.0.2        |
| multi_json                | 1.12.1       |
| plist                     | 3.2.0        |
| rubyzip                   | 1.1.7        |
| terminal-table            | 1.4.5        |
| fastlane_core             | 0.55.1       |
| multipart-post            | 2.0.0        |
| faraday                   | 0.9.2        |
| unf_ext                   | 0.0.7.2      |
| unf                       | 0.1.4        |
| domain_name               | 0.5.20161021 |
| http-cookie               | 1.0.3        |
| faraday-cookie_jar        | 0.0.6        |
| faraday_middleware        | 0.10.1       |
| fastimage                 | 1.6.8        |
| multi_xml                 | 0.5.5        |
| claide                    | 1.0.1        |
| cork                      | 0.2.0        |
| nap                       | 1.1.0        |
| open4                     | 1.3.4        |
| claide-plugins            | 0.9.2        |
| coderay                   | 1.1.1        |
| docile                    | 1.1.5        |
| simplecov-html            | 0.10.0       |
| simplecov                 | 0.12.0       |
| tins                      | 1.12.0       |
| term-ansicolor            | 1.4.0        |
| thor                      | 0.19.1       |
| coveralls                 | 0.8.15       |
| safe_yaml                 | 1.0.4        |
| crack                     | 0.4.3        |
| faraday-http-cache        | 1.3.1        |
| git                       | 1.3.0        |
| sawyer                    | 0.8.0        |
| octokit                   | 4.6.0        |
| redcarpet                 | 3.3.4        |
| danger                    | 0.10.1       |
| diff-lcs                  | 1.2.5        |
| dotenv                    | 2.1.1        |
| fakefs                    | 0.8.1        |
| mini_magick               | 4.5.1        |
| rouge                     | 1.11.1       |
| xcpretty                  | 0.2.4        |
| net-ssh                   | 3.2.0        |
| net-sftp                  | 2.1.2        |
| krausefx-shenzhen         | 0.14.11      |
| slack-notifier            | 1.5.1        |
| xcpretty-travis-formatter | 0.0.4        |
| jwt                       | 1.5.6        |
| little-plugger            | 1.1.4        |
| logging                   | 2.1.0        |
| memoist                   | 0.15.0       |
| os                        | 0.9.6        |
| signet                    | 0.7.3        |
| googleauth                | 0.5.1        |
| httpclient                | 2.8.2.4      |
| hurley                    | 0.2          |
| mime-types                | 1.25.1       |
| uber                      | 0.0.15       |
| representable             | 2.3.0        |
| retriable                 | 2.1.0        |
| google-api-client         | 0.9.20       |
| terminal-notifier         | 1.7.1        |
| word_wrap                 | 1.0.0        |
| xcode-install             | 2.0.9        |
| nanaimo                   | 0.2.2        |
| xcodeproj                 | 1.4.1        |
| method_source             | 0.8.2        |
| parser                    | 2.3.1.4      |
| powerpack                 | 0.1.1        |
| slop                      | 3.6.0        |
| pry                       | 0.10.4       |
| pry-byebug                | 3.4.0        |
| rainbow                   | 2.1.0        |
| rest-client               | 1.6.9        |
| rspec-support             | 3.1.2        |
| rspec-core                | 3.1.7        |
| rspec-expectations        | 3.1.2        |
| rspec-mocks               | 3.1.3        |
| rspec                     | 3.1.0        |
| rspec_junit_formatter     | 0.2.3        |
| ruby-progressbar          | 1.8.1        |
| unicode-display_width     | 1.1.1        |
| rubocop                   | 0.44.1       |
| webmock                   | 1.19.0       |
| yard                      | 0.8.7.6      |
</details>


*generated on:* **2016-11-16**
</details>

