### PR TITLE
[deliver] support app_icons via metadata

### DIFF
--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -107,7 +107,7 @@
               margin-left: 10px;
               margin-right: 10px;
           }
-          .app-icons img{
+          .app-icons img {
             width: 150px;
           }
           .app-icons .app-icon {

--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -107,10 +107,32 @@
               margin-left: 10px;
               margin-right: 10px;
           }
+          .app-icons img{
+            width: 150px;
+          }
+          .app-icons .app-icon {
+              float: left;
+              margin-right: 20px;
+          }
         </style>
     </head>
     
     <body>
+      <div class="app-icons">
+        
+        <% if @options[:app_icon] %>
+        <div class="app-icon">
+          Large App Icon:<br>
+          <img src="<%= @options[:app_icon] %>">
+        </div>
+        <% end %>
+        <% if @options[:apple_watch_app_icon] %>
+        <div class="watch-icon">
+          Watch App Icon:<br>
+          <img src="<%= @options[:apple_watch_app_icon] %>">
+        </div>
+        <% end %>
+      </div>
       <% @languages.each do |language| %>
         <% if @options[:name] %>
           <div class="app-name">

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -52,6 +52,10 @@ module Deliver
       UploadMetadata.new.load_from_filesystem(options)
       UploadMetadata.new.assign_defaults(options)
 
+      # Handle app icon / watch icon
+
+      prepare_app_icons(options)
+
       # Validate
       validate_html(screenshots)
 
@@ -60,6 +64,19 @@ module Deliver
       UploadScreenshots.new.upload(options, screenshots)
       UploadPriceTier.new.upload(options)
       UploadAssets.new.upload(options) # e.g. app icon
+    end
+
+    def prepare_app_icons(options = {})
+      app_icon_path = options[:app_icon] if options[:app_icon]
+      app_icon_metadata = File.join(options[:metadata_path], "app_icon.png")
+      if app_icon_path.nil? && File.exist?(app_icon_metadata)
+        options[:app_icon] = app_icon_metadata
+      end
+      watch_icon_path = options[:apple_watch_app_icon] if options[:apple_watch_app_icon]
+      watch_icon_metadata = File.join(options[:metadata_path], "watch_icon.png")
+      if watch_icon_path.nil? && File.exist?(watch_icon_metadata)
+        options[:apple_watch_app_icon] = watch_icon_metadata
+      end
     end
 
     # Upload the binary to iTunes Connect

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -53,7 +53,6 @@ module Deliver
       UploadMetadata.new.assign_defaults(options)
 
       # Handle app icon / watch icon
-
       prepare_app_icons(options)
 
       # Validate
@@ -66,17 +65,18 @@ module Deliver
       UploadAssets.new.upload(options) # e.g. app icon
     end
 
+    # If options[:app_icon]/options[:apple_watch_app_icon]
+    # is supplied value/path will be used.
+    # If it is unset files (app_icon/watch_icon) exists in
+    # the fastlane/metadata/ folder, those will be used
     def prepare_app_icons(options = {})
-      app_icon_path = options[:app_icon] if options[:app_icon]
-      app_icon_metadata = File.join(options[:metadata_path], "app_icon.png")
-      if app_icon_path.nil? && File.exist?(app_icon_metadata)
-        options[:app_icon] = app_icon_metadata
-      end
-      watch_icon_path = options[:apple_watch_app_icon] if options[:apple_watch_app_icon]
-      watch_icon_metadata = File.join(options[:metadata_path], "watch_icon.png")
-      if watch_icon_path.nil? && File.exist?(watch_icon_metadata)
-        options[:apple_watch_app_icon] = watch_icon_metadata
-      end
+      return unless options[:metadata_path]
+
+      default_app_icon_path = File.join(options[:metadata_path], "app_icon.png")
+      options[:app_icon] ||= default_app_icon_path if File.exist?(default_app_icon_path)
+
+      default_watch_icon_path = File.join(options[:metadata_path], "watch_icon.png")
+      options[:app_icon] ||= default_watch_icon_path if File.exist?(default_watch_icon_path)
     end
 
     # Upload the binary to iTunes Connect

--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -67,6 +67,18 @@ module Deliver
       end
 
       UI.success("Successfully created new configuration files.")
+
+      # get App icon + watch icon
+      if v.large_app_icon.asset_token
+        app_icon_path = File.join(path, "app_icon.png")
+        File.write(app_icon_path, open(v.large_app_icon.url).read)
+        UI.success("Successfully downloaded large app icon")
+      end
+      if v.watch_app_icon.asset_token
+        watch_icon_path = File.join(path, "watch_icon.png")
+        File.write(watch_icon_path, open(v.watch_app_icon.url).read)
+        UI.success("Successfully downloaded watch icon")
+      end
     end
 
     def download_screenshots(deliver_path, options)


### PR DESCRIPTION
This one adds support for upload/download of app_icon/apple_watch_icon.

icons are stored int `metdata/app_icon.png` `metdata/watch_icon.png`

# Upload
as there is an option to explicit set a path to an app_icon, and to not break existing usage of this flags, the option will be used if set. otherwise if unset, and a file exists in the metdata folder root this file will be used

![bildschirmfoto 2016-12-09 um 08 31 43](https://cloud.githubusercontent.com/assets/2891702/21041276/3a3543d0-bdea-11e6-8195-1c3d7ad1c1f4.png)

<img width="651" alt="bildschirmfoto 2016-12-09 um 08 41 47" src="https://cloud.githubusercontent.com/assets/2891702/21041455/5bc193b8-bdeb-11e6-9482-275220d234b6.png">


# Download
`download_metadata`  also downloads existing app icons.

![bildschirmfoto 2016-12-09 um 12 23 49](https://cloud.githubusercontent.com/assets/2891702/21047469/66ee6224-be0a-11e6-94d0-d5b388859b84.png)


> App icon redacted 👍 