### PR TITLE
Bump spaceship version

### DIFF
--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,4 +1,4 @@
 module Spaceship
-  VERSION = "0.37.0".freeze
+  VERSION = "0.38.0".freeze
   DESCRIPTION = "Ruby library to access the Apple Dev Center and iTunes Connect".freeze
 end


### PR DESCRIPTION
[09:06:23]: Changes since release 0.37.0:

* Update primary language API for creaing a new iTC app
* Fix voip cert (#7087)
* Remove use of missing 'app_id' variable from AppVersionCommon (#7120)
* Add information about iTC env variable (#7031)
* Support iMessage Screenshots, fixes #6124 (#6823)
* Ability to list disabled devices, enable and disable them (#7067)
* [Spaceship] Adding in the necessary pieces for iTunes Connect platforms (#4447)
* Collapse markdown code blocks (#7002)
* Spaceship selects cookie path from set of preferred