### PR TITLE
[scan] Add support for thread sanitizer

### DIFF
--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -29,6 +29,7 @@ module Fastlane
         destination_timeout: "-destination-timeout",
         dry_run: "-dry-run",
         enableAddressSanitizer: "-enableAddressSanitizer",
+        enableThreadSanitizer: "-enableThreadSanitizer",
         enableCodeCoverage: "-enableCodeCoverage",
         export_archive: "-exportArchive",
         export_format: "-exportFormat",
@@ -150,6 +151,9 @@ module Fastlane
 
           if params.key? :enable_address_sanitizer
             params[:enableAddressSanitizer] = params[:enable_address_sanitizer] ? 'YES' : 'NO'
+          end
+          if params.key? :enable_thread_sanitizer
+            params[:enableThreadSanitizer] = params[:enable_thread_sanitizer] ? 'YES' : 'NO'
           end
           if params.key? :enable_code_coverage
             params[:enableCodeCoverage] = params[:enable_code_coverage] ? 'YES' : 'NO'

--- a/fastlane/spec/actions_specs/xcodebuild_spec.rb
+++ b/fastlane/spec/actions_specs/xcodebuild_spec.rb
@@ -27,6 +27,7 @@ describe Fastlane do
             destination_timeout: 240,
             dry_run: true,
             enable_address_sanitizer: true,
+            enable_thread_sanitizer: false,
             enable_code_coverage: true,
             export_archive: true,
             export_format: 'ipa',
@@ -65,7 +66,7 @@ describe Fastlane do
           "-hideShellScriptEnvironment -jobs \"5\" -parallelizeTargets OTHER_CODE_SIGN_FLAGS=\"--keychain /path/to/My.keychain\" -project " \
           "\"MyApp.xcodeproj\" -resultBundlePath \"/result/bundle/path\" -scheme \"MyApp\" -sdk \"iphonesimulator\" -skipUnavailableActions -target " \
           "\"MyAppTarget\" -toolchain \"toolchain name\" -workspace \"MyApp.xcworkspace\" -xcconfig \"my.xcconfig\" -newArgument YES -enableAddressSanitizer " \
-          "\"YES\" -enableCodeCoverage \"YES\" | tee 'mypath/xcodebuild.log' | xcpretty --color --test"
+          "\"YES\" -enableThreadSanitizer \"NO\" -enableCodeCoverage \"YES\" | tee 'mypath/xcodebuild.log' | xcpretty --color --test"
         )
       end
 
@@ -442,57 +443,109 @@ describe Fastlane do
       end
     end
 
-    # describe "address sanitizer" do
-    #   it "address sanitizer is enabled" do
-    #     result = Fastlane::FastFile.new.parse("lane :test do
-    #       xctest(
-    #         destination: 'name=iPhone 5s,OS=8.1',
-    #         destination_timeout: 240,
-    #         scheme: 'MyApp',
-    #         workspace: 'MyApp.xcworkspace',
-    #         enable_address_sanitizer: true
-    #       )
-    #     end").runner.execute(:test)
+    describe "address sanitizer" do
+      it "address sanitizer is enabled" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          xctest(
+            destination: 'name=iPhone 5s,OS=8.1',
+            destination_timeout: 240,
+            scheme: 'MyApp',
+            workspace: 'MyApp.xcworkspace',
+            enable_address_sanitizer: true
+          )
+        end").runner.execute(:test)
 
-    #     expect(result).to eq(
-    #       "set -o pipefail && " \
-    #       + "xcodebuild " \
-    #       + "-destination \"name=iPhone 5s,OS=8.1\" " \
-    #       + "-destination-timeout \"240\" " \
-    #       + "-enableAddressSanitizer \"YES\" " \
-    #       + "-scheme \"MyApp\" " \
-    #       + "-workspace \"MyApp.xcworkspace\" " \
-    #       + "build " \
-    #       + "test " \
-    #       + "| tee '#{build_log_path}' | xcpretty --color --test"
-    #     )
-    #   end
+        expect(result).to eq(
+          "set -o pipefail && " \
+          + "xcodebuild " \
+          + "-destination \"name=iPhone 5s,OS=8.1\" " \
+          + "-destination-timeout \"240\" " \
+          + "-scheme \"MyApp\" " \
+          + "-workspace \"MyApp.xcworkspace\" " \
+          + "build " \
+          + "test " \
+          + "-enableAddressSanitizer \"YES\" " \
+          + "| tee '#{build_log_path}' | xcpretty --color --test"
+        )
+      end
 
-    #   it "address sanitizer is disabled" do
-    #     result = Fastlane::FastFile.new.parse("lane :test do
-    #       xctest(
-    #         destination: 'name=iPhone 5s,OS=8.1',
-    #         destination_timeout: 240,
-    #         scheme: 'MyApp',
-    #         workspace: 'MyApp.xcworkspace',
-    #         enable_address_sanitizer: false
-    #       )
-    #     end").runner.execute(:test)
+      it "address sanitizer is disabled" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          xctest(
+            destination: 'name=iPhone 5s,OS=8.1',
+            destination_timeout: 240,
+            scheme: 'MyApp',
+            workspace: 'MyApp.xcworkspace',
+            enable_address_sanitizer: false
+          )
+        end").runner.execute(:test)
 
-    #     expect(result).to eq(
-    #       "set -o pipefail && " \
-    #       + "xcodebuild " \
-    #       + "-destination \"name=iPhone 5s,OS=8.1\" " \
-    #       + "-destination-timeout \"240\" " \
-    #       + "-enableAddressSanitizer \"NO\" " \
-    #       + "-scheme \"MyApp\" " \
-    #       + "-workspace \"MyApp.xcworkspace\" " \
-    #       + "build " \
-    #       + "test " \
-    #       + "| tee '#{build_log_path}' | xcpretty --color --test"
-    #     )
-    #   end
-    # end
+        expect(result).to eq(
+          "set -o pipefail && " \
+          + "xcodebuild " \
+          + "-destination \"name=iPhone 5s,OS=8.1\" " \
+          + "-destination-timeout \"240\" " \
+          + "-scheme \"MyApp\" " \
+          + "-workspace \"MyApp.xcworkspace\" " \
+          + "build " \
+          + "test " \
+          + "-enableAddressSanitizer \"NO\" " \
+          + "| tee '#{build_log_path}' | xcpretty --color --test"
+        )
+      end
+    end
+
+    describe "thread sanitizer" do
+      it "thread sanitizer is enabled" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          xctest(
+            destination: 'name=iPhone 5s,OS=8.1',
+            destination_timeout: 240,
+            scheme: 'MyApp',
+            workspace: 'MyApp.xcworkspace',
+            enable_thread_sanitizer: true
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq(
+          "set -o pipefail && " \
+          + "xcodebuild " \
+          + "-destination \"name=iPhone 5s,OS=8.1\" " \
+          + "-destination-timeout \"240\" " \
+          + "-scheme \"MyApp\" " \
+          + "-workspace \"MyApp.xcworkspace\" " \
+          + "build " \
+          + "test " \
+          + "-enableThreadSanitizer \"YES\" " \
+          + "| tee '#{build_log_path}' | xcpretty --color --test"
+        )
+      end
+
+      it "thread sanitizer is disabled" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          xctest(
+            destination: 'name=iPhone 5s,OS=8.1',
+            destination_timeout: 240,
+            scheme: 'MyApp',
+            workspace: 'MyApp.xcworkspace',
+            enable_thread_sanitizer: false
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq(
+          "set -o pipefail && " \
+          + "xcodebuild " \
+          + "-destination \"name=iPhone 5s,OS=8.1\" " \
+          + "-destination-timeout \"240\" " \
+          + "-scheme \"MyApp\" " \
+          + "-workspace \"MyApp.xcworkspace\" " \
+          + "build " \
+          + "test " \
+          + "-enableThreadSanitizer \"NO\" " \
+          + "| tee '#{build_log_path}' | xcpretty --color --test"
+        )
+      end
+    end
 
     describe "test code coverage" do
       it "code coverage is enabled" do

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -63,11 +63,23 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :code_coverage,
                                      description: "Should generate code coverage (Xcode 7 only)?",
                                      is_string: false,
-                                     default_value: false),
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :address_sanitizer,
                                      description: "Should turn on the address sanitizer?",
                                      is_string: false,
-                                     default_value: false),
+                                     optional: true,
+                                     conflicting_options: [:thread_sanitizer],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("You can't use 'address_sanitizer' and 'thread_sanitizer' options in one run")
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :thread_sanitizer,
+                                     description: "Should turn on the thread sanitizer?",
+                                     is_string: false,
+                                     optional: true,
+                                     conflicting_options: [:address_sanitizer],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("You can't use 'thread_sanitizer' and 'address_sanitizer' options in one run")
+                                     end),
         FastlaneCore::ConfigItem.new(key: :skip_build,
                                      description: "Should skip debug build before test build?",
                                      short_option: "-r",

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -35,8 +35,9 @@ module Scan
         options << destination # generated in `detect_values`
         options << "-derivedDataPath '#{config[:derived_data_path]}'" if config[:derived_data_path]
         options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
-        options << "-enableCodeCoverage YES" if config[:code_coverage]
-        options << "-enableAddressSanitizer YES" if config[:address_sanitizer]
+        options << "-enableCodeCoverage #{config[:code_coverage] ? 'YES' : 'NO'}" unless config[:code_coverage].nil?
+        options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
+        options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?
         options << "-xcconfig '#{config[:xcconfig]}'" if config[:xcconfig]
         options << config[:xcargs] if config[:xcargs]
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Add support for thread sanitizer
- Thread sanitizer can't be enabled together with address sanitizer
- Thread sanitizer is available only for Swift 3.x and above projects
  - We don't need to handle that though, xcodebuild will do it for us and xcpretty will parse the error

### Motivation and Context
It's a new feature as requested in #7945
