### PR TITLE
Removed potential warnings for duplicate module constants

### DIFF
--- a/fastlane/lib/fastlane/actions/s3.rb
+++ b/fastlane/lib/fastlane/actions/s3.rb
@@ -6,11 +6,13 @@ require 'cgi'
 module Fastlane
   module Actions
     module SharedValues
-      S3_IPA_OUTPUT_PATH = :S3_IPA_OUTPUT_PATH
-      S3_DSYM_OUTPUT_PATH = :S3_DSYM_OUTPUT_PATH
-      S3_PLIST_OUTPUT_PATH = :S3_PLIST_OUTPUT_PATH
-      S3_HTML_OUTPUT_PATH = :S3_HTML_OUTPUT_PATH
-      S3_VERSION_OUTPUT_PATH = :S3_VERSION_OUTPUT_PATH
+      # Using ||= because these MAY be defined by the the
+      # preferred aws_s3 plugin
+      S3_IPA_OUTPUT_PATH ||= :S3_IPA_OUTPUT_PATH
+      S3_DSYM_OUTPUT_PATH ||= :S3_DSYM_OUTPUT_PATH
+      S3_PLIST_OUTPUT_PATH ||= :S3_PLIST_OUTPUT_PATH
+      S3_HTML_OUTPUT_PATH ||= :S3_HTML_OUTPUT_PATH
+      S3_VERSION_OUTPUT_PATH ||= :S3_VERSION_OUTPUT_PATH
     end
 
     S3_ARGS_MAP = {


### PR DESCRIPTION
Issue: https://github.com/joshdholtz/fastlane-plugin-s3/issues/3

The `s3` action is deprecated and tells users to use the `aws_s3` action but the same `Fastlane::Actions::SharedValues` are defined in both. This will make sure that the constants are only defined once.

**Example warning**
```
/usr/local/lib/ruby/gems/2.4.0/gems/fastlane-plugin-aws_s3-0.2.0/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb:9: warning: already initialized constant Fastlane::Actions::SharedValues::S3_IPA_OUTPUT_PATH
```