### PR TITLE
Ensure correct line containing Xcode version is used when other outpu…

### DIFF
--- a/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
+++ b/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
@@ -8,7 +8,7 @@ module Fastlane
       def self.run(params)
         required_version = params[:version]
 
-        selected_version = sh "xcversion selected | head -1 | xargs echo -n"
+        selected_version = sh "xcversion selected | grep '^Xcode' | head -1 | xargs echo -n"
 
         versions_match = selected_version == "Xcode #{required_version}"
 


### PR DESCRIPTION
- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

____

Currently the action `ensure_xcode_version` takes the first line of output to match the Xcode version.

This has been working fine for a while until today it fails:

```sh
[14:57:02]: ----------------------------------
[14:57:02]: --- Step: ensure_xcode_version ---
[14:57:02]: ----------------------------------
[14:57:02]: $ xcversion selected | head -1 | xargs echo -n
[14:57:05]: ▸ xargs: unterminated quote

[!] Exit status of command 'xcversion selected | head -1 | xargs echo -n' was 1 instead of 0.
xargs: unterminated quote
```

This is because the output of `xcversion selected` is currently:

```sh
Couldn't verify that spaceship is up to date
Xcode 8.0
Build version 8A218a
```

Ideally, spaceship would be up to date so this wouldn't occur but this caused failing builds on several projects.
This PR fixes this issue by instead taking the first line that starts with 'Xcode'