### PR TITLE
Refactor match CommanderGenerator usage

### DIFF
--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -23,11 +23,11 @@ module Match
 
       global_option('--verbose') { FastlaneCore::Globals.verbose = true }
 
-      FastlaneCore::CommanderGenerator.new.generate(Match::Options.available_options)
-
       command :run do |c|
         c.syntax = 'fastlane match'
         c.description = Match::DESCRIPTION
+
+        FastlaneCore::CommanderGenerator.new.generate(Match::Options.available_options, command: c)
 
         c.action do |args, options|
           if args.count > 0
@@ -44,6 +44,8 @@ module Match
         command type do |c|
           c.syntax = "fastlane match #{type}"
           c.description = "Run match for a #{type} provisioning profile"
+
+          FastlaneCore::CommanderGenerator.new.generate(Match::Options.available_options, command: c)
 
           c.action do |args, options|
             params = FastlaneCore::Configuration.create(Match::Options.available_options, options.__hash__)
@@ -73,6 +75,9 @@ module Match
       command :change_password do |c|
         c.syntax = 'fastlane match change_password'
         c.description = 'Re-encrypt all files with a different password'
+
+        FastlaneCore::CommanderGenerator.new.generate(Match::Options.available_options, command: c)
+
         c.action do |args, options|
           params = FastlaneCore::Configuration.create(Match::Options.available_options, options.__hash__)
           params.load_configuration_file("Matchfile")
@@ -85,6 +90,9 @@ module Match
       command :decrypt do |c|
         c.syntax = "fastlane match decrypt"
         c.description = "Decrypts the repository and keeps it on the filesystem"
+
+        FastlaneCore::CommanderGenerator.new.generate(Match::Options.available_options, command: c)
+
         c.action do |args, options|
           params = FastlaneCore::Configuration.create(Match::Options.available_options, options.__hash__)
           params.load_configuration_file("Matchfile")
@@ -92,6 +100,7 @@ module Match
           UI.success "Repo is at: '#{decrypted_repo}'"
         end
       end
+
       command "nuke" do |c|
         # We have this empty command here, since otherwise the normal `match` command will be executed
         c.syntax = "fastlane match nuke"
@@ -105,6 +114,9 @@ module Match
         command "nuke #{type}" do |c|
           c.syntax = "fastlane match nuke #{type}"
           c.description = "Delete all certificates and provisioning profiles from the Apple Dev Portal of the type #{type}"
+
+          FastlaneCore::CommanderGenerator.new.generate(Match::Options.available_options, command: c)
+
           c.action do |args, options|
             params = FastlaneCore::Configuration.create(Match::Options.available_options, options.__hash__)
             params.load_configuration_file("Matchfile")

--- a/match/spec/commands_generator_spec.rb
+++ b/match/spec/commands_generator_spec.rb
@@ -1,0 +1,129 @@
+require 'match/commands_generator'
+
+describe Match::CommandsGenerator do
+  let(:available_options) { Match::Options.available_options }
+
+  def expect_runner_run_with(expected_options)
+    fake_runner = "runner"
+    expect(Match::Runner).to receive(:new).and_return(fake_runner)
+    expect(fake_runner).to receive(:run) do |actual_options|
+      expect(expected_options._values).to eq(actual_options._values)
+    end
+  end
+
+  Match.environments.each do |env|
+    describe ":#{env} option handling" do
+      it "can use the git_url short flag from tool options" do
+        # leaving out the command name defaults to 'run'
+        stub_commander_runner_args(['-r', 'git@github.com:you/your_repo.git'])
+
+        expected_options = FastlaneCore::Configuration.create(available_options, {
+          git_url: 'git@github.com:you/your_repo.git'
+        })
+
+        expect_runner_run_with(expected_options)
+
+        Match::CommandsGenerator.start
+      end
+
+      it "can use the git_branch flag from tool options" do
+        # leaving out the command name defaults to 'run'
+        stub_commander_runner_args(['--git_branch', 'my-branch'])
+
+        expected_options = FastlaneCore::Configuration.create(available_options, { git_branch: 'my-branch' })
+
+        expect_runner_run_with(expected_options)
+
+        Match::CommandsGenerator.start
+      end
+    end
+  end
+
+  describe ":change_password option handling" do
+    def expect_change_password_with(expected_options)
+      expect(Match::ChangePassword).to receive(:update) do |args|
+        expect(args[:params]._values).to eq(expected_options._values)
+      end
+      expect(FastlaneCore::UI).to receive(:success).with(/Successfully changed the password./)
+    end
+
+    it "can use the git_url short flag from tool options" do
+      stub_commander_runner_args(['change_password', '-r', 'git@github.com:you/your_repo.git'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { git_url: 'git@github.com:you/your_repo.git' })
+
+      expect_change_password_with(expected_options)
+
+      Match::CommandsGenerator.start
+    end
+
+    it "can use the shallow_clone flag from tool options" do
+      stub_commander_runner_args(['change_password', '--shallow_clone', 'true'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { shallow_clone: true })
+
+      expect_change_password_with(expected_options)
+
+      Match::CommandsGenerator.start
+    end
+  end
+
+  describe ":decrypt option handling" do
+    def expect_githelper_clone_with(git_url, shallow_clone, git_branch)
+      expect(Match::GitHelper).to receive(:clone).with(git_url, shallow_clone, git_branch)
+      expect(FastlaneCore::UI).to receive(:success).with(/Repo is at/)
+    end
+
+    it "can use the git_url short flag from tool options" do
+      stub_commander_runner_args(['decrypt', '-r', 'git@github.com:you/your_repo.git'])
+
+      expect_githelper_clone_with('git@github.com:you/your_repo.git', false, { branch: 'master' })
+
+      Match::CommandsGenerator.start
+    end
+
+    it "can use the shallow_clone flag from tool options" do
+      stub_commander_runner_args(['decrypt', '-r', 'git@github.com:you/your_repo.git', '--shallow_clone', 'true'])
+
+      expect_githelper_clone_with('git@github.com:you/your_repo.git', true, { branch: 'master' })
+
+      Match::CommandsGenerator.start
+    end
+  end
+
+  def expect_nuke_run_with(expected_options, type)
+    fake_nuke = "nuke"
+    expect(Match::Nuke).to receive(:new).and_return(fake_nuke)
+    expect(fake_nuke).to receive(:run) do |actual_options, args|
+      expect(actual_options._values).to eq(expected_options._values)
+      expect(args[:type]).to eq(type)
+    end
+  end
+
+  ["development", "distribution"].each do |type|
+    describe "nuke #{type} option handling" do
+      it "can use the git_url short flag from tool options" do
+        stub_commander_runner_args(['nuke', type, '-r', 'git@github.com:you/your_repo.git'])
+
+        expected_options = FastlaneCore::Configuration.create(available_options, { git_url: 'git@github.com:you/your_repo.git' })
+
+        expect_nuke_run_with(expected_options, type)
+
+        Match::CommandsGenerator.start
+      end
+
+      it "can use the git_branch flag from tool options" do
+        # leaving out the command name defaults to 'run'
+        stub_commander_runner_args(['nuke', type, '--git_branch', 'my-branch'])
+
+        expected_options = FastlaneCore::Configuration.create(available_options, { git_branch: 'my-branch' })
+
+        expect_nuke_run_with(expected_options, type)
+
+        Match::CommandsGenerator.start
+      end
+    end
+  end
+
+  # :init is not tested here because it does not use any tool options
+end

--- a/match/spec/commands_generator_spec.rb
+++ b/match/spec/commands_generator_spec.rb
@@ -14,11 +14,11 @@ describe Match::CommandsGenerator do
   Match.environments.each do |env|
     describe ":#{env} option handling" do
       it "can use the git_url short flag from tool options" do
-        # leaving out the command name defaults to 'run'
-        stub_commander_runner_args(['-r', 'git@github.com:you/your_repo.git'])
+        stub_commander_runner_args([env, '-r', 'git@github.com:you/your_repo.git'])
 
         expected_options = FastlaneCore::Configuration.create(available_options, {
-          git_url: 'git@github.com:you/your_repo.git'
+          git_url: 'git@github.com:you/your_repo.git',
+          type: env
         })
 
         expect_runner_run_with(expected_options)
@@ -27,10 +27,12 @@ describe Match::CommandsGenerator do
       end
 
       it "can use the git_branch flag from tool options" do
-        # leaving out the command name defaults to 'run'
-        stub_commander_runner_args(['--git_branch', 'my-branch'])
+        stub_commander_runner_args([env, '--git_branch', 'my-branch'])
 
-        expected_options = FastlaneCore::Configuration.create(available_options, { git_branch: 'my-branch' })
+        expected_options = FastlaneCore::Configuration.create(available_options, {
+          git_branch: 'my-branch',
+          type: env
+        })
 
         expect_runner_run_with(expected_options)
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Carry the work and lessons learned from #8129 over to _match_

### Motivation and Context

_match_ does not currently have any option conflicts, but this refactoring is still generally more correct and safe.