### PR TITLE
Version bump to 2.12.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.11.0'.freeze
+  VERSION = '2.12.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.11.0':**

* Automaticaly retry failed requests on an internal server error for iTunesConnect (#8017)
* Remove information about how to open links in GitHub issues reporter (#8015)
* Fix spaceauth YAML spaceship cookie loading (#8012)
* Add missing duplicate space after emoji (#8016)
* Simplify spaceship requests for account user information (#8013)
* Improve error output when pilot can’t register new testers (#8008)
* Automaticaly retry failed requests on an internal server error for iTunes Connect (#8006)
* Improve scan error message for bad SLACK_URL (#8004)
* Add skip_testing, only_testing options to scan (#8002)
* fix typo in opt out usage action (#8001)
* Update links in auto-generated README to not include https in URL preview (#7989)
* Improve docs and code sample for opt_out_usage action (#7986)
* Update snapshot docs to reflect most recent Xcode release (#7985)
* snapshot support for iPhone SE (#7995)
* Fix number formatting for rubocop violation (#7999)
* Fastlane require format non plugins with dash (#7998)
* Add Automatic Release Date for Tunes Submission (#7151)
* Fix screengrab to doesn’t exit if the app could not be uninstalled (#7994)
* check for homebrew for update message (#7996)
* Update process around merging PRs (#7894)
