### PR TITLE
Fixed snapshot reset simulators versions handling.

### DIFF
--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -15,9 +15,17 @@ module Snapshot
         `xcrun simctl delete #{id}`
       end
 
-      all_runtimes = `xcrun simctl list runtimes`.lines.map { |s| s.slice(/(.*?) \(/, 1) }.compact
-      tv_versions = filter_runtimes(all_runtimes, 'tvOS')
-      watch_versions = filter_runtimes(all_runtimes, 'watchOS')
+      all_runtime_type = `xcrun simctl list runtimes`.scan(/(.*)\s\(.*\((.*)\)/)
+      # == Runtimes ==
+      # iOS 9.3 (9.3 - 13E233) (com.apple.CoreSimulator.SimRuntime.iOS-9-3)
+      # iOS 10.0 (10.0 - 14A345) (com.apple.CoreSimulator.SimRuntime.iOS-10-0)
+      # iOS 10.1 (10.1 - 14B72) (com.apple.CoreSimulator.SimRuntime.iOS-10-1)
+      # iOS 10.2 (10.2 - 14C89) (com.apple.CoreSimulator.SimRuntime.iOS-10-2)
+      # tvOS 10.1 (10.1 - 14U591) (com.apple.CoreSimulator.SimRuntime.tvOS-10-1)
+      # watchOS 3.1 (3.1 - 14S471a) (com.apple.CoreSimulator.SimRuntime.watchOS-3-1)
+      ios_versions_ids = filter_runtimes(all_runtime_type, 'iOS', ios_versions)
+      tv_version_ids = filter_runtimes(all_runtime_type, 'tvOS')
+      watch_versions_ids = filter_runtimes(all_runtime_type, 'watchOS')
 
       all_device_types = `xcrun simctl list devicetypes`.scan(/(.*)\s\((.*)\)/)
       # == Device Types ==
@@ -27,11 +35,11 @@ module Snapshot
       # iPhone 6 (com.apple.CoreSimulator.SimDeviceType.iPhone-6)
       all_device_types.each do |device_type|
         if device_type.join(' ').include?("Watch")
-          create(device_type, watch_versions, 'watchOS')
+          create(device_type, watch_versions_ids, 'watchOS')
         elsif device_type.join(' ').include?("TV")
-          create(device_type, tv_versions, 'tvOS')
+          create(device_type, tv_version_ids, 'tvOS')
         else
-          create(device_type, ios_versions)
+          create(device_type, ios_versions_ids)
         end
       end
 
@@ -40,13 +48,13 @@ module Snapshot
 
     def self.create(device_type, os_versions, os_name = 'iOS')
       os_versions.each do |os_version|
-        puts "Creating #{device_type} for #{os_name} version #{os_version}"
-        `xcrun simctl create '#{device_type[0]}' #{device_type[1]} #{os_version}`
+        puts "Creating #{device_type[0]} for #{os_name} version #{os_version[0]}"
+        `xcrun simctl create '#{device_type[0]}' #{device_type[1]} #{os_version[1]}`
       end
     end
 
-    def self.filter_runtimes(all_runtimes, os = 'iOS')
-      all_runtimes.select { |r| r[/^#{os}/] }.map { |r| r.split(' ')[1] }
+    def self.filter_runtimes(all_runtimes, os = 'iOS', versions = [])
+      all_runtimes.select { |v, id| v[/^#{os}/] }.select { |v, id| v[/#{versions.join("|")}$/] }
     end
 
     def self.devices


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [X] Run `bundle exec rspec` from the root directory.
- [X] Run `bundle exec rubocop -a` to ensure the code style is valid
- [X] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

Suggested solution for issue #6845. Correct command for creating new simulator is:
```
simctl create <name> <device type id> <runtime id>
```

Currently, `snapshot` is using version numer (like `10.1`) instead of the `runtime id` which is the source of the problem. This PR use `runtime id` in place of version number.