### PR TITLE
Fix plugins link not working on docs page

### DIFF
--- a/fastlane/lib/assets/Actions.md.erb
+++ b/fastlane/lib/assets/Actions.md.erb
@@ -18,7 +18,7 @@ import './path/to/other/Fastfile'
 <%- @categories.each do |category, actions| -%>
 - [<%= category %>](#<%= category.gsub(" ", "-").downcase %>)
 <%- end -%>
-- [Plugins](#Plugins)
+- [Plugins](#plugins)
 
 
 


### PR DESCRIPTION
This has to be lower case, see https://docs.fastlane.tools/actions/#plugins vs https://docs.fastlane.tools/actions/#Plugins
