### PR TITLE
[spaceship] app, application finding case insensitive

### DIFF
--- a/spaceship/lib/spaceship/portal/app.rb
+++ b/spaceship/lib/spaceship/portal/app.rb
@@ -103,7 +103,7 @@ module Spaceship
         # @return (App) The app you're looking for. This is nil if the app can't be found.
         def find(bundle_id, mac: false)
           all(mac: mac).find do |app|
-            app.bundle_id == bundle_id
+            return app if app.bundle_id.casecmp(bundle_id) == 0
           end
         end
       end

--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -63,7 +63,7 @@ module Spaceship
         #   as either the App ID or the bundle identifier
         def find(identifier, mac: false)
           all.find do |app|
-            (app.apple_id == identifier.to_s || app.bundle_id == identifier) &&
+            ((app.apple_id && app.apple_id.casecmp(identifier.to_s) == 0) || (app.bundle_id && app.bundle_id.casecmp(identifier.to_s) == 0)) &&
               app.version_sets.any? { |v| (mac ? ["osx"] : ["ios", "appletvos"]).include?(v.platform) }
           end
         end

--- a/spaceship/spec/portal/app_spec.rb
+++ b/spaceship/spec/portal/app_spec.rb
@@ -66,7 +66,7 @@ describe Spaceship::Portal::App do
       expect(app.app_id).to eq("B7JBD8LHAA")
       expect(app.is_wildcard).to eq(false)
     end
-    
+
     it "works with specific App IDs even with diffrent case" do
       app = Spaceship::Portal::App.find("net.sunaPPs.151")
       expect(app.app_id).to eq("B7JBD8LHAA")

--- a/spaceship/spec/portal/app_spec.rb
+++ b/spaceship/spec/portal/app_spec.rb
@@ -66,6 +66,12 @@ describe Spaceship::Portal::App do
       expect(app.app_id).to eq("B7JBD8LHAA")
       expect(app.is_wildcard).to eq(false)
     end
+    
+    it "works with specific App IDs even with diffrent case" do
+      app = Spaceship::Portal::App.find("net.sunaPPs.151")
+      expect(app.app_id).to eq("B7JBD8LHAA")
+      expect(app.is_wildcard).to eq(false)
+    end
 
     it "works with wilcard App IDs" do
       app = Spaceship::Portal::App.find("net.sunapps.*")

--- a/spaceship/spec/tunes/application_spec.rb
+++ b/spaceship/spec/tunes/application_spec.rb
@@ -37,6 +37,12 @@ describe Spaceship::Application do
           expect(a.class).to eq(Spaceship::Application)
           expect(a.apple_id).to eq('898536088')
         end
+        
+        it "returns the application if available ignoring case" do
+          a = Spaceship::Application.find('net.sunaPPs.107')
+          expect(a.class).to eq(Spaceship::Application)
+          expect(a.apple_id).to eq('898536088')
+        end
 
         it "returns nil if not available" do
           a = Spaceship::Application.find('netnot.available')

--- a/spaceship/spec/tunes/application_spec.rb
+++ b/spaceship/spec/tunes/application_spec.rb
@@ -39,7 +39,7 @@ describe Spaceship::Application do
         end
 
         it "returns the application if available ignoring case" do
-          a = Spaceship::Application.find('net.sunaPPs.107')
+          a = Spaceship::Application.find('net.sunAPPs.107')
           expect(a.class).to eq(Spaceship::Application)
           expect(a.apple_id).to eq('898536088')
         end

--- a/spaceship/spec/tunes/application_spec.rb
+++ b/spaceship/spec/tunes/application_spec.rb
@@ -37,7 +37,7 @@ describe Spaceship::Application do
           expect(a.class).to eq(Spaceship::Application)
           expect(a.apple_id).to eq('898536088')
         end
-        
+
         it "returns the application if available ignoring case" do
           a = Spaceship::Application.find('net.sunaPPs.107')
           expect(a.class).to eq(Spaceship::Application)


### PR DESCRIPTION
this PR makes app finding by bundle_id case insensitive.

  * Tunes -> application.find
  * Portal -> app.find


fixes: https://github.com/fastlane/fastlane/issues/8039#issuecomment-276304079

test:

```
# creates new app
bundle exec fastlane produce  --app_identifier some.new.app

# says it already exists, without PR it will produce a exception
bundle exec fastlane produce  --app_identifier some.nEW.app
```


i tested it with about 10 apps and it works - adp shows them with the casing used on first create, but validation if bundle_id is uniqe seems to be done case insensitive on apple side.


i also added specs for this.