### PR TITLE
Remove link to upgrade guide

### DIFF
--- a/deliver/README.md
+++ b/deliver/README.md
@@ -87,8 +87,6 @@ The guide will create all the necessary files for you, using the existing app me
 
 From now on, you can run `fastlane deliver` to deploy a new update, or just upload new app metadata and screenshots.
 
-Already using `deliver` and just updated to 1.0? Check out the [Migration Guide](https://github.com/fastlane/fastlane/blob/master/deliver/MigrationGuide.md).
-
 # Usage
 
 Check out your local `./fastlane/metadata` and `./fastlane/screenshots` folders (if you don't use [fastlane](https://fastlane.tools) it's `./metadata` instead)


### PR DESCRIPTION
By now most people will have upgraded, also the migration guide is still there, just not linked in the _deliver_ main README
