### PR TITLE
Fix sigh download_all options regression

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
   pre:
     - brew install shellcheck
   override:
-    - bundle install --jobs=4 --retry=3
+    - bundle check || bundle install --jobs=4 --retry=3 --path .bundle
 test:
   pre:
     - ulimit -n 400

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
   pre:
     - brew install shellcheck
   override:
-    - bundle check || bundle install --jobs=4 --retry=3 --path .bundle
+    - bundle install --jobs=4 --retry=3
 test:
   pre:
     - ulimit -n 400

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -37,7 +37,13 @@ module Commander
         collector.did_launch_action(@program[:name])
         run_active_command
       rescue InvalidCommandError => e
-        abort "#{e}. Use --help for more information"
+        # calling `abort` makes it likely that tests stop without failing, so
+        # we'll disable that during tests.
+        if FastlaneCore::Helper.test?
+          raise e
+        else
+          abort "#{e}. Use --help for more information"
+        end
       rescue Interrupt => ex
         # We catch it so that the stack trace is hidden by default when using ctrl + c
         if FastlaneCore::Globals.verbose?
@@ -49,7 +55,13 @@ module Commander
         OptionParser::InvalidOption,
         OptionParser::InvalidArgument,
         OptionParser::MissingArgument => e
-        abort e.to_s
+        # calling `abort` makes it likely that tests stop without failing, so
+        # we'll disable that during tests.
+        if FastlaneCore::Helper.test?
+          raise e
+        else
+          abort e.to_s
+        end
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         collector.did_raise_error(@program[:name])
         show_github_issues(e.message) if e.show_github_issues
@@ -159,10 +171,12 @@ module Commander
     end
 
     def display_user_error!(e, message)
-      if FastlaneCore::Globals.verbose? # with stack trace
+      if FastlaneCore::Globals.verbose?
+        # with stack trace
         reraise_formatted!(e, message)
       else
-        abort "\n[!] #{message}".red # without stack trace
+        # without stack trace
+        abort "\n[!] #{message}".red
       end
     end
 

--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -60,6 +60,8 @@ module Sigh
         c.syntax = 'fastlane sigh download_all'
         c.description = 'Downloads all valid provisioning profiles'
 
+        FastlaneCore::CommanderGenerator.new.generate(Sigh::Options.available_options, command: c)
+
         c.action do |args, options|
           Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options.__hash__)
           Sigh::Manager.download_all
@@ -69,6 +71,8 @@ module Sigh
       command :repair do |c|
         c.syntax = 'fastlane sigh repair'
         c.description = 'Repairs all expired or invalid provisioning profiles'
+
+        FastlaneCore::CommanderGenerator.new.generate(Sigh::Options.available_options, command: c)
 
         c.action do |args, options|
           Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options.__hash__)

--- a/sigh/spec/commands_generator_spec.rb
+++ b/sigh/spec/commands_generator_spec.rb
@@ -1,11 +1,5 @@
 require 'sigh/commands_generator'
-
-def expect_resign_run(options)
-  expect(resign).to receive(:run) do |actual_options, actual_args|
-    expect(actual_options).to match_commander_options(options)
-    expect(actual_args).to eq([])
-  end
-end
+require 'sigh/repair'
 
 describe Sigh::CommandsGenerator do
   describe "resign option handling" do
@@ -13,6 +7,13 @@ describe Sigh::CommandsGenerator do
       resign = Sigh::Resign.new
       expect(Sigh::Resign).to receive(:new).and_return(resign)
       resign
+    end
+
+    def expect_resign_run(options)
+      expect(resign).to receive(:run) do |actual_options, actual_args|
+        expect(actual_options).to match_commander_options(options)
+        expect(actual_args).to eq([])
+      end
     end
 
     it "signing_identity short flag is not shadowed by cert_id short flag from tool options" do
@@ -43,6 +44,8 @@ describe Sigh::CommandsGenerator do
       # leaving out the command name defaults to 'renew'
       stub_commander_runner_args(['-i', 'abcd'])
 
+      # start takes no params, but we want to expect the call and prevent
+      # actual execution of the method
       expect(Sigh::Manager).to receive(:start)
 
       Sigh::CommandsGenerator.start
@@ -54,11 +57,62 @@ describe Sigh::CommandsGenerator do
       # leaving out the command name defaults to 'renew'
       stub_commander_runner_args(['-p', 'tvos'])
 
+      # start takes no params, but we want to expect the call and prevent
+      # actual execution of the method
       expect(Sigh::Manager).to receive(:start)
 
       Sigh::CommandsGenerator.start
 
       expect(Sigh.config[:platform]).to eq('tvos')
+    end
+  end
+
+  describe "download_all option handling" do
+    it "cert_id short flag from tool options can be used" do
+      # leaving out the command name defaults to 'renew'
+      stub_commander_runner_args(['download_all', '-i', 'abcd'])
+
+      # download_all takes no params, but we want to expect the call and prevent
+      # actual execution of the method
+      expect(Sigh::Manager).to receive(:download_all)
+
+      Sigh::CommandsGenerator.start
+
+      expect(Sigh.config[:cert_id]).to eq('abcd')
+    end
+
+    it "username short flag from tool options can be used" do
+      # leaving out the command name defaults to 'renew'
+      stub_commander_runner_args(['download_all', '-u', 'me@it.com'])
+
+      # download_all takes no params, but we want to expect the call and prevent
+      # actual execution of the method
+      expect(Sigh::Manager).to receive(:download_all)
+
+      Sigh::CommandsGenerator.start
+
+      expect(Sigh.config[:username]).to eq('me@it.com')
+    end
+  end
+
+  describe "repair option handling" do
+    let(:repair) do
+      repair = Sigh::Repair.new
+      expect(Sigh::Repair).to receive(:new).and_return(repair)
+      repair
+    end
+
+    it "username short flag from tool options can be used" do
+      # leaving out the command name defaults to 'renew'
+      stub_commander_runner_args(['repair', '-u', 'me@it.com'])
+
+      # repair_all takes no params, but we want to expect the call and prevent
+      # actual execution of the method
+      expect(repair).to receive(:repair_all)
+
+      Sigh::CommandsGenerator.start
+
+      expect(Sigh.config[:username]).to eq('me@it.com')
     end
   end
 end


### PR DESCRIPTION
Fixes #8231

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

This now correctly applies the _sigh_ tool options for `download_all` and `repair`, which also need them.

### Motivation and Context

This was caused by the refactoring done in #8129. I incorrectly thought that renew was the only
command that used the sigh tool options. While I added tests to confirm that renew and resign did not conflict anymore, I did not add tests for the other commands.
