### PR TITLE
Fix spaceauth YAML spaceship cookie loading

### DIFF
--- a/spaceship/lib/spaceship/spaceauth_runner.rb
+++ b/spaceship/lib/spaceship/spaceauth_runner.rb
@@ -33,7 +33,7 @@ module Spaceship
       # Example:
       # name: DES5c148586daa451e55afb017aa62418f91
       # value: HSARMTKNSRVTWFlaF/ek8asaa9lymMA0dN8JQ6pY7B3F5kdqTxJvMT19EVEFX8EQudB/uNwBHOHzaa30KYTU/eCP/UF7vGTgxs6PAnlVWKscWssOVHfP2IKWUPaa4Dn+I6ilA7eAFQsiaaVT
-      cookies = YAML.safe_load(itc_cookie_content)
+      cookies = YAML.safe_load(itc_cookie_content, [HTTP::Cookie])
 
       # We remove all the un-needed cookies
       cookies.select! do |cookie|

--- a/spaceship/lib/spaceship/spaceauth_runner.rb
+++ b/spaceship/lib/spaceship/spaceauth_runner.rb
@@ -33,7 +33,12 @@ module Spaceship
       # Example:
       # name: DES5c148586daa451e55afb017aa62418f91
       # value: HSARMTKNSRVTWFlaF/ek8asaa9lymMA0dN8JQ6pY7B3F5kdqTxJvMT19EVEFX8EQudB/uNwBHOHzaa30KYTU/eCP/UF7vGTgxs6PAnlVWKscWssOVHfP2IKWUPaa4Dn+I6ilA7eAFQsiaaVT
-      cookies = YAML.safe_load(itc_cookie_content, [HTTP::Cookie])
+      cookies = YAML.safe_load(
+        itc_cookie_content,
+        [HTTP::Cookie, Time], # classes whitelist
+        [],                   # symbols whitelist
+        true                  # allow YAML aliases
+      )
 
       # We remove all the un-needed cookies
       cookies.select! do |cookie|


### PR DESCRIPTION
introduced by:
  *  https://github.com/fastlane/fastlane/pull/7883 (rubocop rules update)

issues: 
  * https://github.com/fastlane/fastlane/issues/8011