### PR TITLE
[fastlane_core] Version bump to 0.59.0

### DIFF
--- a/fastlane_core/lib/fastlane_core/version.rb
+++ b/fastlane_core/lib/fastlane_core/version.rb
@@ -1,3 +1,3 @@
 module FastlaneCore
-  VERSION = "0.58.0".freeze
+  VERSION = "0.59.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '0.58.0':**

* add support for reporting installation method to refresher (#7348)
* Fix fastlane_core sierra keychain lookup
* Try more combinations of keychain paths (#7276)
* support Commandline apps (#7090)
* Remove `now:` from tests (#7317)
