### PR TITLE
Improve output design of UI.header

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -36,6 +36,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multipart-post', '~> 2.0.0' # Needed for uploading builds to appetize
   spec.add_dependency 'word_wrap', '~> 1.0.0' # to add line breaks for tables with long strings
 
+  # TTY dependencies
+  spec.add_dependency 'tty-screen', '~> 0.5.0' # detect the terminal width
+
   spec.add_dependency 'babosa', '>= 1.0.2', "< 2.0.0"
   spec.add_dependency 'colored' # coloured terminal output
   spec.add_dependency 'commander', '>= 4.4.0', '< 5.0.0' # CLI parser

--- a/fastlane/lib/fastlane/setup/crashlytics_beta_ui.rb
+++ b/fastlane/lib/fastlane/setup/crashlytics_beta_ui.rb
@@ -9,10 +9,7 @@ module Fastlane
     end
 
     def header(text)
-      i = text.length + 8
-      success("-" * i)
-      success("--- " + text + " ---")
-      success("-" * i)
+      FastlaneCore::UI.header(text)
     end
 
     def important(text)

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -358,9 +358,7 @@ module FastlaneCore
       end
 
       if result
-        UI.success("-" * 102)
-        UI.success("Successfully uploaded package to iTunes Connect. It might take a few minutes until it's visible online.")
-        UI.success("-" * 102)
+        UI.header("Successfully uploaded package to iTunes Connect. It might take a few minutes until it's visible online.")
 
         FileUtils.rm_rf(actual_dir) unless Helper.is_test? # we don't need the package any more, since the upload was successful
       else

--- a/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
+++ b/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
@@ -17,13 +17,13 @@ module FastlaneCore
       end
 
       @log.formatter = proc do |severity, datetime, progname, msg|
-        "#{format_string(datetime)}#{msg}\n"
+        "#{format_string(datetime, severity)}#{msg}\n"
       end
 
       @log
     end
 
-    def format_string(datetime)
+    def format_string(datetime, severity)
       if $verbose
         return "#{severity} [#{datetime.strftime('%Y-%m-%d %H:%M:%S.%2N')}]: "
       elsif FastlaneCore::Env.truthy?("FASTLANE_HIDE_TIMESTAMP")
@@ -74,11 +74,12 @@ module FastlaneCore
     end
 
     def header(message)
-      if message.length + 8 < TTY::Screen.width - format_string(Time.now).length
+      format = format_string(Time.now, "")
+      if message.length + 8 < TTY::Screen.width - format.length
         message = "--- #{message} ---"
         i = message.length
       else
-        i = TTY::Screen.width - format_string(Time.now).length
+        i = TTY::Screen.width - format.length
       end
       success("-" * i)
       success(message)


### PR DESCRIPTION
This PR makes use of `tty-screen` to improve the design of `UI.header` depending on the terminal width

<img width="864" alt="screenshot 2017-02-05 17 42 39" src="https://cloud.githubusercontent.com/assets/869950/22632033/a40cc00e-ebca-11e6-9063-0bbcf7435149.png">

<img width="1249" alt="screenshot 2017-02-05 17 42 34" src="https://cloud.githubusercontent.com/assets/869950/22632032/a40a4c84-ebca-11e6-80b8-cc0956490abe.png">
