### PR TITLE
Prefer supply action options over lane context

### DIFF
--- a/fastlane/lib/fastlane/actions/supply.rb
+++ b/fastlane/lib/fastlane/actions/supply.rb
@@ -5,11 +5,15 @@ module Fastlane
         require 'supply'
         require 'supply/options'
 
-        all_apk_paths = Actions.lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] || []
-        if all_apk_paths.length > 1
-          params[:apk_paths] ||= all_apk_paths
-        else
-          params[:apk] ||= Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
+        # If no APK params were provided, try to fill in the values from lane context, preferring
+        # the multiple APKs over the single APK if set.
+        if params[:apk_paths].nil? && params[:apk].nil?
+          all_apk_paths = Actions.lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] || []
+          if all_apk_paths.size > 1
+            params[:apk_paths] = all_apk_paths
+          else
+            params[:apk] = Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
+          end
         end
 
         Supply.config = params # we already have the finished config

--- a/fastlane/spec/actions_specs/supply_spec.rb
+++ b/fastlane/spec/actions_specs/supply_spec.rb
@@ -1,0 +1,118 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "supply" do
+      let(:apk_path) { "app/my.apk" }
+      let(:apk_paths) { ["app/my1.apk", "app/my2.apk"] }
+      let(:wrong_apk_paths) { ['wrong.apk', 'nope.apk'] }
+
+      before :each do
+        allow(File).to receive(:exist?).and_call_original
+        expect(Supply::Uploader).to receive_message_chain(:new, :perform_upload)
+      end
+
+      describe "single APK path handling" do
+        before :each do
+          allow(File).to receive(:exist?).with(apk_path).and_return(true)
+        end
+
+        it "uses a provided APK path" do
+          Fastlane::FastFile.new.parse("lane :test do
+            supply(apk: '#{apk_path}')
+          end").runner.execute(:test)
+
+          expect(Supply.config[:apk]).to eq(apk_path)
+          expect(Supply.config[:apk_paths]).to be_nil
+        end
+
+        it "uses the lane context APK path if no other APK info is present" do
+          with_action_context_values(Fastlane::Actions::SharedValues::GRADLE_APK_OUTPUT_PATH => apk_path) do
+            Fastlane::FastFile.new.parse("lane :test do
+              supply
+            end").runner.execute(:test)
+          end
+
+          expect(Supply.config[:apk]).to eq(apk_path)
+          expect(Supply.config[:apk_paths]).to be_nil
+        end
+
+        it "ignores the lane context APK path if the APK param is present" do
+          with_action_context_values(Fastlane::Actions::SharedValues::GRADLE_APK_OUTPUT_PATH => 'app/wrong.apk') do
+            Fastlane::FastFile.new.parse("lane :test do
+              supply(apk: '#{apk_path}')
+            end").runner.execute(:test)
+          end
+
+          expect(Supply.config[:apk]).to eq(apk_path)
+          expect(Supply.config[:apk_paths]).to be_nil
+        end
+
+        it "ignores the lane context APK paths if the APK param is present" do
+          wrong_apk_paths.each do |path|
+            allow(File).to receive(:exist?).with(path).and_return(true)
+          end
+
+          with_action_context_values(Fastlane::Actions::SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS => wrong_apk_paths) do
+            Fastlane::FastFile.new.parse("lane :test do
+              supply(apk: '#{apk_path}')
+            end").runner.execute(:test)
+          end
+
+          expect(Supply.config[:apk]).to eq(apk_path)
+          expect(Supply.config[:apk_paths]).to be_nil
+        end
+      end
+
+      describe "multiple APK path handling" do
+        before :each do
+          apk_paths.each do |path|
+            allow(File).to receive(:exist?).with(path).and_return(true)
+          end
+        end
+
+        it "uses the provided APK paths" do
+          Fastlane::FastFile.new.parse("lane :test do
+            supply(apk_paths: #{apk_paths})
+          end").runner.execute(:test)
+
+          expect(Supply.config[:apk]).to be_nil
+          expect(Supply.config[:apk_paths]).to eq(apk_paths)
+        end
+
+        it "uses the lane context APK paths if no other APK info is present" do
+          with_action_context_values(Fastlane::Actions::SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS => apk_paths) do
+            Fastlane::FastFile.new.parse("lane :test do
+              supply
+            end").runner.execute(:test)
+          end
+
+          expect(Supply.config[:apk]).to be_nil
+          expect(Supply.config[:apk_paths]).to eq(apk_paths)
+        end
+
+        it "ignores the lane context APK paths if the APK paths param is present" do
+          with_action_context_values(Fastlane::Actions::SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS => ['wrong.apk', 'nope.apk']) do
+            Fastlane::FastFile.new.parse("lane :test do
+              supply(apk_paths: #{apk_paths})
+            end").runner.execute(:test)
+          end
+
+          expect(Supply.config[:apk]).to be_nil
+          expect(Supply.config[:apk_paths]).to eq(apk_paths)
+        end
+
+        it "ignores the lane context APK path if the APK paths param is present" do
+          allow(File).to receive(:exist?).with('wrong.apk').and_return(true)
+
+          with_action_context_values(Fastlane::Actions::SharedValues::GRADLE_APK_OUTPUT_PATH => 'wrong.apk') do
+            Fastlane::FastFile.new.parse("lane :test do
+              supply(apk_paths: #{apk_paths})
+            end").runner.execute(:test)
+          end
+
+          expect(Supply.config[:apk]).to be_nil
+          expect(Supply.config[:apk_paths]).to eq(apk_paths)
+        end
+      end
+    end
+  end
+end

--- a/screengrab/spec/spec_helper.rb
+++ b/screengrab/spec/spec_helper.rb
@@ -3,16 +3,24 @@ require 'active_support/core_ext/string/strip'
 # Executes the provided block after adjusting the ENV to have the
 # provided keys and values set as defined in hash. After the block
 # completes, restores the ENV to its previous state.
-def with_env_values(hash)
-  old_vals = ENV.select { |k, v| hash.include?(k) }
+def with_env_values(hash, &block)
+  with_global_key_values(ENV, hash, &block)
+end
+
+def with_action_context_values(hash, &block)
+  with_global_key_values(Fastlane::Actions.lane_context, hash, &block)
+end
+
+def with_global_key_values(global_store, hash)
+  old_vals = global_store.select { |k, v| hash.include?(k) }
   hash.each do |k, v|
-    ENV[k] = hash[k]
+    global_store[k] = hash[k]
   end
   yield
 ensure
   hash.each do |k, v|
-    ENV.delete(k) unless old_vals.include?(k)
-    ENV[k] = old_vals[k]
+    global_store.delete(k) unless old_vals.include?(k)
+    global_store[k] = old_vals[k]
   end
 end
 


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description

Carry forward the work from #8256 while adding specs to prevent regressions.

### Motivation and Context

Avoid using APK paths from lane context when specific values were provided in the action options