### PR TITLE
Switch from unmaintained colored to maintained colored2

### DIFF
--- a/credentials_manager/lib/credentials_manager.rb
+++ b/credentials_manager/lib/credentials_manager.rb
@@ -4,7 +4,7 @@ require 'credentials_manager/cli'
 require 'credentials_manager/appfile_config'
 
 # Third Party code
-require 'colored'
+require 'colored2'
 require 'security'
 require 'highline/import' # to hide the entered password
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'word_wrap', '~> 1.0.0' # to add line breaks for tables with long strings
 
   spec.add_dependency 'babosa', '>= 1.0.2', "< 2.0.0"
-  spec.add_dependency 'colored' # coloured terminal output
+  spec.add_dependency 'colored2', '>= 3.1.1', "< 4.0.0" # coloured terminal output
   spec.add_dependency 'commander', '>= 4.4.0', '< 5.0.0' # CLI parser
   spec.add_dependency 'excon', '>= 0.45.0', '< 1.0.0' # Great HTTP Client
   spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'  

--- a/fastlane_core/lib/fastlane_core.rb
+++ b/fastlane_core/lib/fastlane_core.rb
@@ -31,7 +31,7 @@ require 'fastlane_core/keychain_importer'
 require 'fastlane_core/swag'
 
 # Third Party code
-require 'colored'
+require 'colored2'
 require 'commander'
 
 # after commander import

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -1,5 +1,5 @@
 require 'logger'
-require 'colored'
+require 'colored2'
 
 module FastlaneCore
   module Helper

--- a/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
+++ b/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
@@ -1,15 +1,15 @@
 # This code overwrites the methods from the colored gem
-# via https://github.com/defunkt/colored/blob/master/lib/colored.rb
+# via https://github.com/kigster/colored2/blob/aa274018906641ffb07aaa3015081a174d169dfe/lib/colored2.rb
 
-require 'colored'
+require 'colored2'
 
 class String
-  Colored::COLORS.keys.each do |color|
+  Colored2::COLORS.keys.each do |color|
     define_method(color) do
       self # do nothing with the string, but return it
     end
   end
-  Colored::EXTRAS.keys.each do |extra|
+  Colored2::EXTRAS.keys.each do |extra|
     define_method(extra) do
       self # do nothing with the string, but return it
     end

--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -1,4 +1,4 @@
-require 'colored'
+require 'colored2'
 require 'mini_magick'
 require 'json'
 

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -1,4 +1,4 @@
-require 'colored'
+require 'colored2'
 require 'ostruct'
 
 describe Pilot::TesterManager do

--- a/rakelib/issue_stats.rake
+++ b/rakelib/issue_stats.rake
@@ -51,7 +51,7 @@ task :issue_stats do
   require 'json'
   require 'faraday'
   require 'terminal-table'
-  require 'colored'
+  require 'colored2'
 
   raise "Please set GITHUB_SCRIPT_TOKEN in your environment with a GitHub personal access token value".red if GITHUB_TOKEN.to_s.empty?
 

--- a/rakelib/release_stats.rake
+++ b/rakelib/release_stats.rake
@@ -23,7 +23,7 @@ desc 'Print stats about how much time has passed and work has happened since the
 task :release_stats do
   require 'date'
   require 'terminal-table'
-  require 'colored'
+  require 'colored2'
   require 'shellwords'
 
   `git pull --tags`


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
The colored gem hasn't seen any activity in over 7 years, colored2 is a maintained fork, more details: https://libraries.io/rubygems/colored2

### Motivation and Context

@KrauseFx mentioned to me that the colored gem was causing failures on https://dependencyci.com so I thought I'd see if I could swap it out with a newer version.

I've also opened a pr to switch xcodeproj to use colored2 as well: https://github.com/CocoaPods/Xcodeproj/pull/463