### PR TITLE
Spaceship access Xcode managed profiles

### DIFF
--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -249,13 +249,13 @@ module Spaceship
         # @return (Array) Returns all profiles registered for this account
         #  If you're calling this from a subclass (like AdHoc), this will
         #  only return the profiles that are of this type
-        def all(mac: false)
+        def all(mac: false, xcode: false)
           profiles = client.provisioning_profiles(mac: mac).map do |profile|
             self.factory(profile)
           end
 
           # filter out the profiles managed by xcode
-          profiles.delete_if(&:managed_by_xcode?)
+          profiles.delete_if(&:managed_by_xcode?) unless xcode
 
           return profiles if self == ProvisioningProfile
 

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -249,6 +249,8 @@ module Spaceship
         # @return (Array) Returns all profiles registered for this account
         #  If you're calling this from a subclass (like AdHoc), this will
         #  only return the profiles that are of this type
+        # @param mac (Bool) (optional): Pass true to get all Mac provisioning profiles
+        # @param xcode (Bool) (optional): Pass true to include Xcode managed provisioning profiles
         def all(mac: false, xcode: false)
           profiles = client.provisioning_profiles(mac: mac).map do |profile|
             self.factory(profile)

--- a/spaceship/spec/portal/fixtures/listProvisioningProfiles.action.plist
+++ b/spaceship/spec/portal/fixtures/listProvisioningProfiles.action.plist
@@ -187,6 +187,174 @@
             <string>2</string>
             <key>dateExpire</key>
             <date>2015-11-25T22:45:50Z</date>
+            <key>managingApp</key>
+            <string>Xcode</string>
+            <key>appId</key>
+            <dict>
+               <key>appIdId</key>
+               <string>572XTN75U2</string>
+               <key>name</key>
+               <string>Broken SunGolf</string>
+               <key>appIdPlatform</key>
+               <string>ios</string>
+               <key>prefix</key>
+               <string>5A997XSHK2</string>
+               <key>identifier</key>
+               <string>net.sunapps.7</string>
+               <key>isWildCard</key>
+               <false />
+               <key>isDuplicate</key>
+               <false />
+               <key>features</key>
+               <dict>
+                  <key>push</key>
+                  <true />
+                  <key>iCloud</key>
+                  <false />
+                  <key>inAppPurchase</key>
+                  <true />
+                  <key>gameCenter</key>
+                  <true />
+                  <key>LPLF93JG7M</key>
+                  <false />
+                  <key>passbook</key>
+                  <false />
+                  <key>IAD53UNK2F</key>
+                  <false />
+                  <key>V66P55NK2I</key>
+                  <false />
+                  <key>dataProtection</key>
+                  <string />
+                  <key>SKC3T5S89Y</key>
+                  <false />
+                  <key>APG3427HIY</key>
+                  <false />
+                  <key>HK421J6T7P</key>
+                  <false />
+                  <key>homeKit</key>
+                  <false />
+                  <key>WC421J6T7P</key>
+                  <false />
+                  <key>cloudKitVersion</key>
+                  <integer>1</integer>
+               </dict>
+               <key>enabledFeatures</key>
+               <array>
+                  <string>gameCenter</string>
+                  <string>inAppPurchase</string>
+                  <string>push</string>
+               </array>
+               <key>isDevPushEnabled</key>
+               <false />
+               <key>isProdPushEnabled</key>
+               <false />
+            </dict>
+            <key>appIdId</key>
+            <string>572XTN75U2</string>
+         </dict>
+         <dict>
+            <key>provisioningProfileId</key>
+            <string>FB8594WWQG</string>
+            <key>name</key>
+            <string>net.sunapps.7 AdHoc</string>
+            <key>status</key>
+            <string>Active</string>
+            <key>type</key>
+            <string>iOS Distribution</string>
+            <key>distributionMethod</key>
+            <string>store</string>
+            <key>proProPlatform</key>
+            <string>ios</string>
+            <key>UUID</key>
+            <string>a8b1563e-7559-41f7-854b-6cd09f950d11</string>
+            <key>version</key>
+            <string>2</string>
+            <key>dateExpire</key>
+            <date>2015-11-25T22:45:50Z</date>
+            <key>managingApp</key>
+            <string>Xcode</string>
+            <key>appId</key>
+            <dict>
+               <key>appIdId</key>
+               <string>572XTN75U2</string>
+               <key>name</key>
+               <string>Broken SunGolf</string>
+               <key>appIdPlatform</key>
+               <string>ios</string>
+               <key>prefix</key>
+               <string>5A997XSHK2</string>
+               <key>identifier</key>
+               <string>net.sunapps.7</string>
+               <key>isWildCard</key>
+               <false />
+               <key>isDuplicate</key>
+               <false />
+               <key>features</key>
+               <dict>
+                  <key>push</key>
+                  <true />
+                  <key>iCloud</key>
+                  <false />
+                  <key>inAppPurchase</key>
+                  <true />
+                  <key>gameCenter</key>
+                  <true />
+                  <key>LPLF93JG7M</key>
+                  <false />
+                  <key>passbook</key>
+                  <false />
+                  <key>IAD53UNK2F</key>
+                  <false />
+                  <key>V66P55NK2I</key>
+                  <false />
+                  <key>dataProtection</key>
+                  <string />
+                  <key>SKC3T5S89Y</key>
+                  <false />
+                  <key>APG3427HIY</key>
+                  <false />
+                  <key>HK421J6T7P</key>
+                  <false />
+                  <key>homeKit</key>
+                  <false />
+                  <key>WC421J6T7P</key>
+                  <false />
+                  <key>cloudKitVersion</key>
+                  <integer>1</integer>
+               </dict>
+               <key>enabledFeatures</key>
+               <array>
+                  <string>gameCenter</string>
+                  <string>inAppPurchase</string>
+                  <string>push</string>
+               </array>
+               <key>isDevPushEnabled</key>
+               <false />
+               <key>isProdPushEnabled</key>
+               <false />
+            </dict>
+            <key>appIdId</key>
+            <string>572XTN75U2</string>
+         </dict>
+         <dict>
+            <key>provisioningProfileId</key>
+            <string>FB8594WWQG</string>
+            <key>name</key>
+            <string>net.sunapps.7 AdHoc</string>
+            <key>status</key>
+            <string>Active</string>
+            <key>type</key>
+            <string>iOS Distribution</string>
+            <key>distributionMethod</key>
+            <string>store</string>
+            <key>proProPlatform</key>
+            <string>ios</string>
+            <key>UUID</key>
+            <string>a8b1563e-7559-41f7-854b-6cd09f950d11</string>
+            <key>version</key>
+            <string>2</string>
+            <key>dateExpire</key>
+            <date>2015-11-25T22:45:50Z</date>
             <key>appId</key>
             <dict>
                <key>appIdId</key>

--- a/spaceship/spec/provisioning_profile_spec.rb
+++ b/spaceship/spec/provisioning_profile_spec.rb
@@ -39,6 +39,18 @@ describe Spaceship::ProvisioningProfile do
       profile = provisioning_profiles.first
       expect(profile.app).to be_instance_of(Spaceship::App)
     end
+
+    describe "include managed by Xcode" do
+      it 'filters Xcode managed profiles' do
+        provisioning_profiles = Spaceship::ProvisioningProfile.all(xcode: false)
+        expect(provisioning_profiles.count).to eq(3) # ignore the Xcode generated profiles
+      end
+
+      it 'includes Xcode managed profiles' do
+        provisioning_profiles = Spaceship::ProvisioningProfile.all(xcode: true)
+        expect(provisioning_profiles.count).to eq(5) # include the Xcode generated profiles
+      end
+    end
   end
 
   describe '#find_by_bundle_id' do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Added an optional parameter to `Spaceship::ProvisioningProfile.all` labeled `xcode` that stops the filtering of Xcode managed profiles. Default is `false` so behaviour before this change is the same.

### Motivation and Context
Spaceship `all` always filters out Xcode managed profiles #7885

- [ ] Need help writing tests
