### PR TITLE
Revise FastlaneCore::FastlaneFolder.path

### DIFF
--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -138,7 +138,7 @@ module Fastlane
 
     # Iterates through all available actions and yields from there
     def self.all_actions(platform = nil)
-      action_symbols = Fastlane::Actions.constants.select { |c| Fastlane::Actions.const_get(c).kind_of? Class }
+      action_symbols = Fastlane::Actions.constants.select { |c| Fastlane::Actions.const_get(c).kind_of?(Class) && c != :TestSampleCodeAction }
       action_symbols.sort.each do |symbol|
         action = Fastlane::Actions.const_get(symbol)
 

--- a/fastlane/spec/action_spec.rb
+++ b/fastlane/spec/action_spec.rb
@@ -56,6 +56,7 @@ describe Fastlane do
 
     describe "Call another action from an action" do
       it "allows the user to call it using `other_action.rocket`" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         Fastlane::Actions.load_external_actions("./fastlane/spec/fixtures/actions")
         ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileActionFromAction')
         Fastlane::Actions.executed_actions.clear

--- a/fastlane/spec/actions_specs/appaloosa_spec.rb
+++ b/fastlane/spec/actions_specs/appaloosa_spec.rb
@@ -37,6 +37,7 @@ describe Fastlane do
         end
 
         it 'raises a Fastlane error for missing api_token' do
+          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
           expect { Fastlane::FastFile.new.parse(appaloosa_lane).runner.execute(:test) }.to(
             raise_error(FastlaneCore::Interface::FastlaneError) do |error|
               expect(error.message).to match(/No value found for 'api_token'/)
@@ -56,6 +57,7 @@ describe Fastlane do
         end
 
         it 'raises a Fastlane error for missing store_id' do
+          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
           expect { Fastlane::FastFile.new.parse(appaloosa_lane).runner.execute(:test) }.to(
             raise_error(FastlaneCore::Interface::FastlaneError) do |error|
               expect(error.message).to match("No value found for 'store_id'")
@@ -71,6 +73,7 @@ describe Fastlane do
         end
 
         it 'returns group_id errors' do
+          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
           expect { Fastlane::FastFile.new.parse(appaloosa_lane).runner.execute(:test) }.to(
             raise_error(FastlaneCore::Interface::FastlaneError) do |error|
               expect(error.message).to match('ERROR: A group id is incorrect')
@@ -94,6 +97,7 @@ describe Fastlane do
         end
 
         it 'raises a Fastlane error for problem with API token or store id' do
+          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
           expect { Fastlane::FastFile.new.parse(appaloosa_lane).runner.execute(:test) }.to(
             raise_error(FastlaneCore::Interface::FastlaneError) do |error|
               expect(error.message).to eq(expect_error)
@@ -117,6 +121,7 @@ describe Fastlane do
         end
 
         it 'raises a Fastlane error for problem with API token or store id' do
+          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
           expect { Fastlane::FastFile.new.parse(appaloosa_lane).runner.execute(:test) }.to(
             raise_error(FastlaneCore::Interface::FastlaneError) do |error|
               expect(error.message).to eq(expect_error)
@@ -146,6 +151,7 @@ describe Fastlane do
         end
 
         it 'works with valid parameters' do
+          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
           Fastlane::FastFile.new.parse(appaloosa_lane).runner.execute(:test)
         end
       end

--- a/fastlane/spec/actions_specs/appaloosa_spec.rb
+++ b/fastlane/spec/actions_specs/appaloosa_spec.rb
@@ -3,6 +3,9 @@ describe Fastlane do
     APPALOOSA_SERVER = Fastlane::Actions::AppaloosaAction::APPALOOSA_SERVER
 
     describe 'Appaloosa Integration' do
+      before :each do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+      end
       let(:appaloosa_lane) do
         "lane :test do appaloosa(
           {
@@ -37,7 +40,6 @@ describe Fastlane do
         end
 
         it 'raises a Fastlane error for missing api_token' do
-          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
           expect { Fastlane::FastFile.new.parse(appaloosa_lane).runner.execute(:test) }.to(
             raise_error(FastlaneCore::Interface::FastlaneError) do |error|
               expect(error.message).to match(/No value found for 'api_token'/)
@@ -57,7 +59,6 @@ describe Fastlane do
         end
 
         it 'raises a Fastlane error for missing store_id' do
-          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
           expect { Fastlane::FastFile.new.parse(appaloosa_lane).runner.execute(:test) }.to(
             raise_error(FastlaneCore::Interface::FastlaneError) do |error|
               expect(error.message).to match("No value found for 'store_id'")
@@ -73,7 +74,6 @@ describe Fastlane do
         end
 
         it 'returns group_id errors' do
-          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
           expect { Fastlane::FastFile.new.parse(appaloosa_lane).runner.execute(:test) }.to(
             raise_error(FastlaneCore::Interface::FastlaneError) do |error|
               expect(error.message).to match('ERROR: A group id is incorrect')
@@ -97,7 +97,6 @@ describe Fastlane do
         end
 
         it 'raises a Fastlane error for problem with API token or store id' do
-          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
           expect { Fastlane::FastFile.new.parse(appaloosa_lane).runner.execute(:test) }.to(
             raise_error(FastlaneCore::Interface::FastlaneError) do |error|
               expect(error.message).to eq(expect_error)
@@ -121,7 +120,6 @@ describe Fastlane do
         end
 
         it 'raises a Fastlane error for problem with API token or store id' do
-          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
           expect { Fastlane::FastFile.new.parse(appaloosa_lane).runner.execute(:test) }.to(
             raise_error(FastlaneCore::Interface::FastlaneError) do |error|
               expect(error.message).to eq(expect_error)
@@ -151,7 +149,6 @@ describe Fastlane do
         end
 
         it 'works with valid parameters' do
-          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
           Fastlane::FastFile.new.parse(appaloosa_lane).runner.execute(:test)
         end
       end

--- a/fastlane/spec/actions_specs/cocoapods_spec.rb
+++ b/fastlane/spec/actions_specs/cocoapods_spec.rb
@@ -2,6 +2,7 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Cocoapods Integration" do
       it "default use case" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods
         end").runner.execute(:test)
@@ -18,6 +19,7 @@ describe Fastlane do
       end
 
       it "adds no-clean to command if clean is set to false" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             clean: false
@@ -28,6 +30,7 @@ describe Fastlane do
       end
 
       it "adds no-integrate to command if integrate is set to false" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             integrate: false
@@ -38,6 +41,7 @@ describe Fastlane do
       end
 
       it "adds repo-update to command if repo_update is set to true" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             repo_update: true
@@ -48,6 +52,7 @@ describe Fastlane do
       end
 
       it "adds silent to command if silent is set to true" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             silent: true
@@ -58,6 +63,7 @@ describe Fastlane do
       end
 
       it "adds verbose to command if verbose is set to true" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             verbose: true
@@ -68,6 +74,7 @@ describe Fastlane do
       end
 
       it "adds no-ansi to command if ansi is set to false" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             ansi: false
@@ -78,6 +85,7 @@ describe Fastlane do
       end
 
       it "changes directory if podfile is set to the Podfile path" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             podfile: 'Project/Podfile'
@@ -88,6 +96,7 @@ describe Fastlane do
       end
 
       it "changes directory if podfile is set to a directory" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             podfile: 'Project'
@@ -98,6 +107,7 @@ describe Fastlane do
       end
 
       it "adds error_callback to command" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             error_callback: lambda { |result| puts 'failure' }

--- a/fastlane/spec/actions_specs/cocoapods_spec.rb
+++ b/fastlane/spec/actions_specs/cocoapods_spec.rb
@@ -1,8 +1,11 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Cocoapods Integration" do
-      it "default use case" do
+      before :each do
         allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+      end
+
+      it "default use case" do
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods
         end").runner.execute(:test)
@@ -19,7 +22,6 @@ describe Fastlane do
       end
 
       it "adds no-clean to command if clean is set to false" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             clean: false
@@ -30,7 +32,6 @@ describe Fastlane do
       end
 
       it "adds no-integrate to command if integrate is set to false" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             integrate: false
@@ -41,7 +42,6 @@ describe Fastlane do
       end
 
       it "adds repo-update to command if repo_update is set to true" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             repo_update: true
@@ -52,7 +52,6 @@ describe Fastlane do
       end
 
       it "adds silent to command if silent is set to true" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             silent: true
@@ -63,7 +62,6 @@ describe Fastlane do
       end
 
       it "adds verbose to command if verbose is set to true" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             verbose: true
@@ -74,7 +72,6 @@ describe Fastlane do
       end
 
       it "adds no-ansi to command if ansi is set to false" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             ansi: false
@@ -85,7 +82,6 @@ describe Fastlane do
       end
 
       it "changes directory if podfile is set to the Podfile path" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             podfile: 'Project/Podfile'
@@ -96,7 +92,6 @@ describe Fastlane do
       end
 
       it "changes directory if podfile is set to a directory" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             podfile: 'Project'
@@ -107,7 +102,6 @@ describe Fastlane do
       end
 
       it "adds error_callback to command" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(
             error_callback: lambda { |result| puts 'failure' }

--- a/fastlane/spec/actions_specs/crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/crashlytics_spec.rb
@@ -2,6 +2,7 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Crashlytics Integration" do
       before :each do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         ENV.delete "CRASHLYTICS_API_TOKEN"
         ENV.delete "CRASHLYTICS_BUILD_SECRET"
         ENV.delete "CRASHLYTICS_FRAMEWORK_PATH"
@@ -9,10 +10,6 @@ describe Fastlane do
       end
 
       describe "Android" do
-        before :each do
-          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
-        end
-
         describe "Valid parameters" do
           it "works with valid parameters" do
             command = Fastlane::FastFile.new.parse('lane :test do
@@ -74,7 +71,6 @@ describe Fastlane do
 
       describe "iOS" do
         before :each do
-          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         end
 
         describe "Valid Parameters" do
@@ -280,7 +276,6 @@ describe Fastlane do
 
         describe "Invalid Parameters" do
           it "raises an error if no crashlytics path was given" do
-            allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
             expect(Fastlane::Helper::CrashlyticsHelper).to receive(:discover_default_crashlytics_path).and_return(nil)
             expect do
               Fastlane::FastFile.new.parse("lane :test do
@@ -307,7 +302,6 @@ describe Fastlane do
           end
 
           it "raises an error if no api token was given" do
-            allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
             expect do
               Fastlane::FastFile.new.parse("lane :test do
                 crashlytics({
@@ -320,7 +314,6 @@ describe Fastlane do
           end
 
           it "raises an error if no build secret was given" do
-            allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
             expect do
               Fastlane::FastFile.new.parse("lane :test do
                 crashlytics({
@@ -333,7 +326,6 @@ describe Fastlane do
           end
 
           it "raises an error if no ipa path was given" do
-            allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
             expect do
               Fastlane::FastFile.new.parse("lane :test do
                 crashlytics({
@@ -346,7 +338,6 @@ describe Fastlane do
           end
 
           it "raises an error if the given ipa path was not found" do
-            allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
             expect do
               Fastlane::FastFile.new.parse("lane :test do
                 crashlytics({

--- a/fastlane/spec/actions_specs/crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/crashlytics_spec.rb
@@ -9,6 +9,10 @@ describe Fastlane do
       end
 
       describe "Android" do
+        before :each do
+          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+        end
+
         describe "Valid parameters" do
           it "works with valid parameters" do
             command = Fastlane::FastFile.new.parse('lane :test do
@@ -69,6 +73,10 @@ describe Fastlane do
       end
 
       describe "iOS" do
+        before :each do
+          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+        end
+
         describe "Valid Parameters" do
           it "works with valid parameters" do
             command = Fastlane::FastFile.new.parse("lane :test do
@@ -272,6 +280,7 @@ describe Fastlane do
 
         describe "Invalid Parameters" do
           it "raises an error if no crashlytics path was given" do
+            allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
             expect(Fastlane::Helper::CrashlyticsHelper).to receive(:discover_default_crashlytics_path).and_return(nil)
             expect do
               Fastlane::FastFile.new.parse("lane :test do
@@ -298,6 +307,7 @@ describe Fastlane do
           end
 
           it "raises an error if no api token was given" do
+            allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
             expect do
               Fastlane::FastFile.new.parse("lane :test do
                 crashlytics({
@@ -310,6 +320,7 @@ describe Fastlane do
           end
 
           it "raises an error if no build secret was given" do
+            allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
             expect do
               Fastlane::FastFile.new.parse("lane :test do
                 crashlytics({
@@ -322,6 +333,7 @@ describe Fastlane do
           end
 
           it "raises an error if no ipa path was given" do
+            allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
             expect do
               Fastlane::FastFile.new.parse("lane :test do
                 crashlytics({
@@ -334,6 +346,7 @@ describe Fastlane do
           end
 
           it "raises an error if the given ipa path was not found" do
+            allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
             expect do
               Fastlane::FastFile.new.parse("lane :test do
                 crashlytics({

--- a/fastlane/spec/actions_specs/crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/crashlytics_spec.rb
@@ -70,9 +70,6 @@ describe Fastlane do
       end
 
       describe "iOS" do
-        before :each do
-        end
-
         describe "Valid Parameters" do
           it "works with valid parameters" do
             command = Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/danger_spec.rb
+++ b/fastlane/spec/actions_specs/danger_spec.rb
@@ -2,6 +2,7 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "danger integration" do
       it "default use case" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           danger
         end").runner.execute(:test)
@@ -18,6 +19,7 @@ describe Fastlane do
       end
 
       it "appends verbose" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           danger(verbose: true)
         end").runner.execute(:test)
@@ -26,6 +28,7 @@ describe Fastlane do
       end
 
       it "sets github token" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           danger(github_api_token: '1234')
         end").runner.execute(:test)
@@ -35,6 +38,7 @@ describe Fastlane do
       end
 
       it "appends danger_id" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           danger(danger_id: 'unit-tests')
         end").runner.execute(:test)
@@ -43,6 +47,7 @@ describe Fastlane do
       end
 
       it "appends dangerfile" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           danger(dangerfile: 'test/OtherDangerfile')
         end").runner.execute(:test)
@@ -51,6 +56,7 @@ describe Fastlane do
       end
 
       it "appends fail-on-errors flag when set" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           danger(fail_on_errors: true)
         end").runner.execute(:test)
@@ -59,6 +65,7 @@ describe Fastlane do
       end
 
       it "does not append fail-on-errors flag when unset" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           danger(fail_on_errors: false)
         end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/danger_spec.rb
+++ b/fastlane/spec/actions_specs/danger_spec.rb
@@ -1,8 +1,11 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "danger integration" do
-      it "default use case" do
+      before :each do
         allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+      end
+
+      it "default use case" do
         result = Fastlane::FastFile.new.parse("lane :test do
           danger
         end").runner.execute(:test)
@@ -19,7 +22,6 @@ describe Fastlane do
       end
 
       it "appends verbose" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           danger(verbose: true)
         end").runner.execute(:test)
@@ -28,7 +30,6 @@ describe Fastlane do
       end
 
       it "sets github token" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           danger(github_api_token: '1234')
         end").runner.execute(:test)
@@ -38,7 +39,6 @@ describe Fastlane do
       end
 
       it "appends danger_id" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           danger(danger_id: 'unit-tests')
         end").runner.execute(:test)
@@ -47,7 +47,6 @@ describe Fastlane do
       end
 
       it "appends dangerfile" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           danger(dangerfile: 'test/OtherDangerfile')
         end").runner.execute(:test)
@@ -56,7 +55,6 @@ describe Fastlane do
       end
 
       it "appends fail-on-errors flag when set" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           danger(fail_on_errors: true)
         end").runner.execute(:test)
@@ -65,7 +63,6 @@ describe Fastlane do
       end
 
       it "does not append fail-on-errors flag when unset" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           danger(fail_on_errors: false)
         end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/delete_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/delete_keychain_spec.rb
@@ -6,6 +6,7 @@ describe Fastlane do
       end
 
       it "works with keychain name found locally" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         allow(File).to receive(:exist?).with(/test.keychain/).and_return(true)
 
         result = Fastlane::FastFile.new.parse("lane :test do
@@ -35,6 +36,7 @@ describe Fastlane do
       end
 
       it "works with keychain name that contain spaces and `\"`" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         allow(File).to receive(:exist?).with(/\" test \".keychain/).and_return(true)
 
         result = Fastlane::FastFile.new.parse("lane :test do
@@ -61,6 +63,7 @@ describe Fastlane do
       end
 
       it "shows an error message if the keychain can't be found" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             delete_keychain ({

--- a/fastlane/spec/actions_specs/deploygate_spec.rb
+++ b/fastlane/spec/actions_specs/deploygate_spec.rb
@@ -10,6 +10,7 @@ describe Fastlane do
       end
 
       it "raises an error if no api token was given" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             deploygate({
@@ -21,6 +22,7 @@ describe Fastlane do
       end
 
       it "raises an error if no target user was given" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             deploygate({
@@ -67,6 +69,7 @@ describe Fastlane do
       end
 
       it "works with valid parameters" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             deploygate({
@@ -79,6 +82,7 @@ describe Fastlane do
       end
 
       it "works with valid parameters include optionals" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             deploygate({

--- a/fastlane/spec/actions_specs/dsym_zip_spec.rb
+++ b/fastlane/spec/actions_specs/dsym_zip_spec.rb
@@ -4,6 +4,7 @@ describe Fastlane do
       xcodebuild_archive = 'MyApp.xcarchive'
 
       before(:each) do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::XCODEBUILD_ARCHIVE] = xcodebuild_archive
       end
 

--- a/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
@@ -1,6 +1,10 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "ensure_no_debug_code" do
+      before :each do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+      end
+
       it "handles extension and extensions parameters correctly" do
         result = Fastlane::FastFile.new.parse("lane :test do
           ensure_no_debug_code(text: 'pry', path: '.', extension: 'rb', extensions: ['m', 'h'])

--- a/fastlane/spec/actions_specs/get_info_plist_value_spec.rb
+++ b/fastlane/spec/actions_specs/get_info_plist_value_spec.rb
@@ -4,6 +4,7 @@ describe Fastlane do
       let (:plist_path) { "./fastlane/spec/fixtures/plist/Info.plist" }
 
       it "fetches the value from the plist" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         value = Fastlane::FastFile.new.parse("lane :test do
           get_info_plist_value(path: '#{plist_path}', key: 'CFBundleIdentifier')
         end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/git_commit_spec.rb
+++ b/fastlane/spec/actions_specs/git_commit_spec.rb
@@ -1,6 +1,10 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "git_commit" do
+      before :each do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+      end
+
       it "generates the correct git command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           git_commit(path: './fastlane/README.md', message: 'message')

--- a/fastlane/spec/actions_specs/gradle_spec.rb
+++ b/fastlane/spec/actions_specs/gradle_spec.rb
@@ -1,6 +1,10 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "gradle" do
+      before :each do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+      end
+
       describe "output controls" do
         let(:expected_command) { "#{File.expand_path('README.md').shellescape} tasks -p ." }
 

--- a/fastlane/spec/actions_specs/hockey_spec.rb
+++ b/fastlane/spec/actions_specs/hockey_spec.rb
@@ -1,6 +1,10 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Hockey Integration" do
+      before :each do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+      end
+
       it "raises an error if no build file was given" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/ipa_spec.rb
+++ b/fastlane/spec/actions_specs/ipa_spec.rb
@@ -121,6 +121,7 @@ describe Fastlane do
       end
 
       it "works with object argument with all and extras and auto-use sigh profile if not given" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         ENV["SIGH_PROFILE_PATH"] = "some/great/value.file"
 
         result = Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/oclint_spec.rb
+++ b/fastlane/spec/actions_specs/oclint_spec.rb
@@ -1,6 +1,10 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "OCLint Integration" do
+      before :each do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+      end
+
       it "raises an exception when the default compile_commands.json is not present" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
+++ b/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
@@ -1,6 +1,10 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Pod Lib Lint action" do
+      before :each do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+      end
+
       it "generates the correct pod lib lint command with no parameters" do
         result = Fastlane::FastFile.new.parse("lane :test do
           pod_lib_lint

--- a/fastlane/spec/actions_specs/pod_push_spec.rb
+++ b/fastlane/spec/actions_specs/pod_push_spec.rb
@@ -1,6 +1,10 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Pod Push action" do
+      before :each do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+      end
+
       it "generates the correct pod push command with no parameters" do
         result = Fastlane::FastFile.new.parse("lane :test do
           pod_push

--- a/fastlane/spec/actions_specs/set_info_plist_value_spec.rb
+++ b/fastlane/spec/actions_specs/set_info_plist_value_spec.rb
@@ -5,6 +5,7 @@ describe Fastlane do
       let (:new_value) { "NewValue#{Time.now.to_i}" }
 
       it "stores changes in the plist file" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         old_value = Fastlane::FastFile.new.parse("lane :test do
           get_info_plist_value(path: '#{plist_path}', key: 'CFBundleIdentifier')
         end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/set_pod_key_spec.rb
+++ b/fastlane/spec/actions_specs/set_pod_key_spec.rb
@@ -2,6 +2,7 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "CocoaPods-Keys Integration" do
       it "default use case" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           set_pod_key(
             key: 'APIToken',
@@ -25,6 +26,7 @@ describe Fastlane do
       end
 
       it "appends the project name when provided" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           set_pod_key(
             key: 'APIToken',

--- a/fastlane/spec/actions_specs/setup_jenkins_spec.rb
+++ b/fastlane/spec/actions_specs/setup_jenkins_spec.rb
@@ -32,6 +32,7 @@ describe Fastlane do
       end
 
       it "works when forced" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         stub_const("ENV", {})
 
         Fastlane::FastFile.new.parse("lane :test do
@@ -58,6 +59,7 @@ describe Fastlane do
       end
 
       it "works inside CI" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         stub_const("ENV", { "TRAVIS" => true })
 
         Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/slather_spec.rb
+++ b/fastlane/spec/actions_specs/slather_spec.rb
@@ -60,6 +60,7 @@ describe Fastlane do
       end
 
       it "works with bundle" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           slather({
             use_bundle_exec: true,
@@ -118,6 +119,7 @@ describe Fastlane do
       end
 
       it "does not require project if .slather.yml is found" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         File.write('./.slather.yml', '')
 
         result = Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/sonar_spec.rb
+++ b/fastlane/spec/actions_specs/sonar_spec.rb
@@ -2,6 +2,7 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Sonar Integration" do
       it "Should not print sonar command" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expected_command = "cd #{File.expand_path('.').shellescape} && sonar-scanner -Dsonar.login=\"asdf\""
         expect(Fastlane::Actions::SonarAction).to receive(:verify_sonar_scanner_binary).and_return(true)
         expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: true).and_call_original

--- a/fastlane/spec/actions_specs/testfairy_spec.rb
+++ b/fastlane/spec/actions_specs/testfairy_spec.rb
@@ -10,6 +10,7 @@ describe Fastlane do
       end
 
       it "raises an error if no api key was given" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             testfairy({
@@ -20,6 +21,7 @@ describe Fastlane do
       end
 
       it "raises an error if no ipa path was given" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             testfairy({
@@ -41,6 +43,7 @@ describe Fastlane do
       end
 
       it "works with valid required parameters" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             testfairy({
@@ -52,6 +55,7 @@ describe Fastlane do
       end
 
       it "works with valid optional parameters" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             testfairy({

--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -1,6 +1,10 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "upload_symbols_to_crashlytics" do
+      before :each do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+      end
+
       it "extracts zip files" do
         binary_path = './fastlane/spec/fixtures/screenshots/screenshot1.png'
         dsym_path = './fastlane/spec/fixtures/dSYM/Themoji.dSYM.zip'

--- a/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
+++ b/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
@@ -110,6 +110,7 @@ describe Fastlane do
 
     describe "version_bump_podspec" do
       before do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         @podspec_path = './fastlane/spec/fixtures/podspecs/test.podspec'
       end
 
@@ -122,7 +123,6 @@ describe Fastlane do
       end
 
       it "bumps patch version when only the path is given" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           version_bump_podspec(path: '#{@podspec_path}')
         end").runner.execute(:test)
@@ -131,7 +131,6 @@ describe Fastlane do
       end
 
       it "bumps patch version when bump_type is set to patch the path is given" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           version_bump_podspec(path: '#{@podspec_path}', bump_type: 'patch')
         end").runner.execute(:test)
@@ -140,7 +139,6 @@ describe Fastlane do
       end
 
       it "bumps minor version when bump_type is set to minor the path is given" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           version_bump_podspec(path: '#{@podspec_path}', bump_type: 'minor')
         end").runner.execute(:test)
@@ -149,7 +147,6 @@ describe Fastlane do
       end
 
       it "bumps major version when bump_type is set to major the path is given" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           version_bump_podspec(path: '#{@podspec_path}', bump_type: 'major')
         end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
+++ b/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
@@ -99,6 +99,7 @@ describe Fastlane do
       end
 
       it "gets the version from a podspec file" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           version_get_podspec(path: './fastlane/spec/fixtures/podspecs/test.podspec')
         end").runner.execute(:test)
@@ -121,6 +122,7 @@ describe Fastlane do
       end
 
       it "bumps patch version when only the path is given" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           version_bump_podspec(path: '#{@podspec_path}')
         end").runner.execute(:test)
@@ -129,6 +131,7 @@ describe Fastlane do
       end
 
       it "bumps patch version when bump_type is set to patch the path is given" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           version_bump_podspec(path: '#{@podspec_path}', bump_type: 'patch')
         end").runner.execute(:test)
@@ -137,6 +140,7 @@ describe Fastlane do
       end
 
       it "bumps minor version when bump_type is set to minor the path is given" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           version_bump_podspec(path: '#{@podspec_path}', bump_type: 'minor')
         end").runner.execute(:test)
@@ -145,6 +149,7 @@ describe Fastlane do
       end
 
       it "bumps major version when bump_type is set to major the path is given" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           version_bump_podspec(path: '#{@podspec_path}', bump_type: 'major')
         end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/zip_spec.rb
+++ b/fastlane/spec/actions_specs/zip_spec.rb
@@ -1,6 +1,7 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     before do
+      allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
       @path = "./fastlane/spec/fixtures/actions/archive.rb"
     end
 

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -327,6 +327,7 @@ describe Fastlane do
       end
 
       it "properly shows an error message when there is a syntax error in the Fastfile" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expect(UI).to receive(:user_error!).with("Syntax error in your Fastfile on line 17: fastlane/spec/fixtures/fastfiles/FastfileSytnaxError:17: syntax error, unexpected keyword_end, expecting ')'")
         ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileSytnaxError')
       end
@@ -340,6 +341,7 @@ describe Fastlane do
       end
 
       it "properly shows an error message when there is a syntax error in the imported Fastfile" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/Fastfile')
         expect(UI).to receive(:user_error!).with("Syntax error in your Fastfile on line 17: fastlane/spec/fixtures/fastfiles/FastfileSytnaxError:17: syntax error, unexpected keyword_end, expecting ')'")
         ff.import('./FastfileSytnaxError')
@@ -365,6 +367,7 @@ describe Fastlane do
       end
 
       it "runs pod install" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expect(Fastlane::Actions).to receive(:verify_gem!).with("cocoapods")
 
         result = Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/plugins_specs/plugin_manager_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_manager_spec.rb
@@ -133,6 +133,7 @@ describe Fastlane do
       end
 
       it "runs the action as expected if the plugin is available" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         # We don't need to set this, since this method shouldn't even be called when the plugin is available
         # expect(Fastlane::Actions).to receive(:formerly_bundled_actions).and_return(["crashlytics"])
 
@@ -201,6 +202,7 @@ describe Fastlane do
       end
 
       it "shows an appropriate error message when a plugin is really broken" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         ex = ScriptError.new
         pm = Fastlane::PluginManager.new
         plugin_name = "broken"

--- a/fastlane_core/lib/fastlane_core/fastlane_folder.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_folder.rb
@@ -8,8 +8,6 @@ module FastlaneCore
       value ||= "./.#{FOLDER_NAME}/" if File.directory?("./.#{FOLDER_NAME}/") # hidden folder
       value ||= "./" if File.basename(Dir.getwd) == FOLDER_NAME && File.exist?('Fastfile') # inside the folder
       value ||= "./" if File.basename(Dir.getwd) == ".#{FOLDER_NAME}" && File.exist?('Fastfile') # inside the folder and hidden
-
-      value = nil if Helper.is_test? # this is required, as the tests would use the ./fastlane folder otherwise
       return value
     end
 

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -230,7 +230,7 @@ module FastlaneCore
 
     def self.fastlane_enabled?
       # This is called from the root context on the first start
-      @enabled ||= (File.directory?("./fastlane") || File.directory?("./.fastlane"))
+      @enabled ||= !FastlaneCore::FastlaneFolder.path.nil?
     end
 
     # <b>DEPRECATED:</b> Use the `ROOT` constant from the appropriate tool module instead

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -78,6 +78,7 @@ describe Scan do
 
     describe "Supports toolchain" do
       it "should fail if :xctestrun and :toolchain is set" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             scan(
@@ -428,6 +429,7 @@ describe Scan do
                                      ])
       end
       it "should raise an exception if two build_modes are set" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             scan(

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -30,10 +30,6 @@ end
 my_main = self
 RSpec.configure do |config|
   config.before(:each) do |current_test|
-    if current_test.id =~ %r{(fastlane\/spec\/(?!lane_manager))|(scan\/spec\/test_command_generator)}
-      allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
-    end
-
     tool_name = current_test.id.match(%r{\.\/(\w+)\/})[1]
     method_name = "before_each_#{tool_name}".to_sym
     begin

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -30,7 +30,7 @@ end
 my_main = self
 RSpec.configure do |config|
   config.before(:each) do |current_test|
-    if current_test.id.match(/\/fastlane\//)
+    if current_test.id =~ %r{(\/fastlane\/spec\/(?!lane_manager))|(test_command_generator)}
       allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
     end
 

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -30,7 +30,7 @@ end
 my_main = self
 RSpec.configure do |config|
   config.before(:each) do |current_test|
-    if current_test.id =~ %r{(\/fastlane\/spec\/(?!lane_manager))|(test_command_generator)}
+    if current_test.id =~ %r{(fastlane\/spec\/(?!lane_manager))|(scan\/spec\/test_command_generator)}
       allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
     end
 

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -30,6 +30,10 @@ end
 my_main = self
 RSpec.configure do |config|
   config.before(:each) do |current_test|
+    if current_test.id.match(/\/fastlane\//)
+      allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+    end
+
     tool_name = current_test.id.match(%r{\.\/(\w+)\/})[1]
     method_name = "before_each_#{tool_name}".to_sym
     begin


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Remove the code below from FastlaneCore::FastlaneFolder.path.
```ruby
value = nil if Helper.is_test? # this is required, as the tests would use the ./fastlane folder otherwise
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`value = nil if Helper.is_test?` should not be there, because it's only for testing.
We can handle this in rspec side.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
I tried to make this change as simple as possible because the main target of this change is #8380.
I also plan to remove other `Helper.is_test?` after this get merged.