### PR TITLE
Add "enterprise" reference to the match documentation

### DIFF
--- a/match/README.md
+++ b/match/README.md
@@ -250,6 +250,10 @@ match(git_url: "https://github.com/fastlane/fastlane/tree/master/certificates",
       type: "adhoc",
       app_identifier: "tools.fastlane.app")
 
+match(git_url: "https://github.com/fastlane/fastlane/tree/master/certificates",
+      type: "enterprise",
+      app_identifier: "tools.fastlane.app")
+
 # `match` should be called before building the app with `gym`
 gym
 ...

--- a/match/lib/assets/MatchfileTemplate
+++ b/match/lib/assets/MatchfileTemplate
@@ -1,6 +1,6 @@
 git_url "[[GIT_URL]]"
 
-type "development" # The default type, can be: appstore, adhoc or development
+type "development" # The default type, can be: appstore, adhoc, enterprise or development
 
 # app_identifier ["tools.fastlane.app", "tools.fastlane.app2"]
 # username "user@fastlane.tools" # Your Apple Developer Portal username

--- a/match/lib/assets/READMETemplate.md
+++ b/match/lib/assets/READMETemplate.md
@@ -47,6 +47,9 @@ fastlane match adhoc
 ```
 fastlane match development
 ```
+```
+fastlane match enterprise
+```
 
 For more information open [fastlane match git repo](https://github.com/fastlane/fastlane/tree/master/match#readme)
 

--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -31,7 +31,7 @@ module Match
 
         c.action do |args, options|
           if args.count > 0
-            FastlaneCore::UI.user_error!("Please run `fastlane match [type]`, allowed values: development, adhoc or appstore")
+            FastlaneCore::UI.user_error!("Please run `fastlane match [type]`, allowed values: development, adhoc, enterprise  or appstore")
           end
 
           params = FastlaneCore::Configuration.create(Match::Options.available_options, options.__hash__)
@@ -106,7 +106,7 @@ module Match
         c.syntax = "fastlane match nuke"
         c.description = "Delete all certificates and provisioning profiles from the Apple Dev Portal"
         c.action do |args, options|
-          FastlaneCore::UI.user_error!("Please run `fastlane match nuke [type], allowed values: distribution and development. For the 'adhoc' type, please use 'distribution' instead.")
+          FastlaneCore::UI.user_error!("Please run `fastlane match nuke [type], allowed values: distribution, enterprise and development. For the 'adhoc' type, please use 'distribution' instead.")
         end
       end
 

--- a/match/lib/match/setup.rb
+++ b/match/lib/match/setup.rb
@@ -11,7 +11,7 @@ module Match
       File.write(path, template)
       UI.success "Successfully created '#{path}'. You can open the file using a code editor."
 
-      UI.important "You can now run `fastlane match development`, `fastlane match adhoc` and `fastlane match appstore`"
+      UI.important "You can now run `fastlane match development`, `fastlane match adhoc`, `fastlane match enterprise` and `fastlane match appstore`"
       UI.message "On the first run for each environment it will create the provisioning profiles and"
       UI.message "certificates for you. From then on, it will automatically import the existing profiles."
       UI.message "For more information visit https://github.com/fastlane/fastlane/tree/master/match"


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
`match` can deal with certificates and provisioning profiles for
development, adhoc, appstore and inhouse builds.
In the `README.md` as well as the generated `MatchFile` no mention are
done about the `enterprise` type.

### Motivation and Context
The goal of this request is to facilitate `match`'s usage for enterprise
users by quickly showing them that this option exists and how to use it.