### PR TITLE
Better errors when reading build settings fail

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -241,8 +241,12 @@ module FastlaneCore
     end
 
     def supported_platforms
-      supported_platforms = build_settings(key: "SUPPORTED_PLATFORMS").split
-      supported_platforms.map do |platform|
+      supported_platforms = build_settings(key: "SUPPORTED_PLATFORMS")
+      if supported_platforms.nil?
+        UI.important("Could not read the \"SUPPORTED_PLATFORMS\" build setting, assuming that the project supports iOS only.")
+        return [:iOS]
+      end
+      supported_platforms.split.map do |platform|
         case platform
         when "macosx" then :macOS
         when "iphonesimulator", "iphoneos" then :iOS

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -288,6 +288,9 @@ module FastlaneCore
           timeout = FastlaneCore::Project.xcode_build_settings_timeout
           retries = FastlaneCore::Project.xcode_build_settings_retries
           @build_settings = FastlaneCore::Project.run_command(command, timeout: timeout, retries: retries, print: !self.xcodebuild_list_silent)
+          if @build_settings.empty?
+            UI.error("Could not read build settings. Make sure that the scheme \"#{options[:scheme]}\" is configured for running by going to Product → Scheme → Edit Scheme…, selecting the \"Build\" section, checking the \"Run\" checkbox and closing the scheme window.")
+          end
         rescue Timeout::Error
           UI.crash!("xcodebuild -showBuildSettings timed-out after #{timeout} seconds and #{retries} retries." \
             " You can override the timeout value with the environment variable FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT," \

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -16,7 +16,7 @@ module FastlaneCore
     end
 
     # Level Important: Can be used to show warnings to the user
-    #   not necessarly negative, but something the user should
+    #   not necessarily negative, but something the user should
     #   be aware of.
     #
     #   By default those messages are shown in yellow


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if neccessary.

### Description
* Display the following error when the build settings can't be read at all:
```
Could not read build settings. Make sure that the scheme "MyScheme" is configured for running by going to Product → Scheme → Edit Scheme…, selecting the "Build" section, checking the "Run" checkbox and closing the scheme window.
```

* Display the following warning when the `SUPPORTED_PLATFORMS` build setting can't be read: 
```
Could not read the "SUPPORTED_PLATFORMS" build setting, assuming that the project supports iOS only.
```

### Motivation and Context
#6925 changed the way the platform is detected, potentially leading to crashes as described in #7682. This pull request restores the old behavior of assuming the iOS platform if the build settings can't be read.