### PR TITLE
Performance: Make .env Dir.glob much less greedy

### DIFF
--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -162,19 +162,20 @@ module Fastlane
     end
 
     def self.load_dot_env(env)
-      return if Dir.glob("**/*.env*", File::FNM_DOTMATCH).count == 0
+      base_path = FastlaneCore::FastlaneFolder.path || '.'
+      return if Dir.glob(File.join(base_path, '*.env*'), File::FNM_DOTMATCH).count == 0
       require 'dotenv'
 
       Actions.lane_context[Actions::SharedValues::ENVIRONMENT] = env if env
 
       # Making sure the default '.env' and '.env.default' get loaded
-      env_file = File.join(FastlaneCore::FastlaneFolder.path || "", '.env')
-      env_default_file = File.join(FastlaneCore::FastlaneFolder.path || "", '.env.default')
+      env_file = File.join(base_path, '.env')
+      env_default_file = File.join(base_path, '.env.default')
       Dotenv.load(env_file, env_default_file)
 
       # Loads .env file for the environment passed in through options
       if env
-        env_file = File.join(FastlaneCore::FastlaneFolder.path || "", ".env.#{env}")
+        env_file = File.join(base_path, ".env.#{env}")
         UI.success "Loading from '#{env_file}'"
         Dotenv.overload(env_file)
       end


### PR DESCRIPTION
I noticed that even the most basic `fastlane` command was hanging for a long time between the version check and the start of running a lane, so I started poking around with `ruby-prof`. The majority of the time was being taken up in `Dir.glob` inside `LaneManager.load_dot_env`.

The glob in question was searching recursively for files matching `*.env*` in all subdirectories, but then only loading `.env` files from either the root or the Fastlane folder (if defined).

The project directory where I ran across this contains an obscene number of files (~690,000), so I was seeing a good 20 second lag while it chewed through them all.

This PR changes the glob in that guard statement to only search the directories where `.env` files will be loaded from, instead of recursing through the entire directory structure.

---

Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes:

- [x] Run `bundle exec rspec` from the root directory.
- [x] Run `bundle exec rubocop -a` to ensure the code style is valid
- [x] Read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] We currently don't accept new actions, please publish a plugin instead, more information in [Plugins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Plugins.md)

Before submitting a pull request, we appreciate if you create an issue first to discuss the change :+1:
