### PR TITLE
Refactor snapshot CommanderGenerator usage

### DIFF
--- a/snapshot/lib/snapshot/commands_generator.rb
+++ b/snapshot/lib/snapshot/commands_generator.rb
@@ -24,11 +24,11 @@ module Snapshot
 
       always_trace!
 
-      FastlaneCore::CommanderGenerator.new.generate(Snapshot::Options.available_options)
-
       command :run do |c|
         c.syntax = 'fastlane snapshot'
         c.description = 'Take new screenshots based on the Snapfile.'
+
+        FastlaneCore::CommanderGenerator.new.generate(Snapshot::Options.available_options, command: c)
 
         c.action do |args, options|
           load_config(options)
@@ -62,7 +62,7 @@ module Snapshot
       command :reset_simulators do |c|
         c.syntax = 'fastlane snapshot reset_simulators'
         c.description = "This will remove all your existing simulators and re-create new ones"
-        c.option '-i', '--ios String', String, 'The comma separated list of iOS Versions you want to use'
+        c.option '-i', '--ios_version String', String, 'The comma separated list of iOS Versions you want to use'
         c.option '--force', 'Disables confirmation prompts'
 
         c.action do |args, options|
@@ -77,6 +77,8 @@ module Snapshot
       command :clear_derived_data do |c|
         c.syntax = 'fastlane snapshot clear_derived_data -f path'
         c.description = "Clear the directory where build products and other derived data will go"
+
+        FastlaneCore::CommanderGenerator.new.generate(Snapshot::Options.available_options, command: c)
 
         c.action do |args, options|
           load_config(options)

--- a/snapshot/spec/commands_generator_spec.rb
+++ b/snapshot/spec/commands_generator_spec.rb
@@ -1,0 +1,95 @@
+require 'snapshot/commands_generator'
+require 'snapshot/reset_simulators'
+
+describe Snapshot::CommandsGenerator do
+  let(:available_options) { Snapshot::Options.available_options }
+
+  describe ":run option handling" do
+    def expect_runner_work
+      allow(Snapshot::DetectValues).to receive(:set_additional_default_values)
+      allow(Snapshot::DependencyChecker).to receive(:check_simulators)
+      expect(Snapshot::Runner).to receive_message_chain(:new, :work)
+    end
+
+    it "can use the languages short flag from tool options" do
+      # leaving out the command name defaults to 'run'
+      stub_commander_runner_args(['-g', 'en-US,fr-FR'])
+
+      expect_runner_work
+
+      Snapshot::CommandsGenerator.start
+
+      expect(Snapshot.config[:languages]).to eq(['en-US', 'fr-FR'])
+    end
+
+    it "can use the output_directory flag from tool options" do
+      # leaving out the command name defaults to 'run'
+      stub_commander_runner_args(['--output_directory', 'output/dir'])
+
+      expect_runner_work
+
+      Snapshot::CommandsGenerator.start
+
+      expect(Snapshot.config[:output_directory]).to eq('output/dir')
+    end
+  end
+
+  describe ":reset_simulators option handling" do
+    it "can use the ios_version short flag" do
+      stub_commander_runner_args(['reset_simulators', '-i', '9.3.5,10.0'])
+
+      allow(Snapshot::DetectValues).to receive(:set_additional_default_values)
+      expect(Snapshot::ResetSimulators).to receive(:clear_everything!).with(['9.3.5', '10.0'], nil)
+
+      Snapshot::CommandsGenerator.start
+    end
+
+    it "can use the ios_version flag" do
+      stub_commander_runner_args(['reset_simulators', '--ios_version', '9.3.5,10.0'])
+
+      allow(Snapshot::DetectValues).to receive(:set_additional_default_values)
+      expect(Snapshot::ResetSimulators).to receive(:clear_everything!).with(['9.3.5', '10.0'], nil)
+
+      Snapshot::CommandsGenerator.start
+    end
+
+    it "can use the force flag" do
+      stub_commander_runner_args(['reset_simulators', '--ios_version', '9.3.5,10.0', '--force'])
+
+      allow(Snapshot::DetectValues).to receive(:set_additional_default_values)
+      expect(Snapshot::ResetSimulators).to receive(:clear_everything!).with(['9.3.5', '10.0'], true)
+
+      Snapshot::CommandsGenerator.start
+    end
+  end
+
+  describe ":clear_derived_data option handling" do
+    def allow_path_check
+      allow(Snapshot::DetectValues).to receive(:set_additional_default_values)
+      allow(Dir).to receive(:exist?).with('data/path').and_return(false)
+      allow(Snapshot::UI).to receive(:important)
+    end
+
+    it "can use the output_directory short flag from tool options" do
+      stub_commander_runner_args(['clear_derived_data', '-f', 'data/path'])
+
+      allow_path_check
+
+      Snapshot::CommandsGenerator.start
+
+      expect(Snapshot.config[:derived_data_path]).to eq('data/path')
+    end
+
+    it "can use the output_directory flag from tool options" do
+      stub_commander_runner_args(['clear_derived_data', '--derived_data_path', 'data/path'])
+
+      allow_path_check
+
+      Snapshot::CommandsGenerator.start
+
+      expect(Snapshot.config[:derived_data_path]).to eq('data/path')
+    end
+  end
+
+  # :init and :update are not tested here because they do not use any options
+end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Carry the work and lessons learned from #8129 over to _snapshot_

### Motivation and Context

_snapshot_ currently has a misconfigured option in `:reset_simulators` that is being masked by the old way of setting up tool options. The option is now renamed to match the expected option name, and the masking is removed by the refactoring