### PR TITLE
add 'remove_git_tag' action

### DIFF
--- a/fastlane/lib/fastlane/actions/remove_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/remove_git_tag.rb
@@ -68,9 +68,9 @@ module Fastlane
 
       def self.example_code
         [
-          'remove_git_tag(tag: "0.1.0"), # Delete both local tag and remote tag',
-          'remove_git_tag(tag: "0.1.0", remove_local: false), # Only delete remote tag',
-          'remove_git_tag(tag: "0.1.0", remove_remote: false), # 0nly delete local tag'
+          'remove_git_tag(tag: "0.1.0") # Delete both local tag and remote tag',
+          'remove_git_tag(tag: "0.1.0", remove_local: false) # Only delete remote tag',
+          'remove_git_tag(tag: "0.1.0", remove_remote: false) # Only delete local tag'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/remove_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/remove_git_tag.rb
@@ -1,0 +1,82 @@
+module Fastlane
+  module Actions
+    class RemoveGitTagAction < Action
+      def self.run(params)
+        command = []
+
+        target_tag = params[:tag]
+        remove_local = params[:remove_local]
+        remove_remote = params[:remove_remote]
+
+        command << "git tag -d #{target_tag}" if remove_local
+        command << "git push origin :#{target_tag}" if remove_remote
+
+        if command.empty?
+          UI.message('👉 If you really want to delete a tag, you should to set up remove_local and remove_remote at least one for true!')
+        else
+          result = command.join(' & ')
+          Actions.sh(result)
+          UI.message('Remove git tag Successfully! 🎉')
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Remove git tag'
+      end
+
+      def self.details
+        'Remove the local tag or remote tag for a git repertory'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :tag,
+                                       description: 'The tag to delete',
+                                       is_string: true,
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :remove_local,
+                                       description: 'If delete local tag',
+                                       is_string: false,
+                                       optional: true,
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :remove_remote,
+                                       description: 'If delete remote tag',
+                                       is_string: false,
+                                       optional: true,
+                                       default_value: true)
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.authors
+        ["ripperhe"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+
+      def self.example_code
+        [
+          'remove_git_tag(tag: "0.1.0"), # Delete both local tag and remote tag
+          remove_git_tag(tag: "0.1.0", remove_local: false), # Only delete remote tag
+          remove_git_tag(tag: "0.1.0", remove_remote: false), # 0nly delete local tag'
+        ]
+      end
+
+      def self.category
+        :source_control
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/remove_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/remove_git_tag.rb
@@ -68,9 +68,9 @@ module Fastlane
 
       def self.example_code
         [
-          'remove_git_tag(tag: "0.1.0"), # Delete both local tag and remote tag
-          remove_git_tag(tag: "0.1.0", remove_local: false), # Only delete remote tag
-          remove_git_tag(tag: "0.1.0", remove_remote: false), # 0nly delete local tag'
+          'remove_git_tag(tag: "0.1.0"), # Delete both local tag and remote tag',
+          'remove_git_tag(tag: "0.1.0", remove_local: false), # Only delete remote tag',
+          'remove_git_tag(tag: "0.1.0", remove_remote: false), # 0nly delete local tag'
         ]
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
I add a action for remove git tag, include local tag and remote tag.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We often need to automatically delete the wrong tag, but now there is no support for this action.

When I use Fastlane released pod lib, may to the final pod lint is not passed, but this time tag has added. If I modify the code and use fastlane released again, tag has been added, this time must be before the manual input command to delete tag, then perform fastlane to release pod lib.

If I have this action, I can directly execute fastlane to release pod lib.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
I have run it for delete local tag, delete remote tag, and delete both of them. The result is ok.


