### PR TITLE
Add missing header

### DIFF
--- a/CORE_CONTRIBUTOR.md
+++ b/CORE_CONTRIBUTOR.md
@@ -1,8 +1,6 @@
 # _fastlane_ Core Contributor Expectations
 
-
 We believe that our most valuable resource is the passionate community members who keep _fastlane_ running. We are always looking for active, enthusiastic members of the _fastlane_ community to become core contributors. We hope to harness the diverse experiences of our community to optimize _fastlane_ as the defacto tool to deploy betas and releases for iOS and Android apps.
-
 
 ## How does one become a core contributor?
 Contributors who have displayed lasting commitment to the evolution and maintenance of _fastlane_ will be invited to become core contributors. For instance, contributors who:
@@ -28,13 +26,16 @@ Contributors who have displayed lasting commitment to the evolution and maintena
 - Keep external dependencies to a minimum
 - Keep test coverage high and ensure up-to-date documentation
 
-### Pull Request Ownership:
+## Pull Request Ownership:
 We work in a high-trust environment which implies that anyone and everyone is able to merge pull requests from the community. If the PR reviewer feels strongly about seeing a PR to completion, they should assign it to themselves and request necessary changes.
 
-### Adding Dependencies:
+## Adding Dependencies:
 We want to keep _fastlane_ slim and robust. Please avoid adding new dependencies to the code base unless it is necessary. In the event that a PR does add a dependency, please ping a member of the _fastlane_ team to approve the pull request.
 
+## Being friendly and supportive
+
 __Most Importantly__, our community prides itself in our supportive and friendly attitude. Above all else, we are always:
+
 - Polite
 - Friendly
 - Having fun


### PR DESCRIPTION
Looks like we used `##` and `###` for the same level. Also it looked like the friendliness was part of the dependencies