### PR TITLE
[match] Version bump to 0.11.1

### DIFF
--- a/match/lib/match/version.rb
+++ b/match/lib/match/version.rb
@@ -1,4 +1,4 @@
 module Match
-  VERSION = "0.11.0"
+  VERSION = "0.11.1"
   DESCRIPTION = "Easily sync your certificates and profiles across your team using git"
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

* Make keychain_password a sensitive option (#7236)
* Update internal dependencies (#7247)
* Update internal dependecies (#7227)
* Update internal dependencies (#7208)
* Update internal dependencies (#7163)
* refactor match to use keychain_path (#7076)
* Fix tests in match for macOS Sierra. (#7101)
* Update dependency on fastlane_core (#7119)
* make match pass the keychain name to cert (#6460)
* Allow more options to disable enterprise mode, fixes #6779 (#7064)
* Update `fastlane_core` dependency to 0.56.0. (#7045)
* print certificate info (#6907)
* Update all tools to latest fastlane_core (#7026)
* Update internal dependencies (#6949)
