### PR TITLE
[deliver] no screenshot information - reword

### DIFF
--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -195,7 +195,7 @@
                   <b>--overwrite_screenshots</b> is set, existing screenshots will be removed, but none will be uploaded.
                 <% else %>
                   The existing screenshots on iTunes Connect will be kept. 
-                  if you want to remove them you have to use  the <i>--overwrite_screenshots</i>  flag.
+                  if you want to remove them you have to use the <i>--overwrite_screenshots</i> flag.
                 <% end %>
               <p>
                 If you want to download your existing screenshots, run <i>deliver download_screenshots</i>.

--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -190,9 +190,15 @@
             <div style="border: 3px solid red; padding: 0px 20px">
               <h2 style="color: red">No Screenshots Found</h2>
               <p>
-                deliver couldn't find any screenshots. This will <b>remove</b> existing screenshots, but will also not upload any.
+                deliver couldn't find any screenshots.
+                <% if options[:overwrite_screenshots] %>
+                  <b>--overwrite_screenshots</b> is set, existing screenshots will be removed, but none will be uploaded.
+                <% else %>
+                  The existing screenshots on iTunes Connect will be kept. 
+                  if you want to remove them you have to use  the <i>--overwrite_screenshots</i>  flag.
+                <% end %>
               <p>
-                Please make sure to store your screenshots in the screenshots folder. If you want to download your existing screenshots, run <i>deliver download_screenshots</i>.
+                If you want to download your existing screenshots, run <i>deliver download_screenshots</i>.
               </p>
             </div>
           <% end %>


### PR DESCRIPTION
be a bit more precise on the error message.
since screenshots won't be deleted by default anymore (only when `overwrite_screenshots` is set) 

as proposed by @KrauseFx 