### PR TITLE
[spaceship] Automatically re-try “UnauthorizedAccessError” errors

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -360,7 +360,7 @@ module Spaceship
 
     def with_retry(tries = 5, &_block)
       return yield
-    rescue Faraday::Error::ConnectionFailed, Faraday::Error::TimeoutError, AppleTimeoutError, UnauthorizedAccessError, Errno::EPIPE => ex # New Faraday version: Faraday::TimeoutError => ex
+    rescue Faraday::Error::ConnectionFailed, Faraday::Error::TimeoutError, AppleTimeoutError, Errno::EPIPE => ex # New Faraday version: Faraday::TimeoutError => ex
       unless (tries -= 1).zero?
         logger.warn("Timeout received: '#{ex.message}'. Retrying after 3 seconds (remaining: #{tries})...")
         sleep 3 unless defined? SpecHelper
@@ -368,7 +368,7 @@ module Spaceship
       end
       raise ex # re-raise the exception
     rescue UnauthorizedAccessError => ex
-      if @loggedin && !(tries -= 1).zero?
+      unless (tries -= 1).zero?
         msg = "Auth error received: '#{ex.message}'. Login in again then retrying after 3 seconds (remaining: #{tries})..."
         puts msg if $verbose
         logger.warn msg

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -360,9 +360,9 @@ module Spaceship
 
     def with_retry(tries = 5, &_block)
       return yield
-    rescue Faraday::Error::ConnectionFailed, Faraday::Error::TimeoutError, AppleTimeoutError, Errno::EPIPE => ex # New Faraday version: Faraday::TimeoutError => ex
+    rescue Faraday::Error::ConnectionFailed, Faraday::Error::TimeoutError, AppleTimeoutError, UnauthorizedAccessError, Errno::EPIPE => ex # New Faraday version: Faraday::TimeoutError => ex
       unless (tries -= 1).zero?
-        logger.warn("Timeout received: '#{ex.message}'.  Retrying after 3 seconds (remaining: #{tries})...")
+        logger.warn("Timeout received: '#{ex.message}'. Retrying after 3 seconds (remaining: #{tries})...")
         sleep 3 unless defined? SpecHelper
         retry
       end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -372,8 +372,13 @@ module Spaceship
         msg = "Auth error received: '#{ex.message}'. Login in again then retrying after 3 seconds (remaining: #{tries})..."
         puts msg if $verbose
         logger.warn msg
-        do_login(self.user, @password)
         sleep 3 unless defined? SpecHelper
+        if @loggedin
+          # If we're not logged in yet, the `retry` call will re-trigger the login anyway
+          # That's why we only login again if that happens when we're already logged in, but the session
+          # got invalidated somehow
+          do_login(self.user, @password)
+        end
         retry
       end
       raise ex # re-raise the exception


### PR DESCRIPTION
Those errors would randomly occur sometimes due to a server error. The full stack trace when this happens:

```
**Unauthorized Access**
/app/local_fastlane/spaceship/lib/spaceship/client.rb:469:in `block in send_request'
/app/local_fastlane/spaceship/lib/spaceship/client.rb:362:in `with_retry'
/app/local_fastlane/spaceship/lib/spaceship/client.rb:463:in `send_request'
/app/local_fastlane/spaceship/lib/spaceship/client.rb:400:in `request'
/app/local_fastlane/spaceship/lib/spaceship/client.rb:306:in `send_shared_login_request'
/app/local_fastlane/spaceship/lib/spaceship/tunes/tunes_client.rb:164:in `send_login_request'
/app/local_fastlane/spaceship/lib/spaceship/client.rb:430:in `do_login'
/app/local_fastlane/spaceship/lib/spaceship/client.rb:245:in `login'
/app/local_fastlane/spaceship/lib/spaceship/client.rb:92:in `login'
/app/local_fastlane/spaceship/lib/spaceship/tunes/spaceship.rb:22:in `login'
```