### PR TITLE
Expose scan custom report file name to env

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -248,9 +248,10 @@ module Scan
                                     is_string: false,
                                     default_value: false),
         FastlaneCore::ConfigItem.new(key: :custom_report_file_name,
-                                    description: "Sets custom full report file name",
-                                    optional: true,
-                                    is_string: true)
+                                     env_name: "SCAN_CUSTOM_REPORT_FILE_NAME",
+                                     description: "Sets custom full report file name",
+                                     optional: true,
+                                     is_string: true)
       ]
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Export `scan --custom_report_file_name` as `SCAN_CUSTOM_REPORT_FILE_NAME`.

### Motivation and Context

Allow users to specify `SCAN_CUSTOM_REPORT_FILE_NAME` globally. Related to https://github.com/fastlane/fastlane/issues/8326
