### PR TITLE
Fix git_branch task for Jenkins Pipeline jobs as they set BRANCH_NAME instead of GIT_BRANCH

### DIFF
--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -6,6 +6,7 @@ module Fastlane
     class GitBranchAction < Action
       def self.run(params)
         return ENV['GIT_BRANCH'] if FastlaneCore::Env.truthy?('GIT_BRANCH')
+        return ENV['BRANCH_NAME'] if FastlaneCore::Env.truthy?('BRANCH_NAME')
         return ENV["TRAVIS_BRANCH"] if FastlaneCore::Env.truthy?("TRAVIS_BRANCH")
         return ENV["BITRISE_GIT_BRANCH"] if FastlaneCore::Env.truthy?("BITRISE_GIT_BRANCH")
         `git symbolic-ref HEAD --short 2>/dev/null`.strip


### PR DESCRIPTION
Without the fix 

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Fix git_branch task for Jenkins Pipeline jobs as they set BRANCH_NAME instead of GIT_BRANCH

### Motivation and Context
Without the fix it end up with `HEAD` branch name
