### PR TITLE
Version bump to 2.15.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.14.2'.freeze
+  VERSION = '2.15.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.14.2':**

* Update help text to prefix tool commands with 'fastlane' (#8214)
* Remove warning when an issue is not linked from a PR (#8215)
* Remove the hardcoded value for external distribution (#8191)
* Show error message if device_details can't be detected (#8205)
* Add optional date_format parameter to changelog_from_git_commits (#8030)
* [CI] Cache dependencies (#8200)
* [Debug] Add exclude-dirs support to ensure_no_debug_code (#8201)
* Fix option conflicts in sigh (#8129)
* Add missing github prefix to Dangerfile (#8198)
* Enable danger for fastlane (#8135)
* [CI] Run using Xcode 8.2
* [all] remove all $ globals (#7301)
* [deliver] respect file extension based on users uploaded one. (#7868)
* [scan] support toolchain parameter (#8172)
* [actions/hockey] support create/update upload mechanism + various improvements (#8110)
* Improve gym and fastlane documentation about error_info property
* Pass options from UI.user_error to FastlaneError without taping into it
* Fix more gym/README indentation issues
* Fix gym/README indentation
* update code snippets in snapshot README to Swift 3
* Fix linting error on spec/error_handler
* Provide detailed error message when gym fails #6292
* [fastlane] Relax supported platforms (#8124)
* Properly catch all kinds of errors, including parsing errors, while loading plugins #8154 (#8166)
* Frameit: Provide option to stack keyword on top of title (#8098)
* ✏️ Fix glaring typographical error (#8165)
* Skip loading and printing plugins when running `--help`
* Move common code into base (#8146)
* Fix retrieval of sim logs. (#8125)
* Fixes tvos sigh profile name (#8123)
* Improve calculations
* Improve output design of UI.header
* Update RubyGems admins
* [spaceship] Webpush Id support added for spaceship. (#6943)
* Fix the broken scan test for include_simulator_logs (#8130)
* Catch and print exceptions occuring in error block
* Frameit layout fix (#8031)
* html encode all error messages (#8104)
* Improve the slack error message on post failure
