### PR TITLE
[fastlane/action] get_version_number, improve target detection/notice doc.

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -104,7 +104,7 @@ module Fastlane
         targets_available = self.parse_targets(results)
         if params[:target] && !targets_available.include?(params[:target])
           UI.important("Could not find specified target: #{params[:target]}")
-          UI.important("Availaible targets:")
+          UI.important("Available targets:")
           targets_available.each do |t|
             UI.important("\t #{t}")
           end

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -80,8 +80,7 @@ module Fastlane
         version_number = line.partition('=').last
         return version_number if Helper.is_test?
 
-        targets_available = self.parse_targets(results)
-        self.validate_target(params, targets_available)
+        self.validate_targets(params, results)
 
         # Store the number in the shared hash
         Actions.lane_context[SharedValues::VERSION_NUMBER] = version_number
@@ -101,7 +100,8 @@ module Fastlane
         return targets_available
       end
 
-      def self.validate_target(params, targets_available)
+      def self.validate_targets(params, results)
+        targets_available = self.parse_targets(results)
         if params[:target] && !targets_available.include?(params[:target])
           UI.important("Could not find specified target: #{params[:target]}")
           UI.important("Availaible targets:")


### PR DESCRIPTION
as discussed here https://github.com/fastlane/fastlane/issues/7361
this PR try's to improve the output once a specified target - is not found, by listing all available targets (as those are not 100% always the same names as in xcode target)


e.g.: Xcode Target: "DemoAs" Plist: "DemoA-Info.plist"

i think it happens once you rename a target in xcode! as the plist name does not change.


![bildschirmfoto 2016-12-09 um 21 20 16](https://cloud.githubusercontent.com/assets/2891702/21063611/ce91530e-be56-11e6-94f1-d31888849c6c.png)