### PR TITLE
[spaceship] identify imessage screenshots

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_image.rb
+++ b/spaceship/lib/spaceship/tunes/app_image.rb
@@ -12,6 +12,8 @@ module Spaceship
 
       attr_accessor :url
 
+      attr_accessor :platform
+
       attr_mapping(
         'assetToken' => :asset_token,
         'sortOrder' => :sort_order,

--- a/spaceship/lib/spaceship/tunes/app_image.rb
+++ b/spaceship/lib/spaceship/tunes/app_image.rb
@@ -12,7 +12,7 @@ module Spaceship
 
       attr_accessor :url
 
-      attr_accessor :platform
+      attr_accessor :is_imessage
 
       attr_mapping(
         'assetToken' => :asset_token,

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -703,7 +703,7 @@ module Spaceship
             data = {
                 device_type: display_family['name'],
                 language: row["language"],
-                platform: "imessage" # to identify imessage screenshots later on (e.g: during download)
+                is_imessage: true # to identify imessage screenshots later on (e.g: during download)
             }.merge(screenshot_data)
             result << Tunes::AppScreenshot.factory(data)
           end

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -702,7 +702,8 @@ module Spaceship
             screenshot_data = screenshot["value"]
             data = {
                 device_type: display_family['name'],
-                language: row["language"]
+                language: row["language"],
+                platform: "imessage" # to identify imessage screenshots later on (e.g: during download)
             }.merge(screenshot_data)
             result << Tunes::AppScreenshot.factory(data)
           end


### PR DESCRIPTION
# PR 1/2

issue: https://github.com/fastlane/fastlane/issues/7366

# Spaceship
 * adds a attr `platform` - sets it to `imessage` if screenshot is imessage.

# deliver
 * download imessage screens into the right folder `iMessage`
 
 
 
  * 1/2 -> https://github.com/fastlane/fastlane/pull/7399 (spaceship)
  * 2/2 -> https://github.com/fastlane/fastlane/pull/7400 (deliver)