### PR TITLE
Fix the tests' allow for interactive? to be for UI, not Helper

### DIFF
--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -137,7 +137,7 @@ describe FastlaneCore do
       describe "#sensitive flag" do
         before(:each) do
           allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
-          allow(FastlaneCore::Helper).to receive(:interactive?).and_return(true)
+          allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
           allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
         end
         it "should set the sensitive flag" do


### PR DESCRIPTION
I suspect that this is causing test failures when trying to ship _fastlane_core_ with `rake push`