### PR TITLE
[snapshot] support for built-for-testing, test-without-building

### DIFF
--- a/snapshot/lib/snapshot.rb
+++ b/snapshot/lib/snapshot.rb
@@ -14,6 +14,7 @@ require 'snapshot/fixes/simulator_zoom_fix'
 require 'snapshot/fixes/hardware_keyboard_fix'
 
 require 'fastlane_core'
+require 'snapshot/features'
 
 require 'open3'
 

--- a/snapshot/lib/snapshot/features.rb
+++ b/snapshot/lib/snapshot/features.rb
@@ -1,0 +1,2 @@
+FastlaneCore::Feature.register(env_var: 'FASTLANE_SNAPSHOT_BUILD_FOR_TESTING',
+                               description: 'Use Build-For-Testing instead of build on every device used in snapshot')

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -32,7 +32,7 @@ module Snapshot
 
       UI.success "Building and running project - this might take some time..."
 
-      build_for_testing(Snapshot.config[:devices].first)
+      build_for_testing(Snapshot.config[:devices].first) if FastlaneCore::Feature.enabled?('FASTLANE_SNAPSHOT_BUILD_FOR_TESTING')
 
       self.number_of_retries_due_to_failing_simulator = 0
       self.collected_errors = []

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -32,6 +32,8 @@ module Snapshot
 
       UI.success "Building and running project - this might take some time..."
 
+      build_for_testing(Snapshot.config[:devices].first)
+
       self.number_of_retries_due_to_failing_simulator = 0
       self.collected_errors = []
       results = {} # collect all the results for a nice table
@@ -118,6 +120,14 @@ module Snapshot
       puts ""
     end
 
+    def build_for_testing(device_type = nil)
+      build_command = TestCommandGenerator.generate(device_type: device_type, build_type: "build-for-testing")
+      # build-for-testing
+      FastlaneCore::CommandExecutor.execute(command: build_command,
+                                          print_all: true,
+                                      print_command: true)
+    end
+
     # Returns true if it succeded
     def launch(language, locale, device_type, launch_arguments)
       screenshots_path = TestCommandGenerator.derived_data_path
@@ -153,8 +163,7 @@ module Snapshot
       add_media(device_type, :video, Snapshot.config[:add_videos]) if Snapshot.config[:add_videos]
 
       open_simulator_for_device(device_type)
-
-      command = TestCommandGenerator.generate(device_type: device_type)
+      test_command = TestCommandGenerator.generate(device_type: device_type, build_type: "test-without-building")
 
       if locale
         UI.header("#{device_type} - #{language} (#{locale})")
@@ -171,7 +180,8 @@ module Snapshot
         }
       ]
 
-      FastlaneCore::CommandExecutor.execute(command: command,
+      # test-without-building
+      FastlaneCore::CommandExecutor.execute(command: test_command,
                                           print_all: true,
                                       print_command: true,
                                              prefix: prefix_hash,

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -2,13 +2,14 @@ module Snapshot
   # Responsible for building the fully working xcodebuild command
   class TestCommandGenerator
     class << self
-      def generate(device_type: nil)
+      def generate(device_type: nil, build_type: "build-for-testing")
         parts = prefix
         parts << "xcodebuild"
         parts += options
-        parts += destination(device_type)
+        parts += destination(device_type) if build_type != "build-for-testing"
+        parts += ['  -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO'] if build_type == "build-for-testing"
         parts += build_settings
-        parts += actions
+        parts += actions(build_type)
         parts += suffix
         parts += pipe
 
@@ -46,11 +47,11 @@ module Snapshot
         build_settings
       end
 
-      def actions
+      def actions(build_type)
         actions = []
-        actions << :clean if Snapshot.config[:clean]
-        actions << :build # https://github.com/fastlane/snapshot/issues/246
-        actions << :test
+        actions << :clean if Snapshot.config[:clean] and build_type != "test-without-building"
+        # actions << :build # https://github.com/fastlane/snapshot/issues/246
+        actions << build_type
 
         actions
       end
@@ -72,6 +73,7 @@ module Snapshot
         #   { platform:iOS Simulator, id:A141F23B-96B3-491A-8949-813B376C28A7, OS:9.0, name:iPhone 5 }
         #
         simulators = FastlaneCore::DeviceManager.simulators
+
         # Sort devices with matching names by OS version, largest first, so that we can
         # pick the device with the newest OS in case an exact OS match is not available
         name_matches = simulators.find_all { |sim| sim.name.strip == device_name.strip }

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -3,11 +3,12 @@ module Snapshot
   class TestCommandGenerator
     class << self
       def generate(device_type: nil, build_type: "build test")
+        simname = device_type =~ /^Apple TV/ ? "appletvsimulator" : "iphonesimulator"
         parts = prefix
         parts << "xcodebuild"
         parts += options
         parts += destination(device_type) if build_type != "build-for-testing"
-        parts += ['  -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO'] if build_type == "build-for-testing"
+        parts += ["  -sdk #{simname} ONLY_ACTIVE_ARCH=NO"] if build_type == "build-for-testing"
         parts += build_settings
         parts += actions(build_type)
         parts += suffix

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -2,7 +2,7 @@ module Snapshot
   # Responsible for building the fully working xcodebuild command
   class TestCommandGenerator
     class << self
-      def generate(device_type: nil, build_type: "build-for-testing")
+      def generate(device_type: nil, build_type: "build test")
         parts = prefix
         parts << "xcodebuild"
         parts += options

--- a/snapshot/spec/spec_helper.rb
+++ b/snapshot/spec/spec_helper.rb
@@ -16,3 +16,19 @@ Information about project "Example":
 EOS
   allow_any_instance_of(FastlaneCore::Project).to receive(:raw_info).and_return fake_result
 end
+
+# Executes the provided block after adjusting the ENV to have the
+# provided keys and values set as defined in hash. After the block
+# completes, restores the ENV to its previous state.
+def with_env_values(hash)
+  old_vals = ENV.select { |k, v| hash.include?(k) }
+  hash.each do |k, v|
+    ENV[k] = hash[k]
+  end
+  yield
+ensure
+  hash.each do |k, v|
+    ENV.delete(k) unless old_vals.include?(k)
+    ENV[k] = old_vals[k]
+  end
+end

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -35,7 +35,7 @@ describe Snapshot do
       def configure(options)
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
       end
-      it "Generates build command (build-for-testing) (FEATURE_FLAG=FASTLANE_SNAPSHOT_BUILD_FOR_TESTING)", now: true do
+      it "Generates build command (build-for-testing) (FEATURE_FLAG=FASTLANE_SNAPSHOT_BUILD_FOR_TESTING)" do
         with_env_values('FASTLANE_SNAPSHOT_BUILD_FOR_TESTING' => '1') do
           configure options
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
@@ -56,7 +56,7 @@ describe Snapshot do
         end
       end
 
-      it "Generates test command (test-without-building) (FEATURE_FLAG=FASTLANE_SNAPSHOT_BUILD_FOR_TESTING)", now: true do
+      it "Generates test command (test-without-building) (FEATURE_FLAG=FASTLANE_SNAPSHOT_BUILD_FOR_TESTING)" do
         with_env_values('FASTLANE_SNAPSHOT_BUILD_FOR_TESTING' => '1') do
           configure options
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -52,8 +52,7 @@ describe Snapshot do
               "-derivedDataPath '/tmp/path/to/snapshot_derived'",
               "-destination 'platform=iOS Simulator,id=#{id},OS=#{ios}'",
               "FASTLANE_SNAPSHOT=YES",
-              :build,
-              :test,
+              "build test",
               "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
             ]
           )
@@ -74,8 +73,7 @@ describe Snapshot do
               "-derivedDataPath '/tmp/path/to/snapshot_derived'",
               "-destination 'platform=tvOS Simulator,id=#{id},OS=#{os}'",
               "FASTLANE_SNAPSHOT=YES",
-              :build,
-              :test,
+              "build test",
               "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
             ]
           )

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -52,7 +52,8 @@ describe Snapshot do
               "-derivedDataPath '/tmp/path/to/snapshot_derived'",
               "-destination 'platform=iOS Simulator,id=#{id},OS=#{ios}'",
               "FASTLANE_SNAPSHOT=YES",
-              "build test",
+              :build,
+              :test,
               "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
             ]
           )
@@ -73,7 +74,8 @@ describe Snapshot do
               "-derivedDataPath '/tmp/path/to/snapshot_derived'",
               "-destination 'platform=tvOS Simulator,id=#{id},OS=#{os}'",
               "FASTLANE_SNAPSHOT=YES",
-              "build test",
+              :build,
+              :test,
               "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
             ]
           )


### PR DESCRIPTION
This one refactors snapshot to use `build-for-testing` and `test-without-building`
to massive improve snapshot runtime.


run with (in fastlane clone):

`bundle exec snapshot --project snapshot/example/Example.xcodeproj -s Example`

```
+----------------------+---------+
|        snapshot results        |
+----------------------+---------+
| Device               | en-US   |
+----------------------+---------+
| iPhone 5             |  💚      |
| iPhone 6             |  💚      |
| iPhone 6 Plus        |  💚      |
| iPhone 7             |  💚      |
| iPhone 7 Plus        |  💚      |
| iPhone SE            |  💚      |
| iPad Air             |  💚      |
| iPad Pro (9.7-inch)  |  💚      |
| iPad Pro (12.9-inch) |  💚      |
+----------------------+---------+
```


Time with all simulators (all sims, atleast one time booted, on my machine):  **8m25.228s**

without this PR:  **9m47.999s**

(depending on project-size i think this will have a huge performance boost)

related issues:
  * https://github.com/fastlane/fastlane/issues/6992

