### PR TITLE
[deliver] support metdata update of live_version

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -25,7 +25,7 @@ module Deliver
                                      description: "The app ID of the app you want to use/modify",
                                      is_string: false), # don't add any verification here, as it's used to store a spaceship ref
         FastlaneCore::ConfigItem.new(key: :edit_live,
-                                     short_option: "-E",
+                                     short_option: "-o",
                                      env_name: "DELIVER_EDIT_LIVE",
                                      description: "Modify live metadata, this option disables ipa upload and screenshot upload",
                                      is_string: false),

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -24,6 +24,11 @@ module Deliver
                                      env_name: "DELIVER_APP_ID",
                                      description: "The app ID of the app you want to use/modify",
                                      is_string: false), # don't add any verification here, as it's used to store a spaceship ref
+        FastlaneCore::ConfigItem.new(key: :edit_live,
+                                     short_option: "-E",
+                                     env_name: "DELIVER_EDIT_LIVE",
+                                     description: "Modify live metadata, this option disables ipa upload and screenshot upload",
+                                     is_string: false),
         FastlaneCore::ConfigItem.new(key: :ipa,
                                      short_option: "-i",
                                      optional: true,

--- a/deliver/lib/deliver/upload_assets.rb
+++ b/deliver/lib/deliver/upload_assets.rb
@@ -1,6 +1,7 @@
 module Deliver
   class UploadAssets
     def upload(options)
+      return if options[:edit_live]
       app = options[:app]
 
       v = app.edit_version(platform: options[:platform])

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -16,10 +16,10 @@ module Deliver
                                 :secondary_first_sub_category, :secondary_second_sub_category]
 
     # Localized app details values, that are editable in live state
-    LOCALISED_LIVE_APP_VALUES = [:description, :release_notes, :support_url, :marketing_url]
+    LOCALISED_LIVE_VALUES = [:description, :release_notes, :support_url, :marketing_url]
 
     # Non localized app details values, that are editable in live state
-    NON_LOCALISED_LIVE_VERSION_VALUES = [:privacy_url]
+    NON_LOCALISED_LIVE_VALUES = [:privacy_url]
 
     # Make sure to call `load_from_filesystem` before calling upload
     def upload(options)
@@ -35,8 +35,8 @@ module Deliver
       if options[:edit_live]
         # not all values are editable when using live_version
         v = app.live_version(platform: options[:platform])
-        localised_options = LOCALISED_LIVE_APP_VALUES
-        non_localised_options = NON_LOCALISED_LIVE_VERSION_VALUES
+        localised_options = LOCALISED_LIVE_VALUES
+        non_localised_options = NON_LOCALISED_LIVE_VALUES
       else
         v = app.edit_version(platform: options[:platform])
         localised_options = (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES)

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -15,6 +15,12 @@ module Deliver
                                 :primary_first_sub_category, :primary_second_sub_category,
                                 :secondary_first_sub_category, :secondary_second_sub_category]
 
+    # Localized app details values, that are editable in live state
+    LOCALISED_LIVE_VALUES = [:description, :release_notes, :support_url, :marketing_url]
+
+    # Non localized app details values, that are editable in live state
+    NON_LOCALISED_LIVE_VERSION_VALUES = [:privacy_url]
+
     # Make sure to call `load_from_filesystem` before calling upload
     def upload(options)
       return if options[:skip_metadata]
@@ -29,8 +35,8 @@ module Deliver
       if options[:edit_live]
         # not all values are editable when using live_version
         v = app.live_version(platform: options[:platform])
-        localised_options = [:description, :release_notes, :support_url, :marketing_url]
-        non_localised_options = [:privacy_url]
+        localised_options = LOCALISED_LIVE_VALUES
+        non_localised_options = NON_LOCALISED_LIVE_VERSION_VALUES
       else
         v = app.edit_version(platform: options[:platform])
         localised_options = (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES)

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -16,7 +16,7 @@ module Deliver
                                 :secondary_first_sub_category, :secondary_second_sub_category]
 
     # Localized app details values, that are editable in live state
-    LOCALISED_LIVE_VALUES = [:description, :release_notes, :support_url, :marketing_url]
+    LOCALISED_LIVE_APP_VALUES = [:description, :release_notes, :support_url, :marketing_url]
 
     # Non localized app details values, that are editable in live state
     NON_LOCALISED_LIVE_VERSION_VALUES = [:privacy_url]
@@ -35,7 +35,7 @@ module Deliver
       if options[:edit_live]
         # not all values are editable when using live_version
         v = app.live_version(platform: options[:platform])
-        localised_options = LOCALISED_LIVE_VALUES
+        localised_options = LOCALISED_LIVE_APP_VALUES
         non_localised_options = NON_LOCALISED_LIVE_VERSION_VALUES
       else
         v = app.edit_version(platform: options[:platform])

--- a/deliver/lib/deliver/upload_price_tier.rb
+++ b/deliver/lib/deliver/upload_price_tier.rb
@@ -3,7 +3,6 @@ module Deliver
   class UploadPriceTier
     def upload(options)
       return unless options[:price_tier]
-      return if options[:edit_live]
       app = options[:app]
 
       # just to be sure, the user might have passed an int (which is fine with us)

--- a/deliver/lib/deliver/upload_price_tier.rb
+++ b/deliver/lib/deliver/upload_price_tier.rb
@@ -3,6 +3,7 @@ module Deliver
   class UploadPriceTier
     def upload(options)
       return unless options[:price_tier]
+      return if options[:edit_live]
       app = options[:app]
 
       # just to be sure, the user might have passed an int (which is fine with us)

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -3,6 +3,7 @@ module Deliver
   class UploadScreenshots
     def upload(options, screenshots)
       return if options[:skip_screenshots]
+      return if options[:edit_live]
 
       app = options[:app]
 


### PR DESCRIPTION
as discussed here: https://github.com/fastlane/fastlane/issues/7156



adds option `edit_live` - supports updating of:

  * `:description, :release_notes, :support_url, :marketing_url`
  * `:privacy_url`


enabling new languages is disabled, it actually works via itc api - but it fails later on - as `:keywords` are protected.


asset, pricetier,screenshots are forced to be disabled.


test with:

`deliver -E`

or from fastfile:

```
deliver(edit_live: true)
```