### PR TITLE
Fix git_branch action issue

### DIFF
--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -5,9 +5,14 @@ module Fastlane
 
     class GitBranchAction < Action
       def self.run(params)
-        env_vars = %w(GIT_BRANCH BRANCH_NAME TRAVIS_BRANCH BITRISE_GIT_BRANCH CI_BUILD_REF_NAME)
-        env_name = env_vars.find { |env_var| FastlaneCore::Env.truthy?(env_var) }
-        ENV.fetch(env_name) { `git symbolic-ref HEAD --short 2>/dev/null`.strip }
+        branch = `git symbolic-ref HEAD --short 2>/dev/null`.strip
+        return branch unless branch.empty?
+        %w(GIT_BRANCH BRANCH_NAME TRAVIS_BRANCH BITRISE_GIT_BRANCH CI_BUILD_REF_NAME)
+          .map { |env_var|
+            FastlaneCore::Env.truthy?(env_var) ? ENV[env_var] : nil
+          }
+          .compact
+          .first
       end
 
       #####################################################

--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -8,9 +8,7 @@ module Fastlane
         branch = `git symbolic-ref HEAD --short 2>/dev/null`.strip
         return branch unless branch.empty?
         %w(GIT_BRANCH BRANCH_NAME TRAVIS_BRANCH BITRISE_GIT_BRANCH CI_BUILD_REF_NAME)
-          .map { |env_var|
-            FastlaneCore::Env.truthy?(env_var) ? ENV[env_var] : nil
-          }
+          .map { |env_var| ENV[env_var] if FastlaneCore::Env.truthy?(env_var) }
           .compact
           .first
       end


### PR DESCRIPTION
### Description

* `git_branch` action does not follow its description. It says "If no branch could be found, this action will return nil" / "Returns the name of the current git branch", but
  * If no branch could be found, it raises an exception.
  * It does not return the actual branch name - returns ENV value first.

### What I did in this PR

* Fixed all issues above.
  * Return actual branch name first
  * Make it not to raise an exception.