### PR TITLE
Version bump to 2.14.2

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.14.1'.freeze
+  VERSION = '2.14.2'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.14.1':**

* Support padding as a percentage of the screen size (#8032)
* Fix: xcodebuild: error: Cannot use -xctestrun with -project, -workspace or -scheme options. (#8107)
* Fix Crash on disabled colors #8100 (#8103)
