### PR TITLE
SnapfileTemplate Wrong device name for iPad pro

### DIFF
--- a/snapshot/lib/assets/SnapfileTemplate
+++ b/snapshot/lib/assets/SnapfileTemplate
@@ -5,8 +5,8 @@
 #   "iPhone 6",
 #   "iPhone 6 Plus",
 #   "iPhone 5",
-#   "iPad Pro (12.9 inch)",
-#   "iPad Pro (9.7 inch)",
+#   "iPad Pro (12.9-inch)",
+#   "iPad Pro (9.7-inch)",
 #   "Apple TV 1080p"
 # ])
 


### PR DESCRIPTION
when executing snapshot reset_simulators the device name for the iPad pro is  "iPad Pro (12.9-inch)" not  "iPad Pro (12.9 inch)"

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [ ] Run `bundle exec rspec` from the root directory.
- [ ] Run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:
