### PR TITLE
Allow our custom Spaceship::Base#inspect to work with object graphes containing circular references

### DIFF
--- a/spaceship/lib/spaceship/base.rb
+++ b/spaceship/lib/spaceship/base.rb
@@ -226,8 +226,9 @@ module Spaceship
       thread[:inspected_objects] = Set.new if tree_root
 
       if thread[:inspected_objects].include? self
-        # already inspected objects have a default value
-        value = "~~DUPE~~"
+        # already inspected objects have a default value,
+        # let's follow Ruby's convention for circular references
+        value = "#<Object ...>"
       else
         thread[:inspected_objects].add self
         begin

--- a/spaceship/lib/spaceship/base.rb
+++ b/spaceship/lib/spaceship/base.rb
@@ -230,8 +230,11 @@ module Spaceship
         value = "~~DUPE~~"
       else
         thread[:inspected_objects].add self
-        value = inspect_value
-        thread[:inspected_objects] = nil if tree_root
+        begin
+          value = inspect_value
+        ensure
+          thread[:inspected_objects] = nil if tree_root
+        end
       end
 
       "<#{self.class.name} \n#{value}>"

--- a/spaceship/spec/base_spec.rb
+++ b/spaceship/spec/base_spec.rb
@@ -2,6 +2,15 @@ describe Spaceship::Base do
   before { Spaceship.login }
   let(:client) { Spaceship::App.client }
 
+  class TestBase < Spaceship::Base
+    attr_accessor :self_reference
+
+    def initialize
+      self.self_reference = self
+    end
+
+  end
+
   describe "#inspect" do
     it "contains the relevant data" do
       app = Spaceship::App.all.first
@@ -17,6 +26,13 @@ describe Spaceship::Base do
       output = v.inspect
       expect(output).to include "Tunes::AppVersion"
       expect(output).to include "Tunes::Application"
+    end
+
+    it 'handles circular references' do
+      test_base = TestBase.new
+      expect do
+        test_base.inspect
+      end.to_not raise_error(SystemStackError)
     end
   end
 

--- a/spaceship/spec/base_spec.rb
+++ b/spaceship/spec/base_spec.rb
@@ -5,13 +5,7 @@ describe Spaceship::Base do
   class TestBase < Spaceship::Base
     attr_accessor :child
 
-    def initialize
-    end
-
-    def self.self_reference
-      r = TestBase.new
-      r.child = r
-      r
+    def initialize # required
     end
   end
 
@@ -33,14 +27,16 @@ describe Spaceship::Base do
     end
 
     it 'handles circular references' do
-      test_base = TestBase.self_reference
+      test_base = TestBase.new
+      test_base.child = test_base # self-references
       expect do
         test_base.inspect
       end.to_not raise_error
     end
 
     it 'displays a placeholder value in inspect/to_s' do
-      test_base = TestBase.self_reference
+      test_base = TestBase.new
+      test_base.child = test_base # self-references
       expect(test_base.to_s).to eq("<TestBase \n\tchild=<TestBase \n\t~~DUPE~~>>")
     end
 

--- a/spaceship/spec/base_spec.rb
+++ b/spaceship/spec/base_spec.rb
@@ -3,10 +3,15 @@ describe Spaceship::Base do
   let(:client) { Spaceship::App.client }
 
   class TestBase < Spaceship::Base
-    attr_accessor :self_reference
+    attr_accessor :child
 
     def initialize
-      self.self_reference = self
+    end
+
+    def self.self_reference
+      r = TestBase.new
+      r.child = r
+      r
     end
   end
 
@@ -28,15 +33,31 @@ describe Spaceship::Base do
     end
 
     it 'handles circular references' do
-      test_base = TestBase.new
+      test_base = TestBase.self_reference
       expect do
         test_base.inspect
       end.to_not raise_error
     end
 
     it 'displays a placeholder value in inspect/to_s' do
+      test_base = TestBase.self_reference
+      expect(test_base.to_s).to eq("<TestBase \n\tchild=<TestBase \n\t~~DUPE~~>>")
+    end
+
+    it "doesn't leak state when throwing expections while inspecting objects" do
+      # an object with a broken inspect
+      test_base2 = TestBase.new
+      error = "faked inspect error"
+      allow(test_base2).to receive(:inspect).and_raise(error)
+
+      # will break the parent
       test_base = TestBase.new
-      expect(test_base.to_s).to eq("<TestBase \n\tself_reference=<TestBase \n\t~~DUPE~~>>")
+      test_base.child = test_base2
+      expect do
+        test_base.inspect
+      end.to raise_error(error)
+
+      expect(Thread.current[:inspected_objects]).to be_nil
     end
   end
 

--- a/spaceship/spec/base_spec.rb
+++ b/spaceship/spec/base_spec.rb
@@ -8,7 +8,6 @@ describe Spaceship::Base do
     def initialize
       self.self_reference = self
     end
-
   end
 
   describe "#inspect" do
@@ -32,7 +31,12 @@ describe Spaceship::Base do
       test_base = TestBase.new
       expect do
         test_base.inspect
-      end.to_not raise_error(SystemStackError)
+      end.to_not raise_error
+    end
+
+    it 'displays a placeholder value in inspect/to_s' do
+      test_base = TestBase.new
+      expect(test_base.to_s).to eq("<TestBase \n\tself_reference=<TestBase \n\t~~DUPE~~>>")
     end
   end
 

--- a/spaceship/spec/base_spec.rb
+++ b/spaceship/spec/base_spec.rb
@@ -37,7 +37,7 @@ describe Spaceship::Base do
     it 'displays a placeholder value in inspect/to_s' do
       test_base = TestBase.new
       test_base.child = test_base # self-references
-      expect(test_base.to_s).to eq("<TestBase \n\tchild=<TestBase \n\t~~DUPE~~>>")
+      expect(test_base.to_s).to eq("<TestBase \n\tchild=<TestBase \n\t#<Object ...>>>")
     end
 
     it "doesn't leak state when throwing expections while inspecting objects" do


### PR DESCRIPTION
for @snatchev 