### PR TITLE
Verify debug code is not there, also in spec sub-folder

### DIFF
--- a/fastlane/fastlane/Fastfile
+++ b/fastlane/fastlane/Fastfile
@@ -241,10 +241,10 @@ desc "Verifies all tests pass and the current state of the repo is valid"
 private_lane :validate_repo do |options|
   # Verifying that no debug code is in the code base
   #
-  ensure_no_debug_code(text: "pry", extension: ".rb", path: "./lib/") # debugging code
-  ensure_no_debug_code(text: "# TODO", extension: ".rb", path: "./lib/") # TODOs
-  ensure_no_debug_code(text: "now: ", extension: ".rb", path: "./lib/") # rspec focus
-  ensure_no_debug_code(text: "<<<<<<<", extension: ".rb", path: "./lib/") # Merge conflict
+  ensure_no_debug_code(text: "binding.pry", extension: ".rb") # debugging code
+  ensure_no_debug_code(text: "# TODO", extension: ".rb") # TODOs
+  ensure_no_debug_code(text: "now: ", extension: ".rb") # rspec focus
+  ensure_no_debug_code(text: "<<<<<<<", extension: ".rb") # Merge conflict
 
   rubocop
 


### PR DESCRIPTION
We only have `now: true` in the `spec` sub-folder. We can now catch that 👍 