### PR TITLE
[fastlane] fix unlock_keychain sierra *3/3*

### DIFF
--- a/fastlane/lib/fastlane/actions/unlock_keychain.rb
+++ b/fastlane/lib/fastlane/actions/unlock_keychain.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class UnlockKeychainAction < Action
       def self.run(params)
-        keychain_path = self.expand_keychain_path(params[:path])
+        keychain_path = FastlaneCore::Helper.keychain_path(params[:path])
         add_to_search_list = params[:add_to_search_list]
         set_default = params[:set_default]
         commands = []
@@ -48,22 +48,6 @@ module Fastlane
       def self.default_keychain(keychain_path)
         escaped_path = keychain_path.shellescape
         Fastlane::Actions.sh("security default-keychain -s #{escaped_path}", log: false)
-      end
-
-      def self.expand_keychain_path(keychain_path)
-        possible_locations = []
-        possible_locations << keychain_path
-        possible_locations << "~/Library/Keychains/#{keychain_path}"
-        possible_locations << "~/Library/Keychains/#{keychain_path}.keychain"
-
-        possible_locations.each do |location|
-          expanded_location = File.expand_path(location)
-          if File.exist?(expanded_location)
-            return expanded_location
-          end
-        end
-
-        UI.user_error!("Could not find the keychain file in: #{possible_locations}")
       end
 
       #####################################################


### PR DESCRIPTION
This series of PR tries to solve following issue:
   * https://github.com/fastlane/fastlane/pull/7048
   
# This is PR 3/3
   
as described the path is to move `keychain_path` to `fastlane_core`:

  * PR 1/3 -> move `keychain_path` to `fastlane_core` #7075 
  * PR 2/3 -> refactor `match` to use fastlane_core `keychain_path` #7076 
  * PR 3/3 -> refactor `unlock_keychain` to use fastlane_core `keychain_path` #7077 
     
     
needs to be merged in the right order     