### PR TITLE
Add note about regressions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@
 
 We use GitHub as support system, please submit a [new issue](https://github.com/fastlane/fastlane/issues/new) to ask questions or to report a problem.
 
+**Note**: If you want to report a regression in _fastlane_ (something that has worked before, but broke with a new release), please mark your issue title as such using `[Regression] Your title here`. This enables us to quickly detect and fix regressions.
+
 Some people might also use the [_fastlane_ tag on StackOverflow](https://stackoverflow.com/questions/tagged/fastlane), however we don’t actively monitor issues submitted there.
 
 ## I want to contribute to _fastlane_


### PR DESCRIPTION
This is just an idea of how we could be alerted faster for issues like https://github.com/fastlane/fastlane/issues/7494, which at first seems like something that could also be a wrong config when just looking at the title.

This way we can easily spot critical issues faster. I wonder if there is a good way to add that to the bot too, basically just replying with: `Hey, if this is an issue that was introduced by updating _fastlane_, please update the title of your issue to include `[Regression]`. 

We could then even get slack alerts for those issues.