### PR TITLE
[fastlane] FastlaneCore::Simulator reset by version 2/2

### DIFF
--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -48,7 +48,7 @@ module Fastlane
 
       def self.example_code
         [
-          'reset_simulators'
+          'reset_simulator_contents'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Actions
-    class ResetSimulatorsAction < Action
+    class ResetSimulatorContentsAction < Action
       def self.run(params)
         if params[:ios]
           params[:ios].each do |os_version|
@@ -27,7 +27,9 @@ module Fastlane
                                        type: Array)
         ]
       end
-
+      def self.aliases
+        ["reset_simulators"]
+      end
       def self.output
         nil
       end

--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -27,9 +27,11 @@ module Fastlane
                                        type: Array)
         ]
       end
+
       def self.aliases
         ["reset_simulators"]
       end
+
       def self.output
         nil
       end

--- a/fastlane/lib/fastlane/actions/reset_simulators.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulators.rb
@@ -21,7 +21,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :ios,
                                        short_option: "-i",
                                        env_name: "FASTLANE_RESET_SIMULATOR_VERSIONS",
-                                       description: "Which versions of Simulators you want to reset",
+                                       description: "Which versions of Simulators you want to reset content and settings, this does not remove/recreate the simulators",
                                        is_string: false,
                                        optional: true,
                                        type: Array)

--- a/fastlane/lib/fastlane/actions/reset_simulators.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulators.rb
@@ -2,7 +2,13 @@ module Fastlane
   module Actions
     class ResetSimulatorsAction < Action
       def self.run(params)
-        FastlaneCore::Simulator.reset_all
+        if params[:ios]
+          params[:ios].each do |os_version|
+            FastlaneCore::Simulator.reset_all_by_version(os_version: os_version)
+          end
+        else
+          FastlaneCore::Simulator.reset_all
+        end
         UI.success('Simulators reset')
       end
 
@@ -11,7 +17,15 @@ module Fastlane
       end
 
       def self.available_options
-        []
+        [
+          FastlaneCore::ConfigItem.new(key: :ios,
+                                       short_option: "-i",
+                                       env_name: "FASTLANE_RESET_SIMULATOR_VERSIONS",
+                                       description: "Which versions of Simulators you want to reset",
+                                       is_string: false,
+                                       optional: true,
+                                       type: Array)
+        ]
       end
 
       def self.output


### PR DESCRIPTION
# PR 2/2
Split of: https://github.com/fastlane/fastlane/pull/7194


as requested here: #7192

```ruby
lane :sim do
        reset_simulators(
                ios: ["8.1", "10.1"]
        )
        reset_simulators
end
```

  * 1/2 -> https://github.com/fastlane/fastlane/pull/7196
  * 2/2 -> https://github.com/fastlane/fastlane/pull/7197
