### PR TITLE
Added action sh, fixing #182

### DIFF
--- a/fastlane/lib/fastlane/actions/sh.rb
+++ b/fastlane/lib/fastlane/actions/sh.rb
@@ -10,12 +10,12 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Runs shell command"
+        "Runs a shell command"
       end
 
       def self.details
         [
-          "Allows running arbitrary shell command"
+          "Allows running an arbitrary shell command"
         ].join("\n")
       end
 

--- a/fastlane/lib/fastlane/actions/sh.rb
+++ b/fastlane/lib/fastlane/actions/sh.rb
@@ -1,0 +1,64 @@
+module Fastlane
+  module Actions
+    class ShAction < Action
+      def self.run(params)
+        # this is implemented in the sh_helper.rb
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Runs shell command"
+      end
+
+      def self.details
+        [
+          "Allows running arbitrary shell command"
+        ].join("\n")
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :command,
+                                         description: 'Shell command to be executed',
+                                         optional: false,
+                                         is_string: true),
+          FastlaneCore::ConfigItem.new(key: :log,
+                                         description: 'Determines whether fastlane should print out the executed command itself and output of the executed command. If command line option --troubleshoot is used, then it overrides this option to true',
+                                         optional: true,
+                                         is_string: false,
+                                         default_value: true),
+          FastlaneCore::ConfigItem.new(key: :error_callback,
+                                         description: 'A callback invoked with the command ouptut if there is a non-zero exit status',
+                                         optional: true,
+                                         is_string: true,
+                                         default_value: 'nil')
+        ]
+      end
+
+      def self.output
+        ['Outputs the string and executes it. When running in tests, it returns the actual command instead of executing it']
+      end
+
+      def self.authors
+        ["KrauseFx"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.example_code
+        [
+          'sh("uname -a")'
+        ]
+      end
+
+      def self.category
+        :misc
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/sh.rb
+++ b/fastlane/lib/fastlane/actions/sh.rb
@@ -38,8 +38,8 @@ module Fastlane
         ]
       end
 
-      def self.output
-        ['Outputs the string and executes it. When running in tests, it returns the actual command instead of executing it']
+      def self.return_value
+        'Outputs the string and executes it. When running in tests, it returns the actual command instead of executing it'
       end
 
       def self.authors
@@ -52,7 +52,8 @@ module Fastlane
 
       def self.example_code
         [
-          'sh("uname -a")'
+          'sh("ls")',
+          'sh("git commit -m \'My message\'")'
         ]
       end
 

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -1,7 +1,7 @@
 describe Fastlane do
   describe Fastlane::Action do
     describe "No unused options" do
-      let (:all_exceptions) { %w(pilot appstore cert deliver gym match pem produce scan sigh snapshot supply testflight mailgun testfairy ipa import_from_git hockey deploygate crashlytics artifactory appledoc slather screengrab download_dsyms notification frameit set_changelog register_devices latest_testflight_build_number app_store_build_number) }
+      let (:all_exceptions) { %w(pilot appstore cert deliver gym match pem produce scan sigh snapshot supply testflight mailgun testfairy ipa import_from_git hockey deploygate crashlytics artifactory appledoc slather screengrab download_dsyms notification frameit set_changelog register_devices latest_testflight_build_number app_store_build_number sh) }
 
       Fastlane::ActionsList.all_actions do |action, name|
         next unless action.available_options.kind_of?(Array)


### PR DESCRIPTION
This is intended to fix fastlane/docs#182 'sh' action not documented
`bundle exec rspec` shows following complaint:
```
  2) Fastlane Fastlane::Action No unused options No unused parameters in 'sh'
     Failure/Error: UI.user_error!("Action '#{name}' doesn't use the option :#{option.key}")
     FastlaneCore::Interface::FastlaneError:
       Action 'sh' doesn't use the option :command
```
Unfortunatelly, I have no idea how to fix it. This is my first ruby contribution ever. I have looked around how other actions are written and tried to do it the same way.
Thanks for all your hard work and making CI better!

- [X] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [X] Run `bundle exec rubocop -a` to ensure the code style is valid
- [X] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

