### PR TITLE
Enable to pass `notes_path` using the file path of parent directoryf

### DIFF
--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -51,7 +51,7 @@ module Fastlane
 
           # Optional
           command << "-betaDistributionEmails '#{params[:emails]}'" if params[:emails]
-          command << "-betaDistributionReleaseNotesFilePath '#{params[:notes_path]}'" if params[:notes_path]
+          command << "-betaDistributionReleaseNotesFilePath '#{File.expand_path(params[:notes_path])}'" if params[:notes_path]
           command << "-betaDistributionGroupAliases '#{params[:groups]}'" if params[:groups]
           command << "-betaDistributionNotifications #{(params[:notifications] ? 'true' : 'false')}"
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

When we publish to android app with`crashlytics` method, we can specify `notes_path`.
But this `notes_path` can only pass below.

- the file path of current directory
- the file path of UNDER current directory
- the absolute path

So if we'd like to pass the file path of parent directories, we have to do `cd ../to/parent_directory`  and call `crashlytics` method, like this. https://github.com/fastlane/fastlane/issues/6325#issuecomment-278862019

This PR will any `notes_path` convert to the absolute path with `File.expand_path`.
Then we can specify `notes_path` with any file path expression.