### PR TITLE
Fix 'fastlane env' not to crash when Xcode Version cannot be obtained

### DIFF
--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -223,7 +223,12 @@ module Fastlane
 
       if Helper.mac?
         table_content["Xcode Path"] = anonymized_path(Helper.xcode_path)
-        table_content["Xcode Version"] = Helper.xcode_version
+        begin
+          table_content["Xcode Version"] = Helper.xcode_version
+        rescue => ex
+          UI.error(ex)
+          UI.error("Could not get Xcode Version")
+        end
       end
 
       table = ["| Key | Value |"]

--- a/fastlane/spec/env_spec.rb
+++ b/fastlane/spec/env_spec.rb
@@ -39,5 +39,18 @@ describe Fastlane do
       expect(Fastlane::EnvironmentPrinter.anonymized_path('/Users/john/', '/Users/john')).to eq('~/')
       expect(Fastlane::EnvironmentPrinter.anonymized_path('/workspace/project/test', '/work')).to eq('/workspace/project/test')
     end
+
+    context 'FastlaneCore::Helper.xcode_version cannot be obtained' do
+      before do
+        allow(FastlaneCore::Helper).to receive(:xcode_version).and_raise("Boom!")
+      end
+
+      it 'contains stack information other than Xcode Version' do
+        expect(env).to include("Bundler?")
+        expect(env).to include("Xcode Path")
+        expect(env).not_to include("Xcode Version")
+        expect(env).to include("OpenSSL")
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Fix `fastlane env` not to crash when Xcode Version cannot be obtained

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If Xcode Version cannot be obtained, fastlane env crashes and the user cannot get any output of fastlane environment.
e.x. https://github.com/fastlane/fastlane/issues/8187#issuecomment-278747763

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
