### PR TITLE
[supply] Added support for google service account credentials via environment variable

### DIFF
--- a/credentials_manager/lib/credentials_manager/appfile_config.rb
+++ b/credentials_manager/lib/credentials_manager/appfile_config.rb
@@ -122,6 +122,10 @@ module CredentialsManager
       setter(:json_key_file, *args, &block)
     end
 
+    def json_key_data_raw(*args, &block)
+      setter(:json_key_data_raw, *args, &block)
+    end
+
     def issuer(*args, &block)
       puts "Appfile: DEPRECATED issuer: use json_key_file instead".red
       setter(:issuer, *args, &block)

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -7,7 +7,7 @@ require 'net/http'
 
 module Supply
   class Client
-    #environment variable that can be used to set credentials
+    # Environment variable that can be used to set credentials
     SUPPLY_JSON_GOOGLE_CREDS = "SUPPLY_JSON_GOOGLE_CREDS"
 
     # Connecting with Google

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -7,6 +7,9 @@ require 'net/http'
 
 module Supply
   class Client
+    #environment variable that can be used to set credentials
+    SUPPLY_JSON_GOOGLE_CREDS = "SUPPLY_JSON_GOOGLE_CREDS"
+
     # Connecting with Google
     attr_accessor :android_publisher
 
@@ -22,7 +25,7 @@ module Supply
 
     # instantiate a client given the supplied configuration
     def self.make_from_config
-      unless Supply.config[:json_key] || (Supply.config[:key] && Supply.config[:issuer])
+      unless Supply.config[:json_key] || ENV[SUPPLY_JSON_GOOGLE_CREDS] || (Supply.config[:key] && Supply.config[:issuer])
         UI.important("To not be asked about this value, you can specify it using 'json_key'")
         Supply.config[:json_key] = UI.input("The service account json file used to authenticate with Google: ")
       end
@@ -41,6 +44,8 @@ module Supply
 
       if path_to_service_account_json
         key_io = File.open(File.expand_path(path_to_service_account_json))
+      elsif ENV[SUPPLY_JSON_GOOGLE_CREDS]
+        key_io = StringIO.new(ENV[SUPPLY_JSON_GOOGLE_CREDS])
       else
         require 'google/api_client/auth/key_utils'
         key = Google::APIClient::KeyUtils.load_from_pkcs12(File.expand_path(path_to_key), 'notasecret')

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -27,23 +27,25 @@ module Supply
         Supply.config[:json_key] = UI.input("The service account json file used to authenticate with Google: ")
       end
 
+      if Supply.config[:json_key]
+        service_account_json = File.open(File.expand_path(Supply.config[:json_key]))
+      elsif Supply.config[:json_key_data]
+        service_account_json = StringIO.new(Supply.config[:json_key_data])
+      end
+
       return Client.new(path_to_key: Supply.config[:key],
-                        issuer: Supply.config[:issuer],
-                        path_to_service_account_json: Supply.config[:json_key], service_account_json: Supply.config[:json_key_data])
+                        issuer: Supply.config[:issuer], service_account_json: service_account_json)
     end
 
     # Initializes the android_publisher and its auth_client using the specified information
     # @param service_account_json: The raw service account Json data
-    # @param path_to_service_account_json: The path to your service account Json file
     # @param path_to_key: The path to your p12 file (@deprecated)
     # @param issuer: Email addresss for oauth (@deprecated)
-    def initialize(path_to_key: nil, issuer: nil, path_to_service_account_json: nil, service_account_json: nil)
+    def initialize(path_to_key: nil, issuer: nil, service_account_json: nil)
       scope = Androidpublisher::AUTH_ANDROIDPUBLISHER
 
-      if path_to_service_account_json
-        key_io = File.open(File.expand_path(path_to_service_account_json))
-      elsif service_account_json
-        key_io = StringIO.new(service_account_json)
+      if service_account_json
+        key_io = service_account_json
       else
         require 'google/api_client/auth/key_utils'
         key = Google::APIClient::KeyUtils.load_from_pkcs12(File.expand_path(path_to_key), 'notasecret')

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -58,12 +58,26 @@ module Supply
         FastlaneCore::ConfigItem.new(key: :json_key,
                                      env_name: "SUPPLY_JSON_KEY",
                                      short_option: "-j",
-                                     conflicting_options: [:issuer, :key],
+                                     conflicting_options: [:issuer, :key, :json_key_data],
                                      optional: true, # this is shouldn't be optional but is until --key and --issuer are completely removed
                                      description: "The service account json file used to authenticate with Google",
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
                                      verify_block: proc do |value|
                                        UI.user_error! "Could not find service account json file at path '#{File.expand_path(value)}'" unless File.exist?(File.expand_path(value))
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :json_key_data,
+                                     env_name: "SUPPLY_JSON_KEY_DATA",
+                                     short_option: "-c",
+                                     conflicting_options: [:issuer, :key, :json_key],
+                                     optional: true,
+                                     description: "The service account json used to authenticate with Google",
+                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
+                                     verify_block: proc do |value|
+                                       begin
+                                         JSON.parse(value)
+                                       rescue JSON::ParserError
+                                         UI.user_error! "Could not parse service account json  JSON::ParseError"
+                                       end
                                      end),
         FastlaneCore::ConfigItem.new(key: :apk,
                                      env_name: "SUPPLY_APK",


### PR DESCRIPTION
[supply] Added support for google service account credentials via environment variable

Existing github issue: https://github.com/fastlane/fastlane/issues/7715

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:
