### PR TITLE
Make terminal table more responsive

### DIFF
--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -37,7 +37,7 @@ module Fastlane
       puts Terminal::Table.new(
         title: "Available fastlane actions".green,
         headings: ['Action', 'Description', 'Author'],
-        rows: rows
+        rows: FastlaneCore::PrintTable.transform_output(rows, :newline)
       )
       puts "  Platform filter: #{platform}".magenta if platform
       puts "  Total of #{rows.count} actions"
@@ -108,7 +108,7 @@ module Fastlane
         puts Terminal::Table.new(
           title: "#{name} Options".green,
           headings: ['Key', 'Description', 'Env Var', 'Default'],
-          rows: options
+          rows: FastlaneCore::PrintTable.transform_output(options, :newline)
         )
       else
         puts "No available options".yellow
@@ -123,7 +123,7 @@ module Fastlane
       puts Terminal::Table.new(
         title: "#{name} Output Variables".green,
         headings: ['Key', 'Description'],
-        rows: output.map { |key, desc| [key.yellow, desc] }
+        rows: FastlaneCore::PrintTable.transform_output(output.map { |key, desc| [key.yellow, desc] }, :newline)
       )
       puts "Access the output values using `lane_context[SharedValues::VARIABLE_NAME]`"
       puts ""
@@ -132,7 +132,7 @@ module Fastlane
     def self.print_return_value(action, name)
       return unless action.return_value
 
-      puts Terminal::Table.new(title: "#{name} Return Value".green, rows: [[action.return_value]])
+      puts Terminal::Table.new(title: "#{name} Return Value".green, rows: FastlaneCore::PrintTable.transform_output([[action.return_value]], :newline))
       puts ""
     end
 

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -225,7 +225,7 @@ module Fastlane
       rows = Actions.lane_context.collect do |key, content|
         [key, content.to_s]
       end
-      rows = FastlaneCore::PrintTable.limit_row_size(rows)
+      rows = FastlaneCore::PrintTable.print_values(config: rows)
 
       require 'terminal-table'
       puts Terminal::Table.new({

--- a/fastlane/spec/fixtures/plist/Info.plist
+++ b/fastlane/spec/fixtures/plist/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/fastlane_core/lib/fastlane_core/string_filters.rb
+++ b/fastlane_core/lib/fastlane_core/string_filters.rb
@@ -31,4 +31,20 @@ class String
 
     "#{self[0, stop]}#{omission}"
   end
+
+  # Base taken from: https://www.ruby-forum.com/topic/57805
+  def wordwrap(length = 80)
+    self.gsub!(/(\S{#{length}})(?=\S)/, '\1 ')
+    self.scan(/.{1,#{length}}(?:\s+|$)/)
+  end
+
+  # Base taken from: http://stackoverflow.com/a/12202205/1945875
+  def middle_truncate(length = 20, options = {})
+    omission = options[:omission] || '...'
+    return self if self.length <= length + omission.length
+    return self[0..length] if length < omission.length
+    len = (length - omission.length) / 2
+    s_len = len - length % 2
+    self[0..s_len] + omission + self[self.length - len..self.length]
+  end
 end

--- a/fastlane_core/spec/print_table_spec.rb
+++ b/fastlane_core/spec/print_table_spec.rb
@@ -48,15 +48,15 @@ describe FastlaneCore do
 
       value = FastlaneCore::PrintTable.print_values(config: @config, title: title, hide_keys: [:a_sensitive])
       expect(value[:title]).to eq(title.green)
-      expect(value[:rows]).to eq([['cert_name', "asdf"], ['output', '..'], ["a_bool", true]])
+      expect(value[:rows]).to eq([["cert_name", "asdf"], :separator, ["output", ".."], :separator, ["a_bool", "true"]])
     end
     it "automatically masks sensitive options" do
       value = FastlaneCore::PrintTable.print_values(config: @config)
-      expect(value[:rows]).to eq([["cert_name", "asdf"], ["output", ".."], ["a_bool", true], ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["cert_name", "asdf"], :separator, ["output", ".."], :separator, ["a_bool", "true"], :separator, ["a_sensitive", "********"]])
     end
     it "supports mask_keys property with symbols and strings" do
       value = FastlaneCore::PrintTable.print_values(config: @config, mask_keys: [:cert_name, 'a_bool'])
-      expect(value[:rows]).to eq([["cert_name", "********"], ["output", ".."], ["a_bool", "********"], ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["cert_name", "********"], :separator, ["output", ".."], :separator, ["a_bool", "********"], :separator, ["a_sensitive", "********"]])
     end
 
     it "supports hide_keys property with symbols and strings" do
@@ -68,30 +68,46 @@ describe FastlaneCore do
       @config[:a_hash][:foo] = 'bar'
       @config[:a_hash][:bar] = { foo: 'bar' }
       value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:cert_name, :a_bool])
-      expect(value[:rows]).to eq([["output", ".."], ["a_hash.foo", "bar"], ["a_hash.bar.foo", "bar"], ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["output", ".."], :separator, ["a_hash.foo", "bar"], :separator, ["a_hash.bar.foo", "bar"], :separator, ["a_sensitive", "********"]])
     end
 
     it "supports hide_keys property in hashes" do
       @config[:a_hash][:foo] = 'bar'
       @config[:a_hash][:bar] = { foo: 'bar' }
       value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:cert_name, :a_bool, 'a_hash.foo', 'a_hash.bar.foo'])
-      expect(value[:rows]).to eq([["output", ".."], ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["output", ".."], :separator, ["a_sensitive", "********"]])
     end
 
     it "supports printing default values and ignores missing unset ones " do
       @config[:cert_name] = nil # compulsory without default
       @config[:output] = nil    # compulsory with default
       value = FastlaneCore::PrintTable.print_values(config: @config)
-      expect(value[:rows]).to eq([["output", "."], ["a_bool", true], ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["output", "."], :separator, ["a_bool", "true"], :separator, ["a_sensitive", "********"]])
     end
+    describe "Breaks down lines" do
+      let(:long_breakable_text) { 'bar ' * 4000 }
+      before do
+        @config[:cert_name] = long_breakable_text
+      end
+      it "middle truncate" do
+        value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output, :a_bool, :a_sensitive], transform: :truncate_middle)
+        expect(value[:rows].count).to eq(1)
+        expect(value[:rows][0][1]).to include "..."
+        expect(value[:rows][0][1].length).to be < long_breakable_text.length
+      end
 
-    it "breaks down long lines" do
-      long_breakable_text = 'bar ' * 40
-      @config[:cert_name] = long_breakable_text
-      value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output, :a_bool, :a_sensitive])
-      expect(value[:rows].count).to eq(1)
-      expect(value[:rows][0][1]).to end_with '...'
-      expect(value[:rows][0][1].length).to be < long_breakable_text.length
+      it "newline" do
+        value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output, :a_bool, :a_sensitive], transform: :newline)
+        expect(value[:rows].count).to eq(1)
+        expect(value[:rows][0][1]).to include "\n"
+        expect(value[:rows][0][1].length).to be > long_breakable_text.length
+      end
+
+      it "no change" do
+        value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output, :a_bool, :a_sensitive], transform: :none)
+        expect(value[:rows].count).to eq(1)
+        expect(value[:rows][0][1].length).to eq(long_breakable_text.length)
+      end
     end
 
     it "supports non-Configuration prints" do


### PR DESCRIPTION
this trys to fix the ugliness of terminal table on small terminals - by making tables fit to terminal width.
in addition to the variable size, i also did a middle_truncate.


so instead of `very long va...`  now `very ... value`  is displayed.


# Large
![large](https://cloud.githubusercontent.com/assets/2891702/21029293/56fd96bc-bd99-11e6-9352-1028db11d62b.png)

# Medium
![medium](https://cloud.githubusercontent.com/assets/2891702/21029292/56fa35f8-bd99-11e6-9383-6f2797a934a9.png)

# Small
![small](https://cloud.githubusercontent.com/assets/2891702/21029294/56feddba-bd99-11e6-862e-519e62f081c0.png)


> Ruby 1.9.3 added 'io/console' to the standard library.
the additional require should not be a problem.

to quickly test it use this ruby script:

```ruby
require "fastlane_core"
FastlaneCore::PrintTable.print_values(config:
  { wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb bbbbbbbbbbbbbbbbbbbbbbb bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
      wwwwwwwwwwwwwwwwwwwwwwwwxw: "ccc bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb bbbbbbbbbbbbbbbbbbbbbbb bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },

                                   hide_keys: [],
                                       title: "Summary SUM")

```
