### PR TITLE
Collect logarchives for iOS 10.0 devices or later

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -224,7 +224,11 @@ module FastlaneCore
         logs_destination_dir = File.expand_path(logs_destination_dir)
         os_version = FastlaneCore::CommandExecutor.execute(command: 'sw_vers -productVersion', print_all: false, print_command: false)
 
-        if Gem::Version.new(os_version) >= Gem::Version.new('10.12.0')
+        host_computer_supports_logarchives = Gem::Version.new(os_version) >= Gem::Version.new('10.12.0')
+        device_supports_logarchives = Gem::Version.new(device.os_version) >= Gem::Version.new('10.0')
+
+        are_logarchives_supported = device_supports_logarchives && host_computer_supports_logarchives
+        if are_logarchives_supported
           copy_logarchive(device, log_identity, logs_destination_dir)
         else
           copy_logfile(device, log_identity, logs_destination_dir)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Changes how we collect logarchive bundles from the Simulator so that it only happens when supported. iOS 10.0 devices on macOS Sierra (10.12) support logarchives. iOS 9 devices do not support logarchives and macOS El Capitan (10.11) does not support logarchives.

### Motivation and Context

Trying to collect logarchives from an iOS 9 device on macOS 10.12 results in an error and no logs are provided to the `scan` and `snapshot` actions.
