### PR TITLE
dont attempt to create apps on the dev center and itc if mac app

### DIFF
--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -23,8 +23,11 @@ module Fastlane
       begin
         setup_project
         ask_for_apple_id
-        detect_if_app_is_available unless self.project.mac?
-        UI.important("Generating apps on the Apple Developer Portal and iTunes Connect is not currently available for Mac apps") if self.project.mac?
+        if self.project.mac?
+          UI.important("Generating apps on the Apple Developer Portal and iTunes Connect is not currently available for Mac apps")
+        else
+          detect_if_app_is_available
+        end
         print_config_table
         if UI.confirm("Please confirm the above values")
           default_setup

--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -23,7 +23,8 @@ module Fastlane
       begin
         setup_project
         ask_for_apple_id
-        detect_if_app_is_available
+        detect_if_app_is_available unless self.project.mac?
+        UI.important("Generating apps on the Apple Developer Portal and iTunes Connect is not currently available for Mac apps") if self.project.mac?
         print_config_table
         if UI.confirm("Please confirm the above values")
           default_setup
@@ -62,7 +63,7 @@ module Fastlane
       copy_existing_files
       generate_appfile(manually: false)
       detect_installed_tools # after copying the existing files
-      if self.itc_ref.nil? && self.portal_ref.nil?
+      if !self.project.mac? && self.itc_ref.nil? && self.portal_ref.nil?
         create_app_if_necessary
       end
       enable_deliver
@@ -112,11 +113,11 @@ module Fastlane
       puts Terminal::Table.new(rows: rows, title: "Detected Values")
       puts ""
 
-      unless self.itc_ref
+      unless self.itc_ref || self.project.mac?
         UI.important "This app identifier doesn't exist on iTunes Connect yet, it will be created for you"
       end
 
-      unless self.portal_ref
+      unless self.portal_ref || self.project.mac?
         UI.important "This app identifier doesn't exist on the Apple Developer Portal yet, it will be created for you"
       end
     end
@@ -191,7 +192,6 @@ module Fastlane
       config = {} # this has to be done like this
       FastlaneCore::Project.detect_projects(config)
       project = FastlaneCore::Project.new(config)
-
       produce_options_hash = {
         app_name: project.app_name,
         app_identifier: self.app_identifier

--- a/fastlane/spec/setup_spec.rb
+++ b/fastlane/spec/setup_spec.rb
@@ -48,6 +48,7 @@ describe Fastlane do
           allow(setup).to receive(:app_identifier).and_return(app_identifier) # to also support linux (travis)
           project = "proj"
           allow(setup).to receive(:project).and_return(project)
+          allow(project).to receive(:mac?).and_return(false)
           allow(project).to receive(:schemes).and_return(["MyScheme"])
           allow(project).to receive(:default_app_identifier).and_return(app_identifier)
           allow(project).to receive(:default_app_name).and_return("Project Name")


### PR DESCRIPTION
Handle Mac apps more gracefully during `fastlane init`.

Currently _spaceship_ does not support generating App IDs for Mac apps, so this solves https://github.com/fastlane/fastlane/issues/8073 by adding a clearer message around why its failing.