### PR TITLE
Handle xcodebuild path differences with export options plist

### DIFF
--- a/fastlane/spec/fixtures/archive/Archive.xcarchive/Info.plist
+++ b/fastlane/spec/fixtures/archive/Archive.xcarchive/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ApplicationProperties</key>
+	<dict>
+		<key>ApplicationPath</key>
+		<string>Applications/MyApp.app</string>
+		<key>CFBundleIdentifier</key>
+		<string>com.krausefx.app</string>
+		<key>CFBundleShortVersionString</key>
+		<string>0.9.14</string>
+		<key>CFBundleVersion</key>
+		<string>0.9.14</string>
+		<key>SigningIdentity</key>
+		<string>iPhone Developer</string>
+	</dict>
+	<key>ArchiveVersion</key>
+	<integer>2</integer>
+	<key>CreationDate</key>
+	<string>2016-11-11T19:27:15Z</string>
+	<key>Name</key>
+	<string>MyApp</string>
+	<key>SchemeName</key>
+	<string>MyApp</string>
+</dict>
+</plist>


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)
----
Fixes #7310 in a somewhat minimal way and adds some tests to prove it.

The behavior _without_ export_options_plist was left to allow generating `path/to/Product.ipa` from the input of `path/to/Product`, as it seems that other things would depend on this, and it mostly matches old `xcodebuild` utility behavior anyway.