### PR TITLE
[fastlane, action] reset_simulator - add :ios version flag

### DIFF
--- a/fastlane/lib/fastlane/actions/reset_simulators.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulators.rb
@@ -2,7 +2,17 @@ module Fastlane
   module Actions
     class ResetSimulatorsAction < Action
       def self.run(params)
-        FastlaneCore::Simulator.reset_all
+        if params[:ios]
+          params[:ios].each do |os_version|
+            FastlaneCore::Simulator.all.each do |dev|
+              if dev.os_version == os_version
+                dev.reset
+              end
+            end
+          end
+        else
+          FastlaneCore::Simulator.reset_all
+        end
         UI.success('Simulators reset')
       end
 
@@ -11,7 +21,15 @@ module Fastlane
       end
 
       def self.available_options
-        []
+        [
+          FastlaneCore::ConfigItem.new(key: :ios,
+                                       short_option: "-i",
+                                       env_name: "FASTLANE_RESET_SIMULATOR_VERSIONS",
+                                       description: "Which versions of Simulators you want to reset",
+                                       is_string: false,
+                                       optional: true,
+                                       type: Array)
+        ]
       end
 
       def self.output


### PR DESCRIPTION
as requested here: https://github.com/fastlane/fastlane/issues/7192
initially i tried: `FastlaneCore::Simulator::reset(udid: nil, name: nil, os_version: nil)`  but it depends on either udid, or name, and i think in this case its ok to get those few more lines in the action itself.

```ruby
lane :sim do
        reset_simulators(
                ios: ["8.1", "10.1"]
        )
        reset_simulators
end
```