### PR TITLE
Update gemspec to require correct version of Play API

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'  
   spec.add_dependency 'fastimage', '>= 1.6' # fetch the image sizes from the screenshots, note: we also support > 2.0
   spec.add_dependency 'gh_inspector', '>= 1.0.1', '< 2.0.0' # search for issues on GitHub when something goes wrong
-  spec.add_dependency 'google-api-client', '~> 0.9.1' # Google API Client to access Play Publishing API
+  spec.add_dependency 'google-api-client', '~> 0.9.2' # Google API Client to access Play Publishing API
   spec.add_dependency 'highline', '>= 1.7.2', '< 2.0.0' # user inputs (e.g. passwords)
   spec.add_dependency 'json', '< 3.0.0' # Because sometimes it's just not installed
   spec.add_dependency 'mini_magick', '~> 4.5.1' # To open, edit and export PSD files


### PR DESCRIPTION
The deobfuscation upload feature in supply requires 0.9.2+ of the google-api-client gem. I didn't realize this because I had a version of that gem on my system already.

bundle exec rspec is failing with a bunch of errors that seem unrelated to this change, but I'm not sure how best to diagnose them. (They also fail on master on my machine) Most likely this is because I don't have Xcode installed. I'll try to get it installed, but didn't want to block uploading this PR on that.

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [ ] Run `bundle exec rspec` from the root directory.
- [ X ] Run `bundle exec rubocop -a` to ensure the code style is valid
- [ X ] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ X ] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:
