### PR TITLE
releases: markup the issue links in the slack release

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -109,12 +109,15 @@ lane :release do
   # After publishing
   #
   if ENV['SLACK_URL']
+    release_notes = github_release['body']
+    # markup - turn github references into links
+    release_notes.gsub!(/\(#([0-9]+)\)/, '(<https://github.com/fastlane/fastlane/issues/\1|#\1>)')
     slack(
       channel: "releases",
       default_payloads: [],
       message: "Successfully released [fastlane #{version}](#{release_url}) :rocket:",
       payload: {
-        "New" => github_release['body']
+        "New" => release_notes
       }
     )
   end


### PR DESCRIPTION
I tested it like this:

```ruby
cat fastlane/Fastfile 
fastlane_version "2.8.0"

lane :test do
  if ENV['SLACK_URL']
    release_notes = File.read 'notes.txt'
    # markup - turn github references into links
    release_notes.gsub!(/\(#([0-9]+)\)/, '(<https://github.com/fastlane/fastlane/issues/\1|#\1>)')
    slack(
      channel: "experiments",
      default_payloads: [],
      message: "Test :rocket:",
      payload: {
        "New" => release_notes
      }
    )
  end
end
```

and a release_notes like this one:
```
* fix `hockey` action without `dsa_signature` (#7875)
* for_lane, for_platform blocks in configurations (#7859)
* Search for dotenvs in either fastlane's or current dir (#7872)
* Add spinning fastlane wheel (#7477)
* Enable --verbose during --capture_output (#7851)
* Deprecated actions will display deprecated notes in actions list, action info, while running, and in docs (#7609)
* Reveal underlying error when decoding provisioning profile fails due to broken keychain environment (#7558)
* Escape title of application for .plist and .plist url in `s3` action (#7565)
* Print a message explaining how to quickly open links on macOS (#7832)
* Add `xcodeproj` param to `set_build_number_repository` action (#7860)
* Fix for multiple tasks in single command in `gradle` action (#7845)
* mark `keychain_password` as sensitive in `setup_jenkins` action (#7880)
* Add json file validation to supply and deliver (#7878)
* [scan] Add support to copy simulator device logs to output directory (#7804)
* [screengrab] AAR version bump (#7840)
* [sigh] If the "force" option is specified, delete and recreate any matching profiles (even invalid ones) (#6518)  
```

results in

![image](https://cloud.githubusercontent.com/assets/24282/22036712/b7bab564-dcf4-11e6-87e2-bea1932ec7da.png)
