### PR TITLE
Update README.md

### DIFF
--- a/snapshot/README.md
+++ b/snapshot/README.md
@@ -154,7 +154,7 @@ XCUIApplication *app = [[XCUIApplication alloc] init];
 [app launch];
 ```
 
-_Make sure you only have one `launch` call, as Xcode adds one automatically on new test files._
+_Make sure you only have one `launch` call in your test class, as Xcode adds one automatically on new test files._
 
 ![assets/snapshot.gif](assets/snapshot.gif)
 

--- a/snapshot/README.md
+++ b/snapshot/README.md
@@ -154,6 +154,8 @@ XCUIApplication *app = [[XCUIApplication alloc] init];
 [app launch];
 ```
 
+_Make sure you only have one `launch` call, as Xcode adds one automatically on new test files._
+
 ![assets/snapshot.gif](assets/snapshot.gif)
 
 You can try the _snapshot_ [example project](https://github.com/fastlane/fastlane/tree/master/snapshot/example) by cloning this repo.


### PR DESCRIPTION
Add harmless warning that prevents Snapshot from failing.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if neccessary.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Xcode adds a `launch` call when you create a new test file. So to prevent Snapshot failing for users that are not accustomed to unit tests, this adds a warning.
<!--- If it fixes an open issue, please link to the issue here. -->
 Fixes #5781.
<!--- Please describe in detail how you tested your changes. --->
