### PR TITLE
Fix sigh resign short options

### DIFF
--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -80,9 +80,9 @@ module Sigh
       command :resign do |c|
         c.syntax = 'fastlane sigh resign'
         c.description = 'Resigns an existing ipa file with the given provisioning profile'
-        c.option '-i', '--signing_identity STRING', String, 'The signing identity to use. Must match the one defined in the provisioning profile.'
+        c.option '--signing_identity STRING', String, 'The signing identity to use. Must match the one defined in the provisioning profile.'
         c.option '-x', '--version_number STRING', String, 'Version number to force binary and all nested binaries to use. Changes both CFBundleShortVersionString and CFBundleIdentifier.'
-        c.option '-p', '--provisioning_profile PATH', String, '(or BUNDLE_ID=PATH) The path to the provisioning profile which should be used. '\
+        c.option '--provisioning_profile PATH', String, '(or BUNDLE_ID=PATH) The path to the provisioning profile which should be used. '\
                  'Can be provided multiple times if the application contains nested applications and app extensions, which need their own provisioning profile. '\
                  'The path may be prefixed with a identifier in order to determine which provisioning profile should be used on which app.',
                  &multiple_values_option_proc(c, "provisioning_profile", &proc { |value| value.split('=', 2) })


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->

Some of the options for resign command (`-i` and `-p`) has been already
invalidated.
Reasons:
- `-i` is used for SIGH_CERTIFICATE_ID
- `-p` is used for SIGH_PLATFORM

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix https://github.com/fastlane/fastlane/issues/7935

<!--- Please describe in detail how you tested your changes. --->
