### PR TITLE
frameit: reduced spacing between keyword and title

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -241,7 +241,7 @@ module Frameit
 
     # The space between the keyword and the title
     def keyword_padding
-      (actual_font_size / 2.0).round
+      (actual_font_size / 3.0).round
     end
 
     # This will build 2 individual images with the title, which will then be added to the real image


### PR DESCRIPTION
Margin between title and keyword should match a standard %20 space (#7346).

As requested in #7334 review, I isolated the parts in separate PRs. This is one of them.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.