### PR TITLE
Allow android platform for testfairy action

### DIFF
--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -136,7 +136,7 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :ipa,
                                        env_name: 'TESTFAIRY_IPA_PATH',
-                                       description: 'Path to your IPA file. Optional if you use the _gym_ or _xcodebuild_ action',
+                                       description: 'Path to your IPA file for iOS or APK for Android',
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find ipa file at path '#{value}'") unless File.exist?(value)
@@ -222,7 +222,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :android].include? platform
       end
     end
   end


### PR DESCRIPTION
Testfairy API for both iOS and Android is exactly the same so the same code can be used for Android uploading too. This PR added android to the supported platform. This is tested on my testfairy account and I am able to upload an Android APK successfully.