### PR TITLE
[actions] hockey: add option to bypass CDN

### DIFF
--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -10,7 +10,8 @@ module Fastlane
         require 'faraday'
         require 'faraday_middleware'
 
-        connection = Faraday.new(url: "https://upload.hockeyapp.net") do |builder|
+        base_url = options[:bypass_cdn] ? "https://rink.hockeyapp.net" : "https://upload.hockeyapp.net"
+        connection = Faraday.new(url: base_url) do |builder|
           builder.request :multipart
           builder.request :url_encoded
           builder.response :json, content_type: /\bjson$/
@@ -211,7 +212,12 @@ module Fastlane
                                        default_value: "add",
                                        verify_block: proc do |value|
                                          UI.user_error!("Invalid value '#{value}' for key 'strategy'. Allowed values are 'add', 'replace'.") unless ['add', 'replace'].include?(value)
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :bypass_cdn,
+                                      env_name: "FL_HOCKEY_BYPASS_CDN",
+                                      description: "Flag to bypass Hockey CDN when it uploads successfully but reports error",
+                                      is_string: false,
+                                      default_value: false)
         ]
       end
 


### PR DESCRIPTION
`https://upload.hockeyapp.net` is a CDN, which reports errors occasionally (see #6101).
Using `https://rink.hockey.net` may be slower outside of US, therefore it is turned off by default.

- [x] Run `bundle exec rspec` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)
