### PR TITLE
[fastlane_core] Version bump to 0.58.0

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.57.2".freeze
+  VERSION = "0.58.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '0.57.2':**

* Move all fastlane configs to ~/.fastlane (#7298)
* Update Gemfile setup to use local copy by default (#7296)
* Show GitHub issue search error only in verbose mode (#7279)
* FastlaneCore::Simulator reset by version 1/2 (#7196)
