### PR TITLE
Version bump to 2.6.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.5.0'.freeze
+  VERSION = '2.5.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.5.1'.freeze
+  VERSION = '2.6.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.5.0':**

* Make waiting for build processing more stable by retrying failed requests (#7762)
* Fix FastlaneRequire#gem_installed? to handle already-loaded libs (#7771)
* [supply] Added support for google service account credentials via environment variable (#7748)
* Update in-code documentation tool calls to use new fastlane syntax (#7751)
* Update screengrab tooling and dependency versions (#7766)
* Update gemspec to require correct version of Play API (#7763)
* Fix frameit 'easy mode' problem in landscape (#7759)
* frameit: support resuming of interrupted downloads of frames (#7750)
* Store spaceship and frameit config in ~/.fastlane (#7743)
* Detect if session was set via env variable if session is invalid, and show appropriate error message (#7742)
