### PR TITLE
Detect if session was set via env variable if session is invalid, and show better error message

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -373,6 +373,11 @@ module Spaceship
         msg = "Auth error received: '#{ex.message}'. Login in again then retrying after 3 seconds (remaining: #{tries})..."
         puts msg if $verbose
         logger.warn msg
+
+        if self.class.spaceship_session_env.to_s.length > 0
+          raise UnauthorizedAccessError.new, "Authentication error, you passed an invalid session using the environment variable FASTLANE_SESSION or SPACESHIP_SESSION"
+        end
+
         do_login(self.user, @password)
         sleep 3 unless defined? SpecHelper
         retry

--- a/spaceship/lib/spaceship/two_step_client.rb
+++ b/spaceship/lib/spaceship/two_step_client.rb
@@ -87,12 +87,11 @@ module Spaceship
     end
 
     def load_session_from_env
-      yaml_text = ENV["FASTLANE_SESSION"] || ENV["SPACESHIP_SESSION"]
-      return if yaml_text.to_s.length == 0
+      return if self.class.spaceship_session_env.to_s.length == 0
       puts "Loading session from environment variable" if $verbose
 
       file = Tempfile.new('cookie.yml')
-      file.write(yaml_text.gsub("\\n", "\n"))
+      file.write(self.class.spaceship_session_env.gsub("\\n", "\n"))
       file.close
 
       begin
@@ -104,6 +103,12 @@ module Spaceship
       ensure
         file.unlink
       end
+    end
+
+    # Fetch the session cookie from the environment
+    # (if exists)
+    def self.spaceship_session_env
+      ENV["FASTLANE_SESSION"] || ENV["SPACESHIP_SESSION"]
     end
 
     def select_device(r, device_id)


### PR DESCRIPTION
<img width="830" alt="screenshot 2017-01-04 19 22 58" src="https://cloud.githubusercontent.com/assets/869950/21653840/66ae1bd4-d2b3-11e6-8d71-58eb623c4669.png">

This bit me a lot in the past