### PR TITLE
Add missing `require` for terminal-table

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -313,6 +313,7 @@ module Fastlane
         end
       end
 
+      require 'terminal-table'
       puts Terminal::Table.new({
         rows: rows,
         title: "Used plugins".green,


### PR DESCRIPTION
This has been working until now, as we require it in `shell.rb`, however we do want to require it here if the `shell.rb` isn't used

```
bundler: failed to load command: fastlane (/Users/felixkrause/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bin/fastlane)
NameError: uninitialized constant Fastlane::PluginManager::Terminal
  /Users/felixkrause/Developer/fastlane/fastlane/lib/fastlane/plugins/plugin_manager.rb:316:in `print_plugin_information'
  /Users/felixkrause/Developer/fastlane/fastlane/lib/fastlane/plugins/plugin_manager.rb:302:in `load_plugins'
  /Users/felixkrause/Developer/fastlane/fastlane/lib/fastlane/commands_generator.rb:39:in `start'
  /Users/felixkrause/Developer/fastlane/fastlane/lib/fastlane/cli_tools_distributor.rb:65:in `take_off'
  /Users/felixkrause/Developer/fastlane/bin/fastlane:17:in `<top (required)>'
  /Users/felixkrause/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bin/fastlane:23:in `load'
  /Users/felixkrause/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bin/fastlane:23:in `<top (required)>'
```