### PR TITLE
Setting --default-path for rspec and made all testing directions accu…

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,6 +2,7 @@ require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
+--default-path ./
 --require ./spec_helper
 --color
 --format d

--- a/RespondingToIssuesAndPullRequests.md
+++ b/RespondingToIssuesAndPullRequests.md
@@ -45,7 +45,7 @@ Each tool has it’s own label, e.g. `fastlane`, `fastlane_core` and `gym`.
     - Repeat the last step for each of the related PRs that the user submitted.
 - After checking out a user’s code, you should always make sure that the tests are still working. 
   - Run `bundle install` to make sure all dependencies are installed
-  - Use `bundle exec rspec` from the _fastlane_ root to run all tests
+  - Use `bundle exec rspec` from the root directory to run all tests
   - Use `bundle exec rspec [tool_name]` to run all tests for a specific tool
   - Use `bundle exec rubocop -a` to run the linter and autocorrect many of the issues it found
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,5 +8,5 @@ dependencies:
     - bundle install --jobs=4 --retry=3
 test:
   override:
-    - bundle exec rspec --pattern ./**/*_spec.rb -r rspec_junit_formatter --format progress --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec/junit.xml
+    - bundle exec rspec -r rspec_junit_formatter --format progress --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec/junit.xml
     - bundle exec rubocop


### PR DESCRIPTION
…rate

## Problem 😱 
- Running `bundle exec rspec` did not run all of the tests. 
- Wrong instructions in `ToolsAndDebugging.md`
  - It said to run `bundle exec rspec` in root directory which resulted in 0 tests being run
- Different instructions in `RespondingToIssuesAndPullRequests.md`
  - It said to run `bundle exec rspec` from `fastlane` root directory
- The `circle.yml` file did used a pattern of `./**/*_spec.rb` to run all the files

- `rspec` uses a default pattern of `**{,/*/**}/*_spec.rb` but uses a default path of `spec`
  - This was causing `bundle exec rspec` to not work because it was looking in a `spec` directory which didn't have all the things ❌ 
  - This was causing `bundle exec rspec <directory>` to work because it used the default pattern in a directory that had tests ✅ 
  - This was causing the `circle.yml` file to work (but to be a bit hacky) because the default pattern included the current directoy ❌ ✅ 

## Solution 🚀 
- Set the `--default-path` in the `.rspec` file to `./`
  - `bundle exec rspec` works because it looks in all of the directory
  - `bundle exec rspec <directory>` still works because it overrides that default directory
  - `cirlce.yml` can remove the pattern because of `bundle exec rspec` just working
- Modified doc so everything is correct everywhere
