### PR TITLE
#7513 fixes non-interactive shell password_ask loop in match

### DIFF
--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -1,6 +1,8 @@
 module Match
+  # These functions should only be used while in (UI.) interactive mode
   class ChangePassword
     def self.update(params: nil, from: nil, to: nil)
+      ensure_ui_interactive
       to ||= ChangePassword.ask_password(message: "New passphrase for Git Repo: ", confirm: false)
       from ||= ChangePassword.ask_password(message: "Old passphrase for Git Repo: ", confirm: true)
       GitHelper.clear_changes
@@ -13,6 +15,7 @@ module Match
     end
 
     def self.ask_password(message: "Passphrase for Git Repo: ", confirm: true)
+      ensure_ui_interactive
       loop do
         password = UI.password(message)
         if confirm
@@ -26,5 +29,11 @@ module Match
         UI.error("Passhprases differ. Try again")
       end
     end
+
+    def self.ensure_ui_interactive
+      raise "This code should only run in interactive mode" unless UI.interactive?
+    end
+
+    private_class_method :ensure_ui_interactive
   end
 end

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -15,11 +15,15 @@ module Match
       end
 
       unless password
-        UI.important "Enter the passphrase that should be used to encrypt/decrypt your certificates"
-        UI.important "This passphrase is specific per repository and will be stored in your local keychain"
-        UI.important "Make sure to remember the password, as you'll need it when you run match on a different machine"
-        password = ChangePassword.ask_password(confirm: true)
-        store_password(git_url, password)
+        if !UI.interactive?
+          UI.error "No password found neither in environment nor in local keychain. Bailing out as in non interactive mode."
+        else
+          UI.important "Enter the passphrase that should be used to encrypt/decrypt your certificates"
+          UI.important "This passphrase is specific per repository and will be stored in your local keychain"
+          UI.important "Make sure to remember the password, as you'll need it when you run match on a different machine"
+          password = ChangePassword.ask_password(confirm: true)
+          store_password(git_url, password)
+        end
       end
 
       return password


### PR DESCRIPTION
I have 2 questions / potential improvements

* we could replace the `UI.error "No password found neither in environment nor in local keychain. Bailing out as in non interactive mode."` with a `UI.user_error!`. If not the current code path relies on the caller to do something with it. But I am not fond off `user_error` being so down the call stack. I don't like returning `nil` either. Preference?

* we could use `UI.crash!` instead of `raise`. Not sure what's the standard when finding invalid API use
