### PR TITLE
Add allow() to fix running unit tests on Sierra

### DIFF
--- a/fastlane/spec/actions_specs/import_certificate_spec.rb
+++ b/fastlane/spec/actions_specs/import_certificate_spec.rb
@@ -9,8 +9,12 @@ describe Fastlane do
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
         expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
+        # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" #{keychain_path.shellescape} &> /dev/null"
+
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
+        allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: false)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: false)
 
         Fastlane::FastFile.new.parse("lane :test do
@@ -30,8 +34,12 @@ describe Fastlane do
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
         expected_command = "security import #{cert_name.shellescape} -k '#{keychain_path.shellescape}' -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
+        # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" #{keychain_path.shellescape} &> /dev/null"
+
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
+        allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: false)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: false)
 
         Fastlane::FastFile.new.parse("lane :test do
@@ -51,8 +59,12 @@ describe Fastlane do
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
         expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security"
 
+        # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" #{keychain_path.shellescape}"
+
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
+        allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: true)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: true)
 
         Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

