### PR TITLE
fix "`persistent_cookie_path': undefined method `tmpdir' for Dir:Class (NoMethodError)" for client.rb 

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -5,6 +5,7 @@ require 'faraday-cookie_jar'
 require 'spaceship/ui'
 require 'spaceship/helper/plist_middleware'
 require 'spaceship/helper/net_http_generic_request'
+require 'tmpdir'
 
 Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder
 


### PR DESCRIPTION
fix for issue #7178