### PR TITLE
Show appropriate error message when running tests without Xcode path being set

### DIFF
--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -7,6 +7,14 @@ WebMock.disable_net_connect!(allow: 'coveralls.io')
 require "fastlane"
 UI = FastlaneCore::UI
 
+unless FastlaneCore::Helper.xcode_path.include?("Contents/Developer")
+  UI.error("Seems like you didn't set the developer tools path correctly")
+  UI.error("Please run the following on your machine")
+  UI.command("sudo xcode-select -s /Applications/Xcode.app")
+  UI.error("Adapt the path if you have Xcode installed/named somewhere else")
+  exit(1)
+end
+
 # This module is only used to check the environment is currently a testing env
 module SpecHelper
 end

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -7,8 +7,10 @@ WebMock.disable_net_connect!(allow: 'coveralls.io')
 require "fastlane"
 UI = FastlaneCore::UI
 
-unless FastlaneCore::Helper.xcode_path.include?("Contents/Developer")
+xcode_path = FastlaneCore::Helper.xcode_path
+unless xcode_path.include?("Contents/Developer")
   UI.error("Seems like you didn't set the developer tools path correctly")
+  UI.error("Detected path '#{xcode_path}'") if xcode_path.to_s.length > 0
   UI.error("Please run the following on your machine")
   UI.command("sudo xcode-select -s /Applications/Xcode.app")
   UI.error("Adapt the path if you have Xcode installed/named somewhere else")


### PR DESCRIPTION
Until now the tests failed later on, which made it harder for people to get started

<img width="644" alt="screenshot 2017-01-21 15 22 52" src="https://cloud.githubusercontent.com/assets/869950/22178538/c22d2abc-dfed-11e6-89ac-51f180a40548.png">
