### PR TITLE
[fastlane] Relax supported platforms

### DIFF
--- a/fastlane/lib/fastlane/actions/add_extra_platforms.rb
+++ b/fastlane/lib/fastlane/actions/add_extra_platforms.rb
@@ -1,0 +1,45 @@
+module Fastlane
+  module Actions
+    class AddExtraPlatformsAction < Action
+      def self.run(params)
+        UI.verbose "Before injecting extra platforms: #{Fastlane::SupportedPlatforms.all}"
+        Fastlane::SupportedPlatforms.extra = params[:platforms]
+        UI.verbose "After injecting extra platforms (#{params[:platforms]})...: #{Fastlane::SupportedPlatforms.all}"
+      end
+
+      def self.description
+        "Modify the default list of supported platforms"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :platforms,
+                                       optional: false,
+                                       type: Array,
+                                       default_value: "",
+                                       description: "The optional extra platforms to support")
+        ]
+      end
+
+      def self.authors
+        ["lacostej"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.example_code
+        [
+          'add_extra_platforms(
+            platforms: [:windows,:neogeo]
+          )'
+        ]
+      end
+
+      def self.category
+        :misc
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -262,12 +262,11 @@ module Fastlane
 
     def verify_supported_os(name, class_ref)
       if class_ref.respond_to?(:is_supported?)
-        if Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
-          # This value is filled in based on the executed platform block. Might be nil when lane is in root of Fastfile
-          platform = Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
-
+        # This value is filled in based on the executed platform block. Might be nil when lane is in root of Fastfile
+        platform = Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
+        if platform
           unless class_ref.is_supported?(platform)
-            UI.user_error!("Action '#{name}' doesn't support required operating system '#{platform}'.")
+            UI.important("Action '#{name}' isn't known to support operating system '#{platform}'.")
           end
         end
       end

--- a/fastlane/lib/fastlane/supported_platforms.rb
+++ b/fastlane/lib/fastlane/supported_platforms.rb
@@ -1,11 +1,21 @@
 module Fastlane
   class SupportedPlatforms
+    class << self
+      attr_accessor :extra
+      attr_reader :default
+
+      def extra=(value)
+        value ||= []
+        UI.important("Setting '#{value}' as extra SupportedPlatforms")
+        @extra = value
+      end
+    end
+
+    @default = [:ios, :mac, :android]
+    @extra = []
+
     def self.all
-      [
-        :ios,
-        :mac,
-        :android
-      ]
+      (@default + @extra).flatten
     end
 
     # this will log a warning if the passed platform is not supported

--- a/fastlane/lib/fastlane/supported_platforms.rb
+++ b/fastlane/lib/fastlane/supported_platforms.rb
@@ -8,10 +8,10 @@ module Fastlane
       ]
     end
 
-    # this will throw an exception if the passed platform is not supported
+    # this will log a warning if the passed platform is not supported
     def self.verify!(platform)
       unless all.include? platform.to_s.to_sym
-        UI.user_error!("Platform '#{platform}' is not supported. Must be either #{self.all}")
+        UI.important("Platform '#{platform}' is not officially supported. Currently supported plaforms are #{self.all}.")
       end
     end
   end

--- a/fastlane/spec/actions_specs/default_platform_spec.rb
+++ b/fastlane/spec/actions_specs/default_platform_spec.rb
@@ -6,11 +6,6 @@ describe Fastlane do
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DEFAULT_PLATFORM]).to eq(:ios)
       end
 
-      it "displays a warning if a platform is not supported" do
-        expect(FastlaneCore::UI).to receive(:important).with("Platform 'notSupportedOS' is not officially supported. Currently supported plaforms are [:ios, :mac, :android].")
-        Fastlane::Actions::DefaultPlatformAction.run(['notSupportedOS'])
-      end
-
       it "raises an error if no platform is given" do
         expect do
           Fastlane::Actions::DefaultPlatformAction.run([])
@@ -22,6 +17,23 @@ describe Fastlane do
           default_platform :ios
         end").runner.execute(:test)
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DEFAULT_PLATFORM]).to eq(:ios)
+      end
+    end
+    describe "Extra platforms" do
+      around(:each) do |example|
+        Fastlane::SupportedPlatforms.extra = []
+        example.run
+        Fastlane::SupportedPlatforms.extra = []
+      end
+      it "displays a warning if a platform is not supported" do
+        expect(FastlaneCore::UI).to receive(:important).with("Platform 'notSupportedOS' is not officially supported. Currently supported plaforms are [:ios, :mac, :android].")
+        Fastlane::Actions::DefaultPlatformAction.run(['notSupportedOS'])
+      end
+
+      it "doesn't display a warning at every run if a platform has been added to extra" do
+        Fastlane::SupportedPlatforms.extra = [:notSupportedOS]
+        expect(FastlaneCore::UI).not_to receive(:important)
+        Fastlane::Actions::DefaultPlatformAction.run(['notSupportedOS'])
       end
     end
   end

--- a/fastlane/spec/actions_specs/default_platform_spec.rb
+++ b/fastlane/spec/actions_specs/default_platform_spec.rb
@@ -6,10 +6,9 @@ describe Fastlane do
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DEFAULT_PLATFORM]).to eq(:ios)
       end
 
-      it "raises an error if platform is not supported" do
-        expect do
-          Fastlane::Actions::DefaultPlatformAction.run(['notSupportedOS'])
-        end.to raise_error("Platform 'notSupportedOS' is not supported. Must be either [:ios, :mac, :android]")
+      it "displays a warning if a platform is not supported" do
+        expect(FastlaneCore::UI).to receive(:important).with("Platform 'notSupportedOS' is not officially supported. Currently supported plaforms are [:ios, :mac, :android].")
+        Fastlane::Actions::DefaultPlatformAction.run(['notSupportedOS'])
       end
 
       it "raises an error if no platform is given" do

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -338,7 +338,7 @@ describe Fastlane do
         ff.import('./FastfileSytnaxError')
       end
 
-      it "imports actions associated with a Fastfile before their Fastfile", focus: true do
+      it "imports actions associated with a Fastfile before their Fastfile" do
         ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/Fastfile')
         expect do
           ff.import('./import1/Fastfile')

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -184,6 +184,13 @@ describe Fastlane do
         end.to raise_error(":windows crash")
       end
 
+      it "allows the user to set the platform in their Fastfile", focus: true do
+        expect(UI).to receive(:important).with("Setting '[:windows, :neogeo]' as extra SupportedPlatforms")
+        ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileAddNewPlatform')
+        expect(UI).to receive(:message).with("echo :windows")
+        ff.runner.execute(:echo, :windows)
+      end
+
       it "before_each and after_each are called every time" do
         ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileLaneBlocks')
         ff.runner.execute(:run_ios, :ios)

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -177,6 +177,13 @@ describe Fastlane do
         File.delete("/tmp/after_all.txt")
       end
 
+      it "allows the user to invent a new platform" do
+        ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileNewPlatform')
+        expect do
+          ff.runner.execute(:crash, :windows)
+        end.to raise_error(":windows crash")
+      end
+
       it "before_each and after_each are called every time" do
         ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileLaneBlocks')
         ff.runner.execute(:run_ios, :ios)

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -131,10 +131,9 @@ describe Fastlane do
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::PLATFORM_NAME]).to eq(nil)
       end
 
-      it "raises an exception if unsupported action is called in unsupported platform" do
-        expect do
-          @ff.runner.execute('unsupported_action', 'android')
-        end.to raise_error "Action 'frameit' doesn't support required operating system 'android'."
+      it "logs a warning if and unsupported action is called on an non officially supported platform" do
+        expect(FastlaneCore::UI).to receive(:important).with("Action 'frameit' isn't known to support operating system 'android'.")
+        @ff.runner.execute('unsupported_action', 'android')
       end
     end
 

--- a/fastlane/spec/fixtures/fastfiles/FastfileAddNewPlatform
+++ b/fastlane/spec/fixtures/fastfiles/FastfileAddNewPlatform
@@ -1,0 +1,10 @@
+add_extra_platforms(platforms: [:windows, :neogeo])
+
+platform :windows do
+  lane :empty do
+  end
+
+  lane :echo do
+    UI.message "echo :windows"
+  end
+end

--- a/fastlane/spec/fixtures/fastfiles/FastfileNewPlatform
+++ b/fastlane/spec/fixtures/fastfiles/FastfileNewPlatform
@@ -1,0 +1,11 @@
+
+default_platform :windows
+
+platform :windows do
+  lane :empty do
+  end
+
+  lane :crash do
+    raise ":windows crash"
+  end
+end

--- a/fastlane/spec/supported_platforms.rb
+++ b/fastlane/spec/supported_platforms.rb
@@ -1,0 +1,24 @@
+describe Fastlane do
+  describe Fastlane::Action do
+    describe "#all" do
+      it "Contains 3 default supported platforms" do
+        expect(Fastlane::SupportedPlatforms.all.count).to eq(3)
+      end
+    end
+    describe "#extra=" do
+      after :each do
+        Fastlane::SupportedPlatforms.extra = []
+      end
+      it "allows to add new platforms the list of supported ones" do
+        expect(FastlaneCore::UI).to receive(:important).with("Setting '[:abcdef]' as extra SupportedPlatforms")
+        Fastlane::SupportedPlatforms.extra = [:abcdef]
+        expect(Fastlane::SupportedPlatforms.all).to include(:abcdef)
+      end
+      it "doesn't break if you pass nil" do
+        expect(FastlaneCore::UI).to receive(:important).with("Setting '[]' as extra SupportedPlatforms")
+        Fastlane::SupportedPlatforms.extra = nil
+        expect(Fastlane::SupportedPlatforms.all.count).to eq(3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Platform support is used in several ways:
* for fastlane to hardcode the list of supported platforms (See `SupportedPlatforms`)
* for actions to list the platforms they support (See `self.is_supported?(platform)` under `fastlane/lib/fastlane/action.rb`)
* for fastlane to list the actions available for a particular platform:  (see `fastlane actions --platform ios`)

The main question is: is there any value in strongly restricting the list of platforms fastlane can support?

I personally think not. In fact we today hack around this to support for the `:windows` platform ( see https://gist.github.com/lacostej/7ac093cf035eb2a87a1559cc81fe8742)

So we propose to:
1. relax it and turn the error throwing into warnings. Fastlane would continue to have a list of supported platforms, but users could define new ones without fastlane preventing them to do so.
2. add the ability for users to register supported platforms per project, to reduce the amount of warnings displayed.

This PR currently adds support for both ideas. The ideas are implemented in different commits. I also added an action `add_extra_platforms` to register the new platform.

One issue to think about is the complexity of the CL. The non determinism of the type of the first argument (lane, action, platform etc) could cause issues if platforms added later conflict with lanes/action names.