### PR TITLE
Refactor supply CommanderGenerator usage

### DIFF
--- a/supply/lib/supply/commands_generator.rb
+++ b/supply/lib/supply/commands_generator.rb
@@ -8,8 +8,6 @@ module Supply
   class CommandsGenerator
     include Commander::Methods
 
-    FastlaneCore::CommanderGenerator.new.generate(Supply::Options.available_options)
-
     def self.start
       new.run
     end
@@ -30,6 +28,9 @@ module Supply
       command :run do |c|
         c.syntax = 'fastlane supply'
         c.description = 'Run a deploy process'
+
+        FastlaneCore::CommanderGenerator.new.generate(Supply::Options.available_options)
+
         c.action do |args, options|
           Supply.config = FastlaneCore::Configuration.create(Supply::Options.available_options, options.__hash__)
           load_supplyfile
@@ -41,6 +42,9 @@ module Supply
       command :init do |c|
         c.syntax = 'fastlane supply init'
         c.description = 'Sets up supply for you'
+
+        FastlaneCore::CommanderGenerator.new.generate(Supply::Options.available_options)
+
         c.action do |args, options|
           require 'supply/setup'
           Supply.config = FastlaneCore::Configuration.create(Supply::Options.available_options, options.__hash__)

--- a/supply/spec/commands_generator_spec.rb
+++ b/supply/spec/commands_generator_spec.rb
@@ -2,33 +2,32 @@ require 'supply/commands_generator'
 require 'supply/setup'
 
 describe Supply::CommandsGenerator do
-  def expect_uploader_run
+  def expect_uploader_perform_upload
     fake_uploader = "uploader"
     expect(Supply::Uploader).to receive(:new).and_return(fake_uploader)
     expect(fake_uploader).to receive(:perform_upload)
   end
 
-  def expect_setup_run
+  def expect_setup_perform_download
     fake_setup = "setup"
     expect(Supply::Setup).to receive(:new).and_return(fake_setup)
     expect(fake_setup).to receive(:perform_download)
   end
 
   describe ":run options handling" do
-    it "can use the package_name param from tool options" do
+    it "can use the skip_upload_metadata flag from tool options" do
       # leaving out the command name defaults to 'run'
       stub_commander_runner_args(['--skip_upload_metadata'])
-      expect_uploader_run
+      expect_uploader_perform_upload
       Supply::CommandsGenerator.start
       expect(Supply.config[:skip_upload_metadata]).to be(true)
     end
   end
 
   describe ":init options handling" do
-    it "can use the package_name param from tool options" do
-      # leaving out the command name defaults to 'run'
+    it "can use the package_name short flag from tool options" do
       stub_commander_runner_args(['init', '-p', 'com.test.package'])
-      expect_setup_run
+      expect_setup_perform_download
       Supply::CommandsGenerator.start
       expect(Supply.config[:package_name]).to eq('com.test.package')
     end

--- a/supply/spec/commands_generator_spec.rb
+++ b/supply/spec/commands_generator_spec.rb
@@ -1,0 +1,36 @@
+require 'supply/commands_generator'
+require 'supply/setup'
+
+describe Supply::CommandsGenerator do
+  def expect_uploader_run
+    fake_uploader = "uploader"
+    expect(Supply::Uploader).to receive(:new).and_return(fake_uploader)
+    expect(fake_uploader).to receive(:perform_upload)
+  end
+
+  def expect_setup_run
+    fake_setup = "setup"
+    expect(Supply::Setup).to receive(:new).and_return(fake_setup)
+    expect(fake_setup).to receive(:perform_download)
+  end
+
+  describe ":run options handling" do
+    it "can use the package_name param from tool options" do
+      # leaving out the command name defaults to 'run'
+      stub_commander_runner_args(['--skip_upload_metadata'])
+      expect_uploader_run
+      Supply::CommandsGenerator.start
+      expect(Supply.config[:skip_upload_metadata]).to be(true)
+    end
+  end
+
+  describe ":init options handling" do
+    it "can use the package_name param from tool options" do
+      # leaving out the command name defaults to 'run'
+      stub_commander_runner_args(['init', '-p', 'com.test.package'])
+      expect_setup_run
+      Supply::CommandsGenerator.start
+      expect(Supply.config[:package_name]).to eq('com.test.package')
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Carry the work and lessons learned from #8129 over to _supply_

### Motivation and Context

_supply_ does not currently have any option conflicts, but this refactoring is still generally more correct and safe.