### PR TITLE
Fix tests in match for macOS Sierra.

### DIFF
--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -4,8 +4,13 @@ describe Match do
       it 'finds a normal keychain name relative to ~/Library/Keychains' do
         expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P '' -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
+        # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" #{Dir.home}/Library/Keychains/login.keychain &> /dev/null"
+
         expect(File).to receive(:exist?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
         expect(File).to receive(:exist?).with('item.path').and_return(true)
+
+        allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: $verbose)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: $verbose)
 
         Match::Utils.import('item.path', 'login.keychain')
@@ -14,11 +19,15 @@ describe Match do
       it 'treats a keychain name it cannot find in ~/Library/Keychains as the full keychain path' do
         expected_command = "security import item.path -k '/my/special.keychain' -P '' -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
+        # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" /my/special.keychain &> /dev/null"
+
         expect(File).to receive(:exist?).with("#{Dir.home}/Library/Keychains/my/special.keychain").and_return(false)
         expect(File).to receive(:exist?).with("#{Dir.home}/Library/Keychains/my/special.keychain-db").and_return(false)
         expect(File).to receive(:exist?).with('/my/special.keychain').and_return(true)
         expect(File).to receive(:exist?).with('item.path').and_return(true)
 
+        allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: $verbose)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: $verbose)
 
         Match::Utils.import('item.path', '/my/special.keychain')
@@ -38,10 +47,14 @@ describe Match do
       it "tries to find the macOS Sierra keychain too" do
         expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain-db' -P '' -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
+        # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" #{Dir.home}/Library/Keychains/login.keychain-db &> /dev/null"
+
         expect(File).to receive(:exist?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(false)
         expect(File).to receive(:exist?).with("#{Dir.home}/Library/Keychains/login.keychain-db").and_return(true)
         expect(File).to receive(:exist?).with("item.path").and_return(true)
 
+        allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: $verbose)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: $verbose)
 
         Match::Utils.import('item.path', "login.keychain")


### PR DESCRIPTION
- [x ] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x ] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x ] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x ] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

This pull request is a follow-up on #6460. The tests for match were failing on macOS Sierra for the same reason as in #7069. I fixed them the same way.