### PR TITLE
Add VISION.md to document the fastlane philosophy

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,45 @@
+# _fastlane_’s Philosophy
+
+_fastlane_ automates the beta and release deployment process for your iOS or Android apps, including build, code signing, automatic screenshot capture, and distribution of your app binaries.
+
+_fastlane_ will continue to evolve in ways that make it indispensable for, and focused on these needs.
+
+_fastlane_ aims to be elegant in success, and empathetic in failure.
+
+_fastlane_ provides intelligent defaults for options, prompts for missing information, and a context that automatically shares relevant information between actions. All of this allows a simple, elegant Fastfile to do a lot of powerful work.
+
+Since errors are inevitable, _fastlane_ should show empathy and provide a suggested solution, or attempt to solve the problem automatically. Errors that can be anticipated should not crash _fastlane_, and should present users with a friendly message that is easy to spot in their terminal or logs.
+
+## Actions and Plugins
+
+_fastlane_ saw a lot of early growth through a wide number of actions that meet a variety of needs. Actions can trigger built-in _fastlane_ tools, talk to external tools and services, and more. However, with more than 170 built-in actions, further growth here will make _fastlane_ harder to understand and get started with. Another consideration is that actions which ship with _fastlane_ represent a maintenance cost for the _fastlane_ core team.
+
+With these challenges in mind, [_fastlane_ plugin system](https://fabric.io/blog/introducing-fastlane-plugins/) allows anyone to develop, share, and use new actions built and maintained by the awesome _fastlane_ community. If you have an idea for a new _fastlane_ action, [create it as a plugin](https://docs.fastlane.tools/plugins/create-plugin/) and it’ll be automatically listed in the [_fastlane_ plugin registry](https://docs.fastlane.tools/actions/#plugins). The most impactful and commonly used plugins could be adopted into _fastlane_ in the future.
+
+## _fastlane_ Tool Responsibilities
+
+Each _fastlane_ tool has a specific purpose and should be kept focused on the functionality required for that task.
+
+* [deliver](https://github.com/fastlane/fastlane/tree/master/deliver): Upload screenshots, metadata, and your app binary to the App Store
+* [supply](https://github.com/fastlane/fastlane/tree/master/supply): Upload your Android app and its metadata to Google Play
+* [snapshot](https://github.com/fastlane/fastlane/tree/master/snapshot): Automate taking localized screenshots of your iOS apps on every device
+* [screengrab](https://github.com/fastlane/fastlane/tree/master/screengrab): Automate taking localized screenshots of your Android app on every device
+* [frameit](https://github.com/fastlane/fastlane/tree/master/frameit): Quickly put your screenshots into the right device frames
+* [pem](https://github.com/fastlane/fastlane/tree/master/pem): Automatically generate and renew your push notification certificates
+* [sigh](https://github.com/fastlane/fastlane/tree/master/sigh): Because you would rather spend your time building stuff than fighting provisioning
+* [produce](https://github.com/fastlane/fastlane/tree/master/produce): Create new iOS apps on iTunes Connect and Apple Developer Portal using the command line
+* [cert](https://github.com/fastlane/fastlane/tree/master/cert): Automatically create and maintain iOS code signing certificates
+* [spaceship](https://github.com/fastlane/fastlane/tree/master/spaceship): Ruby library to access the Apple Developer Portal and iTunes Connect
+* [pilot](https://github.com/fastlane/fastlane/tree/master/pilot): The best way to manage your TestFlight testers and builds from your terminal
+* [boarding](https://github.com/fastlane/boarding): The easiest way to invite your TestFlight beta testers
+* [gym](https://github.com/fastlane/fastlane/tree/master/gym): Building your iOS apps has never been easier
+* [match](https://github.com/fastlane/fastlane/tree/master/match): Easily sync your certificates and profiles across your team using Git
+* [scan](https://github.com/fastlane/fastlane/tree/master/scan): The easiest way to run tests for your iOS and Mac apps
+
+## _fastlane_’s Relationship with Twitter and Fabric
+
+Twitter supports app development teams with the best tools for building, understanding, and growing their mobile app businesses through [Fabric](https://get.fabric.io/).
+
+Twitter has recognized _fastlane_ as the best tool for tackling tough beta and release deployment challenges. In 2015 Twitter acquired the project, and [Felix Krause](https://github.com/krausefx) joined the Fabric team. The team’s mission is to make _fastlane_ the de facto tool to automate beta deployments and app store releases for iOS and Android apps.
+
+Twitter intends to keep _fastlane_ open source and available as a standalone tool for users who are not using Fabric. Twitter is also committed to increasing use of _fastlane_ by promoting it through Fabric products and websites, and developing integrations with Fabric tools to help them work better together.

--- a/VISION.md
+++ b/VISION.md
@@ -36,10 +36,10 @@ Each _fastlane_ tool has a specific purpose and should be kept focused on the fu
 * [match](https://github.com/fastlane/fastlane/tree/master/match): Easily sync your certificates and profiles across your team using Git
 * [scan](https://github.com/fastlane/fastlane/tree/master/scan): The easiest way to run tests for your iOS and Mac apps
 
-## _fastlane_’s Relationship with Twitter and Fabric
+## _fastlane_’s Relationship with [Twitter](https://twitter.com) and [Fabric](https://get.fabric.io/)
 
 Twitter supports app development teams with the best tools for building, understanding, and growing their mobile app businesses through [Fabric](https://get.fabric.io/).
 
-Twitter has recognized _fastlane_ as the best tool for tackling tough beta and release deployment challenges. In 2015 Twitter acquired the project, and [Felix Krause](https://github.com/krausefx) joined the Fabric team. The team’s mission is to make _fastlane_ the de facto tool to automate beta deployments and app store releases for iOS and Android apps.
+Twitter has recognized _fastlane_ as the best tool for tackling tough beta and release deployment challenges. In 2015 Twitter acquired the project, and [Felix Krause](https://twitter.com/krausefx) joined the Fabric team. The team’s mission is to make _fastlane_ the de facto tool to automate beta deployments and app store releases for iOS and Android apps.
 
 Twitter intends to keep _fastlane_ open source and available as a standalone tool for users who are not using Fabric. Twitter is also committed to increasing use of _fastlane_ by promoting it through Fabric products and websites, and developing integrations with Fabric tools to help them work better together.


### PR DESCRIPTION
Documents the _fastlane_ philosophy, explaining the project's focus and goals.

Attempts to make clear the relationship between _fastlane_, Fabric, and Twitter.

This is not intended to be set in stone, and should be a living document that invites community involvement 👍 