### PR TITLE
Add skip_testing, only_testing options to scan

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -36,7 +36,19 @@ module Scan
 
       default_derived_data
 
+      coerce_to_array_of_strings(:only_testing)
+      coerce_to_array_of_strings(:skip_testing)
+
       return config
+    end
+
+    def self.coerce_to_array_of_strings(config_key)
+      config_value = Scan.config[config_key]
+
+      return if config_value.nil?
+
+      config_value = [config_value] unless config_value.kind_of?(Array)
+      Scan.config[config_key] = config_value.map(&:to_s)
     end
 
     def self.default_derived_data

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -47,7 +47,10 @@ module Scan
 
       return if config_value.nil?
 
-      config_value = [config_value] unless config_value.kind_of?(Array)
+      # splitting on comma allows us to support comma-separated lists of values
+      # from the command line, even though the ConfigItem is not defined as an
+      # Array type
+      config_value = config_value.split(',') unless config_value.kind_of?(Array)
       Scan.config[config_key] = config_value.map(&:to_s)
     end
 

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -166,6 +166,34 @@ module Scan
                                      verify_block: proc do |value|
                                        UI.user_error!("File not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                      end),
+        FastlaneCore::ConfigItem.new(key: :only_testing,
+                                     env_name: "SCAN_ONLY_TESTING",
+                                     description: "Array of strings matching Test Bundle/Test Suite/Test Cases to run",
+                                     optional: true,
+                                     is_string: false,
+                                     verify_block: proc do |value|
+                                       if value.kind_of?(Array)
+                                         value.each do |test_path|
+                                           UI.user_error!("'only_testing' array should only contain strings, but found: '#{test_path}' which is of type '#{value.class.name}'") unless test_path.kind_of?(String)
+                                         end
+                                       elsif !value.kind_of?(String)
+                                         UI.user_error!("Incorrect parameter type for 'only_testing': '#{value}'")
+                                       end
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :skip_testing,
+                                     env_name: "SCAN_SKIP_TESTING",
+                                     description: "Array of strings matching Test Bundle/Test Suite/Test Cases to skip",
+                                     optional: true,
+                                     is_string: false,
+                                     verify_block: proc do |value|
+                                       if value.kind_of?(Array)
+                                         value.each do |test_path|
+                                           UI.user_error!("'skip_testing' array should only contain strings, but found: '#{test_path}' which is of type '#{value.class.name}'") unless test_path.kind_of?(String)
+                                         end
+                                       elsif !value.kind_of?(String)
+                                         UI.user_error!("Incorrect parameter type for 'skip_testing': '#{value}'")
+                                       end
+                                     end),
         FastlaneCore::ConfigItem.new(key: :slack_url,
                                      short_option: "-i",
                                      env_name: "SLACK_URL",

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -3,6 +3,11 @@ require "credentials_manager"
 
 module Scan
   class Options
+    def self.verify_type(item_name, acceptable_types, value)
+      type_ok = [Array, String].any? { |type| value.kind_of?(type) }
+      UI.user_error!("'#{item_name}' should be of type #{acceptable_types.join(' or ')} but found: #{value.class.name}") unless type_ok
+    end
+
     def self.available_options
       containing = Helper.fastlane_enabled? ? './fastlane' : '.'
 
@@ -172,13 +177,7 @@ module Scan
                                      optional: true,
                                      is_string: false,
                                      verify_block: proc do |value|
-                                       if value.kind_of?(Array)
-                                         value.each do |test_path|
-                                           UI.user_error!("'only_testing' array should only contain strings, but found: '#{test_path}' which is of type '#{value.class.name}'") unless test_path.kind_of?(String)
-                                         end
-                                       elsif !value.kind_of?(String)
-                                         UI.user_error!("Incorrect parameter type for 'only_testing': '#{value}'")
-                                       end
+                                       verify_type('only_testing', [Array, String], value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :skip_testing,
                                      env_name: "SCAN_SKIP_TESTING",
@@ -186,13 +185,7 @@ module Scan
                                      optional: true,
                                      is_string: false,
                                      verify_block: proc do |value|
-                                       if value.kind_of?(Array)
-                                         value.each do |test_path|
-                                           UI.user_error!("'skip_testing' array should only contain strings, but found: '#{test_path}' which is of type '#{value.class.name}'") unless test_path.kind_of?(String)
-                                         end
-                                       elsif !value.kind_of?(String)
-                                         UI.user_error!("Incorrect parameter type for 'skip_testing': '#{value}'")
-                                       end
+                                       verify_type('skip_testing', [Array, String], value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :slack_url,
                                      short_option: "-i",

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -41,6 +41,22 @@ module Scan
         options << "-xcconfig '#{config[:xcconfig]}'" if config[:xcconfig]
         options << config[:xcargs] if config[:xcargs]
 
+        if config[:only_testing].kind_of?(Array)
+          config[:only_testing].each do |test_path|
+            options << "-only-testing:#{test_path}"
+          end
+        elsif config[:only_testing].kind_of?(String)
+          options << "-only-testing:#{config[:only_testing]}"
+        end
+
+        if config[:skip_testing].kind_of?(Array)
+          config[:skip_testing].each do |test_path|
+            options << "-skip-testing:#{test_path}"
+          end
+        elsif config[:skip_testing].kind_of?(String)
+          options << "-skip-testing:#{config[:skip_testing]}"
+        end
+
         options
       end
 

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -41,21 +41,10 @@ module Scan
         options << "-xcconfig '#{config[:xcconfig]}'" if config[:xcconfig]
         options << config[:xcargs] if config[:xcargs]
 
-        if config[:only_testing].kind_of?(Array)
-          config[:only_testing].each do |test_path|
-            options << "-only-testing:#{test_path}"
-          end
-        elsif config[:only_testing].kind_of?(String)
-          options << "-only-testing:#{config[:only_testing]}"
-        end
-
-        if config[:skip_testing].kind_of?(Array)
-          config[:skip_testing].each do |test_path|
-            options << "-skip-testing:#{test_path}"
-          end
-        elsif config[:skip_testing].kind_of?(String)
-          options << "-skip-testing:#{config[:skip_testing]}"
-        end
+        # detect_values will ensure that these values are present as Arrays if
+        # they are present at all
+        options += config[:only_testing].map { |test_id| "-only-testing:#{test_id}" } if config[:only_testing]
+        options += config[:skip_testing].map { |test_id| "-skip-testing:#{test_id}" } if config[:skip_testing]
 
         options
       end

--- a/scan/spec/detect_values_spec.rb
+++ b/scan/spec/detect_values_spec.rb
@@ -1,26 +1,45 @@
 describe Scan do
   describe Scan::DetectValues do
-    before do
-      options = {
-        project: "./scan/examples/standard/app.xcodeproj",
-        only_testing: "Bundle/SuiteA",
-        skip_testing: "Bundle/SuiteB"
-      }
-      Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
-      @project = FastlaneCore::Project.new(Scan.config)
+    describe 'Xcode config handling' do
+      before do
+        options = { project: "./scan/examples/standard/app.xcodeproj" }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        @project = FastlaneCore::Project.new(Scan.config)
+      end
+
+      it "fetches the path from the Xcode config" do
+        derived_data = Scan.config[:derived_data_path]
+        expect(derived_data).to match(%r{/.*Xcode/DerivedData/app-\w*$})
+      end
     end
 
-    it "fetches the path from the Xcode config" do
-      derived_data = Scan.config[:derived_data_path]
-      expect(derived_data).to match(%r{/.*Xcode/DerivedData/app-\w*$})
-    end
+    describe "value coercion" do
+      it "coerces only_testing to be an array" do
+        options = {
+          project: "./scan/examples/standard/app.xcodeproj",
+          only_testing: "Bundle/SuiteA"
+        }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        expect(Scan.config[:only_testing]).to eq(["Bundle/SuiteA"])
+      end
 
-    it "coerces only_testing to be an array" do
-      expect(Scan.config[:only_testing]).to eq(["Bundle/SuiteA"])
-    end
+      it "coerces skip_testing to be an array" do
+        options = {
+          project: "./scan/examples/standard/app.xcodeproj",
+          skip_testing: "Bundle/SuiteA,Bundle/SuiteB"
+        }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        expect(Scan.config[:skip_testing]).to eq(["Bundle/SuiteA", "Bundle/SuiteB"])
+      end
 
-    it "coerces skip_testing to be an array" do
-      expect(Scan.config[:skip_testing]).to eq(["Bundle/SuiteB"])
+      it "leaves skip_testing as an array" do
+        options = {
+          project: "./scan/examples/standard/app.xcodeproj",
+          skip_testing: ["Bundle/SuiteA", "Bundle/SuiteB"]
+        }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        expect(Scan.config[:skip_testing]).to eq(["Bundle/SuiteA", "Bundle/SuiteB"])
+      end
     end
   end
 end

--- a/scan/spec/detect_values_spec.rb
+++ b/scan/spec/detect_values_spec.rb
@@ -1,7 +1,11 @@
 describe Scan do
   describe Scan::DetectValues do
     before do
-      options = { project: "./scan/examples/standard/app.xcodeproj" }
+      options = {
+        project: "./scan/examples/standard/app.xcodeproj",
+        only_testing: "Bundle/SuiteA",
+        skip_testing: "Bundle/SuiteB"
+      }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       @project = FastlaneCore::Project.new(Scan.config)
     end
@@ -9,6 +13,14 @@ describe Scan do
     it "fetches the path from the Xcode config" do
       derived_data = Scan.config[:derived_data_path]
       expect(derived_data).to match(%r{/.*Xcode/DerivedData/app-\w*$})
+    end
+
+    it "coerces only_testing to be an array" do
+      expect(Scan.config[:only_testing]).to eq(["Bundle/SuiteA"])
+    end
+
+    it "coerces skip_testing to be an array" do
+      expect(Scan.config[:skip_testing]).to eq(["Bundle/SuiteB"])
     end
   end
 end

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -198,6 +198,98 @@ describe Scan do
       end
     end
 
+    describe "Test Exclusion Example" do
+      it "only tests the test bundle/suite/cases specified in only_testing when the input is an array" do
+        log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
+                    only_testing: %w(TestBundleA/TestSuiteB TestBundleC) }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = Scan::TestCommandGenerator.generate
+
+        expect(result).to start_with([
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "-scheme app",
+                                       "-project ./scan/examples/standard/app.xcodeproj",
+                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       '-only-testing:TestBundleA/TestSuiteB',
+                                       '-only-testing:TestBundleC',
+                                       :build,
+                                       :test
+                                     ])
+      end
+
+      it "only tests the test bundle/suite/cases specified in only_testing when the input is a string" do
+        log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
+                    only_testing: 'TestBundleA/TestSuiteB' }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = Scan::TestCommandGenerator.generate
+
+        expect(result).to start_with([
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "-scheme app",
+                                       "-project ./scan/examples/standard/app.xcodeproj",
+                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       '-only-testing:TestBundleA/TestSuiteB',
+                                       :build,
+                                       :test
+                                     ])
+      end
+
+      it "does not the test bundle/suite/cases specified in skip_testing when the input is an array" do
+        log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
+                    skip_testing: %w(TestBundleA/TestSuiteB TestBundleC) }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = Scan::TestCommandGenerator.generate
+
+        expect(result).to start_with([
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "-scheme app",
+                                       "-project ./scan/examples/standard/app.xcodeproj",
+                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       '-skip-testing:TestBundleA/TestSuiteB',
+                                       '-skip-testing:TestBundleC',
+                                       :build,
+                                       :test
+                                     ])
+      end
+
+      it "does not the test bundle/suite/cases specified in skip_testing when the input is a string" do
+        log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
+                    skip_testing: 'TestBundleA/TestSuiteB' }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = Scan::TestCommandGenerator.generate
+
+        expect(result).to start_with([
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "-scheme app",
+                                       "-project ./scan/examples/standard/app.xcodeproj",
+                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       '-skip-testing:TestBundleA/TestSuiteB',
+                                       :build,
+                                       :test
+                                     ])
+      end
+    end
+
     it "uses a device without version specifier" do
       options = { project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 6s" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)


### PR DESCRIPTION

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Description

Carrying forward work from #7601

> This PR adds options to Scan to specify specific test bundles/test suites/test cases to be run using the new -only-testing and -skip-testing options in Xcode 8's version of xcodebuild. More info on the actions can be found in the wwdc talk on [Advanced Testing and Continuous Integration](https://developer.apple.com/videos/play/wwdc2016/409/)

This will need a follow-up to add information to the documentation for _scan_