### PR TITLE
Parametrize ARGV to remove spurious warnings while running tests

### DIFF
--- a/fastlane/spec/cli_tools_distributor_spec.rb
+++ b/fastlane/spec/cli_tools_distributor_spec.rb
@@ -2,21 +2,19 @@ require 'fastlane/cli_tools_distributor'
 
 describe Fastlane::CLIToolsDistributor do
   it "runs the lane instead of the tool when there is a conflict" do
-    FastlaneSpec::Env.with_ARGV(["sigh"]) do
-      require 'fastlane/commands_generator'
-      expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
-      expect(Fastlane::CommandsGenerator).to receive(:start).and_return(nil)
-      Fastlane::CLIToolsDistributor.take_off
-    end
+    FastlaneSpec::Env.with_ARGV(["sigh"])
+    require 'fastlane/commands_generator'
+    expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
+    expect(Fastlane::CommandsGenerator).to receive(:start).and_return(nil)
+    Fastlane::CLIToolsDistributor.take_off
   end
 
   it "runs a separate tool when the tool is available and the name is not used in a lane" do
-    FastlaneSpec::Env.with_ARGV(["gym"]) do
-      require 'gym/options'
-      require 'gym/commands_generator'
-      expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
-      expect(Gym::CommandsGenerator).to receive(:start).and_return(nil)
-      Fastlane::CLIToolsDistributor.take_off
-    end
+    FastlaneSpec::Env.with_ARGV(["gym"])
+    require 'gym/options'
+    require 'gym/commands_generator'
+    expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
+    expect(Gym::CommandsGenerator).to receive(:start).and_return(nil)
+    Fastlane::CLIToolsDistributor.take_off
   end
 end

--- a/fastlane/spec/cli_tools_distributor_spec.rb
+++ b/fastlane/spec/cli_tools_distributor_spec.rb
@@ -2,19 +2,21 @@ require 'fastlane/cli_tools_distributor'
 
 describe Fastlane::CLIToolsDistributor do
   it "runs the lane instead of the tool when there is a conflict" do
-    ARGV = ["sigh"]
-    require 'fastlane/commands_generator'
-    expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
-    expect(Fastlane::CommandsGenerator).to receive(:start).and_return(nil)
-    Fastlane::CLIToolsDistributor.take_off
+    FastlaneSpec::Env.with_ARGV(["sigh"]) do
+      require 'fastlane/commands_generator'
+      expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
+      expect(Fastlane::CommandsGenerator).to receive(:start).and_return(nil)
+      Fastlane::CLIToolsDistributor.take_off
+    end
   end
 
   it "runs a separate tool when the tool is available and the name is not used in a lane" do
-    ARGV = ["gym"]
-    require 'gym/options'
-    require 'gym/commands_generator'
-    expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
-    expect(Gym::CommandsGenerator).to receive(:start).and_return(nil)
-    Fastlane::CLIToolsDistributor.take_off
+    FastlaneSpec::Env.with_ARGV(["gym"]) do
+      require 'gym/options'
+      require 'gym/commands_generator'
+      expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
+      expect(Gym::CommandsGenerator).to receive(:start).and_return(nil)
+      Fastlane::CLIToolsDistributor.take_off
+    end
   end
 end

--- a/fastlane/spec/spec_helper_spec.rb
+++ b/fastlane/spec/spec_helper_spec.rb
@@ -1,0 +1,38 @@
+describe FastlaneSpec::Env do
+  # rubocop:disable Style/VariableName
+  describe "#with_ARGV" do
+    it "temporarily overrides the ARGV values under normal usage" do
+      current_ARGV = ARGV.dup
+      temp_ARGV = ['temp_inside']
+      block_ARGV = nil
+      FastlaneSpec::Env.with_ARGV(temp_ARGV) do
+        block_ARGV = ARGV.dup
+      end
+      expect(block_ARGV).to eq(temp_ARGV)
+      expect(ARGV).to eq(current_ARGV)
+    end
+
+    it "restores ARGV values even if fails in block" do
+      current_ARGV = ARGV.dup
+      begin
+        FastlaneSpec::Env.with_ARGV(['temp_inside']) do
+          raise "BOU"
+        end
+        fail("should not reach here")
+      rescue
+      end
+      expect(ARGV).to eq(current_ARGV)
+    end
+
+    it "sets ARGV for good if no block is given" do
+      current_ARGV = ARGV.dup
+      new_ARGV = ['forever']
+      FastlaneSpec::Env.with_ARGV(new_ARGV)
+      expect(ARGV).to eq(new_ARGV)
+      # reset...
+      FastlaneSpec::Env.with_ARGV(current_ARGV)
+      expect(ARGV).to eq(current_ARGV)
+    end
+  end
+  # rubocop:enable Style/VariableName
+end

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -105,13 +105,15 @@ describe FastlaneCore do
 
       describe "#platform" do
         it "ios" do
-          ARGV = ["--app_identifier", "yolo.app"]
-          expect(FastlaneCore::UpdateChecker.generate_fetch_url("sigh")).to eq("https://fastlane-refresher.herokuapp.com/sigh?p_hash=52629c9a0eebe49c58db83c94c090bd790a101ff2a70ab9514f6a6427644375a&platform=ios")
+          FastlaneSpec::Env.with_ARGV(["--app_identifier", "yolo.app"]) do
+            expect(FastlaneCore::UpdateChecker.generate_fetch_url("sigh")).to eq("https://fastlane-refresher.herokuapp.com/sigh?p_hash=52629c9a0eebe49c58db83c94c090bd790a101ff2a70ab9514f6a6427644375a&platform=ios")
+          end
         end
 
         it "android" do
-          ARGV = ["--app_package_name", "yolo.android.app"]
-          expect(FastlaneCore::UpdateChecker.generate_fetch_url("supply")).to eq("https://fastlane-refresher.herokuapp.com/supply?p_hash=6a8b842e4a75d2a2bc4bdf584406a68eab8cabcc7b7a396c283b390fff30b59b&platform=android")
+          FastlaneSpec::Env.with_ARGV(["--app_package_name", "yolo.android.app"]) do
+            expect(FastlaneCore::UpdateChecker.generate_fetch_url("supply")).to eq("https://fastlane-refresher.herokuapp.com/supply?p_hash=6a8b842e4a75d2a2bc4bdf584406a68eab8cabcc7b7a396c283b390fff30b59b&platform=android")
+          end
         end
       end
     end

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -41,3 +41,26 @@ RSpec.configure do |config|
 
   config.example_status_persistence_file_path = "/tmp/rspec_failed_tests.txt"
 end
+
+module FastlaneSpec
+  module Env
+    # a wrapper to temporarily modify the values of ARGV to
+    # avoid errors like: "warning: already initialized constant ARGV"
+    # if no block is given, modifies ARGV for good
+    # rubocop:disable Style/MethodName
+    def self.with_ARGV(argv)
+      copy = ARGV.dup
+      ARGV.clear
+      ARGV.concat(argv)
+      if block_given?
+        begin
+          yield
+        ensure
+          ARGV.clear
+          ARGV.concat(copy)
+        end
+      end
+    end
+    # rubocop:enable Style/MethodName
+  end
+end


### PR DESCRIPTION
I hate it when the output is like this:

![image](https://cloud.githubusercontent.com/assets/24282/22089413/54a042e4-ddeb-11e6-8db0-95df7f6748c1.png)

Found a much cleaner way