### PR TITLE
Prevent users on Android N from attempting to use internal storage

### DIFF
--- a/screengrab/example/fastlane/Appfile
+++ b/screengrab/example/fastlane/Appfile
@@ -1,3 +1,1 @@
-issuer "asd" # Follow https://github.com/fastlane/supply#setup to get one
-keyfile "sdf" # Path to the keyfile
 package_name "tools.fastlane.localetester"

--- a/screengrab/example/fastlane/Screengrabfile
+++ b/screengrab/example/fastlane/Screengrabfile
@@ -1,4 +1,4 @@
 locales ['en-US', 'fr-FR', 'ja-JP']
 clear_previous_screenshots true
-tests_apk_path 'build/outputs/apk/example-debug-androidTest-unaligned.apk'
+tests_apk_path 'build/outputs/apk/example-debug-androidTest.apk'
 app_apk_path 'build/outputs/apk/example-debug.apk'

--- a/screengrab/example/src/androidTest/java/tools/fastlane/localetester/JUnit4StyleTests.java
+++ b/screengrab/example/src/androidTest/java/tools/fastlane/localetester/JUnit4StyleTests.java
@@ -2,6 +2,7 @@ package tools.fastlane.localetester;
 
 import android.support.test.rule.ActivityTestRule;
 
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -9,6 +10,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import tools.fastlane.screengrab.Screengrab;
+import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
 import tools.fastlane.screengrab.locale.LocaleTestRule;
 
 import static android.support.test.espresso.Espresso.onView;
@@ -25,6 +27,11 @@ public class JUnit4StyleTests {
 
     @Rule
     public ActivityTestRule<MainActivity> activityRule = new ActivityTestRule<>(MainActivity.class);
+
+    @BeforeClass
+    public static void beforeAll() {
+        Screengrab.setDefaultScreenshotStrategy(new UiAutomatorScreenshotStrategy());
+    }
 
     @Test
     public void testTakeScreenshot() {

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FileWritingScreenshotCallback.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FileWritingScreenshotCallback.java
@@ -70,7 +70,9 @@ public class FileWritingScreenshotCallback implements ScreenshotCallback {
             directory = initializeDirectory(externalDir);
         }
 
-        if (directory == null) {
+        // We can only try this fall-back before Android N, since N makes Context.MODE_WORLD_READABLE
+        // result in a SecurityException
+        if (directory == null && Build.VERSION.SDK_INT < 24) {
             File internalDir = new File(context.getDir(SCREENGRAB_DIR_NAME, Context.MODE_WORLD_READABLE), localeToDirName(locale));
             directory = initializeDirectory(internalDir);
         }
@@ -90,7 +92,9 @@ public class FileWritingScreenshotCallback implements ScreenshotCallback {
             if (dir.isDirectory() && dir.canWrite()) {
                 return dir;
             }
-        } catch (IOException ignored) {}
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to initialize directory: " + dir.getAbsolutePath(), e);
+        }
 
         return null;
     }


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if neccessary.

### Description
As reported in #7592, the existing code will encounter a SecurityException on Android N, if the code attempts to use the internal storage location for screenshots.

This change prevents that fall-back from being tried on Android N and above.