### PR TITLE
Print a message explaining how to quickly open links on macOS

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/github_issue_inspector_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/ui/github_issue_inspector_reporter.rb
@@ -18,7 +18,10 @@ module Fastlane
 
       if report.issues.count > NUMBER_OF_ISSUES_INLINE
         puts "and #{report.total_results - NUMBER_OF_ISSUES_INLINE} more at: #{report.url}"
+        puts ""
       end
+
+      print_open_link_hint
     end
 
     # Called once the report has been recieved, but when there are no issues found.
@@ -26,6 +29,7 @@ module Fastlane
       puts "Found no similar issues. To create a new issue, please visit:"
       puts "https://github.com/#{inspector.repo_owner}/#{inspector.repo_name}/issues/new"
       puts "Run `fastlane env` to append the fastlane environment to your issue"
+      print_open_link_hint(true)
     end
 
     # Called when there have been networking issues in creating the report.
@@ -33,6 +37,7 @@ module Fastlane
       puts "Could not access the GitHub API, you may have better luck via the website."
       puts "https://github.com/#{inspector.repo_owner}/#{inspector.repo_name}/search?q=#{query}&type=Issues&utf8=✓"
       puts "Error: #{error.name}"
+      print_open_link_hint(true)
     end
 
     private
@@ -45,6 +50,11 @@ module Fastlane
       puts "   #{issue.html_url} [#{status}] #{issue.comments} 💬"
       puts "   #{Time.parse(issue.updated_at).to_pretty}"
       puts ""
+    end
+
+    def print_open_link_hint(newline = false)
+      puts "" if newline
+      puts "🔗 You can ⌘ + double-click on links to open them directly in your browser." if Helper.mac?
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if neccessary.

### Description
A remake of https://github.com/orta/gh_inspector/pull/14 for the custom inspector reporter.

### Motivation and Context
Because ⌘ + double-click is much faster than
1. double-click + drag
2. ⌘ + C
3. ⌘ + n × ⇥
4. ⌘ + T
5. ⌘ + V
6. ⏎
