### PR TITLE
[core] display a more appropriate update message for mac app-installed fastlane

### DIFF
--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -81,6 +81,8 @@ module FastlaneCore
         "bundle update #{gem_name.downcase}"
       elsif Helper.contained_fastlane? || Helper.homebrew?
         "fastlane update_fastlane"
+      elsif Helper.mac_app?
+        "the Fabric app. Launch the app and navigate to the fastlane tab to get the most recent version."
       else
         "sudo gem update #{gem_name.downcase}"
       end

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -59,7 +59,7 @@ describe FastlaneCore do
         ENV["FASTLANE_SELF_CONTAINED"] = "true"
         expect(FastlaneCore::UpdateChecker.update_command).to eq("fastlane update_fastlane")
       end
-      
+
       with_env_values('FASTLANE_SELF_CONTAINED' => 'false') do
         expect(FastlaneCore::UpdateChecker.update_command).to eq("the Fabric app. Launch the app and navigate to the fastlane tab to get the most recent version.")
       end

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -60,8 +60,7 @@ describe FastlaneCore do
         expect(FastlaneCore::UpdateChecker.update_command).to eq("fastlane update_fastlane")
       end
       
-      it "works with Mac app-installed fastlane" do
-        ENV["FASTLANE_SELF_CONTAINED"] = "false"
+      with_env_values('FASTLANE_SELF_CONTAINED' => 'false') do
         expect(FastlaneCore::UpdateChecker.update_command).to eq("the Fabric app. Launch the app and navigate to the fastlane tab to get the most recent version.")
       end
     end

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -51,17 +51,21 @@ describe FastlaneCore do
       end
 
       it "works with bundler" do
-        ENV["BUNDLE_BIN_PATH"] = "/tmp"
-        expect(FastlaneCore::UpdateChecker.update_command).to eq("bundle update fastlane")
+        with_env_values('BUNDLE_BIN_PATH' => '/tmp') do
+          expect(FastlaneCore::UpdateChecker.update_command).to eq("bundle update fastlane")
+        end
       end
 
       it "works with bundled fastlane" do
-        ENV["FASTLANE_SELF_CONTAINED"] = "true"
-        expect(FastlaneCore::UpdateChecker.update_command).to eq("fastlane update_fastlane")
+        with_env_values('FASTLANE_SELF_CONTAINED' => 'true') do
+          expect(FastlaneCore::UpdateChecker.update_command).to eq("fastlane update_fastlane")
+        end
       end
 
-      with_env_values('FASTLANE_SELF_CONTAINED' => 'false') do
-        expect(FastlaneCore::UpdateChecker.update_command).to eq("the Fabric app. Launch the app and navigate to the fastlane tab to get the most recent version.")
+      it "works with Fabric.app installed fastlane" do
+        with_env_values('FASTLANE_SELF_CONTAINED' => 'false') do
+          expect(FastlaneCore::UpdateChecker.update_command).to eq("the Fabric app. Launch the app and navigate to the fastlane tab to get the most recent version.")
+        end
       end
     end
 

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -59,6 +59,11 @@ describe FastlaneCore do
         ENV["FASTLANE_SELF_CONTAINED"] = "true"
         expect(FastlaneCore::UpdateChecker.update_command).to eq("fastlane update_fastlane")
       end
+      
+      it "works with Mac app-installed fastlane" do
+        ENV["FASTLANE_SELF_CONTAINED"] = "false"
+        expect(FastlaneCore::UpdateChecker.update_command).to eq("the Fabric app. Launch the app and navigate to the fastlane tab to get the most recent version.")
+      end
     end
 
     describe "#p_hash?" do


### PR DESCRIPTION
Users who have installed _fastlane_ via the Fabric Mac app should be shown proper instructions for updates.