### PR TITLE
add attachment support to Mailgun action

### DIFF
--- a/fastlane/lib/fastlane/actions/mailgun.rb
+++ b/fastlane/lib/fastlane/actions/mailgun.rb
@@ -86,7 +86,12 @@ module Fastlane
                                       env_name: "MAILGUN_REPLY_TO",
                                       description: "Mail Reply to",
                                       optional: true,
-                                      is_string: true)
+                                      is_string: true),
+          FastlaneCore::ConfigItem.new(key: :attachment,
+                                      env_name: "MAILGUN_ATTACHMENT",
+                                      description: "Mail Attachments",
+                                      optional: true,
+                                      is_string: false)
 
         ]
       end
@@ -114,6 +119,13 @@ module Fastlane
         unless options[:reply_to].nil?
           params.store(:"h:Reply-To", options[:reply_to])
         end
+
+        unless options[:attachment].nil?
+          attachment_filenames = [*options[:attachment]]
+          attachments = attachment_filenames.map { |filename| File.new(filename, 'rb') }
+          params.store(:attachment, attachments)
+        end
+
         RestClient.post "https://api:#{options[:apikey]}@api.mailgun.net/v3/#{sandbox_domain}/messages", params
         mail_template(options)
       end
@@ -158,7 +170,8 @@ module Fastlane
             message: "Mail Body",
             app_link: "http://www.myapplink.com",
             ci_build_link: "http://www.mycibuildlink.com",
-            template_path: "HTML_TEMPLATE_PATH"
+            template_path: "HTML_TEMPLATE_PATH",
+            attachment: "build/changelog.txt"
           )'
         ]
       end

--- a/fastlane/lib/fastlane/actions/mailgun.rb
+++ b/fastlane/lib/fastlane/actions/mailgun.rb
@@ -89,7 +89,7 @@ module Fastlane
                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :attachment,
                                       env_name: "MAILGUN_ATTACHMENT",
-                                      description: "Mail Attachments",
+                                      description: "Mail Attachment filenames, either an array or just one string",
                                       optional: true,
                                       is_string: false)
 
@@ -171,7 +171,7 @@ module Fastlane
             app_link: "http://www.myapplink.com",
             ci_build_link: "http://www.mycibuildlink.com",
             template_path: "HTML_TEMPLATE_PATH",
-            attachment: "build/changelog.txt"
+            attachment: "dirname/filename.ext"
           )'
         ]
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [✅ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [✅] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [✅] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [✅] I've updated the documentation if necessary.

### Description
Allow using `:attachment` param to add files to email.

### Motivation and Context
As a developer, I wanted to receive an attachment that contains my UI test results.
