### PR TITLE
[spaceship] non-ASCII app name in produce 1/2

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -6,6 +6,7 @@ require 'spaceship/ui'
 require 'spaceship/helper/plist_middleware'
 require 'spaceship/helper/net_http_generic_request'
 require 'tmpdir'
+require "babosa"
 
 Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder
 

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -133,7 +133,8 @@ module Spaceship
     end
 
     def valid_name_for(input)
-      latinazed = input.gsub(/[^0-9A-Za-z\d\s]/, '') # remove non-valid characters
+      latinazed = input.to_slug.transliterate
+      latinazed = latinazed.gsub(/[^0-9A-Za-z\d\s]/, '') # remove non-valid characters
       # it may result in totaly empty strings that only contain chinese symbols.
       if latinazed != input
         latinazed << " "

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -132,6 +132,17 @@ module Spaceship
       details_for_app(app)
     end
 
+    def valid_name_for(input)
+      latinazed = input.to_slug.transliterate.to_s # remove accents
+      latinazed = latinazed.gsub(/[^0-9A-Za-z\d\s]/, '') # remove non-valid characters
+      # it may result in totaly empty strings that only contain chinese symbols.
+      if latinazed != input
+        latinazed << " "
+        latinazed << Digest::MD5.hexdigest(input)
+      end
+      latinazed
+    end
+
     def create_app!(type, name, bundle_id, mac: false)
       # We moved the ensure_csrf to the top of this method
       # as we got some users with issues around creating new apps
@@ -155,7 +166,7 @@ module Spaceship
                      end
 
       params = {
-        name: name,
+        name: valid_name_for(name),
         teamId: team_id
       }
 

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -133,8 +133,7 @@ module Spaceship
     end
 
     def valid_name_for(input)
-      latinazed = input.to_slug.transliterate.to_s # remove accents
-      latinazed = latinazed.gsub(/[^0-9A-Za-z\d\s]/, '') # remove non-valid characters
+      latinazed = input.gsub(/[^0-9A-Za-z\d\s]/, '') # remove non-valid characters
       # it may result in totaly empty strings that only contain chinese symbols.
       if latinazed != input
         latinazed << " "

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -135,7 +135,8 @@ module Spaceship
     def valid_name_for(input)
       latinazed = input.to_slug.transliterate
       latinazed = latinazed.gsub(/[^0-9A-Za-z\d\s]/, '') # remove non-valid characters
-      # it may result in totaly empty strings that only contain chinese symbols.
+      # Check if the input string was modified, since it might be empty now
+      # (if it only contained non-latin symbols) or the duplicate of another app
       if latinazed != input
         latinazed << " "
         latinazed << Digest::MD5.hexdigest(input)

--- a/spaceship/spaceship.gemspec
+++ b/spaceship/spaceship.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware', '~> 0.9'
   spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
   spec.add_dependency 'fastimage', '~> 1.6'
+  spec.add_dependency 'babosa' # transliterate strings
 
   # for the playground
   spec.add_dependency 'colored'

--- a/spaceship/spec/portal/fixtures/addAppId.action.apostroph.json
+++ b/spaceship/spec/portal/fixtures/addAppId.action.apostroph.json
@@ -1,0 +1,51 @@
+{
+  "creationTimestamp": "2015-04-29T00:26:33Z",
+  "resultCode": 0,
+  "userLocale": "en_US",
+  "protocolVersion": "QH65B2",
+  "requestId": null,
+  "requestUrl": "https://developer.apple.com:443//services-account/QH65B2/account/ios/identifiers/addAppId.action",
+  "responseId": "ed5e74cf-8f52-46bf-9cf6-9e9e9fcd9fad",
+  "isAdmin": true,
+  "isMember": false,
+  "isAgent": false,
+  "pageNumber": null,
+  "pageSize": null,
+  "totalRecords": null,
+  "appId": {
+    "appIdId": "2HNR359G63",
+    "name": "pp Test 1ed9e25c93ac7142ff9df53e7f80e84c",
+    "appIdPlatform": "ios",
+    "prefix": "S56PJTAYEL",
+    "identifier": "tools.fastlane.spaceship.some-explicit-app",
+    "isWildCard": false,
+    "isDuplicate": false,
+    "features": {
+      "push": true,
+      "inAppPurchase": true,
+      "gameCenter": true,
+      "passbook": false,
+      "dataProtection": "",
+      "homeKit": false,
+      "cloudKitVersion": 1,
+      "iCloud": false,
+      "LPLF93JG7M": false,
+      "IAD53UNK2F": false,
+      "V66P55NK2I": false,
+      "SKC3T5S89Y": false,
+      "APG3427HIY": false,
+      "HK421J6T7P": false,
+      "WC421J6T7P": false
+    },
+    "enabledFeatures": [
+      "gameCenter",
+      "inAppPurchase",
+      "push"
+    ],
+    "isDevPushEnabled": false,
+    "isProdPushEnabled": false,
+    "associatedApplicationGroupsCount": null,
+    "associatedCloudContainersCount": null,
+    "associatedIdentifiersCount": null
+  }
+}

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -113,6 +113,13 @@ describe Spaceship::Client do
         expect(response['name']).to eq('Development App')
         expect(response['identifier']).to eq('tools.fastlane.spaceship.*')
       end
+
+      it 'should strip non ASCII characters', now: true do
+        response = subject.create_app!(:explicit, 'pp Test 1ed9e25c93ac7142ff9df53e7f80e84c', 'tools.fastlane.spaceship.some-explicit-app')
+        expect(response['isWildCard']).to eq(false)
+        expect(response['name']).to eq('pp Test 1ed9e25c93ac7142ff9df53e7f80e84c')
+        expect(response['identifier']).to eq('tools.fastlane.spaceship.some-explicit-app')
+      end
     end
 
     describe '#delete_app!' do

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -181,6 +181,10 @@ def adp_stub_apps
     with(body: { "name" => "Development App", "identifier" => "tools.fastlane.spaceship.*", "teamId" => "XXXXXXXXXX", "type" => "wildcard" }).
     to_return(status: 200, body: adp_read_fixture_file('addAppId.action.wildcard.json'), headers: { 'Content-Type' => 'application/json' })
 
+  stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
+    with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "pp Test 1ed9e25c93ac7142ff9df53e7f80e84c", "push" => "on", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
+    to_return(status: 200, body: adp_read_fixture_file('addAppId.action.apostroph.json'), headers: { 'Content-Type' => 'application/json' })
+
   stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/deleteAppId.action").
     with(body: { "appIdId" => "LXD24VUE49", "teamId" => "XXXXXXXXXX" }).
     to_return(status: 200, body: adp_read_fixture_file('deleteAppId.action.json'), headers: { 'Content-Type' => 'application/json' })


### PR DESCRIPTION
# PR 1/2

The Problem with non ASCII characters support in Produce is infact a `portal` problem.
`tunes` supports all utf8 characters (as they get converted with `.to_json`)

This one trys to fix this, allowing non-ASCII characters in app_name.

> the app name is in fact still be latinzed but, to prevent an empty string as app_name
> i added a md5 of the string

```ruby
lane :produce_demo do
  produce(app_name: "名倉堂áásaa1")
end
```
  * Branch with all PRS:
    * https://github.com/hjanuschka/fastlane/tree/produce_non_latin_full
  * PRS: 
    * 1/2 -> https://github.com/fastlane/fastlane/pull/7210
    * 2/2 -> https://github.com/fastlane/fastlane/pull/7211
    
  * Issue:
    * https://github.com/fastlane/fastlane/issues/7206
    * https://github.com/fastlane/fastlane/issues/5236

(When it was introduced)
 
  * History:
    * https://github.com/fastlane-old/produce/pull/17/files




