### PR TITLE
Shell escape target name in TEST_TARGET_NAME

### DIFF
--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -44,7 +44,7 @@ module Snapshot
 
         build_settings = []
         build_settings << "FASTLANE_SNAPSHOT=YES"
-        build_settings << "TEST_TARGET_NAME='#{config[:test_target_name]}'" if config[:test_target_name]
+        build_settings << "TEST_TARGET_NAME=#{config[:test_target_name].shellescape}" if config[:test_target_name]
 
         build_settings
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x ] I've updated the documentation if necessary.

### Description
Removed single quotes and used shell escape function instead

### Motivation and Context
If your target has an apostrophe in it the build command will fail when you use the TEST_TARGET_NAME option