### PR TITLE
Provide detailed error message when gym fails #6292

### DIFF
--- a/fastlane/docs/README.md
+++ b/fastlane/docs/README.md
@@ -80,7 +80,7 @@ end
 ### `error` block
 
 This block will get executed when an error occurs, in any of the blocks (*before_all*, the lane itself or *after_all*).
-You can get more information about the error using the field `error_info`.
+You can get more information about the error using the `error_info` property.
 
 ```ruby
 error do |lane, exception|
@@ -91,7 +91,6 @@ error do |lane, exception|
   )
 end
 ```
-
 
 ## Extensions
 

--- a/fastlane/docs/README.md
+++ b/fastlane/docs/README.md
@@ -80,15 +80,18 @@ end
 ### `error` block
 
 This block will get executed when an error occurs, in any of the blocks (*before_all*, the lane itself or *after_all*).
+You can get more information about the error using the field `error_info`.
 
 ```ruby
 error do |lane, exception|
   slack(
     message: "Something went wrong with the deployment.",
-    success: false
+    success: false,
+    payload: { "Error Info" => exception.error_info.to_s } 
   )
 end
 ```
+
 
 ## Extensions
 

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -143,7 +143,6 @@ module FastlaneCore
     # Basically this should be used when you actively catch the error
     # and want to show a nice error message to the user
     def user_error!(error_message, options = {})
-      options = { show_github_issues: false, error_info: nil }.merge(options)
       raise FastlaneError.new(options), error_message.to_s
     end
 

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -118,9 +118,11 @@ module FastlaneCore
     # raised from user_error!
     class FastlaneError < StandardError
       attr_reader :show_github_issues
+      attr_reader :error_info
 
-      def initialize(show_github_issues: false)
+      def initialize(show_github_issues: false, error_info: nil)
         @show_github_issues = show_github_issues
+        @error_info = error_info
       end
     end
 
@@ -141,8 +143,8 @@ module FastlaneCore
     # Basically this should be used when you actively catch the error
     # and want to show a nice error message to the user
     def user_error!(error_message, options = {})
-      options = { show_github_issues: false }.merge(options)
-      raise FastlaneError.new(show_github_issues: options[:show_github_issues]), error_message.to_s
+      options = { show_github_issues: false, error_info: nil }.merge(options)
+      raise FastlaneError.new(options), error_message.to_s
     end
 
     #####################################################

--- a/gym/README.md
+++ b/gym/README.md
@@ -196,11 +196,11 @@ end
 # error block is executed when a error occurs
 error do |lane, exception|
   slack(
-      # message with short human friendly message
-      message: exception.to_s, 
-      success: false, 
-      # Output containing extended log output
-      payload: { "Output" => exception.error_info.to_s } 
+    # message with short human friendly message
+    message: exception.to_s, 
+    success: false, 
+    # Output containing extended log output
+    payload: { "Output" => exception.error_info.to_s } 
   )
 end
 ```

--- a/gym/README.md
+++ b/gym/README.md
@@ -205,8 +205,8 @@ error do |lane, exception|
 end
 ```
 
-When gym raises an error the field `error_info` will contain the process output
-in case you want to display the error in 3rd party tools such as slack.
+When gym raises an error the `error_info` property will contain the process output
+in case you want to display the error in 3rd party tools such as Slack.
 
 You can then easily switch between the beta provider (e.g. `testflight`, `hockey`, `s3` and more).
 

--- a/gym/README.md
+++ b/gym/README.md
@@ -192,7 +192,21 @@ lane :beta do
   gym(scheme: "MyApp")
   crashlytics
 end
+
+# error block is executed when a error occurs
+error do |lane, exception|
+    slack(
+       # message with short human friendly message
+       message: exception.to_s, 
+       success: false, 
+       # Output containing extended log output
+       payload: { "Output" => exception.error_info.to_s } 
+    )
+end
 ```
+
+When gym raises an error the field `error_info` will contain the process output
+in case you want to display the error in 3rd party tools such as slack.
 
 You can then easily switch between the beta provider (e.g. `testflight`, `hockey`, `s3` and more).
 

--- a/gym/README.md
+++ b/gym/README.md
@@ -195,13 +195,13 @@ end
 
 # error block is executed when a error occurs
 error do |lane, exception|
-    slack(
-       # message with short human friendly message
-       message: exception.to_s, 
-       success: false, 
-       # Output containing extended log output
-       payload: { "Output" => exception.error_info.to_s } 
-    )
+  slack(
+      # message with short human friendly message
+      message: exception.to_s, 
+      success: false, 
+      # Output containing extended log output
+      payload: { "Output" => exception.error_info.to_s } 
+  )
 end
 ```
 

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -53,7 +53,7 @@ module Gym
         print_full_log_path
         print_xcode_path_instructions
         print_xcode_version
-        UI.user_error!("Error building the application - see the log above")
+        UI.user_error!("Error building the application - see the log above", error_info: output)
       end
 
       # @param [Array] The output of the errored build (line by line)
@@ -84,7 +84,7 @@ module Gym
           print "provisioning profile and code signing identity."
         end
         print_full_log_path
-        UI.user_error!("Error packaging up the application")
+        UI.user_error!("Error packaging up the application", error_info: output)
       end
 
       def handle_empty_archive

--- a/gym/spec/error_handler.rb
+++ b/gym/spec/error_handler.rb
@@ -28,6 +28,5 @@ describe Gym do
       expect(UI).to receive(:user_error!).with("Error packaging up the application", error_info: @output)
       Gym::ErrorHandler.handle_package_error(@output)
     end
-
   end
 end

--- a/gym/spec/error_handler.rb
+++ b/gym/spec/error_handler.rb
@@ -1,13 +1,33 @@
 describe Gym do
-  describe Gym::ErrorHandler do
-    it "finds the standard output path" do
-      output = %(
+  before(:all) do
+    options = { project: "./gym/examples/multipleSchemes/Example.xcodeproj" }
+    @config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+    @project = FastlaneCore::Project.new(@config)
+
+    @output = %(
 2015-12-15 13:00:57.177 xcodebuild[81544:4350404] [MT] IDEDistribution: -[IDEDistributionLogging _createLoggingBundleAtPath:]: Created bundle at path '/var/folders/88/l77k840955j0x55fkb3m6cdr0000gn/T/EventLink_2015-12-15_13-00-57.177.xcdistributionlogs'.
 2015-12-15 13:00:57.318 xcodebuild[81544:4350404] [MT] IDEDistribution: Failed to generate distribution items with error: Error Domain=DVTMachOErrorDomain Code=0 "Found an unexpected Mach-O header code: 0x72613c21" UserInfo={NSLocalizedDescription=Found an unexpected Mach-O header code: 0x72613c21, NSLocalizedRecoverySuggestion=}
 2015-12-15 13:00:57.318 xcodebuild[81544:4350404] [MT] IDEDistribution: Step failed: <IDEDistributionSigningAssetsStep: 0x7f9d94cb55a0>: Error Domain=DVTMachOErrorDomain Code=0 "Found an unexpected Mach-O header code: 0x72613c21" UserInfo={NSLocalizedDescription=Found an unexpected Mach-O header code: 0x72613c21, NSLocalizedRecoverySuggestion=}
 %)
+  end
+
+  describe Gym::ErrorHandler do
+    before(:each) { Gym.config = @config }
+
+    it "finds the standard output path" do
       expected = '/var/folders/88/l77k840955j0x55fkb3m6cdr0000gn/T/EventLink_2015-12-15_13-00-57.177.xcdistributionlogs/IDEDistribution.standard.log'
-      expect(Gym::ErrorHandler.find_standard_output_path(output)).to eq(expected)
+      expect(Gym::ErrorHandler.find_standard_output_path(@output)).to eq(expected)
     end
+
+    it "raises build error with error_info" do
+      expect(UI).to receive(:user_error!).with("Error building the application - see the log above", error_info: @output)
+      Gym::ErrorHandler.handle_build_error(@output)
+    end
+
+    it "raises package error with error_info" do
+      expect(UI).to receive(:user_error!).with("Error packaging up the application", error_info: @output)
+      Gym::ErrorHandler.handle_package_error(@output)
+    end
+
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
I am adding the field `error_info` to FastlaneError class intended to contain detailed information about the error along side with the error message itself. 
The new field can be specified using the UI.user_error `options` parameter, same way the `show_github_issues` works.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Currently if you have a problem with the gym execution the `error` block will receive only a friendly message saying that you build or package command didn't work. The idea here is to extend the error class so the user can get access to the whole xcodebuild output and use that information when reporting the problem. 

One use case would be sending a slack message with the build output as attachment so everyone in the room can quickly scan and see what went wrong.

### Usage Example

**Badly behaving lane:**

```ruby
lane :build  do
    gym(..)
end

error do |lane, exception|
    slack(
       # message with short human friendly message
       message: exception.to_s, 
       success: false, 
       # Output containing extended log output
       payload: { "Output" => exception.error_info.to_s } 
    )
end
```

**Slack Message:**
![image](https://cloud.githubusercontent.com/assets/117622/22717931/f1dc4d34-ed84-11e6-8c17-145d3fee1975.png)

It would be even better if xcodebuild given us exactly what broke the build (file, line number, etc), this way the error_info would be more precise showing the problem versus just dumping the whole process output.

The original issue/discussion can be found here #6292 

EDIT: Forgot to mention the changes on documentation, I add some information to both fastlane/Readme and Gym specific documentation. 
