### PR TITLE
Remove unnecessary output that the certificates repo was encrypted

### DIFF
--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -90,7 +90,6 @@ module Match
       return unless @dir
 
       FileUtils.rm_rf(@dir)
-      UI.success "🔒  Successfully encrypted certificates repo" # so the user is happy
       @dir = nil
     end
 


### PR DESCRIPTION
After repo cloning fails, it still would print out that the repo was being encrypted. This fixes: https://github.com/fastlane/fastlane/issues/7869