### PR TITLE
Use FastlaneFolder.path instead of fixed './fastlane'

### DIFF
--- a/fastlane/lib/fastlane/actions/set_changelog.rb
+++ b/fastlane/lib/fastlane/actions/set_changelog.rb
@@ -27,7 +27,7 @@ module Fastlane
 
         changelog = params[:changelog]
         unless changelog
-          path = "./fastlane/changelog.txt"
+          path = default_changelog_path
           UI.message("Looking for changelog in '#{path}'...")
           if File.exist? path
             changelog = File.read(path)
@@ -65,6 +65,10 @@ module Fastlane
         UI.success("👼 Successfully pushed the new changelog to #{v.url}")
       end
 
+      def self.default_changelog_path
+        File.join(FastlaneCore::FastlaneFolder.path.to_s, 'changelog.txt')
+      end
+
       #####################################################
       # @!group Documentation
       #####################################################
@@ -76,7 +80,7 @@ module Fastlane
       def self.details
         [
           "This is useful if you have only one changelog for all languages.",
-          "You can store the changelog in `./fastlane/changelog.txt` and it will automatically get loaded from there. This integration is useful if you support e.g. 10 languages and want to use the same \"What's new\"-text for all languages."
+          "You can store the changelog in `#{default_changelog_path}` and it will automatically get loaded from there. This integration is useful if you support e.g. 10 languages and want to use the same \"What's new\"-text for all languages."
         ].join("\n")
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Use FastlaneFolder.path instead of fixed `./fastlane`.
With this change, `set_changelog` action now detect `changelog.txt` inside fastlane folder correctly.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Fix #8392
