### PR TITLE
[match] refactor match to use keychain_path *2/3*

### DIFF
--- a/match/lib/match/generator.rb
+++ b/match/lib/match/generator.rb
@@ -11,7 +11,7 @@ module Match
         force: true, # we don't need a certificate without its private key, we only care about a new certificate
         username: params[:username],
         team_id: params[:team_id],
-        keychain_path: Utils.keychain_path(params[:keychain_name])
+        keychain_path: FastlaneCore::Helper.keychain_path(params[:keychain_name])
       })
 
       Cert.config = arguments

--- a/match/lib/match/utils.rb
+++ b/match/lib/match/utils.rb
@@ -1,34 +1,8 @@
 module Match
   class Utils
     def self.import(item_path, keychain, password: "")
-      keychain_path = self.keychain_path(keychain)
+      keychain_path = FastlaneCore::Helper.keychain_path(keychain)
       FastlaneCore::KeychainImporter.import_file(item_path, keychain_path, keychain_password: password, output: $verbose)
-    end
-
-    def self.keychain_path(name)
-      # Existing code expects that a keychain name will be expanded into a default path to Libary/Keychains
-      # in the user's home directory. However, this will not allow the user to pass an absolute path
-      # for the keychain value
-      #
-      # So, if the passed value can't be resolved as a file in Library/Keychains, just use it as-is
-      # as the keychain path.
-      #
-      # We need to expand each path because File.exist? won't handle directories including ~ properly
-      #
-      # We also try to append `-db` at the end of the file path, as with Sierra the default Keychain name
-      # has changed for some users: https://github.com/fastlane/fastlane/issues/5649
-      #
-
-      keychain_paths = [
-        File.join(Dir.home, 'Library', 'Keychains', name),
-        File.join(Dir.home, 'Library', 'Keychains', "#{name}-db"),
-        name,
-        "#{name}-db"
-      ].map { |path| File.expand_path(path) }
-
-      keychain_path = keychain_paths.find { |path| File.exist?(path) }
-      UI.user_error!("Could not locate the provided keychain. Tried:\n\t#{keychain_paths.join("\n\t")}") unless keychain_path
-      keychain_path
     end
 
     # Fill in an environment variable, ready to be used in _xcodebuild_

--- a/match/spec/generator_spec.rb
+++ b/match/spec/generator_spec.rb
@@ -9,7 +9,7 @@ describe Match::Generator do
         force: true,
         username: 'username',
         team_id: 'team_id',
-        keychain_path: Match::Utils.keychain_path("login.keychain")
+        keychain_path: FastlaneCore::Helper.keychain_path("login.keychain")
       })
 
       # This is the important part. We need to see the right configuration come through


### PR DESCRIPTION
This series of PR tries to solve following issue:
   * https://github.com/fastlane/fastlane/pull/7048
   
# This is PR 2/3
   
as described the path is to move `keychain_path` to `fastlane_core`:

  * PR 1/3 -> move `keychain_path` to `fastlane_core` #7075 
  * PR 2/3 -> refactor `match` to use fastlane_core `keychain_path` #7076 
  * PR 3/3 -> refactor `unlock_keychain` to use fastlane_core `keychain_path` #7077 
     
     
needs to be merged in the right order     