### PR TITLE
Fix typo in SCP action which causes a crash

### DIFF
--- a/fastlane/lib/fastlane/actions/scp.rb
+++ b/fastlane/lib/fastlane/actions/scp.rb
@@ -16,7 +16,7 @@ module Fastlane
           if params[:download]
 
             t_ret = scp.download! params[:download][:src], params[:download][:dst], recursive: true
-            UI.message(['[SCP COMMAND]', "Successfully Downloaded", params[:upload][:src], params[:upload][:dst]].join(': '))
+            UI.message(['[SCP COMMAND]', "Successfully Downloaded", params[:download][:src], params[:download][:dst]].join(': '))
             unless params[:download][:dst]
               ret = t_ret
             end


### PR DESCRIPTION
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)

This PR fixes #7568. It is just a copy-paste typo, but causes fastlane to throw an error as shown in the stacktrace in #7568