### PR TITLE
Revert "Scan Support for connected devices"

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -51,15 +51,12 @@ module FastlaneCore
       def connected_devices(requested_os_type)
         UI.verbose("Fetching available connected devices")
 
-        tvos_devices = ["AppleTV"]
-        ios_devices = ["iPhone", "iPad", "iPod"]
-
         device_types = if requested_os_type == "tvOS"
-                         tvos_devices
+                         ["AppleTV"]
                        elsif requested_os_type == "iOS"
-                         ios_devices
+                         ["iPhone", "iPad", "iPod"]
                        else
-                         ios_devices + tvos_devices
+                         []
                        end
 
         devices = [] # Return early if no supported devices are being searched for

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -82,7 +82,7 @@ module Scan
       deployment_target_version = Scan.project.build_settings(key: deployment_target_key) || '0'
 
       simulators = filter_simulators(
-        FastlaneCore::DeviceManager.all(requested_os_type).tap do |array|
+        FastlaneCore::DeviceManager.simulators(requested_os_type).tap do |array|
           if array.empty?
             UI.user_error!(['No', simulator_type_descriptor, 'simulators found on local machine'].reject(&:nil?).join(' '))
           end
@@ -175,26 +175,10 @@ module Scan
 
       # building up the destination now
       if Scan.devices && Scan.devices.count > 0
-        if Scan.project.ios?
-          Scan.config[:destination] = Scan.devices.map { |d| self.destination("iOS", d) }
-        elsif Scan.project.tvos?
-          Scan.config[:destination] = Scan.devices.map { |d| self.destination("tvOS", d) }
-        else
-          Scan.config[:destination] = min_xcode8? ? [self.destination("macOS", nil)] : [self.destination("OS X", nil)]
-        end
+        Scan.config[:destination] = Scan.devices.map { |d| "platform=#{d.os_type} Simulator,id=#{d.udid}" }
+      else
+        Scan.config[:destination] = min_xcode8? ? ["platform=macOS"] : ["platform=OS X"]
       end
-    end
-
-    def self.destination(platform, device)
-      destination = "platform=#{platform}"
-      unless device.nil?
-        if device.is_simulator
-          destination += " Simulator"
-        end
-        destination += ",id=#{device.udid}"
-      end
-
-      return destination
     end
   end
 end

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -60,18 +60,6 @@ describe Scan do
 "
     FastlaneCore::Simulator.clear_cache
     response = "response"
-    device = "device"
-    system_profiler_output = '<?xml version="1.0" encoding="UTF-8"?>
-                                  <array>
-                                  	<dict>
-                                  		<key>_items</key>
-                                  		<array/>
-                                  	</dict>
-                                  </array>'
-
-    allow(device).to receive(:read).and_return(system_profiler_output)
-    allow(Open3).to receive(:popen3).with("system_profiler SPUSBDataType -xml").and_yield(nil, device, nil, nil)
-
     allow(response).to receive(:read).and_return(@valid_simulators)
     allow(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
 


### PR DESCRIPTION
Reverts fastlane/fastlane#5159, due to concerns about naming ambiguity.