### PR TITLE
sh action now supports log and error_callback parameters and hide sensitive parameters

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -171,8 +171,9 @@ module Fastlane
     end
 
     # Execute shell command
-      Actions.execute_action(command) do
     def sh(command, log: true, error_callback: nil)
+      command_header = log ? command : "shell command"
+      Actions.execute_action(command_header) do
         Actions.sh_no_action(command, log: log, error_callback: error_callback)
       end
     end

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -171,9 +171,9 @@ module Fastlane
     end
 
     # Execute shell command
-    def sh(command)
       Actions.execute_action(command) do
-        Actions.sh_no_action(command)
+    def sh(command, log: true, error_callback: nil)
+        Actions.sh_no_action(command, log: log, error_callback: error_callback)
       end
     end
 


### PR DESCRIPTION
Until now it only worked when using Actions.sh(…).

The method this PR modifies is the alias for Actions.sh

- Hide shell command if `log` is set to false to protect sensitive information