### PR TITLE
[spaceship] Show update message on spaceship failure

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -417,6 +417,9 @@ module Spaceship
         store_csrf_tokens(response)
         content
       end
+    rescue => ex
+      UpdateChecker.ensure_spaceship_version # to show an update message on error if necessary
+      raise ex
     end
 
     private

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -227,6 +227,9 @@ module Spaceship
       puts data['sectionWarningKeys'] if data['sectionWarningKeys']
 
       return data
+    rescue => ex
+      UpdateChecker.ensure_spaceship_version # to show an update message on error if necessary
+      raise ex
     end
     # rubocop:enable Metrics/PerceivedComplexity
 


### PR DESCRIPTION
Since the initial update message is shown on top, we really want the user to see the message if something fails