### PR TITLE
Adding support for a dry-run option

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -94,6 +94,13 @@ module Supply
       self.current_package_name = nil
     end
 
+    # Validates the current edit - does not change data on Google Play
+    def validate_current_edit!
+      ensure_active_edit!
+
+      call_google_api { android_publisher.validate_edit(current_package_name, current_edit.id) }
+    end
+
     # Commits the current edit saving all pending changes on Google Play
     def commit_current_edit!
       ensure_active_edit!

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -125,7 +125,7 @@ module Supply
         FastlaneCore::ConfigItem.new(key: :validate_only,
                                      env_name: "SUPPLY_VALIDATE_ONLY",
                                      optional: true,
-                                     description: "If true, changes will only be validated with Google Play rather than actually uploaded",
+                                     description: "Indicate that changes will only be validated with Google Play rather than actually uploaded",
                                      is_string: false,
                                      default_value: false)
 

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -125,7 +125,7 @@ module Supply
         FastlaneCore::ConfigItem.new(key: :validate_only,
                                      env_name: "SUPPLY_VALIDATE_ONLY",
                                      optional: true,
-                                     description: "Indicate that changes will only be validated with Google Play rather than actually uploaded",
+                                     description: "Indicate that changes will only be validated with Google Play rather than actually published",
                                      is_string: false,
                                      default_value: false)
 

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -121,7 +121,13 @@ module Supply
                                      verify_block: proc do |value|
                                        available = valid_tracks
                                        UI.user_error! "Invalid value '#{value}', must be #{available.join(', ')}" unless available.include? value
-                                     end)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :validate_only,
+                                     env_name: "SUPPLY_VALIDATE_ONLY",
+                                     optional: true,
+                                     description: "If true, changes will only be validated with Google Play rather than actually uploaded",
+                                     is_string: false,
+                                     default_value: false)
 
       ]
     end

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -27,9 +27,15 @@ module Supply
 
       promote_track if Supply.config[:track_promote_to]
 
-      UI.message("Uploading all changes to Google Play...")
-      client.commit_current_edit!
-      UI.success("Successfully finished the upload to Google Play")
+      if Supply.config[:validate_only]
+        UI.message("Validating all changes with Google Play...")
+        client.validate_current_edit!
+        UI.success("Successfully validated the upload to Google Play")
+      else
+        UI.message("Uploading all changes to Google Play...")
+        client.commit_current_edit!
+        UI.success("Successfully finished the upload to Google Play")
+      end
     end
 
     def promote_track


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [ X] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [ X] Run `bundle exec rubocop -a` to ensure the code style is valid
- [ X] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ X] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

Proposed fix for https://github.com/fastlane/fastlane/issues/7094

This pull request adds support for a validate_only option. This will only validate the commit with Google Play, rather than actually uploading the data.

This is useful for testing your changes before actually commiting them. For example, in a CI environment, this can be used to make sure that all changes would successfully upload to Play before merging to master.