### PR TITLE
[spaceship] 1/2 produce create mac app

### DIFF
--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -79,14 +79,18 @@ module Spaceship
         #   can't be changed after you submit your first build.
         # @param company_name (String): The company name or developer name to display on the App Store for your apps.
         # It cannot be changed after you create your first app.
-        def create!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil)
+        # @param platform (String): Platform one of (ios,osx)
+        #  should it be an ios or an osx app
+
+        def create!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil)
           client.create_application!(name: name,
                          primary_language: primary_language,
                                   version: version,
                                       sku: sku,
                                 bundle_id: bundle_id,
                                 bundle_id_suffix: bundle_id_suffix,
-                                company_name: company_name)
+                                company_name: company_name,
+                                    platform: platform)
         end
       end
 

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -264,11 +264,11 @@ module Spaceship
     # @param sku (String): A unique ID for your app that is not visible on the App Store.
     # @param bundle_id (String): The bundle ID must match the one you used in Xcode. It
     #   can't be changed after you submit your first build.
-    def create_application!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil)
+    def create_application!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil)
       # First, we need to fetch the data from Apple, which we then modify with the user's values
       primary_language ||= "English"
-      app_type = 'ios'
-      r = request(:get, "ra/apps/create/v2/?platformString=#{app_type}")
+      platform ||= "ios"
+      r = request(:get, "ra/apps/create/v2/?platformString=#{platform}")
       data = parse_response(r, 'data')
 
       # Now fill in the values we have
@@ -281,10 +281,10 @@ module Spaceship
       data['vendorId'] = { value: sku }
       data['bundleIdSuffix'] = { value: bundle_id_suffix }
       data['companyName'] = { value: company_name } if company_name
-      data['enabledPlatformsForCreation'] = { value: [app_type] }
+      data['enabledPlatformsForCreation'] = { value: [platform] }
 
-      data['initialPlatform'] = app_type
-      data['enabledPlatformsForCreation'] = { value: [app_type] }
+      data['initialPlatform'] = platform
+      data['enabledPlatformsForCreation'] = { value: [platform] }
 
       # Now send back the modified hash
       r = request(:post) do |req|


### PR DESCRIPTION
# PR 1/2

## Those PR's try to add support for creating mac apps with produce.
  * https://github.com/fastlane/fastlane/pull/7180 (adding platform to spaceship)
  * https://github.com/fastlane/fastlane/pull/7181 (adding platform to produce)

## Issues related:
  * https://github.com/fastlane/fastlane/issues/7166  




### run  with:

  * Commandline
```bash
produce -a hjanuschka.macapp2 --platform osx
```

  * Fastfile

```ruby
lane :produce_macapp do
    produce(platform: "osx", app_identifier: "hjanuschka.macapp2")
end
```

there is also a branch with both prs applied: https://github.com/hjanuschka/fastlane/tree/produce_macapp_combined 