### PR TITLE
[fastlane,actions] set_info_plist_value - user_error if plist error

### DIFF
--- a/fastlane/lib/fastlane/actions/set_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/set_info_plist_value.rb
@@ -17,7 +17,7 @@ module Fastlane
           return params[:value]
         rescue => ex
           UI.error(ex)
-          UI.error("Unable to set value to plist file at '#{path}'")
+          UI.user_error!("Unable to set value to plist file at '#{path}'")
         end
       end
 


### PR DESCRIPTION
as reported here: https://github.com/fastlane/fastlane/issues/7535

i think if someone wan'ts to silently fail the action - it should be done in fastfile.