### PR TITLE
[Spaceship] Include appletvos platform when trying to find the app by id

### DIFF
--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -64,7 +64,7 @@ module Spaceship
         def find(identifier, mac: false)
           all.find do |app|
             (app.apple_id == identifier.to_s || app.bundle_id == identifier) &&
-              app.version_sets.any? { |v| v.platform == (mac ? "osx" : "ios") }
+              app.version_sets.any? { |v| (mac ? ["osx"] : ["ios", "appletvos"]).include?(v.platform) }
           end
         end
 


### PR DESCRIPTION

Fixes: https://github.com/fastlane/fastlane/issues/7483
-----

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the subdirectory of each tool you modified. Alternatively, run `rake test_all` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

