### PR TITLE
sensitive flag on config items 

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -1,6 +1,6 @@
 module FastlaneCore
   class ConfigItem
-    attr_accessor :key, :env_name, :description, :short_option, :default_value, :verify_block, :optional, :conflicting_options, :conflict_block, :deprecated
+    attr_accessor :key, :env_name, :description, :short_option, :default_value, :verify_block, :optional, :conflicting_options, :conflict_block, :deprecated, :sensitive
 
     # Creates a new option
     # @param key (Symbol) the key which is used as command paramters or key in the fastlane tools
@@ -17,7 +17,8 @@ module FastlaneCore
     # @param conflicting_options ([]) array of conflicting option keys(@param key). This allows to resolve conflicts intelligently
     # @param conflict_block an optional block which is called when options conflict happens
     # @param deprecated (String) Set if the option is deprecated. A deprecated option should be optional and is made optional if the parameter isn't set, and fails otherwise
-    def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, type: nil, optional: nil, conflicting_options: nil, conflict_block: nil, deprecated: nil)
+    # @param sensitive (Boolean) Set if the variable is sensitive, such as a password or API token, to prevent echoing when prompted for the parameter
+    def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, type: nil, optional: nil, conflicting_options: nil, conflict_block: nil, deprecated: nil, sensitive: nil)
       UI.user_error!("key must be a symbol") unless key.kind_of? Symbol
       UI.user_error!("env_name must be a String") unless (env_name || '').kind_of? String
 
@@ -42,6 +43,8 @@ module FastlaneCore
       end
       optional = false if optional.nil?
 
+      sensitive = false if sensitive.nil?
+
       @key = key
       @env_name = env_name
       @description = description
@@ -54,6 +57,7 @@ module FastlaneCore
       @conflicting_options = conflicting_options
       @conflict_block = conflict_block
       @deprecated = deprecated
+      @sensitive = sensitive
     end
 
     # This will raise an exception if the value is not valid

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -207,7 +207,12 @@ module FastlaneCore
 
       while value.nil?
         UI.important("To not be asked about this value, you can specify it using '#{option.key}'")
-        value = UI.input("#{option.description}: ")
+		if option.sensitive
+			        value = UI.password("#{option.description}: ")
+		else
+			        value = UI.input("#{option.description}: ")
+		end
+
         # Also store this value to use it from now on
         begin
           set(key, value)

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -207,12 +207,7 @@ module FastlaneCore
 
       while value.nil?
         UI.important("To not be asked about this value, you can specify it using '#{option.key}'")
-		if option.sensitive
-			        value = UI.password("#{option.description}: ")
-		else
-			        value = UI.input("#{option.description}: ")
-		end
-
+        value = option.sensitive ? UI.password("#{option.description}: ") : UI.input("#{option.description}: ")
         # Also store this value to use it from now on
         begin
           set(key, value)

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -134,6 +134,18 @@ describe FastlaneCore do
         end
       end
 
+      describe "#sensitive flag" do
+        it "should set the sensitive flag", now: true do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     description: 'foo',
+                                                     type: Array,
+                                                     optional: true,
+                                                     sensitive: true,
+                                                     default_value: ['5', '4', '3', '2', '1'])
+          expect(config_item.sensitive).to eq(true)
+        end
+      end
+
       describe "arrays" do
         it "returns Array default values correctly" do
           config_item = FastlaneCore::ConfigItem.new(key: :foo,

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -135,6 +135,11 @@ describe FastlaneCore do
       end
 
       describe "#sensitive flag" do
+        before(:each) do
+          allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
+          allow(FastlaneCore::Helper).to receive(:interactive?).and_return(true)
+          allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
+        end
         it "should set the sensitive flag" do
           config_item = FastlaneCore::ConfigItem.new(key: :foo,
                                                      description: 'foo',
@@ -152,9 +157,6 @@ describe FastlaneCore do
                                                      optional: false,
                                                      sensitive: true)
           config = FastlaneCore::Configuration.create([config_item], {})
-          allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
-          allow(FastlaneCore::Helper).to receive(:interactive?).and_return(true)
-          allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
           expect(FastlaneCore::UI).to receive(:password).and_return("password")
           expect(config[:foo]).to eq("password")
         end
@@ -166,9 +168,6 @@ describe FastlaneCore do
                                                      optional: false,
                                                      sensitive: false)
           config = FastlaneCore::Configuration.create([config_item], {})
-          allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
-          allow(FastlaneCore::Helper).to receive(:interactive?).and_return(true)
-          allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
           expect(FastlaneCore::UI).to receive(:input).and_return("plaintext")
           expect(config[:foo]).to eq("plaintext")
         end

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -135,7 +135,7 @@ describe FastlaneCore do
       end
 
       describe "#sensitive flag" do
-        it "should set the sensitive flag", now: true do
+        it "should set the sensitive flag" do
           config_item = FastlaneCore::ConfigItem.new(key: :foo,
                                                      description: 'foo',
                                                      type: Array,
@@ -143,6 +143,32 @@ describe FastlaneCore do
                                                      sensitive: true,
                                                      default_value: ['5', '4', '3', '2', '1'])
           expect(config_item.sensitive).to eq(true)
+        end
+        it "should ask using asterisks", now: true do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     description: 'foo',
+                                                     type: String,
+                                                     is_string: true,
+                                                     optional: false,
+                                                     sensitive: true)
+          config = FastlaneCore::Configuration.create([config_item], {})
+          allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
+          allow(FastlaneCore::Helper).to receive(:interactive?).and_return(true)
+          expect(FastlaneCore::UI).to receive(:password).and_return("password")
+          expect(config[:foo]).to eq("password")
+        end
+        it "should ask using plaintext", now: true do
+          config_item = FastlaneCore::ConfigItem.new(key: :foo,
+                                                     description: 'foo',
+                                                     type: String,
+                                                     is_string: false,
+                                                     optional: false,
+                                                     sensitive: false)
+          config = FastlaneCore::Configuration.create([config_item], {})
+          allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
+          allow(FastlaneCore::Helper).to receive(:interactive?).and_return(true)
+          expect(FastlaneCore::UI).to receive(:input).and_return("plaintext")
+          expect(config[:foo]).to eq("plaintext")
         end
       end
 

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -154,6 +154,7 @@ describe FastlaneCore do
           config = FastlaneCore::Configuration.create([config_item], {})
           allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
           allow(FastlaneCore::Helper).to receive(:interactive?).and_return(true)
+          allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
           expect(FastlaneCore::UI).to receive(:password).and_return("password")
           expect(config[:foo]).to eq("password")
         end
@@ -167,6 +168,7 @@ describe FastlaneCore do
           config = FastlaneCore::Configuration.create([config_item], {})
           allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
           allow(FastlaneCore::Helper).to receive(:interactive?).and_return(true)
+          allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
           expect(FastlaneCore::UI).to receive(:input).and_return("plaintext")
           expect(config[:foo]).to eq("plaintext")
         end


### PR DESCRIPTION
as i really like to have the `sensitive` flag - lets push this a bit!
(so we can start modify existing options code to set sensitive to true.; and filter sensitive options out of `env`)

e.g.: unlock_keychain -> password


this is a rebased version of: https://github.com/fastlane/fastlane/pull/5982
original commit is preserved 🍻  @SandyChapman! - 

changes:
  * merge conflict solve
  *  use `UI.password` instead of `ask`




cc @mfurtak  