### PR TITLE
Update help text to prefix tool commands with 'fastlane'

### DIFF
--- a/fastlane/lib/fastlane/setup/setup_android.rb
+++ b/fastlane/lib/fastlane/setup/setup_android.rb
@@ -57,10 +57,10 @@ module Fastlane
           Supply::Setup.new.perform_download
         rescue => ex
           UI.error(ex.to_s)
-          UI.error("supply failed, but don't worry, you can launch supply using `supply init` whenever you want.")
+          UI.error("supply failed, but don't worry, you can launch supply using `fastlane supply init` whenever you want.")
         end
       else
-        UI.success("You can run `supply init` to do so at a later point.")
+        UI.success("You can run `fastlane supply init` to do so at a later point.")
       end
     end
 

--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -56,7 +56,7 @@ task :generate_device_frames do
   puts "Done writing all the things to './output', please upload both the 'latest' and the time stamp '#{current_time}' folder to GitHub".green
   puts "To do so, clone https://github.com/fastlane/frameit-frames, make sure to check out the `gh-pages` branch".green
   puts "and overwrite the 'latest' folder, and copy the time stamp folder into the root.".green
-  puts "Push the changes, and run `frameit update_frames` to ensure everything worked as expected".green
+  puts "Push the changes, and run `fastlane frameit update_frames` to ensure everything worked as expected".green
 end
 
 def confirm

--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -31,7 +31,7 @@ module Match
 
         c.action do |args, options|
           if args.count > 0
-            FastlaneCore::UI.user_error!("Please run `match [type]`, allowed values: development, adhoc or appstore")
+            FastlaneCore::UI.user_error!("Please run `fastlane match [type]`, allowed values: development, adhoc or appstore")
           end
 
           params = FastlaneCore::Configuration.create(Match::Options.available_options, options.__hash__)
@@ -97,7 +97,7 @@ module Match
         c.syntax = "fastlane match nuke"
         c.description = "Delete all certificates and provisioning profiles from the Apple Dev Portal"
         c.action do |args, options|
-          FastlaneCore::UI.user_error!("Please run `match nuke [type], allowed values: distribution and development. For the 'adhoc' type, please use 'distribution' instead.")
+          FastlaneCore::UI.user_error!("Please run `fastlane match nuke [type], allowed values: distribution and development. For the 'adhoc' type, please use 'distribution' instead.")
         end
       end
 

--- a/match/lib/match/generator.rb
+++ b/match/lib/match/generator.rb
@@ -20,7 +20,7 @@ module Match
         cert_path = Cert::Runner.new.launch
       rescue => ex
         if ex.to_s.include?("You already have a current")
-          UI.user_error!("Could not create a new certificate as you reached the maximum number of certificates for this account. You can use the `match nuke` command to revoke your existing certificates. More information https://github.com/fastlane/fastlane/tree/master/match")
+          UI.user_error!("Could not create a new certificate as you reached the maximum number of certificates for this account. You can use the `fastlane match nuke` command to revoke your existing certificates. More information https://github.com/fastlane/fastlane/tree/master/match")
         else
           raise ex
         end

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -23,7 +23,7 @@ module Match
       print_tables
 
       if params[:readonly]
-        UI.user_error!("`match nuke` doesn't delete anything when running with --readonly enabled")
+        UI.user_error!("`fastlane match nuke` doesn't delete anything when running with --readonly enabled")
       end
 
       if (self.certs + self.profiles + self.files).count > 0

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -57,7 +57,7 @@ module Match
       UI.success "All required keys, certificates and provisioning profiles are installed 🙌".green
     rescue Spaceship::Client::UnexpectedResponse, Spaceship::Client::InvalidUserCredentialsError, Spaceship::Client::NoUserCredentialsError => ex
       UI.error("An error occured while verifying your certificates and profiles with the Apple Developer Portal.")
-      UI.error("If you already have your certificates stored in git, you can run `match` in readonly mode")
+      UI.error("If you already have your certificates stored in git, you can run `fastlane match` in readonly mode")
       UI.error("to just install the certificates and profiles without accessing the Dev Portal.")
       UI.error("To do so, just pass `readonly: true` to your match call.")
       raise ex

--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -9,7 +9,7 @@ module Match
       keychain_entry = CredentialsManager::AccountManager.new(user: user)
 
       if keychain_entry.password(ask_if_missing: false).to_s.length == 0
-        UI.important("You can also run `match` in readonly mode to not require any access to the")
+        UI.important("You can also run `fastlane match` in readonly mode to not require any access to the")
         UI.important("Developer Portal. This way you only share the keys and credentials")
         UI.command("fastlane match --readonly")
         UI.important("More information https://github.com/fastlane/fastlane/tree/master/match#access-control")
@@ -33,7 +33,7 @@ module Match
       UI.error("================================================================")
       available_apps = Spaceship.app.all.collect { |a| "#{a.bundle_id} (#{a.name})" }
       UI.message("Available apps:\n- #{available_apps.join("\n- ")}")
-      UI.error("Make sure to run `match` with the same user and team every time.")
+      UI.error("Make sure to run `fastlane match` with the same user and team every time.")
       UI.user_error!("Couldn't find bundle identifier '#{app_identifier}' for the user '#{username}'")
     end
 
@@ -47,7 +47,7 @@ module Match
       UI.error("for the user #{username}")
       UI.error("Make sure to use the same user and team every time you run 'match' for this")
       UI.error("Git repository. This might be caused by revoking the certificate on the Dev Portal")
-      UI.user_error!("To reset the certificates of your Apple account, you can use the `match nuke` feature, more information on https://github.com/fastlane/fastlane/tree/master/match")
+      UI.user_error!("To reset the certificates of your Apple account, you can use the `fastlane match nuke` feature, more information on https://github.com/fastlane/fastlane/tree/master/match")
     end
 
     def profile_exists(username: nil, uuid: nil)
@@ -60,7 +60,7 @@ module Match
         UI.error("for the user #{username}")
         UI.error("Make sure to use the same user and team every time you run 'match' for this")
         UI.error("Git repository. This might be caused by deleting the provisioning profile on the Dev Portal")
-        UI.user_error!("To reset the provisioning profiles of your Apple account, you can use the `match nuke` feature, more information on https://github.com/fastlane/fastlane/tree/master/match")
+        UI.user_error!("To reset the provisioning profiles of your Apple account, you can use the `fastlane match nuke` feature, more information on https://github.com/fastlane/fastlane/tree/master/match")
       end
 
       if found.valid?

--- a/sigh/lib/sigh/local_manage.rb
+++ b/sigh/lib/sigh/local_manage.rb
@@ -82,7 +82,7 @@ module Sigh
       UI.message "#{profiles_soon.count} are valid but will expire within 30 days".yellow
       UI.message "#{profiles_valid.count} are valid".green
 
-      UI.message "You can remove all expired profiles using `sigh manage -e`" if profiles_expired.count > 0
+      UI.message "You can remove all expired profiles using `fastlane sigh manage -e`" if profiles_expired.count > 0
     end
 
     def self.profile_info(profile)

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -298,7 +298,7 @@ module Snapshot
         content = File.read(path)
 
         unless content.include?(current_version)
-          UI.error "Your '#{path}' is outdated, please run `snapshot update`"
+          UI.error "Your '#{path}' is outdated, please run `fastlane snapshot update`"
           UI.error "to update your Helper file"
           UI.user_error!("Please update your Snapshot Helper file")
         end

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -5,7 +5,7 @@ module Supply
 
       client.begin_edit(package_name: Supply.config[:package_name])
 
-      UI.user_error!("No local metadata found, make sure to run `supply init` to setup supply") unless metadata_path || Supply.config[:apk] || Supply.config[:apk_paths]
+      UI.user_error!("No local metadata found, make sure to run `fastlane supply init` to setup supply") unless metadata_path || Supply.config[:apk] || Supply.config[:apk_paths]
 
       if metadata_path
         UI.user_error!("Could not find folder #{metadata_path}") unless File.directory? metadata_path


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->

Update help text to prefix tool commands with 'fastlane'
I check related files with this command.
```
ag --file-search-regex='rb' --ignore='*_spec.rb' -s '`(?!fastlane)(deliver|supply|snapshot|screengrab|frameit|pem|sigh|produce|cert|spaceship|pilot|boarding|gym|match|scan).*$'
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

Related https://github.com/fastlane/fastlane/pull/8214