### PR TITLE
Add "--fail-on-errors" support to Danger action

### DIFF
--- a/fastlane/lib/fastlane/actions/danger.rb
+++ b/fastlane/lib/fastlane/actions/danger.rb
@@ -13,6 +13,7 @@ module Fastlane
         dangerfile = params[:dangerfile]
         cmd << "--danger_id=#{danger_id}" if danger_id
         cmd << "--dangerfile=#{dangerfile}" if dangerfile
+        cmd << "--fail-on-errors=true" if params[:fail_on_errors]
 
         ENV['DANGER_GITHUB_API_TOKEN'] = params[:github_api_token] if params[:github_api_token]
 
@@ -57,7 +58,14 @@ module Fastlane
                                        description: "GitHub API token for danger",
                                        sensitive: true,
                                        is_string: true,
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :fail_on_errors,
+                                       env_name: "FL_DANGER_FAIL_ON_ERRORS",
+                                       description: "Should always fail the build process, defaults
+                                        to false",
+                                       is_string: false,
+                                       optional: true,
+                                       default_value: false)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/danger.rb
+++ b/fastlane/lib/fastlane/actions/danger.rb
@@ -61,8 +61,7 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :fail_on_errors,
                                        env_name: "FL_DANGER_FAIL_ON_ERRORS",
-                                       description: "Should always fail the build process, defaults
-                                        to false",
+                                       description: "Should always fail the build process, defaults to false",
                                        is_string: false,
                                        optional: true,
                                        default_value: false)

--- a/fastlane/spec/actions_specs/danger_spec.rb
+++ b/fastlane/spec/actions_specs/danger_spec.rb
@@ -49,6 +49,22 @@ describe Fastlane do
 
         expect(result).to eq("bundle exec danger --dangerfile=test/OtherDangerfile")
       end
+
+      it "appends fail-on-errors flag when set" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          danger(fail_on_errors: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec danger --fail-on-errors=true")
+      end
+
+      it "does not append fail-on-errors flag when unset" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          danger(fail_on_errors: false)
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec danger")
+      end
     end
   end
 end


### PR DESCRIPTION
Adds optional boolean `fail_on_errors` parameter to Danger action.