### PR TITLE
Automaticaly retry failed requests on an internal server error for iTunes Connect

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -631,7 +631,7 @@ module Spaceship
       # Build trains fail randomly very often
       # we need to catch those errors and retry
       # https://github.com/fastlane/fastlane/issues/6419
-      if ex.to_s.include?("ITC.response.error.OPERATION_FAILED")
+      if ex.to_s.include?("ITC.response.error.OPERATION_FAILED") or ex.to_s.include?("Internal Server Error")
         tries -= 1
         if tries > 0
           logger.warn("Received temporary server error from iTunes Connect. Retrying the request...")

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -631,7 +631,7 @@ module Spaceship
       # Build trains fail randomly very often
       # we need to catch those errors and retry
       # https://github.com/fastlane/fastlane/issues/6419
-      if ex.to_s.include?("ITC.response.error.OPERATION_FAILED") or ex.to_s.include?("Internal Server Error")
+      if ex.to_s.include?("ITC.response.error.OPERATION_FAILED") || ex.to_s.include?("Internal Server Error")
         tries -= 1
         if tries > 0
           logger.warn("Received temporary server error from iTunes Connect. Retrying the request...")


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/6419#issuecomment-275291403