### PR TITLE
Consistent support for DELIVER_USER and DELIVER_USERNAME env variables

### DIFF
--- a/credentials_manager/lib/credentials_manager/appfile_config.rb
+++ b/credentials_manager/lib/credentials_manager/appfile_config.rb
@@ -73,7 +73,7 @@ module CredentialsManager
     end
 
     def fallback_to_default_values
-      data[:apple_id] ||= ENV["FASTLANE_USER"] || ENV["DELIVER_USER"]
+      data[:apple_id] ||= ENV["FASTLANE_USER"] || ENV["DELIVER_USER"] || ENV["DELIVER_USERNAME"]
     end
 
     def data

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -6,6 +6,7 @@ module Deliver
     def self.available_options
       user = CredentialsManager::AppfileConfig.try_fetch_value(:itunes_connect_id)
       user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
+      user ||= ENV["DELIVER_USER"]
 
       [
         FastlaneCore::ConfigItem.new(key: :username,


### PR DESCRIPTION
Fixes #6478

Replaces https://github.com/fastlane/fastlane/pull/6527. I made a new PR for timeliness because the previous one had merge conflicts and it was 3 weeks since the last comment. 