### PR TITLE
[spaceship] refactor out fetch_details to allow users of the API to access the details without having to call a separate method

### DIFF
--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -276,7 +276,7 @@ module Spaceship
           return profiles if self == ProvisioningProfile
 
           # To distinguish between AppStore and AdHoc profiles, we need to send
-          # a details request (see `fetch_details`). This is an expensive operation
+          # a details request (see `profile_details`). This is an expensive operation
           # which we can't do for every single provisioning profile
           # Instead we'll treat App Store profiles the same way as Ad Hoc profiles
           # Spaceship::ProvisioningProfile::AdHoc.all will return the same array as
@@ -460,8 +460,6 @@ module Spaceship
       end
 
       def devices
-        fetch_details
-
         if (@devices || []).empty?
           @devices = (self.profile_details["devices"] || []).collect do |device|
             Device.set_client(client).factory(device)
@@ -472,8 +470,6 @@ module Spaceship
       end
 
       def certificates
-        fetch_details
-
         if (@certificates || []).empty?
           @certificates = (profile_details["certificates"] || []).collect do |cert|
             Certificate.set_client(client).factory(cert)
@@ -484,8 +480,6 @@ module Spaceship
       end
 
       def app
-        fetch_details
-
         App.set_client(client).new(profile_details['appId'])
       end
 
@@ -497,12 +491,11 @@ module Spaceship
         return devices.count > 0
       end
 
-      private
-
-      def fetch_details
+      # This is an expensive operation as it triggers a new request
+      def profile_details
         # Since 15th September 2016 certificates and devices are hidden behind another request
         # see https://github.com/fastlane/fastlane/issues/6137 for more information
-        self.profile_details ||= client.provisioning_profile_details(provisioning_profile_id: self.id, mac: mac?)
+        @profile_details ||= client.provisioning_profile_details(provisioning_profile_id: self.id, mac: mac?)
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Description
This PR adjusts the behaviour from #8251. 

The PP class has a `device_details` field that isn't populated by default as it causes a request. The `fetch_details` method is there to fill it but isn't public. 

It would make more sense to make the `device_details` accessor fill on demand.

It would also make the implementation changes in `provisioning_profile` proposed by #8359 slightly more in line with other methods of the same class (i.e. direct use of `device_details`)
