### PR TITLE
Fix removing uploaded screenshot by using sort_order

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -17,7 +17,7 @@ module Deliver
         # First, clear all previously uploaded screenshots
         screenshots_per_language.keys.each do |language|
           v.screenshots[language].each_with_index do |t, index|
-            v.upload_screenshot!(nil, index, t.language, t.device_type)
+            v.upload_screenshot!(nil, t.sort_order, t.language, t.device_type, false)
           end
         end
       end


### PR DESCRIPTION
This pull request fixes a crash when using deliver with `overwrite_screenshots`
The change uses the correct sort order for each screenshot that is being cleared.

Relevant issues:
https://github.com/fastlane/fastlane/issues/6981
https://github.com/fastlane/fastlane/issues/7165

----
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:
