### PR TITLE
Add error_callback option to cocoapods action

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -24,7 +24,7 @@ module Fastlane
         cmd << '--verbose' if params[:verbose]
         cmd << '--no-ansi' unless params[:ansi]
 
-        Actions.sh(cmd.join(' '))
+        Actions.sh(cmd.join(' '), error_callback: params[:error_callback])
       end
 
       def self.description
@@ -75,7 +75,12 @@ module Fastlane
                                        is_string: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Could not find Podfile") unless File.exist?(value) || Helper.test?
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :error_callback,
+                                       description: 'A callback invoked with the command output if there is a non-zero exit status',
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: nil)
         ]
         # Please don't add a version parameter to the `cocoapods` action. If you need to specify a version when running
         # `cocoapods`, please start using a Gemfile and lock the version there

--- a/fastlane/lib/fastlane/actions/sh.rb
+++ b/fastlane/lib/fastlane/actions/sh.rb
@@ -34,8 +34,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :error_callback,
                                          description: 'A callback invoked with the command output if there is a non-zero exit status',
                                          optional: true,
-                                         is_string: true,
-                                         default_value: 'nil')
+                                         is_string: false,
+                                         default_value: nil)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/sh.rb
+++ b/fastlane/lib/fastlane/actions/sh.rb
@@ -32,7 +32,7 @@ module Fastlane
                                          is_string: false,
                                          default_value: true),
           FastlaneCore::ConfigItem.new(key: :error_callback,
-                                         description: 'A callback invoked with the command ouptut if there is a non-zero exit status',
+                                         description: 'A callback invoked with the command output if there is a non-zero exit status',
                                          optional: true,
                                          is_string: true,
                                          default_value: 'nil')

--- a/fastlane/spec/actions_specs/cocoapods_spec.rb
+++ b/fastlane/spec/actions_specs/cocoapods_spec.rb
@@ -106,6 +106,15 @@ describe Fastlane do
 
         expect(result).to eq("bundle exec pod install")
       end
+
+      it "error_callback is executed on failure" do
+        error_callback = double('error_callback')
+
+        allow(Fastlane::Actions).to receive(:sh_control_output) {
+          expect(Fastlane::Actions).to have_received(:sh_control_output).with(kind_of(String),
+                                                                              hash_including(error_callback: error_callback))
+        }
+      end
     end
   end
 end

--- a/fastlane/spec/actions_specs/cocoapods_spec.rb
+++ b/fastlane/spec/actions_specs/cocoapods_spec.rb
@@ -96,6 +96,16 @@ describe Fastlane do
 
         expect(result).to eq("cd 'Project' && bundle exec pod install")
       end
+
+      it "adds error_callback to command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          cocoapods(
+            error_callback: lambda { |result| puts 'failure' }
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod install")
+      end
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

I introduced new option `error_callback` to `cocoapods` action to handle execution error.

### Motivation and Context

I'd like to retry `cocoapods` with `repo_update` in failure.
Currently, we can't recognize `pod install` is failed. So I added.

```ruby
cocoapods(error_callback: lambda { |result| 
  cocoapods(repo_update: true) 
})
```
