### PR TITLE
[produce] non-ASCII app name in produce 2/2

### DIFF
--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -22,6 +22,12 @@ module Produce
         app = Spaceship.app.create!(bundle_id: app_identifier,
                                          name: app_name)
 
+        if app.name != Produce.config[:app_name]
+          UI.important("Your app name includes non-ASCII characters, which are not supported by the Apple Developer Portal.")
+          UI.important("To fix this a unique (internal) name '#{app.name}' has been created for you. Your app's real name '#{Produce.config[:app_name]}'")
+          UI.important("will still show up correctly on iTunes Connect and the App Store.")
+        end
+
         UI.message "Created app #{app.app_id}"
 
         UI.crash!("Something went wrong when creating the new app - it's not listed in the apps list") unless app_exists?

--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -16,7 +16,7 @@ module Produce
         ENV["CREATED_NEW_APP_ID"] = nil
         # Nothing to do here
       else
-        app_name = valid_name_for(Produce.config[:app_name])
+        app_name = Produce.config[:app_name]
         UI.message "Creating new app '#{app_name}' on the Apple Dev Center"
 
         app = Spaceship.app.create!(bundle_id: app_identifier,
@@ -32,11 +32,6 @@ module Produce
       end
 
       return true
-    end
-
-    def valid_name_for(input)
-      latinazed = input.to_slug.transliterate.to_s # remove accents
-      latinazed.gsub(/[^0-9A-Za-z\d\s]/, '') # remove non-valid characters
     end
 
     def app_identifier


### PR DESCRIPTION
# PR 2/2

The Problem with non ASCII characters support in Produce is infact a `portal` problem.
`tunes` supports all utf8 characters (as they get converted with `.to_json`)

This one trys to fix this, allowing non-ASCII characters in app_name.

> the app name is in fact still be latinzed but, to prevent an empty string as app_name
> i added a md5 of the string

```ruby
lane :produce_demo do
  produce(app_name: "名倉堂áásaa1")
end
```
  * Branch with all PRS:
    * https://github.com/hjanuschka/fastlane/tree/produce_non_latin_full
  * PRS: 
    * 1/2 -> https://github.com/fastlane/fastlane/pull/7210
    * 2/2 -> https://github.com/fastlane/fastlane/pull/7211
    
  * Issue:
    * https://github.com/fastlane/fastlane/issues/7206
    * https://github.com/fastlane/fastlane/issues/5236

(When it was introduced)
 
  * History:
    * https://github.com/fastlane-old/produce/pull/17/files




