### PR TITLE
Fix option conflicts in sigh

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
@@ -6,7 +6,7 @@ module FastlaneCore
     include Commander::Methods
 
     # Calls the appropriate methods for commander to show the available parameters
-    def generate(options)
+    def generate(options, command: nil)
       # First, enable `always_trace`, to show the stack trace
       always_trace!
 

--- a/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
@@ -64,8 +64,12 @@ module FastlaneCore
         # automatically coerced or otherwise handled by the ConfigItem for others.
         args = [short_switch, long_switch, (type || String), description].compact
 
-        # This is the call to Commander to set up the option we've been building.
-        global_option(*args)
+        if command
+          command.option(*args)
+        else
+          # This is the call to Commander to set up the option we've been building.
+          global_option(*args)
+        end
       end
     end
 

--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -22,11 +22,11 @@ module Sigh
 
       global_option('--verbose') { FastlaneCore::Globals.verbose = true }
 
-      FastlaneCore::CommanderGenerator.new.generate(Sigh::Options.available_options)
-
       command :renew do |c|
         c.syntax = 'fastlane sigh renew'
         c.description = 'Renews the certificate (in case it expired) and outputs the path to the generated file'
+
+        FastlaneCore::CommanderGenerator.new.generate(Sigh::Options.available_options, command: c)
 
         c.action do |args, options|
           user_input = options.__hash__

--- a/sigh/spec/commands_generator_spec.rb
+++ b/sigh/spec/commands_generator_spec.rb
@@ -1,0 +1,64 @@
+require 'sigh/commands_generator'
+
+def expect_resign_run(options)
+  expect(resign).to receive(:run) do |actual_options, actual_args|
+    expect(actual_options).to match_commander_options(options)
+    expect(actual_args).to eq([])
+  end
+end
+
+describe Sigh::CommandsGenerator do
+  describe "resign option handling" do
+    let(:resign) do
+      resign = Sigh::Resign.new
+      expect(Sigh::Resign).to receive(:new).and_return(resign)
+      resign
+    end
+
+    it "signing_identity short flag is not shadowed by cert_id short flag from tool options" do
+      stub_commander_runner_args(['resign', '-i', 'abcd'])
+
+      options = Commander::Command::Options.new
+      options.signing_identity = 'abcd'
+
+      expect_resign_run(options)
+
+      Sigh::CommandsGenerator.start
+    end
+
+    it "provisioning_profile short flag is not shadowed by platform short flag from tool options" do
+      stub_commander_runner_args(['resign', '-p', 'abcd'])
+
+      options = Commander::Command::Options.new
+      options.provisioning_profile = [['abcd']]
+
+      expect_resign_run(options)
+
+      Sigh::CommandsGenerator.start
+    end
+  end
+
+  describe "renew option handling" do
+    it "cert_id short flag from tool options can be used" do
+      # leaving out the command name defaults to 'renew'
+      stub_commander_runner_args(['-i', 'abcd'])
+
+      expect(Sigh::Manager).to receive(:start)
+
+      Sigh::CommandsGenerator.start
+
+      expect(Sigh.config[:cert_id]).to eq('abcd')
+    end
+
+    it "platform short flag is not shadowed by cert_id short flag from tool options" do
+      # leaving out the command name defaults to 'renew'
+      stub_commander_runner_args(['-p', 'tvos'])
+
+      expect(Sigh::Manager).to receive(:start)
+
+      Sigh::CommandsGenerator.start
+
+      expect(Sigh.config[:platform]).to eq('tvos')
+    end
+  end
+end

--- a/sigh/spec/spec_helper.rb
+++ b/sigh/spec/spec_helper.rb
@@ -1,1 +1,7 @@
 require_relative 'stubbing.rb'
+
+# Commander::Command::Options does not define sane equals behavior,
+# so we need this to make testing easier
+RSpec::Matchers.define :match_commander_options do |expected|
+  match { |actual| actual.__hash__ == expected.__hash__ }
+end


### PR DESCRIPTION
Adjust command option handling to stop using `global_option` for Commander options that are
generated for the default command (`renew`). Instead, they are now generated as normal options underneath that command.

The only major (negative?) change in behavior affects how help information is generated/shown by Commander.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description

<details><summary><b>Current option handling in sigh</b></summary>

Current help output:
```
$ fastlane sigh -h
  sigh

  CLI for 'sigh' - Because you would rather spend your time building stuff than fighting provisioning

  Commands:
    download_all Downloads all valid provisioning profiles
    help         Display global or [command] help documentation
    manage       Manage installed provisioning profiles on your system.
    renew        Renews the certificate (in case it expired) and outputs the path to the generated file
    repair       Repairs all expired or invalid provisioning profiles
    resign       Resigns an existing ipa file with the given provisioning profile

  Global Options:
    --verbose
    --adhoc [VALUE]      Setting this flag will generate AdHoc profiles instead of App Store Profiles (SIGH_AD_HOC)
    --development [VALUE] Renew the development certificate instead of the production one (SIGH_DEVELOPMENT)
    --skip_install [VALUE] By default, the certificate will be added on your local machine. Setting this flag will skip this action (SIGH_SKIP_INSTALL)
    -f, --force [VALUE]  Renew provisioning profiles regardless of its state - to automatically add all devices for ad hoc profiles (SIGH_FORCE)
    -a, --app_identifier STRING The bundle identifier of your app (SIGH_APP_IDENTIFIER)
    -u, --username STRING Your Apple ID Username (SIGH_USERNAME)
    -b, --team_id STRING The ID of your Developer Portal team if you're in multiple teams (SIGH_TEAM_ID)
    -l, --team_name STRING The name of your Developer Portal team if you're in multiple teams (SIGH_TEAM_NAME)
    -n, --provisioning_name STRING The name of the profile that is used on the Apple Developer Portal (SIGH_PROVISIONING_PROFILE_NAME)
    --ignore_profiles_with_different_name [VALUE] Use in combination with :provisioning_name - when true only profiles matching this exact name will be downloaded
(SIGH_IGNORE_PROFILES_WITH_DIFFERENT_NAME)
    -o, --output_path STRING Directory in which the profile should be stored (SIGH_OUTPUT_PATH)
    -i, --cert_id STRING The ID of the code signing certificate to use (e.g. 78ADL6LVAA)  (SIGH_CERTIFICATE_ID)
    -c, --cert_owner_name STRING The certificate name to use for new profiles, or to renew with. (e.g. "Felix Krause") (SIGH_CERTIFICATE)
    -q, --filename STRING Filename to use for the generated provisioning profile (must include .mobileprovision) (SIGH_PROFILE_FILE_NAME)
    -w, --skip_fetch_profiles [VALUE] Skips the verification of existing profiles which is useful if you have thousands of profiles (SIGH_SKIP_FETCH_PROFILES)
    -z, --skip_certificate_verification [VALUE] Skips the verification of the certificates for every existing profiles. This will make sure the provisioning profile can be used
on the local machine (SIGH_SKIP_CERTIFICATE_VERIFICATION)
    -p, --platform [VALUE] Set the provisioning profile's platform (i.e. ios, tvos) (SIGH_PLATFORM)
    -h, --help           Display help documentation
    -v, --version        Display version information

  Author:
    Felix Krause <sigh@krausefx.com>

  Website:
    https://fastlane.tools
```

This should not work (but it does) since `--force` is not a valid option for the `resign` command
```
$ fastlane sigh resign --force
Path to ipa file: ^C
```

This is good and shows that `--force` is seen by the default command
```
$ fastlane sigh --force

+-------------------------------------+-------+
|           Summary for sigh 2.14.2           |
+-------------------------------------+-------+
| force                               | true  |
| adhoc                               | false |
| development                         | false |
| skip_install                        | false |
| ignore_profiles_with_different_name | false |
| skip_fetch_profiles                 | false |
| skip_certificate_verification       | false |
| platform                            | ios   |
+-------------------------------------+-------+

[11:37:26]: To not be asked about this value, you can specify it using 'username'
Your Apple ID Username: ^C
```

This should be setting the `--provisioning_profile`, but is incorrectly interpreted as the `--platform` from the default command
```
$ fastlane sigh resign -p abcd path.ipa

...

[1] pry(#<Sigh::CommandsGenerator>)> args
=> ["path.ipa"]
[2] pry(#<Sigh::CommandsGenerator>)> options
=> <Commander::Command::Options platform="abcd">
```

</details>

<details><summary><b>Revised option handling in sigh</b></summary>

Help for the top-level executable:
```
$ fastlane sigh -h
  sigh

  CLI for 'sigh' - Because you would rather spend your time building stuff than fighting provisioning

  Commands:
    download_all Downloads all valid provisioning profiles
    help         Display global or [command] help documentation
    manage       Manage installed provisioning profiles on your system.
    renew        Renews the certificate (in case it expired) and outputs the path to the generated file
    repair       Repairs all expired or invalid provisioning profiles
    resign       Resigns an existing ipa file with the given provisioning profile

  Global Options:
    --verbose             
    -h, --help           Display help documentation
    -v, --version        Display version information

  Author:
    Felix Krause <sigh@krausefx.com>

  Website:
    https://fastlane.tools

  GitHub:
    https://github.com/fastlane/sigh
```

Help for the `renew` (default) command:
```
$ fastlane sigh renew -h

  renew

  Usage: fastlane sigh renew

  Renews the certificate (in case it expired) and outputs the path to the generated file

  Options:
    --adhoc [VALUE]      Setting this flag will generate AdHoc profiles instead of App Store Profiles (SIGH_AD_HOC)
    --development [VALUE] Renew the development certificate instead of the production one (SIGH_DEVELOPMENT)
    --skip_install [VALUE] By default, the certificate will be added on your local machine. Setting this flag will skip this action (SIGH_SKIP_INSTALL)
    -f, --force [VALUE]  Renew provisioning profiles regardless of its state - to automatically add all devices for ad hoc profiles (SIGH_FORCE)
    -a, --app_identifier STRING The bundle identifier of your app (SIGH_APP_IDENTIFIER)
    -u, --username STRING Your Apple ID Username (SIGH_USERNAME)
    -b, --team_id STRING The ID of your Developer Portal team if you're in multiple teams (SIGH_TEAM_ID)
    -l, --team_name STRING The name of your Developer Portal team if you're in multiple teams (SIGH_TEAM_NAME)
    -n, --provisioning_name STRING The name of the profile that is used on the Apple Developer Portal (SIGH_PROVISIONING_PROFILE_NAME)
    --ignore_profiles_with_different_name [VALUE] Use in combination with :provisioning_name - when true only profiles matching this exact name will be downloaded
(SIGH_IGNORE_PROFILES_WITH_DIFFERENT_NAME)
    -o, --output_path STRING Directory in which the profile should be stored (SIGH_OUTPUT_PATH)
    -i, --cert_id STRING The ID of the code signing certificate to use (e.g. 78ADL6LVAA)  (SIGH_CERTIFICATE_ID)
    -c, --cert_owner_name STRING The certificate name to use for new profiles, or to renew with. (e.g. "Felix Krause") (SIGH_CERTIFICATE)
    -q, --filename STRING Filename to use for the generated provisioning profile (must include .mobileprovision) (SIGH_PROFILE_FILE_NAME)
    -w, --skip_fetch_profiles [VALUE] Skips the verification of existing profiles which is useful if you have thousands of profiles (SIGH_SKIP_FETCH_PROFILES)
    -z, --skip_certificate_verification [VALUE] Skips the verification of the certificates for every existing profiles. This will make sure the provisioning profile can be used
on the local machine (SIGH_SKIP_CERTIFICATE_VERIFICATION)
    -p, --platform [VALUE] Set the provisioning profile's platform (i.e. ios, tvos) (SIGH_PLATFORM)
```

The `resign` command now correctly throws an error when given the `--force` option
```
$ fastlane sigh resign --force
invalid option: --force
```

The default command still recognizes the `--force` flag
```
$ fastlane sigh --force

+-------------------------------------+-------+
|           Summary for sigh 2.14.2           |
+-------------------------------------+-------+
| force                               | true  |
| adhoc                               | false |
| development                         | false |
| skip_install                        | false |
| ignore_profiles_with_different_name | false |
| skip_fetch_profiles                 | false |
| skip_certificate_verification       | false |
| platform                            | ios   |
+-------------------------------------+-------+

[11:36:19]: To not be asked about this value, you can specify it using 'username'
Your Apple ID Username: ^C
```

The `resign` command correctly receives the `--provisioning_profile` option
```
$ fastlane sigh resign -p abcd path.ipa

...

[1] pry(#<Sigh::CommandsGenerator>)> args
=> ["path.ipa"]
[2] pry(#<Sigh::CommandsGenerator>)> options
=> <Commander::Command::Options provisioning_profile=[["abcd"]]>
```
</details>

### Motivation and Context

#6169 introduced a new option for _sigh_. Unfortunately, it accidentally conflicts with the `-p` short flag as used by the _sigh_ `resign` command. This is one example, but there are other _sigh_ options in use that also have short flag conflicts, such as `-i`. These problems were captured in #7935 and #8076

This is a problem for all _fastlane_ tools, not just _sigh_, but I'm testing out this approach here to see how it works, and gather feedback.