### PR TITLE
[fastlane] Version Bump

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '1.109.0'.freeze
+  VERSION = '1.110.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps"
 end


### PR DESCRIPTION
* Update `fastlane_core` dependency to 0.56.0. (#7045)
* Deprecate SIGH_UDID in favor of corrected SIGH_UUID (#6339)
* Remove .positive? to support ruby < 2.3 (#7036)
* Explain why Xcode project needs setup for version and build number handling (#7033)
* Add option to provide -framework option for archive Carthage command, fixes #6061 (#6106)
* Adding bitrise.io git_branch ENV variable check (#7011)
* ensure no WIP in changelog (#7029)
* Update `fastlane_version` action to show new update message (#6952)
* fail_build expecting a string, fixes #7023 (#7024)