### PR TITLE
Add verbose flag to zip action

### DIFF
--- a/fastlane/lib/fastlane/actions/zip.rb
+++ b/fastlane/lib/fastlane/actions/zip.rb
@@ -7,7 +7,9 @@ module Fastlane
         params[:output_path] ||= "#{params[:path]}.zip"
 
         Dir.chdir(File.expand_path("..", params[:path])) do # required to properly zip
-          Actions.sh "zip -r #{params[:output_path].shellescape} #{File.basename(params[:path]).shellescape}"
+          zip_options = params[:verbose] ? "r" : "rq"
+
+          Actions.sh "zip -#{zip_options} #{params[:output_path].shellescape} #{File.basename(params[:path]).shellescape}"
         end
 
         UI.success "Successfully generated zip file at path '#{File.expand_path(params[:output_path])}'"
@@ -36,6 +38,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :output_path,
                                        env_name: "FL_ZIP_OUTPUT_NAME",
                                        description: "The name of the resulting zip file",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :verbose,
+                                       env_name: "FL_ZIP_VERBOSE",
+                                       description: "Enable verbose output of zipped file",
+                                       default_value: true,
                                        optional: true)
         ]
       end
@@ -46,6 +53,11 @@ module Fastlane
           'zip(
             path: "MyApp.app",
             output_path: "Latest.app.zip"
+          )',
+          'zip(
+            path: "MyApp.app",
+            output_path: "Latest.app.zip"
+            verbose: false
           )'
         ]
       end

--- a/fastlane/spec/actions_specs/zip_spec.rb
+++ b/fastlane/spec/actions_specs/zip_spec.rb
@@ -1,13 +1,23 @@
 describe Fastlane do
   describe Fastlane::FastFile do
+    before do
+      @path = "./fastlane/spec/fixtures/actions/archive.rb"
+    end
+
     describe "zip" do
       it "generates a valid zip command" do
-        path = "./fastlane/spec/fixtures/actions/archive.rb"
-
-        expect(Fastlane::Actions).to receive(:sh).with("zip -r ./fastlane/spec/fixtures/actions/archive.rb.zip archive.rb")
+        expect(Fastlane::Actions).to receive(:sh).with("zip -r #{@path}.zip archive.rb")
 
         result = Fastlane::FastFile.new.parse("lane :test do
-          zip(path: '#{path}')
+          zip(path: '#{@path}')
+        end").runner.execute(:test)
+      end
+
+      it "generates a valid zip command without verbose output" do
+        expect(Fastlane::Actions).to receive(:sh).with("zip -rq #{@path}.zip archive.rb")
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          zip(path: '#{@path}', verbose: 'false')
         end").runner.execute(:test)
       end
     end


### PR DESCRIPTION
This PR adds support for a `verbose` mode with the `zip` action.  I've kept the default to `true` as this is the current behavior of this action.

[See Issue #7729](https://github.com/fastlane/fastlane/issues/7729)

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:
