### PR TITLE
Removed redundant check in reset_git_repo action

### DIFF
--- a/fastlane/lib/fastlane/actions/reset_git_repo.rb
+++ b/fastlane/lib/fastlane/actions/reset_git_repo.rb
@@ -5,7 +5,7 @@ module Fastlane
     # Does a hard reset and clean on the repo
     class ResetGitRepoAction < Action
       def self.run(params)
-        if params[:force] || params[:force] || Actions.lane_context[SharedValues::GIT_REPO_WAS_CLEAN_ON_START]
+        if params[:force] || Actions.lane_context[SharedValues::GIT_REPO_WAS_CLEAN_ON_START]
           paths = params[:files]
 
           return paths if Helper.is_test?


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

I'm almost certain that this code was unintentionally introduced. This doesn't change the behavior of the action at all, so this is a safe change.

I've created an issue https://github.com/fastlane/fastlane/issues/7650 to track this fix.