### PR TITLE
Add macOS support to snapshot

### DIFF
--- a/fastlane/lib/fastlane/actions/snapshot.rb
+++ b/fastlane/lib/fastlane/actions/snapshot.rb
@@ -33,7 +33,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include? platform
       end
 
       def self.example_code

--- a/snapshot/example/Example.xcodeproj/project.pbxproj
+++ b/snapshot/example/Example.xcodeproj/project.pbxproj
@@ -23,6 +23,11 @@
 		CA0BF1721A1117FD007D51BE /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CA0BF1711A1117FD007D51BE /* Images.xcassets */; };
 		CA0BF1751A1117FD007D51BE /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = CA0BF1731A1117FD007D51BE /* LaunchScreen.xib */; };
 		CAF3CF3B1B33E9AB006CEDE9 /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF3CF3A1B33E9AB006CEDE9 /* ExampleUITests.swift */; };
+		DB6ADD7F1E30E65E0031038C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6ADD7E1E30E65E0031038C /* AppDelegate.swift */; };
+		DB6ADD811E30E65E0031038C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DB6ADD801E30E65E0031038C /* Assets.xcassets */; };
+		DB6ADD841E30E65E0031038C /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = DB6ADD821E30E65E0031038C /* MainMenu.xib */; };
+		DB6ADD8F1E30E65E0031038C /* ExampleMacOSUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6ADD8E1E30E65E0031038C /* ExampleMacOSUITests.swift */; };
+		DB6ADD971E30E68E0031038C /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D49E121BC805AC00C47C4F /* SnapshotHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,6 +44,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = CA0BF15D1A1117FD007D51BE;
 			remoteInfo = Example;
+		};
+		DB6ADD8B1E30E65E0031038C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CA0BF1561A1117FD007D51BE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DB6ADD7B1E30E65E0031038C;
+			remoteInfo = ExampleMacOS;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -75,6 +87,14 @@
 		CAF3CF381B33E9AB006CEDE9 /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAF3CF3A1B33E9AB006CEDE9 /* ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITests.swift; sourceTree = "<group>"; };
 		CAF3CF3C1B33E9AB006CEDE9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DB6ADD7C1E30E65E0031038C /* ExampleMacOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleMacOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DB6ADD7E1E30E65E0031038C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		DB6ADD801E30E65E0031038C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		DB6ADD831E30E65E0031038C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		DB6ADD851E30E65E0031038C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DB6ADD8A1E30E65E0031038C /* ExampleMacOSUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleMacOSUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DB6ADD8E1E30E65E0031038C /* ExampleMacOSUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleMacOSUITests.swift; sourceTree = "<group>"; };
+		DB6ADD901E30E65E0031038C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -100,6 +120,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		CAF3CF351B33E9AB006CEDE9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DB6ADD791E30E65E0031038C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DB6ADD871E30E65E0031038C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -148,6 +182,8 @@
 				CAF3CF391B33E9AB006CEDE9 /* ExampleUITests */,
 				2FE467541D5A605000E9FF83 /* ExampleTV */,
 				2FE4677A1D5A608A00E9FF83 /* ExampleTVUITests */,
+				DB6ADD7D1E30E65E0031038C /* ExampleMacOS */,
+				DB6ADD8D1E30E65E0031038C /* ExampleMacOSUITests */,
 				CA0BF15F1A1117FD007D51BE /* Products */,
 			);
 			sourceTree = "<group>";
@@ -159,6 +195,8 @@
 				CAF3CF381B33E9AB006CEDE9 /* ExampleUITests.xctest */,
 				2FE467531D5A605000E9FF83 /* ExampleTV.app */,
 				2FE467791D5A608A00E9FF83 /* ExampleTVUITests.xctest */,
+				DB6ADD7C1E30E65E0031038C /* ExampleMacOS.app */,
+				DB6ADD8A1E30E65E0031038C /* ExampleMacOSUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -197,6 +235,26 @@
 				CAF3CF3C1B33E9AB006CEDE9 /* Info.plist */,
 			);
 			path = ExampleUITests;
+			sourceTree = "<group>";
+		};
+		DB6ADD7D1E30E65E0031038C /* ExampleMacOS */ = {
+			isa = PBXGroup;
+			children = (
+				DB6ADD7E1E30E65E0031038C /* AppDelegate.swift */,
+				DB6ADD801E30E65E0031038C /* Assets.xcassets */,
+				DB6ADD821E30E65E0031038C /* MainMenu.xib */,
+				DB6ADD851E30E65E0031038C /* Info.plist */,
+			);
+			path = ExampleMacOS;
+			sourceTree = "<group>";
+		};
+		DB6ADD8D1E30E65E0031038C /* ExampleMacOSUITests */ = {
+			isa = PBXGroup;
+			children = (
+				DB6ADD8E1E30E65E0031038C /* ExampleMacOSUITests.swift */,
+				DB6ADD901E30E65E0031038C /* Info.plist */,
+			);
+			path = ExampleMacOSUITests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -272,13 +330,48 @@
 			productReference = CAF3CF381B33E9AB006CEDE9 /* ExampleUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		DB6ADD7B1E30E65E0031038C /* ExampleMacOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DB6ADD951E30E65E0031038C /* Build configuration list for PBXNativeTarget "ExampleMacOS" */;
+			buildPhases = (
+				DB6ADD781E30E65E0031038C /* Sources */,
+				DB6ADD791E30E65E0031038C /* Frameworks */,
+				DB6ADD7A1E30E65E0031038C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ExampleMacOS;
+			productName = ExampleMacOS;
+			productReference = DB6ADD7C1E30E65E0031038C /* ExampleMacOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		DB6ADD891E30E65E0031038C /* ExampleMacOSUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DB6ADD961E30E65E0031038C /* Build configuration list for PBXNativeTarget "ExampleMacOSUITests" */;
+			buildPhases = (
+				DB6ADD861E30E65E0031038C /* Sources */,
+				DB6ADD871E30E65E0031038C /* Frameworks */,
+				DB6ADD881E30E65E0031038C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DB6ADD8C1E30E65E0031038C /* PBXTargetDependency */,
+			);
+			name = ExampleMacOSUITests;
+			productName = ExampleMacOSUITests;
+			productReference = DB6ADD8A1E30E65E0031038C /* ExampleMacOSUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		CA0BF1561A1117FD007D51BE /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0730;
+				LastSwiftUpdateCheck = 0820;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "Felix Krause";
 				TargetAttributes = {
@@ -297,6 +390,15 @@
 						CreatedOnToolsVersion = 7.0;
 						LastSwiftMigration = 0800;
 						TestTargetID = CA0BF15D1A1117FD007D51BE;
+					};
+					DB6ADD7B1E30E65E0031038C = {
+						CreatedOnToolsVersion = 8.2.1;
+						ProvisioningStyle = Automatic;
+					};
+					DB6ADD891E30E65E0031038C = {
+						CreatedOnToolsVersion = 8.2.1;
+						ProvisioningStyle = Automatic;
+						TestTargetID = DB6ADD7B1E30E65E0031038C;
 					};
 				};
 			};
@@ -317,6 +419,8 @@
 				CAF3CF371B33E9AB006CEDE9 /* ExampleUITests */,
 				2FE467521D5A605000E9FF83 /* ExampleTV */,
 				2FE467781D5A608A00E9FF83 /* ExampleTVUITests */,
+				DB6ADD7B1E30E65E0031038C /* ExampleMacOS */,
+				DB6ADD891E30E65E0031038C /* ExampleMacOSUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -349,6 +453,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		CAF3CF361B33E9AB006CEDE9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DB6ADD7A1E30E65E0031038C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DB6ADD811E30E65E0031038C /* Assets.xcassets in Resources */,
+				DB6ADD841E30E65E0031038C /* MainMenu.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DB6ADD881E30E65E0031038C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -397,6 +517,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DB6ADD781E30E65E0031038C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DB6ADD7F1E30E65E0031038C /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DB6ADD861E30E65E0031038C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DB6ADD8F1E30E65E0031038C /* ExampleMacOSUITests.swift in Sources */,
+				DB6ADD971E30E68E0031038C /* SnapshotHelper.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -409,6 +546,11 @@
 			isa = PBXTargetDependency;
 			target = CA0BF15D1A1117FD007D51BE /* Example */;
 			targetProxy = CAF3CF3D1B33E9AB006CEDE9 /* PBXContainerItemProxy */;
+		};
+		DB6ADD8C1E30E65E0031038C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DB6ADD7B1E30E65E0031038C /* ExampleMacOS */;
+			targetProxy = DB6ADD8B1E30E65E0031038C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -439,6 +581,14 @@
 				CA0BF18D1A111828007D51BE /* it */,
 			);
 			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+		DB6ADD821E30E65E0031038C /* MainMenu.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				DB6ADD831E30E65E0031038C /* Base */,
+			);
+			name = MainMenu.xib;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
@@ -652,6 +802,106 @@
 			};
 			name = Release;
 		};
+		DB6ADD911E30E65E0031038C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = ExampleMacOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = at.felixkrause.ExampleMacOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		DB6ADD921E30E65E0031038C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = ExampleMacOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = at.felixkrause.ExampleMacOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+		DB6ADD931E30E65E0031038C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = ExampleMacOSUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = at.felixkrause.ExampleMacOSUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TEST_TARGET_NAME = ExampleMacOS;
+			};
+			name = Debug;
+		};
+		DB6ADD941E30E65E0031038C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = ExampleMacOSUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = at.felixkrause.ExampleMacOSUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TEST_TARGET_NAME = ExampleMacOS;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -699,6 +949,22 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		DB6ADD951E30E65E0031038C /* Build configuration list for PBXNativeTarget "ExampleMacOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DB6ADD911E30E65E0031038C /* Debug */,
+				DB6ADD921E30E65E0031038C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		DB6ADD961E30E65E0031038C /* Build configuration list for PBXNativeTarget "ExampleMacOSUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DB6ADD931E30E65E0031038C /* Debug */,
+				DB6ADD941E30E65E0031038C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/snapshot/example/Example.xcodeproj/xcshareddata/xcschemes/ExampleMacOS.xcscheme
+++ b/snapshot/example/Example.xcodeproj/xcshareddata/xcschemes/ExampleMacOS.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DB6ADD7B1E30E65E0031038C"
+               BuildableName = "ExampleMacOS.app"
+               BlueprintName = "ExampleMacOS"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DB6ADD891E30E65E0031038C"
+               BuildableName = "ExampleMacOSUITests.xctest"
+               BlueprintName = "ExampleMacOSUITests"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DB6ADD7B1E30E65E0031038C"
+            BuildableName = "ExampleMacOS.app"
+            BlueprintName = "ExampleMacOS"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DB6ADD7B1E30E65E0031038C"
+            BuildableName = "ExampleMacOS.app"
+            BlueprintName = "ExampleMacOS"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DB6ADD7B1E30E65E0031038C"
+            BuildableName = "ExampleMacOS.app"
+            BlueprintName = "ExampleMacOS"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/snapshot/example/ExampleMacOS/AppDelegate.swift
+++ b/snapshot/example/ExampleMacOS/AppDelegate.swift
@@ -1,0 +1,27 @@
+//
+//  AppDelegate.swift
+//  ExampleMacOS
+//
+//  Created by Alexander Semenov on 1/19/17.
+//  Copyright © 2017 Felix Krause. All rights reserved.
+//
+
+import Cocoa
+
+@NSApplicationMain
+class AppDelegate: NSObject, NSApplicationDelegate {
+
+    @IBOutlet weak var window: NSWindow!
+
+
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
+        // Insert code here to initialize your application
+    }
+
+    func applicationWillTerminate(_ aNotification: Notification) {
+        // Insert code here to tear down your application
+    }
+
+
+}
+

--- a/snapshot/example/ExampleMacOS/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/snapshot/example/ExampleMacOS/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/snapshot/example/ExampleMacOS/Base.lproj/MainMenu.xib
+++ b/snapshot/example/ExampleMacOS/Base.lproj/MainMenu.xib
@@ -1,0 +1,692 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11134"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
+            <connections>
+                <outlet property="delegate" destination="Voe-Tx-rLC" id="GzC-gU-4Uq"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModuleProvider="target">
+            <connections>
+                <outlet property="window" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
+            </connections>
+        </customObject>
+        <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
+        <menu title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+            <items>
+                <menuItem title="ExampleMacOS" id="1Xt-HY-uBw">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="ExampleMacOS" systemMenu="apple" id="uQy-DD-JDr">
+                        <items>
+                            <menuItem title="About ExampleMacOS" id="5kV-Vb-QxS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="orderFrontStandardAboutPanel:" target="-1" id="Exp-CZ-Vem"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                            <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                            <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
+                            <menuItem title="Services" id="NMo-om-nkz">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
+                            <menuItem title="Hide ExampleMacOS" keyEquivalent="h" id="Olw-nP-bQN">
+                                <connections>
+                                    <action selector="hide:" target="-1" id="PnN-Uc-m68"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="hideOtherApplications:" target="-1" id="VT4-aY-XCT"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Show All" id="Kd2-mp-pUS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="unhideAllApplications:" target="-1" id="Dhg-Le-xox"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                            <menuItem title="Quit ExampleMacOS" keyEquivalent="q" id="4sb-4s-VLi">
+                                <connections>
+                                    <action selector="terminate:" target="-1" id="Te7-pn-YzF"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="File" id="dMs-cI-mzQ">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="File" id="bib-Uj-vzu">
+                        <items>
+                            <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
+                                <connections>
+                                    <action selector="newDocument:" target="-1" id="4Si-XN-c54"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
+                                <connections>
+                                    <action selector="openDocument:" target="-1" id="bVn-NM-KNZ"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Open Recent" id="tXI-mr-wws">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
+                                    <items>
+                                        <menuItem title="Clear Menu" id="vNY-rz-j42">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="clearRecentDocuments:" target="-1" id="Daa-9d-B3U"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
+                            <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                <connections>
+                                    <action selector="performClose:" target="-1" id="HmO-Ls-i7Q"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
+                                <connections>
+                                    <action selector="saveDocument:" target="-1" id="teZ-XB-qJY"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                                <connections>
+                                    <action selector="saveDocumentAs:" target="-1" id="mDf-zr-I0C"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Revert to Saved" keyEquivalent="r" id="KaW-ft-85H">
+                                <connections>
+                                    <action selector="revertDocumentToSaved:" target="-1" id="iJ3-Pv-kwq"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
+                            <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                <connections>
+                                    <action selector="runPageLayout:" target="-1" id="Din-rz-gC5"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Print…" keyEquivalent="p" id="aTl-1u-JFS">
+                                <connections>
+                                    <action selector="print:" target="-1" id="qaZ-4w-aoO"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Edit" id="5QF-Oa-p0T">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Edit" id="W48-6f-4Dl">
+                        <items>
+                            <menuItem title="Undo" keyEquivalent="z" id="dRJ-4n-Yzg">
+                                <connections>
+                                    <action selector="undo:" target="-1" id="M6e-cu-g7V"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Redo" keyEquivalent="Z" id="6dh-zS-Vam">
+                                <connections>
+                                    <action selector="redo:" target="-1" id="oIA-Rs-6OD"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="WRV-NI-Exz"/>
+                            <menuItem title="Cut" keyEquivalent="x" id="uRl-iY-unG">
+                                <connections>
+                                    <action selector="cut:" target="-1" id="YJe-68-I9s"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Copy" keyEquivalent="c" id="x3v-GG-iWU">
+                                <connections>
+                                    <action selector="copy:" target="-1" id="G1f-GL-Joy"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
+                                <connections>
+                                    <action selector="paste:" target="-1" id="UvS-8e-Qdg"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Paste and Match Style" keyEquivalent="V" id="WeT-3V-zwk">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="pasteAsPlainText:" target="-1" id="cEh-KX-wJQ"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Delete" id="pa3-QI-u2k">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="delete:" target="-1" id="0Mk-Ml-PaM"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Select All" keyEquivalent="a" id="Ruw-6m-B2m">
+                                <connections>
+                                    <action selector="selectAll:" target="-1" id="VNm-Mi-diN"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="uyl-h8-XO2"/>
+                            <menuItem title="Find" id="4EN-yA-p0u">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Find" id="1b7-l0-nxx">
+                                    <items>
+                                        <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
+                                            <connections>
+                                                <action selector="performFindPanelAction:" target="-1" id="cD7-Qs-BN4"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="performFindPanelAction:" target="-1" id="WD3-Gg-5AJ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
+                                            <connections>
+                                                <action selector="performFindPanelAction:" target="-1" id="NDo-RZ-v9R"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
+                                            <connections>
+                                                <action selector="performFindPanelAction:" target="-1" id="HOh-sY-3ay"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
+                                            <connections>
+                                                <action selector="performFindPanelAction:" target="-1" id="U76-nv-p5D"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
+                                            <connections>
+                                                <action selector="centerSelectionInVisibleArea:" target="-1" id="IOG-6D-g5B"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Spelling and Grammar" id="Dv1-io-Yv7">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Spelling" id="3IN-sU-3Bg">
+                                    <items>
+                                        <menuItem title="Show Spelling and Grammar" keyEquivalent=":" id="HFo-cy-zxI">
+                                            <connections>
+                                                <action selector="showGuessPanel:" target="-1" id="vFj-Ks-hy3"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Check Document Now" keyEquivalent=";" id="hz2-CU-CR7">
+                                            <connections>
+                                                <action selector="checkSpelling:" target="-1" id="fz7-VC-reM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="bNw-od-mp5"/>
+                                        <menuItem title="Check Spelling While Typing" id="rbD-Rh-wIN">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleContinuousSpellChecking:" target="-1" id="7w6-Qz-0kB"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Check Grammar With Spelling" id="mK6-2p-4JG">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleGrammarChecking:" target="-1" id="muD-Qn-j4w"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Correct Spelling Automatically" id="78Y-hA-62v">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleAutomaticSpellingCorrection:" target="-1" id="2lM-Qi-WAP"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Substitutions" id="9ic-FL-obx">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Substitutions" id="FeM-D8-WVr">
+                                    <items>
+                                        <menuItem title="Show Substitutions" id="z6F-FW-3nz">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="orderFrontSubstitutionsPanel:" target="-1" id="oku-mr-iSq"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="gPx-C9-uUO"/>
+                                        <menuItem title="Smart Copy/Paste" id="9yt-4B-nSM">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleSmartInsertDelete:" target="-1" id="3IJ-Se-DZD"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Smart Quotes" id="hQb-2v-fYv">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleAutomaticQuoteSubstitution:" target="-1" id="ptq-xd-QOA"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Smart Dashes" id="rgM-f4-ycn">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleAutomaticDashSubstitution:" target="-1" id="oCt-pO-9gS"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Smart Links" id="cwL-P1-jid">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleAutomaticLinkDetection:" target="-1" id="Gip-E3-Fov"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Data Detectors" id="tRr-pd-1PS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleAutomaticDataDetection:" target="-1" id="R1I-Nq-Kbl"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Text Replacement" id="HFQ-gK-NFA">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleAutomaticTextReplacement:" target="-1" id="DvP-Fe-Py6"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Transformations" id="2oI-Rn-ZJC">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Transformations" id="c8a-y6-VQd">
+                                    <items>
+                                        <menuItem title="Make Upper Case" id="vmV-6d-7jI">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="uppercaseWord:" target="-1" id="sPh-Tk-edu"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Make Lower Case" id="d9M-CD-aMd">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="lowercaseWord:" target="-1" id="iUZ-b5-hil"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Capitalize" id="UEZ-Bs-lqG">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="capitalizeWord:" target="-1" id="26H-TL-nsh"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Speech" id="xrE-MZ-jX0">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Speech" id="3rS-ZA-NoH">
+                                    <items>
+                                        <menuItem title="Start Speaking" id="Ynk-f8-cLZ">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="startSpeaking:" target="-1" id="654-Ng-kyl"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Stop Speaking" id="Oyz-dy-DGm">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="stopSpeaking:" target="-1" id="dX8-6p-jy9"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Format" id="jxT-CU-nIS">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Format" id="GEO-Iw-cKr">
+                        <items>
+                            <menuItem title="Font" id="Gi5-1S-RQB">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Font" systemMenu="font" id="aXa-aM-Jaq">
+                                    <items>
+                                        <menuItem title="Show Fonts" keyEquivalent="t" id="Q5e-8K-NDq">
+                                            <connections>
+                                                <action selector="orderFrontFontPanel:" target="YLy-65-1bz" id="WHr-nq-2xA"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Bold" tag="2" keyEquivalent="b" id="GB9-OM-e27">
+                                            <connections>
+                                                <action selector="addFontTrait:" target="YLy-65-1bz" id="hqk-hr-sYV"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Italic" tag="1" keyEquivalent="i" id="Vjx-xi-njq">
+                                            <connections>
+                                                <action selector="addFontTrait:" target="YLy-65-1bz" id="IHV-OB-c03"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Underline" keyEquivalent="u" id="WRG-CD-K1S">
+                                            <connections>
+                                                <action selector="underline:" target="-1" id="FYS-2b-JAY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="5gT-KC-WSO"/>
+                                        <menuItem title="Bigger" tag="3" keyEquivalent="+" id="Ptp-SP-VEL">
+                                            <connections>
+                                                <action selector="modifyFont:" target="YLy-65-1bz" id="Uc7-di-UnL"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Smaller" tag="4" keyEquivalent="-" id="i1d-Er-qST">
+                                            <connections>
+                                                <action selector="modifyFont:" target="YLy-65-1bz" id="HcX-Lf-eNd"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>
+                                        <menuItem title="Kern" id="jBQ-r6-VK2">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Kern" id="tlD-Oa-oAM">
+                                                <items>
+                                                    <menuItem title="Use Default" id="GUa-eO-cwY">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="useStandardKerning:" target="-1" id="6dk-9l-Ckg"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use None" id="cDB-IK-hbR">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="turnOffKerning:" target="-1" id="U8a-gz-Maa"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Tighten" id="46P-cB-AYj">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="tightenKerning:" target="-1" id="hr7-Nz-8ro"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Loosen" id="ogc-rX-tC1">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="loosenKerning:" target="-1" id="8i4-f9-FKE"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Ligatures" id="o6e-r0-MWq">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Ligatures" id="w0m-vy-SC9">
+                                                <items>
+                                                    <menuItem title="Use Default" id="agt-UL-0e3">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="useStandardLigatures:" target="-1" id="7uR-wd-Dx6"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use None" id="J7y-lM-qPV">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="turnOffLigatures:" target="-1" id="iX2-gA-Ilz"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use All" id="xQD-1f-W4t">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="useAllLigatures:" target="-1" id="KcB-kA-TuK"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Baseline" id="OaQ-X3-Vso">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Baseline" id="ijk-EB-dga">
+                                                <items>
+                                                    <menuItem title="Use Default" id="3Om-Ey-2VK">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="unscript:" target="-1" id="0vZ-95-Ywn"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Superscript" id="Rqc-34-cIF">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="superscript:" target="-1" id="3qV-fo-wpU"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Subscript" id="I0S-gh-46l">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="subscript:" target="-1" id="Q6W-4W-IGz"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Raise" id="2h7-ER-AoG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="raiseBaseline:" target="-1" id="4sk-31-7Q9"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Lower" id="1tx-W0-xDw">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="lowerBaseline:" target="-1" id="OF1-bc-KW4"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="Ndw-q3-faq"/>
+                                        <menuItem title="Show Colors" keyEquivalent="C" id="bgn-CT-cEk">
+                                            <connections>
+                                                <action selector="orderFrontColorPanel:" target="-1" id="mSX-Xz-DV3"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="iMs-zA-UFJ"/>
+                                        <menuItem title="Copy Style" keyEquivalent="c" id="5Vv-lz-BsD">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="copyFont:" target="-1" id="GJO-xA-L4q"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste Style" keyEquivalent="v" id="vKC-jM-MkH">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="pasteFont:" target="-1" id="JfD-CL-leO"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Text" id="Fal-I4-PZk">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Text" id="d9c-me-L2H">
+                                    <items>
+                                        <menuItem title="Align Left" keyEquivalent="{" id="ZM1-6Q-yy1">
+                                            <connections>
+                                                <action selector="alignLeft:" target="-1" id="zUv-R1-uAa"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Center" keyEquivalent="|" id="VIY-Ag-zcb">
+                                            <connections>
+                                                <action selector="alignCenter:" target="-1" id="spX-mk-kcS"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Justify" id="J5U-5w-g23">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="alignJustified:" target="-1" id="ljL-7U-jND"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Align Right" keyEquivalent="}" id="wb2-vD-lq4">
+                                            <connections>
+                                                <action selector="alignRight:" target="-1" id="r48-bG-YeY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="4s2-GY-VfK"/>
+                                        <menuItem title="Writing Direction" id="H1b-Si-o9J">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Writing Direction" id="8mr-sm-Yjd">
+                                                <items>
+                                                    <menuItem title="Paragraph" enabled="NO" id="ZvO-Gk-QUH">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                    </menuItem>
+                                                    <menuItem id="YGs-j5-SAR">
+                                                        <string key="title">	Default</string>
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="makeBaseWritingDirectionNatural:" target="-1" id="qtV-5e-UBP"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem id="Lbh-J2-qVU">
+                                                        <string key="title">	Left to Right</string>
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="makeBaseWritingDirectionLeftToRight:" target="-1" id="S0X-9S-QSf"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem id="jFq-tB-4Kx">
+                                                        <string key="title">	Right to Left</string>
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="makeBaseWritingDirectionRightToLeft:" target="-1" id="5fk-qB-AqJ"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="swp-gr-a21"/>
+                                                    <menuItem title="Selection" enabled="NO" id="cqv-fj-IhA">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                    </menuItem>
+                                                    <menuItem id="Nop-cj-93Q">
+                                                        <string key="title">	Default</string>
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="makeTextWritingDirectionNatural:" target="-1" id="lPI-Se-ZHp"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem id="BgM-ve-c93">
+                                                        <string key="title">	Left to Right</string>
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="makeTextWritingDirectionLeftToRight:" target="-1" id="caW-Bv-w94"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem id="RB4-Sm-HuC">
+                                                        <string key="title">	Right to Left</string>
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="makeTextWritingDirectionRightToLeft:" target="-1" id="EXD-6r-ZUu"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="fKy-g9-1gm"/>
+                                        <menuItem title="Show Ruler" id="vLm-3I-IUL">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleRuler:" target="-1" id="FOx-HJ-KwY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Copy Ruler" keyEquivalent="c" id="MkV-Pr-PK5">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="copyRuler:" target="-1" id="71i-fW-3W2"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste Ruler" keyEquivalent="v" id="LVM-kO-fVI">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="pasteRuler:" target="-1" id="cSh-wd-qM2"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="View" id="H8h-7b-M4v">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="View" id="HyV-fh-RgO">
+                        <items>
+                            <menuItem title="Show Toolbar" keyEquivalent="t" id="snW-S8-Cw5">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleToolbarShown:" target="-1" id="BXY-wc-z0C"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Customize Toolbar…" id="1UK-8n-QPP">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="runToolbarCustomizationPalette:" target="-1" id="pQI-g3-MTW"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
+                            <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleSourceList:" target="-1" id="iwa-gc-5KM"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleFullScreen:" target="-1" id="dU3-MA-1Rq"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Window" id="aUF-d1-5bR">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                        <items>
+                            <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
+                                <connections>
+                                    <action selector="performMiniaturize:" target="-1" id="VwT-WD-YPe"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="performZoom:" target="-1" id="DIl-cC-cCs"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                            <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="arrangeInFront:" target="-1" id="DRN-fu-gQh"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Help" id="wpr-3q-Mcd">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
+                        <items>
+                            <menuItem title="ExampleMacOS Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                <connections>
+                                    <action selector="showHelp:" target="-1" id="y7X-2Q-9no"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+            </items>
+        </menu>
+        <window title="ExampleMacOS" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="335" y="390" width="480" height="360"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+            <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
+                <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </view>
+        </window>
+    </objects>
+</document>

--- a/snapshot/example/ExampleMacOS/Info.plist
+++ b/snapshot/example/ExampleMacOS/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2017 Felix Krause. All rights reserved.</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/snapshot/example/ExampleMacOSUITests/ExampleMacOSUITests.swift
+++ b/snapshot/example/ExampleMacOSUITests/ExampleMacOSUITests.swift
@@ -1,0 +1,25 @@
+//
+//  ExampleMacOSUITests.swift
+//  ExampleMacOSUITests
+//
+//  Created by Alexander Semenov on 1/19/17.
+//  Copyright © 2017 Felix Krause. All rights reserved.
+//
+
+import XCTest
+
+class ExampleMacOSUITests: XCTestCase {
+        
+    override func setUp() {
+        super.setUp()
+        
+        let app = XCUIApplication()
+        setupSnapshot(app)
+        app.launch()
+    }
+    
+    func testExample() {
+        snapshot("0Launch")
+    }
+    
+}

--- a/snapshot/example/ExampleMacOSUITests/Info.plist
+++ b/snapshot/example/ExampleMacOSUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -42,7 +42,7 @@ open class Snapshot: NSObject {
 
         do {
             let trimCharacterSet = CharacterSet.whitespacesAndNewlines
-            deviceLanguage = try NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue).trimmingCharacters(in: trimCharacterSet) as String
+            deviceLanguage = try String(contentsOf: path, encoding: String.Encoding.utf8).trimmingCharacters(in: trimCharacterSet)
             app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
         } catch {
             print("Couldn't detect/set language...")
@@ -58,7 +58,7 @@ open class Snapshot: NSObject {
 
         do {
             let trimCharacterSet = CharacterSet.whitespacesAndNewlines
-            locale = try NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue).trimmingCharacters(in: trimCharacterSet) as String
+            locale = try String(contentsOf: path, encoding: String.Encoding.utf8).trimmingCharacters(in: trimCharacterSet)
         } catch {
             print("Couldn't detect/set locale...")
         }
@@ -77,7 +77,7 @@ open class Snapshot: NSObject {
         app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
 
         do {
-            let launchArguments = try NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue) as String
+            let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
             let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
             let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location:0, length:launchArguments.characters.count))
             let results = matches.map { result -> String in
@@ -120,30 +120,30 @@ open class Snapshot: NSObject {
         }
     }
 
-    class func pathPrefix() -> NSString? {
-        var homeDir: NSString
+    class func pathPrefix() -> URL? {
+        let homeDir: URL
         //on OSX config is stored in /Users/<username>/Library
         //and on iOS/tvOS/WatchOS it's in simulator's home dir
         #if os(OSX)
-            
             guard let user = ProcessInfo().environment["USER"] else {
                 print("Couldn't find Snapshot configuration files - can't detect current user ")
                 return nil
             }
-            
-            guard let usersDir = NSSearchPathForDirectoriesInDomains(.userDirectory, .localDomainMask, true)[0] as NSString? else {
+        
+            guard let usersDir =  FileManager.default.urls(for:.userDirectory, in:.localDomainMask).first else {
                 print("Couldn't find Snapshot configuration files - can't detect `Users` dir")
                 return nil
             }
             
-            homeDir = usersDir.appendingPathComponent(user) as NSString
+            homeDir = usersDir.appendingPathComponent(user)
         #else
-            guard homeDir = ProcessInfo().environment["SIMULATOR_HOST_HOME"] as NSString else {
+            guard let homeDirUrl = URL(string: ProcessInfo().environment["SIMULATOR_HOST_HOME"]!) else {
                 print("Couldn't find Snapshot configuration files at ~/Library/Caches/tools.fastlane")
                 return nil
             }
+            homeDir = homeDirUrl
         #endif
-        return homeDir.appendingPathComponent("Library/Caches/tools.fastlane") as NSString
+        return homeDir.appendingPathComponent("Library/Caches/tools.fastlane")
     }
 }
 

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -137,8 +137,12 @@ open class Snapshot: NSObject {
             
             homeDir = usersDir.appendingPathComponent(user)
         #else
-            guard let homeDirUrl = URL(string: ProcessInfo().environment["SIMULATOR_HOST_HOME"]!) else {
-                print("Couldn't find Snapshot configuration files at ~/Library/Caches/tools.fastlane")
+            guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+                print("Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable.")
+                return nil
+            }
+            guard let homeDirUrl = URL(string: simulatorHostHome) else {
+                print("Can't prepare environment. Simulator home location is inaccessible. Does \(simulatorHostHome) exist?")
                 return nil
             }
             homeDir = homeDirUrl

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -121,7 +121,7 @@ open class Snapshot: NSObject {
     }
 
     class func pathPrefix() -> NSString? {
-        var homeDir : NSString
+        var homeDir: NSString
         //on OSX config is stored in /Users/<username>/Library
         //and on iOS/tvOS/WatchOS it's in simulator's home dir
         #if os(OSX)

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -100,6 +100,8 @@ open class Snapshot: NSObject {
 
         #if os(tvOS)
             XCUIApplication().childrenMatchingType(.Browser).count
+        #elseif os(OSX)
+            XCUIApplication().typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
         #else
             XCUIDevice.shared().orientation = .unknown
         #endif
@@ -119,11 +121,29 @@ open class Snapshot: NSObject {
     }
 
     class func pathPrefix() -> NSString? {
-        if let path = ProcessInfo().environment["SIMULATOR_HOST_HOME"] as NSString? {
-            return path.appendingPathComponent("Library/Caches/tools.fastlane") as NSString?
-        }
-        print("Couldn't find Snapshot configuration files at ~/Library/Caches/tools.fastlane")
-        return nil
+        var homeDir : NSString
+        //on OSX config is stored in /Users/<username>/Library
+        //and on iOS/tvOS/WatchOS it's in simulator's home dir
+        #if os(OSX)
+            
+            guard let user = ProcessInfo().environment["USER"] else {
+                print("Couldn't find Snapshot configuration files - can't detect current user ")
+                return nil
+            }
+            
+            guard let usersDir = NSSearchPathForDirectoriesInDomains(.userDirectory, .localDomainMask, true)[0] as NSString? else {
+                print("Couldn't find Snapshot configuration files - can't detect `Users` dir")
+                return nil
+            }
+            
+            homeDir = usersDir.appendingPathComponent(user) as NSString
+        #else
+            guard homeDir = ProcessInfo().environment["SIMULATOR_HOST_HOME"] as NSString else {
+                print("Couldn't find Snapshot configuration files at ~/Library/Caches/tools.fastlane")
+                return nil
+            }
+        #endif
+        return homeDir.appendingPathComponent("Library/Caches/tools.fastlane") as NSString
     }
 }
 
@@ -139,4 +159,4 @@ extension XCUIElement {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.2]
+// SnapshotHelperVersion [1.3]

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -42,7 +42,7 @@ open class Snapshot: NSObject {
 
         do {
             let trimCharacterSet = CharacterSet.whitespacesAndNewlines
-            deviceLanguage = try String(contentsOf: path, encoding: String.Encoding.utf8).trimmingCharacters(in: trimCharacterSet)
+            deviceLanguage = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
             app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
         } catch {
             print("Couldn't detect/set language...")
@@ -58,7 +58,7 @@ open class Snapshot: NSObject {
 
         do {
             let trimCharacterSet = CharacterSet.whitespacesAndNewlines
-            locale = try String(contentsOf: path, encoding: String.Encoding.utf8).trimmingCharacters(in: trimCharacterSet)
+            locale = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
         } catch {
             print("Couldn't detect/set locale...")
         }
@@ -129,12 +129,12 @@ open class Snapshot: NSObject {
                 print("Couldn't find Snapshot configuration files - can't detect current user ")
                 return nil
             }
-        
-            guard let usersDir =  FileManager.default.urls(for:.userDirectory, in:.localDomainMask).first else {
+
+            guard let usersDir =  FileManager.default.urls(for: .userDirectory, in: .localDomainMask).first else {
                 print("Couldn't find Snapshot configuration files - can't detect `Users` dir")
                 return nil
             }
-            
+
             homeDir = usersDir.appendingPathComponent(user)
         #else
             guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {

--- a/snapshot/lib/assets/SnapshotHelper2-3.swift
+++ b/snapshot/lib/assets/SnapshotHelper2-3.swift
@@ -141,7 +141,7 @@ public class Snapshot: NSObject {
             homeDir = usersDir.stringByAppendingPathComponent(user) as NSString
         #else
             guard homeDir = ProcessInfo().environment["SIMULATOR_HOST_HOME"] as NSString else {
-                print("Couldn't find Snapshot configuration files at ~/Library/Caches/tools.fastlane")
+                print("Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable.")
                 return nil
             }
         #endif

--- a/snapshot/lib/assets/SnapshotHelper2-3.swift
+++ b/snapshot/lib/assets/SnapshotHelper2-3.swift
@@ -123,7 +123,7 @@ public class Snapshot: NSObject {
     }
 
     class func pathPrefix() -> NSString? {
-        var homeDir : NSString
+        var homeDir: NSString
         //on OSX config is stored in /Users/<username>/Library
         //and on iOS/tvOS/WatchOS it's in simulator's home dir
         #if os(OSX)

--- a/snapshot/lib/assets/SnapshotHelper2-3.swift
+++ b/snapshot/lib/assets/SnapshotHelper2-3.swift
@@ -102,6 +102,8 @@ public class Snapshot: NSObject {
 
         #if os(tvOS)
             XCUIApplication().childrenMatchingType(.Browser).count
+        #elseif os(OSX)
+            XCUIApplication().typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
         #else
             XCUIDevice.sharedDevice().orientation = .Unknown
         #endif
@@ -121,11 +123,29 @@ public class Snapshot: NSObject {
     }
 
     class func pathPrefix() -> NSString? {
-        if let path = NSProcessInfo().environment["SIMULATOR_HOST_HOME"] as NSString? {
-            return path.stringByAppendingPathComponent("Library/Caches/tools.fastlane")
-        }
-        print("Couldn't find Snapshot configuration files at ~/Library/Caches/tools.fastlane")
-        return nil
+        var homeDir : NSString
+        //on OSX config is stored in /Users/<username>/Library
+        //and on iOS/tvOS/WatchOS it's in simulator's home dir
+        #if os(OSX)
+            
+            guard let user = ProcessInfo().environment["USER"] else {
+                print("Couldn't find Snapshot configuration files - can't detect current user ")
+                return nil
+            }
+            
+            guard let usersDir = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.NSUserDirectory, NSSearchPathDomainMask.NSLocalDomainMask, true)[0] as NSString? else {
+                print("Couldn't find Snapshot configuration files - can't detect `Users` dir")
+                return nil
+            }
+            
+            homeDir = usersDir.stringByAppendingPathComponent(user) as NSString
+        #else
+            guard homeDir = ProcessInfo().environment["SIMULATOR_HOST_HOME"] as NSString else {
+                print("Couldn't find Snapshot configuration files at ~/Library/Caches/tools.fastlane")
+                return nil
+            }
+        #endif
+        return homeDir.stringByAppendingPathComponent("Library/Caches/tools.fastlane") as NSString
     }
 }
 
@@ -141,4 +161,4 @@ extension XCUIElement {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.2]
+// SnapshotHelperVersion [1.3]

--- a/snapshot/lib/snapshot/detect_values.rb
+++ b/snapshot/lib/snapshot/detect_values.rb
@@ -53,7 +53,7 @@ module Snapshot
             config[:devices] << sim.name
           end
         end
-        #In case, we are targeting mac app - add host Mac machine as testing device
+        # In case, we are targeting mac app - add host Mac machine as testing device
         config[:devices] << "Mac" if mac_target
       end
     end

--- a/snapshot/lib/snapshot/detect_values.rb
+++ b/snapshot/lib/snapshot/detect_values.rb
@@ -50,6 +50,7 @@ module Snapshot
 
           config[:devices] << sim.name
         end
+        config[:devices] << "Mac"
       end
     end
   end

--- a/snapshot/lib/snapshot/detect_values.rb
+++ b/snapshot/lib/snapshot/detect_values.rb
@@ -24,37 +24,34 @@ module Snapshot
       # Devices
       unless config[:devices]
         config[:devices] = []
-        mac_target = Snapshot.project.mac_app?
 
-        unless mac_target
-          # We only care about a subset of the simulators
-          all_simulators = FastlaneCore::Simulator.all
-          all_simulators.each do |sim|
-            # Filter iPads, we only want the following simulators
-            # Xcode 7:
-            #   ["iPad Pro", "iPad Air"]
-            # Xcode 8:
-            #   ["iPad Pro (9.7 Inch)", "iPad Pro (12.9 Inch)"]
-            #
-            # Full list: ["iPad 2", "iPad Retina", "iPad Air", "iPad Air 2", "iPad Pro"]
-            next if sim.name.include?("iPad 2")
-            next if sim.name.include?("iPad Retina")
-            next if sim.name.include?("iPad Air 2")
-            # In Xcode 8, we only need iPad Pro 9.7 inch, not the iPad Air
-            next if all_simulators.any? { |a| a.name.include?("9.7 inch") } && sim.name.include?("iPad Air")
+        # We only care about a subset of the simulators
+        all_simulators = FastlaneCore::Simulator.all
+        all_simulators.each do |sim|
+          # Filter iPads, we only want the following simulators
+          # Xcode 7:
+          #   ["iPad Pro", "iPad Air"]
+          # Xcode 8:
+          #   ["iPad Pro (9.7 Inch)", "iPad Pro (12.9 Inch)"]
+          #
+          # Full list: ["iPad 2", "iPad Retina", "iPad Air", "iPad Air 2", "iPad Pro"]
+          next if sim.name.include?("iPad 2")
+          next if sim.name.include?("iPad Retina")
+          next if sim.name.include?("iPad Air 2")
+          # In Xcode 8, we only need iPad Pro 9.7 inch, not the iPad Air
+          next if all_simulators.any? { |a| a.name.include?("9.7 inch") } && sim.name.include?("iPad Air")
 
-            # Filter iPhones
-            # Full list: ["iPhone 4s", "iPhone 5", "iPhone 5s", "iPhone 6", "iPhone 6 Plus", "iPhone 6s", "iPhone 6s Plus"]
-            next if sim.name.include?("6s") # same screen resolution as iPhone 6, or iPhone 6s Plus
-            next if sim.name.include?("5s") # same screen resolution as iPhone 5
+          # Filter iPhones
+          # Full list: ["iPhone 4s", "iPhone 5", "iPhone 5s", "iPhone 6", "iPhone 6 Plus", "iPhone 6s", "iPhone 6s Plus"]
+          next if sim.name.include?("6s") # same screen resolution as iPhone 6, or iPhone 6s Plus
+          next if sim.name.include?("5s") # same screen resolution as iPhone 5
 
-            next if sim.name.include?("Apple TV")
+          next if sim.name.include?("Apple TV")
 
-            config[:devices] << sim.name
-          end
+          config[:devices] << sim.name
         end
-        # In case, we are targeting mac app - add host Mac machine as testing device
-        config[:devices] << "Mac" if mac_target
+        # as Snapshot can be run only on MacOS - we are always have host mac device
+        config[:devices] << "Mac"
       end
     end
   end

--- a/snapshot/lib/snapshot/detect_values.rb
+++ b/snapshot/lib/snapshot/detect_values.rb
@@ -24,33 +24,37 @@ module Snapshot
       # Devices
       unless config[:devices]
         config[:devices] = []
+        mac_target = Snapshot.project.mac_app?
 
-        # We only care about a subset of the simulators
-        all_simulators = FastlaneCore::Simulator.all
-        all_simulators.each do |sim|
-          # Filter iPads, we only want the following simulators
-          # Xcode 7:
-          #   ["iPad Pro", "iPad Air"]
-          # Xcode 8:
-          #   ["iPad Pro (9.7 Inch)", "iPad Pro (12.9 Inch)"]
-          #
-          # Full list: ["iPad 2", "iPad Retina", "iPad Air", "iPad Air 2", "iPad Pro"]
-          next if sim.name.include?("iPad 2")
-          next if sim.name.include?("iPad Retina")
-          next if sim.name.include?("iPad Air 2")
-          # In Xcode 8, we only need iPad Pro 9.7 inch, not the iPad Air
-          next if all_simulators.any? { |a| a.name.include?("9.7 inch") } && sim.name.include?("iPad Air")
+        unless mac_target
+          # We only care about a subset of the simulators
+          all_simulators = FastlaneCore::Simulator.all
+          all_simulators.each do |sim|
+            # Filter iPads, we only want the following simulators
+            # Xcode 7:
+            #   ["iPad Pro", "iPad Air"]
+            # Xcode 8:
+            #   ["iPad Pro (9.7 Inch)", "iPad Pro (12.9 Inch)"]
+            #
+            # Full list: ["iPad 2", "iPad Retina", "iPad Air", "iPad Air 2", "iPad Pro"]
+            next if sim.name.include?("iPad 2")
+            next if sim.name.include?("iPad Retina")
+            next if sim.name.include?("iPad Air 2")
+            # In Xcode 8, we only need iPad Pro 9.7 inch, not the iPad Air
+            next if all_simulators.any? { |a| a.name.include?("9.7 inch") } && sim.name.include?("iPad Air")
 
-          # Filter iPhones
-          # Full list: ["iPhone 4s", "iPhone 5", "iPhone 5s", "iPhone 6", "iPhone 6 Plus", "iPhone 6s", "iPhone 6s Plus"]
-          next if sim.name.include?("6s") # same screen resolution as iPhone 6, or iPhone 6s Plus
-          next if sim.name.include?("5s") # same screen resolution as iPhone 5
+            # Filter iPhones
+            # Full list: ["iPhone 4s", "iPhone 5", "iPhone 5s", "iPhone 6", "iPhone 6 Plus", "iPhone 6s", "iPhone 6s Plus"]
+            next if sim.name.include?("6s") # same screen resolution as iPhone 6, or iPhone 6s Plus
+            next if sim.name.include?("5s") # same screen resolution as iPhone 5
 
-          next if sim.name.include?("Apple TV")
+            next if sim.name.include?("Apple TV")
 
-          config[:devices] << sim.name
+            config[:devices] << sim.name
+          end
         end
-        config[:devices] << "Mac"
+        #In case, we are targeting mac app - add host Mac machine as testing device
+        config[:devices] << "Mac" if mac_target
       end
     end
   end

--- a/snapshot/lib/snapshot/detect_values.rb
+++ b/snapshot/lib/snapshot/detect_values.rb
@@ -22,7 +22,7 @@ module Snapshot
       Snapshot.project.select_scheme(preferred_to_include: "UITests")
 
       # Devices
-      unless config[:devices]
+      if config[:devices].nil? && !Snapshot.project.mac?
         config[:devices] = []
 
         # We only care about a subset of the simulators
@@ -50,7 +50,7 @@ module Snapshot
 
           config[:devices] << sim.name
         end
-        # as Snapshot can be run only on MacOS - we are always have host mac device
+      elsif Snapshot.project.mac?
         config[:devices] << "Mac"
       end
     end

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -43,7 +43,8 @@ module Snapshot
                                      verify_block: proc do |value|
                                        available = FastlaneCore::DeviceManager.simulators
                                        value.each do |current|
-                                         unless available.any? { |d| d.name.strip == current.strip }
+                                         strip = current.strip
+                                         unless available.any? { |d| d.name.strip == strip } || strip == "Mac"
                                            UI.user_error!("Device '#{current}' not in list of available simulators '#{available.join(', ')}'")
                                          end
                                        end

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -43,9 +43,9 @@ module Snapshot
                                      verify_block: proc do |value|
                                        available = FastlaneCore::DeviceManager.simulators
                                        value.each do |current|
-                                         strip = current.strip
-                                         unless available.any? { |d| d.name.strip == strip } || strip == "Mac"
-                                           UI.user_error!("Device '#{current}' not in list of available simulators '#{available.join(', ')}'")
+                                         device = current.strip
+                                         unless available.any? { |d| d.name.strip == device } || device == "Mac"
+                                           UI.user_error!("Device '#{device}' not in list of available simulators '#{available.join(', ')}'")
                                          end
                                        end
                                      end),

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -146,22 +146,24 @@ module Snapshot
       File.write(File.join(prefix, "locale.txt"), locale || "")
       File.write(File.join(prefix, "snapshot-launch_arguments.txt"), launch_arguments.last)
 
-      # Kill and shutdown all currently running simulators so that the following settings
-      # changes will be picked up when they are started again.
-      Snapshot.kill_simulator # because of https://github.com/fastlane/snapshot/issues/337
-      `xcrun simctl shutdown booted &> /dev/null`
+      unless device_type == "Mac"
+        # Kill and shutdown all currently running simulators so that the following settings
+        # changes will be picked up when they are started again.
+        Snapshot.kill_simulator # because of https://github.com/fastlane/snapshot/issues/337
+        `xcrun simctl shutdown booted &> /dev/null`
 
-      Fixes::SimulatorZoomFix.patch
-      Fixes::HardwareKeyboardFix.patch
+        Fixes::SimulatorZoomFix.patch
+        Fixes::HardwareKeyboardFix.patch
 
-      if Snapshot.config[:erase_simulator] || Snapshot.config[:localize_simulator]
-        erase_simulator(device_type)
-        if Snapshot.config[:localize_simulator]
-          localize_simulator(device_type, language, locale)
+        if Snapshot.config[:erase_simulator] || Snapshot.config[:localize_simulator]
+          erase_simulator(device_type)
+          if Snapshot.config[:localize_simulator]
+            localize_simulator(device_type, language, locale)
+          end
+        elsif Snapshot.config[:reinstall_app]
+          # no need to reinstall if device has been erased
+          uninstall_app(device_type)
         end
-      elsif Snapshot.config[:reinstall_app]
-        # no need to reinstall if device has been erased
-        uninstall_app(device_type)
       end
 
       add_media(device_type, :photo, Snapshot.config[:add_photos]) if Snapshot.config[:add_photos]

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -90,6 +90,9 @@ module Snapshot
       end
 
       def destination(device_name)
+        # on Mac we will always run on host machine, so should specify only platform
+        return ["-destination 'platform=macOS'"] if device_name =~ /^Mac/
+
         os = device_name =~ /^Apple TV/ ? "tvOS" : "iOS"
         os_version = Snapshot.config[:ios_version] || Snapshot::LatestOsVersion.version(os)
 

--- a/snapshot/spec/spec_helper.rb
+++ b/snapshot/spec/spec_helper.rb
@@ -6,6 +6,8 @@ Information about project "Example":
     Targets:
         Example
         ExampleUITests
+        ExampleMacOS
+        ExampleMacOSUITests
     Build Configurations:
         Debug
         Release
@@ -13,6 +15,7 @@ Information about project "Example":
     Schemes:
         Example
         ExampleUITests
+        ExampleMacOS
 EOS
   allow_any_instance_of(FastlaneCore::Project).to receive(:raw_info).and_return fake_result
 end

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -119,7 +119,7 @@ describe Snapshot do
       end
     end
 
-    describe "Valid Configuration" do
+    describe "Valid iOS Configuration" do
       let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests" } }
 
       def configure(options)
@@ -205,6 +205,30 @@ describe Snapshot do
           command = Snapshot::TestCommandGenerator.generate(device_type: "iPhone 6")
           expect(command.join('')).to include("-derivedDataPath 'fake/derived/path'")
         end
+      end
+    end
+
+    describe "Valid macOS Configuration" do
+      let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleMacOS" } }
+
+      it "uses default parameters on macOS" do
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options.merge(devices: ["Mac"]))
+        expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
+        command = Snapshot::TestCommandGenerator.generate(device_type: "Mac")
+        expect(command).to eq(
+          [
+            "set -o pipefail &&",
+            "xcodebuild",
+            "-scheme ExampleMacOS",
+            "-project ./snapshot/example/Example.xcodeproj",
+            "-derivedDataPath '/tmp/path/to/snapshot_derived'",
+            "-destination 'platform=macOS'",
+            "FASTLANE_SNAPSHOT=YES",
+            :build,
+            :test,
+            "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/ExampleMacOS-ExampleMacOS.log")} | xcpretty "
+          ]
+        )
       end
     end
   end


### PR DESCRIPTION
This is a continuation/cleanup of https://github.com/fastlane/fastlane/pull/7363 to get it pushed through after a while of marinating. I know that macOS support is not something we are prioritizing, but it felt like this does not add much complexity and is a nice-to-have. 

I am definitely open to this being kiboshed but having had it mulling around for a while, I wanted to take some action on it. 

I have tested this in macOS 10.12, using Xcode 8.2 with Swift 3 on macOS and iOS apps.

P.S. Worth noting here that this is not reliable when it is run on a machine with 2+ monitors. The screenshot is always of the primary display (the one with the dock).