### PR TITLE
[deliver] support JPG icons for metadata

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -189,16 +189,18 @@ module Deliver
                                      optional: true,
                                      short_option: "-l",
                                      verify_block: proc do |value|
+                                       supported_picture_endings = [".png", ".jpg", ".jpeg"]
                                        UI.user_error!("Could not find png file at path '#{File.expand_path(value)}'") unless File.exist?(value)
-                                       UI.user_error!("'#{value}' doesn't seem to be a png file") unless value.end_with?(".png")
+                                       UI.user_error!("'#{value}' doesn't seem to be one of the supported files. supported: #{supported_picture_endings.join(',')}") unless supported_picture_endings.include?(File.extname(value))
                                      end),
         FastlaneCore::ConfigItem.new(key: :apple_watch_app_icon,
                                      description: "Metadata: The path to the Apple Watch app icon",
                                      optional: true,
                                      short_option: "-q",
                                      verify_block: proc do |value|
+                                       supported_picture_endings = [".png", ".jpg", ".jpeg"]
                                        UI.user_error!("Could not find png file at path '#{File.expand_path(value)}'") unless File.exist?(value)
-                                       UI.user_error!("'#{value}' doesn't seem to be a png file") unless value.end_with?(".png")
+                                       UI.user_error!("'#{value}' doesn't seem to be a png file") unless supported_picture_endings.include?(File.extname(value))
                                      end),
         FastlaneCore::ConfigItem.new(key: :copyright,
                                      description: "Metadata: The copyright notice",

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -189,18 +189,16 @@ module Deliver
                                      optional: true,
                                      short_option: "-l",
                                      verify_block: proc do |value|
-                                       supported_picture_endings = [".png", ".jpg", ".jpeg"]
                                        UI.user_error!("Could not find png file at path '#{File.expand_path(value)}'") unless File.exist?(value)
-                                       UI.user_error!("'#{value}' doesn't seem to be one of the supported files. supported: #{supported_picture_endings.join(',')}") unless supported_picture_endings.include?(File.extname(value))
+                                       UI.user_error!("'#{value}' doesn't seem to be one of the supported files. supported: #{Deliver::UploadAssets::SUPPORTED_ICON_EXTENSIONS.join(',')}") unless Deliver::UploadAssets::SUPPORTED_ICON_EXTENSIONS.include?(File.extname(value).downcase)
                                      end),
         FastlaneCore::ConfigItem.new(key: :apple_watch_app_icon,
                                      description: "Metadata: The path to the Apple Watch app icon",
                                      optional: true,
                                      short_option: "-q",
                                      verify_block: proc do |value|
-                                       supported_picture_endings = [".png", ".jpg", ".jpeg"]
                                        UI.user_error!("Could not find png file at path '#{File.expand_path(value)}'") unless File.exist?(value)
-                                       UI.user_error!("'#{value}' doesn't seem to be a png file") unless supported_picture_endings.include?(File.extname(value))
+                                       UI.user_error!("'#{value}' doesn't seem to be one of the supported files. supported: #{Deliver::UploadAssets::SUPPORTED_ICON_EXTENSIONS.join(',')}") unless Deliver::UploadAssets::SUPPORTED_ICON_EXTENSIONS.include?(File.extname(value).downcase)
                                      end),
         FastlaneCore::ConfigItem.new(key: :copyright,
                                      description: "Metadata: The copyright notice",

--- a/deliver/lib/deliver/upload_assets.rb
+++ b/deliver/lib/deliver/upload_assets.rb
@@ -1,5 +1,6 @@
 module Deliver
   class UploadAssets
+    SUPPORTED_ICON_EXTENSIONS = [".png", ".jpg"]
     def upload(options)
       return if options[:edit_live]
       app = options[:app]

--- a/deliver/lib/deliver/upload_assets.rb
+++ b/deliver/lib/deliver/upload_assets.rb
@@ -1,6 +1,6 @@
 module Deliver
   class UploadAssets
-    SUPPORTED_ICON_EXTENSIONS = [".png", ".jpg"]
+    SUPPORTED_ICON_EXTENSIONS = [".png", ".jpg", ".jpeg"]
     def upload(options)
       return if options[:edit_live]
       app = options[:app]


### PR DESCRIPTION
itunes also supports JPG for app/watch icon in the store entry.

addresses: https://github.com/fastlane/fastlane/issues/8402, #8401