### PR TITLE
Refactor pem CommanderGenerator usage

### DIFF
--- a/pem/lib/pem/commands_generator.rb
+++ b/pem/lib/pem/commands_generator.rb
@@ -22,11 +22,11 @@ module PEM
 
       global_option('--verbose') { FastlaneCore::Globals.verbose = true }
 
-      FastlaneCore::CommanderGenerator.new.generate(PEM::Options.available_options)
-
       command :renew do |c|
         c.syntax = 'fastlane pem renew'
         c.description = 'Renews the certificate (in case it expired) and shows the path to the generated pem file'
+
+        FastlaneCore::CommanderGenerator.new.generate(PEM::Options.available_options, command: c)
 
         c.action do |args, options|
           PEM.config = FastlaneCore::Configuration.create(PEM::Options.available_options, options.__hash__)

--- a/pem/spec/commands_generator_spec.rb
+++ b/pem/spec/commands_generator_spec.rb
@@ -1,0 +1,35 @@
+require 'pem/commands_generator'
+
+describe PEM::CommandsGenerator do
+  let(:available_options) { PEM::Options.available_options }
+
+  describe ":renew option handling" do
+    it "can use the save_private_key short flag from tool options" do
+      # leaving out the command name defaults to 'renew'
+      stub_commander_runner_args(['-s', 'false'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { save_private_key: false })
+
+      expect(PEM::Manager).to receive(:start)
+
+      PEM::CommandsGenerator.start
+
+      expect(PEM.config._values).to eq(expected_options._values)
+    end
+
+    it "can use the development flag from tool options" do
+      # leaving out the command name defaults to 'renew'
+      stub_commander_runner_args(['--development', 'true'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { development: true })
+
+      expect(PEM::Manager).to receive(:start)
+
+      PEM::CommandsGenerator.start
+
+      expect(PEM.config._values).to eq(expected_options._values)
+    end
+  end
+
+  # :init is not tested here because it does not use any tool options.
+end

--- a/pem/spec/commands_generator_spec.rb
+++ b/pem/spec/commands_generator_spec.rb
@@ -30,6 +30,4 @@ describe PEM::CommandsGenerator do
       expect(PEM.config._values).to eq(expected_options._values)
     end
   end
-
-  # :init is not tested here because it does not use any tool options.
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Carry the work and lessons learned from #8129 over to _pem_

### Motivation and Context

_pem_ does not currently have any option conflicts, but this refactoring is still generally more correct and safe.