### PR TITLE
Revert "[produce] non-ASCII app name in produce 2/2"

### DIFF
--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -16,17 +16,11 @@ module Produce
         ENV["CREATED_NEW_APP_ID"] = nil
         # Nothing to do here
       else
-        app_name = Produce.config[:app_name]
+        app_name = valid_name_for(Produce.config[:app_name])
         UI.message "Creating new app '#{app_name}' on the Apple Dev Center"
 
         app = Spaceship.app.create!(bundle_id: app_identifier,
                                          name: app_name)
-
-        if app.name != Produce.config[:app_name]
-          UI.important("Your app name includes non-ASCII characters, which are not supported by the Apple Developer Portal.")
-          UI.important("To fix this a unique (internal) name '#{app.name}' has been created for you. Your app's real name '#{Produce.config[:app_name]}'")
-          UI.important("will still show up correctly on iTunes Connect and the App Store.")
-        end
 
         UI.message "Created app #{app.app_id}"
 
@@ -38,6 +32,11 @@ module Produce
       end
 
       return true
+    end
+
+    def valid_name_for(input)
+      latinazed = input.to_slug.transliterate.to_s # remove accents
+      latinazed.gsub(/[^0-9A-Za-z\d\s]/, '') # remove non-valid characters
     end
 
     def app_identifier


### PR DESCRIPTION
Reverts fastlane/fastlane#7211

Reverting this because we reverted the accompying change: https://github.com/fastlane/fastlane/pull/7232