### PR TITLE
[fastlane] Properly catch all kinds of errors, including parsing errors, while loading plugins #8154

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -279,7 +279,7 @@ module Fastlane
 
           store_plugin_reference(gem_name)
           loaded_plugins = true
-        rescue => ex
+        rescue StandardError, ScriptError => ex # some errors, like ScriptError are not caught unless explicitly
           UI.error("Error loading plugin '#{gem_name}': #{ex}")
 
           # We'll still add it to the table, to make the error

--- a/fastlane/spec/plugins_specs/plugin_manager_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_manager_spec.rb
@@ -199,6 +199,17 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_exception("Could not find action, lane or variable 'my_custom_plugin'. Check out the documentation for more details: https://docs.fastlane.tools/actions")
       end
+
+      it "shows an appropriate error message when a plugin is really broken" do
+        ex = ScriptError.new
+        pm = Fastlane::PluginManager.new
+        plugin_name = "broken"
+        expect(pm).to receive(:available_plugins).and_return([plugin_name])
+        expect(Fastlane::FastlaneRequire).to receive(:install_gem_if_needed).with(gem_name: plugin_name, require_gem: true).and_raise(ex)
+        expect(UI).to receive(:error).with("Error loading plugin '#{plugin_name}': #{ex}")
+        pm.load_plugins
+        expect(pm.plugin_references[plugin_name]).not_to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Before fix:
![image](https://cloud.githubusercontent.com/assets/24282/22715798/f3cd46e4-ed92-11e6-978e-c1c5423401bd.png)

After fix:
![image](https://cloud.githubusercontent.com/assets/24282/22715780/dbd2dc3e-ed92-11e6-9775-dda432f3367c.png)