### PR TITLE
[sigh] Fix shell script quoting issue - follow up

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -551,7 +551,10 @@ function resign {
         do
             if [[ "$framework" == *.framework || "$framework" == *.dylib ]]
             then
-                /usr/bin/codesign ${VERBOSE} "${KEYCHAIN_FLAG}" -f -s "$CERTIFICATE" "$framework"
+                log "Resigning '$framework'"
+                # Must not qote KEYCHAIN_FLAG because it needs to be unwrapped and passed to codesign with spaces
+                # shellcheck disable=SC2086
+                /usr/bin/codesign ${VERBOSE} ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" "$framework"
                 checkStatus
             else
                 log "Ignoring non-framework: $framework"


### PR DESCRIPTION
Fix for #7971 (follow up)

Unnecessary quotes around `${KEYCHAIN_FLAG}` were causing an issue
instead of passing to `codesign` as `--keychain $KEYCHAIN_PATH` it was passed as `"--keychain $KEYCHAIN_PATH"` causing an issue.

An unfortunate side-effect of fixing shellcheck issues.
I have revisited all other changes in that shellcheck update and ran resigning to make sure it works.