### PR TITLE
CONTINUE: Added support for providing utf flag to xcpretty via gym/xcodebuild

### DIFF
--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -426,7 +426,7 @@ module Fastlane
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
           ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
-          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specif    ied.']
+          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specified.']
         ]
       end
     end
@@ -472,7 +472,7 @@ module Fastlane
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
           ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
-          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specif    ied.']
+          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specified.']
         ]
       end
     end
@@ -518,7 +518,7 @@ module Fastlane
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
           ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
-          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specif    ied.']
+          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specified.']
         ]
       end
     end
@@ -560,7 +560,7 @@ module Fastlane
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
           ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
-          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specif    ied.']
+          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specified.']
         ]
       end
 
@@ -610,7 +610,7 @@ module Fastlane
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
           ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
-          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specif    ied.']
+          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specified.']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -106,13 +106,10 @@ module Fastlane
           archiving    = params.key? :archive
           exporting    = params.key? :export_archive
           testing      = params.key? :test
+          xcpretty_utf = params[:xcpretty_utf]
 
           if params.key? :raw_buildlog
             raw_buildlog = params[:raw_buildlog]
-          end
-
-          if params.key? :xcpretty_utf
-            xcpretty_utf = params[:xcpretty_utf]
           end
 
           if exporting
@@ -255,7 +252,9 @@ module Fastlane
 
         xcpretty_command = ""
         xcpretty_command = "| xcpretty #{xcpretty_args}" unless raw_buildlog
-        xcpretty_command = "#{xcpretty_command} --utf" unless raw_buildlog || !xcpretty_utf
+        unless raw_buildlog
+          xcpretty_command = "#{xcpretty_command} --utf" if xcpretty_utf
+        end
 
         pipe_command = "| tee '#{buildlog_path}/xcodebuild.log' #{xcpretty_command}"
 

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -98,6 +98,9 @@ module Fastlane
         # By default we use xcpretty
         raw_buildlog = false
 
+        # By default we don't pass the utf flag
+        xcpretty_utf = false
+
         if params
           # Operation bools
           archiving    = params.key? :archive
@@ -106,6 +109,10 @@ module Fastlane
 
           if params.key? :raw_buildlog
             raw_buildlog = params[:raw_buildlog]
+          end
+
+          if params.key? :xcpretty_utf
+            xcpretty_utf = params[:xcpretty_utf]
           end
 
           if exporting
@@ -248,6 +255,7 @@ module Fastlane
 
         xcpretty_command = ""
         xcpretty_command = "| xcpretty #{xcpretty_args}" unless raw_buildlog
+        xcpretty_command = "#{xcpretty_command} --utf" unless raw_buildlog || !xcpretty_utf
 
         pipe_command = "| tee '#{buildlog_path}/xcodebuild.log' #{xcpretty_command}"
 
@@ -365,7 +373,8 @@ module Fastlane
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
-          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\'']
+          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
+          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specified.']
         ]
       end
 
@@ -417,7 +426,8 @@ module Fastlane
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
-          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\'']
+          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
+          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specif    ied.']
         ]
       end
     end
@@ -462,7 +472,8 @@ module Fastlane
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
-          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\'']
+          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
+          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specif    ied.']
         ]
       end
     end
@@ -507,7 +518,8 @@ module Fastlane
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
-          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\'']
+          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
+          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specif    ied.']
         ]
       end
     end
@@ -548,7 +560,8 @@ module Fastlane
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
-          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\'']
+          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
+          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specif    ied.']
         ]
       end
 
@@ -597,7 +610,8 @@ module Fastlane
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
-          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\'']
+          ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
+          ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specif    ied.']
         ]
       end
 

--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -71,6 +71,7 @@ module Gym
           pipe << " --no-color" if Helper.colors_disabled?
           pipe << " --formatter " if formatter
           pipe << formatter if formatter
+          pipe << "--utf" if Gym.config[:xcpretty_utf]
           report_output_junit = Gym.config[:xcpretty_report_junit]
           report_output_html = Gym.config[:xcpretty_report_html]
           report_output_json = Gym.config[:xcpretty_report_json]

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -248,7 +248,12 @@ module Gym
                                      optional: true,
                                      verify_block: proc do |value|
                                        UI.user_error!("Report output location not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
-                                     end)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :xcpretty_utf,
+                                     env_name: "XCPRETTY_UTF",
+                                     description: "Have xcpretty use unicode encoding when reporting builds",
+                                     optional: true,
+                                     is_string: false)
       ]
     end
   end

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -68,6 +68,33 @@ describe Gym do
                            ])
     end
 
+    it "enables unicode" do
+      log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
+
+      xcargs_hash = { DEBUG: "1", BUNDLE_NAME: "Example App" }
+      xcargs = xcargs_hash.map do |k, v|
+        "#{k.to_s.shellescape}=#{v.shellescape}"
+      end.join ' '
+      options = { project: "./gym/examples/standard/Example.xcodeproj", sdk: "9.0", xcargs: xcargs, scheme: 'Example', xcpretty_utf: true }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      result = Gym::BuildCommandGenerator.generate
+      expect(result).to eq([
+                             "set -o pipefail &&",
+                             "xcodebuild",
+                             "-scheme Example",
+                             "-project ./gym/examples/standard/Example.xcodeproj",
+                             "-sdk '9.0'",
+                             "-destination 'generic/platform=iOS'",
+                             "-archivePath #{Gym::BuildCommandGenerator.archive_path.shellescape}",
+                             "DEBUG=1 BUNDLE_NAME=Example\\ App",
+                             :archive,
+                             "| tee #{log_path.shellescape}",
+                             "| xcpretty",
+                             "--utf"
+                           ])
+    end
+
     describe "Standard Example" do
       before do
         options = { project: "./gym/examples/standard/Example.xcodeproj", scheme: 'Example' }


### PR DESCRIPTION
continuation of: https://github.com/fastlane/fastlane/pull/7659
rebased master, commits preserved.


original-PR body:

-----------

This change adds support for passing the 'utf' flag to xcpretty, which is useful when you don't have strict control over your bash environment to apply the usual encoding fix in .profile.

-----------

/cc @mfurtak @mgrebenets @lyptt 

