### PR TITLE
Enable enterprise in-house profiles for match

### DIFF
--- a/match/README.md
+++ b/match/README.md
@@ -377,13 +377,13 @@ In general those profiles are harmless as they can only be used to install a sig
 
 Attackers could use an In-House profile to distribute signed application to a potentially unlimited number of devices. All this would run under your company name and it could eventually lead to Apple revoking your In-House account. However it is very easy to revoke a certificate to remotely break the app on all devices.
 
-Because of the potentially dangerous nature of In-House profiles we decided to not allow the use of `match` with enterprise accounts.
+Because of the potentially dangerous nature of In-House profiles please use _match_ with enterprise profiles with caution, ensure your git repository is private and use a secure password.
 
 ##### To sum up
 
 - You have full control over the access list of your Git repo, no third party service involved
 - Even if your certificates are leaked, they can't be used to cause any harm without your iTunes Connect login credentials
-- `match` does not currently support In-House Enterprise profiles as they are harder to control
+- Use In-House enterprise profile with _match_ with caution
 - If you use GitHub or Bitbucket we encourage enabling 2 factor authentication for all accounts that have access to the certificates repo
 - The complete source code of `match` is fully open source on [GitHub](https://github.com/fastlane/fastlane/tree/master/match)
 

--- a/match/lib/match.rb
+++ b/match/lib/match.rb
@@ -21,30 +21,18 @@ module Match
   DESCRIPTION = "Easily sync your certificates and profiles across your team using git"
 
   def self.environments
-    envs = %w(appstore adhoc development)
-    envs << "enterprise" if self.enterprise?
-    return envs
-  end
-
-  # @return [Boolean] returns true if the unsupported enterprise mode should be enabled
-  def self.enterprise?
-    return FastlaneCore::Env.truthy?("MATCH_FORCE_ENTERPRISE")
-  end
-
-  # @return [Boolean] returns true if match should interpret the given [certificate|profile] type as an enterprise one
-  def self.type_is_enterprise?(type)
-    Match.enterprise? && type != "development"
+    return %w(appstore adhoc development enterprise)
   end
 
   def self.profile_type_sym(type)
-    return :enterprise if self.type_is_enterprise? type
+    return :enterprise if type == "enterprise"
     return :adhoc if type == "adhoc"
     return :appstore if type == "appstore"
     return :development
   end
 
   def self.cert_type_sym(type)
-    return :enterprise if self.type_is_enterprise? type
+    return :enterprise if type == "enterprise"
     return :development if type == "development"
     return :distribution
   end

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -172,7 +172,7 @@ module Match
     def certificate_type(type)
       cert_type = Spaceship.certificate.production
       cert_type = Spaceship.certificate.development if type == :development
-      cert_type = Spaceship.certificate.in_house if Match.enterprise? && Spaceship.client.in_house?
+      cert_type = Spaceship.certificate.in_house if type == :enterprise
 
       cert_type
     end
@@ -180,7 +180,7 @@ module Match
     # The kind of provisioning profile we're interested in
     def profile_type(type)
       profile_type = Spaceship.provisioning_profile.app_store
-      profile_type = Spaceship.provisioning_profile.in_house if Match.enterprise? && Spaceship.client.in_house?
+      profile_type = Spaceship.provisioning_profile.in_house if type == :enterprise
       profile_type = Spaceship.provisioning_profile.ad_hoc if type == :adhoc
       profile_type = Spaceship.provisioning_profile.development if type == :development
 

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -19,7 +19,7 @@ module Match
                                      default_value: 'master'),
         FastlaneCore::ConfigItem.new(key: :type,
                                      env_name: "MATCH_TYPE",
-                                     description: "Create a development certificate instead of a distribution one",
+                                     description: "Define the profile type, can be #{Match.environments.join(', ')}",
                                      is_string: true,
                                      short_option: "-y",
                                      default_value: 'development',

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -8,10 +8,14 @@ module Match
                                          hide_keys: [:workspace],
                                              title: "Summary for match #{Fastlane::VERSION}")
 
-      UI.error("Enterprise profiles are currently not officially supported in _match_, you might run into issues") if Match.enterprise?
-
       params[:workspace] = GitHelper.clone(params[:git_url], params[:shallow_clone], skip_docs: params[:skip_docs], branch: params[:git_branch])
-      self.spaceship = SpaceshipEnsure.new(params[:username]) unless params[:readonly]
+
+      unless params[:readonly]
+        self.spaceship = SpaceshipEnsure.new(params[:username])
+        if params[:type] == "enterprise" && !Spaceship.client.in_house?
+          UI.user_error!("You defined the profile type 'enterprise', but your Apple account doesn't support In-House profiles")
+        end
+      end
 
       if params[:app_identifier].kind_of?(Array)
         app_identifiers = params[:app_identifier]


### PR DESCRIPTION
Lots of people have already been using _match_ for enterprise profiles, and things have been working really well. Let's enable it, and users can explicitly say they want to use an "enterprise" profile. This PR also updated the documentation to mention to be sure the repo is private and the encryption uses a safe password.
Additionally we're now showing an error if the user tries to use _match_ for an enterprise profile for an account that doesn't support in-house

