### PR TITLE
Support Xcode 8's build_for_testing & test_without_building

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -200,6 +200,15 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :custom_report_file_name,
                                     description: "Sets custom full report file name",
                                     optional: true,
+                                    is_string: true),
+        FastlaneCore::ConfigItem.new(key: :build_for_testing,
+                                    description: "Build for testing (Xcode 8+)",
+                                    optional: true,
+                                    is_string: false,
+                                    default_value: false),
+        FastlaneCore::ConfigItem.new(key: :test_with_xctestrun,
+                                    description: "Path to .xctestrun file to test. Implies 'test-without-building' action (Xcode 8+)",
+                                    optional: true,
                                     is_string: true)
       ]
     end

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -30,7 +30,7 @@ module Scan
         config = Scan.config
 
         options = []
-        options += project_path_array
+        options += project_path_array unless config[:test_with_xctestrun]
         options << "-sdk '#{config[:sdk]}'" if config[:sdk]
         options << destination # generated in `detect_values`
         options << "-derivedDataPath '#{config[:derived_data_path]}'" if config[:derived_data_path]
@@ -39,6 +39,7 @@ module Scan
         options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
         options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?
         options << "-xcconfig '#{config[:xcconfig]}'" if config[:xcconfig]
+        options << "-xctestrun '#{config[:test_with_xctestrun]}'" if config[:test_with_xctestrun]
         options << config[:xcargs] if config[:xcargs]
 
         options
@@ -48,9 +49,17 @@ module Scan
         config = Scan.config
 
         actions = []
+
         actions << :clean if config[:clean]
-        actions << :build unless config[:skip_build]
-        actions << :test
+
+        if config[:build_for_testing]
+          actions << 'build-for-testing'
+        elsif config[:test_with_xctestrun]
+          actions << 'test-without-building'
+        else
+          actions << :build unless config[:skip_build]
+          actions << :test
+        end
 
         actions
       end

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -198,6 +198,22 @@ describe Scan do
       end
     end
 
+    describe "Xcode 8+ Example" do
+      it "supports the build-for-testing command" do
+        options = { project: "./scan/examples/standard/app.xcodeproj", build_for_testing: true }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        result = Scan::TestCommandGenerator.generate
+        expect(result).to include("build-for-testing")
+      end
+
+      it "supports the test-without-building command" do
+        options = { project: "./scan/examples/standard/app.xcodeproj", test_with_xctestrun: '/path/to/test.xctestrun' }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        result = Scan::TestCommandGenerator.generate
+        expect(result).to include("-xctestrun '/path/to/test.xctestrun'", "test-without-building")
+      end
+    end
+
     it "uses a device without version specifier" do
       options = { project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 6s" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)


### PR DESCRIPTION
This PR adds supports for the `build_for_testing` and `test_without_building` actions added to `xcodebuild` in Xcode 8.


Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:
