### PR TITLE
[watchbuild] use buildwatcher from core

### DIFF
--- a/watchbuild/lib/watchbuild/options.rb
+++ b/watchbuild/lib/watchbuild/options.rb
@@ -21,7 +21,16 @@ module WatchBuild
         FastlaneCore::ConfigItem.new(key: :sample_only_once,
                                      description: "Only check for the build once, instead of waiting for it to process",
                                      is_string: false,
-                                     default_value: false)
+                                     default_value: false),
+        FastlaneCore::ConfigItem.new(key: :platform,
+                                     short_option: "-j",
+                                     env_name: "WATCHBUILD_PLATFORM",
+                                     description: "The platform to use (optional)",
+                                     optional: true,
+                                     default_value: "ios",
+                                    verify_block: proc do |value|
+                                      UI.user_error!("The platform can only be ios, appletvos, or osx") unless %('ios', 'appletvos', 'osx').include? value
+                                    end)
       ]
     end
   end


### PR DESCRIPTION
# PR 4/4

This series of PR's try's to de-duplicate the various blocks that check if a build is finished processing.
by moving the logic to fastlanecore.

 * 1/4 ->  https://github.com/fastlane/fastlane/pull/7386 (fastlane_core)
 * 2/4 ->  https://github.com/fastlane/fastlane/pull/7387 (pilot)
 * 3/4 ->  https://github.com/fastlane/fastlane/pull/7388 (deliver)
 * 4/4 ->  https://github.com/fastlane/fastlane/pull/7389 (watchbuild)


a full branch is at this PR: https://github.com/fastlane/fastlane/pull/7381
(i am going to keen the full branch updated, if during review the singel PR's change)


the fastlane_core PR is mandatory for the other ones, but the tools could be merged one by one.
let me know what you guys think.


![bildschirmfoto 2016-12-08 um 21 49 00](https://cloud.githubusercontent.com/assets/2891702/21027885/0e21f47a-bd93-11e6-9e2d-efee33ac08dc.png)
