### PR TITLE
Creating new version for Mac apps now works

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -35,8 +35,10 @@ module Deliver
     def verify_version
       app_version = options[:app_version]
       UI.message("Making sure the latest version on iTunes Connect matches '#{app_version}' from the ipa file...")
-
-      changed = options[:app].ensure_version!(app_version)
+      
+      #Pass platform argument to correctly create new version on iTunes Connect if needed
+      changed = options[:app].ensure_version!(app_version, options[:pkg] ? 'osx' : 'ios')
+      
       if changed
         UI.success("Successfully set the version to '#{app_version}'")
       else

--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -156,12 +156,12 @@ module Spaceship
       # Create a new version of your app
       # Since we have stored the outdated raw_data, we need to refresh this object
       # otherwise `edit_version` will return nil
-      def create_version!(version_number)
+      def create_version!(version_number, platform = 'ios')
         if edit_version
           raise "Cannot create a new version for this app as there already is an `edit_version` available"
         end
 
-        client.create_version!(apple_id, version_number)
+        client.create_version!(apple_id, version_number, platform)
 
         # Future: implemented -reload method
       end
@@ -170,7 +170,7 @@ module Spaceship
       # This will either create a new version or change the version number
       # from an existing version
       # @return (Bool) Was something changed?
-      def ensure_version!(version_number)
+      def ensure_version!(version_number, platform = 'ios')
         if (e = edit_version)
           if e.version.to_s != version_number.to_s
             # Update an existing version
@@ -180,7 +180,7 @@ module Spaceship
           end
           return false
         else
-          create_version!(version_number)
+          create_version!(version_number, platform)
           return true
         end
       end


### PR DESCRIPTION
It's a simple fix discussed [here](https://github.com/fastlane/fastlane/issues/6152) with @TKBurner 

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:
