### PR TITLE
Move all fastlane configs to ~/.fastlane

### DIFF
--- a/fastlane_core/lib/fastlane_core.rb
+++ b/fastlane_core/lib/fastlane_core.rb
@@ -37,4 +37,12 @@ require 'fastlane_core/ui/fastlane_runner' # monkey patch
 
 module FastlaneCore
   ROOT = Pathname.new(File.expand_path('../..', __FILE__))
+
+  # A directory that's being used to user-wide fastlane configs
+  # This directory is also used for the bundled fastlane
+  def self.fastlane_user_dir
+    path = File.expand_path(File.join("~", ".fastlane"))
+    FileUtils.mkdir_p(path) unless File.directory?(path)
+    return path
+  end
 end

--- a/fastlane_core/lib/fastlane_core/tool_collector.rb
+++ b/fastlane_core/lib/fastlane_core/tool_collector.rb
@@ -129,10 +129,16 @@ module FastlaneCore
     end
 
     def did_show_message?
-      path = File.join(File.expand_path('~'), '.did_show_opt_info')
-      did_show = File.exist?(path)
-      File.write(path, '1') unless did_show
-      did_show
+      file_name = ".did_show_opt_info"
+
+      legacy_path = File.join(File.expand_path('~'), file_name)
+      new_path = File.join(FastlaneCore.fastlane_user_dir, file_name)
+      did_show = File.exist?(new_path) || File.exist?(legacy_path)
+
+      return did_show if did_show
+
+      File.write(new_path, '1')
+      false
     end
 
     def determine_version(name)

--- a/fastlane_core/spec/fastlane_user_dir_spec.rb
+++ b/fastlane_core/spec/fastlane_user_dir_spec.rb
@@ -1,0 +1,10 @@
+describe FastlaneCore do
+  it "returns the path to the user's directory" do
+    expected_path = File.join(ENV["HOME"], ".fastlane")
+
+    expect(File).to receive(:directory?).and_return(false)
+    expect(FileUtils).to receive(:mkdir_p).with(expected_path)
+
+    expect(FastlaneCore.fastlane_user_dir).to eq(expected_path)
+  end
+end


### PR DESCRIPTION
_fastlane_ downloads or stores some files per user (e.g. some configs), until now they've been at different places. The goal of this PR is to unify them with the introduction of [bundled _fastlane_](https://twitter.com/FastlaneTools/status/804063684490383360).

- bundled _fastlane_ stores the Ruby libraries in `~/.fastlane/bin`
- `.did_show_opt_info` was stored in `~` until now, that's moved to `~/.fastlane` now
- `~/.frameit/frames` moved to `~/.fastlane` (https://github.com/fastlane/fastlane/pull/7299)

Why this change:
- To not spam the filesystem
- To make it easier to uninstall _fastlane_
- To make it easier to move that folder by overwriting the path (e.g. this could be an env variable)
- To make it easier to test those features