### PR TITLE
produce - enabled_features feature

### DIFF
--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -18,31 +18,33 @@ module Produce
         app_name = Produce.config[:app_name]
         UI.message "Creating new app '#{app_name}' on the Apple Dev Center"
 
+        app_service = Spaceship.app_service
         enabled_clean_options = {}
+        
         Produce.config[:enabled_features].each do |k, v|
           if k == :data_protection
             case v
             when "complete"
-              enabled_clean_options[Spaceship.app_service.data_protection.complete.service_id] = Spaceship.app_service.data_protection.complete.on
+              enabled_clean_options[app_service.data_protection.complete.service_id] = app_service.data_protection.complete.on
             when "unlessopen"
-              enabled_clean_options[Spaceship.app_service.data_protection.unlessopen.service_id] = Spaceship.app_service.data_protection.unlessopen.on
+              enabled_clean_options[app_service.data_protection.unlessopen.service_id] = app_service.data_protection.unlessopen.on
             when "untilfirstauth"
-              enabled_clean_options[Spaceship.app_service.data_protection.untilfirstauth.service_id] = Spaceship.app_service.data_protection.untilfirstauth.on
+              enabled_clean_options[app_service.data_protection.untilfirstauth.service_id] = app_service.data_protection.untilfirstauth.on
             end
           elsif k == :icloud
             case v
             when "legacy"
-              enabled_clean_options[Spaceship.app_service.icloud.on.service_id] = Spaceship.app_service.icloud.on
-              enabled_clean_options[Spaceship.app_service.cloud_kit.xcode5_compatible.service_id] = Spaceship.app_service.cloud_kit.xcode5_compatible
+              enabled_clean_options[app_service.icloud.on.service_id] = app_service.icloud.on
+              enabled_clean_options[app_service.cloud_kit.xcode5_compatible.service_id] = app_service.cloud_kit.xcode5_compatible
             when "cloudkit"
-              enabled_clean_options[Spaceship.app_service.icloud.on.service_id] = Spaceship.app_service.icloud.on
-              enabled_clean_options[Spaceship.app_service.cloud_kit.cloud_kit.service_id] = Spaceship.app_service.cloud_kit.cloud_kit
+              enabled_clean_options[app_service.icloud.on.service_id] = app_service.icloud.on
+              enabled_clean_options[app_service.cloud_kit.cloud_kit.service_id] = app_service.cloud_kit.cloud_kit
             end
           else
             if v == "on"
-              enabled_clean_options[Spaceship.app_service.send(k.to_s).on.service_id] = Spaceship.app_service.send(k.to_s).on
+              enabled_clean_options[app_service.send(k.to_s).on.service_id] = app_service.send(k.to_s).on
             else
-              enabled_clean_options[Spaceship.app_service.send(k.to_s).off.service_id] = Spaceship.app_service.send(k.to_s).off
+              enabled_clean_options[app_service.send(k.to_s).off.service_id] = app_service.send(k.to_s).off
             end
           end
         end

--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -20,7 +20,6 @@ module Produce
 
         app_service = Spaceship.app_service
         enabled_clean_options = {}
-        
         Produce.config[:enabled_features].each do |k, v|
           if k == :data_protection
             case v

--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -18,11 +18,6 @@ module Produce
         app_name = Produce.config[:app_name]
         UI.message "Creating new app '#{app_name}' on the Apple Dev Center"
 
-        allowed_keys = [:app_group, :apple_pay, :associated_domains, :data_protection, :game_center, :health_kit, :home_kit,
-                        :wireless_accessory, :icloud, :in_app_purchase, :inter_app_audio, :passbook, :push_notification, :siri_kit, :vpn_configuration]
-
-        Produce.config[:enabled_features].select { |key, value| allowed_keys.include? key }
-
         enabled_clean_options = {}
         Produce.config[:enabled_features].each do |k, v|
           if k == :data_protection

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -71,7 +71,15 @@ module Produce
                                      env_name: "PRODUCE_ENABLED_FEATURES",
                                      description: "Array with Spaceship App Features",
                                      is_string: false,
-                                     default_value: {}),
+                                     default_value: {},
+                                     verify_block: proc do |value|
+                                                     allowed_keys = [:app_group, :apple_pay, :associated_domains, :data_protection, :game_center, :health_kit, :home_kit,
+                                                                     :wireless_accessory, :icloud, :in_app_purchase, :inter_app_audio, :passbook, :push_notification, :siri_kit, :vpn_configuration]
+                                                     UI.user_error!("enabled_features has to be of type Hash") unless value.kind_of?(Hash)
+                                                     value.each do |key, v|
+                                                       UI.user_error!("The key: '#{key}' is not supported in `enabled_features' - following keys are available: [#{allowed_keys.join(',')}]") unless allowed_keys.include? key.to_sym
+                                                     end
+                                                   end),
 
         FastlaneCore::ConfigItem.new(key: :skip_devcenter,
                                      short_option: "-d",

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -65,6 +65,14 @@ module Produce
                                      description: "Skip the creation of the app on iTunes Connect",
                                      is_string: false,
                                      default_value: false),
+
+        FastlaneCore::ConfigItem.new(key: :enabled_features,
+                                     short_option: "-P",
+                                     env_name: "PRODUCE_ENABLED_FEATURES",
+                                     description: "Array with Spaceship App Features",
+                                     is_string: false,
+                                     default_value: {}),
+
         FastlaneCore::ConfigItem.new(key: :skip_devcenter,
                                      short_option: "-d",
                                      env_name: "PRODUCE_SKIP_DEVCENTER",

--- a/spaceship/lib/spaceship/portal/app.rb
+++ b/spaceship/lib/spaceship/portal/app.rb
@@ -87,14 +87,14 @@ module Spaceship
         # @param name [String] the name of the App
         # @param mac [Bool] is this a Mac app?
         # @return (App) The app you just created
-        def create!(bundle_id: nil, name: nil, mac: false)
+        def create!(bundle_id: nil, name: nil, mac: false, enabled_features: {})
           if bundle_id.end_with?('*')
             type = :wildcard
           else
             type = :explicit
           end
 
-          new_app = client.create_app!(type, name, bundle_id, mac: mac)
+          new_app = client.create_app!(type, name, bundle_id, mac: mac, enabled_features: enabled_features)
           self.new(new_app)
         end
 

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -144,7 +144,7 @@ module Spaceship
       latinized
     end
 
-    def create_app!(type, name, bundle_id, mac: false)
+    def create_app!(type, name, bundle_id, mac: false, enabled_features: {})
       # We moved the ensure_csrf to the top of this method
       # as we got some users with issues around creating new apps
       # https://github.com/fastlane/fastlane/issues/5813
@@ -170,9 +170,10 @@ module Spaceship
         name: valid_name_for(name),
         teamId: team_id
       }
-
       params.merge!(ident_params)
-
+      enabled_features.each do |k, v|
+        params[v.service_id.to_sym] = v.value
+      end
       r = request(:post, "account/#{platform_slug(mac)}/identifiers/addAppId.action", params)
       parse_response(r, 'appId')
     end

--- a/spaceship/spec/portal/app_spec.rb
+++ b/spaceship/spec/portal/app_spec.rb
@@ -80,15 +80,23 @@ describe Spaceship::Portal::App do
 
   describe '#create' do
     it 'creates an app id with an explicit bundle_id' do
-      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false) {
+      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, enabled_features: {}) {
         { 'isWildCard' => true }
       }
       app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App')
       expect(app.is_wildcard).to eq(true)
     end
 
+    it 'creates an app id with an explicit bundle_id and no push notifications' do
+      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, enabled_features: { push_notification: "off" }) {
+        { 'enabledFeatures' => ["inAppPurchase"] }
+      }
+      app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App', enabled_features: { push_notification: "off" })
+      expect(app.enabled_features).not_to include("push")
+    end
+
     it 'creates an app id with a wildcard bundle_id' do
-      expect(client).to receive(:create_app!).with(:wildcard, 'Development App', 'tools.fastlane.spaceship.*', mac: false) {
+      expect(client).to receive(:create_app!).with(:wildcard, 'Development App', 'tools.fastlane.spaceship.*', mac: false, enabled_features: {}) {
         { 'isWildCard' => false }
       }
       app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.*', name: 'Development App')

--- a/spaceship/spec/portal/fixtures/addAppId.action.nopush.json
+++ b/spaceship/spec/portal/fixtures/addAppId.action.nopush.json
@@ -1,0 +1,50 @@
+{
+  "creationTimestamp": "2015-04-29T00:26:33Z",
+  "resultCode": 0,
+  "userLocale": "en_US",
+  "protocolVersion": "QH65B2",
+  "requestId": null,
+  "requestUrl": "https://developer.apple.com:443//services-account/QH65B2/account/ios/identifiers/addAppId.action",
+  "responseId": "ed5e74cf-8f52-46bf-9cf6-9e9e9fcd9fad",
+  "isAdmin": true,
+  "isMember": false,
+  "isAgent": false,
+  "pageNumber": null,
+  "pageSize": null,
+  "totalRecords": null,
+  "appId": {
+    "appIdId": "2HNR359G63",
+    "name": "pp Test 1ed9e25c93ac7142ff9df53e7f80e84c",
+    "appIdPlatform": "ios",
+    "prefix": "S56PJTAYEL",
+    "identifier": "tools.fastlane.spaceship.some-explicit-app",
+    "isWildCard": false,
+    "isDuplicate": false,
+    "features": {
+      "push": true,
+      "inAppPurchase": true,
+      "gameCenter": true,
+      "passbook": false,
+      "dataProtection": "",
+      "homeKit": false,
+      "cloudKitVersion": 1,
+      "iCloud": false,
+      "LPLF93JG7M": false,
+      "IAD53UNK2F": false,
+      "V66P55NK2I": false,
+      "SKC3T5S89Y": false,
+      "APG3427HIY": false,
+      "HK421J6T7P": false,
+      "WC421J6T7P": false
+    },
+    "enabledFeatures": [
+      "gameCenter",
+      "inAppPurchase"
+    ],
+    "isDevPushEnabled": false,
+    "isProdPushEnabled": false,
+    "associatedApplicationGroupsCount": null,
+    "associatedCloudContainersCount": null,
+    "associatedIdentifiersCount": null
+  }
+}

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -118,6 +118,14 @@ describe Spaceship::Client do
         expect(response['name']).to eq('pp Test 1ed9e25c93ac7142ff9df53e7f80e84c')
         expect(response['identifier']).to eq('tools.fastlane.spaceship.some-explicit-app')
       end
+
+      it 'should make a request create an explicit app id with no push feature' do
+        payload = {}
+        payload[Spaceship.app_service.push_notification.on.service_id] = Spaceship.app_service.push_notification.on
+        response = subject.create_app!(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', enabled_features: payload)
+        expect(response['enabledFeatures']).to_not include("push")
+        expect(response['identifier']).to eq('tools.fastlane.spaceship.some-explicit-app')
+      end
     end
 
     describe '#delete_app!' do

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -195,9 +195,9 @@ class PortalStubbing
         to_return(status: 200, body: adp_read_fixture_file('deleteAppId.action.json'), headers: { 'Content-Type' => 'application/json' })
     end
 
-  stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
-    with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "Production App", "push" => "true", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
-    to_return(status: 200, body: adp_read_fixture_file('addAppId.action.nopush.json'), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
+      with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "Production App", "push" => "true", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
+      to_return(status: 200, body: adp_read_fixture_file('addAppId.action.nopush.json'), headers: { 'Content-Type' => 'application/json' })
 
     def adp_stub_app_groups
       stub_request(:post, 'https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/listApplicationGroups.action').

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -193,11 +193,11 @@ class PortalStubbing
       stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/deleteAppId.action").
         with(body: { "appIdId" => "LXD24VUE49", "teamId" => "XXXXXXXXXX" }).
         to_return(status: 200, body: adp_read_fixture_file('deleteAppId.action.json'), headers: { 'Content-Type' => 'application/json' })
-    end
 
-    stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
-      with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "Production App", "push" => "true", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
-      to_return(status: 200, body: adp_read_fixture_file('addAppId.action.nopush.json'), headers: { 'Content-Type' => 'application/json' })
+      stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
+        with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "Production App", "push" => "true", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
+        to_return(status: 200, body: adp_read_fixture_file('addAppId.action.nopush.json'), headers: { 'Content-Type' => 'application/json' })
+    end
 
     def adp_stub_app_groups
       stub_request(:post, 'https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/listApplicationGroups.action').

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -195,6 +195,10 @@ class PortalStubbing
         to_return(status: 200, body: adp_read_fixture_file('deleteAppId.action.json'), headers: { 'Content-Type' => 'application/json' })
     end
 
+  stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
+    with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "Production App", "push" => "true", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
+    to_return(status: 200, body: adp_read_fixture_file('addAppId.action.nopush.json'), headers: { 'Content-Type' => 'application/json' })
+
     def adp_stub_app_groups
       stub_request(:post, 'https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/listApplicationGroups.action').
         with(body: { teamId: 'XXXXXXXXXX', pageSize: "500", pageNumber: "1", sort: 'name=asc' }).


### PR DESCRIPTION
# Resubmit of - as single PR

PRS:
  * 1/2  https://github.com/fastlane/fastlane/pull/7222 -> spaceship
  * 2/2 https://github.com/fastlane/fastlane/pull/7223 -> produce


allowing push notifications to be disabled during app creation.


Issues:
  * https://github.com/fastlane/fastlane/issues/7219
  * https://github.com/fastlane/fastlane/issues/5358



test:

```ruby
lane :produce_feature do
  produce(
    app_name: "1322nopush11 demoapp",
    app_identifier: "o.x.c.a.x.ads.da.d.d.e",
    username: "helmut@januschka.com",
    skip_itc: true,
    enabled_features: {
      game_center: "on",
      icloud: "legacy",
      push_notification: "on",
      vpn_configuration: "on"
    }
  )
end

lane :produce_feature_full do
  produce(
    app_name: "1322nopush11 demoapp",
    app_identifier: "o.x.c.a.x.ads.da.d.d.e",
    username: "helmut@januschka.com",
    skip_itc: true,
    enabled_features: {
      app_group: "on",
      apple_pay: "on",
      associated_domains: "on",
      data_protection: "on",
      game_center: "on",
      health_kit: "on",
      home_kit: "on",
      wireless_accessory: "on",
      icloud: "legacy",
      in_app_purchase: "on",
      inter_app_audio: "on",
      passbook: "on",
      push_notification: "on",
      siri_kit: "on",
      vpn_configuration: "on"
    }
  )
end
```
  