### PR TITLE
Bump supply version

### DIFF
--- a/supply/lib/supply/version.rb
+++ b/supply/lib/supply/version.rb
@@ -1,4 +1,4 @@
 module Supply
-  VERSION = "0.7.1".freeze
+  VERSION = "0.8.0".freeze
   DESCRIPTION = "Command line tool for updating Android apps and their metadata on the Google Play Store"
 end


### PR DESCRIPTION
Changes since release 0.7.1:

* Added validate_only option to supply, fixes #7094 (#7095)
* make use of the rollout option when promoting from a track to the sta… (#6502)
* Remove build badge from READMEs (#6681)
* Update fastlane tagline (#6645)
* Update rubocop and update styling rules (#6573)
* Make formatting match docs.fastlane.tools and correct link text (#6537)
* Prompt for json_key if it and legacy option are both missing (#6536)
* instanciate -> instantiate (#6304)
* Update internal dependencies (#6104)
* Update supply setup steps for correctness (#5992)
* Update instructions for current site structure (#5965)