### PR TITLE
[snapshot] add xcargs option for additional build/test settings

### DIFF
--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -29,6 +29,11 @@ module Snapshot
                                        UI.user_error!("Project file invalid") unless File.directory?(v)
                                        UI.user_error!("Project file is not a project file, must end with .xcodeproj") unless v.include?(".xcodeproj")
                                      end),
+        FastlaneCore::ConfigItem.new(key: :xcargs,
+                                     short_option: "-X",
+                                     env_name: "SNAPSHOT_XCARGS",
+                                     description: "Pass additional arguments to xcodebuild for the test phase. Be sure to quote the setting names and values e.g. OTHER_LDFLAGS=\"-ObjC -lstdc++\"",
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :devices,
                                      description: "A list of devices you want to take the screenshots from",
                                      short_option: "-d",

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -35,7 +35,7 @@ module Snapshot
         options += project_path_array
         options << "-sdk '#{config[:sdk]}'" if config[:sdk]
         options << "-derivedDataPath '#{derived_data_path}'"
-
+        options << config[:xcargs] if config[:xcargs]
         options
       end
 

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -59,6 +59,29 @@ describe Snapshot do
           )
         end
 
+        it "allows to supply custom xcargs" do
+          configure options.merge(xcargs: "-only-testing:TestBundle/TestSuite/Screenshots")
+          expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
+          command = Snapshot::TestCommandGenerator.generate(device_type: "iPhone 6")
+          id = command.join('').match(/id=(.+?),/)[1]
+          ios = command.join('').match(/OS=(\d+.\d+)/)[1]
+          expect(command).to eq(
+            [
+              "set -o pipefail &&",
+              "xcodebuild",
+              "-scheme ExampleUITests",
+              "-project ./example/Example.xcodeproj",
+              "-derivedDataPath '/tmp/path/to/snapshot_derived'",
+              "-only-testing:TestBundle/TestSuite/Screenshots",
+              "-destination 'platform=iOS Simulator,id=#{id},OS=#{ios}'",
+              "FASTLANE_SNAPSHOT=YES",
+              :build,
+              :test,
+              "| tee #{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests.log')} | xcpretty "
+            ]
+          )
+        end
+
         it "uses the default parameters on tvOS too" do
           configure options.merge(devices: ["Apple TV 1080p"])
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")


### PR DESCRIPTION
Implementation of: 

https://github.com/fastlane/fastlane/issues/7255


sample 

```ruby
lane :snap do
        snapshot(project: "snapshot/example/Example.xcodeproj", 
          scheme: "Example",
          xcargs: "-only-testing:TestBundle/TestSuite/Screenshots"
     )
end
```
