### PR TITLE
[spaceship] produce - enabled_features feature 1/2

### DIFF
--- a/spaceship/lib/spaceship/portal/app.rb
+++ b/spaceship/lib/spaceship/portal/app.rb
@@ -87,14 +87,14 @@ module Spaceship
         # @param name [String] the name of the App
         # @param mac [Bool] is this a Mac app?
         # @return (App) The app you just created
-        def create!(bundle_id: nil, name: nil, mac: false)
+        def create!(bundle_id: nil, name: nil, mac: false, disable_push: false)
           if bundle_id.end_with?('*')
             type = :wildcard
           else
             type = :explicit
           end
 
-          new_app = client.create_app!(type, name, bundle_id, mac: mac)
+          new_app = client.create_app!(type, name, bundle_id, mac: mac, disable_push: disable_push)
           self.new(new_app)
         end
 

--- a/spaceship/lib/spaceship/portal/app.rb
+++ b/spaceship/lib/spaceship/portal/app.rb
@@ -87,14 +87,14 @@ module Spaceship
         # @param name [String] the name of the App
         # @param mac [Bool] is this a Mac app?
         # @return (App) The app you just created
-        def create!(bundle_id: nil, name: nil, mac: false, disable_push: false)
+        def create!(bundle_id: nil, name: nil, mac: false, enabled_features: {})
           if bundle_id.end_with?('*')
             type = :wildcard
           else
             type = :explicit
           end
 
-          new_app = client.create_app!(type, name, bundle_id, mac: mac, disable_push: disable_push)
+          new_app = client.create_app!(type, name, bundle_id, mac: mac, enabled_features: enabled_features)
           self.new(new_app)
         end
 

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -144,7 +144,7 @@ module Spaceship
       latinized
     end
 
-    def create_app!(type, name, bundle_id, mac: false)
+    def create_app!(type, name, bundle_id, mac: false, disable_push: false)
       # We moved the ensure_csrf to the top of this method
       # as we got some users with issues around creating new apps
       # https://github.com/fastlane/fastlane/issues/5813
@@ -172,7 +172,7 @@ module Spaceship
       }
 
       params.merge!(ident_params)
-
+      params.delete_if { |key, value| key.to_s == 'push' } if disable_push
       r = request(:post, "account/#{platform_slug(mac)}/identifiers/addAppId.action", params)
       parse_response(r, 'appId')
     end

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -144,7 +144,7 @@ module Spaceship
       latinized
     end
 
-    def create_app!(type, name, bundle_id, mac: false, disable_push: false)
+    def create_app!(type, name, bundle_id, mac: false, enabled_features: {})
       # We moved the ensure_csrf to the top of this method
       # as we got some users with issues around creating new apps
       # https://github.com/fastlane/fastlane/issues/5813
@@ -172,7 +172,8 @@ module Spaceship
       }
 
       params.merge!(ident_params)
-      params.delete_if { |key, value| key.to_s == 'push' } if disable_push
+      params.merge!(enabled_features) if enabled_features
+      params.delete_if { |key, value| value.to_s == 'off' } if enabled_features
       r = request(:post, "account/#{platform_slug(mac)}/identifiers/addAppId.action", params)
       parse_response(r, 'appId')
     end

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -170,10 +170,10 @@ module Spaceship
         name: valid_name_for(name),
         teamId: team_id
       }
-
       params.merge!(ident_params)
-      params.merge!(enabled_features) if enabled_features
-      params.delete_if { |key, value| value.to_s == 'off' } if enabled_features
+      enabled_features.each do |k, v|
+        params[v.service_id.to_sym] = v.value
+      end
       r = request(:post, "account/#{platform_slug(mac)}/identifiers/addAppId.action", params)
       parse_response(r, 'appId')
     end

--- a/spaceship/spec/portal/app_spec.rb
+++ b/spaceship/spec/portal/app_spec.rb
@@ -90,10 +90,10 @@ describe Spaceship::Portal::App do
     end
 
     it 'creates an app id with an explicit bundle_id and no push notifications' do
-      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, enabled_features: {}) {
+      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, enabled_features: { push_notification: "off"}) {
         { 'enabledFeatures' => ["inAppPurchase"] }
       }
-      app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App', enabled_features: {})
+      app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App', enabled_features: {push_notification: "off"})
       expect(app.enabled_features).not_to include("push")
     end
 

--- a/spaceship/spec/portal/app_spec.rb
+++ b/spaceship/spec/portal/app_spec.rb
@@ -90,10 +90,10 @@ describe Spaceship::Portal::App do
     end
 
     it 'creates an app id with an explicit bundle_id and no push notifications' do
-      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, enabled_features: { push_notification: "off"}) {
+      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, enabled_features: { push_notification: "off" }) {
         { 'enabledFeatures' => ["inAppPurchase"] }
       }
-      app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App', enabled_features: {push_notification: "off"})
+      app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App', enabled_features: { push_notification: "off" })
       expect(app.enabled_features).not_to include("push")
     end
 

--- a/spaceship/spec/portal/app_spec.rb
+++ b/spaceship/spec/portal/app_spec.rb
@@ -82,15 +82,23 @@ describe Spaceship::Portal::App do
 
   describe '#create' do
     it 'creates an app id with an explicit bundle_id' do
-      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false) {
+      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, disable_push: false) {
         { 'isWildCard' => true }
       }
       app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App')
       expect(app.is_wildcard).to eq(true)
     end
 
+    it 'creates an app id with an explicit bundle_id and no push notifications' do
+      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, disable_push: true) {
+        { 'enabledFeatures' => ["inAppPurchase"] }
+      }
+      app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App', disable_push: true)
+      expect(app.enabled_features).not_to include("push")
+    end
+
     it 'creates an app id with a wildcard bundle_id' do
-      expect(client).to receive(:create_app!).with(:wildcard, 'Development App', 'tools.fastlane.spaceship.*', mac: false) {
+      expect(client).to receive(:create_app!).with(:wildcard, 'Development App', 'tools.fastlane.spaceship.*', mac: false, disable_push: false) {
         { 'isWildCard' => false }
       }
       app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.*', name: 'Development App')

--- a/spaceship/spec/portal/app_spec.rb
+++ b/spaceship/spec/portal/app_spec.rb
@@ -82,7 +82,7 @@ describe Spaceship::Portal::App do
 
   describe '#create' do
     it 'creates an app id with an explicit bundle_id' do
-      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, disable_push: false) {
+      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, enabled_features: {}) {
         { 'isWildCard' => true }
       }
       app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App')
@@ -90,15 +90,15 @@ describe Spaceship::Portal::App do
     end
 
     it 'creates an app id with an explicit bundle_id and no push notifications' do
-      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, disable_push: true) {
+      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, enabled_features: {}) {
         { 'enabledFeatures' => ["inAppPurchase"] }
       }
-      app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App', disable_push: true)
+      app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App', enabled_features: {})
       expect(app.enabled_features).not_to include("push")
     end
 
     it 'creates an app id with a wildcard bundle_id' do
-      expect(client).to receive(:create_app!).with(:wildcard, 'Development App', 'tools.fastlane.spaceship.*', mac: false, disable_push: false) {
+      expect(client).to receive(:create_app!).with(:wildcard, 'Development App', 'tools.fastlane.spaceship.*', mac: false, enabled_features: {}) {
         { 'isWildCard' => false }
       }
       app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.*', name: 'Development App')

--- a/spaceship/spec/portal/fixtures/addAppId.action.nopush.json
+++ b/spaceship/spec/portal/fixtures/addAppId.action.nopush.json
@@ -1,0 +1,50 @@
+{
+  "creationTimestamp": "2015-04-29T00:26:33Z",
+  "resultCode": 0,
+  "userLocale": "en_US",
+  "protocolVersion": "QH65B2",
+  "requestId": null,
+  "requestUrl": "https://developer.apple.com:443//services-account/QH65B2/account/ios/identifiers/addAppId.action",
+  "responseId": "ed5e74cf-8f52-46bf-9cf6-9e9e9fcd9fad",
+  "isAdmin": true,
+  "isMember": false,
+  "isAgent": false,
+  "pageNumber": null,
+  "pageSize": null,
+  "totalRecords": null,
+  "appId": {
+    "appIdId": "2HNR359G63",
+    "name": "pp Test 1ed9e25c93ac7142ff9df53e7f80e84c",
+    "appIdPlatform": "ios",
+    "prefix": "S56PJTAYEL",
+    "identifier": "tools.fastlane.spaceship.some-explicit-app",
+    "isWildCard": false,
+    "isDuplicate": false,
+    "features": {
+      "push": true,
+      "inAppPurchase": true,
+      "gameCenter": true,
+      "passbook": false,
+      "dataProtection": "",
+      "homeKit": false,
+      "cloudKitVersion": 1,
+      "iCloud": false,
+      "LPLF93JG7M": false,
+      "IAD53UNK2F": false,
+      "V66P55NK2I": false,
+      "SKC3T5S89Y": false,
+      "APG3427HIY": false,
+      "HK421J6T7P": false,
+      "WC421J6T7P": false
+    },
+    "enabledFeatures": [
+      "gameCenter",
+      "inAppPurchase"
+    ],
+    "isDevPushEnabled": false,
+    "isProdPushEnabled": false,
+    "associatedApplicationGroupsCount": null,
+    "associatedCloudContainersCount": null,
+    "associatedIdentifiersCount": null
+  }
+}

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -120,6 +120,12 @@ describe Spaceship::Client do
         expect(response['name']).to eq('pp Test 1ed9e25c93ac7142ff9df53e7f80e84c')
         expect(response['identifier']).to eq('tools.fastlane.spaceship.some-explicit-app')
       end
+
+      it 'should make a request create an explicit app id with no push feature' do
+        response = subject.create_app!(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', disable_push: true)
+        expect(response['enabledFeatures']).to_not include("push")
+        expect(response['identifier']).to eq('tools.fastlane.spaceship.some-explicit-app')
+      end
     end
 
     describe '#delete_app!' do

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -122,7 +122,9 @@ describe Spaceship::Client do
       end
 
       it 'should make a request create an explicit app id with no push feature' do
-        response = subject.create_app!(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', enabled_features: { push: "no" })
+        payload = {}
+        payload[Spaceship.app_service.push_notification.on.service_id] = Spaceship.app_service.push_notification.on
+        response = subject.create_app!(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', enabled_features: payload)
         expect(response['enabledFeatures']).to_not include("push")
         expect(response['identifier']).to eq('tools.fastlane.spaceship.some-explicit-app')
       end

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -122,7 +122,7 @@ describe Spaceship::Client do
       end
 
       it 'should make a request create an explicit app id with no push feature' do
-        response = subject.create_app!(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', disable_push: true)
+        response = subject.create_app!(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', enabled_features: { push: "no" })
         expect(response['enabledFeatures']).to_not include("push")
         expect(response['identifier']).to eq('tools.fastlane.spaceship.some-explicit-app')
       end

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -188,6 +188,10 @@ def adp_stub_apps
   stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/deleteAppId.action").
     with(body: { "appIdId" => "LXD24VUE49", "teamId" => "XXXXXXXXXX" }).
     to_return(status: 200, body: adp_read_fixture_file('deleteAppId.action.json'), headers: { 'Content-Type' => 'application/json' })
+
+  stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
+    with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "Production App", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
+    to_return(status: 200, body: adp_read_fixture_file('addAppId.action.nopush.json'), headers: { 'Content-Type' => 'application/json' })
 end
 
 def adp_stub_app_groups

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -190,7 +190,7 @@ def adp_stub_apps
     to_return(status: 200, body: adp_read_fixture_file('deleteAppId.action.json'), headers: { 'Content-Type' => 'application/json' })
 
   stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
-    with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "Production App", "push" => "no", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
+    with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "Production App", "push" => "true", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
     to_return(status: 200, body: adp_read_fixture_file('addAppId.action.nopush.json'), headers: { 'Content-Type' => 'application/json' })
 end
 

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -190,7 +190,7 @@ def adp_stub_apps
     to_return(status: 200, body: adp_read_fixture_file('deleteAppId.action.json'), headers: { 'Content-Type' => 'application/json' })
 
   stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
-    with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "Production App", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
+    with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "Production App", "push" => "no", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
     to_return(status: 200, body: adp_read_fixture_file('addAppId.action.nopush.json'), headers: { 'Content-Type' => 'application/json' })
 end
 


### PR DESCRIPTION
# PR 1/2 

allowing push notifications to be disabled during app creation.

Issues:
  * https://github.com/fastlane/fastlane/issues/7219
  * https://github.com/fastlane/fastlane/issues/5358

Combined Branch
  * https://github.com/hjanuschka/fastlane/tree/produce_push_combined

PRS:
  * 1/2  https://github.com/fastlane/fastlane/pull/7222 -> spaceship
  * 2/2 https://github.com/fastlane/fastlane/pull/7223 -> produce


test:

```ruby
lane :produce_feature do
  produce(app_name: "1322nopush11 demoapp", app_identifier: "o.x.c.a.x.ads.da.d.d.e", username: "helmut@januschka.com", skip_itc: true, enabled_features: {
    game_center: "on",
    icloud: "legacy",
    push_notification: "on",
    vpn_configuration: "on"
    }, platform: "osx")
end

lane :produce_feature_full do
  produce(app_name: "1322nopush11 demoapp", app_identifier: "o.x.c.a.x.ads.da.d.d.e", username: "helmut@januschka.com", skip_itc: true, enabled_features: {
    app_group: "on",
    apple_pay: "on",
    associated_domains: "on",
    data_protection: "on",
    game_center: "on",
    health_kit: "on",
    home_kit: "on",
    wireless_accessory: "on",
    icloud: "legacy",
    in_app_purchase: "on",
    inter_app_audio: "on",
    passbook: "on",
    push_notification: "on",
    siri_kit: "on",
    vpn_configuration: "on"
    }, platform: "osx")
end
```
  