### PR TITLE
Fix hardcoded fastlane paths

### DIFF
--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -124,7 +124,7 @@ module Deliver
           options = FastlaneCore::Configuration.create(deliverfile_options(skip_verification: true), options.__hash__)
           options.load_configuration_file("Deliverfile")
           Deliver::Runner.new(options, skip_version: true) # to login...
-          containing = FastlaneCore::Helper.fastlane_enabled? ? './fastlane' : '.'
+          containing = FastlaneCore::Helper.fastlane_enabled? ? FastlaneCore::FastlaneFolder.path : '.'
           path = options[:screenshots_path] || File.join(containing, 'screenshots')
           Deliver::DownloadScreenshots.run(options, path)
         end
@@ -140,7 +140,7 @@ module Deliver
           options = FastlaneCore::Configuration.create(deliverfile_options(skip_verification: true), options.__hash__)
           options.load_configuration_file("Deliverfile")
           Deliver::Runner.new(options) # to login...
-          containing = FastlaneCore::Helper.fastlane_enabled? ? './fastlane' : '.'
+          containing = FastlaneCore::Helper.fastlane_enabled? ? FastlaneCore::FastlaneFolder.path : '.'
           path = options[:metadata_path] || File.join(containing, 'metadata')
           res = ENV["DELIVER_FORCE_OVERWRITE"]
           res ||= UI.confirm("Do you want to overwrite existing metadata on path '#{File.expand_path(path)}'?")

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -9,7 +9,7 @@ module Scan
     end
 
     def self.available_options
-      containing = Helper.fastlane_enabled? ? './fastlane' : '.'
+      containing = Helper.fastlane_enabled? ? FastlaneCore::FastlaneFolder.path : '.'
 
       [
         FastlaneCore::ConfigItem.new(key: :workspace,

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -78,7 +78,7 @@ describe Scan do
 
     describe "Supports toolchain" do
       it "should fail if :xctestrun and :toolchain is set" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(".")
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             scan(
@@ -429,7 +429,7 @@ describe Scan do
                                      ])
       end
       it "should raise an exception if two build_modes are set" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(".")
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             scan(

--- a/screengrab/lib/screengrab/commands_generator.rb
+++ b/screengrab/lib/screengrab/commands_generator.rb
@@ -48,7 +48,7 @@ module Screengrab
 
         c.action do |args, options|
           require 'screengrab/setup'
-          path = (Screengrab::Helper.fastlane_enabled? ? './fastlane' : '.')
+          path = Screengrab::Helper.fastlane_enabled? ? FastlaneCore::FastlaneFolder.path : '.'
           Screengrab::Setup.create(path)
         end
       end

--- a/snapshot/lib/snapshot/commands_generator.rb
+++ b/snapshot/lib/snapshot/commands_generator.rb
@@ -44,7 +44,7 @@ module Snapshot
 
         c.action do |args, options|
           require 'snapshot/setup'
-          path = (Snapshot::Helper.fastlane_enabled? ? './fastlane' : '.')
+          path = Snapshot::Helper.fastlane_enabled? ? FastlaneCore::FastlaneFolder.path : '.'
           Snapshot::Setup.create(path)
         end
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Change hard-coded "./fastlane" to use `FastlaneCore::FastlaneFolder.path` in `deliver`, `scan`, `screengrab` and `snapshot`.

### Motivation and Context
Fix for https://github.com/fastlane/fastlane/issues/8379
I had to modify number of specs to stub `FastlaneCore::FastlaneFolder.path` before execution.

