### PR TITLE
Fix regression with delete_keychain(name:)

### DIFF
--- a/fastlane/lib/fastlane/actions/delete_keychain.rb
+++ b/fastlane/lib/fastlane/actions/delete_keychain.rb
@@ -18,7 +18,7 @@ module Fastlane
         keychain_path = search_paths.find { |path| File.exist?(path) }
 
         if keychain_path.nil?
-          UI.user_error!("Unable to find the specified keychain. Looked in:\n\t" + search_paths.join("\n\t") )
+          UI.user_error!("Unable to find the specified keychain. Looked in:\n\t" + search_paths.join("\n\t"))
         end
 
         Fastlane::Actions.sh("security default-keychain -s #{original}", log: false) unless original.nil?

--- a/fastlane/spec/actions_specs/delete_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/delete_keychain_spec.rb
@@ -1,7 +1,28 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Delete keychain Integration" do
-      it "works with keychain name" do
+      before :each do
+        allow(File).to receive(:exist?).and_return(false)
+      end
+
+      it "works with keychain name found locally" do
+        allow(File).to receive(:exist?).with(/test.keychain/).and_return(true)
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          delete_keychain ({
+            name: 'test.keychain'
+          })
+        end").runner.execute(:test)
+
+        keychain = File.expand_path('test.keychain')
+
+        expect(result).to eq("security delete-keychain #{keychain}")
+      end
+
+      it "works with keychain name found in ~/Library/Keychains" do
+        allow(File).to receive(:exist?).with(/test.keychain/).and_return(false)
+        allow(File).to receive(:exist?).with(/Library\/Keychains\/test.keychain/).and_return(true)
+
         result = Fastlane::FastFile.new.parse("lane :test do
           delete_keychain ({
             name: 'test.keychain'
@@ -14,18 +35,22 @@ describe Fastlane do
       end
 
       it "works with keychain name that contain spaces and `\"`" do
+        allow(File).to receive(:exist?).with(/\" test \".keychain/).and_return(true)
+
         result = Fastlane::FastFile.new.parse("lane :test do
           delete_keychain ({
             name: '\" test \".keychain'
           })
         end").runner.execute(:test)
 
-        keychain = File.expand_path(%(~/Library/Keychains/\\\"\\ test\\ \\\".keychain))
+        keychain = File.expand_path('\\"\\ test\\ \\".keychain')
 
         expect(result).to eq %(security delete-keychain #{keychain})
       end
 
       it "works with absolute keychain path" do
+        allow(File).to receive(:exist?).with('/projects/test.keychain').and_return(true)
+
         result = Fastlane::FastFile.new.parse("lane :test do
           delete_keychain ({
             keychain_path: '/projects/test.keychain'
@@ -33,6 +58,20 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result).to eq("security delete-keychain /projects/test.keychain")
+      end
+
+      it "shows an error message if the keychain can't be found" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            delete_keychain ({
+              name: 'test.keychain'
+            })
+          end").runner.execute(:test)
+        end.to raise_error(
+          "Unable to find the specified keychain. Looked in:" +
+          "\n\t#{File.expand_path('test.keychain')}" +
+          "\n\t#{File.expand_path('~/Library/Keychains/test.keychain')}"
+        )
       end
     end
   end

--- a/fastlane/spec/actions_specs/delete_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/delete_keychain_spec.rb
@@ -73,6 +73,14 @@ describe Fastlane do
           "\n\t#{File.expand_path('~/Library/Keychains/test.keychain')}"
         )
       end
+
+      it "shows an error message if neither :name nor :keychain_path is given" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            delete_keychain
+          end").runner.execute(:test)
+        end.to raise_error('You either have to set :name or :keychain_path')
+      end
     end
   end
 end

--- a/fastlane/spec/actions_specs/delete_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/delete_keychain_spec.rb
@@ -21,7 +21,7 @@ describe Fastlane do
 
       it "works with keychain name found in ~/Library/Keychains" do
         allow(File).to receive(:exist?).with(/test.keychain/).and_return(false)
-        allow(File).to receive(:exist?).with(/Library\/Keychains\/test.keychain/).and_return(true)
+        allow(File).to receive(:exist?).with(%r{Library/Keychains/test.keychain}).and_return(true)
 
         result = Fastlane::FastFile.new.parse("lane :test do
           delete_keychain ({
@@ -68,8 +68,8 @@ describe Fastlane do
             })
           end").runner.execute(:test)
         end.to raise_error(
-          "Unable to find the specified keychain. Looked in:" +
-          "\n\t#{File.expand_path('test.keychain')}" +
+          "Unable to find the specified keychain. Looked in:" \
+          "\n\t#{File.expand_path('test.keychain')}" \
           "\n\t#{File.expand_path('~/Library/Keychains/test.keychain')}"
         )
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

This attempts to allow both the `:name` and `:keychain_path` style calls to work.

### Motivation and Context

#8003 introduced a regression for some users that were already using `delete_keychain` with a `:name` that was a fully-qualified path.
