### PR TITLE
mask all sensitive options by default when printing summary table

### DIFF
--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -10,6 +10,12 @@ module FastlaneCore
         options = {}
         unless config.nil?
           if config.kind_of?(FastlaneCore::Configuration)
+            # find sensitive options and mask them by default
+            config.available_options.each do |config_item|
+              if config_item.sensitive
+                mask_keys << config_item.key.to_s
+              end
+            end
             options = config.values(ask: false)
           else
             options = config


### PR DESCRIPTION
mask all sensitive options when printing summary tables.
required in: https://github.com/fastlane/fastlane/pull/7880

![bildschirmfoto 2017-01-16 um 16 00 48](https://cloud.githubusercontent.com/assets/2891702/21987793/28922196-dc05-11e6-90ea-27d386e54824.png)