### PR TITLE
Update information about https://developerservices2.apple.com API

### DIFF
--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -151,8 +151,7 @@ I won't go into too much technical details about the various API endpoints, but 
 
 - `https://idmsa.apple.com`: Used to authenticate to get a valid session
 - `https://developerservices2.apple.com`:
- - Get a detailed list of all available provisioning profiles
- - This API returns the devices, certificates and app for each of the profiles
+ - Get a list of all available provisioning profiles
  - Register new devices
 - `https://developer.apple.com`:
  - List all devices, certificates, apps and app groups


### PR DESCRIPTION
This API doesn't return the certificates and devices any more