### PR TITLE
Fix sigh manage short options

### DIFF
--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -106,7 +106,7 @@ module Sigh
         c.option '-f', '--force', 'Force remove all expired provisioning profiles. Required on CI.'
         c.option '-e', '--clean_expired', 'Remove all expired provisioning profiles.'
 
-        c.option '-p', '--clean_pattern STRING', String, 'Remove any provisioning profiles that matches the regular expression.'
+        c.option '--clean_pattern STRING', String, 'Remove any provisioning profiles that matches the regular expression.'
         c.example 'Remove all "iOS Team Provisioning" provisioning profiles', 'sigh manage -p "iOS\ ?Team Provisioning Profile"'
 
         c.action do |args, options|


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->

One of the options for manage command (`-p`) has been already
invalidated.
Reasons:
- `-p` is used for SIGH_PLATFORM

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix https://github.com/fastlane/fastlane/issues/8076

<!--- Please describe in detail how you tested your changes. --->
