### PR TITLE
Remove the hardcoded value for external distribution

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -61,7 +61,8 @@ module Pilot
           return
         end
 
-        UI.message("Distributing build #{build.train_version}(#{build.build_version}) from #{build.testing_status} -> External")
+        type = options[:distribute_external] ? 'External' : 'Internal'
+        UI.message("Distributing build #{build.train_version}(#{build.build_version}) from #{build.testing_status} -> #{type}")
       end
 
       unless config[:update_build_info_on_upload]

--- a/pilot/lib/pilot/commands_generator.rb
+++ b/pilot/lib/pilot/commands_generator.rb
@@ -64,7 +64,6 @@ module Pilot
         c.description = "Distribute a previously uploaded binary to Apple TestFlight"
         c.action do |args, options|
           config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
-          config[:distribute_external] = true
           Pilot::BuildManager.new.distribute(config)
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
The distribute_external flag was completely ignored because it was hardcoded set to 'true'. @negebauer already created an issue for this bug (see issue #8151).  

### Motivation and Context
**Why is this change required? What problem does it solve?**
This change makes it possible to distribute your app for internal testing on TestFlight. 

**If it fixes an open issue, please link to the issue here.**
See issue #8151 [https://github.com/fastlane/fastlane/issues/8151]

**Please describe in detail how you tested your changes.**
I have tested it by distributing an actual app for internal testing.

