### PR TITLE
Fix 'No such file or directory' error in sigh resign

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -764,7 +764,9 @@ function resign {
         log "Resigning application using certificate: '$CERTIFICATE'"
         log "and entitlements from provisioning profile: $NEW_PROVISION"
         cp -- "$TEMP_DIR/newEntitlements" "$APP_PATH/archived-expanded-entitlements.xcent"
-        /usr/bin/codesign ${VERBOSE} "${KEYCHAIN_FLAG}" -f -s "$CERTIFICATE" --entitlements "$TEMP_DIR/newEntitlements" "$APP_PATH"
+        # Must not qote KEYCHAIN_FLAG because it needs to be unwrapped and passed to codesign with spaces
+        # shellcheck disable=SC2086
+        /usr/bin/codesign ${VERBOSE} ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" --entitlements "$TEMP_DIR/newEntitlements" "$APP_PATH"
         checkStatus
     fi
 

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -51,8 +51,8 @@ module Sigh
         use_app_entitlements_flag,
         verbose,
         bundle_id,
-        ipa.shellescape,
-        specific_keychain
+        specific_keychain,
+        ipa.shellescape # Output path must always be last argument
       ].join(' ')
 
       puts command.magenta


### PR DESCRIPTION
Fix for #7971 

Unnecessary quotes around `${KEYCHAIN_FLAG}` were causing an issue
instead of passing to `codesign` as `--keychain $KEYCHAIN_PATH` it was passed as `"--keychain $KEYCHAIN_PATH"` causing an issue.

An unfortunate side-effect of fixing shellcheck issues.
I have revisited all other changes in that shellcheck update and ran resigning to make sure it works.