### PR TITLE
Fix Crash on disabled colors #8100

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
+++ b/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
@@ -9,9 +9,11 @@ class String
       self # do nothing with the string, but return it
     end
   end
-  Colored2::EXTRAS.keys.each do |extra|
-    define_method(extra) do
-      self # do nothing with the string, but return it
+  if Object.const_defined?("Colored2::EXTRAS")
+    Colored2::EXTRAS.keys.each do |extra|
+      define_method(extra) do
+        self # do nothing with the string, but return it
+      end
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
+++ b/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
@@ -9,11 +9,9 @@ class String
       self # do nothing with the string, but return it
     end
   end
-  if Object.const_defined?("Colored2::EXTRAS")
-    Colored2::EXTRAS.keys.each do |extra|
-      define_method(extra) do
-        self # do nothing with the string, but return it
-      end
+  Colored2::EFFECTS.keys.each do |extra|
+    define_method(extra) do
+      self # do nothing with the string, but return it
     end
   end
 end


### PR DESCRIPTION
fixes: #8100  a crash on disabled colors since moving to colored2 #8028 



to test:

```
export FASTLANE_DISABLE_COLORS=1
fastlane actions

export FASTLANE_DISABLE_COLORS=0
fastlane actions
```
