### PR TITLE
Add Android version code increment action

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_version_code.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_code.rb
@@ -1,0 +1,67 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      VERSION_CODE = :VERSION_CODE
+    end
+
+    class IncrementVersionCodeAction < Action
+      def self.run(params)
+        path = params[:build_gradle_path] || './app/build.gradle'
+        contents = File.read(path)
+        new_version = 0
+        new_contents = contents.gsub(/versionCode (\d*)/) do |s|
+          current_version = s.match(/[0-9]+/).to_s.to_i
+          version_code_param = params[:version_code] ? params[:version_code].to_i : nil
+          new_version = version_code_param || current_version + 1
+          "versionCode #{new_version}"
+        end
+        File.open(path, 'w') { |f| f.puts new_contents }
+
+        return Actions.lane_context[SharedValues::VERSION_CODE] = new_version
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Increment the version code of your Android project'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :version_code,
+                                       env_name: 'FL_INCREMENT_VERSION_CODE_VERSION_CODE',
+                                       description: 'Change to a specific version code',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :build_gradle_path,
+                                       env_name: 'FL_INCREMENT_VERSION_CODE_BUILD_GRADLE_PATH',
+                                       description: 'Path to the project build.gradle',
+                                       optional: true)
+        ]
+      end
+
+      def self.output
+        [
+          ['VERSION_CODE', 'The new version code']
+        ]
+      end
+
+      def self.return_value
+        'The new version code'
+      end
+
+      def self.authors
+        ['mandybess', 'jamescmartinez']
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+
+      def self.category
+        :project
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/increment_version_code_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_code_action_spec.rb
@@ -1,0 +1,30 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Increment Version Code Integration" do
+      require 'shellwords'
+
+      after(:each) do
+        # Reset version code
+        Fastlane::FastFile.new.parse("lane :test do
+          increment_version_code(build_gradle_path: 'fastlane/spec/fixtures/androidproj/app/build.gradle', version_code: '1234')
+        end").runner.execute(:test)
+      end
+
+      it "increments the version code of the Android project" do
+        Fastlane::FastFile.new.parse("lane :test do
+          increment_version_code(build_gradle_path: 'fastlane/spec/fixtures/androidproj/app/build.gradle')
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_CODE]).to eq 1235
+      end
+
+      it "increments the version code to the version code specified" do
+        Fastlane::FastFile.new.parse("lane :test do
+          increment_version_code(build_gradle_path: 'fastlane/spec/fixtures/androidproj/app/build.gradle', version_code: '4321')
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_CODE]).to eq 4321
+      end
+    end
+  end
+end

--- a/fastlane/spec/fixtures/androidproj/app/build.gradle
+++ b/fastlane/spec/fixtures/androidproj/app/build.gradle
@@ -1,0 +1,5 @@
+android {
+  defaultConfig {
+    versionCode 1234
+  }
+}


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Description
I've added an action that increments the `versionCode` of Android's `build.gradle` file. This is analogous to the `increment_build_number` for iOS.

I know the CONTRIBUTING docs say you're not accepting actions, but I figured I'd PR this anyway. I'd love to create an open discussion about my PR and see if/how we can merge it in. I totally understand if it's not great in its current state. Also, I have not added documentation yet but I definitely will if it's decided that this can be accepted.
