### PR TITLE
credentials-manager: Fetch port, path, protocol for new internet passwords

### DIFF
--- a/credentials_manager/lib/credentials_manager/account_manager.rb
+++ b/credentials_manager/lib/credentials_manager/account_manager.rb
@@ -56,7 +56,11 @@ module CredentialsManager
     end
 
     def add_to_keychain
-      Security::InternetPassword.add(server_name, user, password, options)
+      if options
+        Security::InternetPassword.add(server_name, user, password, options)
+      else
+        Security::InternetPassword.add(server_name, user, password)
+      end
     end
 
     def remove_from_keychain
@@ -68,8 +72,14 @@ module CredentialsManager
       "#{@prefix}.#{user}"
     end
 
+    # Use env variables from this method to augment internet password item with additional data.
+    # These variables are used by Xamarin Studio to authenticate Apple developers.
     def options
-      { p: ENV["FASTLANE_PATH"], P: ENV["FASTLANE_PORT"], r: ENV["FASTLANE_PROTOCOL"] }
+      hash = {}
+      hash[:p] = ENV["FASTLANE_PATH"] if ENV["FASTLANE_PATH"]
+      hash[:P] = ENV["FASTLANE_PORT"] if ENV["FASTLANE_PORT"]
+      hash[:r] = ENV["FASTLANE_PROTOCOL"] if ENV["FASTLANE_PROTOCOL"]
+      hash.empty? ? nil : hash
     end
 
     private

--- a/credentials_manager/lib/credentials_manager/account_manager.rb
+++ b/credentials_manager/lib/credentials_manager/account_manager.rb
@@ -56,7 +56,7 @@ module CredentialsManager
     end
 
     def add_to_keychain
-      Security::InternetPassword.add(server_name, user, password)
+      Security::InternetPassword.add(server_name, user, password, options)
     end
 
     def remove_from_keychain
@@ -66,6 +66,10 @@ module CredentialsManager
 
     def server_name
       "#{@prefix}.#{user}"
+    end
+
+    def options
+      { p: ENV["FASTLANE_PATH"], P: ENV["FASTLANE_PORT"], r: ENV["FASTLANE_PROTOCOL"] }
     end
 
     private


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

DESCRIPTION:

In case if user want to supply internet passwords added by
credentials-manager with additional metadata(port, path, protocol)
he/she can set environment variables which then will be fetched
in 'add_to_keychain' method passed to security tool.

List of env variables used:
* FASTLANE_PATH - path
* FASTLANE_PORT - port
* FASTLANE_PROTOCOL - protocol
