### PR TITLE
Fix frameit 'easy mode' problem in landscape

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -22,7 +22,7 @@ module Frameit
         @image = complex_framing
       else
         # easy mode from 1.0 - no title or background
-        width = offset['width']
+        width = self.screenshot.portrait? ? offset['width'] : self.screenshot.size[0]
         image.resize width # resize the image to fit the frame
         put_into_frame # put it in the frame
       end

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -22,8 +22,6 @@ module Frameit
         @image = complex_framing
       else
         # easy mode from 1.0 - no title or background
-        width = self.screenshot.portrait? ? offset['width'] : self.screenshot.size[0]
-        image.resize width # resize the image to fit the frame
         put_into_frame # put it in the frame
       end
 


### PR DESCRIPTION
Addresses #6987 by removing some resizing code in the "easy" mode, that does not appear to be necessary.