### PR TITLE
Revise other action

### DIFF
--- a/fastlane/lib/fastlane/other_action.rb
+++ b/fastlane/lib/fastlane/other_action.rb
@@ -21,7 +21,7 @@ module Fastlane
       # the fastlane folder too
 
       self.runner.trigger_action_by_name(method_sym,
-                                         "./fastlane",
+                                         FastlaneCore::FastlaneFolder.path,
                                          true,
                                          *arguments)
     end

--- a/fastlane/spec/action_spec.rb
+++ b/fastlane/spec/action_spec.rb
@@ -62,7 +62,7 @@ describe Fastlane do
 
         response = {
           rocket: "🚀",
-          pwd: File.join(Dir.pwd, "fastlane")
+          pwd: Dir.pwd
         }
         expect(ff.runner.execute(:something, :ios)).to eq(response)
         expect(Fastlane::Actions.executed_actions.map { |a| a[:name] }).to eq(['from'])


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->

Use FastlaneCore::FastlaneFolder.path instead of using fixed path to fastlane dir.
By this changes, other_action support not only `fastlane` folder but `.fastlane` folder.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

@mgrebenets found that other_action throws errors below if we use `.fastlane` folder.

```
/Users/grebenma/.rvm/gems/ruby-2.2.2/gems/fastlane-2.12.0/fastlane/lib/fastlane/runner.rb:213:in `chdir': [!] No such file or directory @ dir_chdir - ./fastlane (Errno::ENOENT)
```

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
