### PR TITLE
Add link to docs.fastlane.tools in docs directory

### DIFF
--- a/fastlane/docs/README.md
+++ b/fastlane/docs/README.md
@@ -1,3 +1,10 @@
+-----
+
+<h4 align="center">For fastlane guides, check out the new <a href="https://docs.fastlane.tools">docs.fastlane.tools</a> page</h4>
+
+-----
+
+
 # Documentation
 
 - [fastlane guide](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Guide.md) to get started. 
@@ -23,6 +30,12 @@
 - [Jenkins.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Jenkins.md) for Jenkins specific help
 - [Circle.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Circle.md) for Circle CI specific help
 - [Bamboo.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Bamboo.md) for Bamboo specific help
+
+-----
+
+<h4 align="center">For fastlane guides, check out the new <a href="https://docs.fastlane.tools">docs.fastlane.tools</a> page</h4>
+
+-----
 
 ## Fastfile
 


### PR DESCRIPTION
We still have docs here and there, so for now, let's get even more people to use the docs page

<img width="933" alt="screenshot 2017-01-23 21 26 40" src="https://cloud.githubusercontent.com/assets/869950/22235170/b7d2ce5c-e1b2-11e6-9f50-745664454a97.png">
