### PR TITLE
Add sign option to add_git_tag action

### DIFF
--- a/fastlane/lib/fastlane/actions/add_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/add_git_tag.rb
@@ -12,6 +12,7 @@ module Fastlane
 
         cmd << ["-am #{message.shellescape}"]
         cmd << '--force' if options[:force]
+        cmd << '-s' if options[:sign]
         cmd << "'#{tag}'"
         cmd << options[:commit].to_s if options[:commit]
 
@@ -65,6 +66,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :force,
                                        env_name: "FL_GIT_TAG_FORCE",
                                        description: "Force adding the tag",
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :sign,
+                                       env_name: "FL_GIT_TAG_SIGN",
+                                       description: "Make a GPG-signed tag, using the default e-mail address's key",
                                        optional: true,
                                        is_string: false,
                                        default_value: false)

--- a/fastlane/spec/actions_specs/add_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/add_git_tag_spec.rb
@@ -129,6 +129,21 @@ describe Fastlane do
 
         expect(result).to eq("git tag -am #{message} \'#{tag}\' #{commit}")
       end
+
+      it "allows you to sign the tag using the default e-mail address's key." do
+        tag = '2.0.0'
+        message = "message"
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          add_git_tag ({
+            tag: '#{tag}',
+            message: '#{message}',
+            sign: true
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("git tag -am #{message} -s \'#{tag}\'")
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds an ability to invoke `add_git_tag` with `-s` flag. 

This can be useful when releasing a new version of some library/SDK to verify that the tagged release comes from trusted source.
