### PR TITLE
Update screengrab latest version source

### DIFF
--- a/screengrab/README.md
+++ b/screengrab/README.md
@@ -58,7 +58,7 @@ sudo gem install fastlane
 androidTestCompile 'tools.fastlane:screengrab:x.x.x'
 ```
 
-The latest version can be determined by visiting the [screengrab RubyGems page](https://rubygems.org/gems/screengrab)
+The latest version is [ ![Download](https://api.bintray.com/packages/fastlane/fastlane/screengrab/images/download.svg) ](https://bintray.com/fastlane/fastlane/screengrab/_latestVersion)
 
 ##### Configuring your Manifest Permissions
 Ensure that the following permissions exist in your **src/debug/AndroidManifest.xml**


### PR DESCRIPTION
RubyGems is no longer the right source for the _screengrab_ AAR version.