### PR TITLE
Re-implement csrf token retreval for provisioning profiles

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -492,7 +492,9 @@ module Spaceship
     end
 
     def create_provisioning_profile!(name, distribution_method, app_id, certificate_ids, device_ids, mac: false, sub_platform: nil)
-      ensure_csrf(Spaceship::ProvisioningProfile)
+      ensure_csrf(Spaceship::ProvisioningProfile) do
+        fetch_csrf_token_for_provisioning
+      end
 
       params = {
         teamId: team_id,
@@ -509,7 +511,9 @@ module Spaceship
     end
 
     def download_provisioning_profile(profile_id, mac: false)
-      ensure_csrf(Spaceship::ProvisioningProfile)
+      ensure_csrf(Spaceship::ProvisioningProfile) do
+        fetch_csrf_token_for_provisioning
+      end
 
       r = request(:get, "account/#{platform_slug(mac)}/profile/downloadProfileContent", {
         teamId: team_id,
@@ -524,7 +528,9 @@ module Spaceship
     end
 
     def delete_provisioning_profile!(profile_id, mac: false)
-      ensure_csrf(Spaceship::ProvisioningProfile)
+      ensure_csrf(Spaceship::ProvisioningProfile) do
+        fetch_csrf_token_for_provisioning
+      end
 
       r = request(:post, "account/#{platform_slug(mac)}/profile/deleteProvisioningProfile.action", {
         teamId: team_id,
@@ -534,7 +540,9 @@ module Spaceship
     end
 
     def repair_provisioning_profile!(profile_id, name, distribution_method, app_id, certificate_ids, device_ids, mac: false, sub_platform: nil)
-      ensure_csrf(Spaceship::ProvisioningProfile)
+      ensure_csrf(Spaceship::ProvisioningProfile) do
+        fetch_csrf_token_for_provisioning
+      end
 
       params = {
           teamId: team_id,
@@ -583,6 +591,24 @@ module Spaceship
       block_given? ? yield : klass.all
 
       csrf_cache[klass] = self.csrf_tokens
+    end
+
+    # We need a custom way to fetch the csrf token for the provisioning profile requests, since
+    # we use a separate API endpoint (host of Xcode API) to fetch the provisioning profiles
+    # All we do is fetch one profile (if exists) to get a valid csrf token with its time stamp
+    # This method is being called from all requests that modify, create or downloading provisioning
+    # profiles.
+    # Source https://github.com/fastlane/fastlane/issues/5903
+    def fetch_csrf_token_for_provisioning(mac: false)
+      req = request(:post, "account/#{platform_slug(mac)}/profile/listProvisioningProfiles.action", {
+         teamId: team_id,
+         pageNumber: 1,
+         pageSize: 1,
+         sort: 'name=asc'
+       })
+
+      parse_response(req, 'provisioningProfiles')
+      return nil
     end
   end
   # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Fix #8408 
Fix #8409 
Fixes a regression in csrf_token loading for provisioning profiles in spaceship. Regression caused by #8359 

