### PR TITLE
Beautify Logging output

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
+++ b/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
@@ -21,12 +21,9 @@ module FastlaneCore
         timestamp = format_string(datetime, severity)
 
         colors = msg.scan(/(\e\[.*?m)/)
-        if colors && colors.length > 0
-          colors.each do |color|
-            msg.delete!(color.first)
-            msg.delete!(color.last)
-          end
-        else
+        msg = FastlaneCore::Helper.strip_ansi_colors(msg)
+
+        unless colors && colors.length > 0
           colors = ["", ""]
         end
 

--- a/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
+++ b/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
@@ -17,7 +17,27 @@ module FastlaneCore
       end
 
       @log.formatter = proc do |severity, datetime, progname, msg|
-        "#{format_string(datetime, severity)}#{msg}\n"
+        terminal_length = TTY::Screen.width
+        timestamp = format_string(datetime, severity)
+
+        colors = msg.scan(/(\e\[.*?m)/)
+        if colors && colors.length > 0
+          colors.each do |color|
+            msg.delete!(color.first)
+            msg.delete!(color.last)
+          end
+        else
+          colors = ["", ""]
+        end
+
+        max_msg_length = terminal_length - timestamp.length - 5 # 5 = padding
+        msg.gsub!(/(\S{#{max_msg_length}})(?=\S)/, '\1 ')
+        components = msg.scan(/.{1,#{max_msg_length}}(?:\s+|$)/)
+        final_msg = ""
+        components.each do |choped|
+          final_msg << timestamp << "#{colors.first[0]}#{choped}#{colors.last[0]}\n"
+        end
+        final_msg
       end
 
       @log


### PR DESCRIPTION
Wraps line according to terminal size.


turns this:
![bildschirmfoto 2017-02-27 um 10 23 33](https://cloud.githubusercontent.com/assets/2891702/23355630/e7a0b24a-fcd6-11e6-9c68-dc129eb597fd.png)


into this:
![bildschirmfoto 2017-02-27 um 10 22 05](https://cloud.githubusercontent.com/assets/2891702/23355636/ee66ea5e-fcd6-11e6-87de-bdaf037962ae.png)


test script:

```ruby
require "fastlane_core"

FastlaneCore::UI.important("a"*2048)
```
