### PR TITLE
[WIP] Windows

### DIFF
--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -180,6 +180,11 @@ module Fastlane
         product, version, build = `sw_vers`.strip.split("\n").map { |line| line.split(':').last.strip }
         os_version = version
       end
+      
+      if Helper.windows?
+        version = os_version = `ver`.strip
+        product = "Windows"
+      end
 
       if Helper.linux?
         # this should work on pretty much all linux distros

--- a/fastlane_core/fastlane_core.gemspec
+++ b/fastlane_core/fastlane_core.gemspec
@@ -31,7 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'plist', '>= 3.1.0', '< 4.0.0' # needed for parsing provisioning profiles
   spec.add_dependency 'terminal-table', '>= 1.4.5', '< 2.0.0' # options summary
   spec.add_dependency 'gh_inspector', '>= 1.0.1', '< 2.0.0' # search for issues on GitHub when something goes wrong
-
+  spec.add_dependency 'systemu' # cross platform command execution
+  
   spec.add_dependency "credentials_manager", ">= 0.16.2", "< 1.0.0" # fastlane password manager
 
   # Development only

--- a/fastlane_core/lib/fastlane_core.rb
+++ b/fastlane_core/lib/fastlane_core.rb
@@ -27,6 +27,7 @@ require 'fastlane_core/ui/ui'
 require 'fastlane_core/tool_collector'
 require 'fastlane_core/fastlane_folder'
 require 'fastlane_core/keychain_importer'
+require 'fastlane_core/PTY'
 
 # Third Party code
 require 'colored'

--- a/fastlane_core/lib/fastlane_core/PTY.rb
+++ b/fastlane_core/lib/fastlane_core/PTY.rb
@@ -1,0 +1,20 @@
+module FastlaneCore
+  class PTY
+    def self.spawn(*cmd, &block)
+      # Utopia - we have PTY
+      if Gem::Specification.any? { |s| s.name == "pty" }
+          require "pty"
+          PTY.spawn(command) do |stdout, stdin, pid|
+            block.call(stdin, stdout, pid)
+          end
+      else
+      # Sucks - but lets try to handle it
+          require "systemu"
+          stdout, stderr = '', ''
+          status = systemu cmd, 'stdout' => stdout, 'stderr' => stderr
+          block.call("", stdout, 0)
+          
+      end
+    end
+  end
+end

--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -43,7 +43,7 @@ module FastlaneCore
         end
 
         begin
-          PTY.spawn(command) do |stdin, stdout, pid|
+          FastlaneCore::PTY.spawn(command) do |stdin, stdout, pid|
             begin
               stdin.each do |l|
                 line = l.strip # strip so that \n gets removed

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -56,8 +56,8 @@ module FastlaneCore
     end
 
     def self.windows?
-      # taken from: http://stackoverflow.com/a/171011/1945875
-      (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+      # taken from: http://stackoverflow.com/a/4871457/1945875
+      (ENV['OS'] == 'Windows_NT')
     end
 
     def self.linux?

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -1,4 +1,3 @@
-require 'pty'
 require 'shellwords'
 require 'fileutils'
 require 'credentials_manager/account_manager'
@@ -40,7 +39,7 @@ module FastlaneCore
       end
 
       begin
-        PTY.spawn(command) do |stdin, stdout, pid|
+        FastlaneCore::PTY.spawn(command) do |stdin, stdout, pid|
           begin
             stdin.each do |line|
               parse_line(line, hide_output) # this is where the parsing happens

--- a/fastlane_core/lib/fastlane_core/tool_collector.rb
+++ b/fastlane_core/lib/fastlane_core/tool_collector.rb
@@ -76,7 +76,7 @@ module FastlaneCore
       if Helper.is_test? # don't send test data
         return url
       else
-        fork do
+        Thread.new do
           begin
             Excon.post(url)
           rescue

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -34,7 +34,7 @@ module FastlaneCore
     end
 
     def self.show_update_status(gem_name, current_version)
-      fork do
+      Thread.new do
         begin
           finished_running(gem_name)
         rescue

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -17,7 +17,7 @@ describe FastlaneCore do
         expect($?).to receive(:exitstatus).and_return 0
 
         # Make a fake child process so we have a valid PID and $? is set correctly
-        expect(PTY).to receive(:spawn) do |command, &block|
+        expect(FastlaneCore::PTY).to receive(:spawn) do |command, &block|
           expect(command).to eq('ls')
           block.yield fake_std_in, 'not_really_std_out', child_process_id
         end

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -1,4 +1,3 @@
-require 'pty'
 require 'open3'
 require 'fileutils'
 require 'shellwords'

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -1,4 +1,3 @@
-require 'pty'
 require 'open3'
 require 'fileutils'
 require 'terminal-table'

--- a/snapshot/lib/snapshot/screenshot_rotate.rb
+++ b/snapshot/lib/snapshot/screenshot_rotate.rb
@@ -25,7 +25,7 @@ module Snapshot
         next unless command
 
         # Only rotate if we need to
-        PTY.spawn(command) do |r, w, pid|
+        FastlaneCore::PTY.spawn(command) do |r, w, pid|
           r.sync
           r.each do |line|
             # We need to read this otherwise things hang


### PR DESCRIPTION
i don't really like windows as a platform et-all - just to be said. (doing this as a research project, using some trial windows in virtualbox 😢 )
but i think, atleast for the android world, it would be really awesome to get fastlane running on windows.

the biggest pain point is PTY.
this PR trys to eliminate the requirement on PTY and fallback using `systemu` (the only gem i got working 😄 )

# Changes
  * Env better windows detection
  * remove all direct dependencies on PTY
  * put a PTY shim inside Fastlane Core
  * use PTY or systemu
  * `Thread.new` instead of `fork`


Sample Fastfile (just to proof concept):

```ruby
require "fastlane_core"
lane :demo do
  ENV["HELI"]="1"
  FastlaneCore::PTY.spawn("env") do |stdin, stdout, pid|
      puts stdout
  end
end
```


i know there are like more than 80% of the tools not working.
anyone want to join the road trip (Or should we just drop it?)? 

# Goals
  * Make spaceship working (fix: /tmp)
  * supply
  * adb, gradle - the whole android chain


see below ENV output ❤️ 

<details><summary>🚫 fastlane environment 🚫</summary>

### Stack

| Key                 | Value                                             |
| ------------------- | ------------------------------------------------- |
| OS                  | Microsoft Windows [Version 10.0.10586]            |
| Ruby                | 2.3.1                                             |
| Bundler?            | true                                              |
| Git                 | git version 2.10.2.windows.1                      |
| Installation Source | C:/Ruby23-x64/lib/ruby/gems/2.3.0/bin/fastlane    |
| Host                | Windows Microsoft Windows [Version 10.0.10586] () |
| Ruby Lib Dir        | C:/Ruby23-x64/lib                                 |
| OpenSSL Version     | OpenSSL 1.0.1l 15 Jan 2015                        |
| Is contained        | false                                             |


### System Locale

| Error                       |
| --------------------------- |
| No Locale with UTF8 found 🚫 |


### fastlane files:

<details><summary>`./fastlane/Fastfile`</summary>

```ruby
require "fastlane_core"
lane :demo do
  ENV["HELI"]="1"
  FastlaneCore::PTY.spawn("env") do |stdin, stdout, pid|
      puts stdout
  end
end
```
</details>

**No Appfile found**


### fastlane gems

| Gem                 | Version | Update-Status |
| ------------------- | ------- | ------------- |
| credentials_manager | 0.16.2  | ✅ Up-To-Date  |
| fastlane_core       | 0.57.1  | ✅ Up-To-Date  |
| spaceship           | 0.38.1  | ✅ Up-To-Date  |
| cert                | 1.4.4   | ✅ Up-To-Date  |
| deliver             | 1.15.1  | ✅ Up-To-Date  |
| frameit             | 3.0.0   | ✅ Up-To-Date  |
| gym                 | 1.12.1  | ✅ Up-To-Date  |
| sigh                | 1.11.2  | ✅ Up-To-Date  |
| match               | 0.11.0  | ✅ Up-To-Date  |
| pem                 | 1.4.0   | ✅ Up-To-Date  |
| pilot               | 1.12.1  | ✅ Up-To-Date  |
| produce             | 1.3.1   | ✅ Up-To-Date  |
| scan                | 0.14.2  | ✅ Up-To-Date  |
| screengrab          | 0.5.6   | ✅ Up-To-Date  |
| snapshot            | 1.16.4  | ✅ Up-To-Date  |
| supply              | 0.7.1   | ✅ Up-To-Date  |
| fastlane            | 1.110.0 | ✅ Up-To-Date  |


### Loaded fastlane plugins:

**No plugins Loaded**


<details><summary><b>Loaded gems</b></summary>

| Gem                       | Version      |
| ------------------------- | ------------ |
| did_you_mean              | 1.0.0        |
| io-console                | 0.4.5        |
| rake                      | 11.3.0       |
| CFPropertyList            | 2.3.4        |
| i18n                      | 0.7.0        |
| json                      | 1.8.3        |
| minitest                  | 5.9.1        |
| thread_safe               | 0.3.5        |
| tzinfo                    | 1.2.2        |
| activesupport             | 4.2.7.1      |
| public_suffix             | 2.0.4        |
| addressable               | 2.5.0        |
| ast                       | 2.3.0        |
| babosa                    | 1.0.2        |
| builder                   | 3.2.2        |
| bundler                   | 1.13.6       |
| byebug                    | 9.0.6        |
| colored                   | 1.2          |
| highline                  | 1.7.8        |
| commander                 | 4.4.0        |
| security                  | 0.1.3        |
| credentials_manager       | 0.16.2       |
| excon                     | 0.54.0       |
| gh_inspector              | 1.0.2        |
| multi_json                | 1.12.1       |
| plist                     | 3.2.0        |
| rubyzip                   | 1.1.7        |
| systemu                   | 2.6.5        |
| terminal-table            | 1.4.5        |
| fastlane_core             | 0.57.1       |
| multipart-post            | 2.0.0        |
| faraday                   | 0.10.0       |
| unf_ext                   | 0.0.7.2      |
| unf                       | 0.1.4        |
| domain_name               | 0.5.20161021 |
| http-cookie               | 1.0.3        |
| faraday-cookie_jar        | 0.0.6        |
| faraday_middleware        | 0.10.1       |
| fastimage                 | 1.6.8        |
| multi_xml                 | 0.5.5        |
| claide                    | 1.0.1        |
| cork                      | 0.2.0        |
| nap                       | 1.1.0        |
| open4                     | 1.3.4        |
| claide-plugins            | 0.9.2        |
| coderay                   | 1.1.1        |
| docile                    | 1.1.5        |
| simplecov-html            | 0.10.0       |
| simplecov                 | 0.12.0       |
| tins                      | 1.13.0       |
| term-ansicolor            | 1.3.2        |
| thor                      | 0.19.4       |
| coveralls                 | 0.8.16       |
| safe_yaml                 | 1.0.4        |
| crack                     | 0.4.3        |
| faraday-http-cache        | 1.3.1        |
| git                       | 1.3.0        |
| sawyer                    | 0.8.1        |
| octokit                   | 4.6.2        |
| redcarpet                 | 3.3.4        |
| danger                    | 0.10.1       |
| diff-lcs                  | 1.2.5        |
| dotenv                    | 2.1.1        |
| fakefs                    | 0.8.1        |
| mini_magick               | 4.5.1        |
| rouge                     | 1.11.1       |
| xcpretty                  | 0.2.4        |
| net-ssh                   | 3.2.0        |
| net-sftp                  | 2.1.2        |
| krausefx-shenzhen         | 0.14.11      |
| slack-notifier            | 1.5.1        |
| xcpretty-travis-formatter | 0.0.4        |
| jwt                       | 1.5.6        |
| little-plugger            | 1.1.4        |
| logging                   | 2.1.0        |
| memoist                   | 0.15.0       |
| os                        | 0.9.6        |
| signet                    | 0.7.3        |
| googleauth                | 0.5.1        |
| httpclient                | 2.8.2.4      |
| hurley                    | 0.2          |
| mime-types                | 1.25.1       |
| uber                      | 0.0.15       |
| representable             | 2.3.0        |
| retriable                 | 2.1.0        |
| google-api-client         | 0.9.20       |
| terminal-notifier         | 1.7.1        |
| word_wrap                 | 1.0.0        |
| xcode-install             | 2.0.9        |
| nanaimo                   | 0.2.2        |
| xcodeproj                 | 1.4.1        |
| method_source             | 0.8.2        |
| parser                    | 2.3.2.0      |
| powerpack                 | 0.1.1        |
| slop                      | 3.6.0        |
| pry                       | 0.10.4       |
| pry-byebug                | 3.4.1        |
| rainbow                   | 2.1.0        |
| rest-client               | 1.6.9        |
| rspec-support             | 3.1.2        |
| rspec-core                | 3.1.7        |
| rspec-expectations        | 3.1.2        |
| rspec-mocks               | 3.1.3        |
| rspec                     | 3.1.0        |
| rspec_junit_formatter     | 0.2.3        |
| ruby-progressbar          | 1.8.1        |
| unicode-display_width     | 1.1.1        |
| rubocop                   | 0.44.1       |
| webmock                   | 1.19.0       |
| yard                      | 0.8.7.6      |
</details>


*generated on:* **2016-11-28**
</details>