### PR TITLE
Add support for new and existing groups for iTC testers in spaceship

### DIFF
--- a/spaceship/docs/iTunesConnect.md
+++ b/spaceship/docs/iTunesConnect.md
@@ -283,7 +283,8 @@ app.external_testers            # => Array of all external testers for this appl
 # Creating new external testers
 Spaceship::Tunes::Tester::External.create!(email: "github@krausefx.com",
                                       first_name: "Felix",
-                                       last_name: "Krause")
+                                       last_name: "Krause",
+                                          groups: ["spaceship"])
 
 # Add all external testers to an application
 app.add_all_testers!

--- a/spaceship/lib/spaceship/tunes/tester.rb
+++ b/spaceship/lib/spaceship/tunes/tester.rb
@@ -104,7 +104,7 @@ module Spaceship
         # @param last_name (String) (optional): The last name of the new tester
         # @param groups (Array) (option): Names/IDs of existing groups for the new tester
         # @example
-        #   Spaceship::Tunes::Tester.external.create!(email: "tester@mathiascarignani.com", first_name: "Cary", last_name:"Bennett", groups:["Testers"])
+        #   Spaceship::Tunes::Tester.external.create!(email: "tester@mathiascarignani.com", first_name: "Cary", last_name: "Bennett", groups: ["Testers"])
         # @return (Tester): The newly created tester
         def create!(email: nil, first_name: nil, last_name: nil, groups: nil)
           data = client.create_tester!(tester: self,

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -901,13 +901,13 @@ module Spaceship
 
       if groups
         tester_data[:groups] = groups.map do |group_name_or_group_id|
-          if self.groups.values.include?(group_name_or_group_id)
+          if self.groups.has_value?(group_name_or_group_id)
             # This is an existing group, let's use that, the user specified the group name
             group_name = group_name_or_group_id
-            group_id = self.groups.find { |id, name| name == group_name_or_group_id }[0]
-          elsif self.groups.keys.include?(group_name_or_group_id)
+            group_id = self.groups.key(group_name_or_group_id)
+          elsif self.groups.has_key?(group_name_or_group_id)
             # This is an existing group, let's use that, the user specified the group ID
-            group_name = self.groups.find { |id, name| id == group_name_or_group_id }[1]
+            group_name = self.groups[group_name_or_group_id]
             group_id = group_name_or_group_id
           else
             group_name = group_name_or_group_id

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -901,11 +901,11 @@ module Spaceship
 
       if groups
         tester_data[:groups] = groups.map do |group_name_or_group_id|
-          if self.groups.has_value?(group_name_or_group_id)
+          if self.groups.value?(group_name_or_group_id)
             # This is an existing group, let's use that, the user specified the group name
             group_name = group_name_or_group_id
             group_id = self.groups.key(group_name_or_group_id)
-          elsif self.groups.has_key?(group_name_or_group_id)
+          elsif self.groups.key?(group_name_or_group_id)
             # This is an existing group, let's use that, the user specified the group ID
             group_name = self.groups[group_name_or_group_id]
             group_id = group_name_or_group_id

--- a/spaceship/spec/tunes/fixtures/testers/create_tester.json
+++ b/spaceship/spec/tunes/fixtures/testers/create_tester.json
@@ -1,0 +1,91 @@
+{
+  "data": {
+    "sectionErrorKeys": null,
+    "sectionInfoKeys": [],
+    "sectionWarningKeys": [],
+    "testers": [{
+      "emailAddress": {
+        "value": "customtesters@krausefx.com",
+        "isEditable": false,
+        "isRequired": false,
+        "errorKeys": [],
+        "maxLength": null,
+        "minLength": null
+      },
+      "firstName": {
+        "value": "FirstName",
+        "isEditable": false,
+        "isRequired": false,
+        "errorKeys": [],
+        "maxLength": null,
+        "minLength": null
+      },
+      "lastName": {
+        "value": "LastName",
+        "isEditable": false,
+        "isRequired": false,
+        "errorKeys": [],
+        "maxLength": null,
+        "minLength": null
+      },
+      "testerId": null,
+      "devices": null,
+      "latestInstalledAppAdamId": null,
+      "latestInstalledVersion": null,
+      "latestInstalledShortVersion": null,
+      "latestInstalledDate": null,
+      "latestInstalledName": null,
+      "latestInstallByPlatform": null,
+      "hasAddedOrInvitedApp": null,
+      "warnOnDelete": null,
+      "itcUsername": null,
+      "dsId": null,
+      "groups": [{
+        "id": "c4739ccc-672f-46d4-9dad-23df8c60a35f",
+        "name": {
+          "value": "boarding123",
+          "isEditable": false,
+          "isRequired": false,
+          "errorKeys": null,
+          "maxLength": null,
+          "minLength": null
+        },
+        "testerCount": null,
+        "testers": null,
+        "isDeleted": null
+      }, {
+        "id": "b6f65dbd-c845-4d91-bc39-0b661d608970",
+        "name": {
+          "value": "Boarding",
+          "isEditable": false,
+          "isRequired": false,
+          "errorKeys": null,
+          "maxLength": null,
+          "minLength": null
+        },
+        "testerCount": null,
+        "testers": null,
+        "isDeleted": null
+      }, {
+        "id": "555f48c8-a968-4e8f-a41b-0417c4d9c70a",
+        "name": {
+          "value": "custom-new-group",
+          "isEditable": false,
+          "isRequired": false,
+          "errorKeys": null,
+          "maxLength": null,
+          "minLength": null
+        },
+        "testerCount": null,
+        "testers": null,
+        "isDeleted": null
+      }]
+    }]
+  },
+  "messages": {
+    "warn": null,
+    "error": null,
+    "info": null
+  },
+  "statusCode": "SUCCESS"
+}

--- a/spaceship/spec/tunes/fixtures/testers/get_external.json
+++ b/spaceship/spec/tunes/fixtures/testers/get_external.json
@@ -102,7 +102,13 @@
       "iPhone": ["iPhone 6"]
     },
     "groups": {
-      "8dfd9f94-3983-46d5-a298-c866b2369a33": "MyGroup"
+      "8dfd9f94-3983-46d5-a298-c866b2369a33": "MyGroup",
+      "b6f65dbd-c845-4d91-bc39-0b661d608970": "Boarding",
+      "abe0122c-7b67-4931-ad91-54458118b3e2": "some random name",
+      "d5db2d1e-204d-434a-8672-cdae3582604a": "yolo new name yeah",
+      "3b493466-392c-49ce-8f6b-b2143fdf822a": "Test Group",
+      "c4739ccc-672f-46d4-9dad-23df8c60a35f": "boarding123",
+      "70402368-9deb-409f-9a26-bb3f215dfee3": "Automatic"
     }
   },
   "messages": {

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -185,6 +185,8 @@ class TunesStubbing
         to_return(status: 200, body: itc_read_fixture_file('testers/get_external.json'), headers: { 'Content-Type' => 'application/json' })
       stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/user/internalTesters/898536088/").
         to_return(status: 200, body: itc_read_fixture_file('testers/existing_internal_testers.json'), headers: { 'Content-Type' => 'application/json' })
+
+      # Creating new testers is stubbed in `testers_spec.rb`
     end
 
     def itc_stub_testflight


### PR DESCRIPTION
Until now we haven't really supported groups in _spaceship_, this PR adds full support for existing group IDs, group names, and creating new groups on the fly 👍 