### PR TITLE
[spaceship] Fix AppDetails's multilingual fields

### DIFF
--- a/spaceship/lib/spaceship/tunes/language_item.rb
+++ b/spaceship/lib/spaceship/tunes/language_item.rb
@@ -31,7 +31,7 @@ module Spaceship
 
       # @return (Array) An array containing all languages that are already available
       def keys
-        self.original_array.collect { |l| l.fetch('language') }
+        self.original_array.collect { |l| get_locale_code(l) }
       end
 
       # @return (Array) An array containing all languages that are already available
@@ -43,9 +43,13 @@ module Spaceship
       def inspect
         result = ""
         self.original_array.collect do |current|
-          result += "#{current.fetch('language')}: #{current.fetch(identifier, {}).fetch('value')}\n"
+          result += "#{get_locale_code(current)}: #{current.fetch(identifier, {}).fetch('value')}\n"
         end
         result
+      end
+
+      def get_locale_code(lang)
+        lang.key?('language') ? lang.fetch('language') : lang.fetch('localeCode')
       end
 
       def to_s


### PR DESCRIPTION
LanguageItem expects the languages hashes have 'language' key for the
locale code, however for AppDetails, the languages hashes are using
'localeCode' for locale code.