### PR TITLE
[spaceship] Add missing require block

### DIFF
--- a/spaceship/lib/spaceship/update_checker.rb
+++ b/spaceship/lib/spaceship/update_checker.rb
@@ -23,6 +23,8 @@ module Spaceship
     end
 
     def self.show_update_message(local_version, live_version)
+      require 'colored'
+
       puts "---------------------------------------------".red
       puts "-------------------WARNING-------------------".red
       puts "---------------------------------------------".red


### PR DESCRIPTION
This would cause an error if spaceship isn't used from within fastlane