### PR TITLE
integrate fastlane-plugin-update_project_codesigning

### DIFF
--- a/fastlane/actions/test_sample_code.rb
+++ b/fastlane/actions/test_sample_code.rb
@@ -43,6 +43,13 @@ module Fastlane
         return if blacklist.include?(method_sym)
 
         class_ref = self.runner.class_reference_from_action_name(method_sym)
+        unless class_ref
+          alias_found = self.runner.find_alias(method_sym.to_s)
+          if alias_found
+            class_ref = self.runner.class_reference_from_action_name(alias_found.to_sym)
+          end
+        end
+
         UI.user_error!("Could not find method or action named '#{method_sym}'") if class_ref.nil?
         available_options = class_ref.available_options
 

--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -37,17 +37,17 @@ module Fastlane
         end
         project.save
 
-        if changed_targets.length == 0
+        if changed_targets.empty?
           UI.important("None of the specified targets has been modified")
           UI.important("available targets:")
-          target_dictionary.each do |tar|
-            UI.important("\t* #{tar[:name]}")
+          target_dictionary.each do |target|
+            UI.important("\t* #{target[:name]}")
           end
         else
           UI.success("Successfully updated project settings to use ProvisioningStyle '#{params[:use_automatic_signing] ? 'Automatic' : 'Manual'}'")
           UI.success("Modified Targets:")
-          changed_targets.each do |tar|
-            UI.success("\t * #{tar}")
+          changed_targets.each do |target|
+            UI.success("\t * #{target}")
           end
         end
 

--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -13,6 +13,7 @@ module Fastlane
 
         unless project.root_object.attributes["TargetAttributes"]
           UI.user_error!("Seems to be a very old project file format - please use xcode to upgrade to atlease 0800")
+          return false
         end
 
         target_dictionary = project.targets.map { |f| { name: f.name, uuid: f.uuid } }

--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -1,0 +1,182 @@
+require 'xcodeproj'
+module Fastlane
+  module Actions
+    class AutomaticCodeSigningAction < Action
+      def self.run(params)
+        FastlaneCore::PrintTable.print_values(config: params, title: "Summary for Automatic Codesigning")
+        path = params[:path]
+        path = File.join(File.expand_path(path), "project.pbxproj")
+
+        project = Xcodeproj::Project.open(params[:path])
+        UI.user_error!("Could not find path to project config '#{path}'. Pass the path to your project (not workspace)!") unless File.exist?(path)
+        UI.message("Updating the Automatic Codesigning flag to #{params[:use_automatic_signing] ? 'enabled' : 'disabled'} for the given project '#{path}'")
+
+        unless project.root_object.attributes["TargetAttributes"]
+          UI.error("Seems to be a very old project file format")
+          UI.error("PLEASE BACKUP ALL FILES before doing this.")
+          if ENV["FL_PROJECT_SIGNING_FORCE_UPGRADE"] || UI.confirm("Proceed with upgrade to xcode8 format?")
+            UI.important("Upgrading project to use xcode8 signing stuff")
+            unless params[:team_id]
+              UI.important("TEAM id is not set")
+              UI.error!("Provide :team_id")
+            end
+
+            # set upgrade market to xcdoe8
+            project.root_object.attributes["LastUpgradeCheck"] = "0800"
+            target_attr_hash = {}
+
+            # for each target add the TargetAttributes Entry
+            # setting team id, and signing mode
+            project.root_object.targets.each do |target|
+              new_hash = {}
+              new_hash["CreatedOnToolsVersion"] = "8.0"
+              new_hash["DevelopmentTeam"] = params[:team_id]
+              new_hash["ProvisioningStyle"] = params[:use_automatic_signing] ? 'Automatic' : 'Manual'
+              target_attr_hash[target.uuid] = new_hash
+            end
+
+            # for each configuration set a signing identity
+            project.build_configurations.each do |config|
+              config.build_settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'] = config.name == "Release" ? 'iPhone Distribution' : "iPhone Development"
+            end
+            project.root_object.attributes["TargetAttributes"] = target_attr_hash
+          else
+            UI.user_error!("canceled upgrade")
+          end
+        end
+
+        target_dictionary = project.targets.map { |f| { name: f.name, uuid: f.uuid } }
+        changed_targets = []
+        project.root_object.attributes["TargetAttributes"].each do |target, sett|
+          found_target = target_dictionary.detect { |h| h[:uuid] == target }
+          if params[:targets]
+            # get target name
+            unless params[:targets].include?(found_target[:name])
+              UI.important("Skipping #{found_target[:name]} not selected (#{params[:targets].join(',')})")
+              next
+            end
+          end
+
+          sett["ProvisioningStyle"] = params[:use_automatic_signing] ? 'Automatic' : 'Manual'
+          sett["DevelopmentTeam"] = params[:team_id] if params[:team_id]
+          changed_targets << found_target[:name]
+        end
+        project.save
+
+        if changed_targets.length == 0
+          UI.important("None of the specified targets has been modified")
+          UI.important("available targets:")
+          target_dictionary.each do |tar|
+            UI.important("\t* #{tar[:name]}")
+          end
+        else
+          UI.success("Successfully updated project settings to use ProvisioningStyle '#{params[:use_automatic_signing] ? 'Automatic' : 'Manual'}'")
+          UI.success("Modified Targets:")
+          changed_targets.each do |tar|
+            UI.success("\t * #{tar}")
+          end
+        end
+        params[:use_automatic_signing]
+      end
+      
+      def self.alias_used(action_alias, params)
+        params[:use_automatic_signing] = true if action_alias == "enable_automatic_code_signing"
+      end
+
+      def self.aliases
+        ["enable_automatic_code_signing", "disable_automatic_code_signing"]
+      end
+      
+      def self.description
+        "Updates the Xcode 8 Automatic Codesigning Flag"
+      end
+
+      def self.details
+        "Updates the Xcode 8 Automatic Codesigning Flag of all targets in the project"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: "FL_PROJECT_SIGNING_PROJECT_PATH",
+                                       description: "Path to your Xcode project",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Path is invalid") unless File.exist?(File.expand_path(value))
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :use_automatic_signing,
+                                       env_name: "FL_PROJECT_USE_AUTOMATIC_SIGNING",
+                                       description: "Defines if project should use automatic signing",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :team_id,
+                                        env_name: "FASTLANE_TEAM_ID",
+                                        optional: true,
+                                        description: "Team ID, is used when upgrading project",
+                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :targets,
+                                       env_name: "FL_PROJECT_SIGNING_TARGETS",
+                                       optional: true,
+                                       type: Array,
+                                       description: "Specify targets you want to toggle the signing mech. (default to all targets)",
+                                       is_string: false)
+        ]
+      end
+
+      def self.output
+      end
+      
+      def self.example_code
+        [
+          '# enable automatic code signing
+          enable_automatic_code_signing',
+          'enable_automatic_code_signing(
+            path: "demo-project/demo/demo.xcodeproj"
+          )',
+          '# disable automatic code signing
+          disable_automatic_code_signing',
+          'disable_automatic_code_signing(
+            path: "demo-project/demo/demo.xcodeproj"
+          )',
+          '# also set team id
+          disable_automatic_code_signing(
+            path: "demo-project/demo/demo.xcodeproj",
+            team_id: "XXXX"
+          )',
+          '# Only specific targets
+            disable_automatic_code_signing(
+              path: "demo-project/demo/demo.xcodeproj",
+              use_automatic_signing: false,
+              targets: ["demo"]
+            )
+          ',
+          ' # via generic action
+          automatic_code_signing(
+            path: "demo-project/demo/demo.xcodeproj"
+            use_automatic_signing: false
+          )',
+          'automatic_code_signing(
+            path: "demo-project/demo/demo.xcodeproj"
+            use_automatic_signing: true
+          )'
+
+        ]
+      end
+      
+      def self.category
+        :code_signing
+      end
+      
+      def self.return_value
+        "The current status (boolean) of codesigning after modification"
+      end
+
+      def self.authors
+        ["mathiasAichinger", "hjanuschka"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -126,11 +126,11 @@ module Fastlane
           ',
           ' # via generic action
           automatic_code_signing(
-            path: "demo-project/demo/demo.xcodeproj"
+            path: "demo-project/demo/demo.xcodeproj",
             use_automatic_signing: false
           )',
           'automatic_code_signing(
-            path: "demo-project/demo/demo.xcodeproj"
+            path: "demo-project/demo/demo.xcodeproj",
             use_automatic_signing: true
           )'
 

--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -12,37 +12,7 @@ module Fastlane
         UI.message("Updating the Automatic Codesigning flag to #{params[:use_automatic_signing] ? 'enabled' : 'disabled'} for the given project '#{path}'")
 
         unless project.root_object.attributes["TargetAttributes"]
-          UI.error("Seems to be a very old project file format")
-          UI.error("PLEASE BACKUP ALL FILES before doing this.")
-          if ENV["FL_PROJECT_SIGNING_FORCE_UPGRADE"] || UI.confirm("Proceed with upgrade to xcode8 format?")
-            UI.important("Upgrading project to use xcode8 signing stuff")
-            unless params[:team_id]
-              UI.important("TEAM id is not set")
-              UI.error!("Provide :team_id")
-            end
-
-            # set upgrade market to xcdoe8
-            project.root_object.attributes["LastUpgradeCheck"] = "0800"
-            target_attr_hash = {}
-
-            # for each target add the TargetAttributes Entry
-            # setting team id, and signing mode
-            project.root_object.targets.each do |target|
-              new_hash = {}
-              new_hash["CreatedOnToolsVersion"] = "8.0"
-              new_hash["DevelopmentTeam"] = params[:team_id]
-              new_hash["ProvisioningStyle"] = params[:use_automatic_signing] ? 'Automatic' : 'Manual'
-              target_attr_hash[target.uuid] = new_hash
-            end
-
-            # for each configuration set a signing identity
-            project.build_configurations.each do |config|
-              config.build_settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'] = config.name == "Release" ? 'iPhone Distribution' : "iPhone Development"
-            end
-            project.root_object.attributes["TargetAttributes"] = target_attr_hash
-          else
-            UI.user_error!("canceled upgrade")
-          end
+          UI.user_error!("Seems to be a very old project file format - please use xcode to upgrade to atlease 0800")
         end
 
         target_dictionary = project.targets.map { |f| { name: f.name, uuid: f.uuid } }
@@ -78,7 +48,7 @@ module Fastlane
         end
         params[:use_automatic_signing]
       end
-      
+
       def self.alias_used(action_alias, params)
         params[:use_automatic_signing] = true if action_alias == "enable_automatic_code_signing"
       end
@@ -86,7 +56,7 @@ module Fastlane
       def self.aliases
         ["enable_automatic_code_signing", "disable_automatic_code_signing"]
       end
-      
+
       def self.description
         "Updates the Xcode 8 Automatic Codesigning Flag"
       end
@@ -124,7 +94,7 @@ module Fastlane
 
       def self.output
       end
-      
+
       def self.example_code
         [
           '# enable automatic code signing
@@ -161,11 +131,11 @@ module Fastlane
 
         ]
       end
-      
+
       def self.category
         :code_signing
       end
-      
+
       def self.return_value
         "The current status (boolean) of codesigning after modification"
       end

--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -28,7 +28,10 @@ module Fastlane
           end
 
           sett["ProvisioningStyle"] = params[:use_automatic_signing] ? 'Automatic' : 'Manual'
-          sett["DevelopmentTeam"] = params[:team_id] if params[:team_id]
+          if params[:team_id]
+            sett["DevelopmentTeam"] = params[:team_id]
+            UI.important("Set Team id to: #{params[:team_id]} for target: #{found_target[:name]}")
+          end
           changed_targets << found_target[:name]
         end
         project.save
@@ -46,6 +49,7 @@ module Fastlane
             UI.success("\t * #{tar}")
           end
         end
+
         params[:use_automatic_signing]
       end
 

--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -1,0 +1,74 @@
+require "xcodeproj"
+# 771D79501D9E69C900D840FA = demo
+# 77C503031DD3175E00AC8FF0 = today
+describe Fastlane do
+  describe "Automatic Code Signing" do
+    it "enable_automatic_code_signing" do
+      allow(UI).to receive(:success)
+      expect(UI).to receive(:success).with("Successfully updated project settings to use ProvisioningStyle 'Automatic'")
+      result = Fastlane::FastFile.new.parse("lane :test do
+        enable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'XXXX')
+      end").runner.execute(:test)
+      expect(result).to eq(true)
+
+      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      root_attrs = project.root_object.attributes["TargetAttributes"]
+      expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Automatic")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Automatic")
+
+      expect(root_attrs["771D79501D9E69C900D840FA"]["DevelopmentTeam"]).to eq("XXXX")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["DevelopmentTeam"]).to eq("XXXX")
+    end
+    
+    it "disable_automatic_code_signing for specific target" do
+      allow(UI).to receive(:success)
+      expect(UI).to receive(:success).with("Successfully updated project settings to use ProvisioningStyle 'Manual'")
+      expect(UI).to receive(:success).with("\t * today")
+      expect(UI).to receive(:important).with("Skipping demo not selected (today)")
+      result = Fastlane::FastFile.new.parse("lane :test do
+        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', targets: ['today'])
+      end").runner.execute(:test)
+      expect(result).to eq(false)
+
+      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      root_attrs = project.root_object.attributes["TargetAttributes"]
+      expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Automatic")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
+    end
+    
+    it "disable_automatic_code_signing" do
+      allow(UI).to receive(:success)
+      expect(UI).to receive(:success).with("Successfully updated project settings to use ProvisioningStyle 'Manual'")
+      result = Fastlane::FastFile.new.parse("lane :test do
+        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj')
+      end").runner.execute(:test)
+      expect(result).to eq(false)
+
+      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      root_attrs = project.root_object.attributes["TargetAttributes"]
+      expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
+    end
+    
+    it "sets team id" do
+      # G3KGXDXQL9
+      allow(UI).to receive(:success)
+      expect(UI).to receive(:success).with("Successfully updated project settings to use ProvisioningStyle 'Manual'")
+      expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: demo")
+      expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: today")
+      result = Fastlane::FastFile.new.parse("lane :test do
+        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9')
+      end").runner.execute(:test)
+      expect(result).to eq(false)
+
+      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      root_attrs = project.root_object.attributes["TargetAttributes"]
+
+      expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
+
+      expect(root_attrs["771D79501D9E69C900D840FA"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -70,5 +70,22 @@ describe Fastlane do
       expect(root_attrs["771D79501D9E69C900D840FA"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
     end
+
+    it "targets not found notice" do
+      allow(UI).to receive(:important)
+      expect(UI).to receive(:important).with("None of the specified targets has been modified")
+      result = Fastlane::FastFile.new.parse("lane :test do
+        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', targets: ['not_found'])
+      end").runner.execute(:test)
+      expect(result).to eq(false)
+    end
+
+    it "raises exception on old projects" do
+      expect(UI).to receive(:user_error!).with("Seems to be a very old project file format - please use xcode to upgrade to atlease 0800")
+      result = Fastlane::FastFile.new.parse("lane :test do
+        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic-code-signing-old.xcodeproj')
+      end").runner.execute(:test)
+      expect(result).to eq(false)
+    end
   end
 end

--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -19,7 +19,7 @@ describe Fastlane do
       expect(root_attrs["771D79501D9E69C900D840FA"]["DevelopmentTeam"]).to eq("XXXX")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["DevelopmentTeam"]).to eq("XXXX")
     end
-    
+
     it "disable_automatic_code_signing for specific target" do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use ProvisioningStyle 'Manual'")
@@ -35,7 +35,7 @@ describe Fastlane do
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Automatic")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
     end
-    
+
     it "disable_automatic_code_signing" do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use ProvisioningStyle 'Manual'")
@@ -49,7 +49,7 @@ describe Fastlane do
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
     end
-    
+
     it "sets team id" do
       # G3KGXDXQL9
       allow(UI).to receive(:success)

--- a/fastlane/spec/fixtures/xcodeproj/automatic-code-signing-old.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/xcodeproj/automatic-code-signing-old.xcodeproj/project.pbxproj
@@ -1,0 +1,441 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+/* Begin PBXBuildFile section */
+		0207DA581B56EA530066E2B4 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0207DA571B56EA530066E2B4 /* Images.xcassets */; };
+		1D3623260D0F684500981E51 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* AppDelegate.m */; };
+		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
+		301BF552109A68D80062928A /* libCordova.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 301BF535109A57CC0062928A /* libCordova.a */; };
+		302D95F114D2391D003F00A1 /* MainViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 302D95EF14D2391D003F00A1 /* MainViewController.m */; };
+		302D95F214D2391D003F00A1 /* MainViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 302D95F014D2391D003F00A1 /* MainViewController.xib */; };
+		3047A5121AB8059700498E2A /* build-debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3047A50F1AB8059700498E2A /* build-debug.xcconfig */; };
+		3047A5131AB8059700498E2A /* build-release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3047A5101AB8059700498E2A /* build-release.xcconfig */; };
+		3047A5141AB8059700498E2A /* build.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3047A5111AB8059700498E2A /* build.xcconfig */; };
+		2BA40EC72A1C4BB6A6FB1208 /* CDVLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C23B88AA96D4407AD939A69 /* CDVLogger.m */; };
+		DBED73A7AC684FE6977D8F7D /* CDVDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 959E761C0F18489D97BD2ACB /* CDVDevice.m */; };
+		2F975397723940528836AEA1 /* CDVSplashScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = EC62D996FB5744109688EAF5 /* CDVSplashScreen.m */; };
+		A6073B39C65244D397877C5A /* CDVViewController+SplashScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B97EBF91D494B5E8C755EB1 /* CDVViewController+SplashScreen.m */; };
+		AF5CA901B9964ACBAD27389A /* CDVStatusBar.m in Sources */ = {isa = PBXBuildFile; fileRef = AF74CD07FD224CFE9F94E1E9 /* CDVStatusBar.m */; };
+		EE8E1967A8A74775934DD809 /* IonicKeyboard.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B7FF98F2ED41158B0ADF4F /* IonicKeyboard.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		301BF534109A57CC0062928A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 301BF52D109A57CC0062928A /* CordovaLib.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D2AAC07E0554694100DB518D;
+			remoteInfo = CordovaLib;
+		};
+		301BF550109A68C00062928A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 301BF52D109A57CC0062928A /* CordovaLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = D2AAC07D0554694100DB518D;
+			remoteInfo = CordovaLib;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0207DA571B56EA530066E2B4 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "HelloCordova/Images.xcassets"; sourceTree = SOURCE_ROOT; };
+		1D3623240D0F684500981E51 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		1D3623250D0F684500981E51 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		1D6058910D05DD3D006BFB54 /* HelloCordova.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "HelloCordova.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		301BF52D109A57CC0062928A /* CordovaLib.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CordovaLib.xcodeproj; path = CordovaLib/CordovaLib.xcodeproj; sourceTree = "<group>"; };
+		301BF56E109A69640062928A /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; path = www; sourceTree = SOURCE_ROOT; };
+		302D95EE14D2391D003F00A1 /* MainViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MainViewController.h; sourceTree = "<group>"; };
+		302D95EF14D2391D003F00A1 /* MainViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MainViewController.m; sourceTree = "<group>"; };
+		302D95F014D2391D003F00A1 /* MainViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainViewController.xib; sourceTree = "<group>"; };
+		3047A50F1AB8059700498E2A /* build-debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "build-debug.xcconfig"; path = cordova/build-debug.xcconfig; sourceTree = SOURCE_ROOT; };
+		3047A5101AB8059700498E2A /* build-release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "build-release.xcconfig"; path = cordova/build-release.xcconfig; sourceTree = SOURCE_ROOT; };
+		3047A5111AB8059700498E2A /* build.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = build.xcconfig; path = cordova/build.xcconfig; sourceTree = SOURCE_ROOT; };
+		32CA4F630368D1EE00C91783 /* HelloCordova-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "HelloCordova-Prefix.pch"; sourceTree = "<group>"; };
+		8D1107310486CEB800E47090 /* HelloCordova-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "HelloCordova-Info.plist"; path = "HelloCordova/HelloCordova-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = SOURCE_ROOT; };
+		EB87FDF31871DA8E0020F90C /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; name = www; path = ../../www; sourceTree = "<group>"; };
+		EB87FDF41871DAF40020F90C /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = config.xml; path = ../../config.xml; sourceTree = "<group>"; };
+		F840E1F0165FE0F500CFE078 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = config.xml; path = "HelloCordova/config.xml"; sourceTree = "<group>"; };
+		ED33DF2A687741AEAF9F8254 /* Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Bridging-Header.h"; path = "Bridging-Header.h"; sourceTree = "<group>"; };
+		6C23B88AA96D4407AD939A69 /* CDVLogger.m */ = {isa = PBXFileReference; name = "CDVLogger.m"; path = "cordova-plugin-console/CDVLogger.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		C71E284A038140F395498D9E /* CDVLogger.h */ = {isa = PBXFileReference; name = "CDVLogger.h"; path = "cordova-plugin-console/CDVLogger.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		959E761C0F18489D97BD2ACB /* CDVDevice.m */ = {isa = PBXFileReference; name = "CDVDevice.m"; path = "cordova-plugin-device/CDVDevice.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		8EA78B9970124908B5AE2F5B /* CDVDevice.h */ = {isa = PBXFileReference; name = "CDVDevice.h"; path = "cordova-plugin-device/CDVDevice.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		EC62D996FB5744109688EAF5 /* CDVSplashScreen.m */ = {isa = PBXFileReference; name = "CDVSplashScreen.m"; path = "cordova-plugin-splashscreen/CDVSplashScreen.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		0B97EBF91D494B5E8C755EB1 /* CDVViewController+SplashScreen.m */ = {isa = PBXFileReference; name = "CDVViewController+SplashScreen.m"; path = "cordova-plugin-splashscreen/CDVViewController+SplashScreen.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		0BD9EC9210A44E5796507087 /* CDVSplashScreen.h */ = {isa = PBXFileReference; name = "CDVSplashScreen.h"; path = "cordova-plugin-splashscreen/CDVSplashScreen.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		70E485DB97244FBC815AA275 /* CDVViewController+SplashScreen.h */ = {isa = PBXFileReference; name = "CDVViewController+SplashScreen.h"; path = "cordova-plugin-splashscreen/CDVViewController+SplashScreen.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		AF74CD07FD224CFE9F94E1E9 /* CDVStatusBar.m */ = {isa = PBXFileReference; name = "CDVStatusBar.m"; path = "cordova-plugin-statusbar/CDVStatusBar.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		76A0C82DCC8E446C86319134 /* CDVStatusBar.h */ = {isa = PBXFileReference; name = "CDVStatusBar.h"; path = "cordova-plugin-statusbar/CDVStatusBar.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		58B7FF98F2ED41158B0ADF4F /* IonicKeyboard.m */ = {isa = PBXFileReference; name = "IonicKeyboard.m"; path = "ionic-plugin-keyboard/IonicKeyboard.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		C1E24C62274241F5B0324283 /* IonicKeyboard.h */ = {isa = PBXFileReference; name = "IonicKeyboard.h"; path = "ionic-plugin-keyboard/IonicKeyboard.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1D60588F0D05DD3D006BFB54 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				301BF552109A68D80062928A /* libCordova.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		080E96DDFE201D6D7F000001 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				302D95EE14D2391D003F00A1 /* MainViewController.h */,
+				302D95EF14D2391D003F00A1 /* MainViewController.m */,
+				302D95F014D2391D003F00A1 /* MainViewController.xib */,
+				1D3623240D0F684500981E51 /* AppDelegate.h */,
+				1D3623250D0F684500981E51 /* AppDelegate.m */,
+			);
+			name = Classes;
+			path = "HelloCordova/Classes";
+			sourceTree = SOURCE_ROOT;
+		};
+		19C28FACFE9D520D11CA2CBB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1D6058910D05DD3D006BFB54 /* HelloCordova.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
+			isa = PBXGroup;
+			children = (
+				EB87FDF41871DAF40020F90C /* config.xml */,
+				EB87FDF31871DA8E0020F90C /* www */,
+				EB87FDF11871DA420020F90C /* Staging */,
+				301BF52D109A57CC0062928A /* CordovaLib.xcodeproj */,
+				080E96DDFE201D6D7F000001 /* Classes */,
+				307C750510C5A3420062BCA9 /* Plugins */,
+				29B97315FDCFA39411CA2CEA /* Other Sources */,
+				29B97317FDCFA39411CA2CEA /* Resources */,
+				29B97323FDCFA39411CA2CEA /* Frameworks */,
+				19C28FACFE9D520D11CA2CBB /* Products */,
+			);
+			name = CustomTemplate;
+			sourceTree = "<group>";
+		};
+		29B97315FDCFA39411CA2CEA /* Other Sources */ = {
+			isa = PBXGroup;
+			children = (
+				32CA4F630368D1EE00C91783 /* HelloCordova-Prefix.pch */,
+				29B97316FDCFA39411CA2CEA /* main.m */,
+				ED33DF2A687741AEAF9F8254 /* Bridging-Header.h */,
+			);
+			name = "Other Sources";
+			path = "HelloCordova";
+			sourceTree = "<group>";
+		};
+		29B97317FDCFA39411CA2CEA /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				0207DA571B56EA530066E2B4 /* Images.xcassets */,
+				3047A50E1AB8057F00498E2A /* config */,
+				8D1107310486CEB800E47090 /* HelloCordova-Info.plist */,
+			);
+			name = Resources;
+			path = "HelloCordova/Resources";
+			sourceTree = "<group>";
+		};
+		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		301BF52E109A57CC0062928A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				301BF535109A57CC0062928A /* libCordova.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3047A50E1AB8057F00498E2A /* config */ = {
+			isa = PBXGroup;
+			children = (
+				3047A50F1AB8059700498E2A /* build-debug.xcconfig */,
+				3047A5101AB8059700498E2A /* build-release.xcconfig */,
+				3047A5111AB8059700498E2A /* build.xcconfig */,
+			);
+			name = config;
+			sourceTree = "<group>";
+		};
+		307C750510C5A3420062BCA9 /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+				6C23B88AA96D4407AD939A69 /* CDVLogger.m */,
+				C71E284A038140F395498D9E /* CDVLogger.h */,
+				959E761C0F18489D97BD2ACB /* CDVDevice.m */,
+				8EA78B9970124908B5AE2F5B /* CDVDevice.h */,
+				EC62D996FB5744109688EAF5 /* CDVSplashScreen.m */,
+				0B97EBF91D494B5E8C755EB1 /* CDVViewController+SplashScreen.m */,
+				0BD9EC9210A44E5796507087 /* CDVSplashScreen.h */,
+				70E485DB97244FBC815AA275 /* CDVViewController+SplashScreen.h */,
+				AF74CD07FD224CFE9F94E1E9 /* CDVStatusBar.m */,
+				76A0C82DCC8E446C86319134 /* CDVStatusBar.h */,
+				58B7FF98F2ED41158B0ADF4F /* IonicKeyboard.m */,
+				C1E24C62274241F5B0324283 /* IonicKeyboard.h */,
+			);
+			name = Plugins;
+			path = "HelloCordova/Plugins";
+			sourceTree = SOURCE_ROOT;
+		};
+		EB87FDF11871DA420020F90C /* Staging */ = {
+			isa = PBXGroup;
+			children = (
+				F840E1F0165FE0F500CFE078 /* config.xml */,
+				301BF56E109A69640062928A /* www */,
+			);
+			name = Staging;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1D6058900D05DD3D006BFB54 /* HelloCordova */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "HelloCordova" */;
+			buildPhases = (
+				304B58A110DAC018002A0835 /* Copy www directory */,
+				1D60588D0D05DD3D006BFB54 /* Resources */,
+				1D60588E0D05DD3D006BFB54 /* Sources */,
+				1D60588F0D05DD3D006BFB54 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				301BF551109A68C00062928A /* PBXTargetDependency */,
+			);
+			name = "HelloCordova";
+			productName = "HelloCordova";
+			productReference = 1D6058910D05DD3D006BFB54 /* HelloCordova.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		29B97313FDCFA39411CA2CEA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 510;
+			};
+			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "__NON-CLI__" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 1;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 301BF52E109A57CC0062928A /* Products */;
+					ProjectRef = 301BF52D109A57CC0062928A /* CordovaLib.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				1D6058900D05DD3D006BFB54 /* HelloCordova */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		301BF535109A57CC0062928A /* libCordova.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libCordova.a;
+			remoteRef = 301BF534109A57CC0062928A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXResourcesBuildPhase section */
+		1D60588D0D05DD3D006BFB54 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				302D95F214D2391D003F00A1 /* MainViewController.xib in Resources */,
+				3047A5131AB8059700498E2A /* build-release.xcconfig in Resources */,
+				3047A5141AB8059700498E2A /* build.xcconfig in Resources */,
+				0207DA581B56EA530066E2B4 /* Images.xcassets in Resources */,
+				3047A5121AB8059700498E2A /* build-debug.xcconfig in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		304B58A110DAC018002A0835 /* Copy www directory */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy www directory";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "NODEJS_PATH=/usr/local/bin; NVM_NODE_PATH=~/.nvm/versions/node/`nvm version 2>/dev/null`/bin; N_NODE_PATH=`find /usr/local/n/versions/node/* -maxdepth 0 -type d 2>/dev/null | tail -1`/bin; XCODE_NODE_PATH=`xcode-select --print-path`/usr/share/xcs/Node/bin; PATH=$NODEJS_PATH:$NVM_NODE_PATH:$N_NODE_PATH:$XCODE_NODE_PATH:$PATH && node cordova/lib/copy-www-build-step.js";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1D60588E0D05DD3D006BFB54 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1D60589B0D05DD56006BFB54 /* main.m in Sources */,
+				1D3623260D0F684500981E51 /* AppDelegate.m in Sources */,
+				302D95F114D2391D003F00A1 /* MainViewController.m in Sources */,
+				2BA40EC72A1C4BB6A6FB1208 /* CDVLogger.m in Sources */,
+				DBED73A7AC684FE6977D8F7D /* CDVDevice.m in Sources */,
+				2F975397723940528836AEA1 /* CDVSplashScreen.m in Sources */,
+				A6073B39C65244D397877C5A /* CDVViewController+SplashScreen.m in Sources */,
+				AF5CA901B9964ACBAD27389A /* CDVStatusBar.m in Sources */,
+				EE8E1967A8A74775934DD809 /* IonicKeyboard.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		301BF551109A68C00062928A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CordovaLib;
+			targetProxy = 301BF550109A68C00062928A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		1D6058940D05DD3E006BFB54 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3047A50F1AB8059700498E2A /* build-debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "HelloCordova/HelloCordova-Prefix.pch";
+				GCC_THUMB_SUPPORT = NO;
+				GCC_VERSION = "";
+				INFOPLIST_FILE = "HelloCordova/HelloCordova-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				PRODUCT_NAME = "HelloCordova";
+			};
+			name = Debug;
+		};
+		1D6058950D05DD3E006BFB54 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3047A5101AB8059700498E2A /* build-release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "HelloCordova/HelloCordova-Prefix.pch";
+				GCC_THUMB_SUPPORT = NO;
+				GCC_VERSION = "";
+				INFOPLIST_FILE = "HelloCordova/HelloCordova-Info.plist";
+				PRODUCT_NAME = "HelloCordova";
+			};
+			name = Release;
+		};
+		C01FCF4F08A954540054247B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3047A5111AB8059700498E2A /* build.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_THUMB_SUPPORT = NO;
+				GCC_VERSION = "";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = NO;
+				PRODUCT_NAME = "HelloCordova";
+			};
+			name = Debug;
+		};
+		C01FCF5008A954540054247B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3047A5111AB8059700498E2A /* build.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_THUMB_SUPPORT = NO;
+				GCC_VERSION = "";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = NO;
+				PRODUCT_NAME = "HelloCordova";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "HelloCordova" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1D6058940D05DD3E006BFB54 /* Debug */,
+				1D6058950D05DD3E006BFB54 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C01FCF4E08A954540054247B /* Build configuration list for PBXProject "__NON-CLI__" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C01FCF4F08A954540054247B /* Debug */,
+				C01FCF5008A954540054247B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
+}

--- a/fastlane/spec/fixtures/xcodeproj/automatic-code-signing-old.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/fastlane/spec/fixtures/xcodeproj/automatic-code-signing-old.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
@@ -1,0 +1,473 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		771D79561D9E69C900D840FA /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 771D79551D9E69C900D840FA /* main.m */; };
+		771D79591D9E69C900D840FA /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 771D79581D9E69C900D840FA /* AppDelegate.m */; };
+		771D795C1D9E69C900D840FA /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 771D795B1D9E69C900D840FA /* ViewController.m */; };
+		771D795F1D9E69C900D840FA /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 771D795D1D9E69C900D840FA /* Main.storyboard */; };
+		771D79611D9E69C900D840FA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 771D79601D9E69C900D840FA /* Assets.xcassets */; };
+		771D79641D9E69C900D840FA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 771D79621D9E69C900D840FA /* LaunchScreen.storyboard */; };
+		77C503071DD3175E00AC8FF0 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77C503061DD3175E00AC8FF0 /* NotificationCenter.framework */; };
+		77C5030B1DD3175E00AC8FF0 /* TodayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 77C5030A1DD3175E00AC8FF0 /* TodayViewController.m */; };
+		77C5030E1DD3175E00AC8FF0 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 77C5030C1DD3175E00AC8FF0 /* MainInterface.storyboard */; };
+		77C503121DD3175E00AC8FF0 /* today.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 77C503041DD3175E00AC8FF0 /* today.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		77C503101DD3175E00AC8FF0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 771D79491D9E69C900D840FA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 77C503031DD3175E00AC8FF0;
+			remoteInfo = today;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		77C503161DD3175E00AC8FF0 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				77C503121DD3175E00AC8FF0 /* today.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		771D79511D9E69C900D840FA /* demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		771D79551D9E69C900D840FA /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		771D79571D9E69C900D840FA /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		771D79581D9E69C900D840FA /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		771D795A1D9E69C900D840FA /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		771D795B1D9E69C900D840FA /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		771D795E1D9E69C900D840FA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		771D79601D9E69C900D840FA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		771D79631D9E69C900D840FA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		771D79651D9E69C900D840FA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		77C503041DD3175E00AC8FF0 /* today.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = today.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		77C503061DD3175E00AC8FF0 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
+		77C503091DD3175E00AC8FF0 /* TodayViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TodayViewController.h; sourceTree = "<group>"; };
+		77C5030A1DD3175E00AC8FF0 /* TodayViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TodayViewController.m; sourceTree = "<group>"; };
+		77C5030D1DD3175E00AC8FF0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		77C5030F1DD3175E00AC8FF0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		771D794E1D9E69C900D840FA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77C503011DD3175E00AC8FF0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77C503071DD3175E00AC8FF0 /* NotificationCenter.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		771D79481D9E69C900D840FA = {
+			isa = PBXGroup;
+			children = (
+				771D79531D9E69C900D840FA /* demo */,
+				77C503081DD3175E00AC8FF0 /* today */,
+				77C503051DD3175E00AC8FF0 /* Frameworks */,
+				771D79521D9E69C900D840FA /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		771D79521D9E69C900D840FA /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				771D79511D9E69C900D840FA /* demo.app */,
+				77C503041DD3175E00AC8FF0 /* today.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		771D79531D9E69C900D840FA /* demo */ = {
+			isa = PBXGroup;
+			children = (
+				771D79571D9E69C900D840FA /* AppDelegate.h */,
+				771D79581D9E69C900D840FA /* AppDelegate.m */,
+				771D795A1D9E69C900D840FA /* ViewController.h */,
+				771D795B1D9E69C900D840FA /* ViewController.m */,
+				771D795D1D9E69C900D840FA /* Main.storyboard */,
+				771D79601D9E69C900D840FA /* Assets.xcassets */,
+				771D79621D9E69C900D840FA /* LaunchScreen.storyboard */,
+				771D79651D9E69C900D840FA /* Info.plist */,
+				771D79541D9E69C900D840FA /* Supporting Files */,
+			);
+			path = demo;
+			sourceTree = "<group>";
+		};
+		771D79541D9E69C900D840FA /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				771D79551D9E69C900D840FA /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		77C503051DD3175E00AC8FF0 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				77C503061DD3175E00AC8FF0 /* NotificationCenter.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		77C503081DD3175E00AC8FF0 /* today */ = {
+			isa = PBXGroup;
+			children = (
+				77C503091DD3175E00AC8FF0 /* TodayViewController.h */,
+				77C5030A1DD3175E00AC8FF0 /* TodayViewController.m */,
+				77C5030C1DD3175E00AC8FF0 /* MainInterface.storyboard */,
+				77C5030F1DD3175E00AC8FF0 /* Info.plist */,
+			);
+			path = today;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		771D79501D9E69C900D840FA /* demo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 771D79681D9E69C900D840FA /* Build configuration list for PBXNativeTarget "demo" */;
+			buildPhases = (
+				771D794D1D9E69C900D840FA /* Sources */,
+				771D794E1D9E69C900D840FA /* Frameworks */,
+				771D794F1D9E69C900D840FA /* Resources */,
+				77C503161DD3175E00AC8FF0 /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				77C503111DD3175E00AC8FF0 /* PBXTargetDependency */,
+			);
+			name = demo;
+			productName = demo;
+			productReference = 771D79511D9E69C900D840FA /* demo.app */;
+			productType = "com.apple.product-type.application";
+		};
+		77C503031DD3175E00AC8FF0 /* today */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 77C503151DD3175E00AC8FF0 /* Build configuration list for PBXNativeTarget "today" */;
+			buildPhases = (
+				77C503001DD3175E00AC8FF0 /* Sources */,
+				77C503011DD3175E00AC8FF0 /* Frameworks */,
+				77C503021DD3175E00AC8FF0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = today;
+			productName = today;
+			productReference = 77C503041DD3175E00AC8FF0 /* today.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		771D79491D9E69C900D840FA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0800;
+				ORGANIZATIONNAME = hjanuschka;
+				TargetAttributes = {
+					771D79501D9E69C900D840FA = {
+						CreatedOnToolsVersion = 8.0;
+						DevelopmentTeam = G3KGXDXQL9;
+						ProvisioningStyle = Manual;
+					};
+					77C503031DD3175E00AC8FF0 = {
+						CreatedOnToolsVersion = 8.1;
+						DevelopmentTeam = G3KGXDXQL9;
+						ProvisioningStyle = Manual;
+					};
+				};
+			};
+			buildConfigurationList = 771D794C1D9E69C900D840FA /* Build configuration list for PBXProject "automatic_code_signing" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 771D79481D9E69C900D840FA;
+			productRefGroup = 771D79521D9E69C900D840FA /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				771D79501D9E69C900D840FA /* demo */,
+				77C503031DD3175E00AC8FF0 /* today */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		771D794F1D9E69C900D840FA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				771D79641D9E69C900D840FA /* LaunchScreen.storyboard in Resources */,
+				771D79611D9E69C900D840FA /* Assets.xcassets in Resources */,
+				771D795F1D9E69C900D840FA /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77C503021DD3175E00AC8FF0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77C5030E1DD3175E00AC8FF0 /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		771D794D1D9E69C900D840FA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				771D795C1D9E69C900D840FA /* ViewController.m in Sources */,
+				771D79591D9E69C900D840FA /* AppDelegate.m in Sources */,
+				771D79561D9E69C900D840FA /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77C503001DD3175E00AC8FF0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77C5030B1DD3175E00AC8FF0 /* TodayViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		77C503111DD3175E00AC8FF0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 77C503031DD3175E00AC8FF0 /* today */;
+			targetProxy = 77C503101DD3175E00AC8FF0 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		771D795D1D9E69C900D840FA /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				771D795E1D9E69C900D840FA /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		771D79621D9E69C900D840FA /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				771D79631D9E69C900D840FA /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		77C5030C1DD3175E00AC8FF0 /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				77C5030D1DD3175E00AC8FF0 /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		771D79661D9E69C900D840FA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		771D79671D9E69C900D840FA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		771D79691D9E69C900D840FA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = G3KGXDXQL9;
+				INFOPLIST_FILE = demo/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = demo.test.demo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		771D796A1D9E69C900D840FA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = G3KGXDXQL9;
+				INFOPLIST_FILE = demo/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = demo.test.demo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		77C503131DD3175E00AC8FF0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEVELOPMENT_TEAM = G3KGXDXQL9;
+				INFOPLIST_FILE = today/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = demo.test.demo.today;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		77C503141DD3175E00AC8FF0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEVELOPMENT_TEAM = G3KGXDXQL9;
+				INFOPLIST_FILE = today/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = demo.test.demo.today;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		771D794C1D9E69C900D840FA /* Build configuration list for PBXProject "automatic_code_signing" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				771D79661D9E69C900D840FA /* Debug */,
+				771D79671D9E69C900D840FA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		771D79681D9E69C900D840FA /* Build configuration list for PBXNativeTarget "demo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				771D79691D9E69C900D840FA /* Debug */,
+				771D796A1D9E69C900D840FA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		77C503151DD3175E00AC8FF0 /* Build configuration list for PBXNativeTarget "today" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				77C503131DD3175E00AC8FF0 /* Debug */,
+				77C503141DD3175E00AC8FF0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 771D79491D9E69C900D840FA /* Project object */;
+}

--- a/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:demo.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -1,5 +1,5 @@
-require "simplecov"
-SimpleCov.start
+require "coveralls"
+Coveralls.wear! unless ENV["FASTLANE_SKIP_UPDATE_CHECK"]
 
 require "webmock/rspec"
 WebMock.disable_net_connect!(allow: 'coveralls.io')

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -1,5 +1,5 @@
-require "coveralls"
-Coveralls.wear! unless ENV["FASTLANE_SKIP_UPDATE_CHECK"]
+require "simplecov"
+SimpleCov.start
 
 require "webmock/rspec"
 WebMock.disable_net_connect!(allow: 'coveralls.io')


### PR DESCRIPTION
This PR integrates the `fastlane-plugin_update_project_codesigning`
for not breaking existing setups - we decided to change the name 👍 

cc @mathiasAichinger 🍻 🎉 🎈 

adds the following actions:
  * automatic_code_signing
  * enable_automatic_code_signing ( as alias )
  * disable_automatic_code_signing ( as alias ) 

TODO:
  - [x] add specs (the last 10% are calls to `self.description`, `self.details`, `self.example_code`, `self.return_value`, `self.authors` and `self.is_supported?(platform)` ) 
<img width="1159" alt="bildschirmfoto 2017-03-02 um 10 53 24" src="https://cloud.githubusercontent.com/assets/2891702/23502015/823e8b40-ff36-11e6-86bd-989065449dc1.png">

  - [x] update codesigning guide -> https://github.com/fastlane/docs/pull/297
  - [x] release plugin as new version, with deprecation note https://github.com/hjanuschka/fastlane-plugin-update_project_codesigning/pull/7
  - [x] send me some hugs, as i am loosing my most popular - most downloaded gem 😢 