### PR TITLE
Improve scan error message for bad SLACK_URL

### DIFF
--- a/scan/lib/scan/slack_poster.rb
+++ b/scan/lib/scan/slack_poster.rb
@@ -51,7 +51,10 @@ module Scan
 
       if result.code.to_i == 200
         UI.success('Successfully sent Slack notification')
+      elsif result.code.to_i == 404
+        UI.error("The Slack URL you provided could not be reached (404)")
       else
+        UI.error("The Slack notification could not be sent:")
         UI.error(result.to_s)
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description
Improve error messaging when _scan_'s `SlackPoster` gets a 404 back from Slack

### Motivation and Context
When a `SLACK_URL` is given, but it is not quite right, people were seeing this error message in their _scan_ run logs. It's rather impossible to know what to do with this message.

```
[16:11:13]: ▸ Test Succeeded
[16:11:13]: #<Net::HTTPNotFound:0x007f93332e8df8>
```

This PR changes the error message in this case to be:

```
[16:15:18]: ▸ Test Succeeded
[16:15:19]: The Slack URL you provided (https://hooks.slack.com/services/XXX/XXX/XXX) could not be reached (404)
```