### PR TITLE
setup_jenkins: mark keychain_password as sensitive and mask it on output

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/setup_jenkins.rb
@@ -26,6 +26,7 @@ module Fastlane
         # Print table
         FastlaneCore::PrintTable.print_values(
           config: params,
+          mask_keys: [:keychain_password],
           title: "Summary for Setup Jenkins Action"
         )
 
@@ -133,6 +134,7 @@ module Fastlane
                                        env_name: "KEYCHAIN_PASSWORD",
                                        description: "Keychain password",
                                        is_string: true,
+                                       sensitive: true,
                                        default_value: ""),
 
           # Code signing identity

--- a/fastlane/lib/fastlane/actions/setup_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/setup_jenkins.rb
@@ -26,7 +26,6 @@ module Fastlane
         # Print table
         FastlaneCore::PrintTable.print_values(
           config: params,
-          mask_keys: [:keychain_password],
           title: "Summary for Setup Jenkins Action"
         )
 


### PR DESCRIPTION
sets the option :keychain_password to sensitive.
reported by: https://github.com/fastlane/fastlane/issues/7879

![bildschirmfoto 2017-01-16 um 16 00 48](https://cloud.githubusercontent.com/assets/2891702/21987793/28922196-dc05-11e6-90ea-27d386e54824.png)


requires this PR: https://github.com/fastlane/fastlane/pull/7881 to mask sensitive options