### PR TITLE
[snapshot] fix issue with launch arguments during copy of screenshots

### DIFF
--- a/snapshot/lib/snapshot/collector.rb
+++ b/snapshot/lib/snapshot/collector.rb
@@ -26,8 +26,8 @@ module Snapshot
         FileUtils.mkdir_p(language_folder)
 
         device_name = device_type.delete(" ")
-        components = [launch_arguments_index, name].delete_if { |a| a.to_s.length == 0 }
-        screenshot_name = device_name + "-" + Digest::MD5.hexdigest(components.join("-")) + ".png"
+        components = [launch_arguments_index].delete_if { |a| a.to_s.length == 0 }
+        screenshot_name = device_name + "-" + name + "-" + Digest::MD5.hexdigest(components.join("-")) + ".png"
         output_path = File.join(language_folder, screenshot_name)
         from_path = File.join(attachments_path, filename)
         if $verbose

--- a/snapshot/lib/snapshot/collector.rb
+++ b/snapshot/lib/snapshot/collector.rb
@@ -26,9 +26,9 @@ module Snapshot
         FileUtils.mkdir_p(language_folder)
 
         device_name = device_type.delete(" ")
-        components = [device_name, launch_arguments_index, name].delete_if { |a| a.to_s.length == 0 }
-
-        output_path = File.join(language_folder, components.join("-") + ".png")
+        components = [launch_arguments_index, name].delete_if { |a| a.to_s.length == 0 }
+        screenshot_name = device_name + "-" + Digest::MD5.hexdigest(components.join("-")) + ".png"
+        output_path = File.join(language_folder, screenshot_name)
         from_path = File.join(attachments_path, filename)
         if $verbose
           UI.success "Copying file '#{from_path}' to '#{output_path}'..."


### PR DESCRIPTION
should fix: https://github.com/fastlane/fastlane/issues/7663


test with:

```ruby
lane :sd do
	snapshot(project: "snapshot/example/Example.xcodeproj",
          scheme: "Example", 
          launch_arguments: ["-myUrl https://google.com"], 
          devices: ["iPhone 5s"]
        )
end
```


result:
![bildschirmfoto 2016-12-25 um 00 08 31](https://cloud.githubusercontent.com/assets/2891702/21469040/5b63649e-ca36-11e6-9008-1aeb9d2dcc4c.png)

