### PR TITLE
[produce] 2/2 produce create mac app

### DIFF
--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -20,7 +20,8 @@ module Produce
         UI.message "Creating new app '#{app_name}' on the Apple Dev Center"
 
         app = Spaceship.app.create!(bundle_id: app_identifier,
-                                         name: app_name)
+                                         name: app_name,
+                                         mac: Produce.config[:platform] == "osx")
 
         UI.message "Created app #{app.app_id}"
 
@@ -46,7 +47,7 @@ module Produce
     private
 
     def app_exists?
-      Spaceship.app.find(app_identifier) != nil
+      Spaceship.app.find(app_identifier, mac: Produce.config[:platform] == "osx") != nil
     end
 
     def login

--- a/produce/lib/produce/itunes_connect.rb
+++ b/produce/lib/produce/itunes_connect.rb
@@ -51,7 +51,7 @@ module Produce
         UI.success "Successfully created new app '#{Produce.config[:app_name]}' on iTunes Connect with ID #{application.apple_id}"
       end
 
-      return Spaceship::Application.find(@full_bundle_identifier).apple_id
+      return Spaceship::Application.find(@full_bundle_identifier, mac: Produce.config[:platform] == "osx").apple_id
     end
 
     private

--- a/produce/lib/produce/itunes_connect.rb
+++ b/produce/lib/produce/itunes_connect.rb
@@ -28,7 +28,8 @@ module Produce
                                                               sku: Produce.config[:sku].to_s, # might be an int
                                                               bundle_id: app_identifier,
                                                               bundle_id_suffix: Produce.config[:bundle_identifier_suffix],
-                                                              company_name: Produce.config[:company_name])
+                                                              company_name: Produce.config[:company_name],
+                                                              platform: Produce.config[:platform])
 
         UI.crash!("Something went wrong when creating the new app on iTC") if generated_app["adamId"].to_s.empty?
 

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -38,6 +38,15 @@ module Produce
                                      description: "SKU Number (e.g. '1234')",
                                      default_value: Time.now.to_i.to_s,
                                      is_string: true),
+        FastlaneCore::ConfigItem.new(key: :platform,
+                                     short_option: "-j",
+                                     env_name: "PRODUCE_PLATFORM",
+                                     description: "The platform to use (optional)",
+                                     optional: true,
+                                     default_value: "ios",
+                                     verify_block: proc do |value|
+                                                     UI.user_error!("The platform can only be ios or osx") unless %('ios', 'osx').include? value
+                                                   end),
         FastlaneCore::ConfigItem.new(key: :language,
                                      short_option: "-m",
                                      env_name: "PRODUCE_LANGUAGE",


### PR DESCRIPTION
# PR 2/2

## Those PR's try to add support for creating mac apps with produce.
  * https://github.com/fastlane/fastlane/pull/7180 (adding platform to spaceship)
  * https://github.com/fastlane/fastlane/pull/7181 (adding platform to produce)

## Issues related:
  * https://github.com/fastlane/fastlane/issues/7166  


### run  with:

  * Commandline
```bash
produce -a hjanuschka.macapp2 --platform osx
```

  * Fastfile

```ruby
lane :produce_macapp do
    produce(platform: "osx", app_identifier: "hjanuschka.macapp2")
end
```

there is also a branch with both prs applied: https://github.com/hjanuschka/fastlane/tree/produce_macapp_combined -