### PR TITLE
primaryLanguageCode detection fix

### DIFF
--- a/spaceship/lib/assets/languageMapping.json
+++ b/spaceship/lib/assets/languageMapping.json
@@ -26,14 +26,12 @@
         "game-center": true,
         "alternatives": [
             "nl"
-        ],
-        "itc_locale": "nl-NL"
+        ]
     },
     {
         "locale": "en-AU",
         "name": "Australian English",
-        "game-center": false,
-        "itc_locale": "en-AU"
+        "game-center": false
     },
     {
         "locale": "en-AU",

--- a/spaceship/lib/assets/languageMapping.json
+++ b/spaceship/lib/assets/languageMapping.json
@@ -2,12 +2,14 @@
     {
         "locale": "cmn-Hans",
         "name": "Simplified Chinese",
-        "game-center": true
+        "game-center": true,
+        "itc_locale": "zh-Hans"        
     },
     {
         "locale": "cmn-Hant",
         "name": "Traditional Chinese",
-        "game-center": true
+        "game-center": true,
+        "itc_locale": "zh-Hant"
     },
     {
         "locale": "da-DK",
@@ -15,7 +17,8 @@
         "game-center": true,
         "alternatives": [
             "da"
-        ]
+        ],
+        "itc_locale": "da"
     },
     {
         "locale": "nl-NL",
@@ -23,42 +26,50 @@
         "game-center": true,
         "alternatives": [
             "nl"
-        ]
+        ],
+        "itc_locale": "nl-NL"
     },
     {
         "locale": "en-AU",
         "name": "Australian English",
-        "game-center": false
+        "game-center": false,
+        "itc_locale": "en-AU"
     },
     {
         "locale": "en-AU",
         "name": "English_Australian",
-        "game-center": false
+        "game-center": false,
+        "itc_locale": "en-AU"
     },
     {
         "locale": "en-CA",
         "name": "Canadian English",
-        "game-center": false
+        "game-center": false,
+        "itc_locale": "en-CA"
     },
     {
         "locale": "en-CA",
         "name": "English_CA",
-        "game-center": false
+        "game-center": false,
+        "itc_locale": "en-CA"
     },
     {
         "locale": "en-GB",
         "name": "UK English",
-        "game-center": true
+        "game-center": true,
+        "itc_locale": "en-GB"
     },
     {
         "locale": "en-GB",
         "name": "English_UK",
-        "game-center": true
+        "game-center": true,
+        "itc_locale": "en-GB"
     },
     {
         "locale": "en-US",
         "name": "English",
-        "game-center": true
+        "game-center": true,
+        "itc_locale": "en-US"
     },
     {
         "locale": "fi-FI",
@@ -66,17 +77,20 @@
         "game-center": true,
         "alternatives": [
             "fi"
-        ]
+        ],
+        "itc_locale": "fin"
     },
     {
         "locale": "fr-CA",
         "name": "Canadian French",
-        "game-center": false
+        "game-center": false,
+        "itc_locale": "fr-CA"
     },
     {
         "locale": "fr-CA",
         "name": "French_CA",
-        "game-center": false
+        "game-center": false,
+        "itc_locale": "fr-CA"
     },
     {
         "locale": "fr-FR",
@@ -84,7 +98,8 @@
         "game-center": true,
         "alternatives": [
             "fr"
-        ]
+        ],
+        "itc_locale": "fr-FR"
     },
     {
         "locale": "de-DE",
@@ -92,7 +107,8 @@
         "game-center": true,
         "alternatives": [
             "de"
-        ]
+        ],
+        "itc_locale": "de-DE"
     },
     {
         "locale": "el-GR",
@@ -100,7 +116,8 @@
         "game-center": true,
         "alternatives": [
             "el"
-        ]
+        ],
+        "itc_locale": "el"
     },
     {
         "locale": "id-ID",
@@ -108,7 +125,8 @@
         "game-center": true,
         "alternatives": [
             "id"
-        ]
+        ],
+        "itc_locale": "id"
     },
     {
         "locale": "it-IT",
@@ -116,7 +134,8 @@
         "game-center": true,
         "alternatives": [
             "it"
-        ]
+        ],
+        "itc_locale": "it"
     },
     {
         "locale": "ja-JP",
@@ -124,7 +143,8 @@
         "game-center": true,
         "alternatives": [
             "ja"
-        ]
+        ],
+        "itc_locale": "ja"
     },
     {
         "locale": "ko-KR",
@@ -132,7 +152,8 @@
         "game-center": true,
         "alternatives": [
             "ko"
-        ]
+        ],
+        "itc_locale": "ko"
     },
     {
         "locale": "ms-MY",
@@ -140,7 +161,8 @@
         "game-center": true,
         "alternatives": [
             "ms"
-        ]
+        ],
+        "itc_locale": "ms"
     },
     {
         "locale": "no-NO",
@@ -148,12 +170,14 @@
         "game-center": true,
         "alternatives": [
             "no"
-        ]
+        ],
+        "itc_locale": "no"
     },
     {
         "locale": "pt-BR",
         "name": "Brazilian Portuguese",
-        "game-center": true
+        "game-center": true,
+        "itc_locale": "pt-BR"
     },
     {
         "locale": "pt-PT",
@@ -161,7 +185,8 @@
         "game-center": true,
         "alternatives": [
             "pt"
-        ]
+        ],
+        "itc_locale": "pt-PT"
     },
     {
         "locale": "ru-RU",
@@ -169,17 +194,20 @@
         "game-center": true,
         "alternatives": [
             "ru"
-        ]
+        ],
+        "itc_locale": "ru"
     },
     {
         "locale": "es-MX",
         "name": "Mexican Spanish",
-        "game-center": false
+        "game-center": false,
+        "itc_locale": "es-MX"
     },
     {
         "locale": "es-MX",
         "name": "Spanish_MX",
-        "game-center": false
+        "game-center": false,
+        "itc_locale": "es-MX"
     },
     {
         "locale": "es-ES",
@@ -187,7 +215,8 @@
         "game-center": true,
         "alternatives": [
             "es"
-        ]
+        ],
+        "itc_locale": "es-ES"
     },
     {
         "locale": "sv-SE",
@@ -195,7 +224,8 @@
         "game-center": true,
         "alternatives": [
             "sv"
-        ]
+        ],
+        "itc_locale": "sv"
     },
     {
         "locale": "th-TH",
@@ -203,7 +233,8 @@
         "game-center": true,
         "alternatives": [
             "th"
-        ]
+        ],
+        "itc_locale": "th"
     },
     {
         "locale": "tr-TR",
@@ -211,7 +242,8 @@
         "game-center": true,
         "alternatives": [
             "tr"
-        ]
+        ],
+        "itc_locale": "tr"
     },
     {
         "locale": "vi-VI",
@@ -219,6 +251,7 @@
         "game-center": true,
         "alternatives": [
             "vi"
-        ]
+        ],
+        "itc_locale": "vi"
     }
 ]

--- a/spaceship/lib/assets/languageMapping.json
+++ b/spaceship/lib/assets/languageMapping.json
@@ -186,7 +186,7 @@
     {
         "locale": "es-MX",
         "name": "Mexican Spanish",
-        "game-center": false        
+        "game-center": false
     },
     {
         "locale": "es-MX",

--- a/spaceship/lib/assets/languageMapping.json
+++ b/spaceship/lib/assets/languageMapping.json
@@ -38,38 +38,32 @@
     {
         "locale": "en-AU",
         "name": "English_Australian",
-        "game-center": false,
-        "itc_locale": "en-AU"
+        "game-center": false
     },
     {
         "locale": "en-CA",
         "name": "Canadian English",
-        "game-center": false,
-        "itc_locale": "en-CA"
+        "game-center": false
     },
     {
         "locale": "en-CA",
         "name": "English_CA",
-        "game-center": false,
-        "itc_locale": "en-CA"
+        "game-center": false
     },
     {
         "locale": "en-GB",
         "name": "UK English",
-        "game-center": true,
-        "itc_locale": "en-GB"
+        "game-center": true
     },
     {
         "locale": "en-GB",
         "name": "English_UK",
-        "game-center": true,
-        "itc_locale": "en-GB"
+        "game-center": true
     },
     {
         "locale": "en-US",
         "name": "English",
-        "game-center": true,
-        "itc_locale": "en-US"
+        "game-center": true
     },
     {
         "locale": "fi-FI",
@@ -83,14 +77,12 @@
     {
         "locale": "fr-CA",
         "name": "Canadian French",
-        "game-center": false,
-        "itc_locale": "fr-CA"
+        "game-center": false
     },
     {
         "locale": "fr-CA",
         "name": "French_CA",
-        "game-center": false,
-        "itc_locale": "fr-CA"
+        "game-center": false
     },
     {
         "locale": "fr-FR",
@@ -98,8 +90,7 @@
         "game-center": true,
         "alternatives": [
             "fr"
-        ],
-        "itc_locale": "fr-FR"
+        ]
     },
     {
         "locale": "de-DE",
@@ -107,8 +98,7 @@
         "game-center": true,
         "alternatives": [
             "de"
-        ],
-        "itc_locale": "de-DE"
+        ]
     },
     {
         "locale": "el-GR",
@@ -176,8 +166,7 @@
     {
         "locale": "pt-BR",
         "name": "Brazilian Portuguese",
-        "game-center": true,
-        "itc_locale": "pt-BR"
+        "game-center": true
     },
     {
         "locale": "pt-PT",
@@ -185,8 +174,7 @@
         "game-center": true,
         "alternatives": [
             "pt"
-        ],
-        "itc_locale": "pt-PT"
+        ]
     },
     {
         "locale": "ru-RU",
@@ -200,14 +188,12 @@
     {
         "locale": "es-MX",
         "name": "Mexican Spanish",
-        "game-center": false,
-        "itc_locale": "es-MX"
+        "game-center": false        
     },
     {
         "locale": "es-MX",
         "name": "Spanish_MX",
-        "game-center": false,
-        "itc_locale": "es-MX"
+        "game-center": false
     },
     {
         "locale": "es-ES",
@@ -215,8 +201,7 @@
         "game-center": true,
         "alternatives": [
             "es"
-        ],
-        "itc_locale": "es-ES"
+        ]
     },
     {
         "locale": "sv-SE",

--- a/spaceship/lib/spaceship/tunes/language_converter.rb
+++ b/spaceship/lib/spaceship/tunes/language_converter.rb
@@ -11,7 +11,9 @@ module Spaceship
         # Converts the Language "UK English" to itc locale en-GB
         def from_standard_to_itc_locale(from)
           result = mapping.find { |a| a['name'] == from }
-          (result || {}).fetch('itc_locale', nil)
+          itc_locale = (result || {}).fetch('itc_locale', nil)
+          return itc_locale if itc_locale
+          (result || {}).fetch('locale', nil)
         end
 
         # Converts the language short codes: (en-US, de-DE) to the iTC format (English_CA, Brazilian Portuguese)

--- a/spaceship/lib/spaceship/tunes/language_converter.rb
+++ b/spaceship/lib/spaceship/tunes/language_converter.rb
@@ -8,6 +8,12 @@ module Spaceship
           (result || {}).fetch('locale', nil)
         end
 
+        # Converts the Language "UK English" to itc locale en-GB
+        def from_standard_to_itc_locale(from)
+          result = mapping.find { |a| a['name'] == from }
+          (result || {}).fetch('itc_locale', nil)
+        end
+
         # Converts the language short codes: (en-US, de-DE) to the iTC format (English_CA, Brazilian Portuguese)
         def from_standard_to_itc(from)
           result = mapping.find { |a| a['locale'] == from || (a['alternatives'] || []).include?(from) }
@@ -45,6 +51,10 @@ end
 class String
   def to_language_code
     Spaceship::Tunes::LanguageConverter.from_itc_to_standard(self)
+  end
+
+  def to_itc_locale
+    Spaceship::Tunes::LanguageConverter.from_standard_to_itc_locale(self)
   end
 
   def to_full_language

--- a/spaceship/lib/spaceship/tunes/language_converter.rb
+++ b/spaceship/lib/spaceship/tunes/language_converter.rb
@@ -10,10 +10,8 @@ module Spaceship
 
         # Converts the Language "UK English" to itc locale en-GB
         def from_standard_to_itc_locale(from)
-          result = mapping.find { |a| a['name'] == from }
-          itc_locale = (result || {}).fetch('itc_locale', nil)
-          return itc_locale if itc_locale
-          (result || {}).fetch('locale', nil)
+          result = mapping.find { |a| a['name'] == from } || {}
+          return result['itc_locale'] || result['locale']
         end
 
         # Converts the language short codes: (en-US, de-DE) to the iTC format (English_CA, Brazilian Portuguese)

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -277,7 +277,7 @@ module Spaceship
       data['name'] = { value: name }
       data['bundleId'] = { value: bundle_id }
       data['primaryLanguage'] = { value: primary_language }
-      data['primaryLocaleCode'] = { value: primary_language.to_language_code }
+      data['primaryLocaleCode'] = { value: primary_language.to_itc_locale }
       data['vendorId'] = { value: sku }
       data['bundleIdSuffix'] = { value: bundle_id_suffix }
       data['companyName'] = { value: company_name } if company_name

--- a/spaceship/spec/tunes/language_converter_spec.rb
+++ b/spaceship/spec/tunes/language_converter_spec.rb
@@ -51,7 +51,41 @@ describe Spaceship::Tunes::LanguageConverter do
   end
 end
 
-describe String do
+describe String, now: true do
+  describe "#to_itc_locale" do
+    # verify all available itc primary languages match the right locale (itc variation)
+    it "redirects to the actual converter" do
+      expect("German".to_itc_locale).to eq("de-DE")
+      expect("Traditional Chinese".to_itc_locale).to eq("zh-Hant")
+      expect("Simplified Chinese".to_itc_locale).to eq("zh-Hans")
+      expect("Danish".to_itc_locale).to eq("da")
+      expect("Australian English".to_itc_locale).to eq("en-AU")
+      expect("UK English".to_itc_locale).to eq("en-GB")
+      expect("Canadian English".to_itc_locale).to eq("en-CA")
+      expect("English".to_itc_locale).to eq("en-US")
+      expect("Finnish".to_itc_locale).to eq("fin")
+      expect("French".to_itc_locale).to eq("fr-FR")
+      expect("Canadian French".to_itc_locale).to eq("fr-CA")
+      expect("Greek".to_itc_locale).to eq("el")
+      expect("Indonesian".to_itc_locale).to eq("id")
+      expect("Italian".to_itc_locale).to eq("it")
+      expect("Japanese".to_itc_locale).to eq("ja")
+      expect("Korean".to_itc_locale).to eq("ko")
+      expect("Malay".to_itc_locale).to eq("ms")
+      expect("Dutch".to_itc_locale).to eq("nl-NL")
+      expect("Norwegian".to_itc_locale).to eq("no")
+      expect("Brazilian Portuguese".to_itc_locale).to eq("pt-BR")
+      expect("Portuguese".to_itc_locale).to eq("pt-PT")
+      expect("Russian".to_itc_locale).to eq("ru")
+      expect("Swedish".to_itc_locale).to eq("sv")
+      expect("Mexican Spanish".to_itc_locale).to eq("es-MX")
+      expect("Spanish".to_itc_locale).to eq("es-ES")
+      expect("Thai".to_itc_locale).to eq("th")
+      expect("Turkish".to_itc_locale).to eq("tr")
+      expect("Vietnamese".to_itc_locale).to eq("vi")
+    end
+  end
+
   describe "#to_language_code" do
     it "redirects to the actual converter" do
       expect("German".to_language_code).to eq("de-DE")


### PR DESCRIPTION
as we still have errors on produce - even with latest `primaryLocale` fixes (https://github.com/fastlane/fastlane/pull/7084):
  * https://github.com/fastlane/fastlane/issues/7189 (chinese)
  * https://github.com/fastlane/fastlane/pull/7084#issuecomment-263103679 (turkish)

initial PR used `to_language_code` which resolved in the following the wrong way.

|  INPUT  |  BEFORE PR  |  Required by iTC (after PR)  |
|---|---|---|
| Turkish  |  tr-TR  |   tr |
| Simplified Chinese  |  cmn-Hans  |   zh-Hans |
| Traditional Chinese  |  cmn-Hant   |  zh-Hant |
| Danish | da-DK | da |
| Finnish | fi-FI | fin |
| Greek | el-GR | el |
| Indonesian | id-ID | id |
| Italian | it-IT | it |
| Japanese | ja-JP | ja |
| Korean | ko-KR | ko |
| Malay | ms-MY | ms |
| Norwegian | no-NO | no |
| Russian | ru-RU | ru |
| Swedish | sv-ES | sv |
| Thai | th-TH | th |
| Turkish | tr-TR | tr |
| Vietnamese | vi-VI | vi |


this PR does the following:

  * add `itc_locale`  to  `languageMapping.json`
  * add `to_itc_locale` to `language_convertor` returning new json field
  * add a spec for it!
  * `tunes_client.rb`  use new `to_itc_locale`




i really hope this one fixes, the produce error once-and-for-all