### PR TITLE
Bump deliver version

### DIFF
--- a/deliver/lib/deliver/version.rb
+++ b/deliver/lib/deliver/version.rb
@@ -1,4 +1,4 @@
 module Deliver
-  VERSION = "1.15.1"
+  VERSION = "1.16.0"
   DESCRIPTION = 'Upload screenshots, metadata and your app to the App Store using a single command'
 end


### PR DESCRIPTION
Changes since release 1.15.1:

* platform bug (#7174)
* Update internal dependencies (#7163)
* Ensure that `ensure_version!` gets passed the right platform (#7121)
* Revert "add new mac version fix" (#7137)
* add new mac version fix (#7063)
* Fixed unintended fastlane folder generation bug (#7129)
* Update dependency on fastlane_core (#7119)
* Support iMessage Screenshots, fixes #6124 (#6830)
* Adding in platform support for deliver. Depends on #4447 (#4781)