### PR TITLE
[spaceship] Version bump to 0.38.5

### DIFF
--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,4 +1,4 @@
 module Spaceship
-  VERSION = "0.38.4".freeze
+  VERSION = "0.38.5".freeze
   DESCRIPTION = "Ruby library to access the Apple Dev Center and iTunes Connect".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '0.38.4':**

* Update Gemfile setup to use local copy by default (#7296)
* Added comment to keep track when the babosa fix can be removed again. (#7277)
* Update information about https://developerservices2.apple.com API (#7265)
* Remove the "I" in spaceship readme (#7264)
* Fix alignment of spaceship version number (#7249)
