### PR TITLE
Fix frameit for Mac screenshots

### DIFF
--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -60,7 +60,7 @@ module Frameit
     end
 
     def mac?
-      return device_name == 'Mac'
+      return device_name == 'MacBook'
     end
 
     # The name of the orientation of a screenshot. Used to find the correct template


### PR DESCRIPTION
Addresses #7782

Corrects the string comparison to correctly identify Mac screenshots. `device_name` turns `FRAMEIT_FORCE_DEVICE_TYPE=Mac` into `'MacBook'`
