### PR TITLE
Fix call set_info_plist_value resulting in bplist file

### DIFF
--- a/fastlane/lib/fastlane/actions/set_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/set_info_plist_value.rb
@@ -11,7 +11,7 @@ module Fastlane
           path = File.expand_path(params[:path])
           plist = Plist.parse_xml(path)
           plist[params[:key]] = params[:value]
-          new_plist = plist.to_plist
+          new_plist = Plist::Emit.dump(plist)
           File.write(path, new_plist)
 
           return params[:value]


### PR DESCRIPTION
Refer to #6810 

Since, I'm not too familiar with ruby and this issue happens on some specific machines (which happens to be me). So I try to fix it.

This PR seem like it solve that problem but I don't know why. Can someone explain this to me?

Thanks.

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:
