### PR TITLE
[Regression] Fixed wrong keys (with dots) inserted when resigning IPA

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -703,7 +703,7 @@ function resign {
             # otherwise it interprets they key path as nested keys
             # TODO: Should be able to replace with echo ${KEY//\./\\\\.} and remove shellcheck disable directive
             # shellcheck disable=SC2001
-            PLUTIL_KEY=$(echo "$KEY" | sed 's/\./\\\\./g')
+            PLUTIL_KEY=$(echo "$KEY" | sed 's/\./\\\./g')
             plutil -insert "$PLUTIL_KEY" -xml "$ENTITLEMENTS_VALUE" "$PATCHED_ENTITLEMENTS"
 
             # Patch the ID value if specified


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

 I tried to run `bundle exec rspec`, but it fails even though without changes yet.

### Description
Using the resign action, wrong keys are inserted as new entitlements when the key contains dots.
For example, if key is "com.apple.developer.associated-domains", it is incorrectly inserted as "com\.apple.developer\.associated-domains".

This issue was brought by the change from the use of \`\` to $().
\`\` replaces some of the escaped characters, but $() treats the contents as the command itself.
For this reason, we also need to change the contents of $() to take into account unnecessary escapes.

### Motivation and Context

> Why is this change required? What problem does it solve?

Resign action succeeds, but user will not be able to install the IPA because entitlements do not match.

> If it fixes an open issue, please link to the issue here.

n/a

> Please describe in detail how you tested your changes.

I tested by resigning an app with Associated Domains capability enabled.

1. Run resign action before the change. This will produce an IPA that can't be installed.
1. Inspect the entitlements of the IPA using `codesign -d --entitlements :- <path to .app>`. It will have a line like this: `<key>com\.apple\.developer\.associated-domains</key>`.
1. Run resign action again after the change. It will now produced an IPA that I can install.

I tried running `bundle exec rspec`, but it fails even though without changes yet.


### Existing problems
I created this PR to seek possible help on how to handle another problem.
With the change in my current PR, entitlement keys like `com.apple.developer.associated-domains` will be correctly inserted to the patched entitlements. But it will also soon be removed because of `BLACKLISTED_KEYS`. The IPA is installable, but Universal Links will not work because the `com.apple.developer.associated-domains` entitlement has been removed.

I am not sure what the reason for adding things like `com.apple.developer.associated-domains` in the `BLACKLISTED_KEYS` is, but it's weird that it is included in `ENTITLEMENTS_TRANSFER_RULES` but it is deleted immediately after because of blacklisting.

By the way, I am trying to resign an AppStore IPA into an AdHoc IPA.
Any ideas?