### PR TITLE
Ensure that `ensure_version!` gets passed the right platform

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -36,7 +36,8 @@ module Deliver
       app_version = options[:app_version]
       UI.message("Making sure the latest version on iTunes Connect matches '#{app_version}' from the ipa file...")
 
-      changed = options[:app].ensure_version!(app_version)
+      changed = options[:app].ensure_version!(app_version, platform: options[:pkg] ? 'osx' : 'ios')
+
       if changed
         UI.success("Successfully set the version to '#{app_version}'")
       else


### PR DESCRIPTION
Adjustment of #7063 to account for _spaceship_ changes which are already on master.