### PR TITLE
Refactor cert CommanderGenerator usage

### DIFF
--- a/cert/lib/cert/commands_generator.rb
+++ b/cert/lib/cert/commands_generator.rb
@@ -22,11 +22,11 @@ module Cert
 
       global_option('--verbose') { FastlaneCore::Globals.verbose = true }
 
-      FastlaneCore::CommanderGenerator.new.generate(Cert::Options.available_options)
-
       command :create do |c|
         c.syntax = 'fastlane cert create'
         c.description = 'Create new iOS code signing certificates'
+
+        FastlaneCore::CommanderGenerator.new.generate(Cert::Options.available_options, command: c)
 
         c.action do |args, options|
           Cert.config = FastlaneCore::Configuration.create(Cert::Options.available_options, options.__hash__)
@@ -37,6 +37,8 @@ module Cert
       command :revoke_expired do |c|
         c.syntax = 'fastlane cert revoke_expired'
         c.description = 'Revoke expired iOS code signing certificates'
+
+        FastlaneCore::CommanderGenerator.new.generate(Cert::Options.available_options, command: c)
 
         c.action do |args, options|
           Cert.config = FastlaneCore::Configuration.create(Cert::Options.available_options, options.__hash__)

--- a/cert/spec/commands_generator_spec.rb
+++ b/cert/spec/commands_generator_spec.rb
@@ -1,0 +1,63 @@
+require 'cert/commands_generator'
+
+describe Cert::CommandsGenerator do
+  let(:runner) do
+    runner = Cert::Runner.new
+    expect(Cert::Runner).to receive(:new).and_return(runner)
+    runner
+  end
+
+  describe ":create option handling" do
+    it "username short flag from tool options can be used" do
+      # leaving out the command name defaults to 'create'
+      stub_commander_runner_args(['-u', 'me@it.com'])
+
+      # launch takes no params, but we want to expect the call and prevent
+      # actual execution of the method
+      expect(runner).to receive(:launch)
+
+      Cert::CommandsGenerator.start
+
+      expect(Cert.config[:username]).to eq('me@it.com')
+    end
+
+    it "platform flag from tool options can be used" do
+      # leaving out the command name defaults to 'create'
+      stub_commander_runner_args(['--platform', 'macos'])
+
+      # launch takes no params, but we want to expect the call and prevent
+      # actual execution of the method
+      expect(runner).to receive(:launch)
+
+      Cert::CommandsGenerator.start
+
+      expect(Cert.config[:platform]).to eq('macos')
+    end
+  end
+
+  describe ":revoke_expired option handling" do
+    it "development flag from tool options can be used" do
+      stub_commander_runner_args(['revoke_expired', '--development', 'true'])
+
+      # revoke_expired_certs! takes no params, but we want to expect the call
+      # and prevent actual execution of the method
+      expect(runner).to receive(:revoke_expired_certs!)
+
+      Cert::CommandsGenerator.start
+
+      expect(Cert.config[:development]).to be(true)
+    end
+
+    it "output_path short flag from tool options can be used" do
+      stub_commander_runner_args(['revoke_expired', '-o', 'output/path'])
+
+      # revoke_expired_certs! takes no params, but we want to expect the call
+      # and prevent actual execution of the method
+      expect(runner).to receive(:revoke_expired_certs!)
+
+      Cert::CommandsGenerator.start
+
+      expect(Cert.config[:output_path]).to eq('output/path')
+    end
+  end
+end

--- a/cert/spec/commands_generator_spec.rb
+++ b/cert/spec/commands_generator_spec.rb
@@ -8,7 +8,7 @@ describe Cert::CommandsGenerator do
   end
 
   describe ":create option handling" do
-    it "username short flag from tool options can be used" do
+    it "can use the username short flag from tool options" do
       # leaving out the command name defaults to 'create'
       stub_commander_runner_args(['-u', 'me@it.com'])
 
@@ -21,7 +21,7 @@ describe Cert::CommandsGenerator do
       expect(Cert.config[:username]).to eq('me@it.com')
     end
 
-    it "platform flag from tool options can be used" do
+    it "can use the platform flag from tool options" do
       # leaving out the command name defaults to 'create'
       stub_commander_runner_args(['--platform', 'macos'])
 
@@ -36,7 +36,7 @@ describe Cert::CommandsGenerator do
   end
 
   describe ":revoke_expired option handling" do
-    it "development flag from tool options can be used" do
+    it "can use the development flag from tool options" do
       stub_commander_runner_args(['revoke_expired', '--development', 'true'])
 
       # revoke_expired_certs! takes no params, but we want to expect the call
@@ -48,7 +48,7 @@ describe Cert::CommandsGenerator do
       expect(Cert.config[:development]).to be(true)
     end
 
-    it "output_path short flag from tool options can be used" do
+    it "can use the output_path short flag from tool options" do
       stub_commander_runner_args(['revoke_expired', '-o', 'output/path'])
 
       # revoke_expired_certs! takes no params, but we want to expect the call


### PR DESCRIPTION

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Carry the work and lessons learned from #8129 over to _cert_

### Motivation and Context

_cert_ does not currently have any option conflicts, but this refactoring is still generally more correct and safe.
