### PR TITLE
Version bump to 2.19.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.18.3'.freeze
+  VERSION = '2.19.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.18.3':**

* [cert] Print a better error message when user is not Team Admin (#8397)
* spaceship: fix flaky test. Not all sampled provisioningProfile for xcode seem to have a managingApp field (#8399)
* use Xcode API for listing provisioning profiles (#8359)
* doc update for linux pilot upload (#8383)
* [spaceship] refactor out fetch_details to allow users of the API to access the details without having to call a separate method (#8363)
* Remove unnecessary output that the certificates repo was encrypted (#8378)
* fix foreign branch shallow clone issue (#8341)
* [match] Set Provisioning Profile path for environment variables (#8280)
* Expose scan custom report file name to env (#8351)
* expand the upload symbols binary path (#8353)
* Fix the example code for delete_keychain action (#8352)
* Add keychain_path option to delete_keychain action (#8003)
* Bump Screengrab aar version (#8350)
* Update README.md (#7914)
