### PR TITLE
Fix the retrieval of simulator logs

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -97,8 +97,8 @@ module Scan
 
       UI.header("Collecting system logs")
       Scan.devices.each do |device|
-        logarchive_dest = File.join(Scan.config[:output_directory], "system_logs-#{device.name}_#{device.os_type}_#{device.os_version}.logarchive")
-        FastlaneCore::Simulator.copy_logarchive(device, logarchive_dest)
+        log_identity = "#{device.name}_#{device.os_type}_#{device.os_version}"
+        FastlaneCore::Simulator.copy_logs(device, log_identity, Scan.config[:output_directory])
       end
     end
 

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -20,7 +20,7 @@ describe Scan do
             project: './scan/examples/standard/app.xcodeproj',
             include_simulator_logs: false
           })
-          expect(FastlaneCore::Simulator).not_to receive(:copy_logarchive)
+          expect(FastlaneCore::Simulator).not_to receive(:copy_logs)
           @scan.handle_results(0)
         end
       end
@@ -34,7 +34,7 @@ describe Scan do
             project: './scan/examples/standard/app.xcodeproj',
             include_simulator_logs: true
           })
-          expect(FastlaneCore::Simulator).to receive(:copy_logarchive)
+          expect(FastlaneCore::Simulator).to receive(:copy_logs)
           @scan.handle_results(0)
         end
       end

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -63,6 +63,8 @@ describe Scan do
     allow(response).to receive(:read).and_return(@valid_simulators)
     allow(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
 
+    allow(FastlaneCore::CommandExecutor).to receive(:execute).with(command: "sw_vers -productVersion", print_all: false, print_command: false).and_return('10.12.1')
+
     allow(Scan).to receive(:project).and_return(@project)
   end
 

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -107,8 +107,8 @@ module Snapshot
       components = [launch_arguments].delete_if { |a| a.to_s.length == 0 }
 
       UI.header("Collecting system logs #{device_name} - #{language}")
-      logarchive_dest = File.join(language_folder, "system_logs-" + Digest::MD5.hexdigest(components.join("-")) + ".logarchive")
-      FastlaneCore::Simulator.copy_logarchive(device, logarchive_dest)
+      log_identity = Digest::MD5.hexdigest(components.join("-"))
+      FastlaneCore::Simulator.copy_logs(device, log_identity, language_folder)
     end
 
     def print_results(results)


### PR DESCRIPTION
### Description

Fix the retrieval of simulator device logs so that it works on Mac OS 10.11 and no longer fails if the destination directory does not exist or is not normalized.

#### Details

1. Make sure the destination directory exists by using `FileUtils.mkdir_p`
2. Make sure that the destination directory is expanded so that we are not writing to a directory named `~`.
3. Detect if we are running on Mac OS 10.12 before trying to copy a logarchive as they are not useable on Mac OS X 10.11 like they are on Mac OS 10.12. If we are running on 10.12+, copy the logarchive, otherwise copy the system.log like we did before.

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary. - N/A

### Description

Added a command to make sure that the logarchive destination directory was fully expanded to handle the case where we get a `~` as the first character and added a command to ensure that the destination directory also exists so that FileUtils.cp_r

### Motivation and Context

Copying the logarchives is failing because the destination directory does not exist. This is not a problem for Ruby 2.2.5, but it is a problem on 2.3.3. Additionally, Mac OS 10.11 does not have the enhanced `logarchive` files that 10.12 has and are no useable.

```
Errno::ENOENT: [!] No such file or directory @ dir_s_mkdir - /Users/jenkins/workspace/workspace/lyndsey-ferguson_MyTests/fastlane/artifacts/tests/system_logs-iPhone 5s_iOS_10.0.logarchive
  /usr/local/Cellar/ruby23/2.3.3/lib/ruby/2.3.0/fileutils.rb:1366:in `mkdir'
  /usr/local/Cellar/ruby23/2.3.3/lib/ruby/2.3.0/fileutils.rb:1366:in `copy'
  /usr/local/Cellar/ruby23/2.3.3/lib/ruby/2.3.0/fileutils.rb:472:in `block in copy_entry'
  /usr/local/Cellar/ruby23/2.3.3/lib/ruby/2.3.0/fileutils.rb:1498:in `wrap_traverse'
  /usr/local/Cellar/ruby23/2.3.3/lib/ruby/2.3.0/fileutils.rb:469:in `copy_entry'
  /usr/local/Cellar/ruby23/2.3.3/lib/ruby/2.3.0/fileutils.rb:444:in `block in cp_r'
  /usr/local/Cellar/ruby23/2.3.3/lib/ruby/2.3.0/fileutils.rb:1571:in `block in fu_each_src_dest'
  /usr/local/Cellar/ruby23/2.3.3/lib/ruby/2.3.0/fileutils.rb:1587:in `fu_each_src_dest0'
  /usr/local/Cellar/ruby23/2.3.3/lib/ruby/2.3.0/fileutils.rb:1569:in `fu_each_src_dest'
  /usr/local/Cellar/ruby23/2.3.3/lib/ruby/2.3.0/fileutils.rb:443:in `cp_r'
  /Users/appian/.gems/gems/fastlane-2.14.2/fastlane_core/lib/fastlane_core/device_manager.rb:208:in `copy_logarchive'
  /Users/appian/.gems/gems/fastlane-2.14.2/scan/lib/scan/runner.rb:101:in `block in copy_simulator_logs'
```