### PR TITLE
[deliver] download imessage screens in right folder

### DIFF
--- a/deliver/lib/deliver/download_screenshots.rb
+++ b/deliver/lib/deliver/download_screenshots.rb
@@ -28,7 +28,7 @@ module Deliver
             containing_folder = File.join(folder_path, screenshot.language)
           end
 
-          if screenshot.platform == "imessage"
+          if screenshot.is_imessage
             containing_folder = File.join(folder_path, "iMessage", screenshot.language)
           end
 

--- a/deliver/lib/deliver/download_screenshots.rb
+++ b/deliver/lib/deliver/download_screenshots.rb
@@ -28,6 +28,10 @@ module Deliver
             containing_folder = File.join(folder_path, screenshot.language)
           end
 
+          if screenshot.platform == "imessage"
+            containing_folder = File.join(folder_path, "iMessage", screenshot.language)
+          end
+
           begin
             FileUtils.mkdir_p(containing_folder)
           rescue


### PR DESCRIPTION
# PR 2/2

issue: https://github.com/fastlane/fastlane/issues/7366

# Spaceship
 * adds a attr `platform` - sets it to `imessage` if screenshot is imessage.

# deliver
 * download imessage screens into the right folder `iMessage`
 
 
 
  * 1/2 -> https://github.com/fastlane/fastlane/pull/7399 (spaceship)
  * 2/2 -> https://github.com/fastlane/fastlane/pull/7400 (deliver)