### PR TITLE
[fastlane_core] FastlaneCore::Simulator reset by version 1/2

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -186,7 +186,7 @@ module FastlaneCore
       end
 
       def reset_all_by_version(os_version: nil)
-        return false until os_version
+        return false unless os_version
         version_sim = all.select { |device| device.os_version == os_version }
         version_sim.each(&:reset) if version_sim
       end

--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -185,6 +185,12 @@ module FastlaneCore
         all.each(&:reset)
       end
 
+      def reset_all_by_version(os_version: nil)
+        return false until os_version
+        version_sim = all.select { |device| device.os_version == os_version }
+        version_sim.each(&:reset) if version_sim
+      end
+
       # Reset simulator by UDID or name and OS version
       # Latter is useful when combined with -destination option of xcodebuild
       def reset(udid: nil, name: nil, os_version: nil)

--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -187,8 +187,7 @@ module FastlaneCore
 
       def reset_all_by_version(os_version: nil)
         return false unless os_version
-        version_sim = all.select { |device| device.os_version == os_version }
-        version_sim.each(&:reset) if version_sim
+        all.select { |device| device.os_version == os_version }.each(&:reset)
       end
 
       # Reset simulator by UDID or name and OS version


### PR DESCRIPTION
# PR 1/2
Split of: https://github.com/fastlane/fastlane/pull/7194

as requested here: #7192

```ruby
lane :sim do
        reset_simulators(
                ios: ["8.1", "10.1"]
        )
        reset_simulators
end
```

  * 1/2 -> https://github.com/fastlane/fastlane/pull/7196
  * 2/2 -> https://github.com/fastlane/fastlane/pull/7197