### PR TITLE
Fix the type of option reinstall_app in Screengrab tool

### DIFF
--- a/screengrab/lib/screengrab/options.rb
+++ b/screengrab/lib/screengrab/options.rb
@@ -116,7 +116,8 @@ module Screengrab
         FastlaneCore::ConfigItem.new(key: :reinstall_app,
                                      env_name: 'SCREENGRAB_REINSTALL_APP',
                                      description: "Enabling this option will automatically uninstall the application before running it",
-                                     default_value: false)
+                                     default_value: false,
+                                     is_string: false)
       ]
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Add the property `is_string` with value `false` to `reinstall_app` Screengrab options that need to have it.

### Motivation and Context
This Screengrab option is a flag and need to be boolean type. If the property `is_string` is not set to `false`, Fastlane doesn't recognize it as boolean and crash with the error:
>`'reinstall_app' value must be a String! Found TrueClass instead.`