### PR TITLE
Revert "[spaceship] Show update message on spaceship failure"

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -418,9 +418,6 @@ module Spaceship
         store_csrf_tokens(response)
         content
       end
-    rescue => ex
-      UpdateChecker.ensure_spaceship_version # to show an update message on error if necessary
-      raise ex
     end
 
     private

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -227,9 +227,6 @@ module Spaceship
       puts data['sectionWarningKeys'] if data['sectionWarningKeys']
 
       return data
-    rescue => ex
-      UpdateChecker.ensure_spaceship_version # to show an update message on error if necessary
-      raise ex
     end
     # rubocop:enable Metrics/PerceivedComplexity
 


### PR DESCRIPTION
Reverts fastlane/fastlane#7325

This was breaking a bunch of tests once it got merged into master https://circleci.com/gh/fastlane/fastlane/6658?utm_campaign=build-failed&utm_medium=email&utm_source=notification