### PR TITLE
Refactor screengrab CommanderGenerator usage

### DIFF
--- a/screengrab/lib/screengrab/commands_generator.rb
+++ b/screengrab/lib/screengrab/commands_generator.rb
@@ -24,11 +24,11 @@ module Screengrab
 
       always_trace!
 
-      FastlaneCore::CommanderGenerator.new.generate(Screengrab::Options.available_options)
-
       command :run do |c|
         c.syntax = 'fastlane screengrab'
-        c.description = 'Take new screenshots based on the screengrabfile.'
+        c.description = 'Take new screenshots based on the Screengrabfile.'
+
+        FastlaneCore::CommanderGenerator.new.generate(Screengrab::Options.available_options, command: c)
 
         c.action do |args, options|
           o = options.__hash__.dup

--- a/screengrab/spec/commands_generator_spec.rb
+++ b/screengrab/spec/commands_generator_spec.rb
@@ -1,0 +1,36 @@
+require 'screengrab/commands_generator'
+
+describe Screengrab::CommandsGenerator do
+  let(:available_options) { Screengrab::Options.available_options }
+
+  describe ":run option handling" do
+    def expect_runner_run_with(android_home)
+      allow(Screengrab::DetectValues).to receive(:set_additional_default_values)
+      expect(Screengrab::AndroidEnvironment).to receive(:new).with(android_home, nil)
+      allow(Screengrab::DependencyChecker).to receive(:check)
+      expect(Screengrab::Runner).to receive_message_chain(:new, :run)
+    end
+
+    it "can use the android_home short flag from tool options" do
+      # leaving out the command name defaults to 'run'
+      stub_commander_runner_args(['-n', 'home/path'])
+
+      expect_runner_run_with('home/path')
+
+      Screengrab::CommandsGenerator.start
+    end
+
+    it "can use the output_directory flag from tool options" do
+      # leaving out the command name defaults to 'run'
+      stub_commander_runner_args(['-n', 'home/path', '--output_directory', 'output/dir'])
+
+      expect_runner_run_with('home/path')
+
+      Screengrab::CommandsGenerator.start
+
+      expect(Screengrab.config[:output_directory]).to eq('output/dir')
+    end
+  end
+
+  # :init is not tested here because it does not use any tool options
+end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Carry the work and lessons learned from #8129 over to _screengrab_

### Motivation and Context

_screengrab_ does not currently have any option conflicts, but this refactoring is still generally more correct and safe.