### PR TITLE
[gym] temp. disable `produces_archives?` to fix user issues.

### DIFF
--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -11,7 +11,7 @@ module Gym
         clear_old_files
         build_app
       end
-      verify_archive if Gym.project.produces_archive?
+      verify_archive
       FileUtils.mkdir_p(File.expand_path(Gym.config[:output_directory]))
 
       if Gym.project.ios? || Gym.project.tvos?
@@ -32,14 +32,6 @@ module Gym
           return path
         end
         copy_files_from_path(File.join(BuildCommandGenerator.archive_path, "Products/usr/local/bin/*")) if Gym.project.command_line_tool?
-      end
-
-      if Gym.project.library? || Gym.project.framework?
-        base_framework_path = Gym.project.build_settings(key: "BUILD_ROOT")
-        base_framework_path = Gym.config[:derived_data_path] + "/Build/Products/" if Gym.config[:derived_data_path]
-
-        copy_files_from_path("#{base_framework_path}/*/*")
-        path = base_framework_path
       end
       path
     end

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -16,10 +16,10 @@ module Gym
 
       if Gym.project.ios? || Gym.project.tvos?
         fix_generic_archive # See https://github.com/fastlane/fastlane/pull/4325
-        package_app # FIXME  if Gym.project.produces_archive?
+        package_app
         fix_package
         compress_and_move_dsym
-        path = move_ipa # FIXME: if Gym.project.produces_archive?
+        path = move_ipa
         move_manifest
         move_app_thinning
         move_app_thinning_size_report

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -89,7 +89,6 @@ module Gym
     end
 
     def mark_archive_as_built_by_gym(archive_path)
-      return if Gym.project.library? || Gym.project.framework?
       escaped_archive_path = archive_path.shellescape
       system("xattr -w info.fastlane.generated_by_gym 1 #{escaped_archive_path}")
     end

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -16,10 +16,10 @@ module Gym
 
       if Gym.project.ios? || Gym.project.tvos?
         fix_generic_archive # See https://github.com/fastlane/fastlane/pull/4325
-        package_app if Gym.project.produces_archive?
+        package_app # FIXME  if Gym.project.produces_archive?
         fix_package
         compress_and_move_dsym
-        path = move_ipa if Gym.project.produces_archive?
+        path = move_ipa # FIXME: if Gym.project.produces_archive?
         move_manifest
         move_app_thinning
         move_app_thinning_size_report


### PR DESCRIPTION
as discussed here: #7581 

reverts changes introduced by: https://github.com/fastlane/fastlane/pull/7207 - which causes archive/ipa-move not done when having multiple targets in build phase in a scheme.



<img width="909" alt="bildschirmfoto 2016-12-20 um 09 31 46" src="https://cloud.githubusercontent.com/assets/2891702/21343517/4f1833c4-c697-11e6-8579-8542b5d8b7be.png">



` xcodebuild clean -showBuildSettings -workspace Fotoplus-iOS/cewe_myphotos.xcworkspace -scheme CeweMyphotosJenkins -configuration Jenkins`


returns build  settings for app and pods target.
which results in a false/positive return in  `build_settings`  for PRODUCT_TYPE key. (returns from the first, POD, type == framework)