### PR TITLE
Update supply to promote version codes correctly

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -43,9 +43,7 @@ module Supply
       # the actual value passed for the rollout argument does not matter because it will be ignored by the Google Play API
       # but it has to be between 0.05 and 0.5 to pass the validity check. So we are passing the default value 0.1
       client.update_track(Supply.config[:track], 0.1, nil)
-      version_codes.each do |apk_version_code|
-        client.update_track(Supply.config[:track_promote_to], Supply.config[:rollout], apk_version_code)
-      end
+      client.update_track(Supply.config[:track_promote_to], Supply.config[:rollout], version_codes)
     end
 
     def upload_changelogs(language)


### PR DESCRIPTION
This PR fixes a minor bug in Supply for promoting tracks with multiple APKs.

### Checklist
- [ X ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ X ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ X ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ X ] I've updated the documentation if necessary.

### Description

As previously written, supply was promoting each version code in the original track separately. The result was that only the highest version code ended up in the destination track. This PR tweaks the logic such that all the previous version codes are uploaded at once, ensuring that they all end up in the new track.

### Motivation and Context

To test this change, I used this version on my app to promote from Alpha to Beta. With the prior version, only one of my APKs ended up in the beta channel. With this version, they all do.
