### PR TITLE
Use eval_gemfile to install plugins

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -241,12 +241,12 @@ module Fastlane
         fastlane_folder_name = "fastlane"
       end
       "plugins_path = File.join(File.dirname(__FILE__), '#{fastlane_folder_name}', '#{PluginManager::PLUGINFILE_NAME}')\n" \
-      "eval(File.read(plugins_path), binding) if File.exist?(plugins_path)"
+      "eval_gemfile(plugins_path) if File.exist?(plugins_path)"
     end
 
     # Makes sure, the user's Gemfile actually loads the Plugins file
     def plugins_attached?
-      gemfile_path && gemfile_content.include?(self.class.code_to_attach)
+      gemfile_path && gemfile_content.include?(PluginManager::PLUGINFILE_NAME)
     end
 
     def ensure_plugins_attached!


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Adding plugins, `PluginManager` inserts `eval`. However, it is a bit dangerous.
This PR make using `eval_gemfile` instead.

### Motivation and Context

We prefer using `eval_gemfile` to load `Gemfile` recursively.
This way is more safety and recommended by bundler.

https://github.com/bundler/bundler/blob/master/lib/bundler/dsl.rb#L36