### PR TITLE
[spaceship] Version bump to 0.39.0

### DIFF
--- a/spaceship/lib/spaceship/version.rb
+++ b/spaceship/lib/spaceship/version.rb
@@ -1,4 +1,4 @@
 module Spaceship
-  VERSION = "0.38.5".freeze
+  VERSION = "0.39.0".freeze
   DESCRIPTION = "Ruby library to access the Apple Dev Center and iTunes Connect".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '0.38.5':**

* Fix rubocop trailing multiline if warning (#7443)
* upgrade fastimage, fixes #7370 (#7401)
* Identify imessage screenshots, fixes #7366 (#7399)
* Add Portal module name when using the Developer Portal interface (#7030)
* Teach pilot about apps with multiple platforms (#7267)
* Add platform parameter to spaceship iTC client (#7328)
* add support for mac apps (#7180)
* Remove `now:` from tests (#7317)
