### PR TITLE
Change eval to eval_gemfile for Pluginfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem "danger-junit", ">= 0.7.3", "< 1.0.0"
 gemspec path: "."
 
 plugins_path = File.join(File.expand_path("..", __FILE__), 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding)
+eval_gemfile(plugins_path)

--- a/fastlane/docs/PluginsTroubleshooting.md
+++ b/fastlane/docs/PluginsTroubleshooting.md
@@ -46,7 +46,7 @@ Your `Gemfile` should look something like this:
 gem "fastlane"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+eval_gemfile(plugins_path) if File.exist?(plugins_path)
 ```
 
 Your `Pluginfile` should look something like this

--- a/fastlane/lib/fastlane/plugins/template/Gemfile
+++ b/fastlane/lib/fastlane/plugins/template/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 gemspec
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/fastlane/spec/fixtures/plugins/GemfileWithAttached
+++ b/fastlane/spec/fixtures/plugins/GemfileWithAttached
@@ -1,5 +1,5 @@
 gem "fastlane"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+eval_gemfile(plugins_path) if File.exist?(plugins_path)
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Apply #8282 changes to other places

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

Now `code_to_attach` in `plugin_manager.rb` has changed to use `eval_gemfile` instead of `eval`.
That's why it would be better that related codes and documents also use `eval_gemfile`.
