### PR TITLE
[deliver] use buildwatcher class

### DIFF
--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -39,7 +39,7 @@ module Deliver
         end
       else
         UI.message("Selecting the latest build...")
-        build = wait_for_build(app)
+        build = FastlaneCore::BuildWatcher.wait_for_build(app, options[:app_platform], sleep_time)
       end
       UI.message("Selecting build #{build.train_version} (#{build.build_version})...")
 
@@ -47,41 +47,6 @@ module Deliver
       v.save!
 
       UI.success("Successfully selected build")
-    end
-
-    def wait_for_build(app)
-      UI.user_error!("Could not find app with app identifier") unless app
-
-      start = Time.now
-
-      loop do
-        build = find_build(app.latest_version.candidate_builds)
-        return build if build.processing == false
-
-        UI.message("Waiting iTunes Connect processing for build #{build.train_version} (#{build.build_version})... this might take a while...")
-        if (Time.now - start) > (60 * 5)
-          UI.message("")
-          UI.message("You can tweet: \"iTunes Connect #iosprocessingtime #{((Time.now - start) / 60).round} minutes\"")
-        end
-        sleep 30
-      end
-      nil
-    end
-
-    def find_build(candidate_builds)
-      build = nil
-      candidate_builds.each do |b|
-        if !build or b.upload_date > build.upload_date
-          build = b
-        end
-      end
-
-      unless build
-        UI.error(candidate_builds)
-        UI.crash!("Could not find build")
-      end
-
-      return build
     end
   end
 end


### PR DESCRIPTION
# PR 3/4

This series of PR's try's to de-duplicate the various blocks that check if a build is finished processing.
by moving the logic to fastlanecore.

 * 1/4 ->  https://github.com/fastlane/fastlane/pull/7386 (fastlane_core)
 * 2/4 ->  https://github.com/fastlane/fastlane/pull/7387 (pilot)
 * 3/4 ->  https://github.com/fastlane/fastlane/pull/7388 (deliver)
 * 4/4 ->  https://github.com/fastlane/fastlane/pull/7389 (watchbuild)


a full branch is at this PR: https://github.com/fastlane/fastlane/pull/7381
(i am going to keen the full branch updated, if during review the singel PR's change)


the fastlane_core PR is mandatory for the other ones, but the tools could be merged one by one.
let me know what you guys think.



![bildschirmfoto 2016-12-08 um 21 49 00](https://cloud.githubusercontent.com/assets/2891702/21027885/0e21f47a-bd93-11e6-9e2d-efee33ac08dc.png)