### PR TITLE
Update process around merging PRs

### DIFF
--- a/CORE_CONTRIBUTOR.md
+++ b/CORE_CONTRIBUTOR.md
@@ -11,7 +11,8 @@ Contributors who have displayed lasting commitment to the evolution and maintena
 
 
 ## As core contributors, we:
-- Review and merge pull requests
+- Review pull requests
+- Merge pull requests we review, except for PRs where the author has commit access. Commit access is noted in Github with the `Member` tag
 - Respond to issues and help others
 - Own regressions caused by our own contributions and PR approvals
 - Maintain consistent coding standards

--- a/CORE_CONTRIBUTOR.md
+++ b/CORE_CONTRIBUTOR.md
@@ -11,8 +11,8 @@ Contributors who have displayed lasting commitment to the evolution and maintena
 
 
 ## As core contributors, we:
-- Review pull requests
-- Merge pull requests we review, except for PRs where the author has push access. Push access to _fastlane_ repos is noted in Github with the `Member` tag
+- Review pull requests using the "Review Changes" feature in Github
+- Merge pull requests we review, except for PRs where the author has push access. Push access to _fastlane_ repos is noted in Github with the `Member` tag. Merge PRs using the "Squash and Merge" feature in Github
 - Respond to issues and help others
 - Own regressions caused by our own contributions and PR approvals
 - Maintain consistent coding standards

--- a/CORE_CONTRIBUTOR.md
+++ b/CORE_CONTRIBUTOR.md
@@ -12,7 +12,7 @@ Contributors who have displayed lasting commitment to the evolution and maintena
 
 ## As core contributors, we:
 - Review pull requests
-- Merge pull requests we review, except for PRs where the author has commit access. Commit access is noted in Github with the `Member` tag
+- Merge pull requests we review, except for PRs where the author has push access. Push access to _fastlane_ repos is noted in Github with the `Member` tag
 - Respond to issues and help others
 - Own regressions caused by our own contributions and PR approvals
 - Maintain consistent coding standards


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
If you review a PR that is submitted by someone with a `Member` tag, they should merge it themselves. Otherwise that PR should be merged for them.
![image](https://cloud.githubusercontent.com/assets/1848683/22040790/33cef8a4-dcd2-11e6-9631-bac80e3ba962.png)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Codify our process around merging PRs
