### PR TITLE
Add option to change provisioning style of targets between automatic …

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -39,6 +39,7 @@ module Fastlane
 
         target_filter = params[:target_filter] || params[:build_configuration_filter]
         configuration = params[:build_configuration]
+        provisioning_style = params[:provisioning_style]
 
         # manipulate project file
         UI.success("Going to update project '#{folder}' with UUID")
@@ -52,6 +53,8 @@ module Fastlane
             UI.important("Skipping target #{target.product_name} as it doesn't match the filter '#{target_filter}'")
             next
           end
+
+          project.root_object.attributes["TargetAttributes"][target.uuid]["ProvisioningStyle"] = provisioning_style unless provisioning_style.nil?
 
           target.build_configuration_list.build_configurations.each do |build_configuration|
             config_name = build_configuration.name
@@ -108,6 +111,14 @@ module Fastlane
                                        env_name: "FL_PROJECT_PROVISIONING_PROFILE_TARGET_FILTER",
                                        description: "A filter for the target name. Use a standard regex",
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :provisioning_style,
+                                       env_name: "FL_PROJECT_PROVISIONING_STYLE",
+                                       description: "Change provisoining styles between 'Automatic' and 'Manual'. Does nothing if not set",
+                                       optional: true,
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Path to provisioning profile is invalid") unless value == "Automatic" || value == "Manual"
+                                       end),
           FastlaneCore::ConfigItem.new(key: :build_configuration_filter,
                                        env_name: "FL_PROJECT_PROVISIONING_PROFILE_FILTER",
                                        description: "Legacy option, use 'target_filter' instead",


### PR DESCRIPTION
…and manual

I need to be able to change provisioning styles in fastlane. We have automatic provisioning set during development so that developers can build to their device with minimal effort, but during a beta or appstore build we need to tightly control the signing process. We currently don't use match since it doesn't support enterprise builds according to the docs, so we set up signing with cert and sigh and update_project_provisioning, and we need to be able to change provisioning style here too to make sure everything works as expected.

I'm open to the idea of moving this option to a different action, perhaps update_development_team or something that is agreed on as a better alternative, but putting it here seems like a reasonable place to me.

If there's any other considerations to make here, I'm open to them.

Thanks!
 
---

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1: