### PR TITLE
Add optional date_format parameter to changelog_from_git_commits

### DIFF
--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -30,9 +30,9 @@ module Fastlane
         end
 
         if params[:commits_count]
-          changelog = Actions.git_log_last_commits(params[:pretty], params[:commits_count], merge_commit_filtering)
+          changelog = Actions.git_log_last_commits(params[:pretty], params[:commits_count], merge_commit_filtering, params[:date_format])
         else
-          changelog = Actions.git_log_between(params[:pretty], from, to, merge_commit_filtering)
+          changelog = Actions.git_log_between(params[:pretty], from, to, merge_commit_filtering, params[:date_format])
         end
         changelog = changelog.gsub("\n\n", "\n") if changelog # as there are duplicate newlines
         Actions.lane_context[SharedValues::FL_CHANGELOG] = changelog
@@ -89,6 +89,11 @@ module Fastlane
                                        optional: true,
                                        default_value: '%B',
                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :date_format,
+                                       env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_DATE_FORMAT',
+                                       description: 'The date format applied to each commit while generating the collected value ',
+                                       optional: true,
+                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :tag_match_pattern,
                                        env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_TAG_MATCH_PATTERN',
                                        description: 'A glob(7) pattern to match against when finding the last git tag',
@@ -136,9 +141,10 @@ module Fastlane
           'changelog_from_git_commits',
           'changelog_from_git_commits(
             between: ["7b092b3", "HEAD"], # Optional, lets you specify a revision/tag range between which to collect commit info
-            pretty: "- (%ae) %s", # Optional, lets you provide a custom format to apply to each commit when generating the changelog text
+            pretty: "- (%ae) %s",         # Optional, lets you provide a custom format to apply to each commit when generating the changelog text
+            date_format: "short",         # Optional, lets you provide an additional date format to dates within the pretty-formatted string
             match_lightweight_tag: false, # Optional, lets you ignore lightweight (non-annotated) tags when searching for the last tag
-            include_merges: true # Optional, lets you filter out merge commits
+            include_merges: true          # Optional, lets you filter out merge commits
           )'
         ]
       end

--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -129,7 +129,7 @@ module Fastlane
       end
 
       def self.author
-        ['mfurtak', 'asfalcone', 'SiarheiFedartsou']
+        ['mfurtak', 'asfalcone', 'SiarheiFedartsou', 'allewun']
       end
 
       def self.is_supported?(platform)

--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -91,7 +91,7 @@ module Fastlane
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :date_format,
                                        env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_DATE_FORMAT',
-                                       description: 'The date format applied to each commit while generating the collected value ',
+                                       description: 'The date format applied to each commit while generating the collected value',
                                        optional: true,
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :tag_match_pattern,

--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -140,11 +140,11 @@ module Fastlane
         [
           'changelog_from_git_commits',
           'changelog_from_git_commits(
-            between: ["7b092b3", "HEAD"], # Optional, lets you specify a revision/tag range between which to collect commit info
-            pretty: "- (%ae) %s",         # Optional, lets you provide a custom format to apply to each commit when generating the changelog text
-            date_format: "short",         # Optional, lets you provide an additional date format to dates within the pretty-formatted string
-            match_lightweight_tag: false, # Optional, lets you ignore lightweight (non-annotated) tags when searching for the last tag
-            include_merges: true          # Optional, lets you filter out merge commits
+            between: ["7b092b3", "HEAD"],            # Optional, lets you specify a revision/tag range between which to collect commit info
+            pretty: "- (%ae) %s",                    # Optional, lets you provide a custom format to apply to each commit when generating the changelog text
+            date_format: "short",                    # Optional, lets you provide an additional date format to dates within the pretty-formatted string
+            match_lightweight_tag: false,            # Optional, lets you ignore lightweight (non-annotated) tags when searching for the last tag
+            merge_commit_filtering: "exclude_merges" # Optional, lets you filter out merge commits
           )'
         ]
       end

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -2,20 +2,22 @@ module Fastlane
   module Actions
     GIT_MERGE_COMMIT_FILTERING_OPTIONS = [:include_merges, :exclude_merges, :only_include_merges].freeze
 
-    def self.git_log_between(pretty_format, from, to, merge_commit_filtering)
-      command = 'git log'
-      command << " --pretty=\"#{pretty_format}\" #{from.shellescape}...#{to.shellescape}"
+    def self.git_log_between(pretty_format, from, to, merge_commit_filtering, date_format = nil)
+      command = ['git log']
+      command << "--pretty=\"#{pretty_format}\" #{from.shellescape}...#{to.shellescape}"
+      command << "--date=\"#{date_format}\"" if date_format
       command << git_log_merge_commit_filtering_option(merge_commit_filtering)
-      Actions.sh(command, log: false).chomp
+      Actions.sh(command.join(' '), log: false).chomp
     rescue
       nil
     end
 
-    def self.git_log_last_commits(pretty_format, commit_count, merge_commit_filtering)
-      command = 'git log'
-      command << " --pretty=\"#{pretty_format}\" -n #{commit_count}"
+    def self.git_log_last_commits(pretty_format, commit_count, merge_commit_filtering, date_format = nil)
+      command = ['git log']
+      command << "--pretty=\"#{pretty_format}\" -n #{commit_count}"
+      command << "--date=\"#{date_format}\"" if date_format
       command << git_log_merge_commit_filtering_option(merge_commit_filtering)
-      Actions.sh(command, log: false).chomp
+      Actions.sh(command.join(' '), log: false).chomp
     rescue
       nil
     end
@@ -44,8 +46,11 @@ module Fastlane
 
     # Gets the last git commit information formatted into a String by the provided
     # pretty format String. See the git-log documentation for valid format placeholders
-    def self.last_git_commit_formatted_with(pretty_format)
-      Actions.sh("git log -1 --pretty=#{pretty_format}", log: false).chomp
+    def self.last_git_commit_formatted_with(pretty_format, date_format = nil)
+      command = ['git log -1']
+      command << "--pretty=\"#{pretty_format}\""
+      command << "--date=\"#{date_format}\"" if date_format
+      Actions.sh(command.join(' '), log: false).chomp
     rescue
       nil
     end

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -52,7 +52,7 @@ module Fastlane
       command = ['git log -1']
       command << "--pretty=\"#{pretty_format}\""
       command << "--date=\"#{date_format}\"" if date_format
-      Actions.sh(command.join(' '), log: false).chomp
+      Actions.sh(command.compact.join(' '), log: false).chomp
     rescue
       nil
     end

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -103,6 +103,8 @@ module Fastlane
         "--no-merges"
       when :only_include_merges
         "--merges"
+      when :include_merges
+        nil
       end
     end
   end

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -103,8 +103,6 @@ module Fastlane
         "--no-merges"
       when :only_include_merges
         "--merges"
-      else
-        nil
       end
     end
   end

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -4,20 +4,22 @@ module Fastlane
 
     def self.git_log_between(pretty_format, from, to, merge_commit_filtering, date_format = nil)
       command = ['git log']
-      command << "--pretty=\"#{pretty_format}\" #{from.shellescape}...#{to.shellescape}"
+      command << "--pretty=\"#{pretty_format}\""
       command << "--date=\"#{date_format}\"" if date_format
+      command << "#{from.shellescape}...#{to.shellescape}"
       command << git_log_merge_commit_filtering_option(merge_commit_filtering)
-      Actions.sh(command.join(' '), log: false).chomp
+      Actions.sh(command.compact.join(' '), log: false).chomp
     rescue
       nil
     end
 
     def self.git_log_last_commits(pretty_format, commit_count, merge_commit_filtering, date_format = nil)
       command = ['git log']
-      command << "--pretty=\"#{pretty_format}\" -n #{commit_count}"
+      command << "--pretty=\"#{pretty_format}\""
       command << "--date=\"#{date_format}\"" if date_format
+      command << "-n #{commit_count}"
       command << git_log_merge_commit_filtering_option(merge_commit_filtering)
-      Actions.sh(command.join(' '), log: false).chomp
+      Actions.sh(command.compact.join(' '), log: false).chomp
     rescue
       nil
     end
@@ -28,7 +30,7 @@ module Fastlane
       command = ['git describe']
       command << '--tags' if match_lightweight
       command << "`git rev-list --tags#{tag_pattern_param} --max-count=1`"
-      Actions.sh(command.join(' '), log: false).chomp
+      Actions.sh(command.compact.join(' '), log: false).chomp
     rescue
       nil
     end
@@ -98,11 +100,11 @@ module Fastlane
     def self.git_log_merge_commit_filtering_option(merge_commit_filtering)
       case merge_commit_filtering
       when :exclude_merges
-        " --no-merges"
+        "--no-merges"
       when :only_include_merges
-        " --merges"
+        "--merges"
       else
-        ""
+        nil
       end
     end
   end

--- a/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -17,6 +17,14 @@ describe Fastlane do
         expect(result).to eq("git log --pretty=\"%s%n%b\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD")
       end
 
+      it "Uses the provided date format to collect log messages if specified" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          changelog_from_git_commits(pretty: '%s%n%b', date_format: 'short')
+        end").runner.execute(:test)
+
+        expect(result).to eq("git log --pretty=\"%s%n%b\" --date=\"short\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD")
+      end
+
       it "Does not match lightweight tags when searching for the last one if so requested" do
         result = Fastlane::FastFile.new.parse("lane :test do
           changelog_from_git_commits(match_lightweight_tag: false)
@@ -33,7 +41,7 @@ describe Fastlane do
         expect(result).to eq("git log --pretty=\"%B\" abcd...1234")
       end
 
-      it "handles tag names with characters that need shell escaping" do
+      it "Handles tag names with characters that need shell escaping" do
         result = Fastlane::FastFile.new.parse("lane :test do
           changelog_from_git_commits(between: ['v1.8.0(30)', 'HEAD'])
         end").runner.execute(:test)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
The git helper methods that allow git log customization via the `pretty_format` parameter were extended to also allow an optional `date_format` parameter.

The existing `pretty_format` parameter maps to the `--pretty` flag for `git log`.
The  new`date_format` parameter similarly maps to the `--date` flag for `git log`.

### Motivation and Context
The `changelog_from_git_commits` action provides the `pretty_format` parameter to customize the git commit messages. However, `pretty_format` alone lacks the ability to customize the date format, hence why `date_format` is needed. I don't believe you can customize the date format without this flag (see: https://git-scm.com/docs/pretty-formats).