### PR TITLE
fix error reporting missing html decoding

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -8,6 +8,7 @@ require 'spaceship/helper/net_http_generic_request'
 require 'spaceship/helper/plist_middleware'
 require 'spaceship/ui'
 require 'tmpdir'
+require 'cgi'
 
 Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder
 
@@ -78,8 +79,8 @@ module Spaceship
 
         [
           "Apple provided the following error info:",
-          @error_info['resultString'],
-          @error_info['userString']
+          CGI.unescapeHTML(@error_info['resultString']),
+          CGI.unescapeHTML(@error_info['userString'])
         ].compact.uniq # sometimes 'resultString' and 'userString' are the same value
       end
     end


### PR DESCRIPTION
should fix apple error html encoding.

from:
![bildschirmfoto 2017-01-31 um 22 54 16](https://cloud.githubusercontent.com/assets/2891702/22487420/8f7da7e0-e80d-11e6-901a-f2e489ce32d8.png)


to:

![bildschirmfoto 2017-01-31 um 23 34 12](https://cloud.githubusercontent.com/assets/2891702/22487469/cba7c160-e80d-11e6-8179-2e419710ad03.png)


