### PR TITLE
Version bump to 2.17.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.16.0'.freeze
+  VERSION = '2.17.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.16.0':**

* remove developerservices2 in favor of developer.apple.com (#8251)
* [deliver] display error while trying to detect app version (helping #8245) (#8247)
* Refactor deliver CommanderGenerator usage (#8248)
* Test code samples at build time (#8232)
* Refactor cert CommanderGenerator usage (#8246)
