### PR TITLE
[deliver] Fix uncaught nil value + watch icon option name

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -76,7 +76,7 @@ module Deliver
       options[:app_icon] ||= default_app_icon_path if default_app_icon_path && File.exist?(default_app_icon_path)
 
       default_watch_icon_path = Dir[File.join(options[:metadata_path], "watch_icon.{png,jpg}")].first
-      options[:app_icon] ||= default_watch_icon_path if default_watch_icon_path && File.exist?(default_watch_icon_path)
+      options[:apple_watch_app_icon] ||= default_watch_icon_path if default_watch_icon_path && File.exist?(default_watch_icon_path)
     end
 
     # Upload the binary to iTunes Connect

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -73,10 +73,10 @@ module Deliver
       return unless options[:metadata_path]
 
       default_app_icon_path = Dir[File.join(options[:metadata_path], "app_icon.{png,jpg}")].first
-      options[:app_icon] ||= default_app_icon_path if File.exist?(default_app_icon_path)
+      options[:app_icon] ||= default_app_icon_path if default_app_icon_path && File.exist?(default_app_icon_path)
 
       default_watch_icon_path = Dir[File.join(options[:metadata_path], "watch_icon.{png,jpg}")].first
-      options[:app_icon] ||= default_watch_icon_path if File.exist?(default_watch_icon_path)
+      options[:app_icon] ||= default_watch_icon_path if default_watch_icon_path && File.exist?(default_watch_icon_path)
     end
 
     # Upload the binary to iTunes Connect


### PR DESCRIPTION
### Description

- Fixes an uncaught nil value in cases where no app icon was found, introduced in #7868 
- While fixing that ☝️, I noticed that watch icons were being set to `options[:app_icon]` instead of `options[:apple_watch_app_icon]`

### Motivation and Context

My app's `deliver` step started failing with `[!] no implicit conversion of nil into String (TypeError)` after updating.