### PR TITLE
Finish platform support for cert & sigh

### DIFF
--- a/cert/lib/cert/options.rb
+++ b/cert/lib/cert/options.rb
@@ -60,7 +60,17 @@ module Cert
                                      env_name: "CERT_KEYCHAIN_PASSWORD",
                                      sensitive: true,
                                      description: "This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password",
-                                     optional: true)
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :platform,
+                                     env_name: "CERT_PLATFORM",
+                                     description: "Set the provisioning profile's platform (ios, macos)",
+                                     is_string: false,
+                                     default_value: "ios",
+                                     verify_block: proc do |value|
+                                       value = value.to_s
+                                       pt = %w(macos ios)
+                                       UI.user_error!("Unsupported platform, must be: #{pt}") unless pt.include?(value)
+                                     end)
       ]
     end
   end

--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -132,7 +132,7 @@ module Cert
       when 'macos'
         cert_type = Spaceship.certificate.mac_app_distribution
         cert_type = Spaceship.certificate.mac_development if Cert.config[:development]
-        
+
       end
 
       cert_type

--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -123,9 +123,17 @@ module Cert
 
     # The kind of certificate we're interested in
     def certificate_type
-      cert_type = Spaceship.certificate.production
-      cert_type = Spaceship.certificate.in_house if Spaceship.client.in_house?
-      cert_type = Spaceship.certificate.development if Cert.config[:development]
+      case Cert.config[:platform].to_s
+      when 'ios', 'tvos'
+        cert_type = Spaceship.certificate.production
+        cert_type = Spaceship.certificate.in_house if Spaceship.client.in_house?
+        cert_type = Spaceship.certificate.development if Cert.config[:development]
+
+      when 'macos'
+        cert_type = Spaceship.certificate.mac_app_distribution
+        cert_type = Spaceship.certificate.mac_development if Cert.config[:development]
+        
+      end
 
       cert_type
     end

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -140,8 +140,7 @@ module Sigh
       profile
     end
 
-    # Certificate to use based on the current distribution mode
-    def certificate_to_use
+    def certificates_for_profile_and_platform
       case Sigh.config[:platform].to_s
       when 'ios'
         if profile_type == Spaceship.provisioning_profile.Development
@@ -159,9 +158,17 @@ module Sigh
           certificates = Spaceship.certificate.mac_app_distribution.all
         elsif profile_type == Spaceship.provisioning_profile.Direct
           certificates = Spaceship.certificate.developer_id_application.all
+        else
+          certificates = Spaceship.certificate.mac_app_distribution.all
         end
       end
-        
+
+      certificates
+    end
+
+    # Certificate to use based on the current distribution mode
+    def certificate_to_use
+      certificates = certificates_for_profile_and_platform
 
       # Filter them
       certificates = certificates.find_all do |c|

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -65,7 +65,7 @@ module Sigh
     # Fetches a profile matching the user's search requirements
     def fetch_profiles
       UI.message "Fetching profiles..."
-      results = profile_type.find_by_bundle_id(Sigh.config[:app_identifier])
+      results = profile_type.find_by_bundle_id(Sigh.config[:app_identifier], mac: Sigh.config[:platform].to_s == 'macos')
       results = results.find_all do |current_profile|
         if current_profile.valid?
           true

--- a/spaceship/lib/spaceship/portal/certificate.rb
+++ b/spaceship/lib/spaceship/portal/certificate.rb
@@ -283,6 +283,7 @@ module Spaceship
         # @return (Certificate): The newly created certificate
         def create!(csr: nil, bundle_id: nil)
           type = CERTIFICATE_TYPE_IDS.key(self)
+          mac = MAC_CERTIFICATE_TYPE_IDS.include? type
 
           # look up the app_id by the bundle_id
           if bundle_id
@@ -295,7 +296,7 @@ module Spaceship
           csr = OpenSSL::X509::Request.new(csr) if csr.kind_of?(String)
 
           # if this succeeds, we need to save the .cer and the private key in keychain access or wherever they go in linux
-          response = client.create_certificate!(type, csr.to_pem, app_id)
+          response = client.create_certificate!(type, csr.to_pem, app_id, mac)
           # munge the response to make it work for the factory
           response['certificateTypeDisplayId'] = response['certificateType']['certificateTypeDisplayId']
           self.new(response)

--- a/spaceship/lib/spaceship/portal/device.rb
+++ b/spaceship/lib/spaceship/portal/device.rb
@@ -100,10 +100,12 @@ module Spaceship
           all.select { |device| device.device_type != "tvOS" }
         end
 
-        # @return (Array) Returns all devices that can be used for iOS profiles (all devices except TVs)
+        # @return (Array) Returns all devices matching the provided profile_type
         def all_for_profile_type(profile_type)
           if profile_type.include? "tvOS"
             Spaceship::Device.all_apple_tvs
+          elsif profile_type.include? "Mac"
+            Spaceship::Device.all_macs
           else
             Spaceship::Device.all_ios_profile_devices
           end

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -314,10 +314,10 @@ module Spaceship
       end
     end
 
-    def create_certificate!(type, csr, app_id = nil)
+    def create_certificate!(type, csr, app_id = nil, mac = false)
       ensure_csrf(Spaceship::Certificate)
 
-      r = request(:post, 'account/ios/certificate/submitCertificateRequest.action', {
+      r = request(:post, "account/#{platform_slug(mac)}/certificate/submitCertificateRequest.action", {
         teamId: team_id,
         type: type,
         csrContent: csr,

--- a/spaceship/spec/portal/certificate_spec.rb
+++ b/spaceship/spec/portal/certificate_spec.rb
@@ -85,7 +85,7 @@ describe Spaceship::Certificate do
 
   describe '#create' do
     it 'should create and return a new certificate' do
-      expect(client).to receive(:create_certificate!).with('UPV3DW712I', /BEGIN CERTIFICATE REQUEST/, 'B7JBD8LHAA') {
+      expect(client).to receive(:create_certificate!).with('UPV3DW712I', /BEGIN CERTIFICATE REQUEST/, 'B7JBD8LHAA', false) {
         JSON.parse(PortalStubbing.adp_read_fixture_file('certificateCreate.certRequest.json'))
       }
       csr, pkey = Spaceship::Portal::Certificate.create_certificate_signing_request
@@ -94,7 +94,7 @@ describe Spaceship::Certificate do
     end
 
     it 'should create a new certificate using a CSR from a file' do
-      expect(client).to receive(:create_certificate!).with('UPV3DW712I', /BEGIN CERTIFICATE REQUEST/, 'B7JBD8LHAA') {
+      expect(client).to receive(:create_certificate!).with('UPV3DW712I', /BEGIN CERTIFICATE REQUEST/, 'B7JBD8LHAA', false) {
         JSON.parse(PortalStubbing.adp_read_fixture_file('certificateCreate.certRequest.json'))
       }
       csr, pkey = Spaceship::Portal::Certificate.create_certificate_signing_request


### PR DESCRIPTION
Currently this correctly generates, or downloads existing, development & production certificates for an iOS & macOS application set. It does the same for the related provisioning profiles.

## Sigh
Fixes search for certificates by types using the `platform` option. Also, fixes the lookup of application ids by passing the `mac` flag; again using the `platform` option.

## Cert
Adds a `platform` option (allows only `macos` or `ios`). Using the `platform` option it can now determine the correct certificate type.

## Spaceship
Certificate creation uses `mac` flag (identical to most other methods) to target the correct developer portal account section and create the certificates there.

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1: