### PR TITLE
[produce] produce - enabled_features 2/2

### DIFF
--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -65,6 +65,14 @@ module Produce
                                      description: "Skip the creation of the app on iTunes Connect",
                                      is_string: false,
                                      default_value: false),
+
+        FastlaneCore::ConfigItem.new(key: :enabled_features,
+                                     short_option: "-P",
+                                     env_name: "PRODUCE_ENABLED_FEATURES",
+                                     description: "Array with Spaceship App Features",
+                                     is_string: false,
+                                     default_value: {}),
+
         FastlaneCore::ConfigItem.new(key: :skip_devcenter,
                                      short_option: "-d",
                                      env_name: "PRODUCE_SKIP_DEVCENTER",


### PR DESCRIPTION
# PR 2/2 

allowing push notifications to be disabled during app creation.


Issues:
  * https://github.com/fastlane/fastlane/issues/7219
  * https://github.com/fastlane/fastlane/issues/5358

Combined Branch
  * https://github.com/hjanuschka/fastlane/tree/produce_push_combined

PRS:
  * 1/2  https://github.com/fastlane/fastlane/pull/7222 -> spaceship
  * 2/2 https://github.com/fastlane/fastlane/pull/7223 -> produce


test:

```ruby
lane :produce_feature do
  produce(app_name: "1322nopush11 demoapp", app_identifier: "o.x.c.a.x.ads.da.d.d.e", username: "helmut@januschka.com", skip_itc: true, enabled_features: {
    game_center: "on",
    icloud: "legacy",
    push_notification: "on",
    vpn_configuration: "on"
    })
end

lane :produce_feature_full do
  produce(app_name: "1322nopush11 demoapp", app_identifier: "o.x.c.a.x.ads.da.d.d.e", username: "helmut@januschka.com", skip_itc: true, enabled_features: {
    app_group: "on",
    apple_pay: "on",
    associated_domains: "on",
    data_protection: "on",
    game_center: "on",
    health_kit: "on",
    home_kit: "on",
    wireless_accessory: "on",
    icloud: "legacy",
    in_app_purchase: "on",
    inter_app_audio: "on",
    passbook: "on",
    push_notification: "on",
    siri_kit: "on",
    vpn_configuration: "on"
    })
end
```
  