### PR TITLE
add new param 'disable_notify'  to deploygate-action

### DIFF
--- a/fastlane/lib/fastlane/actions/deploygate.rb
+++ b/fastlane/lib/fastlane/actions/deploygate.rb
@@ -45,7 +45,7 @@ module Fastlane
         user_name = options[:user]
         ipa = options[:ipa]
         upload_options = options.values.select do |key, _|
-          [:message, :distribution_key, :release_note].include? key
+          [:message, :distribution_key, :release_note, :disable_notify].include? key
         end
 
         return ipa if Helper.test?
@@ -141,7 +141,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :release_note,
                                        optional: true,
                                        env_name: "DEPLOYGATE_RELEASE_NOTE",
-                                       description: "Release note for distribution page")
+                                       description: "Release note for distribution page"),
+          FastlaneCore::ConfigItem.new(key: :disable_notify,
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false,
+                                       env_name: "DEPLOYGATE_DISABLE_NOTIFY",
+                                       description: "Disables Push notification emails")
         ]
       end
 

--- a/fastlane/spec/actions_specs/deploygate_spec.rb
+++ b/fastlane/spec/actions_specs/deploygate_spec.rb
@@ -74,6 +74,7 @@ describe Fastlane do
               user: 'deploygate',
               api_token: 'thisistest',
               release_note: 'This is a test release.',
+              disable_notify: true,
             })
           end").runner.execute(:test)
         end.not_to raise_error


### PR DESCRIPTION
disable_notify is boolean-flag. API reference here:
https://docs.deploygate.com/reference#upload

- similar/related patch: Add Android support to DeployGate action #6166

<hr>

- [x] Run `bundle exec rspec` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)