### PR TITLE
Add support for uploading proguard mapping files👍

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -211,6 +211,21 @@ module Supply
       return result_upload.version_code
     end
 
+    def upload_mapping(path_to_mapping, apk_version_code)
+      ensure_active_edit!
+
+      call_google_api do
+        android_publisher.upload_edit_deobfuscationfile(
+          current_package_name,
+          current_edit.id,
+          apk_version_code,
+          "proguard",
+          upload_source: path_to_mapping,
+          content_type: "application/octet-stream"
+        )
+      end
+    end
+
     # Updates the track for the provided version code(s)
     def update_track(track, rollout, apk_version_code)
       ensure_active_edit!

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -127,7 +127,29 @@ module Supply
                                      optional: true,
                                      description: "Indicate that changes will only be validated with Google Play rather than actually published",
                                      is_string: false,
-                                     default_value: false)
+                                     default_value: false),
+        FastlaneCore::ConfigItem.new(key: :mapping,
+                                     env_name: "SUPPLY_MAPPING",
+                                     description: "Path to the mapping file to upload",
+                                     short_option: "-d",
+                                     conflicting_options: [:mapping_paths],
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       UI.user_error! "Could not find mapping file at path '#{value}'" unless File.exist?(value)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :mapping_paths,
+                                     env_name: "SUPPLY_MAPPING_PATHS",
+                                     conflicting_options: [:mapping],
+                                     optional: true,
+                                     type: Array,
+                                     description: "An array of paths to mapping files to upload",
+                                     short_option: "-s",
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
+                                       value.each do |path|
+                                         UI.user_error! "Could not find mapping file at path '#{path}'" unless File.exist?(path)
+                                       end
+                                     end)
 
       ]
     end

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -115,6 +115,13 @@ module Supply
         apk_version_codes.push(upload_binary_data(apk_path))
       end
 
+      mapping_paths = [Supply.config[:mapping]] unless (mapping_paths = Supply.config[:mapping_paths])
+      mapping_paths.zip(apk_version_codes).each do |mapping_path, version_code|
+        if mapping_path
+          client.upload_mapping(mapping_path, version_code)
+        end
+      end
+
       update_track(apk_version_codes)
     end
 


### PR DESCRIPTION
Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [ X ] Run `bundle exec rspec` from the root directory.
- [ X ] Run `bundle exec rubocop -a` to ensure the code style is valid
- [ X ] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ X ] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:

This PR adds functionality to support adding a proguard mapping file per apk. This will allow developers to upload their deobfuscation files at the same time as they upload their APKs, making life better for everyone.

This is an attempt to implement the functionality requested in #7183.
