### PR TITLE
[snapshot,scan] logarchive extraction 📖

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -194,6 +194,20 @@ module FastlaneCore
         all.each(&:reset)
       end
 
+      def copy_logarchive(device, dest)
+        sim_resource_dir = FastlaneCore::CommandExecutor.execute(command: "xcrun simctl getenv #{device.udid} SIMULATOR_SHARED_RESOURCES_DIRECTORY 2>/dev/null", print_all: false, print_command: true)
+        logarchive_src = File.join(sim_resource_dir, "system_logs.logarchive")
+        FileUtils.rm_rf(logarchive_src) if File.exist?(logarchive_src)
+
+        command = "xcrun simctl spawn #{device.udid} log collect 2>/dev/null"
+        FastlaneCore::CommandExecutor.execute(command: command, print_all: false, print_command: true)
+
+        # if logarchive already exists it fails as the .logarchive is a directory, so delete it. to be sure its gone
+        FileUtils.rm_rf(dest) if File.exist?(dest)
+        FileUtils.cp_r(logarchive_src, dest)
+        UI.success "Copying file '#{logarchive_src}' to '#{dest}'..."
+      end
+
       def reset_all_by_version(os_version: nil)
         return false unless os_version
         all.select { |device| device.os_version == os_version }.each(&:reset)

--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -197,13 +197,14 @@ module FastlaneCore
       def copy_logarchive(device, dest)
         sim_resource_dir = FastlaneCore::CommandExecutor.execute(command: "xcrun simctl getenv #{device.udid} SIMULATOR_SHARED_RESOURCES_DIRECTORY 2>/dev/null", print_all: false, print_command: true)
         logarchive_src = File.join(sim_resource_dir, "system_logs.logarchive")
-        FileUtils.rm_rf(logarchive_src) if File.exist?(logarchive_src)
+
+        FileUtils.rm_rf(logarchive_src)
+        FileUtils.rm_rf(dest)
 
         command = "xcrun simctl spawn #{device.udid} log collect 2>/dev/null"
         FastlaneCore::CommandExecutor.execute(command: command, print_all: false, print_command: true)
 
         # if logarchive already exists it fails as the .logarchive is a directory, so delete it. to be sure its gone
-        FileUtils.rm_rf(dest) if File.exist?(dest)
         FileUtils.cp_r(logarchive_src, dest)
         UI.success "Copying file '#{logarchive_src}' to '#{dest}'..."
       end

--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -198,13 +198,13 @@ module FastlaneCore
         sim_resource_dir = FastlaneCore::CommandExecutor.execute(command: "xcrun simctl getenv #{device.udid} SIMULATOR_SHARED_RESOURCES_DIRECTORY 2>/dev/null", print_all: false, print_command: true)
         logarchive_src = File.join(sim_resource_dir, "system_logs.logarchive")
 
+        # if logarchive already exists it fails as the .logarchive is a directory, so delete it. to be sure its gone
         FileUtils.rm_rf(logarchive_src)
         FileUtils.rm_rf(dest)
 
         command = "xcrun simctl spawn #{device.udid} log collect 2>/dev/null"
         FastlaneCore::CommandExecutor.execute(command: command, print_all: false, print_command: true)
 
-        # if logarchive already exists it fails as the .logarchive is a directory, so delete it. to be sure its gone
         FileUtils.cp_r(logarchive_src, dest)
         UI.success "Copying file '#{logarchive_src}' to '#{dest}'..."
       end

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -21,30 +21,6 @@ describe Scan do
           @scan.handle_results(0)
         end
       end
-
-      describe "with Scan option :include_simulator_logs" do
-        before(:each) do
-          allow(File).to receive(:exist?).and_return(true)
-
-          allow(FileUtils).to receive(:cp).with(anything, anything) do
-            # nothing
-          end
-        end
-
-        context "extract system.logarchive", now: true do
-          it "copies all device logs to the output directory" do
-            Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
-              output_directory: '/tmp/scan_results',
-              include_simulator_logs: true,
-              devices: ["iPhone 6s", "iPad Air"],
-              project: './scan/examples/standard/app.xcodeproj'
-            })
-            expect(FileUtils).to receive(:cp_r).with(/.*/, /system_logs-.*.logarchive/)
-            expect(FileUtils).to receive(:cp_r).with(/.*/, /system_logs-.*.logarchive/)
-            @scan.handle_results(0)
-          end
-        end
-      end
     end
   end
 end

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -31,21 +31,7 @@ describe Scan do
           end
         end
 
-        context "and only one device requested" do
-          it "copies one simulated device log to the output directory" do
-            Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
-              output_directory: '/tmp/scan_results',
-              include_simulator_logs: true,
-              device: 'iPhone 5s (10.2)',
-              project: './scan/examples/standard/app.xcodeproj'
-            })
-
-            expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Scan.config[:output_directory]}\/iPhone .*_iOS_.*system.log})
-            @scan.handle_results(0)
-          end
-        end
-
-        context "and more than one device requested" do
+        context "extract system.logarchive", now: true do
           it "copies all device logs to the output directory" do
             Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
               output_directory: '/tmp/scan_results',
@@ -53,8 +39,8 @@ describe Scan do
               devices: ["iPhone 6s", "iPad Air"],
               project: './scan/examples/standard/app.xcodeproj'
             })
-            expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Scan.config[:output_directory]}\/iPhone .*_iOS_.*system.log})
-            expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Scan.config[:output_directory]}\/iPad Air_iOS_.*system.log})
+            expect(FileUtils).to receive(:cp_r).with(/.*/, /system_logs-.*.logarchive/)
+            expect(FileUtils).to receive(:cp_r).with(/.*/, /system_logs-.*.logarchive/)
             @scan.handle_results(0)
           end
         end

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -98,13 +98,13 @@ module Snapshot
       end
     end
 
-    def output_simulator_logs(device_name, language, locale, launch_arguments_index)
+    def output_simulator_logs(device_name, language, locale, launch_arguments)
       return unless Snapshot.config[:output_simulator_logs]
 
       detected_language = locale || language
       language_folder = File.join(Snapshot.config[:output_directory], detected_language)
       device = TestCommandGenerator.find_device(device_name)
-      components = [launch_arguments_index].delete_if { |a| a.to_s.length == 0 }
+      components = [launch_arguments].delete_if { |a| a.to_s.length == 0 }
       UI.header("Collecting system logs #{device_name} - #{language}")
 
       sim_resource_dir = FastlaneCore::CommandExecutor.execute(command: "xcrun simctl getenv #{device.udid} SIMULATOR_SHARED_RESOURCES_DIRECTORY 2>/dev/null", print_all: false, print_command: true)

--- a/snapshot/spec/runner_spec.rb
+++ b/snapshot/spec/runner_spec.rb
@@ -7,24 +7,5 @@ describe Snapshot do
         expect(helper_version).to match(/^SnapshotHelperVersion \[\d.\d\]$/)
       end
     end
-
-    describe 'output_simulator_logs' do
-      before(:each) do
-        allow(FileUtils).to receive(:cp).with(anything, anything)
-        allow(File).to receive(:exist?).and_return(true)
-      end
-
-      it 'copies all device logs to the output directory' do
-        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, {
-          output_directory: '/tmp/scan_results',
-          output_simulator_logs: true,
-          devices: ['iPhone 6s', 'iPad Air'],
-          project: './snapshot/example/Example.xcodeproj',
-          scheme: 'ExampleUITests'
-        })
-        expect(FileUtils).to receive(:cp_r).with(/.*/, /.*system_logs-.*.logarchive/).and_return(true)
-        runner.output_simulator_logs("iPhone 6s", "de-DE", nil, 0)
-      end
-    end
   end
 end

--- a/snapshot/spec/runner_spec.rb
+++ b/snapshot/spec/runner_spec.rb
@@ -22,8 +22,7 @@ describe Snapshot do
           project: './snapshot/example/Example.xcodeproj',
           scheme: 'ExampleUITests'
         })
-        expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Snapshot.config[:output_directory]}/de-DE/system-cfcd208495d565ef66e7dff9f98764da.lo}).and_return(true)
-        expect(FileUtils).to receive(:cp_r).with(/.*/, %r{#{Snapshot.config[:output_directory]}/de-DE/system-cfcd208495d565ef66e7dff9f98764dasystem_logs.logarchive}).and_return(true)
+        expect(FileUtils).to receive(:cp_r).with(/.*/, /.*system_logs-.*.logarchive/).and_return(true)
         runner.output_simulator_logs("iPhone 6s", "de-DE", nil, 0)
       end
     end

--- a/snapshot/spec/runner_spec.rb
+++ b/snapshot/spec/runner_spec.rb
@@ -22,9 +22,9 @@ describe Snapshot do
           project: './snapshot/example/Example.xcodeproj',
           scheme: 'ExampleUITests'
         })
-        expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Snapshot.config[:output_directory]}/iPhone .*_iOS_.*system.log})
-        expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Snapshot.config[:output_directory]}/iPad Air_iOS_.*system.log})
-        runner.output_simulator_logs
+        expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Snapshot.config[:output_directory]}/de-DE/system-cfcd208495d565ef66e7dff9f98764da.lo}).and_return(true)
+        expect(FileUtils).to receive(:cp_r).with(/.*/, %r{#{Snapshot.config[:output_directory]}/de-DE/system-cfcd208495d565ef66e7dff9f98764dasystem_logs.logarchive}).and_return(true)
+        runner.output_simulator_logs("iPhone 6s", "de-DE", nil, 0)
       end
     end
   end

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -30,7 +30,7 @@ describe Snapshot do
       end
     end
 
-    describe 'output_simulator_logs' do
+    describe 'copy_simulator_logs' do
       it 'copies all device logs to the output directory' do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, {
           output_directory: '/tmp/scan_results',
@@ -62,8 +62,8 @@ describe Snapshot do
           with(command: "xcrun simctl spawn 22222 log collect 2>/dev/null", print_all: false, print_command: true).
           and_return("/tmp/folder")
 
-        Snapshot::Runner.new.output_simulator_logs("iPhone 6s", "de-DE", nil, 0)
-        Snapshot::Runner.new.output_simulator_logs("iPhone 6", "en-US", nil, 0)
+        Snapshot::Runner.new.copy_simulator_logs("iPhone 6s", "de-DE", nil, 0)
+        Snapshot::Runner.new.copy_simulator_logs("iPhone 6", "en-US", nil, 0)
       end
     end
 

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -2,13 +2,14 @@ describe Snapshot do
   describe Snapshot::TestCommandGenerator do
     let(:os_version) { "9.3" }
     let(:iphone6_9_3) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 6", os_version: os_version, udid: "11111", state: "Don't Care", is_simulator: true) }
+    let(:iphone6_9_3_2) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 6s", os_version: os_version, udid: "22222", state: "Don't Care", is_simulator: true) }
     let(:iphone6_9_0) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 6", os_version: '9.0', udid: "11111", state: "Don't Care", is_simulator: true) }
     let(:iphone6_9_2) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 6", os_version: '9.2', udid: "11111", state: "Don't Care", is_simulator: true) }
     let(:appleTV) { FastlaneCore::DeviceManager::Device.new(name: "Apple TV 1080p", os_version: os_version, udid: "22222", state: "Don't Care", is_simulator: true) }
 
     before do
       allow(Snapshot::LatestOsVersion).to receive(:version).and_return(os_version)
-      allow(FastlaneCore::DeviceManager).to receive(:simulators).and_return([iphone6_9_0, iphone6_9_3, iphone6_9_2, appleTV])
+      allow(FastlaneCore::DeviceManager).to receive(:simulators).and_return([iphone6_9_0, iphone6_9_3, iphone6_9_2, appleTV, iphone6_9_3_2])
       fake_out_xcode_project_loading
     end
 
@@ -26,6 +27,43 @@ describe Snapshot do
       it 'finds a device with the same name, but a different OS version, picking the highest available OS version' do
         found = Snapshot::TestCommandGenerator.find_device('iPhone 6', '10.0')
         expect(found).to be(iphone6_9_3)
+      end
+    end
+
+    describe 'output_simulator_logs' do
+      it 'copies all device logs to the output directory' do
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, {
+          output_directory: '/tmp/scan_results',
+          output_simulator_logs: true,
+          devices: ['iPhone 6', 'iPhone 6s'],
+          project: './snapshot/example/Example.xcodeproj',
+          scheme: 'ExampleUITests'
+        })
+        expect(FileUtils).to receive(:cp_r).with(/.*/, %r{de-DE/system_logs-cfcd208495d565ef66e7dff9f98764da.logarchive}).and_return(true)
+        expect(FileUtils).to receive(:cp_r).with(/.*/, %r{en-US/system_logs-cfcd208495d565ef66e7dff9f98764da.logarchive}).and_return(true)
+
+        expect(FastlaneCore::CommandExecutor).
+          to receive(:execute).
+          with(command: "xcrun simctl getenv 11111 SIMULATOR_SHARED_RESOURCES_DIRECTORY 2>/dev/null", print_all: false, print_command: true).
+          and_return("/tmp/folder")
+
+        expect(FastlaneCore::CommandExecutor).
+          to receive(:execute).
+          with(command: "xcrun simctl spawn 11111 log collect 2>/dev/null", print_all: false, print_command: true).
+          and_return("/tmp/folder")
+
+        expect(FastlaneCore::CommandExecutor).
+          to receive(:execute).
+          with(command: "xcrun simctl getenv 22222 SIMULATOR_SHARED_RESOURCES_DIRECTORY 2>/dev/null", print_all: false, print_command: true).
+          and_return("/tmp/folder")
+
+        expect(FastlaneCore::CommandExecutor).
+          to receive(:execute).
+          with(command: "xcrun simctl spawn 22222 log collect 2>/dev/null", print_all: false, print_command: true).
+          and_return("/tmp/folder")
+
+        Snapshot::Runner.new.output_simulator_logs("iPhone 6s", "de-DE", nil, 0)
+        Snapshot::Runner.new.output_simulator_logs("iPhone 6", "en-US", nil, 0)
       end
     end
 


### PR DESCRIPTION
as reffered in https://github.com/fastlane/fastlane/pull/7906, also extract the logarchive from the simulator.

implements:
  - [x] snapshot support logarchive extraction + fix system log output per language/locale  and launchg arguments
  - [x] scan support logarchive extraction




# Snapshot

```ruby
lane :os_collect_snapshot do
        snapshot(
                project: "snapshot/example/Example.xcodeproj",
                scheme: "Example",
                output_simulator_logs: true,
                languages: ["en-US", "de-DE"],
                devices: ["iPhone 6", "iPhone 6s"]

        )
end

```

![bildschirmfoto 2017-01-27 um 20 17 27](https://cloud.githubusercontent.com/assets/2891702/22384321/2019c1b4-e4ce-11e6-8456-8b435e5b25e5.png)


![bildschirmfoto 2017-01-27 um 20 17 54](https://cloud.githubusercontent.com/assets/2891702/22384339/3217283e-e4ce-11e6-9f8e-997cb3995f30.png)




# Scan


Test Lane:


```ruby
lane :os_collect_scan do

        scan(
                project: "scan/examples/standard/app.xcodeproj",
                include_simulator_logs: true,
                devices: ["iPhone 6", "iPhone 6s"]
        )

end
```


![bildschirmfoto 2017-01-29 um 20 41 47](https://cloud.githubusercontent.com/assets/2891702/22407268/700be94a-e663-11e6-9794-035925147489.png)


![bildschirmfoto 2017-01-29 um 20 42 50](https://cloud.githubusercontent.com/assets/2891702/22407274/8b2eae10-e663-11e6-89ae-c561b72d28cb.png)

