### PR TITLE
Add reinstall_app config to screengrab to uninstall the APKs before run it

### DIFF
--- a/screengrab/lib/screengrab/options.rb
+++ b/screengrab/lib/screengrab/options.rb
@@ -112,7 +112,11 @@ module Screengrab
         FastlaneCore::ConfigItem.new(key: :exit_on_test_failure,
                                      env_name: 'EXIT_ON_TEST_FAILURE',
                                      description: "Whether or not to exit Screengrab on test failure. Exiting on failure will not copy sceenshots to local machine nor open sceenshots summary",
-                                     default_value: true)
+                                     default_value: true),
+        FastlaneCore::ConfigItem.new(key: :reinstall_app,
+                                     env_name: 'SCREENGRAB_REINSTALL_APP',
+                                     description: "Enabling this option will automatically uninstall the application before running it",
+                                     default_value: false)
       ]
     end
   end

--- a/screengrab/spec/runner_spec.rb
+++ b/screengrab/spec/runner_spec.rb
@@ -19,7 +19,7 @@ describe Screengrab::Runner do
       .and_return(mock_response)
   end
 
-  describe :run_tests do
+  describe :run_tests_for_locale do
     let(:device_serial) { 'device_serial' }
     let(:test_classes_to_use) { nil }
     let(:test_packages_to_use) { nil }
@@ -34,7 +34,7 @@ describe Screengrab::Runner do
         # expect(FastlaneCore::CommandExecutor).to receive(:execute).with(/hjanuschka/)
         expect(mock_executor).to receive(:execute)
           .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e username hjanuschka -e build_type x500 \\\n/"))
-        @runner.run_tests(device_serial, test_classes_to_use, test_packages_to_use, config[:launch_arguments])
+        @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, config[:launch_arguments])
       end
     end
 
@@ -57,7 +57,7 @@ describe Screengrab::Runner do
           it 'prints an error and exits the program' do
             expect(ui).to receive(:user_error!).with("Tests failed", show_github_issues: false).and_call_original
 
-            expect { @runner.run_tests(device_serial, test_classes_to_use, test_packages_to_use, nil) }.to raise_fastlane_error
+            expect { @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, nil) }.to raise_fastlane_error
           end
         end
 
@@ -69,7 +69,7 @@ describe Screengrab::Runner do
           it 'prints an error and does not exit the program' do
             expect(ui).to receive(:error).with("Tests failed").and_call_original
 
-            @runner.run_tests(device_serial, test_classes_to_use, test_packages_to_use, nil)
+            @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, nil)
           end
         end
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Adds config to screengrab called `reinstall_app` to uninstall APKs before running tests for each `locale` configured in the `Screengrabfile`.

### Motivation and Context
We have some configurations that are set the first time that the app runs and is locale bound. Even if we change the language of the device, most of the configurations are already set by the first run and will never change.

Following the configurations of iOS' `Snapshot`, that already features this configuration, we believe that it would be a good addition to `Screengrab` to have that as well.
