### PR TITLE
Version bump

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.57.1".freeze
+  VERSION = "0.57.2".freeze
 end


### PR DESCRIPTION
Changes since release 0.57.1:

* Remove babosa dependency from fastlane_core (#7248)
* Added the missed fix to fastlane_core fastlane_folder (#7220)
* sensitive flag on config items  (#7169)
* Add missing backtick (#7170)
* Fix rbenv install message (#7173)
* Fix tool collector on ruby == 2.0.0 (#7164)