### PR TITLE
Update screengrab aar version

### DIFF
--- a/screengrab/version.properties
+++ b/screengrab/version.properties
@@ -1,3 +1,3 @@
-major=0
-minor=6
-patch=1
+major=1
+minor=0
+patch=0


### PR DESCRIPTION
Updating screengrab version to match the version of screengrab currently in [rubygems](https://rubygems.org/gems/screengrab/versions). I'll deploy the aar after this commit.

Going forward we'll come up with a sensible strategy for versioning the aar and making sure it is deployed accordingly.