### PR TITLE
Search for dotenvs in either fastlane's or current dir

### DIFF
--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -162,8 +162,12 @@ module Fastlane
     end
 
     def self.load_dot_env(env)
-      base_path = FastlaneCore::FastlaneFolder.path || '.'
-      return if Dir.glob(File.join(base_path, '*.env*'), File::FNM_DOTMATCH).count == 0
+      # search for dotenvs in either fastlane or the current dir
+      search_paths = [FastlaneCore::FastlaneFolder.path, '.'].compact
+      base_path = search_paths.find do |dir|
+        Dir.glob(File.join(dir, '*.env*'), File::FNM_DOTMATCH).count > 0
+      end
+      return unless base_path
       require 'dotenv'
 
       Actions.lane_context[Actions::SharedValues::ENVIRONMENT] = env if env


### PR DESCRIPTION
This should allow the .env files to be located one level up the fastlane directory (as requested by @KrauseFx  in #7810) and partially solve #7072

**Details**

this has been merged, but I would be happy if someone could get some more eyes on it.

My goal was to have our dotenvs in the parent directory of fastlane. Today we have links so that they work properly, but this is not fun to maintain at all. This parent directory is the current directory when it comes to running fastlane.

My understanding is that it was requested (#7072) and it was maybe a regression (#7810). I couldn't confirm that this feature was working before. I made the following test project
```
$ cat .env 
BUILD_VERSION=1.0.2
$ cat Gemfile
ruby "2.2.4"
source 'https://rubygems.org'

gem 'fastlane', "2.7.0"
$ cat fastlane/Fastfile 
lane :test do
  UI.message("BUILD_VERSION: #{ENV['BUILD_VERSION']}")
end

$ bundle install
...
$ bundle exec fastlane test
[07:22:25]: Driving the lane 'test' 🚀
[07:22:25]: BUILD_VERSION: 
[07:22:25]: fastlane.tools finished successfully 🎉
```

and tested with various versions (1.80, 2.2.0, 2.6.0, 2.7.0. 2.8.0) and couldn't see any version that displays the environment variable. I checked the dotenv code as well and it didn't change since 2015 until the performance fixes in the past weeks.

The drawbacks I can see in my change
* it could affect people who had no dotenv under fastlane folder before, but a dotenv in the current directory. Their dotenv might now be loaded.
* is that it will only find it if the dotenvs are in the current directory.
If you run the command from within the `fastlane` directory, then the dotenv in the parent aren't read
* one could instead want to load explicitly from fastlane's parent instead of current, which might be more consistent/repeatable

Note that if you had dotenvs in both fastlane folder and current, only fastlane's are loaded.

I am happy to add tests if needed, but would like to have some feedback on the change.