### PR TITLE
Version bump to 2.10.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.9.0'.freeze
+  VERSION = '2.10.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.9.0':**

* Add shellcheck to circle.yml (#7947)
* [sigh] #7330 - Ignore blacklisted keys when using --use-app-entitlements option for sign resign (#7916)
* Show appropriate error message when running tests without Xcode path being set (#7951)
* Allow GeofencingIcon + LocationTracking Icon (#7940)
* Update to new macOS spelling (#7948)
* [scan] Add support for thread sanitizer (#7946)
* Prevent text to appear in stdout/stderr during rspec (#7942)
* Modify ARGV instead of reassigning it to remove spurious warnings while running tests (#7909)
* Add sensitive ConfigItem for sonar_login (#7939)
* Add language about dependencies. (#7922)
* Add reinstall_app config to screengrab to uninstall the APKs before run tests for each locale configured (#7923)
* Update documentation links (#7934)
* screengrab specs remove dead code (#7917)
* Finish platform support for cert & sigh (#7730)
* Reword the missing reference error to handle variables (#7899). Also add a missing require to be able to run a spec standalone (#7915)
* Add the option to export simulator device logs (#7906)
* add support for custom launch_arguments (#7911)
* Rubocop: change namespace of Lint/Eval to Security to remove warnings
* dotenv: load from either fastlane folder or parent, instead of fastlane folder or current.
* rspec: enforce argument to raise_error. Doing so uncover a couple of broken tests and/or inconsistent implementations. This also clears the build output
* Since faraday 0.10.0, Faraday properly wraps EPIPE errors
* Added support for providing utf flag to xcpretty via gym/xcodebuild (#7891)
* Spaceship access Xcode managed profiles (#7886)
* add PR ownership language to core contributors doc (#7896)
* Make cert checker output look better (#7796)
* releases: markup the issue links in the slack release
* Add information about rephrasing the changelog to be easier to understand (#7889)
* mask all sensitive options by default when printing summary table (#7881)
* Fix spelling of gym (#7890)
