### PR TITLE
Specify docs_url via gemspec metadata

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -16,6 +16,9 @@ Gem::Specification.new do |spec|
   spec.description   = Fastlane::DESCRIPTION
   spec.homepage      = "https://fastlane.tools"
   spec.license       = "MIT"
+  spec.metadata      = {
+    "docs_url" => "https://docs.fastlane.tools"
+  }
 
   spec.required_ruby_version = '>= 2.0.0'
 


### PR DESCRIPTION
We don't link to our beautiful docs page anywhere on RubyGems, let's change this: http://guides.rubygems.org/specification-reference/#metadata

I don't know where this is going to be displayed (if anywhere), but at least we have it in the `gemspec` somewhere.