### PR TITLE
Increase ulimit to prevent issues with too many open files

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,8 @@ dependencies:
   override:
     - bundle install --jobs=4 --retry=3
 test:
+  pre:
+    - ulimit -n 400
   override:
     - bundle exec rspec -r rspec_junit_formatter --format progress --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec/junit.xml
     - bundle exec rubocop


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Description
<!--- Describe your changes in detail -->
Sometimes the Circleci build fails with 
`/Users/distiller/.gem/ruby/2.3.1/gems/coveralls-0.8.17/lib/coveralls/output.rb:63:in `require': Too many open files - getcwd (Errno::EMFILE)`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Increasing from the default of 250 to 400 should give us enough headroom to run without failing but not increase too high to hide actual problems 
