### PR TITLE
Bump spaceship version

### DIFF
--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,4 +1,4 @@
 module Spaceship
-  VERSION = "0.38.1".freeze
+  VERSION = "0.38.2".freeze
   DESCRIPTION = "Ruby library to access the Apple Dev Center and iTunes Connect".freeze
 end


### PR DESCRIPTION
Changes since release 0.38.1:

* non-ASCII app name in produce 1/2 (#7210)
* primaryLanguageCode detection fix (#7193)