### PR TITLE
Update help text to prefix tool commands with 'fastlane'

### DIFF
--- a/match/lib/match/setup.rb
+++ b/match/lib/match/setup.rb
@@ -11,7 +11,7 @@ module Match
       File.write(path, template)
       UI.success "Successfully created '#{path}'. You can open the file using a code editor."
 
-      UI.important "You can now run `match development`, `match adhoc` and `match appstore`"
+      UI.important "You can now run `fastlane match development`, `fastlane match adhoc` and `fastlane match appstore`"
       UI.message "On the first run for each environment it will create the provisioning profiles and"
       UI.message "certificates for you. From then on, it will automatically import the existing profiles."
       UI.message "For more information visit https://github.com/fastlane/fastlane/tree/master/match"

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -247,7 +247,7 @@ module Sigh
       UI.message "Could not find App ID with bundle identifier '#{config[:app_identifier]}'"
       UI.message "You can easily generate a new App ID on the Developer Portal using 'produce':"
       UI.message ""
-      UI.message "produce -u #{config[:username]} -a #{config[:app_identifier]} --skip_itc".yellow
+      UI.message "fastlane produce -u #{config[:username]} -a #{config[:app_identifier]} --skip_itc".yellow
       UI.message ""
       UI.message "You will be asked for any missing information, like the full name of your app"
       UI.message "If the app should also be created on iTunes Connect, remove the " + "--skip_itc".yellow + " from the command above"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description

I found a couple places where we're providing commands to run, but we haven't updated to suggest the new `fastlane` prefixed command style
