### PR TITLE
Refactor gym CommanderGenerator usage

### DIFF
--- a/gym/lib/gym/commands_generator.rb
+++ b/gym/lib/gym/commands_generator.rb
@@ -8,8 +8,6 @@ module Gym
     include Commander::Methods
     UI = FastlaneCore::UI
 
-    FastlaneCore::CommanderGenerator.new.generate(Gym::Options.available_options)
-
     def self.start
       new.run
     end
@@ -34,6 +32,9 @@ module Gym
       command :build do |c|
         c.syntax = "fastlane gym"
         c.description = "Just builds your app"
+
+        FastlaneCore::CommanderGenerator.new.generate(Gym::Options.available_options, command: c)
+
         c.action do |_args, options|
           config = FastlaneCore::Configuration.create(Gym::Options.available_options,
                                                       convert_options(options))

--- a/gym/spec/commands_generator_spec.rb
+++ b/gym/spec/commands_generator_spec.rb
@@ -1,0 +1,37 @@
+require 'gym/commands_generator'
+
+describe Gym::CommandsGenerator do
+  def expect_manager_work_with(expected_options)
+    fake_manager = "manager"
+    expect(Gym::Manager).to receive(:new).and_return(fake_manager)
+    expect(fake_manager).to receive(:work) do |actual_options|
+      expect(expected_options._values).to eq(actual_options._values)
+    end
+  end
+
+  describe ":build option handling" do
+    it "can use the scheme short flag from tool options" do
+      # leaving out the command name defaults to 'build'
+      stub_commander_runner_args(['-s', 'MyScheme'])
+
+      expected_options = FastlaneCore::Configuration.create(Gym::Options.available_options, { scheme: 'MyScheme' })
+
+      expect_manager_work_with(expected_options)
+
+      Gym::CommandsGenerator.start
+    end
+
+    it "can use the clean flag from tool options" do
+      # leaving out the command name defaults to 'build'
+      stub_commander_runner_args(['--clean', 'true'])
+
+      expected_options = FastlaneCore::Configuration.create(Gym::Options.available_options, { clean: true })
+
+      expect_manager_work_with(expected_options)
+
+      Gym::CommandsGenerator.start
+    end
+  end
+
+  # :init is not tested here because it does not use any tool options.
+end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Carry the work and lessons learned from #8129 over to _gym_

### Motivation and Context

_gym_ does not currently have any option conflicts, but this refactoring is still generally more correct and safe.