### PR TITLE
Version bump to 2.19.2

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.19.1'.freeze
+  VERSION = '2.19.2'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.19.1':**

* Test ReportsGenerator available_devices (#8451)
* Snapshot: fix #8432For the HTML report generation, we are looking for “iPhone SE” files (with a space), but snapshots generated “iPhoneSE” files (without space) (#8449)
* Prefer supply options over lane context (#8445)
* fix right rounded corner - and beautify svg (#8447)
* collect logarchives for iOS 10.0 devices or later (#8433)
* update author emails for screengrab (#8436)
* Add missing header (#8415)
* add mac app installation row to env table (#8425)
* Sigh allows members to download their own certs and  doesn't error out if the user does not have enough permissions to download certificate (#8394)
* Expand file path when notes_path was passed (#8416)
* updated xcov initialization (#8400)
