### PR TITLE
Revert json dependency update to support bundled fastlane

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'gh_inspector', '>= 1.0.1', '< 2.0.0' # search for issues on GitHub when something goes wrong
   spec.add_dependency 'google-api-client', '~> 0.9.1' # Google API Client to access Play Publishing API
   spec.add_dependency 'highline', '>= 1.7.2', '< 2.0.0' # user inputs (e.g. passwords)
-  spec.add_dependency 'json', '>= 2.0.1', '< 3.0.0' # Because sometimes it's just not installed
+  spec.add_dependency 'json', '< 3.0.0' # Because sometimes it's just not installed
   spec.add_dependency 'mini_magick', '~> 4.5.1' # To open, edit and export PSD files
   spec.add_dependency 'multi_json' # Because sometimes it's just not installed
   spec.add_dependency 'multi_xml', '~> 0.5'


### PR DESCRIPTION
We are reverting this change to allow versions of `json` below `2.x` to be installed. Ruby 2.4 introduced an incompatibility with json 2.x.

This will fix the standalone _fastlane_ update issues but will not support Ruby 2.4.

Reverting this change: https://github.com/fastlane/fastlane/pull/7674/files

Due to these issues: 
* https://github.com/CocoaPods/CocoaPods/issues/6299
* https://github.com/fastlane/fastlane/issues/7691#issuecomment-269527122