### PR TITLE
Add missing duplicate space after emoji

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/github_issue_inspector_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/ui/github_issue_inspector_reporter.rb
@@ -54,7 +54,7 @@ module Fastlane
 
     def print_open_link_hint(newline = false)
       puts "" if newline
-      puts "🔗 You can ⌘ + double-click on links to open them directly in your browser." if Helper.mac?
+      puts "🔗  You can ⌘ + double-click on links to open them directly in your browser." if Helper.mac?
     end
   end
 end


### PR DESCRIPTION
On terminals you need 2 spaces to make emojis look nice
