### PR TITLE
Fix missing `!` when calling `user_error`

### DIFF
--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -9,7 +9,7 @@ module Frameit
     # path: Path to screenshot
     # color: Color to use for the frame
     def initialize(path, color)
-      UI.user_error "Couldn't find file at path '#{path}'" unless File.exist? path
+      UI.user_error!("Couldn't find file at path '#{path}'") unless File.exist? path
       @color = color
       @path = path
       @size = FastImage.size(path)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Fix invalid call to `UI.user_error` - missing `!` in the end.

### Motivation and Context

> [!] Unknown method 'user_error', supported [:error, :important, :success, :message, :deprecated, :command, :command_output, :verbose, :header, :interactive?, :input, :confirm, :select, :password, :crash!, :user_error!, :not_implemented]
