### PR TITLE
Fix FastlaneRequire#gem_installed? to handle already-loaded libs

### DIFF
--- a/fastlane/lib/fastlane/fastlane_require.rb
+++ b/fastlane/lib/fastlane/fastlane_require.rb
@@ -45,7 +45,7 @@ module Fastlane
         # See https://github.com/fastlane/fastlane/issues/6951
         fork do
           begin
-            exit(1) unless require name
+            require name
           rescue LoadError
             exit(1)
           end


### PR DESCRIPTION
`fastlane_require`'s `gem_installed?` check seems to be misinterpreting a `false` return value from [Kernel#require](http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-require).

The `require` returns true when that call to require is the one that loads the library and false if the library was already loaded. The `gem_installed?` check is treating a false return as a failure to find/load the requested library.

Fixes #7770

---

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1: