### PR TITLE
Fix git-branch crash if no ENV vars present

### DIFF
--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -7,7 +7,7 @@ module Fastlane
       def self.run(params)
         env_vars = %w(GIT_BRANCH BRANCH_NAME TRAVIS_BRANCH BITRISE_GIT_BRANCH CI_BUILD_REF_NAME)
         env_name = env_vars.find { |env_var| FastlaneCore::Env.truthy?(env_var) }
-        ENV.fetch(env_name) { `git symbolic-ref HEAD --short 2>/dev/null`.strip }
+        ENV.fetch(env_name.to_s) { `git symbolic-ref HEAD --short 2>/dev/null`.strip }
       end
 
       #####################################################

--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -15,7 +15,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Returns the name of the current git branch, possibly as controled by CI ENV variables"
+        "Returns the name of the current git branch, possibly as controled by CI ENV vars"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -1,12 +1,12 @@
 module Fastlane
   module Actions
     module SharedValues
+      GIT_BRANCH_ENV_VARS = %w(GIT_BRANCH BRANCH_NAME TRAVIS_BRANCH BITRISE_GIT_BRANCH CI_BUILD_REF_NAME).freeze
     end
 
     class GitBranchAction < Action
       def self.run(params)
-        env_vars = %w(GIT_BRANCH BRANCH_NAME TRAVIS_BRANCH BITRISE_GIT_BRANCH CI_BUILD_REF_NAME)
-        env_name = env_vars.find { |env_var| FastlaneCore::Env.truthy?(env_var) }
+        env_name = SharedValues::GIT_BRANCH_ENV_VARS.find { |env_var| FastlaneCore::Env.truthy?(env_var) }
         ENV.fetch(env_name.to_s) { `git symbolic-ref HEAD --short 2>/dev/null`.strip }
       end
 
@@ -15,11 +15,11 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Returns the name of the current git branch"
+        "Returns the name of the current git branch, possibly as controled by CI ENV variables"
       end
 
       def self.details
-        "If no branch could be found, this action will return nil"
+        "If no branch could be found, this action will return an empty string"
       end
 
       def self.available_options

--- a/fastlane/spec/actions_specs/git_branch_spec.rb
+++ b/fastlane/spec/actions_specs/git_branch_spec.rb
@@ -1,0 +1,29 @@
+describe Fastlane::Actions::GitBranchAction do
+  describe "CI set ENV values" do
+    Fastlane::Actions::SharedValues::GIT_BRANCH_ENV_VARS.each do |env_var|
+      it "can control the output of the action with #{env_var}" do
+        with_env_values(env_var => "#{env_var}-branch-name") do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            git_branch
+          end").runner.execute(:test)
+
+          expect(result).to eq("#{env_var}-branch-name")
+        end
+      end
+    end
+  end
+
+  describe "with no CI set ENV values" do
+    it "gets the value from Git directly" do
+      expect(Fastlane::Actions::GitBranchAction).to receive(:`)
+        .with('git symbolic-ref HEAD --short 2>/dev/null')
+        .and_return('branch-name')
+
+      result = Fastlane::FastFile.new.parse("lane :test do
+        git_branch
+      end").runner.execute(:test)
+
+      expect(result).to eq("branch-name")
+    end
+  end
+end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Fix a crash in the `git_branch` action that happens if no Git branch indicating ENV vars are present.

### Motivation and Context

```
/Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane/lib/fastlane/actions/git_branch.rb:10:in `fetch': [!] no implicit conversion of nil into String (TypeError)
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane/lib/fastlane/actions/git_branch.rb:10:in `run'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane/lib/fastlane/runner.rb:243:in `block (2 levels) in execute_action'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane/lib/fastlane/actions/actions_helper.rb:50:in `execute_action'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane/lib/fastlane/runner.rb:221:in `block in execute_action'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane/lib/fastlane/runner.rb:217:in `chdir'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane/lib/fastlane/runner.rb:217:in `execute_action'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane/lib/fastlane/one_off.rb:41:in `run'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane/lib/fastlane/one_off.rb:22:in `execute'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane/lib/fastlane/commands_generator.rb:192:in `block (2 levels) in run'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/commander-4.4.3/lib/commander/command.rb:178:in `call'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/commander-4.4.3/lib/commander/command.rb:153:in `run'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/commander-4.4.3/lib/commander/runner.rb:446:in `run_active_command'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:38:in `run!'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/commander-4.4.3/lib/commander/delegates.rb:15:in `run!'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane/lib/fastlane/commands_generator.rb:303:in `run'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane/lib/fastlane/commands_generator.rb:42:in `start'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/fastlane/lib/fastlane/cli_tools_distributor.rb:63:in `take_off'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.17.1/bin/fastlane:15:in `<top (required)>'
	from /Users/mfurtak/.rbenv/versions/2.3.1/bin/fastlane:23:in `load'
	from /Users/mfurtak/.rbenv/versions/2.3.1/bin/fastlane:23:in `<main>'
```
