### PR TITLE
[match] Set Provisioning Profile path for environment variables

### DIFF
--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -62,7 +62,7 @@ module FastlaneCore
           end
         end
 
-        true
+        destination
       end
 
       private

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -134,7 +134,7 @@ module Match
         self.changes_to_commit = true
       end
 
-      FastlaneCore::ProvisioningProfile.install(profile)
+      installed_profile = FastlaneCore::ProvisioningProfile.install(profile)
 
       parsed = FastlaneCore::ProvisioningProfile.parse(profile)
       uuid = parsed["UUID"]
@@ -162,6 +162,11 @@ module Match
                                                                                     type: prov_type,
                                                                                 platform: params[:platform]),
                              parsed["Name"])
+
+      Utils.fill_environment(Utils.environment_variable_name_profile_path(app_identifier: app_identifier,
+                                                                                    type: prov_type,
+                                                                                platform: params[:platform]),
+                             installed_profile)
 
       return uuid
     end

--- a/match/lib/match/table_printer.rb
+++ b/match/lib/match/table_printer.rb
@@ -26,6 +26,7 @@ module Match
       {
         Utils.environment_variable_name(app_identifier: app_identifier, type: type, platform: platform) => "Profile UUID",
         Utils.environment_variable_name_profile_name(app_identifier: app_identifier, type: type, platform: platform) => "Profile Name",
+        Utils.environment_variable_name_profile_path(app_identifier: app_identifier, type: type, platform: platform) => "Profile Path",
         Utils.environment_variable_name_team_id(app_identifier: app_identifier, type: type, platform: platform) => "Development Team ID"
       }.each do |env_key, name|
         rows << [name, env_key, ENV[env_key]]

--- a/match/lib/match/utils.rb
+++ b/match/lib/match/utils.rb
@@ -23,6 +23,10 @@ module Match
       (base_environment_variable_name(app_identifier: app_identifier, type: type, platform: platform) + ["profile-name"]).join("_")
     end
 
+    def self.environment_variable_name_profile_path(app_identifier: nil, type: nil, platform: :ios)
+      (base_environment_variable_name(app_identifier: app_identifier, type: type, platform: platform) + ["profile-path"]).join("_")
+    end
+
     def self.get_cert_info(cer_certificate_path)
       command = "openssl x509 -inform der -in #{cer_certificate_path.shellescape} -subject -dates -noout"
       command << " &" # start in separate process

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -13,6 +13,7 @@ describe Match do
       repo_dir = Dir.mktmpdir
       cert_path = File.join(repo_dir, "something")
       profile_path = "./match/spec/fixtures/test.mobileprovision"
+      destination = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision")
 
       expect(Match::GitHelper).to receive(:clone).with(git_url, true, skip_docs: false, branch: "master").and_return(repo_dir)
       expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution).and_return(cert_path)
@@ -20,7 +21,7 @@ describe Match do
                                                                             prov_type: :appstore,
                                                                        certificate_id: "something",
                                                                        app_identifier: values[:app_identifier]).and_return(profile_path)
-      expect(FastlaneCore::ProvisioningProfile).to receive(:install).with(profile_path)
+      expect(FastlaneCore::ProvisioningProfile).to receive(:install).with(profile_path).and_return(destination)
       expect(Match::GitHelper).to receive(:commit_changes).with(repo_dir, "[fastlane] Updated appstore and platform ios", git_url, "master")
 
       spaceship = "spaceship"
@@ -30,6 +31,16 @@ describe Match do
       expect(spaceship).to receive(:bundle_identifier_exists).and_return(true)
 
       Match::Runner.new.run(config)
+
+      expect(ENV[Match::Utils.environment_variable_name(app_identifier: "tools.fastlane.app",
+                                                        type: "appstore")]).to eql('98264c6b-5151-4349-8d0f-66691e48ae35')
+      expect(ENV[Match::Utils.environment_variable_name_team_id(app_identifier: "tools.fastlane.app",
+                                                                type: "appstore")]).to eql('439BBM9367')
+      expect(ENV[Match::Utils.environment_variable_name_profile_name(app_identifier: "tools.fastlane.app",
+                                                                     type: "appstore")]).to eql('tools.fastlane.app AppStore')
+      profile_path = File.expand_path('~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision')
+      expect(ENV[Match::Utils.environment_variable_name_profile_path(app_identifier: "tools.fastlane.app",
+                                                                     type: "appstore")]).to eql(profile_path)
     end
 
     it "uses existing certificates and profiles if they exist" do
@@ -61,6 +72,16 @@ describe Match do
       expect(spaceship).to receive(:bundle_identifier_exists).and_return(true)
 
       Match::Runner.new.run(config)
+
+      expect(ENV[Match::Utils.environment_variable_name(app_identifier: "tools.fastlane.app",
+                                                        type: "appstore")]).to eql('736590c3-dfe8-4c25-b2eb-2404b8e65fb8')
+      expect(ENV[Match::Utils.environment_variable_name_team_id(app_identifier: "tools.fastlane.app",
+                                                                type: "appstore")]).to eql('439BBM9367')
+      expect(ENV[Match::Utils.environment_variable_name_profile_name(app_identifier: "tools.fastlane.app",
+                                                                     type: "appstore")]).to eql('match AppStore tools.fastlane.app 1449198835')
+      profile_path = File.expand_path('~/Library/MobileDevice/Provisioning Profiles/736590c3-dfe8-4c25-b2eb-2404b8e65fb8.mobileprovision')
+      expect(ENV[Match::Utils.environment_variable_name_profile_path(app_identifier: "tools.fastlane.app",
+                                                                     type: "appstore")]).to eql(profile_path)
     end
   end
 end

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -74,6 +74,11 @@ describe Match do
         expect(result).to eq("sigh_tools.fastlane.app_appstore_profile-name")
       end
 
+      it "#environment_variable_name_profile_path uses the correct env variable" do
+        result = Match::Utils.environment_variable_name_profile_path(app_identifier: "tools.fastlane.app", type: "appstore")
+        expect(result).to eq("sigh_tools.fastlane.app_appstore_profile-path")
+      end
+
       it "pre-fills the environment" do
         my_key = "my_test_key"
         uuid = "my_uuid"


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Using match, Added environment variable which indicates fetched Provisioning Profile installed path.

![match](https://cloud.githubusercontent.com/assets/147051/23049347/c33f2c9a-f4fe-11e6-891e-20a74411f54b.png)

### Motivation and Context

I'd like to use Provisioning Profile path to fight against code signing.
This value can be passed to other actions. (e.g. `update_project_provisioning`)