### PR TITLE
Improve description of dsa_signature option in hockey action

### DIFF
--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -220,7 +220,7 @@ module Fastlane
                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :dsa_signature,
                                       env_name: "FL_HOCKEY_DSA_SIGNATURE",
-                                      description: "dsa signature(en.wikipedia.org/wiki/Digital_signature) for sparkle(sparkle-project.org) updates (macOS)",
+                                      description: "DSA signature for sparkle updates for macOS",
                                       is_string: true,
                                       optional: true)
         ]


### PR DESCRIPTION
We should probably avoid links in the description of options, as they'll be shown in tables with a limited column width already