### PR TITLE
Fix order of keychain files in action helper, fixes #7505

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -199,13 +199,13 @@ module FastlaneCore
         name
       ].map { |path| File.expand_path(path) }
 
-      # Transforms ["thing"] to ["thing", "thing-db", "thing.keychain", "thing.keychain-db"]
+      # Transforms ["thing"] to ["thing-db", "thing.keychain-db", "thing", "thing.keychain"]
       keychain_paths = []
       possible_locations.each do |location|
-        keychain_paths << location
         keychain_paths << "#{location}-db"
-        keychain_paths << "#{location}.keychain"
         keychain_paths << "#{location}.keychain-db"
+        keychain_paths << location
+        keychain_paths << "#{location}.keychain"
       end
 
       keychain_path = keychain_paths.find { |path| File.exist?(path) }


### PR DESCRIPTION
It seems like on machines that were upgraded from El Cap to Sierra, both `login.keychain` and `login.keychain-db` exists, so `login.keychain` was preferred by the helper. Sierra uses the `-db` files, so this created problems. 