### PR TITLE
Catch and print exceptions occuring in error block

### DIFF
--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -58,10 +58,14 @@ module Fastlane
       rescue => ex
         Dir.chdir(path_to_use) do
           # Provide error block exception without colour code
-          error_ex = ex.exception(ex.message.gsub(/\033\[\d+m/, ''))
-
-          error_blocks[current_platform].call(current_lane, error_ex, parameters) if error_blocks[current_platform] && current_platform
-          error_blocks[nil].call(current_lane, error_ex, parameters) if error_blocks[nil]
+          begin
+            error_blocks[current_platform].call(current_lane, ex, parameters) if current_platform && error_blocks[current_platform]
+            error_blocks[nil].call(current_lane, ex, parameters) if error_blocks[nil]
+          rescue => error_block_exception
+            UI.error("An error occured while executing the `error` block:")
+            UI.error(error_block_exception.to_s)
+            raise ex # raise the original error message
+          end
         end
 
         raise ex

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -211,6 +211,17 @@ describe Fastlane do
         File.delete("/tmp/error.txt")
       end
 
+      it "Exception in error block are swallowed and shown, and original exception is re-raised" do
+        ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileErrorInError')
+
+        expect(FastlaneCore::UI).to receive(:error).with("An error occured while executing the `error` block:")
+        expect(FastlaneCore::UI).to receive(:error).with("Error in error")
+
+        expect do
+          ff.runner.execute(:beta, nil, {})
+        end.to raise_error("Original error")
+      end
+
       describe "supports switching lanes" do
         it "use case 1: passing parameters to another lane and getting the result" do
           ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/SwitcherFastfile')

--- a/fastlane/spec/fixtures/fastfiles/FastfileErrorInError
+++ b/fastlane/spec/fixtures/fastfiles/FastfileErrorInError
@@ -1,0 +1,7 @@
+lane :beta do
+  UI.user_error!("Original error")
+end
+
+error do
+  UI.user_error!("Error in error")
+end


### PR DESCRIPTION
This has been annoying, and really hard to debug: when the error block raised an exception, it basically replaced the actual reason of error. The error block is usually used to notify about the failure, but the user is interested in the *actual* error message.

This PR also adds a test covering exactly that

<img width="834" alt="screenshot 2017-02-03 16 02 55" src="https://cloud.githubusercontent.com/assets/869950/22613198/1ed21a7e-ea2b-11e6-9226-5dccc2fb40ca.png">
