### PR TITLE
README: added openssl instructions for password-less p12 files

### DIFF
--- a/pem/README.md
+++ b/pem/README.md
@@ -120,6 +120,22 @@ Instead, you may verify the file is valid using OpenSSL:
 
     openssl pkcs12 -info -in my.p12
 
+If you need the `p12` in your keychain, perhaps to test push with an app like [Knuff](https://github.com/KnuffApp/Knuff) or [Pusher](https://github.com/noodlewerk/NWPusher), you can use `openssl` to export the `p12` to `pem` and back to `p12`:
+
+    % openssl pkcs12 -in my.p12 -out my.pem
+    Enter Import Password:
+      <hit enter: the p12 has no password>
+    MAC verified OK
+    Enter PEM pass phrase:
+      <enter a temporary password to encrypt the pem file>
+      
+    % openssl pkcs12 -export -in my.pem -out my-with-passphrase.p12
+    Enter pass phrase for temp.pem:
+      <enter the temporary password to decrypt the pem file>
+
+    Enter Export Password:
+      <enter a password for encrypting the new p12 file>
+
 ##### [Like this tool? Be the first to know about updates and new fastlane tools](https://tinyletter.com/krausefx)
 
 ## Environment Variables


### PR DESCRIPTION
Added usage of `openssl` to export the `p12` to `pem` and back to `p12` for importing into the OS X keychain

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

I hit the same problem as many others around the password-less `p12` file from `pem`. It turns out, it's easy to change those files with a little `openssl` knowledge.

This is just a README update, no code changes.