### PR TITLE
[gym] Uses `output_name` to attempt to find the correct .app package

### DIFF
--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -60,10 +60,11 @@ module Gym
         FastlaneCore::ConfigItem.new(key: :output_name,
                                      short_option: "-n",
                                      env_name: "GYM_OUTPUT_NAME",
-                                     description: "The name of the resulting ipa file",
+                                     description: "The name of the resulting ipa/app file",
                                      optional: true,
                                      verify_block: proc do |value|
                                        value.gsub!(".ipa", "")
+                                       value.gsub!(".app", "")
                                        value.gsub!(File::SEPARATOR, "_")
                                      end),
         FastlaneCore::ConfigItem.new(key: :configuration,

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -157,7 +157,7 @@ module Gym
 
     # Copies the .app from the archive into the output directory
     def copy_mac_app
-      app_path = Dir[File.join(BuildCommandGenerator.archive_path, "Products/Applications/*.app")].last
+      app_path = find_app_path
       UI.crash!("Couldn't find application in '#{BuildCommandGenerator.archive_path}'") unless app_path
 
       FileUtils.cp_r(app_path, File.expand_path(Gym.config[:output_directory]), remove_destination: true)
@@ -165,6 +165,18 @@ module Gym
 
       UI.success "Successfully exported the .app file:"
       UI.message app_path
+      app_path
+    end
+
+    # Finds the most likely candidate for this target's .app
+    def find_app_path
+      # guess the correct .app name from the config
+      output_path = File.join(BuildCommandGenerator.archive_path, "Products/Applications", Gym.config[:output_name] + ".app")
+      app_path = output_path if File.exist?(output_path)
+
+      # default to finding an arbitrary .app file, since we can't know any better
+      app_path ||= Dir[File.join(BuildCommandGenerator.archive_path, "Products/Applications/*.app")].last
+
       app_path
     end
 

--- a/gym/spec/options_spec.rb
+++ b/gym/spec/options_spec.rb
@@ -14,6 +14,13 @@ describe Gym do
       expect(Gym.config[:output_name]).to eq("Example")
     end
 
+    it "removes the `app` from the output name if given" do
+      options = { output_name: "Example.app", project: "./examples/standard/Example.xcodeproj" }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      expect(Gym.config[:output_name]).to eq("Example")
+    end
+
     it "automatically chooses an existing scheme if the the defined one is not available" do
       options = { project: "./examples/standard/Example.xcodeproj", scheme: "NotHere" }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)


### PR DESCRIPTION
Fixes #7190.

I can see some circumstances where this might not be 100% the best fix, but I can't see it causing any regressions.

As a sidebar, I noticed there are two different ways this is being generated ([here](https://github.com/fastlane/fastlane/blob/11cf73824a176496b15f55902bd3c3e11435231b/gym/lib/gym/generators/package_command_generator_legacy.rb#L50-L55) and [here](https://github.com/fastlane/fastlane/blob/11cf73824a176496b15f55902bd3c3e11435231b/gym/lib/gym/runner.rb#L160) - one using `.first` and one using `.last`). I didn't bother touching the `*_legacy` (for obvious reasons), but there will potentially be inconsistencies for legacy projects (which were likely already there though, so not a big problem for this PR).

---

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1: