### PR TITLE
Snapshot: fix #8432 (HTML report generation issue with iPhone SE)

### DIFF
--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -53,7 +53,7 @@ module Snapshot
         'iPhone6' => "iPhone6 (4.7-Inch)",
         'iPhone5' => "iPhone5 (4-Inch)",
         'iPhone4' => "iPhone4 (3.5-Inch)",
-        'iPhone SE' => "iPhone SE",
+        'iPhoneSE' => "iPhone SE",
         'iPad2' => "iPad2",
         'iPadAir2' => 'iPad Air 2',
         'iPadPro(12.9-inch)' => 'iPad Air Pro (12.9 inch)',


### PR DESCRIPTION


### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
This PR fix #8432.

For the HTML report generation in snapshot, we are looking for “iPhone SE” files (with a space), but snapshots generated “iPhoneSE” files (without space). So, iPhone SE screenshots are not displayed in the report.

I just edited `available_devices` value for `iPhoneSE`. After some researches, it seems that there is no side effect.