### PR TITLE
Refactor frameit CommanderGenerator usage

### DIFF
--- a/frameit/lib/frameit/commands_generator.rb
+++ b/frameit/lib/frameit/commands_generator.rb
@@ -22,13 +22,14 @@ module Frameit
       program :help_formatter, :compact
 
       global_option('--verbose') { FastlaneCore::Globals.verbose = true }
-      FastlaneCore::CommanderGenerator.new.generate(Frameit::Options.available_options)
 
       default_command :run
 
       command :run do |c|
         c.syntax = 'fastlane frameit black'
         c.description = "Adds a black frame around all screenshots"
+
+        FastlaneCore::CommanderGenerator.new.generate(Frameit::Options.available_options, command: c)
 
         c.action do |args, options|
           load_config(options)
@@ -40,6 +41,8 @@ module Frameit
         c.syntax = 'fastlane frameit silver'
         c.description = "Adds a silver frame around all screenshots"
 
+        FastlaneCore::CommanderGenerator.new.generate(Frameit::Options.available_options, command: c)
+
         c.action do |args, options|
           load_config(options)
           Frameit::Runner.new.run('.', Frameit::Color::SILVER)
@@ -50,6 +53,8 @@ module Frameit
         c.syntax = 'fastlane frameit gold'
         c.description = "Adds a gold frame around all screenshots"
 
+        FastlaneCore::CommanderGenerator.new.generate(Frameit::Options.available_options, command: c)
+
         c.action do |args, options|
           load_config(options)
           Frameit::Runner.new.run('.', Frameit::Color::GOLD)
@@ -59,6 +64,8 @@ module Frameit
       command :rose_gold do |c|
         c.syntax = 'fastlane frameit rose_gold'
         c.description = "Adds a rose gold frame around all screenshots"
+
+        FastlaneCore::CommanderGenerator.new.generate(Frameit::Options.available_options, command: c)
 
         c.action do |args, options|
           load_config(options)

--- a/frameit/spec/commands_generator_spec.rb
+++ b/frameit/spec/commands_generator_spec.rb
@@ -1,0 +1,49 @@
+require 'frameit/commands_generator'
+
+describe Frameit::CommandsGenerator do
+  def expect_runner_run
+    fake_runner = "runner"
+    expect(Frameit::Runner).to receive(:new).and_return(fake_runner)
+    expect(fake_runner).to receive(:run)
+  end
+
+  describe ":run options handling" do
+    it "can use the use_legacy_iphone5s flag from tool options" do
+      # leaving out the command name defaults to 'run'
+      stub_commander_runner_args(['--use_legacy_iphone5s', 'true'])
+      expect_runner_run
+      Frameit::CommandsGenerator.start
+      expect(Frameit.config[:use_legacy_iphone5s]).to be(true)
+    end
+  end
+
+  describe ":silver options handling" do
+    it "can use the use_legacy_iphone5s flag from tool options" do
+      stub_commander_runner_args(['silver', '--use_legacy_iphone5s', 'true'])
+      expect_runner_run
+      Frameit::CommandsGenerator.start
+      expect(Frameit.config[:use_legacy_iphone5s]).to be(true)
+    end
+  end
+
+  describe ":gold options handling" do
+    it "can use the use_legacy_iphone5s flag from tool options" do
+      stub_commander_runner_args(['gold', '--use_legacy_iphone5s', 'true'])
+      expect_runner_run
+      Frameit::CommandsGenerator.start
+      expect(Frameit.config[:use_legacy_iphone5s]).to be(true)
+    end
+  end
+
+  describe ":rose_gold options handling" do
+    it "can use the use_legacy_iphone5s flag from tool options" do
+      stub_commander_runner_args(['rose_gold', '--use_legacy_iphone5s', 'true'])
+      expect_runner_run
+      Frameit::CommandsGenerator.start
+      expect(Frameit.config[:use_legacy_iphone5s]).to be(true)
+    end
+  end
+
+  # :setup and :download_frames are not tested here because they do not use any
+  # tool options.
+end


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description

Carry the work and lessons learned from #8129 over to _frameit_

### Motivation and Context

_frameit_ does not currently have any option conflicts, but this refactoring is still generally more correct and safe.