### PR TITLE
Fix the broken scan test for include_simulator_logs

### DIFF
--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -24,6 +24,20 @@ describe Scan do
           @scan.handle_results(0)
         end
       end
+
+      describe "with scan option :include_simulator_logs set to true" do
+        it "copies any device logs to the output directory" do
+          # Circle CI is setting the SCAN_INCLUDE_SIMULATOR_LOGS env var, so just leaving
+          # the include_simulator_logs option out does not let it default to false
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            output_directory: '/tmp/scan_results',
+            project: './scan/examples/standard/app.xcodeproj',
+            include_simulator_logs: true
+          })
+          expect(FastlaneCore::Simulator).to receive(:copy_logarchive)
+          @scan.handle_results(0)
+        end
+      end
     end
   end
 end

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -11,13 +11,16 @@ describe Scan do
         @scan = Scan::Runner.new
       end
 
-      describe "without Scan option :include_simulator_logs" do
+      describe "with scan option :include_simulator_logs set to false" do
         it "does not copy any device logs to the output directory" do
+          # Circle CI is setting the SCAN_INCLUDE_SIMULATOR_LOGS env var, so just leaving
+          # the include_simulator_logs option out does not let it default to false
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
             output_directory: '/tmp/scan_results',
-            project: './scan/examples/standard/app.xcodeproj'
+            project: './scan/examples/standard/app.xcodeproj',
+            include_simulator_logs: false
           })
-          expect(FileUtils).not_to receive(:cp)
+          expect(FastlaneCore::Simulator).not_to receive(:copy_logarchive)
           @scan.handle_results(0)
         end
       end


### PR DESCRIPTION
I think Circle CI is setting the env var for this option which is making our test fail. It passes when run locally. This makes the test more explicit.

```
Failures:

  1) Scan Scan::Runner handle_results without Scan option :include_simulator_logs does not copy any device logs to the output directory
     Failure/Error: @scan.handle_results(0)

     FastlaneCore::Interface::FastlaneError:
       Exit status: 159
     # ./fastlane_core/lib/fastlane_core/ui/interface.rb:145:in `user_error!'
     # ./fastlane_core/lib/fastlane_core/ui/ui.rb:14:in `method_missing'
     # ./fastlane_core/lib/fastlane_core/command_executor.rb:90:in `execute'
     # ./fastlane_core/lib/fastlane_core/device_manager.rb:198:in `copy_logarchive'
     # ./scan/lib/scan/runner.rb:101:in `block in copy_simulator_logs'
     # ./scan/lib/scan/runner.rb:99:in `each'
     # ./scan/lib/scan/runner.rb:99:in `copy_simulator_logs'
     # ./scan/lib/scan/runner.rb:82:in `handle_results'
     # ./scan/spec/runner_spec.rb:21:in `block (5 levels) in <top (required)>'
```

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.
