### PR TITLE
[pilot] use buildWatcher class

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -31,8 +31,7 @@ module Pilot
       end
 
       UI.message("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-      uploaded_build = wait_for_processing_build(options, platform) # this might take a while
-
+      uploaded_build = FastlaneCore::BuildWatcher.wait_for_build(app, platform, config[:wait_processing_interval].to_i)
       distribute(options, uploaded_build)
     end
 
@@ -120,71 +119,6 @@ module Pilot
 
     def should_update_build_information(options)
       options[:changelog].to_s.length > 0 or options[:beta_app_description].to_s.length > 0 or options[:beta_app_feedback_email].to_s.length > 0
-    end
-
-    # This method will takes care of checking for the processing builds every few seconds
-    # @return [Build] The build that we just uploaded
-    def wait_for_processing_build(options, platform)
-      # the upload date of the new buid
-      # we use it to identify the build
-      start = Time.now
-      wait_processing_interval = config[:wait_processing_interval].to_i
-      latest_build = nil
-      UI.message("Waiting for iTunes Connect to process the new build")
-      must_update_build_info = config[:update_build_info_on_upload]
-      loop do
-        sleep(wait_processing_interval)
-
-        # before we look for processing builds, we need to ensure that there
-        #  is a build train for this application; new applications don't
-        #  build trains right away, and if we don't do this check, we will
-        #  get break out of this loop and then generate an error later when we
-        #  have a nil build
-        if app.build_trains(platform: platform).count == 0
-          UI.message("New application; waiting for build train to appear on iTunes Connect")
-        else
-          builds = app.all_processing_builds(platform: platform)
-          break if builds.count == 0
-          latest_build = builds.last
-
-          if latest_build.valid and must_update_build_info
-            # Set the changelog and/or description if necessary
-            if should_update_build_information(options)
-              latest_build.update_build_information!(whats_new: options[:changelog], description: options[:beta_app_description], feedback_email: options[:beta_app_feedback_email])
-              UI.success "Successfully set the changelog and/or description for build"
-            end
-            must_update_build_info = false
-          end
-
-          UI.message("Waiting for iTunes Connect to finish processing the new build (#{latest_build.train_version} - #{latest_build.build_version})")
-        end
-      end
-
-      UI.user_error!("Error receiving the newly uploaded binary, please check iTunes Connect") if latest_build.nil?
-      full_build = nil
-
-      while full_build.nil? || full_build.processing
-        # The build's processing state should go from true to false, and be done. But sometimes it goes true -> false ->
-        # true -> false, where the second true is transient. This causes a spurious failure. Find build by build_version
-        # and ensure it's not processing before proceeding - it had to have already been false before, to get out of the
-        # previous loop.
-        full_build = app.build_trains(platform: platform)[latest_build.train_version].builds.find do |b|
-          b.build_version == latest_build.build_version
-        end
-
-        UI.message("Waiting for iTunes Connect to finish processing the new build (#{latest_build.train_version} - #{latest_build.build_version})")
-        sleep(wait_processing_interval)
-      end
-
-      if full_build && !full_build.processing && full_build.valid
-        minutes = ((Time.now - start) / 60).round
-        UI.success("Successfully finished processing the build")
-        UI.message("You can now tweet: ")
-        UI.important("iTunes Connect #iosprocessingtime #{minutes} minutes")
-        return full_build
-      else
-        UI.user_error!("Error: Seems like iTunes Connect didn't properly pre-process the binary")
-      end
     end
 
     def distribute_build(uploaded_build, options)


### PR DESCRIPTION
# PR 2/4

This series of PR's try's to de-duplicate the various blocks that check if a build is finished processing.
by moving the logic to fastlanecore.

 * 1/4 ->  https://github.com/fastlane/fastlane/pull/7386 (fastlane_core)
 * 2/4 ->  https://github.com/fastlane/fastlane/pull/7387 (pilot)
 * 3/4 ->  https://github.com/fastlane/fastlane/pull/7388 (deliver)
 * 4/4 ->  https://github.com/fastlane/fastlane/pull/7389 (watchbuild)


a full branch is at this PR: https://github.com/fastlane/fastlane/pull/7381
(i am going to keen the full branch updated, if during review the singel PR's change)


the fastlane_core PR is mandatory for the other ones, but the tools could be merged one by one.
let me know what you guys think.


![bildschirmfoto 2016-12-08 um 21 49 00](https://cloud.githubusercontent.com/assets/2891702/21027885/0e21f47a-bd93-11e6-9e2d-efee33ac08dc.png)


