### PR TITLE
Update Gemfile setup to use local copy by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,19 @@
 source "https://rubygems.org"
 
-gemspec path: "fastlane"
-
+# Needed for CI
 gem "danger", "~> 0.10"
 
-if ENV["FASTLANE_LOCAL_DEV"]
-  require "fastlane/tools.rb"
-  local_deps = Fastlane::TOOLS + [:fastlane_core, :credentials_manager]
-  local_deps.each do |dep|
-    next if dep == :fastlane    
-    gem dep.to_s, path: dep.to_s
-  end
+# Local fastlane, important to be included using `gemspec`, as this will
+# also include development dependencies
+gemspec path: File.join(Dir.pwd, "fastlane")
 
+plugins_path = File.join(Dir.pwd, 'fastlane', 'fastlane', 'Pluginfile')
+eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+
+# Use the local copy of all tools
+require "fastlane/tools.rb"
+tools = Fastlane::TOOLS + [:fastlane_core, :credentials_manager]
+tools.each do |tool_name|
+  next if tool_name == :fastlane
+  gem tool_name.to_s, path: File.join(Dir.pwd, tool_name.to_s)
 end

--- a/cert/Gemfile
+++ b/cert/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/credentials_manager/Gemfile
+++ b/credentials_manager/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/deliver/Gemfile
+++ b/deliver/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/fastlane/Gemfile
+++ b/fastlane/Gemfile
@@ -1,24 +1,3 @@
-source 'https://rubygems.org'
-
-# Specify your gem's dependencies in .gemspec
-gemspec
-
-if `cd ..; git remote -v`.include?("countdown")
-  gem "fastlane_core", path: "../fastlane_core"
-  gem "credentials_manager", path: "../credentials_manager"
-  gem "spaceship", path: "../spaceship"
-  gem "deliver", path: "../deliver"
-  gem "snapshot", path: "../snapshot"
-  gem "frameit", path: "../frameit"
-  gem "pem", path: "../pem"
-  gem "cert", path: "../cert"
-  gem "sigh", path: "../sigh"
-  gem "produce", path: "../produce"
-  gem "gym", path: "../gym"
-  gem "pilot", path: "../pilot"
-  gem "supply", path: "../supply"
-  gem "scan", path: "../scan"
+Dir.chdir("..") do
+  eval File.read("Gemfile")
 end
-
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -276,25 +276,31 @@ describe Fastlane::PluginGenerator do
       it "rspec tests are passing" do
         # Actually run our generated spec as part of this spec #yodawg
         Dir.chdir(gem_name) do
-          `rspec &> /dev/null`
-          expect($?.exitstatus).to be(0)
+          Bundler.setup do
+            `rspec &> /dev/null`
+            expect($?.exitstatus).to be(0)
+          end
         end
       end
 
       it "rubocop validations are passing" do
         # Actually run our generated spec as part of this spec #yodawg
         Dir.chdir(gem_name) do
-          `rubocop &> /dev/null`
-          expect($?.exitstatus).to be(0)
+          Bundler.setup do
+            `rubocop &> /dev/null`
+            expect($?.exitstatus).to be(0)
+          end
         end
       end
 
       it "`rake` runs both rspec and rubocop" do
         Dir.chdir(gem_name) do
-          result = `rake`
-          expect($?.exitstatus).to be(0)
-          expect(result).to include("no offenses detected") # rubocop
-          expect(result).to include("example, 0 failures") # rspec
+          Bundler.setup do
+            result = `rake`
+            expect($?.exitstatus).to be(0)
+            expect(result).to include("no offenses detected") # rubocop
+            expect(result).to include("example, 0 failures") # rspec
+          end
         end
       end
     end

--- a/fastlane_core/Gemfile
+++ b/fastlane_core/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/frameit/Gemfile
+++ b/frameit/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/gym/Gemfile
+++ b/gym/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/match/Gemfile
+++ b/match/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/pem/Gemfile
+++ b/pem/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/pilot/Gemfile
+++ b/pilot/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/produce/Gemfile
+++ b/produce/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/scan/Gemfile
+++ b/scan/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/screengrab/Gemfile
+++ b/screengrab/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/sigh/Gemfile
+++ b/sigh/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/snapshot/Gemfile
+++ b/snapshot/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/spaceship/Gemfile
+++ b/spaceship/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end

--- a/supply/Gemfile
+++ b/supply/Gemfile
@@ -1,6 +1,3 @@
-source "https://rubygems.org"
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), '..', 'fastlane', 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+Dir.chdir("..") do
+  eval File.read("Gemfile")
+end


### PR DESCRIPTION
When someone wants to modify the fastlane code base (e.g. _fastlane_core_), it is really hard for them to actually try the changes and see them in effect. So many users submit PRs without actually running and testing the code.

With this change, users can just clone the repo, run `bundle update` in e.g. the _sigh_ sub-directory and test the changes in _fastlane_core_ when running _bundle exec sigh_ 👍 

While writing the tooling community ownership documents we noticed that before it was very tedious to get things up and running.

This will use one central `Gemfile` instead of one per tool. The `Gemfile` links to each tool using a local path, and links to _fastlane_ using the `gemspec` attribute, so that we also have all development dependencies

So all bundler-based fastlane execution now uses source code, instead of deployed Gems

