### PR TITLE
Fix error in resign.sh bash syntax

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -564,8 +564,8 @@ function resign {
             REF_PROVISION=`provision_for_bundle_id $REF_BUNDLE_ID`
             # Map to the new bundle id
             NEW_REF_BUNDLE_ID=`bundle_id_for_provison "$REF_PROVISION"`
-            # Change if not the same
-            if [ "$REF_BUNDLE_ID" != "$NEW_REF_BUNDLE_ID" && ! "$NEW_REF_BUNDLE_ID" =~ \* ];
+            # Change if not the same and if doesn't contain wildcard
+            if [[ "$REF_BUNDLE_ID" != "$NEW_REF_BUNDLE_ID" ]] && ! [[ "$NEW_REF_BUNDLE_ID" =~ \* ]];
             then
                 log "Updating nested app or extension reference for ${key} key from ${REF_BUNDLE_ID} to ${NEW_REF_BUNDLE_ID}"
                 `PlistBuddy -c "Set ${key} $NEW_REF_BUNDLE_ID" "$APP_PATH/Info.plist"`


### PR DESCRIPTION

This is a bash syntax fix for #7105 closed with PR #7110.

There is an error in bash syntax that causes the following condition to be always false:

```
if [ "$REF_BUNDLE_ID" != "$NEW_REF_BUNDLE_ID" && ! "$NEW_REF_BUNDLE_ID" =~ \* ];
```

Here's an example of running this code in bash 3.2:

```
bash-3.2$ REF_BUNDLE_ID="app.prod" NEW_REF_BUNDLE_ID="app.*"; if [ "$REF_BUNDLE_ID" != "$NEW_REF_BUNDLE_ID" && ! "$NEW_REF_BUNDLE_ID" =~ \* ]; then echo "YES"; else echo "NO"; fi
bash: [: missing `]'
NO
bash-3.2$ REF_BUNDLE_ID="app.prod" NEW_REF_BUNDLE_ID="app"; if [ "$REF_BUNDLE_ID" != "$NEW_REF_BUNDLE_ID" && ! "$NEW_REF_BUNDLE_ID" =~ \* ]; then echo "YES"; else echo "NO"; fi
bash: [: missing `]'
NO
bash-3.2$
```

In both cases we get an error and end up in "false" branch.

The fix is to update shell syntax.