### PR TITLE
Fastlane require format non plugins with dash

### DIFF
--- a/fastlane/lib/fastlane/fastlane_require.rb
+++ b/fastlane/lib/fastlane/fastlane_require.rb
@@ -62,11 +62,11 @@ module Fastlane
 
         return gems.first
       end
-      
+
       def format_gem_require_name(gem_name)
         # from "fastlane-plugin-xcversion" to "fastlane/plugin/xcversion"
         gem_name = gem_name.tr("-", "/") if gem_name.start_with? "fastlane-plugin-"
-        
+
         return gem_name
       end
     end

--- a/fastlane/lib/fastlane/fastlane_require.rb
+++ b/fastlane/lib/fastlane/fastlane_require.rb
@@ -2,7 +2,7 @@ module Fastlane
   class FastlaneRequire
     class << self
       def install_gem_if_needed(gem_name: nil, require_gem: true)
-        gem_require_name = gem_name.tr("-", "/") # from "fastlane-plugin-xcversion" to "fastlane/plugin/xcversion"
+        gem_require_name = format_gem_require_name(gem_name)
 
         # check if it's installed
         if gem_installed?(gem_name)
@@ -61,6 +61,13 @@ module Fastlane
         gems = fetcher.suggest_gems_from_name(user_supplied_name)
 
         return gems.first
+      end
+      
+      def format_gem_require_name(gem_name)
+        # from "fastlane-plugin-xcversion" to "fastlane/plugin/xcversion"
+        gem_name = gem_name.tr("-", "/") if gem_name.start_with? "fastlane-plugin-"
+        
+        return gem_name
       end
     end
   end

--- a/fastlane/spec/fastlane_require_spec.rb
+++ b/fastlane/spec/fastlane_require_spec.rb
@@ -1,0 +1,17 @@
+require 'fastlane/fastlane_require'
+
+describe Fastlane do
+  describe Fastlane::FastlaneRequire do
+    it "formats gem require name for fastlane-plugin" do
+      gem_name = "fastlane-plugin-test"
+      gem_require_name = Fastlane::FastlaneRequire.format_gem_require_name(gem_name)
+      expect(gem_require_name).to eq("fastlane/plugin/test")
+    end
+
+    it "formats gem require name for non-fastlane-plugin" do
+      gem_name = "rest-client"
+      gem_require_name = Fastlane::FastlaneRequire.format_gem_require_name(gem_name)
+      expect(gem_require_name).to eq("rest-client")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #7502

`fastlane_require "rest-client"` was formatting `rest-client` as `rest/client` was causing a 💥 

The comment above that logic was saying that replacing of `-` with `/` was specifically for `fastlane-plugin-` so now the logic inside of `fastlane_require` only replaces `-` with `/` if it starts with `fastlane-plugin-` 🚀 