### PR TITLE
Test ReportsGenerator available_devices

### DIFF
--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -38,8 +38,6 @@ module Snapshot
       system("open '#{export_path}'") unless Snapshot.config[:skip_open_summary]
     end
 
-    private
-
     def available_devices
       # The order IS important, since those names are used to check for include?
       # and the iPhone 6 is inlucded in the iPhone 6 Plus
@@ -60,7 +58,7 @@ module Snapshot
         'iPadPro(9.7-inch)' => 'iPad Air Pro (9.7 inch)',
         'iPadPro(9.7inch)' => "iPad Pro (9.7 inch)",
         'iPadPro(12.9inch)' => "iPad Pro (12.9 inch)",
-        'iPad Pro' => "iPad Pro",
+        'iPadPro' => "iPad Pro",
         'iPad' => "iPad",
         'Mac' => "Mac"
       }

--- a/snapshot/spec/reports_generator_spec.rb
+++ b/snapshot/spec/reports_generator_spec.rb
@@ -1,0 +1,12 @@
+require 'snapshot/reports_generator'
+
+describe Snapshot::ReportsGenerator do
+  describe '#available_devices' do
+    # the Collector generates file names that remove all spaces from the device names, so
+    # any keys here can't contain spaces
+    it "doesn't have keys that contain spaces" do
+      device_name_keys = Snapshot::ReportsGenerator.new.available_devices.keys
+      expect(device_name_keys.none? { |k| k.include?(' ') }).to be(true)
+    end
+  end
+end


### PR DESCRIPTION




<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description

Since the `Collector` creates file names where the device names are stripped of any spaces we should give ourselves a safety check on `available_devices` that ensures that we don't introduce keys with spaces in the future.

### Motivation and Context

#8432 discovered a mistake with the device name key for the iPhone SE in `ReportsGenerator`