### PR TITLE
Update checker ensures valid RubyGems source for fastlane updates

### DIFF
--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -71,6 +71,8 @@ module FastlaneCore
       end
       puts '#######################################################################'.green
       Changelog.show_changes(gem_name, current_version) unless FastlaneCore::Env.truthy?("FASTLANE_HIDE_CHANGELOG")
+
+      ensure_rubygems_source
     end
 
     # The command that the user should use to update their mac
@@ -82,6 +84,20 @@ module FastlaneCore
       else
         "sudo gem update #{gem_name.downcase}"
       end
+    end
+
+    # Check if RubyGems is set as a gem source
+    # on some machines that might not be the case
+    # and then users can't find the update when
+    # running the specified command
+    def self.ensure_rubygems_source
+      return if Helper.contained_fastlane?
+      return if `gem sources`.include?("https://rubygems.org")
+      puts ""
+      UI.error("RubyGems is not listed as your Gem source")
+      UI.error("You can run `gem sources` to see all your sources")
+      UI.error("Please run the following command to fix this:")
+      UI.command("gem sources --add https://rubygems.org")
     end
 
     # Generate the URL on the main thread (since we're switching directory)


### PR DESCRIPTION
<img width="948" alt="screenshot 2017-01-04 14 39 14" src="https://cloud.githubusercontent.com/assets/869950/21644036/c4115aac-d28b-11e6-9728-a1edf55742b2.png">

See the red error message at the bottom. I've had multiple users who couldn't update because of that