### PR TITLE
Git stats

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -307,3 +307,24 @@ lane :donate_food do
     )
   end
 end
+
+desc "Display git statistics about number of commits, files, lines changed and days between the last releases"
+lane :git_stats do
+  count = 25
+  last_tags = `git tag --sort version:refname | grep "^[0-9]" | tail -#{count}`.split("\n")
+  count = last_tags.count
+  last_tags << 'HEAD'
+  datetimes = last_tags.map do |commit|
+    unixtimestamp = `git log #{commit} -n 1 --format=%ct;`.strip
+    DateTime.strptime(unixtimestamp, '%s')
+  end
+  last_tags.each_with_index do |t, i|
+    break if i == count
+    n = last_tags[i + 1]
+    puts "Comparing: #{t}, #{n}"
+    commit_count = `git log --pretty=oneline #{t}..#{n}^1 | wc -l`.strip
+    shortstat = `git diff --shortstat #{t} #{n}`.strip
+    timediff = (datetimes[i + 1] - datetimes[i]).to_f.round(1)
+    puts "#{commit_count} commit(s) #{shortstat} #{timediff} day(s)"
+  end
+end


### PR DESCRIPTION
@KrauseFX the script I used to make the stats. Could be merge &|| turned into a plugin?

```
[23:09:43]: Driving the lane 'git_stats' 🚀
[23:09:43]: Comparing: 2.1.0, 2.1.1
[23:09:43]: 2 commit(s) 6 files changed, 7 insertions(+), 3 deletions(-) 0.2 day(s)
[23:09:43]: Comparing: 2.1.1, 2.1.2
[23:09:43]: 12 commit(s) 17 files changed, 29 insertions(+), 46 deletions(-) 1.5 day(s)
[23:09:43]: Comparing: 2.1.2, 2.1.3
[23:09:43]: 3 commit(s) 4 files changed, 19 insertions(+), 8 deletions(-) 0.2 day(s)
[23:09:43]: Comparing: 2.1.3, 2.2.0
[23:09:43]: 7 commit(s) 31 files changed, 49 insertions(+), 125 deletions(-) 1.0 day(s)
[23:09:43]: Comparing: 2.2.0, 2.3.0
[23:09:43]: 18 commit(s) 31 files changed, 229 insertions(+), 111 deletions(-) 1.7 day(s)
[23:09:43]: Comparing: 2.3.0, 2.3.1
[23:09:43]: 8 commit(s) 10 files changed, 52 insertions(+), 26 deletions(-) 5.0 day(s)
[23:09:43]: Comparing: 2.3.1, 2.4.0
[23:09:43]: 15 commit(s) 25 files changed, 360 insertions(+), 52 deletions(-) 6.2 day(s)
[23:09:43]: Comparing: 2.4.0, 2.5.0
[23:09:43]: 10 commit(s) 17 files changed, 1060 insertions(+), 56 deletions(-) 1.0 day(s)
[23:09:43]: Comparing: 2.5.0, 2.6.0
[23:09:43]: 14 commit(s) 43 files changed, 438 insertions(+), 78 deletions(-) 4.2 day(s)
[23:09:43]: Comparing: 2.6.0, 2.7.0
[23:09:43]: 8 commit(s) 24 files changed, 116 insertions(+), 67 deletions(-) 1.0 day(s)
[23:09:43]: Comparing: 2.7.0, 2.8.0
[23:09:43]: 15 commit(s) 51 files changed, 298 insertions(+), 62 deletions(-) 2.8 day(s)
[23:09:43]: Comparing: 2.8.0, 2.9.0
[23:09:44]: 42 commit(s) 56 files changed, 672 insertions(+), 76 deletions(-) 5.0 day(s)
[23:09:44]: Comparing: 2.9.0, 2.10.0
[23:09:44]: 33 commit(s) 100 files changed, 939 insertions(+), 244 deletions(-) 6.2 day(s)
[23:09:44]: Comparing: 2.10.0, 2.11.0
[23:09:44]: 15 commit(s) 41 files changed, 2173 insertions(+), 101 deletions(-) 1.2 day(s)
[23:09:44]: Comparing: 2.11.0, 2.12.0
[23:09:44]: 22 commit(s) 35 files changed, 1487 insertions(+), 74 deletions(-) 2.1 day(s)
[23:09:44]: Comparing: 2.12.0, 2.13.0
[23:09:44]: 3 commit(s) 17 files changed, 2209 insertions(+), 6 deletions(-) 3.6 day(s)
[23:09:44]: Comparing: 2.13.0, 2.14.0
[23:09:44]: 23 commit(s) 144 files changed, 5113 insertions(+), 1479 deletions(-) 3.2 day(s)
[23:09:44]: Comparing: 2.14.0, 2.14.1
[23:09:44]: 11 commit(s) 11 files changed, 38 insertions(+), 12 deletions(-) 0.1 day(s)
[23:09:44]: Comparing: 2.14.1, 2.14.2
[23:09:44]: 8 commit(s) 17 files changed, 26 insertions(+), 25 deletions(-) 0.7 day(s)
[23:09:44]: Comparing: 2.14.2, HEAD
[23:09:44]: 33 commit(s) 80 files changed, 959 insertions(+), 321 deletions(-) 5.7 day(s)
```