### PR TITLE
Refactor deliver CommanderGenerator usage

### DIFF
--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -37,8 +37,6 @@ module Deliver
       program :help, 'GitHub', 'https://github.com/fastlane/fastlane/tree/master/deliver'
       program :help_formatter, :compact
 
-      FastlaneCore::CommanderGenerator.new.generate(deliverfile_options)
-
       global_option('--verbose') { FastlaneCore::Globals.verbose = true }
 
       always_trace!
@@ -46,6 +44,9 @@ module Deliver
       command :run do |c|
         c.syntax = 'fastlane deliver'
         c.description = 'Upload metadata and binary to iTunes Connect'
+
+        FastlaneCore::CommanderGenerator.new.generate(deliverfile_options, command: c)
+
         c.action do |args, options|
           options = FastlaneCore::Configuration.create(deliverfile_options, options.__hash__)
           loaded = options.load_configuration_file("Deliverfile")
@@ -62,9 +63,13 @@ module Deliver
           Deliver::Runner.new(options).run
         end
       end
+
       command :submit_build do |c|
         c.syntax = 'fastlane deliver submit_build'
         c.description = 'Submit a specific build-nr for review, use latest for the latest build'
+
+        FastlaneCore::CommanderGenerator.new.generate(deliverfile_options, command: c)
+
         c.action do |args, options|
           options = FastlaneCore::Configuration.create(deliverfile_options, options.__hash__)
           options.load_configuration_file("Deliverfile")
@@ -73,9 +78,13 @@ module Deliver
           Deliver::Runner.new(options).run
         end
       end
+
       command :init do |c|
         c.syntax = 'fastlane deliver init'
         c.description = 'Create the initial `deliver` configuration based on an existing app'
+
+        FastlaneCore::CommanderGenerator.new.generate(deliverfile_options, command: c)
+
         c.action do |args, options|
           if File.exist?("Deliverfile") or File.exist?("fastlane/Deliverfile")
             UI.important("You already have a running deliver setup in this directory")
@@ -92,6 +101,9 @@ module Deliver
       command :generate_summary do |c|
         c.syntax = 'fastlane deliver generate_summary'
         c.description = 'Generate HTML Summary without uploading/downloading anything'
+
+        FastlaneCore::CommanderGenerator.new.generate(deliverfile_options, command: c)
+
         c.action do |args, options|
           options = FastlaneCore::Configuration.create(deliverfile_options, options.__hash__)
           options.load_configuration_file("Deliverfile")
@@ -106,6 +118,8 @@ module Deliver
         c.syntax = 'fastlane deliver download_screenshots'
         c.description = "Downloads all existing screenshots from iTunes Connect and stores them in the screenshots folder"
 
+        FastlaneCore::CommanderGenerator.new.generate(deliverfile_options, command: c)
+
         c.action do |args, options|
           options = FastlaneCore::Configuration.create(deliverfile_options(skip_verification: true), options.__hash__)
           options.load_configuration_file("Deliverfile")
@@ -119,6 +133,8 @@ module Deliver
       command :download_metadata do |c|
         c.syntax = 'fastlane deliver download_metadata'
         c.description = "Downloads existing metadata and stores it locally. This overwrites the local files."
+
+        FastlaneCore::CommanderGenerator.new.generate(deliverfile_options, command: c)
 
         c.action do |args, options|
           options = FastlaneCore::Configuration.create(deliverfile_options(skip_verification: true), options.__hash__)

--- a/deliver/spec/commands_generator_spec.rb
+++ b/deliver/spec/commands_generator_spec.rb
@@ -2,6 +2,18 @@ require 'deliver/commands_generator'
 require 'deliver/setup'
 
 describe Deliver::CommandsGenerator do
+  def expect_runner_run_with(expected_options)
+    fake_runner = "runner"
+    expect_runner_new_with(expected_options).and_return(fake_runner)
+    expect(fake_runner).to receive(:run)
+  end
+
+  def expect_runner_new_with(expected_options)
+    expect(Deliver::Runner).to receive(:new) do |actual_options|
+      expect(expected_options._values).to eq(actual_options._values)
+    end
+  end
+
   describe ":run option handling" do
     it "can use the username short flag from tool options" do
       # leaving out the command name defaults to 'run'
@@ -12,11 +24,7 @@ describe Deliver::CommandsGenerator do
         username: 'me@it.com'
       })
 
-      fake_runner = "runner"
-      expect(Deliver::Runner).to receive(:new) do |actual_options|
-        expect(expected_options._values).to eq(actual_options._values)
-      end.and_return(fake_runner)
-      expect(fake_runner).to receive(:run)
+      expect_runner_run_with(expected_options)
 
       Deliver::CommandsGenerator.start
     end
@@ -30,11 +38,7 @@ describe Deliver::CommandsGenerator do
         app_identifier: 'abcd'
       })
 
-      fake_runner = "runner"
-      expect(Deliver::Runner).to receive(:new) do |actual_options|
-        expect(expected_options._values).to eq(actual_options._values)
-      end.and_return(fake_runner)
-      expect(fake_runner).to receive(:run)
+      expect_runner_run_with(expected_options)
 
       Deliver::CommandsGenerator.start
     end
@@ -51,7 +55,7 @@ describe Deliver::CommandsGenerator do
         build_number: 'latest'
       })
 
-      expect_run_with_options(expected_options)
+      expect_runner_run_with(expected_options)
 
       Deliver::CommandsGenerator.start
     end
@@ -66,13 +70,21 @@ describe Deliver::CommandsGenerator do
         build_number: 'latest'
       })
 
-      expect_run_with_options(expected_options)
+      expect_runner_run_with(expected_options)
 
       Deliver::CommandsGenerator.start
     end
   end
 
   describe ":init option handling" do
+    def expect_setup_run_with(expected_options)
+      fake_setup = "setup"
+      expect(Deliver::Setup).to receive(:new).and_return(fake_setup)
+      expect(fake_setup).to receive(:run) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end
+    end
+
     it "can use the username short flag from tool options" do
       stub_commander_runner_args(['init', '--description', 'My description', '-u', 'me@it.com'])
 
@@ -81,15 +93,8 @@ describe Deliver::CommandsGenerator do
         username: 'me@it.com'
       })
 
-      expect(Deliver::Runner).to receive(:new) do |actual_options|
-        expect(expected_options._values).to eq(actual_options._values)
-      end
-
-      fake_setup = "setup"
-      expect(Deliver::Setup).to receive(:new).and_return(fake_setup)
-      expect(fake_setup).to receive(:run) do |actual_options|
-        expect(expected_options._values).to eq(actual_options._values)
-      end
+      expect_runner_new_with(expected_options)
+      expect_setup_run_with(expected_options)
 
       Deliver::CommandsGenerator.start
     end
@@ -102,21 +107,22 @@ describe Deliver::CommandsGenerator do
         app_identifier: 'abcd'
       })
 
-      expect(Deliver::Runner).to receive(:new) do |actual_options|
-        expect(expected_options._values).to eq(actual_options._values)
-      end
-
-      fake_setup = "setup"
-      expect(Deliver::Setup).to receive(:new).and_return(fake_setup)
-      expect(fake_setup).to receive(:run) do |actual_options|
-        expect(expected_options._values).to eq(actual_options._values)
-      end
+      expect_runner_new_with(expected_options)
+      expect_setup_run_with(expected_options)
 
       Deliver::CommandsGenerator.start
     end
   end
 
   describe ":generate_summary option handling" do
+    def expect_generate_summary_run_with(expected_options)
+      fake_generate_summary = "generate_summary"
+      expect(Deliver::GenerateSummary).to receive(:new).and_return(fake_generate_summary)
+      expect(fake_generate_summary).to receive(:run) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end
+    end
+
     it "can use the username short flag from tool options" do
       stub_commander_runner_args(['generate_summary', '--description', 'My description', '-u', 'me@it.com', '-f', 'true'])
 
@@ -126,15 +132,8 @@ describe Deliver::CommandsGenerator do
         force: true
       })
 
-      expect(Deliver::Runner).to receive(:new) do |actual_options|
-        expect(expected_options._values).to eq(actual_options._values)
-      end
-
-      fake_generate_summary = "generate_summary"
-      expect(Deliver::GenerateSummary).to receive(:new).and_return(fake_generate_summary)
-      expect(fake_generate_summary).to receive(:run) do |actual_options|
-        expect(expected_options._values).to eq(actual_options._values)
-      end
+      expect_runner_new_with(expected_options)
+      expect_generate_summary_run_with(expected_options)
 
       Deliver::CommandsGenerator.start
     end
@@ -148,21 +147,21 @@ describe Deliver::CommandsGenerator do
         force: true
       })
 
-      expect(Deliver::Runner).to receive(:new) do |actual_options|
-        expect(expected_options._values).to eq(actual_options._values)
-      end
-
-      fake_generate_summary = "generate_summary"
-      expect(Deliver::GenerateSummary).to receive(:new).and_return(fake_generate_summary)
-      expect(fake_generate_summary).to receive(:run) do |actual_options|
-        expect(expected_options._values).to eq(actual_options._values)
-      end
+      expect_runner_new_with(expected_options)
+      expect_generate_summary_run_with(expected_options)
 
       Deliver::CommandsGenerator.start
     end
   end
 
   describe ":download_screenshots option handling" do
+    def expect_download_screenshots_run_with(expected_options)
+      expect(Deliver::DownloadScreenshots).to receive(:run) do |actual_options, screenshots_path|
+        expect(expected_options._values).to eq(actual_options._values)
+        expect(screenshots_path).to eq('screenshots/path')
+      end
+    end
+
     it "can use the username short flag from tool options" do
       stub_commander_runner_args(['download_screenshots', '--description', 'My description', '-u', 'me@it.com', '-w', 'screenshots/path'])
 
@@ -172,14 +171,8 @@ describe Deliver::CommandsGenerator do
         screenshots_path: 'screenshots/path'
       })
 
-      expect(Deliver::Runner).to receive(:new) do |actual_options|
-        expect(expected_options._values).to eq(actual_options._values)
-      end
-
-      expect(Deliver::DownloadScreenshots).to receive(:run) do |actual_options, screenshots_path|
-        expect(expected_options._values).to eq(actual_options._values)
-        expect(screenshots_path).to eq('screenshots/path')
-      end
+      expect_runner_new_with(expected_options)
+      expect_download_screenshots_run_with(expected_options)
 
       Deliver::CommandsGenerator.start
     end
@@ -193,14 +186,8 @@ describe Deliver::CommandsGenerator do
         screenshots_path: 'screenshots/path'
       })
 
-      expect(Deliver::Runner).to receive(:new) do |actual_options|
-        expect(expected_options._values).to eq(actual_options._values)
-      end
-
-      expect(Deliver::DownloadScreenshots).to receive(:run) do |actual_options, screenshots_path|
-        expect(expected_options._values).to eq(actual_options._values)
-        expect(screenshots_path).to eq('screenshots/path')
-      end
+      expect_runner_new_with(expected_options)
+      expect_download_screenshots_run_with(expected_options)
 
       Deliver::CommandsGenerator.start
     end

--- a/deliver/spec/commands_generator_spec.rb
+++ b/deliver/spec/commands_generator_spec.rb
@@ -1,0 +1,242 @@
+require 'deliver/commands_generator'
+require 'deliver/setup'
+
+describe Deliver::CommandsGenerator do
+
+  def expect_run_with_options(expected_options)
+    fake_runner = "runner"
+    expect(Deliver::Runner).to receive(:new) do |actual_options|
+      expect(expected_options._values).to eq(actual_options._values)
+    end.and_return(fake_runner)
+    expect(fake_runner).to receive(:run)
+  end
+
+  describe ":run option handling" do
+    it "can use the username short flag from tool options" do
+      # leaving out the command name defaults to 'run'
+      stub_commander_runner_args(['--description', 'My description', '-u', 'me@it.com'])
+
+      expected_options = FastlaneCore::Configuration.create(Deliver::Options.available_options, {
+        description: 'My description',
+        username: 'me@it.com'
+      })
+
+      expect_run_with_options(expected_options)
+
+      Deliver::CommandsGenerator.start
+    end
+
+    it "can use the app_identifier flag from tool options" do
+      # leaving out the command name defaults to 'run'
+      stub_commander_runner_args(['--description', 'My description', '--app_identifier', 'abcd'])
+
+      expected_options = FastlaneCore::Configuration.create(Deliver::Options.available_options, {
+        description: 'My description',
+        app_identifier: 'abcd'
+      })
+
+      expect_run_with_options(expected_options)
+
+      Deliver::CommandsGenerator.start
+    end
+  end
+
+  describe ":submit_build option handling" do
+    it "can use the username short flag from tool options" do
+      stub_commander_runner_args(['submit_build', '--description', 'My description', '-u', 'me@it.com'])
+
+      expected_options = FastlaneCore::Configuration.create(Deliver::Options.available_options, {
+        description: 'My description',
+        username: 'me@it.com',
+        submit_for_review: true,
+        build_number: 'latest'
+      })
+
+      expect_run_with_options(expected_options)
+
+      Deliver::CommandsGenerator.start
+    end
+
+    it "can use the app_identifier flag from tool options" do
+      stub_commander_runner_args(['submit_build', '--description', 'My description', '--app_identifier', 'abcd'])
+
+      expected_options = FastlaneCore::Configuration.create(Deliver::Options.available_options, {
+        description: 'My description',
+        app_identifier: 'abcd',
+        submit_for_review: true,
+        build_number: 'latest'
+      })
+
+      expect_run_with_options(expected_options)
+
+      Deliver::CommandsGenerator.start
+    end
+  end
+
+  describe ":init option handling" do
+    it "can use the username short flag from tool options" do
+      stub_commander_runner_args(['init', '--description', 'My description', '-u', 'me@it.com'])
+
+      expected_options = FastlaneCore::Configuration.create(Deliver::Options.available_options, {
+        description: 'My description',
+        username: 'me@it.com'
+      })
+
+      expect(Deliver::Runner).to receive(:new) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end
+
+      fake_setup = "setup"
+      expect(Deliver::Setup).to receive(:new).and_return(fake_setup)
+      expect(fake_setup).to receive(:run) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end
+
+      Deliver::CommandsGenerator.start
+    end
+
+    it "can use the app_identifier flag from tool options" do
+      stub_commander_runner_args(['init', '--description', 'My description', '--app_identifier', 'abcd'])
+
+      expected_options = FastlaneCore::Configuration.create(Deliver::Options.available_options, {
+        description: 'My description',
+        app_identifier: 'abcd'
+      })
+
+      expect(Deliver::Runner).to receive(:new) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end
+
+      fake_setup = "setup"
+      expect(Deliver::Setup).to receive(:new).and_return(fake_setup)
+      expect(fake_setup).to receive(:run) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end
+
+      Deliver::CommandsGenerator.start
+    end
+  end
+
+  describe ":generate_summary option handling" do
+    it "can use the username short flag from tool options" do
+      stub_commander_runner_args(['generate_summary', '--description', 'My description', '-u', 'me@it.com', '-f', 'true'])
+
+      expected_options = FastlaneCore::Configuration.create(Deliver::Options.available_options, {
+        description: 'My description',
+        username: 'me@it.com',
+        force: true
+      })
+
+      expect(Deliver::Runner).to receive(:new) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end
+
+      fake_generate_summary = "generate_summary"
+      expect(Deliver::GenerateSummary).to receive(:new).and_return(fake_generate_summary)
+      expect(fake_generate_summary).to receive(:run) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end
+
+      Deliver::CommandsGenerator.start
+    end
+
+    it "can use the app_identifier flag from tool options" do
+      stub_commander_runner_args(['generate_summary', '--description', 'My description', '--app_identifier', 'abcd', '-f', 'true'])
+
+      expected_options = FastlaneCore::Configuration.create(Deliver::Options.available_options, {
+        description: 'My description',
+        app_identifier: 'abcd',
+        force: true
+      })
+
+      expect(Deliver::Runner).to receive(:new) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end
+
+      fake_generate_summary = "generate_summary"
+      expect(Deliver::GenerateSummary).to receive(:new).and_return(fake_generate_summary)
+      expect(fake_generate_summary).to receive(:run) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end
+
+      Deliver::CommandsGenerator.start
+    end
+  end
+
+  describe ":download_screenshots option handling" do
+    it "can use the username short flag from tool options" do
+      stub_commander_runner_args(['download_screenshots', '--description', 'My description', '-u', 'me@it.com', '-w', 'screenshots/path'])
+
+      expected_options = FastlaneCore::Configuration.create(Deliver::Options.available_options, {
+        description: 'My description',
+        username: 'me@it.com',
+        screenshots_path: 'screenshots/path'
+      })
+
+      expect(Deliver::Runner).to receive(:new) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end
+
+      expect(Deliver::DownloadScreenshots).to receive(:run) do |actual_options, screenshots_path|
+        expect(expected_options._values).to eq(actual_options._values)
+        expect(screenshots_path).to eq('screenshots/path')
+      end
+
+      Deliver::CommandsGenerator.start
+    end
+
+    it "can use the app_identifier flag from tool options" do
+      stub_commander_runner_args(['download_screenshots', '--description', 'My description', '--app_identifier', 'abcd', '-w', 'screenshots/path'])
+
+      expected_options = FastlaneCore::Configuration.create(Deliver::Options.available_options, {
+        description: 'My description',
+        app_identifier: 'abcd',
+        screenshots_path: 'screenshots/path'
+      })
+
+      expect(Deliver::Runner).to receive(:new) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end
+
+      expect(Deliver::DownloadScreenshots).to receive(:run) do |actual_options, screenshots_path|
+        expect(expected_options._values).to eq(actual_options._values)
+        expect(screenshots_path).to eq('screenshots/path')
+      end
+
+      Deliver::CommandsGenerator.start
+    end
+  end
+
+  describe ":download_metadata option handling" do
+    it "can use the app_identifier flag from tool options" do
+      stub_commander_runner_args(['download_metadata', '--description', 'My description', '--app_identifier', 'abcd', '-m', 'metadata/path'])
+
+      expected_options = FastlaneCore::Configuration.create(Deliver::Options.available_options, {
+        description: 'My description',
+        app_identifier: 'abcd',
+        metadata_path: 'metadata/path'
+      })
+
+      fake_app = "fake_app"
+      expect(fake_app).to receive(:latest_version).and_return('1.0.0')
+
+      expect(Deliver::Runner).to receive(:new) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+        # ugly work-around to do the work that DetectValues would normally do
+        actual_options[:app] = fake_app
+      end
+
+      fake_setup = "fake_setup"
+      expect(Deliver::Setup).to receive(:new).and_return(fake_setup)
+      expect(fake_setup).to receive(:generate_metadata_files) do |version, metadata_path|
+        expect(version).to eq('1.0.0')
+        expect(metadata_path).to eq('metadata/path')
+      end
+
+      # ENV var is needed to prevent user prompting for confirmation
+      with_env_values('DELIVER_FORCE_OVERWRITE' => '1') do
+        Deliver::CommandsGenerator.start
+      end
+    end
+  end
+end

--- a/deliver/spec/commands_generator_spec.rb
+++ b/deliver/spec/commands_generator_spec.rb
@@ -2,15 +2,6 @@ require 'deliver/commands_generator'
 require 'deliver/setup'
 
 describe Deliver::CommandsGenerator do
-
-  def expect_run_with_options(expected_options)
-    fake_runner = "runner"
-    expect(Deliver::Runner).to receive(:new) do |actual_options|
-      expect(expected_options._values).to eq(actual_options._values)
-    end.and_return(fake_runner)
-    expect(fake_runner).to receive(:run)
-  end
-
   describe ":run option handling" do
     it "can use the username short flag from tool options" do
       # leaving out the command name defaults to 'run'
@@ -21,7 +12,11 @@ describe Deliver::CommandsGenerator do
         username: 'me@it.com'
       })
 
-      expect_run_with_options(expected_options)
+      fake_runner = "runner"
+      expect(Deliver::Runner).to receive(:new) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end.and_return(fake_runner)
+      expect(fake_runner).to receive(:run)
 
       Deliver::CommandsGenerator.start
     end
@@ -35,7 +30,11 @@ describe Deliver::CommandsGenerator do
         app_identifier: 'abcd'
       })
 
-      expect_run_with_options(expected_options)
+      fake_runner = "runner"
+      expect(Deliver::Runner).to receive(:new) do |actual_options|
+        expect(expected_options._values).to eq(actual_options._values)
+      end.and_return(fake_runner)
+      expect(fake_runner).to receive(:run)
 
       Deliver::CommandsGenerator.start
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Carry the work and lessons learned from #8129 over to _deliver_

### Motivation and Context

_deliver_ does not currently have any option conflicts, but this refactoring is still generally more correct and safe.
