### PR TITLE
Remove warning when an issue is not linked from a PR

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -11,14 +11,6 @@ if github.pr_body.length < 5
   warn("Please provide a changelog summary in the Pull Request description @#{github.pr_author}")
 end
 
-# We want contributors to create an issue first before submitting a PR
-# Exceptions are version bumps
-if !github.pr_title.downcase.include?('version bump') &&
-   !github.pr_body.include?("https://github.com/fastlane/fastlane/issues/") &&
-   github.pr_body.match(/#\d+/).nil?
-  warn("Before submitting a Pull Request, please create an issue on GitHub to discuss the change. Please add a link to the issue in the PR body.")
-end
-
 # To avoid "PR & Runs" for which tests don't pass, we want to make spec errors more visible
 # The code below will run on Circle, parses the results in JSON and posts them to the PR as comment
 containing_dir = ENV["CIRCLE_TEST_REPORTS"] || "." # for local testing


### PR DESCRIPTION
We had decided that this was no longer a part of our contributor guidelines.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.
