### PR TITLE
deliver: respect the '--platform' command-line setting

### DIFF
--- a/deliver/lib/deliver/detect_values.rb
+++ b/deliver/lib/deliver/detect_values.rb
@@ -1,12 +1,12 @@
 module Deliver
   class DetectValues
     def run!(options, skip_params = {})
+      find_platform(options)
       find_app_identifier(options)
       find_app(options)
       find_folders(options)
       ensure_folders_created(options)
       find_version(options) unless skip_params[:skip_version]
-      find_platform(options)
     end
 
     def find_app_identifier(options)

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -36,7 +36,7 @@ module Deliver
       app_version = options[:app_version]
       UI.message("Making sure the latest version on iTunes Connect matches '#{app_version}' from the ipa file...")
 
-      changed = options[:app].ensure_version!(app_version, platform: options[:pkg] ? 'osx' : 'ios')
+      changed = options[:app].ensure_version!(app_version, platform: options[:platform])
 
       if changed
         UI.success("Successfully set the version to '#{app_version}'")
@@ -86,13 +86,15 @@ module Deliver
         package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
           app_id: options[:app].apple_id,
           ipa_path: options[:ipa],
-          package_path: "/tmp"
+          package_path: "/tmp",
+          platform: options[:platform]
         )
       elsif options[:pkg]
         package_path = FastlaneCore::PkgUploadPackageBuilder.new.generate(
           app_id: options[:app].apple_id,
           pkg_path: options[:pkg],
-          package_path: "/tmp"
+          package_path: "/tmp",
+          platform: options[:platform]
         )
       end
 

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -5,7 +5,7 @@ describe Deliver::Runner do
     allow(Spaceship::Tunes).to receive(:login).and_return(true)
     allow(Spaceship::Tunes).to receive(:select_team).and_return(true)
     allow_any_instance_of(Deliver::DetectValues).to receive(:run!) { |opt| opt }
-    Deliver::Runner.new(options) 
+    Deliver::Runner.new(options)
   end
 
   let(:options) do
@@ -16,7 +16,7 @@ describe Deliver::Runner do
       app_identifier: 'com.acme.acme',
       app_version: '1.0.7',
       app: double('app', { apple_id: 'YI8C2AS' }),
-      platform: 'ios',
+      platform: 'ios'
     }
   end
 

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -1,0 +1,69 @@
+require 'deliver/runner'
+
+describe Deliver::Runner do
+  let(:runner) do
+    allow(Spaceship::Tunes).to receive(:login).and_return(true)
+    allow(Spaceship::Tunes).to receive(:select_team).and_return(true)
+    allow_any_instance_of(Deliver::DetectValues).to receive(:run!) { |opt| opt }
+    Deliver::Runner.new(options) 
+  end
+
+  let(:options) do
+    # A typical options hash expected from Deliver::DetectValues
+    {
+      username: 'bill@acme.com',
+      ipa: 'ACME.ipa',
+      app_identifier: 'com.acme.acme',
+      app_version: '1.0.7',
+      app: double('app', { apple_id: 'YI8C2AS' }),
+      platform: 'ios',
+    }
+  end
+
+  describe :upload_binary do
+    let(:transporter) { double }
+    before do
+      allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(transporter)
+    end
+
+    describe 'with an IPA file for iOS' do
+      it 'uploads the IPA for the iOS platform' do
+        expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'ios')
+          .and_return('path')
+        expect(transporter).to receive(:upload).with('YI8C2AS', 'path').and_return(true)
+        runner.upload_binary
+      end
+    end
+
+    describe 'with an IPA file for AppleTV' do
+      before do
+        options[:platform] = 'appletvos'
+      end
+
+      it 'uploads the IPA for the appletvos platform' do
+        expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'appletvos')
+          .and_return('path')
+        expect(transporter).to receive(:upload).with('YI8C2AS', 'path').and_return(true)
+        runner.upload_binary
+      end
+    end
+
+    describe 'with a PKG file for Mac OSX' do
+      before do
+        options[:platform] = 'osx'
+        options[:pkg] = 'ACME.pkg'
+        options[:ipa] = nil
+      end
+
+      it 'uploads the PKG for the osx platform' do
+        expect_any_instance_of(FastlaneCore::PkgUploadPackageBuilder).to receive(:generate)
+          .with(app_id: 'YI8C2AS', pkg_path: 'ACME.pkg', package_path: '/tmp', platform: 'osx')
+          .and_return('path')
+        expect(transporter).to receive(:upload).with('YI8C2AS', 'path').and_return(true)
+        runner.upload_binary
+      end
+    end
+  end
+end

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -36,12 +36,12 @@ describe Deliver::Runner do
       end
     end
 
-    describe 'with an IPA file for AppleTV' do
+    describe 'with an IPA file for tvOS' do
       before do
         options[:platform] = 'appletvos'
       end
 
-      it 'uploads the IPA for the appletvos platform' do
+      it 'uploads the IPA for the tvOS platform' do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
           .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'appletvos')
           .and_return('path')
@@ -50,14 +50,14 @@ describe Deliver::Runner do
       end
     end
 
-    describe 'with a PKG file for Mac OSX' do
+    describe 'with a PKG file for macOS' do
       before do
         options[:platform] = 'osx'
         options[:pkg] = 'ACME.pkg'
         options[:ipa] = nil
       end
 
-      it 'uploads the PKG for the osx platform' do
+      it 'uploads the PKG for the macOS platform' do
         expect_any_instance_of(FastlaneCore::PkgUploadPackageBuilder).to receive(:generate)
           .with(app_id: 'YI8C2AS', pkg_path: 'ACME.pkg', package_path: '/tmp', platform: 'osx')
           .and_return('path')


### PR DESCRIPTION
### GOAL
Allow users to successfully upload AppleTV apps to iTunes Connect (using `--platform appletvos`).  See issue https://github.com/fastlane/fastlane/issues/7623.

### CHANGES
* Modify `Deliver::Runner` so that it correctly passes the value of `options[:platform]` (valid values are `ios`, `appletvos`, and `osx`) to the various backend tools.
* Modify `Deliver::DetectValues` to guess the platform correctly when possible (the platform check now comes first, before the other method calls which look at `options[:platform]`).
* Add some basic tests for `Deliver::Runner#upload_binary`.

### TESTS
- [x] Run `bundle exec rspec` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)