### PR TITLE
Fix fastlane update checking for sub-tools

### DIFF
--- a/fastlane/lib/fastlane/actions/frameit.rb
+++ b/fastlane/lib/fastlane/actions/frameit.rb
@@ -6,8 +6,6 @@ module Fastlane
 
         require 'frameit'
 
-        FastlaneCore::UpdateChecker.start_looking_for_update('frameit') unless Helper.is_test?
-
         UI.message("Framing screenshots at path #{config[:path]}")
 
         Dir.chdir(config[:path]) do

--- a/fastlane/lib/fastlane/actions/produce.rb
+++ b/fastlane/lib/fastlane/actions/produce.rb
@@ -10,7 +10,6 @@ module Fastlane
 
         return if Helper.test?
 
-        FastlaneCore::UpdateChecker.start_looking_for_update('produce')
         Produce.config = params # we alread have the finished config
 
         Dir.chdir(FastlaneCore::FastlaneFolder.path || Dir.pwd) do

--- a/fastlane/lib/fastlane/actions/supply.rb
+++ b/fastlane/lib/fastlane/actions/supply.rb
@@ -5,8 +5,6 @@ module Fastlane
         require 'supply'
         require 'supply/options'
 
-        FastlaneCore::UpdateChecker.start_looking_for_update('supply') unless Helper.is_test?
-
         all_apk_paths = Actions.lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] || []
         if all_apk_paths.length > 1
           params[:apk_paths] ||= all_apk_paths

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -22,6 +22,8 @@ module Fastlane
           print_slow_fastlane_warning
         end
 
+        FastlaneCore::UpdateChecker.start_looking_for_update('fastlane')
+
         ARGV.unshift("spaceship") if ARGV.first == "spaceauth"
         tool_name = ARGV.first ? ARGV.first.downcase : nil
 
@@ -62,6 +64,8 @@ module Fastlane
           require "fastlane/commands_generator"
           Fastlane::CommandsGenerator.start
         end
+      ensure
+        FastlaneCore::UpdateChecker.show_update_status('fastlane', Fastlane::VERSION)
       end
 
       # Since fastlane also supports the rocket and biceps emoji as executable

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -30,7 +30,7 @@ module Fastlane
         $stdout = out_channel
         $stderr = out_channel
       end
-      FastlaneCore::UpdateChecker.start_looking_for_update('fastlane')
+
       Fastlane.load_actions
       FastlaneCore::Swag.stop_loader
       # do not use "include" as it may be some where in the commandline where "env" is required, therefore explicit index->0
@@ -41,7 +41,6 @@ module Fastlane
       end
       self.new.run
     ensure
-      FastlaneCore::UpdateChecker.show_update_status('fastlane', Fastlane::VERSION)
       Fastlane::PluginUpdateManager.show_update_status
       if FastlaneCore::Globals.capture_output?
         FastlaneCore::Globals.captured_output = Helper.strip_ansi_colors($stdout.string)

--- a/fastlane/spec/cli_tools_distributor_spec.rb
+++ b/fastlane/spec/cli_tools_distributor_spec.rb
@@ -1,20 +1,53 @@
 require 'fastlane/cli_tools_distributor'
 
 describe Fastlane::CLIToolsDistributor do
-  it "runs the lane instead of the tool when there is a conflict" do
-    FastlaneSpec::Env.with_ARGV(["sigh"])
-    require 'fastlane/commands_generator'
-    expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
-    expect(Fastlane::CommandsGenerator).to receive(:start).and_return(nil)
-    Fastlane::CLIToolsDistributor.take_off
+  describe "command handling" do
+    it "runs the lane instead of the tool when there is a conflict" do
+      FastlaneSpec::Env.with_ARGV(["sigh"])
+      require 'fastlane/commands_generator'
+      expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
+      expect(Fastlane::CommandsGenerator).to receive(:start).and_return(nil)
+      Fastlane::CLIToolsDistributor.take_off
+    end
+
+    it "runs a separate tool when the tool is available and the name is not used in a lane" do
+      FastlaneSpec::Env.with_ARGV(["gym"])
+      require 'gym/options'
+      require 'gym/commands_generator'
+      expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
+      expect(Gym::CommandsGenerator).to receive(:start).and_return(nil)
+      Fastlane::CLIToolsDistributor.take_off
+    end
   end
 
-  it "runs a separate tool when the tool is available and the name is not used in a lane" do
-    FastlaneSpec::Env.with_ARGV(["gym"])
-    require 'gym/options'
-    require 'gym/commands_generator'
-    expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
-    expect(Gym::CommandsGenerator).to receive(:start).and_return(nil)
-    Fastlane::CLIToolsDistributor.take_off
+  describe "update checking" do
+    it "checks for updates when running a lane" do
+      FastlaneSpec::Env.with_ARGV(["sigh"])
+      require 'fastlane/commands_generator'
+      expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
+      expect(FastlaneCore::UpdateChecker).to receive(:start_looking_for_update).with('fastlane')
+      expect(Fastlane::CommandsGenerator).to receive(:start).and_return(nil)
+      expect(FastlaneCore::UpdateChecker).to receive(:show_update_status).with('fastlane', Fastlane::VERSION)
+      Fastlane::CLIToolsDistributor.take_off
+    end
+
+    it "checks for updates when running a tool" do
+      FastlaneSpec::Env.with_ARGV(["gym"])
+      require 'gym/options'
+      require 'gym/commands_generator'
+      expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
+      expect(FastlaneCore::UpdateChecker).to receive(:start_looking_for_update).with('fastlane')
+      expect(Gym::CommandsGenerator).to receive(:start).and_return(nil)
+      expect(FastlaneCore::UpdateChecker).to receive(:show_update_status).with('fastlane', Fastlane::VERSION)
+      Fastlane::CLIToolsDistributor.take_off
+    end
+
+    it "checks for updates even if the lane has an error" do
+      FastlaneSpec::Env.with_ARGV(["beta"])
+      expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileErrorInError").at_least(:once)
+      expect(FastlaneCore::UpdateChecker).to receive(:start_looking_for_update).with('fastlane')
+      expect(FastlaneCore::UpdateChecker).to receive(:show_update_status).with('fastlane', Fastlane::VERSION)
+      Fastlane::CLIToolsDistributor.take_off
+    end
   end
 end

--- a/fastlane/spec/cli_tools_distributor_spec.rb
+++ b/fastlane/spec/cli_tools_distributor_spec.rb
@@ -47,7 +47,9 @@ describe Fastlane::CLIToolsDistributor do
       expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileErrorInError").at_least(:once)
       expect(FastlaneCore::UpdateChecker).to receive(:start_looking_for_update).with('fastlane')
       expect(FastlaneCore::UpdateChecker).to receive(:show_update_status).with('fastlane', Fastlane::VERSION)
-      Fastlane::CLIToolsDistributor.take_off
+      expect do
+        Fastlane::CLIToolsDistributor.take_off
+      end.to raise_error(SystemExit)
     end
   end
 end


### PR DESCRIPTION

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

This moves the update checking and display code to be sooner in the process so that it will be executed before the fastlane and sub-tools code diverges.

### Motivation and Context

fastlane update checking is currently not happening when users run sub-tool commands, like `fastlane frameit`