### PR TITLE
Version bump to 2.2.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.1.3'.freeze
+  VERSION = '2.2.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.1.3':**

* Revert library support of gym, fixing archive errors, fixes #7630 (#7631)
* Update Gemfile for monogem (#7612)
* Setting --default-path for rspec and made all testing directions accurate (#7607)
* [spaceship] fix path to referenced fastfile (#7604)
* iCell mailgun (#7605)
* anon. the sensitive options (#7335)
* [snapshot] add additional ipad classifiers. (#7570)
