### PR TITLE
Skip loading and printing plugins when running `--help`

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -8,6 +8,10 @@ module Fastlane
         ARGV.include?('-v') || ARGV.include?('--version')
       end
 
+      def running_help_command?
+        ARGV.include?('-h') || ARGV.include?('--help')
+      end
+
       def take_off
         before_import_time = Time.now
 

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -34,7 +34,7 @@ module Fastlane
       Fastlane.load_actions
       FastlaneCore::Swag.stop_loader
       # do not use "include" as it may be some where in the commandline where "env" is required, therefore explicit index->0
-      unless ARGV[0] == "env" || CLIToolsDistributor.running_version_command?
+      unless ARGV[0] == "env" || CLIToolsDistributor.running_version_command? || CLIToolsDistributor.running_help_command?
         # *after* loading the plugins
         Fastlane.plugin_manager.load_plugins
         Fastlane::PluginUpdateManager.start_looking_for_updates


### PR DESCRIPTION
You can reproduce using `bundle exec fastlane --help | cat`