### PR TITLE
Add path option to delete_keychain action

### DIFF
--- a/fastlane/lib/fastlane/actions/delete_keychain.rb
+++ b/fastlane/lib/fastlane/actions/delete_keychain.rb
@@ -5,8 +5,19 @@ module Fastlane
     class DeleteKeychainAction < Action
       def self.run(params)
         original = Actions.lane_context[Actions::SharedValues::ORIGINAL_DEFAULT_KEYCHAIN]
+
+        if params[:name]
+          keychain_path = File.expand_path(File.join("~", "Library", "Keychains", params[:name]))
+        else
+          keychain_path = params[:path]
+        end
+
+        if keychain_path.nil?
+          UI.user_error!("You either have to set :name or :path")
+        end
+
         Fastlane::Actions.sh("security default-keychain -s #{original}", log: false) unless original.nil?
-        Fastlane::Actions.sh "security delete-keychain #{params[:name].shellescape}", log: false
+        Fastlane::Actions.sh "security delete-keychain #{keychain_path.shellescape}", log: false
       end
 
       def self.details
@@ -22,13 +33,20 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :name,
                                        env_name: "KEYCHAIN_NAME",
                                        description: "Keychain name",
-                                       optional: false)
+                                       conflicting_options: [:path],
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: "KEYCHAIN_PATH",
+                                       description: "Keychain path",
+                                       conflicting_options: [:name],
+                                       optional: true)
         ]
       end
 
       def self.example_code
         [
-          'delete_keychain(name: "KeychainName")'
+          'delete_keychain(name: "KeychainName")',
+          'delete_keychain(path: "/keychains/project.keychain")'
         ]
       end
 
@@ -37,7 +55,7 @@ module Fastlane
       end
 
       def self.authors
-        ["gin0606"]
+        ["gin0606", "koenpunt"]
       end
 
       def self.is_supported?(platform)

--- a/fastlane/lib/fastlane/actions/delete_keychain.rb
+++ b/fastlane/lib/fastlane/actions/delete_keychain.rb
@@ -9,7 +9,7 @@ module Fastlane
         if params[:name]
           keychain_path = File.expand_path(File.join("~", "Library", "Keychains", params[:name]))
         else
-          keychain_path = params[:path]
+          keychain_path = params[:keychain_path]
         end
 
         if keychain_path.nil?
@@ -33,9 +33,9 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :name,
                                        env_name: "KEYCHAIN_NAME",
                                        description: "Keychain name",
-                                       conflicting_options: [:path],
+                                       conflicting_options: [:keychain_path],
                                        optional: true),
-          FastlaneCore::ConfigItem.new(key: :path,
+          FastlaneCore::ConfigItem.new(key: :keychain_path,
                                        env_name: "KEYCHAIN_PATH",
                                        description: "Keychain path",
                                        conflicting_options: [:name],

--- a/fastlane/spec/actions_specs/delete_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/delete_keychain_spec.rb
@@ -8,17 +8,31 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("security delete-keychain test.keychain")
+        keychain = File.expand_path('~/Library/Keychains/test.keychain')
+
+        expect(result).to eq("security delete-keychain #{keychain}")
       end
 
-      it "works with keychain name that contain spaces or `\"`" do
+      it "works with keychain name that contain spaces and `\"`" do
         result = Fastlane::FastFile.new.parse("lane :test do
           delete_keychain ({
             name: '\" test \".keychain'
           })
         end").runner.execute(:test)
 
-        expect(result).to eq %(security delete-keychain \\\"\\ test\\ \\\".keychain)
+        keychain = File.expand_path(%(~/Library/Keychains/\\\"\\ test\\ \\\".keychain))
+
+        expect(result).to eq %(security delete-keychain #{keychain})
+      end
+
+      it "works with absolute keychain path" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          delete_keychain ({
+            path: '/projects/test.keychain'
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("security delete-keychain /projects/test.keychain")
       end
     end
   end

--- a/fastlane/spec/actions_specs/delete_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/delete_keychain_spec.rb
@@ -28,7 +28,7 @@ describe Fastlane do
       it "works with absolute keychain path" do
         result = Fastlane::FastFile.new.parse("lane :test do
           delete_keychain ({
-            path: '/projects/test.keychain'
+            keychain_path: '/projects/test.keychain'
           })
         end").runner.execute(:test)
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Add `path` option to specify a keychain somewhere else than `~/Library/Keychains`

### Motivation and Context
This complements the `create_keychain` command, which already supports specifying the keychain with a path.

