### PR TITLE
[S3] escape title of application for .plist and .plist url

### DIFF
--- a/fastlane/lib/fastlane/actions/s3.rb
+++ b/fastlane/lib/fastlane/actions/s3.rb
@@ -1,6 +1,7 @@
 require 'fastlane/erb_template_helper'
 require 'ostruct'
 require 'uri'
+require 'cgi'
 
 module Fastlane
   module Actions
@@ -111,13 +112,13 @@ module Fastlane
         build_num = info['CFBundleVersion']
         bundle_id = info['CFBundleIdentifier']
         bundle_version = info['CFBundleShortVersionString']
-        title = info['CFBundleName']
+        title = CGI.escapeHTML(info['CFBundleName'])
         device_family = info['UIDeviceFamily']
         full_version = "#{bundle_version}.#{build_num}"
 
         # Creating plist and html names
         s3_domain = AWS::Core::Endpoints.hostname(s3_region, 's3') || 's3.amazonaws.com'
-        plist_file_name ||= "#{url_part}#{title.delete(' ')}.plist"
+        plist_file_name ||= "#{url_part}#{URI.escape(title)}.plist"
         plist_url = URI::HTTPS.build(host: s3_domain, path: "/#{s3_bucket}/#{plist_file_name}").to_s
 
         html_file_name ||= "index.html"


### PR DESCRIPTION
Addresses issue #7504 
1. Since the `.plist` file name is derived from the `CFBundleName`, it can contain unsafe html characters like "&".
2. Escaping the file name will prevent incidents like a `.plist` named `"you&I.plist` which will fail to download.
3. Those same unsafe characters will fail the `.ipa` download since they are not allowed in xml. Using `You &amp; I` instead of `You & I` fixes that.

Thanks!

---
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:
