### PR TITLE
Fix bundler env after recent change with Gemfiles

### DIFF
--- a/fastlane/fastlane/Fastfile
+++ b/fastlane/fastlane/Fastfile
@@ -169,9 +169,11 @@ lane :verify_docs do
     temporary_gemfile = []
     Fastlane::TOOLS.each { |tool| temporary_gemfile << "gem '#{tool}', path: '#{File.join(local_fastlane_dir, tool.to_s)}'" }
     temporary_gemfile = temporary_gemfile.join("\n")
-    puts `sed -i -e "s/activate_bin_path/bin_path/g" $(which bundle)` # workaround for bundler https://github.com/bundler/bundler/issues/4602#issuecomment-233619696
-    sh "bundle install"
-    sh "bundle exec fastlane test skip_building:true" # skip_building since we don't have a proper python environment set up
+    Bundler.with_clean_env do
+      puts `sed -i -e "s/activate_bin_path/bin_path/g" $(which bundle)` # workaround for bundler https://github.com/bundler/bundler/issues/4602#issuecomment-233619696
+      sh "bundle install"
+      sh "bundle exec fastlane test skip_building:true" # skip_building since we don't have a proper python environment set up
+    end
   end
 end
 


### PR DESCRIPTION
Before that, the following error was shown

```
[11:52:27]: Exit status of command 'bundle install' was 1 instead of 0.
/Users/fkrause/Developer/fastlane/spaceship/Gemfile:2:in `read':  (Bundler::Dsl::DSLError)
[!] There was an error parsing `Gemfile`: No such file or directory @ rb_sysopen - Gemfile. Bundler cannot continue.

 #  from /Users/fkrause/Developer/fastlane/spaceship/Gemfile:2
 #  -------------------------------------------
 #  Dir.chdir("..") do
 >    eval File.read("Gemfile")
 #  end
 #  -------------------------------------------
	from /Users/fkrause/Developer/fastlane/spaceship/Gemfile:2:in `block in eval_gemfile'
	from /Users/fkrause/Developer/fastlane/spaceship/Gemfile:1:in `chdir'
	from /Users/fkrause/Developer/fastlane/spaceship/Gemfile:1:in `eval_gemfile'
	from /Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.13.3/lib/bundler/dsl.rb:41:in `instance_eval'
	from /Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.13.3/lib/bundler/dsl.rb:41:in `eval_gemfile'
	from /Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.13.3/lib/bundler/dsl.rb:11:in `evaluate'
	from /Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.13.3/lib/bundler/definition.rb:33:in `build'
	from /Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.13.3/lib/bundler.rb:127:in `definition'
	from /Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.13.3/lib/bundler.rb:93:in `setup'
	from /Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.13.3/lib/bundler/setup.rb:20:in `<top (required)>'
	from /Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:55:in `require'
```

This way we'll ensure the local Gemfile isn't used for our docs