### PR TITLE
Force binary reading/writing when analyzing IPAs

### DIFF
--- a/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
@@ -28,7 +28,7 @@ module FastlaneCore
 
     def self.fetch_info_plist_file(path)
       UI.user_error!("Could not find file at path '#{path}'") unless File.exist?(path)
-      Zip::File.open(path) do |zipfile|
+      Zip::File.open(path, "rb") do |zipfile|
         file = zipfile.glob('**/Payload/*.app/Info.plist').first
         return nil unless file
 
@@ -37,7 +37,9 @@ module FastlaneCore
         Dir.mktmpdir("fastlane") do |tmp|
           # The XML file has to be properly unpacked first
           tmp_path = File.join(tmp, "Info.plist")
-          File.write(tmp_path, zipfile.read(file))
+          File.open(tmp_path, 'wb') do |output|
+            output.write zipfile.read(file)
+          end
           system("plutil -convert xml1 #{tmp_path}")
           result = Plist.parse_xml(tmp_path)
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Force binary reading/writing when analyzing IPAs

### Motivation and Context
This is a PR to work-around #8245

We keep having weird UTF issues. It looks better in some cases to be a bit more pro-active and avoid string encoding when not necessary.

It was tested by the user facing the issue.