### PR TITLE
[supply] only set apk path when none is given

### DIFF
--- a/fastlane/lib/fastlane/actions/supply.rb
+++ b/fastlane/lib/fastlane/actions/supply.rb
@@ -7,11 +7,13 @@ module Fastlane
 
         FastlaneCore::UpdateChecker.start_looking_for_update('supply') unless Helper.is_test?
 
-        all_apk_paths = Actions.lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] || []
-        if all_apk_paths.length > 1
-          params[:apk_paths] ||= all_apk_paths
-        else
-          params[:apk] ||= Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
+        unless params[:apk_paths].present? || params[:apk].present?
+          all_apk_paths = Actions.lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] || []
+          if all_apk_paths.length > 1
+            params[:apk_paths] = all_apk_paths
+          else
+            params[:apk] = Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
+          end
         end
 
         Supply.config = params # we already have the finished config


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

only set apk path when none is given

### Motivation and Context

User options should always have precedence, and if for some reason multiple apks are generated, it should still be possible to only use one.
