### PR TITLE
Babosa fix

### DIFF
--- a/spaceship/lib/spaceship/babosa_fix.rb
+++ b/spaceship/lib/spaceship/babosa_fix.rb
@@ -1,0 +1,28 @@
+# Babosa has a conflict with the unicode-string_width gem. unicode-string_width defines
+# a module called `Unicode`, but Babosa uses the presence of this constant as
+# the sign that it should try to require the `unicode` gem, which will not be present.
+#
+# We don't want to introduce the `unicode` gem because it depends on native extensions.
+#
+# This works around the possibility that the unicode-string_width gem may already be
+# loaded by temporarily undefining the `Unicode` constant while we load Babosa,
+# then restoring it to its previous state if necessary.
+class BabosaFix
+  def apply
+    unicode_removed = false
+
+    if defined? Unicode
+      orig_unicode = Unicode
+      Object.send(:remove_const, :Unicode)
+      unicode_removed = true
+    end
+
+    require 'babosa'
+
+    if unicode_removed
+      Object.send(:const_set, :Unicode, orig_unicode)
+    end
+  end
+end
+
+BabosaFix.new.apply

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -6,6 +6,7 @@ require 'spaceship/ui'
 require 'spaceship/helper/plist_middleware'
 require 'spaceship/helper/net_http_generic_request'
 require 'tmpdir'
+require "babosa"
 
 Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder
 

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -6,7 +6,7 @@ require 'spaceship/ui'
 require 'spaceship/helper/plist_middleware'
 require 'spaceship/helper/net_http_generic_request'
 require 'tmpdir'
-require "babosa"
+require 'spaceship/babosa_fix'
 
 Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder
 

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -132,6 +132,18 @@ module Spaceship
       details_for_app(app)
     end
 
+    def valid_name_for(input)
+      latinazed = input.to_slug.transliterate
+      latinazed = latinazed.gsub(/[^0-9A-Za-z\d\s]/, '') # remove non-valid characters
+      # Check if the input string was modified, since it might be empty now
+      # (if it only contained non-latin symbols) or the duplicate of another app
+      if latinazed != input
+        latinazed << " "
+        latinazed << Digest::MD5.hexdigest(input)
+      end
+      latinazed
+    end
+
     def create_app!(type, name, bundle_id, mac: false)
       # We moved the ensure_csrf to the top of this method
       # as we got some users with issues around creating new apps
@@ -155,7 +167,7 @@ module Spaceship
                      end
 
       params = {
-        name: name,
+        name: valid_name_for(name),
         teamId: team_id
       }
 

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -133,15 +133,15 @@ module Spaceship
     end
 
     def valid_name_for(input)
-      latinazed = input.to_slug.transliterate
-      latinazed = latinazed.gsub(/[^0-9A-Za-z\d\s]/, '') # remove non-valid characters
+      latinized = input.to_slug.transliterate
+      latinized = latinized.gsub(/[^0-9A-Za-z\d\s]/, '') # remove non-valid characters
       # Check if the input string was modified, since it might be empty now
       # (if it only contained non-latin symbols) or the duplicate of another app
-      if latinazed != input
-        latinazed << " "
-        latinazed << Digest::MD5.hexdigest(input)
+      if latinized != input
+        latinized << " "
+        latinized << Digest::MD5.hexdigest(input)
       end
-      latinazed
+      latinized
     end
 
     def create_app!(type, name, bundle_id, mac: false)
@@ -207,7 +207,7 @@ module Spaceship
       ensure_csrf(Spaceship::AppGroup)
 
       r = request(:post, 'account/ios/identifiers/addApplicationGroup.action', {
-        name: name,
+        name: valid_name_for(name),
         identifier: group_id,
         teamId: team_id
       })

--- a/spaceship/spaceship.gemspec
+++ b/spaceship/spaceship.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware', '~> 0.9'
   spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
   spec.add_dependency 'fastimage', '~> 1.6'
-  spec.add_dependency 'babosa' # transliterate strings
+  spec.add_dependency 'babosa', '1.0.2'
 
   # for the playground
   spec.add_dependency 'colored'

--- a/spaceship/spaceship.gemspec
+++ b/spaceship/spaceship.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware', '~> 0.9'
   spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
   spec.add_dependency 'fastimage', '~> 1.6'
+  spec.add_dependency 'babosa' # transliterate strings
 
   # for the playground
   spec.add_dependency 'colored'

--- a/spaceship/spec/portal/fixtures/addAppId.action.apostroph.json
+++ b/spaceship/spec/portal/fixtures/addAppId.action.apostroph.json
@@ -1,0 +1,51 @@
+{
+  "creationTimestamp": "2015-04-29T00:26:33Z",
+  "resultCode": 0,
+  "userLocale": "en_US",
+  "protocolVersion": "QH65B2",
+  "requestId": null,
+  "requestUrl": "https://developer.apple.com:443//services-account/QH65B2/account/ios/identifiers/addAppId.action",
+  "responseId": "ed5e74cf-8f52-46bf-9cf6-9e9e9fcd9fad",
+  "isAdmin": true,
+  "isMember": false,
+  "isAgent": false,
+  "pageNumber": null,
+  "pageSize": null,
+  "totalRecords": null,
+  "appId": {
+    "appIdId": "2HNR359G63",
+    "name": "pp Test 1ed9e25c93ac7142ff9df53e7f80e84c",
+    "appIdPlatform": "ios",
+    "prefix": "S56PJTAYEL",
+    "identifier": "tools.fastlane.spaceship.some-explicit-app",
+    "isWildCard": false,
+    "isDuplicate": false,
+    "features": {
+      "push": true,
+      "inAppPurchase": true,
+      "gameCenter": true,
+      "passbook": false,
+      "dataProtection": "",
+      "homeKit": false,
+      "cloudKitVersion": 1,
+      "iCloud": false,
+      "LPLF93JG7M": false,
+      "IAD53UNK2F": false,
+      "V66P55NK2I": false,
+      "SKC3T5S89Y": false,
+      "APG3427HIY": false,
+      "HK421J6T7P": false,
+      "WC421J6T7P": false
+    },
+    "enabledFeatures": [
+      "gameCenter",
+      "inAppPurchase",
+      "push"
+    ],
+    "isDevPushEnabled": false,
+    "isProdPushEnabled": false,
+    "associatedApplicationGroupsCount": null,
+    "associatedCloudContainersCount": null,
+    "associatedIdentifiersCount": null
+  }
+}

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -113,6 +113,13 @@ describe Spaceship::Client do
         expect(response['name']).to eq('Development App')
         expect(response['identifier']).to eq('tools.fastlane.spaceship.*')
       end
+
+      it 'should strip non ASCII characters', now: true do
+        response = subject.create_app!(:explicit, 'pp Test 1ed9e25c93ac7142ff9df53e7f80e84c', 'tools.fastlane.spaceship.some-explicit-app')
+        expect(response['isWildCard']).to eq(false)
+        expect(response['name']).to eq('pp Test 1ed9e25c93ac7142ff9df53e7f80e84c')
+        expect(response['identifier']).to eq('tools.fastlane.spaceship.some-explicit-app')
+      end
     end
 
     describe '#delete_app!' do

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -181,6 +181,10 @@ def adp_stub_apps
     with(body: { "name" => "Development App", "identifier" => "tools.fastlane.spaceship.*", "teamId" => "XXXXXXXXXX", "type" => "wildcard" }).
     to_return(status: 200, body: adp_read_fixture_file('addAppId.action.wildcard.json'), headers: { 'Content-Type' => 'application/json' })
 
+  stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
+    with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "pp Test 1ed9e25c93ac7142ff9df53e7f80e84c", "push" => "on", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
+    to_return(status: 200, body: adp_read_fixture_file('addAppId.action.apostroph.json'), headers: { 'Content-Type' => 'application/json' })
+
   stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/deleteAppId.action").
     with(body: { "appIdId" => "LXD24VUE49", "teamId" => "XXXXXXXXXX" }).
     to_return(status: 200, body: adp_read_fixture_file('deleteAppId.action.json'), headers: { 'Content-Type' => 'application/json' })


### PR DESCRIPTION
Reintroduces the changes from #7210, with an additional layer of `babosa` loading work-arounds suggested by @hjanuschka 

Will need to be followed up with a restore of #7211, and a change for _fastlane_core_ that removes its dependency on `babosa`