### PR TITLE
Load review_information from text files

### DIFF
--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -66,6 +66,17 @@ module Deliver
         UI.message("Writing to '#{resulting_path}'")
       end
 
+      # Review information
+      UploadMetadata::REVIEW_INFORMATION_VALUES.each do |key, option_name|
+        content = v.send(key).to_s
+        content << "\n"
+        base_dir = File.join(path, UploadMetadata::REVIEW_INFORMATION_DIR)
+        FileUtils.mkdir_p(base_dir)
+        resulting_path = File.join(base_dir, "#{option_name}.txt")
+        File.write(resulting_path, content)
+        UI.message("Writing to '#{resulting_path}'")
+      end
+
       UI.success("Successfully created new configuration files.")
 
       # get App icon + watch icon

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -15,6 +15,10 @@ module Deliver
                                 :primary_first_sub_category, :primary_second_sub_category,
                                 :secondary_first_sub_category, :secondary_second_sub_category]
 
+    # Review information values
+    REVIEW_INFORMATION_VALUES = [:first_name, :last_name, :phone_number,
+                                 :email_address, :demo_user, :demo_password, :notes]
+
     # Localized app details values, that are editable in live state
     LOCALISED_LIVE_VALUES = [:description, :release_notes, :support_url, :marketing_url]
 
@@ -182,6 +186,17 @@ module Deliver
 
         UI.message("Loading '#{path}'...")
         options[key] ||= File.read(path)
+      end
+
+      # Load review information
+      options[:app_review_information] ||= {}
+      REVIEW_INFORMATION_VALUES.each do |key|
+        path = File.join(options[:metadata_path], "review_information", "#{key}.txt")
+        next unless File.exist?(path)
+        next if options[:app_review_information][key]
+
+        UI.message("Loading '#{path}'...")
+        options[:app_review_information][key] ||= File.read(path)
       end
     end
 

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -16,14 +16,24 @@ module Deliver
                                 :secondary_first_sub_category, :secondary_second_sub_category]
 
     # Review information values
-    REVIEW_INFORMATION_VALUES = [:first_name, :last_name, :phone_number,
-                                 :email_address, :demo_user, :demo_password, :notes]
+    REVIEW_INFORMATION_VALUES = {
+      review_first_name: :first_name,
+      review_last_name: :last_name,
+      review_phone_number: :phone_number,
+      review_email: :email_address,
+      review_demo_user: :demo_user,
+      review_demo_password: :demo_password,
+      review_notes: :notes
+    }
 
     # Localized app details values, that are editable in live state
     LOCALISED_LIVE_VALUES = [:description, :release_notes, :support_url, :marketing_url]
 
     # Non localized app details values, that are editable in live state
     NON_LOCALISED_LIVE_VALUES = [:privacy_url]
+
+    # Directory name it contains review information
+    REVIEW_INFORMATION_DIR = "review_information"
 
     # Make sure to call `load_from_filesystem` before calling upload
     def upload(options)
@@ -190,13 +200,13 @@ module Deliver
 
       # Load review information
       options[:app_review_information] ||= {}
-      REVIEW_INFORMATION_VALUES.each do |key|
-        path = File.join(options[:metadata_path], "review_information", "#{key}.txt")
+      REVIEW_INFORMATION_VALUES.values.each do |option_name|
+        path = File.join(options[:metadata_path], REVIEW_INFORMATION_DIR, "#{option_name}.txt")
         next unless File.exist?(path)
-        next if options[:app_review_information][key]
+        next if options[:app_review_information][option_name]
 
         UI.message("Loading '#{path}'...")
-        options[:app_review_information][key] ||= File.read(path)
+        options[:app_review_information][option_name] ||= File.read(path)
       end
     end
 
@@ -207,14 +217,10 @@ module Deliver
       info = options[:app_review_information]
       UI.user_error!("`app_review_information` must be a hash", show_github_issues: true) unless info.kind_of?(Hash)
 
-      v.review_first_name = info[:first_name] if info[:first_name]
-      v.review_last_name = info[:last_name] if info[:last_name]
-      v.review_phone_number = info[:phone_number] if info[:phone_number]
-      v.review_email = info[:email_address] if info[:email_address]
-      v.review_demo_user = info[:demo_user] if info[:demo_user]
-      v.review_demo_password = info[:demo_password] if info[:demo_password]
+      REVIEW_INFORMATION_VALUES.each do |key, option_name|
+        v.send("#{key}=", info[option_name]) if info[option_name]
+      end
       v.review_user_needed = (v.review_demo_user.to_s + v.review_demo_password.to_s).length > 0
-      v.review_notes = info[:notes] if info[:notes]
     end
 
     def set_app_rating(v, options)

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -203,7 +203,7 @@ module Deliver
       REVIEW_INFORMATION_VALUES.values.each do |option_name|
         path = File.join(options[:metadata_path], REVIEW_INFORMATION_DIR, "#{option_name}.txt")
         next unless File.exist?(path)
-        next if options[:app_review_information][option_name]
+        next if options[:app_review_information][option_name].to_s.length > 0
 
         UI.message("Loading '#{path}'...")
         options[:app_review_information][option_name] ||= File.read(path)

--- a/deliver/spec/setup_spec.rb
+++ b/deliver/spec/setup_spec.rb
@@ -20,16 +20,14 @@ describe Deliver do
     describe '#generate_metadata_files' do
       context 'with review_information' do
         let(:version) do
-          double(
-              'version',
-              review_first_name: 'John',
-              review_last_name: 'Smith',
-              review_phone_number: '+819012345678',
-              review_email: 'deliver@example.com',
-              review_demo_user: 'user',
-              review_demo_password: 'password',
-              review_notes: 'This is a note',
-          )
+          double('version',
+                 review_first_name: 'John',
+                 review_last_name: 'Smith',
+                 review_phone_number: '+819012345678',
+                 review_email: 'deliver@example.com',
+                 review_demo_user: 'user',
+                 review_demo_password: 'password',
+                 review_notes: 'This is a note')
         end
         let(:application) { double('application') }
         let(:setup) { Deliver::Setup.new }

--- a/deliver/spec/setup_spec.rb
+++ b/deliver/spec/setup_spec.rb
@@ -48,6 +48,10 @@ describe Deliver do
             expect(File.exist?(File.join(base_dir, "#{filename}.txt"))).to be_truthy
           end
         end
+
+        after do
+          FileUtils.remove_entry_secure(tempdir)
+        end
       end
     end
   end

--- a/deliver/spec/setup_spec.rb
+++ b/deliver/spec/setup_spec.rb
@@ -16,5 +16,41 @@ describe Deliver do
       # Deliver::Runner.new(options) # to login
       # Deliver::Setup.new.run(options)
     end
+
+    describe '#generate_metadata_files' do
+      context 'with review_information' do
+        let(:version) do
+          double(
+              'version',
+              review_first_name: 'John',
+              review_last_name: 'Smith',
+              review_phone_number: '+819012345678',
+              review_email: 'deliver@example.com',
+              review_demo_user: 'user',
+              review_demo_password: 'password',
+              review_notes: 'This is a note',
+          )
+        end
+        let(:application) { double('application') }
+        let(:setup) { Deliver::Setup.new }
+        let(:tempdir) { Dir.mktmpdir }
+        before do
+          allow(version).to receive_message_chain('application.details').and_return(application)
+          allow(version).to receive_message_chain('description.languages').and_return([])
+          allow(version).to receive_message_chain('large_app_icon.asset_token').and_return(nil)
+          allow(version).to receive_message_chain('watch_app_icon.asset_token').and_return(nil)
+          stub_const('Deliver::UploadMetadata::NON_LOCALISED_VERSION_VALUES', [])
+          stub_const('Deliver::UploadMetadata::NON_LOCALISED_APP_VALUES', [])
+        end
+
+        it 'generates review information' do
+          setup.generate_metadata_files(version, tempdir)
+          base_dir = File.join(tempdir, 'review_information')
+          %w(first_name last_name phone_number email_address demo_user demo_password notes).each do |filename|
+            expect(File.exist?(File.join(base_dir, "#{filename}.txt"))).to be_truthy
+          end
+        end
+      end
+    end
   end
 end

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -8,7 +8,7 @@ describe Deliver::UploadMetadata do
   describe '#load_from_filesystem' do
     context 'with review information' do
       let(:tmpdir) { Dir.mktmpdir }
-      let(:options) { {metadata_path: tmpdir, app_review_information: app_review_information} }
+      let(:options) { { metadata_path: tmpdir, app_review_information: app_review_information } }
 
       def create_metadata(path, text)
         File.open(File.join(path), 'w') do |f|
@@ -25,7 +25,7 @@ describe Deliver::UploadMetadata do
           email_address: 'deliver@example.com',
           demo_user: 'user',
           demo_password: 'password',
-          notes: 'This is a note from file',
+          notes: 'This is a note from file'
         }.each do |prefix, text|
           create_metadata(File.join(base_dir, "#{prefix}.txt"), text)
         end
@@ -46,7 +46,7 @@ describe Deliver::UploadMetadata do
       end
 
       context 'with app_review_information' do
-        let(:app_review_information) { {notes: 'This is a note from option'} }
+        let(:app_review_information) { { notes: 'This is a note from option' } }
         it 'values will be masked by the in options' do
           uploader.load_from_filesystem(options)
           expect(options[:app_review_information][:first_name]).to eql('Alice')

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -1,0 +1,67 @@
+require 'deliver/upload_metadata'
+require 'tempfile'
+require 'fileutils'
+
+describe Deliver::UploadMetadata do
+  let(:uploader) { Deliver::UploadMetadata.new }
+
+  describe '#load_from_filesystem' do
+    context 'with review information' do
+      let(:tmpdir) { Dir.mktmpdir }
+      let(:options) { {metadata_path: tmpdir, app_review_information: app_review_information} }
+
+      def create_metadata(path, text)
+        File.open(File.join(path), 'w') do |f|
+          f.write(text)
+        end
+      end
+
+      before do
+        base_dir = FileUtils.mkdir_p(File.join(tmpdir, 'review_information'))
+        {
+          first_name: 'Alice',
+          last_name: 'Smith',
+          phone_number: '+819012345678',
+          email_address: 'deliver@example.com',
+          demo_user: 'user',
+          demo_password: 'password',
+          notes: 'This is a note from file',
+        }.each do |prefix, text|
+          create_metadata(File.join(base_dir, "#{prefix}.txt"), text)
+        end
+      end
+
+      context 'without app_review_information' do
+        let(:app_review_information) { nil }
+        it 'can load review information from file' do
+          uploader.load_from_filesystem(options)
+          expect(options[:app_review_information][:first_name]).to eql('Alice')
+          expect(options[:app_review_information][:last_name]).to eql('Smith')
+          expect(options[:app_review_information][:phone_number]).to eql('+819012345678')
+          expect(options[:app_review_information][:email_address]).to eql('deliver@example.com')
+          expect(options[:app_review_information][:demo_user]).to eql('user')
+          expect(options[:app_review_information][:demo_password]).to eql('password')
+          expect(options[:app_review_information][:notes]).to eql('This is a note from file')
+        end
+      end
+
+      context 'with app_review_information' do
+        let(:app_review_information) { {notes: 'This is a note from option'} }
+        it 'values will be masked by the in options' do
+          uploader.load_from_filesystem(options)
+          expect(options[:app_review_information][:first_name]).to eql('Alice')
+          expect(options[:app_review_information][:last_name]).to eql('Smith')
+          expect(options[:app_review_information][:phone_number]).to eql('+819012345678')
+          expect(options[:app_review_information][:email_address]).to eql('deliver@example.com')
+          expect(options[:app_review_information][:demo_user]).to eql('user')
+          expect(options[:app_review_information][:demo_password]).to eql('password')
+          expect(options[:app_review_information][:notes]).to eql('This is a note from option')
+        end
+      end
+
+      after do
+        FileUtils.remove_entry_secure(tmpdir)
+      end
+    end
+  end
+end

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -1,6 +1,5 @@
 require 'deliver/upload_metadata'
 require 'tempfile'
-require 'fileutils'
 
 describe Deliver::UploadMetadata do
   let(:uploader) { Deliver::UploadMetadata.new }


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

This PR adds the feature to set review_information from text files.

Load `metadata/review_information/*.txt` and upload value to iTunes Connect.

### Motivation and Context

My app has notes for reviewers.
I'd like to manage reviewer note easily.
Currently, if we want to upload reviewer notes, we have to define it on `Deliverfile`.
However, it is difficult to handle.

```ruby
app_review_information({
  notes: "it is difficult to define it here!!!\n" \
         "especially, in case of it contains multi lines" 
})
```