### PR TITLE
[Request for comment] Update gemspec to not support Ruby 2.4.0

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://fastlane.tools"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = ['>= 2.2.0', '< 2.4.0']
 
   spec.files = Dir.glob("*/lib/**/*", File::FNM_DOTMATCH) + Dir["bin/*"] + Dir["*/README.md"] + %w(README.md LICENSE) - Dir["fastlane/lib/fastlane/actions/device_grid/assets/*"]
   spec.bindir = "bin"


### PR DESCRIPTION
I was able to install fastlane in Ruby 2.4.0 using the source code, but I'm unsure if everything is fixed already. This should be merged if we really don't support 2.4.0

I'm not sure how to best test this tbh