### PR TITLE
frameit: fix show_complete_frame=false, improve speed

### DIFF
--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -83,6 +83,8 @@ module Frameit
             unless value.kind_of?(Integer) || value.split('x').length == 2 || (value.end_with?('%') && value.to_f > 0)
               UI.user_error!("padding must be type integer or pair of integers of format 'AxB' or a percentage of screen size")
             end
+          when 'show_complete_frame'
+            UI.user_error! "show_complete_frame must be a Boolean" unless [true, false].include?(value)
           when 'font_scale_factor'
             UI.user_error!("font_scale_factor must be numeric") unless value.kind_of?(Numeric)
           end


### PR DESCRIPTION
fixes #8300;
now the screenshot resizing completely happens in complex_framing and the screenshot is only resized once (instead of 3 times worst case), resulting in a 20% speed improvement (for show_complete_frame = true) and potentially a quality improvement because resizing multiple times degrades quality;
added parameter validation for `show_complete_frame.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
