### PR TITLE
Refactor produce CommanderGenerator usage

### DIFF
--- a/produce/lib/produce/commands_generator.rb
+++ b/produce/lib/produce/commands_generator.rb
@@ -22,11 +22,11 @@ module Produce
 
       global_option('--verbose') { FastlaneCore::Globals.verbose = true }
 
-      FastlaneCore::CommanderGenerator.new.generate(Produce::Options.available_options)
-
       command :create do |c|
         c.syntax = 'fastlane produce create'
         c.description = 'Creates a new app on iTunes Connect and the Apple Developer Portal'
+
+        FastlaneCore::CommanderGenerator.new.generate(Produce::Options.available_options, command: c)
 
         c.action do |args, options|
           Produce.config = FastlaneCore::Configuration.create(Produce::Options.available_options, options.__hash__)
@@ -55,6 +55,8 @@ module Produce
         c.option '--push-notification', 'Enable Push notification (only enables the service, does not configure certificates)'
         c.option '--sirikit', 'Enable SiriKit'
         c.option '--vpn-conf', 'Enable VPN Configuration'
+
+        FastlaneCore::CommanderGenerator.new.generate(Produce::Options.available_options, command: c)
 
         c.action do |args, options|
           # Filter the options so that we can still build the configuration
@@ -87,6 +89,8 @@ module Produce
         c.option '--sirikit', 'Disable SiriKit'
         c.option '--vpn-conf', 'Disable VPN Configuration'
 
+        FastlaneCore::CommanderGenerator.new.generate(Produce::Options.available_options, command: c)
+
         c.action do |args, options|
           # Filter the options so that we can still build the configuration
           allowed_keys = Produce::Options.available_options.collect(&:key)
@@ -105,6 +109,8 @@ module Produce
         c.option '-n', '--group_name STRING', String, 'Name for the group that is created (PRODUCE_GROUP_NAME)'
         c.option '-g', '--group_identifier STRING', String, 'Group identifier for the group (PRODUCE_GROUP_IDENTIFIER)'
 
+        FastlaneCore::CommanderGenerator.new.generate(Produce::Options.available_options, command: c)
+
         c.action do |args, options|
           allowed_keys = Produce::Options.available_options.collect(&:key)
           Produce.config = FastlaneCore::Configuration.create(Produce::Options.available_options, options.__hash__.select { |key, value| allowed_keys.include? key })
@@ -118,6 +124,8 @@ module Produce
         c.syntax = 'fastlane produce associate_group -a APP_IDENTIFIER GROUP_IDENTIFIER1, GROUP_IDENTIFIER2, ...'
         c.description = 'Associate with a group, which is created if needed or simply located otherwise'
         c.example 'Associate with group', 'produce associate-group -a com.example.app group.example.com'
+
+        FastlaneCore::CommanderGenerator.new.generate(Produce::Options.available_options, command: c)
 
         c.action do |args, options|
           Produce.config = FastlaneCore::Configuration.create(Produce::Options.available_options, options.__hash__)

--- a/produce/spec/commands_generator_spec.rb
+++ b/produce/spec/commands_generator_spec.rb
@@ -1,0 +1,169 @@
+require 'produce/commands_generator'
+require 'produce/service'
+require 'produce/group'
+
+describe Produce::CommandsGenerator do
+  let(:available_options) { Produce::Options.available_options }
+
+  describe ":create option handling" do
+    it "can use the skip_itc short flag from tool options" do
+      # leaving out the command name defaults to 'create'
+      stub_commander_runner_args(['-i', 'true'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { skip_itc: true })
+
+      expect(Produce::Manager).to receive(:start_producing)
+
+      Produce::CommandsGenerator.start
+
+      expect(Produce.config[:skip_itc]).to be(true)
+    end
+
+    it "can use the skip_devcenter flag from tool options" do
+      # leaving out the command name defaults to 'create'
+      stub_commander_runner_args(['--skip_devcenter', 'true'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { skip_devcenter: true })
+
+      expect(Produce::Manager).to receive(:start_producing)
+
+      Produce::CommandsGenerator.start
+
+      expect(Produce.config[:skip_devcenter]).to be(true)
+    end
+  end
+
+  describe ":enable_services option handling" do
+    it "can use the username short flag from tool options" do
+      stub_commander_runner_args(['enable_services', '-u', 'me@it.com', '--healthkit'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { username: 'me@it.com' })
+
+      expect(Produce::Service).to receive(:enable) do |options, args|
+        expect(options.healthkit).to be(true)
+        expect(args).to eq([])
+      end
+
+      Produce::CommandsGenerator.start
+
+      expect(Produce.config[:username]).to eq('me@it.com')
+    end
+
+    it "can use the app_identifier flag from tool options" do
+      stub_commander_runner_args(['enable_services', '--app_identifier', 'your.awesome.App', '--game-center'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { app_identifier: 'your.awesome.App' })
+
+      expect(Produce::Service).to receive(:enable) do |options, args|
+        expect(options.game_center).to be(true)
+        expect(args).to eq([])
+      end
+
+      Produce::CommandsGenerator.start
+
+      expect(Produce.config[:app_identifier]).to eq('your.awesome.App')
+    end
+  end
+
+  describe ":disable_services option handling" do
+    it "can use the username short flag from tool options" do
+      stub_commander_runner_args(['disable_services', '-u', 'me@it.com', '--healthkit'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { username: 'me@it.com' })
+
+      expect(Produce::Service).to receive(:disable) do |options, args|
+        expect(options.healthkit).to be(true)
+        expect(args).to eq([])
+      end
+
+      Produce::CommandsGenerator.start
+
+      expect(Produce.config[:username]).to eq('me@it.com')
+    end
+
+    it "can use the app_identifier flag from tool options" do
+      stub_commander_runner_args(['disable_services', '--app_identifier', 'your.awesome.App', '--game-center'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { app_identifier: 'your.awesome.App' })
+
+      expect(Produce::Service).to receive(:disable) do |options, args|
+        expect(options.game_center).to be(true)
+        expect(args).to eq([])
+      end
+
+      Produce::CommandsGenerator.start
+
+      expect(Produce.config[:app_identifier]).to eq('your.awesome.App')
+    end
+  end
+
+  describe ":group option handling" do
+    def expect_group_create_with(group_name, group_identifier)
+      fake_group = "fake_group"
+      expect(Produce::Group).to receive(:new).and_return(fake_group)
+      expect(fake_group).to receive(:create) do |options, args|
+        expect(options.group_name).to eq(group_name)
+        expect(options.group_identifier).to eq(group_identifier)
+        expect(args).to eq([])
+      end
+    end
+
+    it "can use the username short flag from tool options" do
+      stub_commander_runner_args(['group', '-u', 'me@it.com', '-g', 'group.example.app', '-n', 'Example App Group'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { username: 'me@it.com' })
+
+      expect_group_create_with('Example App Group', 'group.example.app')
+
+      Produce::CommandsGenerator.start
+
+      expect(Produce.config[:username]).to eq('me@it.com')
+    end
+
+    it "can use the app_identifier flag from tool options" do
+      stub_commander_runner_args(['group', '--app_identifier', 'your.awesome.App', '-g', 'group.example.app', '-n', 'Example App Group'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { app_identifier: 'your.awesome.App' })
+
+      expect_group_create_with('Example App Group', 'group.example.app')
+
+      Produce::CommandsGenerator.start
+
+      expect(Produce.config[:app_identifier]).to eq('your.awesome.App')
+    end
+  end
+
+  describe ":associate_group option handling" do
+    def expect_group_associate_with(group_ids)
+      fake_group = "fake_group"
+      expect(Produce::Group).to receive(:new).and_return(fake_group)
+      expect(fake_group).to receive(:associate) do |options, args|
+        expect(args).to eq(group_ids)
+      end
+    end
+
+    it "can use the username short flag from tool options" do
+      stub_commander_runner_args(['associate_group', '-u', 'me@it.com', 'group1.example.app', 'group2.example.app'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { username: 'me@it.com' })
+
+      expect_group_associate_with(['group1.example.app', 'group2.example.app'])
+
+      Produce::CommandsGenerator.start
+
+      expect(Produce.config[:username]).to eq('me@it.com')
+    end
+
+    it "can use the app_identifier flag from tool options" do
+      stub_commander_runner_args(['associate_group', '--app_identifier', 'your.awesome.App', 'group1.example.app', 'group2.example.app'])
+
+      expected_options = FastlaneCore::Configuration.create(available_options, { app_identifier: 'your.awesome.App' })
+
+      expect_group_associate_with(['group1.example.app', 'group2.example.app'])
+
+      Produce::CommandsGenerator.start
+
+      expect(Produce.config[:app_identifier]).to eq('your.awesome.App')
+    end
+  end
+end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Carry the work and lessons learned from #8129 over to _produce_

### Motivation and Context

produce does not currently have any option conflicts, but this refactoring is still generally more correct and safe.