### PR TITLE
[CI] Run using Xcode 8.2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   environment:
     FL_BUILDLOG_PATH: ~/Library/Logs
   xcode:
-    version: "7.3"
+    version: "8.2"
 dependencies:
   pre:
     - brew install shellcheck


### PR DESCRIPTION
This updates fastlane CI to Xcode 8.2, with the advantages being:
- Testing on the Xcode version that many Fastlane users will be using
- Validating Sierra support (Xcode 7 is funky on Sierra sometimes)