### PR TITLE
[fastlane] anon. the sensitive options

### DIFF
--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -2,6 +2,12 @@ module Fastlane
   class EnvironmentPrinter
     def self.output
       env_info = get
+
+      # Remove sensitive option values
+      FastlaneCore::Configuration.sensitive_strings.compact.each do |sensitive_element|
+        env_info.gsub!(sensitive_element, "#########")
+      end
+
       puts env_info
       if FastlaneCore::Helper.mac? && UI.interactive? && UI.confirm("🙄  Wow, that's a lot of markdown text... should fastlane put it into your clipboard, so you can easily paste it on GitHub?")
         copy_to_clipboard(env_info)

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -51,9 +51,8 @@ module FastlaneCore
       # those will be later - replaced by ####
       if $capture_output
         available_options.each do |element|
-          if element.sensitive
-            self.class.sensitive_strings << values[element.key]
-          end
+          next unless element.sensitive
+          self.class.sensitive_strings << values[element.key]
         end
       end
 

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -35,9 +35,27 @@ module FastlaneCore
     # @!group Setting up the configuration
     #####################################################
 
+    # collect sensitive strings
+    def self.sensitive_strings
+      unless @sensitive_strings
+        @sensitive_strings = []
+      end
+      @sensitive_strings
+    end
+
     def initialize(available_options, values)
       self.available_options = available_options || []
       self.values = values || {}
+
+      # if we are in captured output mode - keep a array of sensitive option values
+      # those will be later - replaced by ####
+      if $capture_output
+        available_options.each do |element|
+          if element.sensitive
+            self.class.sensitive_strings << values[element.key]
+          end
+        end
+      end
 
       verify_input_types
       verify_value_exists

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -37,10 +37,7 @@ module FastlaneCore
 
     # collect sensitive strings
     def self.sensitive_strings
-      unless @sensitive_strings
-        @sensitive_strings = []
-      end
-      @sensitive_strings
+      @sensitive_strings ||= []
     end
 
     def initialize(available_options, values)


### PR DESCRIPTION
this one try's to replace sensitive option values from a `captured_output` run.

anyone has a idea how to find sensitive options in `fastlane env` - without capture output?

