### PR TITLE
[produce] `app_version` option is ignored.

### DIFF
--- a/produce/lib/produce/itunes_connect.rb
+++ b/produce/lib/produce/itunes_connect.rb
@@ -47,7 +47,7 @@ module Produce
 
         UI.crash!("Something went wrong when creating the new app - it's not listed in the App's list") unless application
 
-        UI.message("Ensureing version number")
+        UI.message("Ensuring version number")
         application.ensure_version!(Produce.config[:app_version], platform: Produce.config[:platform]) if Produce.config[:app_version]
 
         UI.success "Successfully created new app '#{Produce.config[:app_name]}' on iTunes Connect with ID #{application.apple_id}"

--- a/produce/lib/produce/itunes_connect.rb
+++ b/produce/lib/produce/itunes_connect.rb
@@ -24,7 +24,6 @@ module Produce
 
         generated_app = Spaceship::Tunes::Application.create!(name: Produce.config[:app_name],
                                                               primary_language: language,
-                                                              version: Produce.config[:app_version] || "1.0",
                                                               sku: Produce.config[:sku].to_s, # might be an int
                                                               bundle_id: app_identifier,
                                                               bundle_id_suffix: Produce.config[:bundle_identifier_suffix],

--- a/produce/lib/produce/itunes_connect.rb
+++ b/produce/lib/produce/itunes_connect.rb
@@ -47,6 +47,9 @@ module Produce
 
         UI.crash!("Something went wrong when creating the new app - it's not listed in the App's list") unless application
 
+        UI.message("Ensureing version number")
+        application.ensure_version!(Produce.config[:app_version], platform: Produce.config[:platform]) if Produce.config[:app_version]
+
         UI.success "Successfully created new app '#{Produce.config[:app_name]}' on iTunes Connect with ID #{application.apple_id}"
       end
 

--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -67,8 +67,6 @@ module Spaceship
         #   This can't be longer than 255 characters.
         # @param primary_language (String): If localized app information isn't available in an
         #   App Store territory, the information from your primary language will be used instead.
-        # @param version (String): The version number is shown on the App Store and should
-        #   match the one you used in Xcode.
         # @param sku (String): A unique ID for your app that is not visible on the App Store.
         # @param bundle_id (String): The bundle ID must match the one you used in Xcode. It
         #   can't be changed after you submit your first build.
@@ -77,10 +75,9 @@ module Spaceship
         # @param platform (String): Platform one of (ios,osx)
         #  should it be an ios or an osx app
 
-        def create!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil)
+        def create!(name: nil, primary_language: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil)
           client.create_application!(name: name,
                          primary_language: primary_language,
-                                  version: version,
                                       sku: sku,
                                 bundle_id: bundle_id,
                                 bundle_id_suffix: bundle_id_suffix,

--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -67,6 +67,8 @@ module Spaceship
         #   This can't be longer than 255 characters.
         # @param primary_language (String): If localized app information isn't available in an
         #   App Store territory, the information from your primary language will be used instead.
+        # @param version *DEPRECATED: Use `ensure_version!` method instead*
+        #   (String): The version number is shown on the App Store and should match the one you used in Xcode.
         # @param sku (String): A unique ID for your app that is not visible on the App Store.
         # @param bundle_id (String): The bundle ID must match the one you used in Xcode. It
         #   can't be changed after you submit your first build.
@@ -75,7 +77,8 @@ module Spaceship
         # @param platform (String): Platform one of (ios,osx)
         #  should it be an ios or an osx app
 
-        def create!(name: nil, primary_language: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil)
+        def create!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil)
+          UI.deprecated("The `version` parameter is deprecated. Use `ensure_version!` method instead") if version
           client.create_application!(name: name,
                          primary_language: primary_language,
                                       sku: sku,

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -259,12 +259,10 @@ module Spaceship
     #   This can't be longer than 255 characters.
     # @param primary_language (String): If localized app information isn't available in an
     #   App Store territory, the information from your primary language will be used instead.
-    # @param version (String): The version number is shown on the App Store and should
-    #   match the one you used in Xcode.
     # @param sku (String): A unique ID for your app that is not visible on the App Store.
     # @param bundle_id (String): The bundle ID must match the one you used in Xcode. It
     #   can't be changed after you submit your first build.
-    def create_application!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil)
+    def create_application!(name: nil, primary_language: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil)
       # First, we need to fetch the data from Apple, which we then modify with the user's values
       primary_language ||= "English"
       platform ||= "ios"
@@ -273,7 +271,6 @@ module Spaceship
 
       # Now fill in the values we have
       # some values are nil, that's why there is a hash
-      data['versionString'] = { value: version }
       data['name'] = { value: name }
       data['bundleId'] = { value: bundle_id }
       data['primaryLanguage'] = { value: primary_language }

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -259,10 +259,14 @@ module Spaceship
     #   This can't be longer than 255 characters.
     # @param primary_language (String): If localized app information isn't available in an
     #   App Store territory, the information from your primary language will be used instead.
+    # @param version *DEPRECATED: Use `Spaceship::Tunes::Application.ensure_version!` method instead*
+    #   (String): The version number is shown on the App Store and should match the one you used in Xcode.
     # @param sku (String): A unique ID for your app that is not visible on the App Store.
     # @param bundle_id (String): The bundle ID must match the one you used in Xcode. It
     #   can't be changed after you submit your first build.
-    def create_application!(name: nil, primary_language: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil)
+    def create_application!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil)
+      UI.deprecated("The `version` parameter is deprecated. Use `Spaceship::Tunes::Application.ensure_version!` method instead") if version
+
       # First, we need to fetch the data from Apple, which we then modify with the user's values
       primary_language ||= "English"
       platform ||= "ios"

--- a/spaceship/spec/tunes/application_spec.rb
+++ b/spaceship/spec/tunes/application_spec.rb
@@ -68,7 +68,6 @@ describe Spaceship::Application do
     describe "#create!" do
       it "works with valid data and defaults to English" do
         Spaceship::Tunes::Application.create!(name: "My name",
-                                              version: "1.0",
                                               sku: "SKU123",
                                               bundle_id: "net.sunapps.123")
       end
@@ -77,7 +76,6 @@ describe Spaceship::Application do
         TunesStubbing.itc_stub_broken_create
         expect do
           Spaceship::Tunes::Application.create!(name: "My Name",
-                                                version: "1.0",
                                                 sku: "SKU123",
                                                 bundle_id: "net.sunapps.123")
         end.to raise_error "You must choose a primary language. You must choose a primary language."
@@ -87,7 +85,6 @@ describe Spaceship::Application do
         TunesStubbing.itc_stub_broken_create_wildcard
         expect do
           Spaceship::Tunes::Application.create!(name: "My Name",
-                                                version: "1.0",
                                                 sku: "SKU123",
                                                 bundle_id: "net.sunapps.*")
         end.to raise_error "You must enter a Bundle ID Suffix. You must enter a Bundle ID Suffix."
@@ -98,7 +95,6 @@ describe Spaceship::Application do
       it "works with valid data and defaults to English" do
         TunesStubbing.itc_stub_applications_first_create
         Spaceship::Tunes::Application.create!(name: "My Name",
-                                              version: "1.0",
                                               sku: "SKU123",
                                               bundle_id: "net.sunapps.123",
                                               company_name: "SunApps GmbH")
@@ -108,7 +104,6 @@ describe Spaceship::Application do
         TunesStubbing.itc_stub_applications_broken_first_create
         expect do
           Spaceship::Tunes::Application.create!(name: "My Name",
-                                                version: "1.0",
                                                 sku: "SKU123",
                                                 bundle_id: "net.sunapps.123")
         end.to raise_error "You must provide a company name to use on the App Store. You must provide a company name to use on the App Store."


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
`Version` removed from the form of creating new application from some day.
So I removed `version` argument from `Spaceship::Tunes::Application.create`.
And I added code to chage the version after the creating new application.

| before | after |
|---|---|
| ![new_ios_app_filled](https://cloud.githubusercontent.com/assets/6880730/23825492/0a1d5570-06ce-11e7-88e2-48e48771f845.png) | <img width="462" alt="2017-03-12 2 48 36" src="https://cloud.githubusercontent.com/assets/6880730/23825507/72b8b0d4-06ce-11e7-8f51-8ef04b2b9e63.png"> |

### Motivation and Context
Issue: #8469 