### PR TITLE
Support loading multiple dotenvs

### DIFF
--- a/fastlane/docs/FAQs.md
+++ b/fastlane/docs/FAQs.md
@@ -90,6 +90,9 @@ lane :deploy_all do
 end
 ```
 
+And you can combine multiple envs in one go
+Ex: `fastlane build --env app1,env1,env2` will use `.env.app1` `.env.env1` and `.env.env2`
+
 More on the `.env` file can be found [here](https://github.com/bkeepers/dotenv).
 
 ### Disable colored output

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -98,7 +98,7 @@ module Fastlane
       command :trigger do |c|
         c.syntax = 'fastlane [lane]'
         c.description = 'Run a specific lane. Pass the lane name and optionally the platform first.'
-        c.option '--env STRING', String, 'Add environment to use with `dotenv`'
+        c.option '--env STRING[,STRING2]', String, 'Add environment(s) to use with `dotenv`'
 
         c.action do |args, options|
           if ensure_fastfile

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -161,16 +161,29 @@ module Fastlane
       end
     end
 
-    def self.load_dot_env(envs)
-      # find the first directory of [fastlane, its parent] containing dotenv files
+    # @param env_cl_param [String] an optional list of dotenv environment names separated by commas, without space
+    def self.load_dot_env(env_cl_param)
+      base_path = find_dotenv_directory
+
+      return unless base_path
+
+      load_dot_envs_from(env_cl_param, base_path)
+    end
+
+    # finds the first directory of [fastlane, its parent] containing dotenv files
+    def self.find_dotenv_directory
       path = FastlaneCore::FastlaneFolder.path
       search_paths = [path]
       search_paths << path + "/.." unless path.nil?
       search_paths.compact!
-      base_path = search_paths.find do |dir|
+      search_paths.find do |dir|
         Dir.glob(File.join(dir, '*.env*'), File::FNM_DOTMATCH).count > 0
       end
-      return unless base_path
+    end
+
+    # loads the dotenvs. First the .env and .env.default and
+    # then override with all speficied extra environments
+    def self.load_dot_envs_from(env_cl_param, base_path)
       require 'dotenv'
 
       # Making sure the default '.env' and '.env.default' get loaded
@@ -178,21 +191,22 @@ module Fastlane
       env_default_file = File.join(base_path, '.env.default')
       Dotenv.load(env_file, env_default_file)
 
-      return unless envs
+      return unless env_cl_param
 
-      envs = envs.split(",") # multiple envs?
+      Actions.lane_context[Actions::SharedValues::ENVIRONMENT] = env_cl_param
 
-      Actions.lane_context[Actions::SharedValues::ENVIRONMENT] = envs
+      # multiple envs?
+      envs = env_cl_param.split(",")
 
       # Loads .env file for the environment(s) passed in through options
-      envs = [envs] unless envs.kind_of? Array
-
       envs.each do |env|
         env_file = File.join(base_path, ".env.#{env}")
         UI.success "Loading from '#{env_file}'"
         Dotenv.overload(env_file)
       end
     end
+
+    private_class_method :find_dotenv_directory, :load_dot_envs_from
 
     def self.print_lane_context
       return if Actions.lane_context.empty?

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -173,23 +173,24 @@ module Fastlane
       return unless base_path
       require 'dotenv'
 
-      envs = envs.split(",") if envs # multiple envs?
-
-      Actions.lane_context[Actions::SharedValues::ENVIRONMENT] = envs if envs
-
       # Making sure the default '.env' and '.env.default' get loaded
       env_file = File.join(base_path, '.env')
       env_default_file = File.join(base_path, '.env.default')
       Dotenv.load(env_file, env_default_file)
 
-      # Loads .env file for the environment passed in through options
-      if envs
-        envs = [envs] unless envs.kind_of? Array
-        envs.each do |env|
-          env_file = File.join(base_path, ".env.#{env}")
-          UI.success "Loading from '#{env_file}'"
-          Dotenv.overload(env_file)
-        end
+      return unless envs
+
+      envs = envs.split(",") # multiple envs?
+
+      Actions.lane_context[Actions::SharedValues::ENVIRONMENT] = envs
+
+      # Loads .env file for the environment(s) passed in through options
+      envs = [envs] unless envs.kind_of? Array
+
+      envs.each do |env|
+        env_file = File.join(base_path, ".env.#{env}")
+        UI.success "Loading from '#{env_file}'"
+        Dotenv.overload(env_file)
       end
     end
 

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -161,7 +161,7 @@ module Fastlane
       end
     end
 
-    def self.load_dot_env(env)
+    def self.load_dot_env(envs)
       # find the first directory of [fastlane, its parent] containing dotenv files
       path = FastlaneCore::FastlaneFolder.path
       search_paths = [path]
@@ -173,7 +173,9 @@ module Fastlane
       return unless base_path
       require 'dotenv'
 
-      Actions.lane_context[Actions::SharedValues::ENVIRONMENT] = env if env
+      envs = envs.split(",") if envs # multiple envs?
+
+      Actions.lane_context[Actions::SharedValues::ENVIRONMENT] = envs if envs
 
       # Making sure the default '.env' and '.env.default' get loaded
       env_file = File.join(base_path, '.env')
@@ -181,10 +183,13 @@ module Fastlane
       Dotenv.load(env_file, env_default_file)
 
       # Loads .env file for the environment passed in through options
-      if env
-        env_file = File.join(base_path, ".env.#{env}")
-        UI.success "Loading from '#{env_file}'"
-        Dotenv.overload(env_file)
+      if envs
+        envs = [envs] unless envs.kind_of? Array
+        envs.each do |env|
+          env_file = File.join(base_path, ".env.#{env}")
+          UI.success "Loading from '#{env_file}'"
+          Dotenv.overload(env_file)
+        end
       end
     end
 

--- a/fastlane/spec/fixtures/dotenvs/multiple/fastlane/.env.one
+++ b/fastlane/spec/fixtures/dotenvs/multiple/fastlane/.env.one
@@ -1,0 +1,1 @@
+DOTENV1=one

--- a/fastlane/spec/fixtures/dotenvs/multiple/fastlane/.env.two
+++ b/fastlane/spec/fixtures/dotenvs/multiple/fastlane/.env.two
@@ -1,0 +1,2 @@
+DOTENV1=two
+DOTENV2=two

--- a/fastlane/spec/lane_manager_spec.rb
+++ b/fastlane/spec/lane_manager_spec.rb
@@ -14,53 +14,60 @@ describe Fastlane do
 
       describe "dotenv" do
         it "Finds the dotenv in the parent" do
-          ensure_dot_env_value_from_fastlane_or_parent('withFastfiles/parentonly', 'parent')
-          ensure_dot_env_value_from_parent_only('withoutFastfiles/parentonly', 'parent')
+          ensure_dot_env_value_from_fastlane_or_parent('withFastfiles/parentonly', nil, { DOTENV: 'parent' })
+          ensure_dot_env_value_from_parent_only('withoutFastfiles/parentonly', nil, { DOTENV: 'parent' })
         end
 
         it "Finds the dotenv in the fastlane dir" do
-          ensure_dot_env_value_from_fastlane_or_parent('withFastfiles/fastlaneonly', 'fastlane')
-          ensure_dot_env_value_from_parent_only('withoutFastfiles/fastlaneonly', 'fastlane')
+          ensure_dot_env_value_from_fastlane_or_parent('withFastfiles/fastlaneonly', nil, { DOTENV: 'fastlane' })
+          ensure_dot_env_value_from_parent_only('withoutFastfiles/fastlaneonly', nil, { DOTENV: 'fastlane' })
         end
 
         it "Finds the dotenv in the fastlane dir when in both parent and fastlane" do
-          ensure_dot_env_value_from_fastlane_or_parent('withFastfiles/parentandfastlane', 'fastlane')
-          ensure_dot_env_value_from_parent_only('withoutFastfiles/parentandfastlane', 'fastlane')
+          ensure_dot_env_value_from_fastlane_or_parent('withFastfiles/parentandfastlane', nil, { DOTENV: 'fastlane' })
+          ensure_dot_env_value_from_parent_only('withoutFastfiles/parentandfastlane', nil, { DOTENV: 'fastlane' })
         end
 
         it "Doesn't find dotenv when not running in a parent of fastlane folder" do
-          ensure_dot_env_value_from_parent_only('elsewhere', nil)
+          ensure_dot_env_value_from_parent_only('elsewhere', nil, { DOTENV: nil })
+        end
+
+        it "Supports multiple envs, and loads them in the specified order" do
+          ensure_dot_env_value_from_fastlane_or_parent('multiple', "one,two", { DOTENV1: 'two', DOTENV2: 'two' })
         end
 
         # this method ensures that the .env file contains the expected value
         # when reading it from either fastlane or its parent
         # the fastlane folders should contain a Fastfile
-        def ensure_dot_env_value_from_fastlane_or_parent(parent_dir, expected_value)
+        def ensure_dot_env_value_from_fastlane_or_parent(parent_dir, envs, expected_values)
           project_dir = File.absolute_path('./fastlane/spec/fixtures/dotenvs/' + parent_dir)
           fastlane_dir = File.absolute_path(project_dir + '/fastlane')
-          # current limitation in FastlaneFolder.
-          allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
-          [project_dir, fastlane_dir].each do |dir|
-            ENV.delete('DOTENV')
-            Dir.chdir(dir) do
-              ff = Fastlane::LaneManager.load_dot_env(nil)
-              expect(ENV['DOTENV']).to eq(expected_value)
-            end
-          end
+          ensure_dot_env_value_from_folders([project_dir, fastlane_dir], envs, expected_values)
         end
 
         # this method ensures that the .env file contains the expected value
         # when reading it from fastlane's parent only.
         # the fastlane folders shouldn't contain a Fastfile
-        def ensure_dot_env_value_from_parent_only(parent_dir, expected_value)
+        def ensure_dot_env_value_from_parent_only(parent_dir, envs, expected_values)
           project_dir = File.absolute_path('./fastlane/spec/fixtures/dotenvs/' + parent_dir)
+          ensure_dot_env_value_from_folders([project_dir], envs, expected_values)
+        end
+
+        def ensure_dot_env_value_from_folders(folders, envs, expected_values)
           # current limitation in FastlaneFolder.
           allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
-          [project_dir].each do |dir|
-            ENV.delete('DOTENV')
+          folders.each do |dir|
+            expected_values.each do |k, v|
+              ENV.delete(k.to_s)
+            end
             Dir.chdir(dir) do
-              ff = Fastlane::LaneManager.load_dot_env(nil)
-              expect(ENV['DOTENV']).to eq(expected_value)
+              ff = Fastlane::LaneManager.load_dot_env(envs)
+              ENV.each do |k, v|
+                puts "#{k} = #{v}"
+              end
+              expected_values.each do |k, v|
+                expect(ENV[k.to_s]).to eq(v)
+              end
             end
           end
         end

--- a/fastlane/spec/lane_manager_spec.rb
+++ b/fastlane/spec/lane_manager_spec.rb
@@ -62,9 +62,6 @@ describe Fastlane do
             end
             Dir.chdir(dir) do
               ff = Fastlane::LaneManager.load_dot_env(envs)
-              ENV.each do |k, v|
-                puts "#{k} = #{v}"
-              end
               expected_values.each do |k, v|
                 expect(ENV[k.to_s]).to eq(v)
               end


### PR DESCRIPTION
Things I am a bit unsure of:

* do we want to rename `--env` into `--envs`
* `Actions.lane_context[Actions::SharedValues::ENVIRONMENT]`  should a new one be added with an array? should the original one keep the CSV passed on the CL?
* documentation