### PR TITLE
Adding Carthage cache-builds flag

### DIFF
--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -1,6 +1,7 @@
 module Fastlane
   module Actions
     class CarthageAction < Action
+      # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         validate(params)
 
@@ -26,9 +27,11 @@ module Fastlane
         cmd << "--derived-data #{params[:derived_data].shellescape}" if params[:derived_data]
         cmd << "--toolchain #{params[:toolchain]}" if params[:toolchain]
         cmd << "--project-directory #{params[:project_directory]}" if params[:project_directory]
+        cmd << "--cache-builds" if params[:cache_builds] == true
 
         Actions.sh(cmd.join(' '))
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       def self.validate(params)
         command_name = params[:command]
@@ -127,6 +130,11 @@ module Fastlane
                                            UI.user_error!("Please pass a valid platform. Use one of the following: #{available_platforms.join(', ')}") unless available_platforms.map(&:downcase).include?(platform.downcase)
                                          end
                                        end),
+          FastlaneCore::ConfigItem.new(key: :cache_builds,
+                                       env_name: "FL_CARTHAGE_CACHE_BUILDS",
+                                       description: "By default Carthage will rebuild a dependency regardless of whether it\'s the same resolved version as before. Passing the --cache-builds will cause carthage to avoid rebuilding a dependency if it can",
+                                       is_string: false,
+                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :frameworks,
                                        description: "Framework name or names to archive, could be applied only along with the archive command",
                                        default_value: [],
@@ -175,6 +183,7 @@ module Fastlane
             verbose: false,                                 # Print xcodebuild output inline
             platform: "all",                                # Define which platform to build for (one of ‘all’, ‘Mac’, ‘iOS’, ‘watchOS’, ‘tvOS‘, or comma-separated values of the formers except for ‘all’)
             configuration: "Release",                       # Build configuration to use when building
+            cache_builds: true,                             # By default Carthage will rebuild a dependency regardless of whether it\'s the same resolved version as before.
             toolchain: "com.apple.dt.toolchain.Swift_2_3"   # Specify the xcodebuild toolchain
           )'
         ]

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -27,7 +27,7 @@ module Fastlane
         cmd << "--derived-data #{params[:derived_data].shellescape}" if params[:derived_data]
         cmd << "--toolchain #{params[:toolchain]}" if params[:toolchain]
         cmd << "--project-directory #{params[:project_directory]}" if params[:project_directory]
-        cmd << "--cache-builds" if params[:cache_builds] == true
+        cmd << "--cache-builds" if params[:cache_builds]
 
         Actions.sh(cmd.join(' '))
       end
@@ -132,7 +132,7 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :cache_builds,
                                        env_name: "FL_CARTHAGE_CACHE_BUILDS",
-                                       description: "By default Carthage will rebuild a dependency regardless of whether it\'s the same resolved version as before. Passing the --cache-builds will cause carthage to avoid rebuilding a dependency if it can",
+                                       description: "By default Carthage will rebuild a dependency regardless of whether it's the same resolved version as before. Passing the --cache-builds will cause carthage to avoid rebuilding a dependency if it can",
                                        is_string: false,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :frameworks,
@@ -183,7 +183,7 @@ module Fastlane
             verbose: false,                                 # Print xcodebuild output inline
             platform: "all",                                # Define which platform to build for (one of ‘all’, ‘Mac’, ‘iOS’, ‘watchOS’, ‘tvOS‘, or comma-separated values of the formers except for ‘all’)
             configuration: "Release",                       # Build configuration to use when building
-            cache_builds: true,                             # By default Carthage will rebuild a dependency regardless of whether it\'s the same resolved version as before.
+            cache_builds: true,                             # By default Carthage will rebuild a dependency regardless of whether its the same resolved version as before.
             toolchain: "com.apple.dt.toolchain.Swift_2_3"   # Specify the xcodebuild toolchain
           )'
         ]

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -359,6 +359,26 @@ describe Fastlane do
         expect(result).to eq("carthage bootstrap --toolchain com.apple.dt.toolchain.Swift_2_3 --project-directory other")
       end
 
+      it "does not add a cache_builds flag to command if cache_builds is set to false" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              cache_builds: false
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap")
+      end
+
+      it "add a cache_builds flag to command if cache_builds is set to true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              cache_builds: true
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap --cache-builds")
+      end
+
       it "does not set the project directory if none is provided" do
         result = Fastlane::FastFile.new.parse("lane :test do
           carthage
@@ -417,6 +437,20 @@ describe Fastlane do
               use_ssh: true,
               use_submodules: true,
               use_binaries: false,
+              platform: 'iOS'
+            )
+          end").runner.execute(:test)
+        end.not_to raise_error
+      end
+
+      it "works with cache_builds" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              use_ssh: true,
+              use_submodules: true,
+              use_binaries: false,
+              cache_builds: true,
               platform: 'iOS'
             )
           end").runner.execute(:test)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Enabled cache-builds flag

By default Carthage will rebuild a dependency regardless of whether it's the same resolved version as before. Passing the --cache-builds will cause carthage to avoid rebuilding a dependency if it can. See https://github.com/Carthage/Carthage/blob/master/Documentation/VersionFile.md

### Motivation and Context
Carthage has a new cache-builds flag
