### PR TITLE
Fix xcodebuild action specs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  environment:
+    FL_BUILDLOG_PATH: ~/Library/Logs
   xcode:
     version: "7.3"
 dependencies:

--- a/fastlane/spec/actions_specs/xcodebuild_spec.rb
+++ b/fastlane/spec/actions_specs/xcodebuild_spec.rb
@@ -1,6 +1,6 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    build_log_path = File.expand_path("~/Library/Logs/fastlane/xcbuild/#{Time.now.strftime('%F')}/#{Process.pid}/xcodebuild.log")
+    build_log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/fastlane/xcbuild/#{Time.now.strftime('%F')}/#{Process.pid}/xcodebuild.log")
 
     describe "Xcodebuild Integration" do
       before :each do

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -16,7 +16,7 @@ describe Gym do
     end
 
     it "supports additional parameters" do
-      log_path = File.expand_path("~/Library/Logs/gym/ExampleProductName-Example.log")
+      log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 
       xcargs_hash = { DEBUG: "1", BUNDLE_NAME: "Example App" }
       xcargs = xcargs_hash.map do |k, v|
@@ -43,7 +43,7 @@ describe Gym do
     end
 
     it "disables xcpretty formatting" do
-      log_path = File.expand_path("~/Library/Logs/gym/ExampleProductName-Example.log")
+      log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 
       xcargs_hash = { DEBUG: "1", BUNDLE_NAME: "Example App" }
       xcargs = xcargs_hash.map do |k, v|
@@ -74,7 +74,7 @@ describe Gym do
       end
 
       it "uses the correct build command with the example project with no additional parameters" do
-        log_path = File.expand_path("~/Library/Logs/gym/ExampleProductName-Example.log")
+        log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 
         result = Gym::BuildCommandGenerator.generate
         expect(result).to eq([
@@ -123,7 +123,7 @@ describe Gym do
 
       it "#buildlog_path is not used when not provided" do
         result = Gym::BuildCommandGenerator.xcodebuild_log_path
-        expect(result.to_s).to include("Library/Logs/gym")
+        expect(result.to_s).to include(File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym"))
       end
     end
 
@@ -134,7 +134,7 @@ describe Gym do
       end
 
       it "uses the correct build command with the example project" do
-        log_path = File.expand_path("~/Library/Logs/gym/ExampleProductName-Example.log")
+        log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 
         result = Gym::BuildCommandGenerator.generate
         expect(result).to eq([
@@ -154,7 +154,7 @@ describe Gym do
 
     describe "Result Bundle Example" do
       it "uses the correct build command with the example project" do
-        log_path = File.expand_path("~/Library/Logs/gym/ExampleProductName-Example.log")
+        log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 
         options = { project: "./examples/standard/Example.xcodeproj", result_bundle: true, scheme: 'Example' }
         Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -149,7 +149,7 @@ describe Scan do
 
       it "#buildlog_path is not used when not provided" do
         result = Scan::TestCommandGenerator.xcodebuild_log_path
-        expect(result.to_s).to include("Library/Logs/scan")
+        expect(result.to_s).to include(File.expand_path("#{FastlaneCore::Helper.buildlog_path}/scan"))
       end
     end
 

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -54,7 +54,7 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee #{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests.log')} | xcpretty "
+              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
             ]
           )
         end
@@ -76,7 +76,7 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee #{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests.log')} | xcpretty "
+              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
             ]
           )
         end


### PR DESCRIPTION
As of 2016-12-7, CircleCI has started setting the `FL_BUILDLOG_PATH` environment variable, which changes the output location for build logs.

Many specs were assuming that the generated commands would include the default log path, rather than using the `buildlog_path` helper function that takes into account the environment variable.

This fixes those specs to use the helper and get the right path.