### PR TITLE
[fastlane] support aliases in actions

### DIFF
--- a/fastlane/lib/fastlane.rb
+++ b/fastlane/lib/fastlane.rb
@@ -3,6 +3,7 @@ require 'fastlane_core'
 require 'fastlane/version'
 require 'fastlane/features'
 require 'fastlane/tools'
+require 'fastlane/documentation/actions_list'
 require 'fastlane/actions/actions_helper' # has to be before fast_file
 require 'fastlane/fast_file'
 require 'fastlane/runner'
@@ -36,6 +37,7 @@ module Fastlane
         actions_path = File.join(Fastlane::FastlaneFolder.path, 'actions')
         Fastlane::Actions.load_external_actions(actions_path) if File.directory?(actions_path)
       end
+      Fastlane::Actions.load_action_aliases
     end
 
     def plugin_manager

--- a/fastlane/lib/fastlane.rb
+++ b/fastlane/lib/fastlane.rb
@@ -37,7 +37,6 @@ module Fastlane
         actions_path = File.join(Fastlane::FastlaneFolder.path, 'actions')
         Fastlane::Actions.load_external_actions(actions_path) if File.directory?(actions_path)
       end
-      Fastlane::Actions.load_action_aliases
     end
 
     def plugin_manager

--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -1,4 +1,3 @@
-# rubocop:disable ModuleLength
 module Fastlane
   module Actions
     module SharedValues
@@ -69,36 +68,14 @@ module Fastlane
     # Returns the class ref to the action based on the action name
     # Returns nil if the action is not aailable
     def self.action_class_ref(action_name)
-      alias_found = find_alias(action_name)
-      orig_action = action_name
-      if alias_found
-        action_name = alias_found
-      end
       class_name = action_name.to_s.fastlane_class + 'Action'
       class_ref = nil
       begin
         class_ref = Fastlane::Actions.const_get(class_name)
-        if alias_found
-          # notify action that it has been used by alias
-          if class_ref.respond_to?(:alias_used)
-            class_ref.alias_used(orig_action)
-          end
-        end
       rescue NameError
         return nil
       end
       return class_ref
-    end
-
-    # lookup if an alias exists
-    def self.find_alias(action_name)
-      alias_actions.each do |key, v|
-        next unless alias_actions[key]
-        if alias_actions[key].include?(action_name)
-          return key
-        end
-      end
-      return nil
     end
 
     # load aliases of actions

--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -6,8 +6,19 @@ module Fastlane
       ENVIRONMENT = :ENVIRONMENT
     end
 
+    def self.reset_aliases
+      @alias_actions = nil
+    end
+
     def self.alias_actions
-      @alias_actions ||= {}
+      unless @alias_actions
+        @alias_actions = {}
+        ActionsList.all_actions do |action, name|
+          next unless action.respond_to?(:aliases)
+          @alias_actions[name] = action.aliases
+        end
+      end
+      @alias_actions
     end
 
     def self.executed_actions
@@ -78,15 +89,6 @@ module Fastlane
       return class_ref
     end
 
-    # load aliases of actions
-    def self.load_action_aliases
-      ActionsList.all_actions do |action, name|
-        if action.respond_to?(:aliases)
-          alias_actions[name] = action.aliases
-        end
-      end
-    end
-
     def self.load_default_actions
       Dir[File.expand_path('*.rb', File.dirname(__FILE__))].each do |file|
         require file
@@ -126,6 +128,7 @@ module Fastlane
           UI.user_error!("Action '#{file_name}' is damaged!", show_github_issues: true)
         end
       end
+      Actions.reset_aliases
     end
 
     def self.formerly_bundled_actions

--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -70,6 +70,7 @@ module Fastlane
     # Returns nil if the action is not aailable
     def self.action_class_ref(action_name)
       alias_found = find_alias(action_name)
+      orig_action = action_name
       if alias_found
         action_name = alias_found
       end
@@ -77,6 +78,12 @@ module Fastlane
       class_ref = nil
       begin
         class_ref = Fastlane::Actions.const_get(class_name)
+        if alias_found
+          # notify action that it has been used by alias
+          if class_ref.respond_to?(:alias_used)
+            class_ref.alias_used(orig_action)
+          end
+        end
       rescue NameError
         return nil
       end

--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -91,6 +91,7 @@ module Fastlane
           return key
         end
       end
+      return nil
     end
 
     # load aliases of actions

--- a/fastlane/lib/fastlane/actions/puts.rb
+++ b/fastlane/lib/fastlane/actions/puts.rb
@@ -21,6 +21,10 @@ module Fastlane
         true
       end
 
+      def self.aliases
+        ["println", "echo"]
+      end
+
       # We don't want to show this as step
       def self.step_text
         nil

--- a/fastlane/lib/fastlane/actions/puts.rb
+++ b/fastlane/lib/fastlane/actions/puts.rb
@@ -21,7 +21,7 @@ module Fastlane
         true
       end
 
-      def self.alias_used(action_alias, options)
+      def self.alias_used(action_alias, params)
         UI.important("#{action_alias} called please use 'puts' instead!")
       end
 

--- a/fastlane/lib/fastlane/actions/puts.rb
+++ b/fastlane/lib/fastlane/actions/puts.rb
@@ -21,6 +21,10 @@ module Fastlane
         true
       end
 
+      def self.alias_used(action_alias)
+        UI.important("#{action_alias} called please use 'puts' instead!")
+      end
+
       def self.aliases
         ["println", "echo"]
       end

--- a/fastlane/lib/fastlane/actions/puts.rb
+++ b/fastlane/lib/fastlane/actions/puts.rb
@@ -22,7 +22,7 @@ module Fastlane
       end
 
       def self.alias_used(action_alias, params)
-        UI.important("#{action_alias} called please use 'puts' instead!")
+        UI.important("#{action_alias} called, please use 'puts' instead!")
       end
 
       def self.aliases

--- a/fastlane/lib/fastlane/actions/puts.rb
+++ b/fastlane/lib/fastlane/actions/puts.rb
@@ -21,7 +21,7 @@ module Fastlane
         true
       end
 
-      def self.alias_used(action_alias)
+      def self.alias_used(action_alias, options)
         UI.important("#{action_alias} called please use 'puts' instead!")
       end
 

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -97,11 +97,33 @@ module Fastlane
       nil
     end
 
+    # lookup if an alias exists
+    def find_alias(action_name)
+      Actions.alias_actions.each do |key, v|
+        next unless Actions.alias_actions[key]
+        if Actions.alias_actions[key].include?(action_name)
+          return key
+        end
+      end
+      return nil
+    end
+
     # This is being called from `method_missing` from the Fastfile
     # It's also used when an action is called from another action
     def trigger_action_by_name(method_sym, custom_dir, *arguments)
       # First, check if there is a predefined method in the actions folder
       class_ref = class_reference_from_action_name(method_sym)
+      unless class_ref
+        alias_found = find_alias(method_sym.to_s)
+        if alias_found
+          orig_action = method_sym.to_s
+          class_ref = class_reference_from_action_name(alias_found.to_sym)
+          # notify action that it has been used by alias
+          if class_ref && class_ref.respond_to?(:alias_used)
+            class_ref.alias_used(orig_action, arguments)
+          end
+        end
+      end
 
       # It's important to *not* have this code inside the rescue block
       # otherwise all NameErrors will be caught and the error message is

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -101,11 +101,10 @@ module Fastlane
     def find_alias(action_name)
       Actions.alias_actions.each do |key, v|
         next unless Actions.alias_actions[key]
-        if Actions.alias_actions[key].include?(action_name)
-          return key
-        end
+        next unless Actions.alias_actions[key].include?(action_name)
+        return key
       end
-      return nil
+      nil
     end
 
     # This is being called from `method_missing` from the Fastfile

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -119,9 +119,7 @@ module Fastlane
           orig_action = method_sym.to_s
           class_ref = class_reference_from_action_name(alias_found.to_sym)
           # notify action that it has been used by alias
-          if class_ref && class_ref.respond_to?(:alias_used)
-            class_ref.alias_used(orig_action, arguments)
-          end
+          class_ref.alias_used(orig_action, arguments.first)
         end
       end
 

--- a/fastlane/spec/action_spec.rb
+++ b/fastlane/spec/action_spec.rb
@@ -20,26 +20,25 @@ describe Fastlane do
           println \"alias\"
         end").runner.execute(:test)
       end
+
       it "alias can override option" do
         Fastlane::Actions.load_external_actions("spec/fixtures/actions")
-        Fastlane::Actions.load_action_aliases
-
         expect(UI).to receive(:important).with("modified")
         result = Fastlane::FastFile.new.parse("lane :test do
           somealias(example: \"alias\", example_two: 'alias2')
         end").runner.execute(:test)
       end
+
       it "alias can override option with single param" do
         Fastlane::Actions.load_external_actions("spec/fixtures/actions")
-        Fastlane::Actions.load_action_aliases
         expect(UI).to receive(:important).with("modified")
         result = Fastlane::FastFile.new.parse("lane :test do
           someshortalias('PARAM')
         end").runner.execute(:test)
       end
+
       it "alias can override option with no param" do
         Fastlane::Actions.load_external_actions("spec/fixtures/actions")
-        Fastlane::Actions.load_action_aliases
         expect(UI).to receive(:important).with("modified")
         result = Fastlane::FastFile.new.parse("lane :test do
           somealias_no_param('PARAM')

--- a/fastlane/spec/action_spec.rb
+++ b/fastlane/spec/action_spec.rb
@@ -13,6 +13,14 @@ describe Fastlane do
         expect(Fastlane::Action.lane_context).to eq({ something: 1 })
       end
     end
+  
+    describe "can call alias action" do
+      it "redirects to the correct class and method" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          println \"alias\"
+        end").runner.execute(:test)
+      end
+    end
 
     describe "Call another action from an action" do
       it "allows the user to call it using `other_action.rocket`" do

--- a/fastlane/spec/action_spec.rb
+++ b/fastlane/spec/action_spec.rb
@@ -13,11 +13,36 @@ describe Fastlane do
         expect(Fastlane::Action.lane_context).to eq({ something: 1 })
       end
     end
-  
+
     describe "can call alias action" do
       it "redirects to the correct class and method" do
         result = Fastlane::FastFile.new.parse("lane :test do
           println \"alias\"
+        end").runner.execute(:test)
+      end
+      it "alias can override option" do
+        Fastlane::Actions.load_external_actions("spec/fixtures/actions")
+        Fastlane::Actions.load_action_aliases
+
+        expect(UI).to receive(:important).with("modified")
+        result = Fastlane::FastFile.new.parse("lane :test do
+          somealias(example: \"alias\", example_two: 'alias2')
+        end").runner.execute(:test)
+      end
+      it "alias can override option with single param" do
+        Fastlane::Actions.load_external_actions("spec/fixtures/actions")
+        Fastlane::Actions.load_action_aliases
+        expect(UI).to receive(:important).with("modified")
+        result = Fastlane::FastFile.new.parse("lane :test do
+          someshortalias('PARAM')
+        end").runner.execute(:test)
+      end
+      it "alias can override option with no param" do
+        Fastlane::Actions.load_external_actions("spec/fixtures/actions")
+        Fastlane::Actions.load_action_aliases
+        expect(UI).to receive(:important).with("modified")
+        result = Fastlane::FastFile.new.parse("lane :test do
+          somealias_no_param('PARAM')
         end").runner.execute(:test)
       end
     end

--- a/fastlane/spec/fixtures/actions/alias_short_test.rb
+++ b/fastlane/spec/fixtures/actions/alias_short_test.rb
@@ -1,0 +1,21 @@
+module Fastlane
+  module Actions
+    class AliasShortTestAction < Action
+      def self.run(params)
+        UI.important(params.join(","))
+      end
+
+      def self.alias_used(action_alias, params)
+        params.replace("modified")
+      end
+
+      def self.aliases
+        ["someshortalias"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/fastlane/spec/fixtures/actions/alias_test.rb
+++ b/fastlane/spec/fixtures/actions/alias_test.rb
@@ -1,0 +1,38 @@
+module Fastlane
+  module Actions
+    class AliasTestAction < Action
+      def self.run(params)
+        UI.important(params[:example])
+      end
+
+      def self.alias_used(action_alias, params)
+        params[:example] = "modified"
+      end
+
+      def self.aliases
+        ["somealias"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :example,
+                                     short_option: "-e",
+                                     description: "Example Param",
+                                     optional: true,
+                                     default_value: "Test String",
+                                     is_string: true),
+          FastlaneCore::ConfigItem.new(key: :example_two,
+                                     short_option: "-t",
+                                     description: "Example Param",
+                                     optional: true,
+                                     default_value: "Test String",
+                                     is_string: true)
+        ]
+      end
+    end
+  end
+end

--- a/fastlane/spec/fixtures/actions/alias_test_no_param.rb
+++ b/fastlane/spec/fixtures/actions/alias_test_no_param.rb
@@ -1,0 +1,25 @@
+module Fastlane
+  module Actions
+    class AliasTestNoParamAction < Action
+      attr_accessor :global_test
+      def self.run(params)
+        UI.important(@global_test)
+      end
+
+      def self.alias_used(action_alias, params)
+        @global_test = "modified"
+      end
+
+      def self.aliases
+        ["somealias_no_param"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.available_options
+      end
+    end
+  end
+end


### PR DESCRIPTION
In order to refactor actions, and easier deprecate actions - but not breaking existing fastfiles. 
let me know what you think.

PR includes 
  * a sample in `puts.rb` action to add aliases for `println`, `echo`
  * specs to test all different types of actions - using `alias_used`

**alias_used** is called before run, so that actions may tweak options. (e.g: latest_testflight_number, app_store_version) - values are mutable

Sample use-case would be here: 
  * https://github.com/fastlane/fastlane/issues/7192#issuecomment-263499724
  * testflight, pilot - are basically the same

inside actions:
```ruby
def self.aliases
   ["println", "echo"]
end
def self.alias_used(action_alias, params)
        # only action with options
        params[:option]="overriden"
        # on string based actions
        params.replace("override")
        UI.important("#{action_alias} called please use 'puts' instead!")
end
```

Fastfile:
```ruby
lane :alias_test do
        println "asdf"
        puts "asdf"
        echo "asdf"
end
```

![bildschirmfoto 2016-11-29 um 10 23 07](https://cloud.githubusercontent.com/assets/2891702/20703920/e09a0050-b61d-11e6-8f68-196fc42744a6.png)