### PR TITLE
Changed validation of success code

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -42,7 +42,7 @@ module Fastlane
                                icon_url: icon_url,
                                attachments: [slack_attachment]
 
-        if result.code.to_i == 200
+        if (200..299) === result.code.to_i
           UI.success('Successfully sent Slack notification')
         else
           UI.verbose(result)

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -35,7 +35,8 @@ module Fastlane
         end
 
         slack_attachment = generate_slack_attachments(options)
-
+        UI.verbose(slack_attachment)
+        
         return [notifier, slack_attachment] if Helper.is_test? # tests will verify the slack attachments and other properties
 
         result = notifier.ping '',


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Just one line of changes :)

### Motivation and Context
We use Ryver messenger for team communications. It realises same to Slack web hooks to make migration more simple. If I enter Ryver URL in this module – I will find error, but message is sent. 

The main reason is status code – Slack returns 200, Ryver returns 204. I think that we should fix this check to be more flexible, because successful http codes is between 200 and 299.