### PR TITLE
Avoid runtime error when using override_screenshots options.

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -16,8 +16,12 @@ module Deliver
         UI.message("Removing all previously uploaded screenshots...")
         # First, clear all previously uploaded screenshots
         screenshots_per_language.keys.each do |language|
-          v.screenshots[language].each_with_index do |t, index|
-            v.upload_screenshot!(nil, t.sort_order, t.language, t.device_type, false)
+          v.screenshots[language].each_with_index do |screenshot, index|
+            begin
+              v.upload_screenshot!(nil, index + 1, screenshot.language, screenshot.device_type, false)
+            rescue
+              UI.error("Removing existing screenshot is failure")
+            end
           end
         end
       end

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -16,9 +16,9 @@ module Deliver
         UI.message("Removing all previously uploaded screenshots...")
         # First, clear all previously uploaded screenshots
         screenshots_per_language.keys.each do |language|
-          v.screenshots[language].each_with_index do |screenshot, index|
+          v.screenshots[language].each do |screenshot|
             begin
-              v.upload_screenshot!(nil, index + 1, screenshot.language, screenshot.device_type, false)
+              v.upload_screenshot!(nil, screenshot.sort_order, screenshot.language, screenshot.device_type, false)
             rescue
               UI.user_error!("Removing existing screenshot is failure")
             end

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -20,7 +20,7 @@ module Deliver
             begin
               v.upload_screenshot!(nil, index + 1, screenshot.language, screenshot.device_type, false)
             rescue
-              UI.error("Removing existing screenshot is failure")
+              UI.user_error!("Removing existing screenshot is failure")
             end
           end
         end


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

Fixes #6981

Avoid runtime error when using `override_screenshots` options.

I introduced `overwrite_screenshots` option on #6540.
However, it didn't work correctly.

I apologize for the inconvenience caused by my changes.