### PR TITLE
Disable rake < 12 in gem specs

### DIFF
--- a/cert/cert.gemspec
+++ b/cert/cert.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fastlane_core", ">= 0.58.0", "< 1.0.0" # all shared code and dependencies
-  spec.add_dependency "spaceship", ">= 0.38.5", "< 1.0.0" # access to the Dev Portal
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "spaceship", ">= 0.39.0", "< 1.0.0" # access to the Dev Portal
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/cert/cert.gemspec
+++ b/cert/cert.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'

--- a/credentials_manager/credentials_manager.gemspec
+++ b/credentials_manager/credentials_manager.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'

--- a/danger-device_grid/danger-device_grid.gemspec
+++ b/danger-device_grid/danger-device_grid.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fastlane", ">= 1.111.0", "< 2.0.0"
 
   spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'rubocop', '~> 0.44.0'

--- a/deliver/deliver.gemspec
+++ b/deliver/deliver.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # fastlane dependencies
-  spec.add_dependency "fastlane_core", ">= 0.58.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency "credentials_manager", ">= 0.16.2", "< 1.0.0"
-  spec.add_dependency "spaceship", ">= 0.38.5", "< 1.0.0" # Communication with iTunes Connect
+  spec.add_dependency "spaceship", ">= 0.39.0", "< 1.0.0" # Communication with iTunes Connect
 
   # third party dependencies
   spec.add_dependency 'fastimage', '>= 1.6'

--- a/deliver/deliver.gemspec
+++ b/deliver/deliver.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'

--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -63,7 +63,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '< 5'
 
   # Development only
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'

--- a/fastlane/fastlane.gemspec
+++ b/fastlane/fastlane.gemspec
@@ -36,19 +36,19 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'xcode-install', '~> 2.0.0' # Needed for xcversion and xcode_install actions
   spec.add_dependency 'word_wrap', '~> 1.0.0' # to add line breaks for tables with long strings
 
-  spec.add_dependency "fastlane_core", ">= 0.59.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
 
   spec.add_dependency 'bundler', "~> 1.12" # Used for fastlane plugins
   spec.add_dependency "credentials_manager", ">= 0.16.2", "< 1.0.0" # Password Manager
-  spec.add_dependency "spaceship", ">= 0.38.5", "< 1.0.0" # communication layer with Apple's web services
+  spec.add_dependency "spaceship", ">= 0.39.0", "< 1.0.0" # communication layer with Apple's web services
   spec.add_dependency 'faraday', '~> 0.9' # Used for deploygate, hockey and testfairy actions
   spec.add_dependency 'faraday_middleware', '~> 0.9' # same as faraday
 
   # All the fastlane tools
-  spec.add_dependency "deliver", ">= 1.16.0", "< 2.0.0"
+  spec.add_dependency "deliver", ">= 1.16.1", "< 2.0.0"
   spec.add_dependency "snapshot", ">= 1.16.4", "< 2.0.0"
   spec.add_dependency "frameit", ">= 3.0.0", "< 4.0.0"
-  spec.add_dependency "pem", ">= 1.4.0", "< 2.0.0"
+  spec.add_dependency "pem", ">= 1.4.1", "< 2.0.0"
   spec.add_dependency "cert", ">= 1.4.4", "< 2.0.0"
   spec.add_dependency "sigh", ">= 1.12.1", "< 2.0.0"
   spec.add_dependency "produce", ">= 1.3.2", "< 2.0.0"
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pilot", ">= 1.12.1", "< 2.0.0"
   spec.add_dependency "scan", ">= 0.14.2", "< 1.0.0"
   spec.add_dependency "supply", ">= 0.8.0", "< 1.0.0"
-  spec.add_dependency "match", ">= 0.11.0", "< 1.0.0"
+  spec.add_dependency "match", ">= 0.11.1", "< 1.0.0"
   spec.add_dependency 'screengrab', '>= 0.5.2', '< 1.0.0'
 
   # Lock `activesupport` (transitive depedency via `xcodeproj`) to keep supporting system ruby

--- a/fastlane_core/fastlane_core.gemspec
+++ b/fastlane_core/fastlane_core.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'

--- a/frameit/frameit.gemspec
+++ b/frameit/frameit.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'

--- a/frameit/frameit.gemspec
+++ b/frameit/frameit.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fastlane_core", ">= 0.58.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'fastimage', '>= 1.6'
   spec.add_dependency 'mini_magick', '~> 4.5.1' # To open, edit and export PSD files
   spec.add_dependency 'deliver', '> 0.3' # To determine the device type based on a screenshot file

--- a/gym/gym.gemspec
+++ b/gym/gym.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fastlane_core", ">= 0.58.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'xcpretty', '>= 0.2.4', '< 1.0.0' # pretty xcodebuild output
   spec.add_dependency 'terminal-table', '>= 1.4.5', '< 2.0.0' # print out build information
   spec.add_dependency 'plist', '>= 3.1.0', '< 4.0.0' # Generate the Xcode config plist file

--- a/gym/gym.gemspec
+++ b/gym/gym.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   # Development only
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "fastlane", ">= 1.33.0" # yes, we use fastlane for testing
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", '< 12'
   spec.add_development_dependency "rspec", "~> 3.1.0"
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency "pry"

--- a/match/match.gemspec
+++ b/match/match.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'security' # Mac OS Keychain manager
 
-  spec.add_dependency "fastlane_core", ">= 0.58.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency "credentials_manager", ">= 0.16.2", "< 1.0.0" # fastlane password manager
-  spec.add_dependency "spaceship", ">= 0.38.5", "< 1.0.0" # communication layer with Apple's web services
+  spec.add_dependency "spaceship", ">= 0.39.0", "< 1.0.0" # communication layer with Apple's web services
   spec.add_dependency "sigh", ">= 1.12.1", "< 2.0.0"
   spec.add_dependency "cert", ">= 1.4.4", "< 2.0.0"
 

--- a/match/match.gemspec
+++ b/match/match.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'

--- a/pem/pem.gemspec
+++ b/pem/pem.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fastlane_core", ">= 0.58.0", "< 1.0.0" # all shared code and dependencies
-  spec.add_dependency "spaceship", ">= 0.38.5", "< 1.0.0" # Communicating with the Apple Dev Portal
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "spaceship", ">= 0.39.0", "< 1.0.0" # Communicating with the Apple Dev Portal
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/pem/pem.gemspec
+++ b/pem/pem.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'

--- a/pilot/pilot.gemspec
+++ b/pilot/pilot.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', "~> 3.1.0"
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'

--- a/pilot/pilot.gemspec
+++ b/pilot/pilot.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fastlane_core", ">= 0.58.0", "< 1.0.0" # all shared code and dependencies
-  spec.add_dependency "spaceship", ">= 0.38.5", "< 1.0.0" # iTunes Connect communication
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "spaceship", ">= 0.39.0", "< 1.0.0" # iTunes Connect communication
   spec.add_dependency 'credentials_manager', '>= 0.16.0'
 
   spec.add_dependency 'terminal-table', '>= 1.4.5', '< 2.0.0' # User's information

--- a/produce/produce.gemspec
+++ b/produce/produce.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'

--- a/produce/produce.gemspec
+++ b/produce/produce.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fastlane_core", ">= 0.58.0", "< 1.0.0" # all shared code and dependencies
-  spec.add_dependency "spaceship", ">= 0.38.5", "< 1.0.0" # Apple Dev Portal and iTunes Connect Access
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "spaceship", ">= 0.39.0", "< 1.0.0" # Apple Dev Portal and iTunes Connect Access
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/scan/scan.gemspec
+++ b/scan/scan.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   # Development only
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "fastlane", ">= 1.25.0" # yes, we use fastlane for testing
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", '< 12'
   spec.add_development_dependency "rspec", "~> 3.1.0"
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency "pry"

--- a/scan/scan.gemspec
+++ b/scan/scan.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fastlane_core", ">= 0.58.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'xcpretty', '>= 0.2.4', '< 1.0.0' # pretty xcodebuild output
   spec.add_dependency 'xcpretty-travis-formatter', '>= 0.0.3'
   spec.add_dependency 'slack-notifier', '~> 1.3'

--- a/screengrab/screengrab.gemspec
+++ b/screengrab/screengrab.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fastlane_core", ">= 0.58.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/screengrab/screengrab.gemspec
+++ b/screengrab/screengrab.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'fastlane'
   spec.add_development_dependency 'activesupport'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'yard', '~> 0.8.7.4'

--- a/sigh/sigh.gemspec
+++ b/sigh/sigh.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'

--- a/sigh/sigh.gemspec
+++ b/sigh/sigh.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fastlane_core", ">= 0.58.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'plist', '>= 3.1.0', '< 4.0.0' # for reading the provisioning profile
-  spec.add_dependency "spaceship", ">= 0.38.5", "< 1.0.0" # communication with Apple
+  spec.add_dependency "spaceship", ">= 0.39.0", "< 1.0.0" # communication with Apple
 
   # Development only
   spec.add_development_dependency 'bundler'

--- a/snapshot/snapshot.gemspec
+++ b/snapshot/snapshot.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'fastimage', '>= 1.6'
-  spec.add_dependency "fastlane_core", ">= 0.58.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
   spec.add_dependency 'xcpretty', '>= 0.2.4', '< 1.0.0' # beautiful Xcode output
   spec.add_dependency 'plist', '>= 3.1.0', '< 4.0.0' # parsing the Xcode output plist
 

--- a/snapshot/snapshot.gemspec
+++ b/snapshot/snapshot.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'

--- a/spaceship/spaceship.gemspec
+++ b/spaceship/spaceship.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'fastlane', ">= 1.15.0" # yes, we use fastlane to test fastlane
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'diff_matcher'
   spec.add_development_dependency 'multi_json'

--- a/supply/supply.gemspec
+++ b/supply/supply.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'

--- a/watchbuild/watchbuild.gemspec
+++ b/watchbuild/watchbuild.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2.3'
   spec.add_development_dependency 'pry'

--- a/watchbuild/watchbuild.gemspec
+++ b/watchbuild/watchbuild.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fastlane_core", ">= 0.58.0", "< 1.0.0" # all shared code and dependencies
-  spec.add_dependency "spaceship", ">= 0.38.5", "< 1.0.0" # communication with Apple
+  spec.add_dependency "fastlane_core", ">= 0.60.0", "< 1.0.0" # all shared code and dependencies
+  spec.add_dependency "spaceship", ">= 0.39.0", "< 1.0.0" # communication with Apple
   spec.add_dependency 'terminal-notifier' # show a notification once the build is ready
 
   # Development only


### PR DESCRIPTION
rake 12.0.0 results in the following error when releasing: 

<img width="659" alt="screenshot 2016-12-12 20 37 05" src="https://cloud.githubusercontent.com/assets/279407/21128388/7ab047bc-c0af-11e6-964b-57c93fc6046c.png">

To fix this, all gems/dependencies that call `last_comment` in rake tasks would need to be disabled. 