### PR TITLE
show --env option in help

### DIFF
--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -92,6 +92,7 @@ module Fastlane
         FastlaneCore::Globals.verbose = true
       end
       global_option('--troubleshoot', 'Enables extended verbose mode. Use with caution, as this even includes ALL sensitive data. Cannot be used on CI.')
+      global_option('--env STRING[,STRING2]', String, 'Add environment(s) to use with `dotenv`')
 
       always_trace!
 


### PR DESCRIPTION
the --env option should be shown in the default help.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ X] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->

Added line for --env to global params

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

the --env option is very useful, but not shown in the help. finding it in the documentation is possible, but takes a while.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
