### PR TITLE
Apply new calling method to match README

### DIFF
--- a/match/lib/assets/READMETemplate.md
+++ b/match/lib/assets/READMETemplate.md
@@ -23,13 +23,13 @@ xcode-select --install
 Navigate to your project folder and run
 
 ```
-match appstore
+fastlane match appstore
 ```
 ```
-match adhoc
+fastlane match adhoc
 ```
 ```
-match development
+fastlane match development
 ```
 
 For more information open [fastlane match git repo](https://github.com/fastlane/fastlane/tree/master/match#readme)


### PR DESCRIPTION
- [x] Run `bundle exec rspec` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

On 2.x, the command to call `match` changed.

We should call in `match` like following.

```
fastlane match development
```