### PR TITLE
Frameit: Provide option to stack keyword on top of title

### DIFF
--- a/frameit/README.md
+++ b/frameit/README.md
@@ -138,7 +138,8 @@ Use it to define the general information:
     },
     "background": "./background.jpg",
     "padding": 50,
-    "show_complete_frame": false
+    "show_complete_frame": false,
+    "stack_title" : false
   },
 
   "data": [
@@ -169,6 +170,8 @@ Use it to define the general information:
   ]
 }
 ```
+The `stack_title` value specifies whether `frameit` should display the keyword above the title when both keyword and title are defined.
+
 The `show_complete_frame` value specifies whether `frameit` should shrink the device and frame so that they show in full in the framed screenshot. If it is false, then they can hang over the bottom of the screenshot.
 
 The `filter` value is a part of the screenshot named for which the given option should be used. If a screenshot is named `iPhone5_Brainstorming.png` the first entry in the `data` array will be used.

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -109,7 +109,7 @@ module Frameit
       if fetch_config['title']
         background = put_title_into_background(background, fetch_config['stack_title'])
       end
-      
+
       if self.frame # we have no frame on le mac
         resize_frame!
         put_into_frame
@@ -213,11 +213,12 @@ module Frameit
       vertical_padding = vertical_frame_padding
       keyword_top_space = vertical_padding
 
-      title_top_space = vertical_padding + keyword.height + (title.height / 2)
+      spacing_between_title_and_keyword = (title.height / 2)
+      title_top_space = vertical_padding + keyword.height + spacing_between_title_and_keyword
       title_left_space = (background.width / 2.0 - title_width / 2.0).round
       keyword_left_space = (background.width / 2.0 - keyword_width / 2.0).round
 
-      self.top_space_above_device += title.height + keyword.height + vertical_padding
+      self.top_space_above_device += title.height + keyword.height + spacing_between_title_and_keyword + vertical_padding
       # keyword
       background = background.composite(keyword, "png") do |c|
         c.compose "Over"
@@ -237,7 +238,7 @@ module Frameit
       keyword = title_images[:keyword]
       title = title_images[:title]
 
-      if stack_title && keyword != nil && title != nil &&  keyword.width > 0 && title.width > 0
+      if stack_title && !keyword.nil? && !title.nil? && keyword.width > 0 && title.width > 0
         background = put_title_into_background_stacked(background, title, keyword)
         return background
       end

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -237,7 +237,7 @@ module Frameit
       keyword = title_images[:keyword]
       title = title_images[:title]
 
-      if stack_title && keyword.width > 0 && title.width > 0
+      if stack_title && keyword != nil && title != nil &&  keyword.width > 0 && title.width > 0
         background = put_title_into_background_stacked(background, title, keyword)
         return background
       end

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -107,9 +107,9 @@ module Frameit
       self.top_space_above_device = vertical_frame_padding
 
       if fetch_config['title']
-        background = put_title_into_background(background)
+        background = put_title_into_background(background, fetch_config['stack_title'])
       end
-
+      
       if self.frame # we have no frame on le mac
         resize_frame!
         put_into_frame
@@ -192,13 +192,55 @@ module Frameit
       modify_offset(multiplicator) # modify the offset to properly insert the screenshot into the frame later
     end
 
+    def resize_text(text)
+      width = text.width
+      ratio = (width + (keyword_padding + horizontal_frame_padding) * 2) / image.width.to_f
+      if ratio > 1.0
+        # too large - resizing now
+        smaller = (1.0 / ratio)
+        text.resize "#{(smaller * text.width).round}x"
+      end
+    end
     # Add the title above the device
-    def put_title_into_background(background)
+
+    def put_title_into_background_stacked(background, title, keyword)
+      resize_text(title)
+      resize_text(keyword)
+
+      title_width = title.width
+      keyword_width = keyword.width
+
+      vertical_padding = vertical_frame_padding
+      keyword_top_space = vertical_padding
+
+      title_top_space = vertical_padding + keyword.height + (title.height / 2)
+      title_left_space = (background.width / 2.0 - title_width / 2.0).round
+      keyword_left_space = (background.width / 2.0 - keyword_width / 2.0).round
+
+      self.top_space_above_device += title.height + keyword.height + vertical_padding
+      # keyword
+      background = background.composite(keyword, "png") do |c|
+        c.compose "Over"
+        c.geometry "+#{keyword_left_space}+#{keyword_top_space}"
+      end
+      # Then, put the title on top of the screenshot next to the keyword
+      background = background.composite(title, "png") do |c|
+        c.compose "Over"
+        c.geometry "+#{title_left_space}+#{title_top_space}"
+      end
+      background
+    end
+
+    def put_title_into_background(background, stack_title)
       title_images = build_title_images(image.width - 2 * horizontal_frame_padding, image.height - 2 * vertical_frame_padding)
 
       keyword = title_images[:keyword]
       title = title_images[:title]
 
+      if stack_title && keyword.width > 0 && title.width > 0
+        background = put_title_into_background_stacked(background, title, keyword)
+        return background
+      end
       # sum_width: the width of both labels together including the space inbetween
       #   is used to calculate the ratio
       sum_width = title.width


### PR DESCRIPTION
### Checklist
- I've successfully run bundle exec rspec frameit
- I've successfully run bundle exec rubocop -a frameit

### Description
I've add an option,"stack_title" , to frameit so that they keyword can be displayed above the title instead of to the side.

### Screenshots
Here are two screenshots. The first screenshot is with the stack_title property set to true and the second screenshot is with the stack_title property set to false.

**stack_title=true && padding=50**
![iphone6plus-main_p50_stacked](https://cloud.githubusercontent.com/assets/863201/22612313/ad64c20c-ea24-11e6-9c3b-f60106646ece.png)

**stack_title=false  && padding=50**
![iphone6plus-main_p50_nonstacked](https://cloud.githubusercontent.com/assets/863201/22612319/b74c8642-ea24-11e6-89b0-b6c44e1abbfe.png)

