### PR TITLE
Make the lane context dump on crashes more pretty

### DIFF
--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -55,8 +55,7 @@ module Fastlane
         # (or similar). We still want to catch that, since we want properly finish running fastlane
         # Tested with `xcake`, which throws a `Xcake::Informative` object
 
-        UI.important 'Variable Dump:'.yellow
-        UI.message Actions.lane_context
+        print_lane_context
         UI.error ex.to_s if ex.kind_of?(StandardError) # we don't want to print things like 'system exit'
         e = ex
       end
@@ -179,6 +178,26 @@ module Fastlane
         UI.success "Loading from '#{env_file}'"
         Dotenv.overload(env_file)
       end
+    end
+
+    def self.print_lane_context
+      if $verbose
+        UI.important 'Lane Context:'.yellow
+        UI.message Actions.lane_context
+        return
+      end
+
+      # Print a nice table unless in $verbose mode
+      rows = Actions.lane_context.collect do |key, content|
+        [key, content.to_s]
+      end
+      rows = FastlaneCore::PrintTable.limit_row_size(rows)
+
+      require 'terminal-table'
+      puts Terminal::Table.new({
+        title: "Lane Context".yellow,
+        rows: rows,
+      })
     end
   end
 end

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -196,7 +196,7 @@ module Fastlane
       require 'terminal-table'
       puts Terminal::Table.new({
         title: "Lane Context".yellow,
-        rows: rows,
+        rows: rows
       })
     end
   end

--- a/match/lib/match/table_printer.rb
+++ b/match/lib/match/table_printer.rb
@@ -3,8 +3,8 @@ module Match
     # logs public key's  name, user, organisation, country, availability dates
     def self.print_certificate_info(cert_info: nil)
       params = {
-          rows: cert_info,
-          title: "Installed Certificate".green
+        rows: cert_info,
+        title: "Installed Certificate".green
       }
 
       puts ""


### PR DESCRIPTION
<img width="871" alt="screenshot 2016-12-02 13 45 35" src="https://cloud.githubusercontent.com/assets/869950/20851515/dcdd5af0-b895-11e6-8493-13de0c620eaf.png">
