### PR TITLE
Version bump to 2.11.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.10.0'.freeze
+  VERSION = '2.11.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.10.0':**

* [sigh] Fix 'No such file or directory' error in sigh resign (#7975)
* [sigh] Fix shell script quoting issue - follow up (#7982)
* Add support for --quiet option for swiftlint action (#7953)
* Make exit_on_test_failure have `is_string: false` (#7981)
* [spaceship] Get and set territories (#6601)
* ensure `xcode-install` gem is installed when using the action (#7972)
* Update match README template installation instructions (#7967)
* Removed potential warnings for duplicate module constants
* Support loading multiple dotenvs (#7943)
* _produce_: fix data_protection in enabled features (#7955)
* Update bundler dependency to be more flexible (#7964)
* Fix the type of option reinstall_app in _screengrab_ tool (#7980)
