### PR TITLE
Add sensitive ConfigItem for sonar_login

### DIFF
--- a/fastlane/lib/fastlane/actions/sonar.rb
+++ b/fastlane/lib/fastlane/actions/sonar.rb
@@ -18,6 +18,7 @@ module Fastlane
         sonar_scanner_args << "-Dsonar.sources=\"#{params[:sources_path]}\"" if params[:sources_path]
         sonar_scanner_args << "-Dsonar.language=\"#{params[:project_language]}\"" if params[:project_language]
         sonar_scanner_args << "-Dsonar.sourceEncoding=\"#{params[:source_encoding]}\"" if params[:source_encoding]
+        sonar_scanner_args << "-Dsonar.login=\"#{params[:sonar_login]}\"" if params[:sonar_login]
         sonar_scanner_args << params[:sonar_runner_args] if params[:sonar_runner_args]
 
         command = [
@@ -25,8 +26,8 @@ module Fastlane
           'sonar-scanner',
           sonar_scanner_args
         ].join(' ')
-
-        Action.sh command
+        # hide command, as it may contain credentials
+        Fastlane::Actions.sh_control_output(command, print_command: false, print_command_output: true)
       end
 
       def self.verify_sonar_scanner_binary
@@ -84,7 +85,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :sonar_runner_args,
                                        env_name: "FL_SONAR_RUNNER_ARGS",
                                        description: "Pass additional arguments to sonar-scanner. Be sure to provide the arguments with a leading `-D` e.g. FL_SONAR_RUNNER_ARGS=\"-Dsonar.verbose=true\"",
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :sonar_login,
+                                       env_name: "FL_SONAR_LOGIN",
+                                       description: "Pass the Sonar Login token (e.g: xxxxxxprivate_token_XXXXbXX7e)",
+                                       optional: true,
+                                       is_string: true,
+                                       sensitive: true)
         ]
       end
 

--- a/fastlane/spec/actions_specs/sonar_spec.rb
+++ b/fastlane/spec/actions_specs/sonar_spec.rb
@@ -1,0 +1,14 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Sonar Integration" do
+      it "Should not print sonar command" do
+        expected_command = "cd /Users/hja/Desktop/SPORTPORTAL/fastlane && sonar-scanner -Dsonar.login=\"asdf\""
+        expect(Fastlane::Actions::SonarAction).to receive(:verify_sonar_scanner_binary).and_return(true)
+        expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: true).and_call_original
+        Fastlane::FastFile.new.parse("lane :sonar_test do
+          sonar(sonar_login: 'asdf')
+        end").runner.execute(:sonar_test)
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/sonar_spec.rb
+++ b/fastlane/spec/actions_specs/sonar_spec.rb
@@ -2,7 +2,7 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Sonar Integration" do
       it "Should not print sonar command" do
-        expected_command = "cd /Users/hja/Desktop/SPORTPORTAL/fastlane && sonar-scanner -Dsonar.login=\"asdf\""
+        expected_command = "cd #{File.expand_path('.').shellescape} && sonar-scanner -Dsonar.login=\"asdf\""
         expect(Fastlane::Actions::SonarAction).to receive(:verify_sonar_scanner_binary).and_return(true)
         expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: true).and_call_original
         Fastlane::FastFile.new.parse("lane :sonar_test do


### PR DESCRIPTION
hide executed command (as it may contain credentials).
and add special option for login token.

fixes: https://github.com/fastlane/fastlane/issues/7937