### PR TITLE
Add new xcodebuild options for skip-testing and only-testing to scan

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -148,6 +148,34 @@ module Scan
                                      verify_block: proc do |value|
                                        UI.user_error!("File not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                      end),
+        FastlaneCore::ConfigItem.new(key: :only_testing,
+                                     env_name: "SCAN_ONLY_TESTING",
+                                     description: "Array of strings matching Test Bundle/Test Suite/Test Cases to run",
+                                     optional: true,
+                                     is_string: false,
+                                     verify_block: proc do |value|
+                                       if value.kind_of?(Array)
+                                         value.each do |test_path|
+                                           UI.user_error!("'only_testing' array should only contain strings, but found: '#{test_path}' which is of type '#{value.class.name}'") unless test_path.kind_of?(String)
+                                         end
+                                       elsif !value.kind_of?(String)
+                                         UI.user_error!("Incorrect parameter type for 'only_testing': '#{value}'")
+                                       end
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :skip_testing,
+                                     env_name: "SCAN_SKIP_TESTING",
+                                     description: "Array of strings matching Test Bundle/Test Suite/Test Cases to skip",
+                                     optional: true,
+                                     is_string: false,
+                                     verify_block: proc do |value|
+                                       if value.kind_of?(Array)
+                                         value.each do |test_path|
+                                           UI.user_error!("'skip_testing' array should only contain strings, but found: '#{test_path}' which is of type '#{value.class.name}'") unless test_path.kind_of?(String)
+                                         end
+                                       elsif !value.kind_of?(String)
+                                         UI.user_error!("Incorrect parameter type for 'skip_testing': '#{value}'")
+                                       end
+                                     end),
         FastlaneCore::ConfigItem.new(key: :slack_url,
                                      short_option: "-i",
                                      env_name: "SLACK_URL",

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -40,6 +40,22 @@ module Scan
         options << "-xcconfig '#{config[:xcconfig]}'" if config[:xcconfig]
         options << config[:xcargs] if config[:xcargs]
 
+        if config[:only_testing].kind_of?(Array)
+          config[:only_testing].each do |test_path|
+            options << "-only-testing:#{test_path}"
+          end
+        elsif config[:only_testing].kind_of?(String)
+          options << "-only-testing:#{config[:only_testing]}"
+        end
+
+        if config[:skip_testing].kind_of?(Array)
+          config[:skip_testing].each do |test_path|
+            options << "-skip-testing:#{test_path}"
+          end
+        elsif config[:skip_testing].kind_of?(String)
+          options << "-skip-testing:#{config[:skip_testing]}"
+        end
+
         options
       end
 

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -198,6 +198,98 @@ describe Scan do
       end
     end
 
+    describe "Test Exclusion Example" do
+      it "only tests the test bundle/suite/cases specified in only_testing when the input is an array" do
+        log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
+                    only_testing: %w(TestBundleA/TestSuiteB TestBundleC) }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = Scan::TestCommandGenerator.generate
+
+        expect(result).to start_with([
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "-scheme app",
+                                       "-project ./scan/examples/standard/app.xcodeproj",
+                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       '-only-testing:TestBundleA/TestSuiteB',
+                                       '-only-testing:TestBundleC',
+                                       :build,
+                                       :test
+                                     ])
+      end
+
+      it "only tests the test bundle/suite/cases specified in only_testing when the input is a string" do
+        log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
+                    only_testing: 'TestBundleA/TestSuiteB' }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = Scan::TestCommandGenerator.generate
+
+        expect(result).to start_with([
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "-scheme app",
+                                       "-project ./scan/examples/standard/app.xcodeproj",
+                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       '-only-testing:TestBundleA/TestSuiteB',
+                                       :build,
+                                       :test
+                                     ])
+      end
+
+      it "does not the test bundle/suite/cases specified in skip_testing when the input is an array" do
+        log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
+                    skip_testing: %w(TestBundleA/TestSuiteB TestBundleC) }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = Scan::TestCommandGenerator.generate
+
+        expect(result).to start_with([
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "-scheme app",
+                                       "-project ./scan/examples/standard/app.xcodeproj",
+                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       '-skip-testing:TestBundleA/TestSuiteB',
+                                       '-skip-testing:TestBundleC',
+                                       :build,
+                                       :test
+                                     ])
+      end
+
+      it "does not the test bundle/suite/cases specified in skip_testing when the input is a string" do
+        log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
+                    skip_testing: 'TestBundleA/TestSuiteB' }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = Scan::TestCommandGenerator.generate
+
+        expect(result).to start_with([
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "-scheme app",
+                                       "-project ./scan/examples/standard/app.xcodeproj",
+                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       '-skip-testing:TestBundleA/TestSuiteB',
+                                       :build,
+                                       :test
+                                     ])
+      end
+    end
+
     it "uses a device without version specifier" do
       options = { project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 6s" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [X] Run `bundle exec rspec` from the root directory.
- [X] Run `bundle exec rubocop -a` to ensure the code style is valid
- [X] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

This PR adds options to Scan to specify specific test bundles/test suites/test cases to be run using the new -only-testing and -skip-testing options in Xcode 8's version of xcodebuild. More info on the actions can be found in the wwdc talk on [Advanced Testing and Continuous Integration](https://developer.apple.com/videos/play/wwdc2016/409/)
