### PR TITLE
frameit: Added font_scale_factor as a fraction of the screen width

### DIFF
--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -64,11 +64,10 @@ module Frameit
         if value.kind_of?(Hash)
           validate_values(value) # recursive call
         else
-          if key == 'font'
+          case key
+          when 'font'
             UI.user_error!("Could not find font at path '#{File.expand_path(value)}'") unless File.exist?(value)
-          end
-
-          if key == 'fonts'
+          when 'fonts'
             UI.user_error!("`fonts` must be an array") unless value.kind_of?(Array)
 
             value.each do |current|
@@ -76,23 +75,15 @@ module Frameit
               UI.user_error!("Could not find font at path '#{File.expand_path(current.fetch('font'))}'") unless File.exist?(current.fetch('font'))
               UI.user_error!("`supported` must be an array") unless current.fetch('supported', []).kind_of? Array
             end
-          end
-
-          if key == 'background'
+          when 'background'
             UI.user_error!("Could not find background image at path '#{File.expand_path(value)}'") unless File.exist? value
-          end
-
-          if key == 'color'
+          when 'color'
             UI.user_error!("Invalid color '#{value}'. Must be valid Hex #123123") unless value.include?("#")
-          end
-
-          if key == 'padding'
+          when 'padding'
             unless value.kind_of?(Integer) || value.split('x').length == 2
               UI.user_error!("padding must be type integer or pair of integers of format 'AxB'")
             end
-          end
-
-          if key == 'font_scale_factor'
+          when 'font_scale_factor'
             UI.user_error! "font_scale_factor must be numeric" unless value.kind_of?(Numeric)
           end
         end

--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -91,6 +91,10 @@ module Frameit
               UI.user_error!("padding must be type integer or pair of integers of format 'AxB'")
             end
           end
+
+          if key == 'font_scale_factor'
+            UI.user_error! "font_scale_factor must be numeric" unless value.kind_of?(Numeric)
+          end
         end
       end
     end

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -236,7 +236,8 @@ module Frameit
     end
 
     def actual_font_size
-      [@image.width / 10.0].max.round
+      font_scale_factor = fetch_config['font_scale_factor'] || 0.1
+      [@image.width * font_scale_factor].max.round
     end
 
     # The space between the keyword and the title


### PR DESCRIPTION
Allows to limit the font size in order to achieve the same font size for all shots;
should fix #1728;

As requested in #7334 review, I isolated the parts in separate PRs. This is one of them.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.