### PR TITLE
[Debug] Add exclude-dirs support to ensure_no_debug_code

### DIFF
--- a/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
+++ b/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
@@ -95,6 +95,7 @@ module Fastlane
                                        env_name: "FL_ENSURE_NO_DEBUG_CODE_EXCLUDE_DIRS",
                                        description: "An array of dirs that should not be included in the search",
                                        optional: true,
+                                       type: Array,
                                        is_string: false)
         ]
       end

--- a/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
+++ b/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
@@ -24,7 +24,7 @@ module Fastlane
 
         if params[:exclude_dirs]
           params[:exclude_dirs].each do |dir|
-            command << " --exclude-dir #{dir}"
+            command << " --exclude-dir #{dir.shellescape}"
           end
         end
 

--- a/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
+++ b/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
@@ -22,6 +22,12 @@ module Fastlane
 
         command << " --exclude #{params[:exclude]}" if params[:exclude]
 
+        if params[:exclude_dirs]
+          params[:exclude_dirs].each do |dir|
+            command << " --exclude-dir #{dir}"
+          end
+        end
+
         return command if Helper.is_test?
 
         UI.important(command)
@@ -84,7 +90,12 @@ module Fastlane
                                        env_name: "FL_ENSURE_NO_DEBUG_CODE_EXCLUDE",
                                        description: "Exclude a certain pattern from the search",
                                        optional: true,
-                                       is_string: true)
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :exclude_dirs,
+                                       env_name: "FL_ENSURE_NO_DEBUG_CODE_EXCLUDE_DIRS",
+                                       description: "An array of dirs that should not be included in the search",
+                                       optional: true,
+                                       is_string: false)
         ]
       end
 

--- a/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
@@ -42,6 +42,27 @@ describe Fastlane do
         end").runner.execute(:test)
         expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('./')}'")
       end
+
+      it "handles the exclude_dirs parameter with no elements correctly" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_no_debug_code(text: 'pry', path: '.', exclude_dirs: [])
+        end").runner.execute(:test)
+        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('./')}'")
+      end
+
+      it "handles the exclude_dirs parameter with a single element correctly" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_no_debug_code(text: 'pry', path: '.', exclude_dirs: ['.bundle'])
+        end").runner.execute(:test)
+        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('./')}' --exclude-dir .bundle")
+      end
+
+      it "handles the exclude_dirs parameter with multiple  elements correctly" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_no_debug_code(text: 'pry', path: '.', exclude_dirs: ['.bundle', 'Packages/'])
+        end").runner.execute(:test)
+        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('./')}' --exclude-dir .bundle --exclude-dir Packages/")
+      end
     end
   end
 end

--- a/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
@@ -51,10 +51,17 @@ describe Fastlane do
       end
 
       it "handles the exclude_dirs parameter with a single element correctly" do
-        result = Fastlane::FastFile.new.parse("lane :test do
+        result = fastlane::fastfile.new.parse("lane :test do
           ensure_no_debug_code(text: 'pry', path: '.', exclude_dirs: ['.bundle'])
         end").runner.execute(:test)
-        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('./')}' --exclude-dir .bundle")
+        expect(result).to eq("grep -re 'pry' '#{file.absolute_path('./')}' --exclude-dir .bundle")
+      end
+
+      it "shellescapes the exclude_dirs correctly" do
+        result = fastlane::fastfile.new.parse("lane :test do
+          ensure_no_debug_code(text: 'pry', path: '.', exclude_dirs: ['My Dir'])
+        end").runner.execute(:test)
+        expect(result).to eq("grep -re 'pry' '#{file.absolute_path('./')}' --exclude-dir My\ Dir")
       end
 
       it "handles the exclude_dirs parameter with multiple  elements correctly" do

--- a/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
@@ -51,17 +51,17 @@ describe Fastlane do
       end
 
       it "handles the exclude_dirs parameter with a single element correctly" do
-        result = fastlane::fastfile.new.parse("lane :test do
+        result = Fastlane::FastFile.new.parse("lane :test do
           ensure_no_debug_code(text: 'pry', path: '.', exclude_dirs: ['.bundle'])
         end").runner.execute(:test)
-        expect(result).to eq("grep -re 'pry' '#{file.absolute_path('./')}' --exclude-dir .bundle")
+        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('./')}' --exclude-dir .bundle")
       end
 
       it "shellescapes the exclude_dirs correctly" do
-        result = fastlane::fastfile.new.parse("lane :test do
+        result = Fastlane::FastFile.new.parse("lane :test do
           ensure_no_debug_code(text: 'pry', path: '.', exclude_dirs: ['My Dir'])
         end").runner.execute(:test)
-        expect(result).to eq("grep -re 'pry' '#{file.absolute_path('./')}' --exclude-dir My\ Dir")
+        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('./')}' --exclude-dir My\\ Dir")
       end
 
       it "handles the exclude_dirs parameter with multiple  elements correctly" do


### PR DESCRIPTION
This PR adds support for passing `exclude_dirs` to the `ensure_no_debug_code`
action.

This allows people to ignore their dependencies during the linting process
as `--exclude` is not really designed for excluding directory trees.

Unblocks #8200.