### PR TITLE
Add support for --quiet option for swiftlint action

### DIFF
--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -18,7 +18,7 @@ module Fastlane
         command << supported_option_switch(params, :quiet, "0.9.0", true)
 
         if params[:files]
-          if version < Gem::Version.new('0.5.1') and !Helper.test?
+          if version < Gem::Version.new('0.5.1')
             UI.user_error!("Your version of swiftlint (#{version}) does not support list of files as input.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
           end
 
@@ -38,14 +38,14 @@ module Fastlane
 
       # Get current SwiftLint version
       def self.swiftlint_version
-        Gem::Version.new(Helper.test? ? '0.0.0' : `swiftlint version`.chomp)
+        Gem::Version.new(`swiftlint version`.chomp)
       end
 
       # Return "--option" switch if option is on and current SwiftLint version is greater or equal than min version.
       # Return "" otherwise.
       def self.supported_option_switch(params, option, min_version, can_ignore = false)
         return "" unless params[option]
-        if swiftlint_version < Gem::Version.new(min_version) and !Helper.test?
+        if swiftlint_version < Gem::Version.new(min_version)
           message = "Your version of swiftlint (#{swiftlint_version}) does not support '--#{option}' option.\nUpdate swiftlint to #{min_version} or above using `brew update && brew upgrade swiftlint`"
           message += "\nThe option will be ignored." if can_ignore
           can_ignore ? UI.important(message) : UI.user_error!(message)

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -6,15 +6,16 @@ module Fastlane
           UI.user_error!("You have to install swiftlint using `brew install swiftlint`")
         end
 
-        version = Gem::Version.new(Helper.test? ? '0.0.0' : `swiftlint version`.chomp)
+        version = swiftlint_version
         if params[:mode] == :autocorrect and version < Gem::Version.new('0.5.0') and !Helper.test?
           UI.user_error!("Your version of swiftlint (#{version}) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
         end
 
         command = "swiftlint #{params[:mode]}"
-        command << " --strict" if params[:strict]
+        command << supported_option_switch(params, :strict, "0.9.2", true)
         command << " --config #{params[:config_file].shellescape}" if params[:config_file]
         command << " --reporter #{params[:reporter]}" if params[:reporter]
+        command << supported_option_switch(params, :quiet, "0.9.0", true)
 
         if params[:files]
           if version < Gem::Version.new('0.5.1') and !Helper.test?
@@ -32,6 +33,25 @@ module Fastlane
           Actions.sh(command)
         rescue
           handle_swiftlint_error(params[:ignore_exit_status], $?.exitstatus)
+        end
+      end
+
+      # Get current SwiftLint version
+      def self.swiftlint_version
+        Gem::Version.new(Helper.test? ? '0.0.0' : `swiftlint version`.chomp)
+      end
+
+      # Return "--option" switch if option is on and current SwiftLint version is greater or equal than min version.
+      # Return "" otherwise.
+      def self.supported_option_switch(params, option, min_version, can_ignore = false)
+        return "" unless params[option]
+        if swiftlint_version < Gem::Version.new(min_version) and !Helper.test?
+          message = "Your version of swiftlint (#{swiftlint_version}) does not support '--#{option}' option.\nUpdate swiftlint to #{min_version} or above using `brew update && brew upgrade swiftlint`"
+          message += "\nThe option will be ignored." if can_ignore
+          can_ignore ? UI.important(message) : UI.user_error!(message)
+          ""
+        else
+          " --#{option}"
         end
       end
 
@@ -77,6 +97,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :reporter,
                                        description: 'Choose output reporter',
                                        is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :quiet,
+                                       description: "Don't print status logs like 'Linting <file>' & 'Done linting'",
+                                       default_value: false,
+                                       is_string: false,
                                        optional: true)
         ]
       end

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -188,6 +188,18 @@ describe Fastlane do
           expect(result).to eq("swiftlint lint --reporter json")
         end
       end
+
+      context "when specify quiet option" do
+        it "adds quiet option" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              quiet: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint --quiet")
+        end
+      end
     end
   end
 end

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -1,8 +1,13 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "SwiftLint" do
+      let (:swiftlint_gem_version) { Gem::Version.new('0.9.2') }
       let (:output_file) { "swiftlint.result.json" }
       let (:config_file) { ".swiftlint-ci.yml" }
+
+      before :each do
+        allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(swiftlint_gem_version)
+      end
 
       context "default use case" do
         it "default use case" do
@@ -14,7 +19,7 @@ describe Fastlane do
         end
       end
 
-      context "when specify strict options" do
+      context "when specify strict option" do
         it "adds strict option" do
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(
@@ -23,6 +28,18 @@ describe Fastlane do
           end").runner.execute(:test)
 
           expect(result).to eq("swiftlint lint --strict")
+        end
+      end
+
+      context "when specify false for strict option" do
+        it "doesn't add strict option" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              strict: false
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint")
         end
       end
 
@@ -198,6 +215,30 @@ describe Fastlane do
           end").runner.execute(:test)
 
           expect(result).to eq("swiftlint lint --quiet")
+        end
+
+        it "omits the switch if swiftlint version is too low" do
+          allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.8.0'))
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              quiet: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint")
+        end
+      end
+
+      context "when specify false for quiet option" do
+        it "doesn't add quiet option" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              quiet: false
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint")
         end
       end
     end

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -1,7 +1,7 @@
 describe Fastlane do
   describe Fastlane::Action do
     describe "No unused options" do
-      let (:all_exceptions) { %w(pilot appstore cert deliver gym match pem produce scan sigh snapshot supply testflight mailgun testfairy ipa import_from_git hockey deploygate crashlytics artifactory appledoc slather screengrab download_dsyms notification frameit set_changelog register_device register_devices latest_testflight_build_number app_store_build_number sh) }
+      let (:all_exceptions) { %w(pilot appstore cert deliver gym match pem produce scan sigh snapshot supply testflight mailgun testfairy ipa import_from_git hockey deploygate crashlytics artifactory appledoc slather screengrab download_dsyms notification frameit set_changelog register_device register_devices latest_testflight_build_number app_store_build_number sh swiftlint) } # rubocop:disable Metrics/LineLength
 
       Fastlane::ActionsList.all_actions do |action, name|
         next unless action.available_options.kind_of?(Array)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Add support for `swiftlint`'s `--quiet` option.

### Motivation and Context
Allow users to have quiet `swiftlint` runs to reduce console output.
