### PR TITLE
Fix screengrab to doesn’t exit if the app could not be uninstalled

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -187,16 +187,14 @@ module Screengrab
 
     def uninstall_apks(device_serial, app_package_name, tests_package_name)
       UI.message 'Uninstalling app APK'
-      apk_uninstall_output = run_adb_command("adb -s #{device_serial} uninstall #{app_package_name}",
-                                             print_all: true,
-                                             print_command: true)
-      UI.user_error! "App APK could not be uninstalled" if apk_uninstall_output.include?("Failure [")
+      run_adb_command("adb -s #{device_serial} uninstall #{app_package_name}",
+                      print_all: true,
+                      print_command: true)
 
       UI.message 'Uninstalling tests APK'
-      apk_uninstall_output = run_adb_command("adb -s #{device_serial} uninstall -r #{tests_package_name}",
-                                             print_all: true,
-                                             print_command: true)
-      UI.user_error! "Tests APK could not be uninstalled" if apk_uninstall_output.include?("Failure [")
+      run_adb_command("adb -s #{device_serial} uninstall #{tests_package_name}",
+                      print_all: true,
+                      print_command: true)
     end
 
     def grant_permissions(device_serial)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Using the new Screengrab flag `reinstall_app`, Fastlane will uninstall the APKs for each locale configured in the Screengrabfile. Fastlane should not exit if APKs could not be uninstalled, so I remove the code that the runner checks the output of `adb uninstall` command.

### Motivation and Context
At the first run of Screengrab, the APKs may not be installed yet, so the uninstall command will fail.
After the first run, the APK will be installed and the uninstall command will success normally.