### PR TITLE
[spaceship] Add support for providing group names for testers and creating new groups

### DIFF
--- a/spaceship/lib/spaceship/tunes/tester.rb
+++ b/spaceship/lib/spaceship/tunes/tester.rb
@@ -102,16 +102,18 @@ module Spaceship
         # @param email (String) (required): The email of the new tester
         # @param first_name (String) (optional): The first name of the new tester
         # @param last_name (String) (optional): The last name of the new tester
-        # @param groups (Array) (option): Names/IDs of existing groups for the new tester
+        # @param groups (Array) (option): IDs of existing groups for the new tester
+        # @param group_names (Array) (option): Names of existing or new groups for the new tester
         # @example
         #   Spaceship::Tunes::Tester.external.create!(email: "tester@mathiascarignani.com", first_name: "Cary", last_name:"Bennett", groups:["Testers"])
         # @return (Tester): The newly created tester
-        def create!(email: nil, first_name: nil, last_name: nil, groups: nil)
+        def create!(email: nil, first_name: nil, last_name: nil, groups: nil, group_names: nil)
           data = client.create_tester!(tester: self,
                                         email: email,
                                    first_name: first_name,
                                     last_name: last_name,
-                                       groups: groups)
+                                       groups: groups,
+                                  group_names: group_names)
           self.factory(data)
         end
 

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -831,26 +831,46 @@ module Spaceship
       @cached_groups = parse_response(r, 'data')['groups']
     end
 
-    def create_tester!(tester: nil, email: nil, first_name: nil, last_name: nil, groups: nil)
+    # @param groups [String] An array of group IDs to add the tester to
+    # @param group_names [String] An array of group names to add the tester to
+    def create_tester!(tester: nil, email: nil, first_name: nil, last_name: nil, groups: nil, group_names: nil)
       url = tester.url[:create]
       raise "Action not provided for this tester type." unless url
 
       tester_data = {
-            emailAddress: {
-              value: email
-            },
-            firstName: {
-              value: first_name || ""
-            },
-            lastName: {
-              value: last_name || ""
-            },
-            testing: {
-              value: true
-            }
-          }
+        emailAddress: {
+          value: email
+        },
+        firstName: {
+          value: first_name || ""
+        },
+        lastName: {
+          value: last_name || ""
+        },
+        testing: {
+          value: true
+        },
+        groups: []
+      }
+
       if groups
-        tester_data[:groups] = groups.map { |x| { "id" => x } }
+        tester_data[:groups] += groups.map do |x|
+          {
+            "id" => x,
+            "isSelected" => true
+          }
+        end
+      end
+
+      if group_names
+        tester_data[:groups] += group_names.map do |x|
+          {
+            "name" => {
+              "value" => x
+            },
+            "isSelected" => true
+          }
+        end
       end
 
       data = { testers: [tester_data] }

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -854,19 +854,19 @@ module Spaceship
       }
 
       if groups
-        tester_data[:groups] += groups.map do |x|
+        tester_data[:groups] += groups.map do |group_id|
           {
-            "id" => x,
+            "id" => group_id,
             "isSelected" => true
           }
         end
       end
 
       if group_names
-        tester_data[:groups] += group_names.map do |x|
+        tester_data[:groups] += group_names.map do |group_name|
           {
             "name" => {
-              "value" => x
+              "value" => group_name
             },
             "isSelected" => true
           }

--- a/spaceship/spec/tunes/fixtures/testers/created_tester.json
+++ b/spaceship/spec/tunes/fixtures/testers/created_tester.json
@@ -1,0 +1,52 @@
+{
+  "data": {
+    "sectionErrorKeys": null,
+    "sectionInfoKeys": [],
+    "sectionWarningKeys": [],
+    "testers": [{
+      "emailAddress": {
+        "value": "yolo2@krausefx.com",
+        "isEditable": false,
+        "isRequired": false,
+        "errorKeys": [],
+        "maxLength": null,
+        "minLength": null
+      },
+      "firstName": {
+        "value": "First Name Yo",
+        "isEditable": false,
+        "isRequired": false,
+        "errorKeys": [],
+        "maxLength": null,
+        "minLength": null
+      },
+      "lastName": {
+        "value": "Last Name Yo",
+        "isEditable": false,
+        "isRequired": false,
+        "errorKeys": [],
+        "maxLength": null,
+        "minLength": null
+      },
+      "testerId": null,
+      "devices": null,
+      "latestInstalledAppAdamId": null,
+      "latestInstalledVersion": null,
+      "latestInstalledShortVersion": null,
+      "latestInstalledDate": null,
+      "latestInstalledName": null,
+      "latestInstallByPlatform": null,
+      "hasAddedOrInvitedApp": null,
+      "warnOnDelete": null,
+      "itcUsername": null,
+      "dsId": null,
+      "groups": []
+    }]
+  },
+  "messages": {
+    "warn": null,
+    "error": null,
+    "info": null
+  },
+  "statusCode": "SUCCESS"
+}

--- a/spaceship/spec/tunes/testers_spec.rb
+++ b/spaceship/spec/tunes/testers_spec.rb
@@ -70,6 +70,26 @@ describe Spaceship::Tunes::Tester do
     end
   end
 
+  describe "Creating external testers" do
+    it "sends a valid request" do
+      stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/users/pre/create").
+        with(body: "{\"testers\":[{\"emailAddress\":{\"value\":\"something@krausefx.com\"},\"firstName\":{\"value\":\"First Name Yo\"},\"lastName\":{\"value\":\"Last Name Yo\"},\"testing\":{\"value\":true},\"groups\":[{\"id\":\"b6f65dbd-c845-4d91-bc39-0b661d608970\",\"isSelected\":true},{\"name\":{\"value\":\"CustomGroup\"},\"isSelected\":true}]}]}").
+        to_return(status: 200, body: TunesStubbing.itc_read_fixture_file("testers/created_tester.json"), headers: { 'Content-Type' => 'application/json' })
+
+      tester = Spaceship::Tunes::Tester.external.create!(
+        email: "something@krausefx.com",
+        first_name: "First Name Yo",
+        last_name: "Last Name Yo",
+        groups: ["b6f65dbd-c845-4d91-bc39-0b661d608970"],
+        group_names: ["CustomGroup"]
+      )
+
+      expect(tester.first_name).to eq("First Name Yo")
+      expect(tester.last_name).to eq("Last Name Yo")
+      expect(tester.email).to eq("yolo2@krausefx.com")
+    end
+  end
+
   describe "Sandbox testers" do
     describe "listing" do
       it 'loads sandbox testers correctly' do


### PR DESCRIPTION
Use the following code to use an existing group based on the ID and to create or use a group based on the name

```ruby
Spaceship::Tunes::Tester.external.create!(
  email: "something@krausefx.com",  
  groups: ["b6f65dbd-c845-4d91-bc39-0b661d608970"], 
  group_names: ["CustomGroup"])
```