### PR TITLE
Add shellcheck to circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,10 @@ machine:
   xcode:
     version: "7.3"
 dependencies:
+  pre:
+    - brew install shellcheck
   override:
-    - bundle install --jobs=4 --retry=3
+    - bundle install --jobs=4 --retry=3    
 test:
   pre:
     - ulimit -n 400

--- a/circle.yml
+++ b/circle.yml
@@ -14,4 +14,4 @@ test:
   override:
     - bundle exec rspec -r rspec_junit_formatter --format progress --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec/junit.xml
     - bundle exec rubocop
-    - find -E . -regex ".*\.(sh|bash)" -exec shellcheck {} +
+    - find -E . -regex ".*\.(sh|bash)" -not -name "Pods-*" -exec shellcheck {} +

--- a/circle.yml
+++ b/circle.yml
@@ -7,10 +7,11 @@ dependencies:
   pre:
     - brew install shellcheck
   override:
-    - bundle install --jobs=4 --retry=3    
+    - bundle install --jobs=4 --retry=3
 test:
   pre:
     - ulimit -n 400
   override:
     - bundle exec rspec -r rspec_junit_formatter --format progress --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec/junit.xml
     - bundle exec rubocop
+    - find -E . -regex ".*\.(sh|bash)" -exec shellcheck {} +

--- a/fastlane/lib/assets/completions/completion.bash
+++ b/fastlane/lib/assets/completions/completion.bash
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 _fastlane_complete() {
   COMPREPLY=()
   local word="${COMP_WORDS[COMP_CWORD]}"

--- a/fastlane/lib/assets/completions/completion.bash
+++ b/fastlane/lib/assets/completions/completion.bash
@@ -15,7 +15,7 @@ _fastlane_complete() {
   fi
 
   # parse 'beta' out of 'lane :beta do', etc
-  completions=`cat $file | grep "^\s*lane \:" | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}'`
+  completions=$(grep "^\s*lane \:" $file | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}')
 
   COMPREPLY=( $(compgen -W "$completions" -- "$word") )
 }

--- a/fastlane/lib/assets/completions/completion.sh
+++ b/fastlane/lib/assets/completions/completion.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2155
 if [ -n "$BASH_VERSION" ]; then
   source ~/.fastlane/completions/completion.bash
 

--- a/fastlane/lib/assets/completions/completion.sh
+++ b/fastlane/lib/assets/completions/completion.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 # shellcheck disable=SC2155
-if [ -n "$BASH_VERSION" ]; then
-  source ~/.fastlane/completions/completion.bash
+# shellcheck disable=SC1090
 
+if [ -n "$BASH_VERSION" ]; then
+  . ~/.fastlane/completions/completion.bash
 elif [ -n "$ZSH_VERSION" ]; then
-  source ~/.fastlane/completions/completion.zsh
+  . ~/.fastlane/completions/completion.zsh
 fi
 
 # Do not remove v0.0.1

--- a/fastlane/lib/assets/completions/completion.sh
+++ b/fastlane/lib/assets/completions/completion.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 # shellcheck disable=SC2155
 # shellcheck disable=SC1090
+# shellcheck disable=SC2039
 
 if [ -n "$BASH_VERSION" ]; then
-  . ~/.fastlane/completions/completion.bash
+  source ~/.fastlane/completions/completion.bash
 elif [ -n "$ZSH_VERSION" ]; then
-  . ~/.fastlane/completions/completion.zsh
+  source ~/.fastlane/completions/completion.zsh
 fi
 
 # Do not remove v0.0.1

--- a/fastlane/lib/assets/completions/completion.zsh
+++ b/fastlane/lib/assets/completions/completion.zsh
@@ -1,3 +1,5 @@
+#!/bin/zsh
+
 _fastlane_complete() {
   local word completions
   word="$1"

--- a/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
+++ b/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
@@ -1,5 +1,6 @@
 #!/bin/bash --login
 # shellcheck disable=SC2155
+# shellcheck disable=SC1090
 
 # Originally from, https://stackoverflow.com/questions/33041109
 # Modified to work in RVM and non RVM environments

--- a/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
+++ b/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
@@ -23,6 +23,7 @@
 # -----
 
 which rvm > /dev/null
+# shellcheck disable=SC2181
 if [[ $? -eq 0 ]]; then
   echo "RVM detected, forcing to use system ruby"
   # This allows you to use rvm in a script. Otherwise you get a BS

--- a/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
+++ b/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
@@ -1,4 +1,5 @@
 #!/bin/bash --login
+# shellcheck disable=SC2155
 
 # Originally from, https://stackoverflow.com/questions/33041109
 # Modified to work in RVM and non RVM environments

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -309,6 +309,7 @@ export PATH=$PATH:/usr/libexec
 # The first one may contain the wildcard character '*', in which case pattern matching will be used unless the third parameter is "STRICT"
 function does_bundle_id_match {
 
+    # shellcheck disable=SC2049
     if [[ "$1" == "$2" ]]; then
         return 0
     elif [[ "$3" != STRICT && "$1" =~ \* ]]; then
@@ -427,6 +428,7 @@ function resign {
 
     # Use provisioning profile's bundle identifier
     if [ "$BUNDLE_IDENTIFIER" == "" ]; then
+        # shellcheck disable=SC2049
         if [[ "$PROVISION_BUNDLE_IDENTIFIER" =~ \* ]]; then
             log "Bundle Identifier contains a *, using the current bundle identifier"
             BUNDLE_IDENTIFIER="$CURRENT_BUNDLE_IDENTIFIER"
@@ -556,7 +558,7 @@ function resign {
 
     # Check for and update bundle identifiers for extensions and associated nested apps
     log "Fixing nested app and extension references"
-    for key in ${NESTED_APP_REFERENCE_KEYS[@]}; do
+    for key in "${NESTED_APP_REFERENCE_KEYS[@]}"; do
         # Check if Info.plist has a reference to another app or extension
         REF_BUNDLE_ID=`PlistBuddy -c "Print ${key}" "$APP_PATH/Info.plist" 2>/dev/null`
         if [ -n "$REF_BUNDLE_ID" ];
@@ -566,6 +568,7 @@ function resign {
             # Map to the new bundle id
             NEW_REF_BUNDLE_ID=`bundle_id_for_provison "$REF_PROVISION"`
             # Change if not the same and if doesn't contain wildcard
+            # shellcheck disable=SC2049
             if [[ "$REF_BUNDLE_ID" != "$NEW_REF_BUNDLE_ID" ]] && ! [[ "$NEW_REF_BUNDLE_ID" =~ \* ]];
             then
                 log "Updating nested app or extension reference for ${key} key from ${REF_BUNDLE_ID} to ${NEW_REF_BUNDLE_ID}"
@@ -671,7 +674,7 @@ function resign {
             "keychain-access-groups|APP_ID")
 
         # Loop over all the entitlement keys that need to be transferred from app entitlements
-        for RULE in ${ENTITLEMENTS_TRANSFER_RULES[@]}; do
+        for RULE in "${ENTITLEMENTS_TRANSFER_RULES[@]}"; do
             KEY=$(echo $RULE | cut -d'|' -f1)
             ID_TYPE=$(echo $RULE | cut -d'|' -f2)
 

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2155
 
 # Copyright (c) 2011 Float Mobile Learning
 # http://www.floatlearning.com/
@@ -224,7 +225,7 @@ then
 fi
 
 # Log the options
-for provision in ${RAW_PROVISIONS[@]}; do
+for provision in "${RAW_PROVISIONS[@]}"; do
     if [[ "$provision" =~ .+=.+ ]]; then
         log "Specified provisioning profile: '${provision#*=}' for bundle identifier: '${provision%%=*}'"
     else

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -746,7 +746,7 @@ function resign {
         )
 
         # Blacklisted keys must not be included into new profile, so remove them from patched profile
-        for KEY in ${BLACKLISTED_KEYS[@]}; do
+        for KEY in "${BLACKLISTED_KEYS[@]}"; do
             log "Removing blacklisted key: $KEY"
             PlistBuddy -c "Delete $KEY" "$PATCHED_ENTITLEMENTS" 2>/dev/null
         done

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -87,7 +87,7 @@ function checkStatus {
 }
 
 usage() {
-    echo -e "Usage: $(basename $0) source identity -p|--provisioning provisioning" >&2
+    echo -e "Usage: $(basename "$0") source identity -p|--provisioning provisioning" >&2
     echo -e "\t\t[-e|--entitlements entitlements]" >&2
     echo -e "\t\t[-k|--keychain keychain]" >&2
     echo -e "\t\t[-d|--display-name displayName]" >&2
@@ -97,7 +97,7 @@ usage() {
     echo -e "\t\t[-b|--bundle-id bundleId]" >&2
     echo -e "\t\t[--use-app-entitlements]" >&2
     echo -e "\t\toutputIpa" >&2
-    echo "Usage: $(basename $0) -h|--help" >&2
+    echo "Usage: $(basename "$0") -h|--help" >&2
     echo "Options:" >&2
     echo -e "\t-p, --provisioning provisioning\t\tProvisioning profile option, may be provided multiple times." >&2
     echo -e "\t\t\t\t\t\tYou can specify provisioning profile file name." >&2
@@ -292,9 +292,9 @@ fi
 # check the keychain
 if [ "${KEYCHAIN}" != "" ];
 then
-    security list-keychains -s $KEYCHAIN
-    security unlock $KEYCHAIN
-    security default-keychain -s $KEYCHAIN
+    security list-keychains -s "$KEYCHAIN"
+    security unlock "$KEYCHAIN"
+    security default-keychain -s "$KEYCHAIN"
 fi
 
 # Set the app name
@@ -548,7 +548,7 @@ function resign {
         do
             if [[ "$framework" == *.framework || "$framework" == *.dylib ]]
             then
-                /usr/bin/codesign ${VERBOSE} ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" "$framework"
+                /usr/bin/codesign ${VERBOSE} "${KEYCHAIN_FLAG}" -f -s "$CERTIFICATE" "$framework"
                 checkStatus
             else
                 log "Ignoring non-framework: $framework"
@@ -564,7 +564,7 @@ function resign {
         if [ -n "$REF_BUNDLE_ID" ];
         then
             # Found a reference bundle id, now get the corresponding provisioning profile for this bundle id
-            REF_PROVISION=$(provision_for_bundle_id $REF_BUNDLE_ID)
+            REF_PROVISION=$(provision_for_bundle_id "$REF_BUNDLE_ID")
             # Map to the new bundle id
             NEW_REF_BUNDLE_ID=$(bundle_id_for_provison "$REF_PROVISION")
             # Change if not the same and if doesn't contain wildcard
@@ -675,8 +675,8 @@ function resign {
 
         # Loop over all the entitlement keys that need to be transferred from app entitlements
         for RULE in "${ENTITLEMENTS_TRANSFER_RULES[@]}"; do
-            KEY=$(echo $RULE | cut -d'|' -f1)
-            ID_TYPE=$(echo $RULE | cut -d'|' -f2)
+            KEY=$(echo "$RULE" | cut -d'|' -f1)
+            ID_TYPE=$(echo "$RULE" | cut -d'|' -f2)
 
             # Get the entry from app's entitlements
             # Read it with PlistBuddy as XML, then strip the header and <plist></plist> part
@@ -759,7 +759,7 @@ function resign {
         log "Resigning application using certificate: '$CERTIFICATE'"
         log "and entitlements from provisioning profile: $NEW_PROVISION"
         cp -- "$TEMP_DIR/newEntitlements" "$APP_PATH/archived-expanded-entitlements.xcent"
-        /usr/bin/codesign ${VERBOSE} ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" --entitlements "$TEMP_DIR/newEntitlements" "$APP_PATH"
+        /usr/bin/codesign ${VERBOSE} "${KEYCHAIN_FLAG}" -f -s "$CERTIFICATE" --entitlements "$TEMP_DIR/newEntitlements" "$APP_PATH"
         checkStatus
     fi
 

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -80,6 +80,7 @@ warning() {
 
 function checkStatus {
 
+    # shellcheck disable=SC2181
     if [ $? -ne 0 ];
     then
         error "Encountered an error, aborting!"

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -448,7 +448,7 @@ function resign {
         if [ "${DISPLAY_NAME}" != "${CURRENT_NAME}" ];
         then
             log "Changing display name from '$CURRENT_NAME' to '$DISPLAY_NAME'"
-            `PlistBuddy -c "Set :CFBundleDisplayName $DISPLAY_NAME" "$APP_PATH/Info.plist"`
+            PlistBuddy -c "Set :CFBundleDisplayName $DISPLAY_NAME" "$APP_PATH/Info.plist"
         fi
     fi
 
@@ -498,7 +498,7 @@ function resign {
     if [ "$CURRENT_BUNDLE_IDENTIFIER" != "$BUNDLE_IDENTIFIER" ];
     then
         log "Updating the bundle identifier from '$CURRENT_BUNDLE_IDENTIFIER' to '$BUNDLE_IDENTIFIER'"
-        `PlistBuddy -c "Set :CFBundleIdentifier $BUNDLE_IDENTIFIER" "$APP_PATH/Info.plist"`
+        PlistBuddy -c "Set :CFBundleIdentifier $BUNDLE_IDENTIFIER" "$APP_PATH/Info.plist"
         checkStatus
     fi
 
@@ -509,8 +509,8 @@ function resign {
         if [ "$VERSION_NUMBER" != "$CURRENT_VERSION_NUMBER" ];
         then
             log "Updating the version from '$CURRENT_VERSION_NUMBER' to '$VERSION_NUMBER'"
-            `PlistBuddy -c "Set :CFBundleVersion $VERSION_NUMBER" "$APP_PATH/Info.plist"`
-            `PlistBuddy -c "Set :CFBundleShortVersionString $VERSION_NUMBER" "$APP_PATH/Info.plist"`
+            PlistBuddy -c "Set :CFBundleVersion $VERSION_NUMBER" "$APP_PATH/Info.plist"
+            PlistBuddy -c "Set :CFBundleShortVersionString $VERSION_NUMBER" "$APP_PATH/Info.plist"
         fi
     fi
 
@@ -569,7 +569,7 @@ function resign {
             if [[ "$REF_BUNDLE_ID" != "$NEW_REF_BUNDLE_ID" ]] && ! [[ "$NEW_REF_BUNDLE_ID" =~ \* ]];
             then
                 log "Updating nested app or extension reference for ${key} key from ${REF_BUNDLE_ID} to ${NEW_REF_BUNDLE_ID}"
-                `PlistBuddy -c "Set ${key} $NEW_REF_BUNDLE_ID" "$APP_PATH/Info.plist"`
+                PlistBuddy -c "Set ${key} $NEW_REF_BUNDLE_ID" "$APP_PATH/Info.plist"
             fi
         fi
     done

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -301,7 +301,9 @@ fi
 # Set the app name
 # In Payload directory may be another file except .app file, such as StoreKit folder.
 # Search the first .app file within the Payload directory
-APP_NAME=$(ls "$TEMP_DIR/Payload/"|grep ".app$"| head -1)
+# TODO: Replace with glob or call to 'find'; and remove shellcheck directive
+# shellcheck disable=SC2010
+APP_NAME=$(ls "$TEMP_DIR/Payload/" | grep ".app$" | head -1)
 
 # Make sure that PATH includes the location of the PlistBuddy helper tool as its location is not standard
 export PATH=$PATH:/usr/libexec
@@ -696,6 +698,8 @@ function resign {
             # Add new entry to patched entitlements
             # plutil needs dots in the key path to be escaped (e.g. com\.apple\.security\.application-groups)
             # otherwise it interprets they key path as nested keys
+            # TODO: Should be able to replace with echo ${KEY//\./\\\\.} and remove shellcheck disable directive
+            # shellcheck disable=SC2001
             PLUTIL_KEY=$(echo "$KEY" | sed 's/\./\\\\./g')
             plutil -insert "$PLUTIL_KEY" -xml "$ENTITLEMENTS_VALUE" "$PATCHED_ENTITLEMENTS"
 
@@ -794,6 +798,8 @@ log "Repackaging as $NEW_FILE"
 # Zip all the contents, saving the zip file in the above directory
 # Navigate back to the orignating directory (sending the output to null)
 pushd "$TEMP_DIR" > /dev/null
+# TODO: Fix shellcheck warning and remove directive
+# shellcheck disable=SC2035
 zip -qry "../$TEMP_DIR.ipa" *
 popd > /dev/null
 

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -66,7 +66,7 @@
 log() {
     # Make sure it returns 0 code even when verose mode is off (test 1)
     # To use like [[ condition ]] && log "x" && something
-    [[ -n "$VERBOSE" ]] && echo -e "$@" || test 1
+    if [[ -n "$VERBOSE" ]]; then echo -e "$@"; else test 1; fi
 }
 
 error() {


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Add `shellckeck` utility to Circle CI setup.
Fix all shellcheck warnings and errors as well as "notes" (aka info level messages).
In some cases it was safer/preferable to disable warnings and add TODOs to address later.

### Motivation and Context
Add `shellckeck` step to validate and lint all shell scripts in the project.
This is not just about style, some of the warnings reported by `shellcheck` are indicators of serious issues and possible bugs, for example:

- Not using quotes around output can cause troubles when output has spaces



