### PR TITLE
for_lane, for_platform blocks in configurations

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -44,6 +44,9 @@ module FastlaneCore
       self.available_options = available_options || []
       self.values = values || {}
 
+      # used for pushing and popping values to provide nesting configuration contexts
+      @values_stack = []
+
       # if we are in captured output mode - keep a array of sensitive option values
       # those will be later - replaced by ####
       if $capture_output
@@ -262,6 +265,25 @@ module FastlaneCore
     # Direct access to the values, without iterating through all items
     def _values
       @values
+    end
+
+    # Clears away any current configuration values by pushing them onto a stack.
+    # Values set after calling push_values! will be merged with the previous
+    # values after calling pop_values!
+    #
+    # see: pop_values!
+    def push_values!
+      @values_stack.push(@values)
+      @values = {}
+    end
+
+    # Restores a previous set of configuration values by merging any current
+    # values on top of them
+    #
+    # see: push_values!
+    def pop_values!
+      return if @values_stack.empty?
+      @values = @values_stack.pop.merge(@values)
     end
 
     def all_keys

--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -80,13 +80,13 @@ module FastlaneCore
       end
     end
 
-    # Override configuration for a specific lane.
+    # Override configuration for a specific lane. If received lane name does not
+    # match the lane name available as environment variable, no changes will
+    # be applied.
     #
-    # lane_name  - Symbol representing a lane name.
-    # block - Block to execute to override configuration values.
+    # @param lane_name Symbol representing a lane name.
+    # @yield Block to run for overriding configuration values.
     #
-    # Discussion If received lane name does not match the lane name available as environment variable, no changes will
-    #             be applied.
     def for_lane(lane_name)
       if ENV["FASTLANE_LANE_NAME"] == lane_name.to_s
         with_a_clean_config_merged_when_complete do
@@ -95,13 +95,13 @@ module FastlaneCore
       end
     end
 
-    # Override Appfile configuration for a specific platform.
+    # Override configuration for a specific platform. If received platform name
+    # does not match the platform name available as environment variable, no
+    # changes will be applied.
     #
-    # platform_name  - Symbol representing a platform name.
-    # block - Block to execute to override configuration values.
+    # @param platform_name Symbol representing a platform name.
+    # @yield Block to run for overriding configuration values.
     #
-    # Discussion If received paltform name does not match the platform name available as environment variable, no changes will
-    #             be applied.
     def for_platform(platform_name)
       if ENV["FASTLANE_PLATFORM_NAME"] == platform_name.to_s
         with_a_clean_config_merged_when_complete do

--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -58,9 +58,6 @@ module FastlaneCore
     def method_missing(method_sym, *arguments, &block)
       # First, check if the key is actually available
       if self.config.all_keys.include?(method_sym)
-        # This silently prevents a value from having its value set more than once.
-        return unless self.config._values[method_sym].to_s.empty?
-
         value = arguments.first
         value = yield if value.nil? && block_given?
 
@@ -76,6 +73,32 @@ module FastlaneCore
         else
           self.config[method_sym] = '' # important, since this will raise a good exception for free
         end
+      end
+    end
+
+    # Override configuration for a specific lane.
+    #
+    # lane_name  - Symbol representing a lane name.
+    # block - Block to execute to override configuration values.
+    #
+    # Discussion If received lane name does not match the lane name available as environment variable, no changes will
+    #             be applied.
+    def for_lane(lane_name)
+      if ENV["FASTLANE_LANE_NAME"] == lane_name.to_s
+        yield
+      end
+    end
+
+    # Override Appfile configuration for a specific platform.
+    #
+    # platform_name  - Symbol representing a platform name.
+    # block - Block to execute to override configuration values.
+    #
+    # Discussion If received paltform name does not match the platform name available as environment variable, no changes will
+    #             be applied.
+    def for_platform(platform_name)
+      if ENV["FASTLANE_PLATFORM_NAME"] == platform_name.to_s
+        yield
       end
     end
   end

--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -9,11 +9,6 @@ module FastlaneCore
     def initialize(config, path, block_for_missing)
       self.config = config
 
-      # Setting this variable to be true allows a one-time overwrite of a particular
-      # configuration value. This is used by the override block methods to allow
-      # giving a more specific config value for a particular circumstance
-      @allow_overwite = false
-
       @block_for_missing = block_for_missing
       content = File.read(path)
 

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -407,6 +407,41 @@ describe FastlaneCore do
           expect(config.values[:test]).to eq('456value')
           ENV.delete("FL_TEST")
         end
+
+        it "can push and pop configuration values" do
+          name = FastlaneCore::ConfigItem.new(key: :name)
+          platform = FastlaneCore::ConfigItem.new(key: :platform)
+          other = FastlaneCore::ConfigItem.new(key: :other)
+
+          config = FastlaneCore::Configuration.create([name, other, platform], {})
+          config.set(:name, "name1")
+          config.set(:other, "other")
+          config.push_values!
+
+          expect(config._values).to be_empty
+
+          config.set(:name, "name2")
+          config.set(:platform, "platform")
+          config.pop_values!
+
+          expect(config.fetch(:name)).to eq("name2")
+          expect(config.fetch(:other)).to eq("other")
+          expect(config.fetch(:platform)).to eq("platform")
+        end
+
+        it "does nothing if you pop values with nothing pushed" do
+          name = FastlaneCore::ConfigItem.new(key: :name)
+          platform = FastlaneCore::ConfigItem.new(key: :platform)
+          other = FastlaneCore::ConfigItem.new(key: :other)
+
+          config = FastlaneCore::Configuration.create([name, other, platform], {})
+          config.set(:name, "name1")
+          config.set(:other, "other")
+          config.pop_values!
+
+          expect(config.fetch(:name)).to eq("name1")
+          expect(config.fetch(:other)).to eq("other")
+        end
       end
 
       describe "Automatically removes the --verbose flag" do

--- a/fastlane_core/spec/fixtures/ConfigFileForLane
+++ b/fastlane_core/spec/fixtures/ConfigFileForLane
@@ -6,8 +6,14 @@ end
 
 for_platform "ios" do
   app_identifier "com.forplatform.ios"
-  
+
   for_lane "release" do
     app_identifier "com.forplatformios.forlanerelease"
+    app_identifier "com.forplatformios.ignored"
+  end
+
+  for_lane "explode" do
+    app_identifier "com.forplatformios.boom"
+    raise "oh noes!"
   end
 end

--- a/fastlane_core/spec/fixtures/ConfigFileForLane
+++ b/fastlane_core/spec/fixtures/ConfigFileForLane
@@ -1,0 +1,13 @@
+app_identifier "com.global.id"
+
+for_lane "enterprise" do
+  app_identifier "com.forlane.enterprise"
+end
+
+for_platform "ios" do
+  app_identifier "com.forplatform.ios"
+  
+  for_lane "release" do
+    app_identifier "com.forplatformios.forlanerelease"
+  end
+end

--- a/fastlane_core/spec/fixtures/ConfigFileRepeatedValueSet
+++ b/fastlane_core/spec/fixtures/ConfigFileRepeatedValueSet
@@ -1,0 +1,2 @@
+app_identifier 'the.expected.value'
+app_identifier 'the.ignored.value'

--- a/fastlane_core/spec/fixtures/ConfigFileRepeatedValueSet
+++ b/fastlane_core/spec/fixtures/ConfigFileRepeatedValueSet
@@ -1,2 +1,0 @@
-app_identifier 'the.expected.value'
-app_identifier 'the.ignored.value'


### PR DESCRIPTION
A continuation of work on #6549 

This reconciles the new configuration blocks (`for_lane`, `for_platform`) and their desire to be able to override configuration values, with the existing rules about "first assignment wins" for configurations.

It does this by having the new configuration blocks create a fresh configuration context every time you enter one. This way, each block gets a fresh application of the "first assignment wins" rule. As each block exits, any values set during the block are merged with any configuration context that was present at the time the block started. Thus, we can override values in these blocks, but only once, and still build a single comprehensive configuration!

This is supported with new `push_values!` and `pop_values!` methods on `Configuration`

If we like the solution, we can always add documentation as a follow-up.

/cc @maschall 