### PR TITLE
Fix Interface `interactive?` method takes no parameters

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -81,7 +81,7 @@ module FastlaneCore
     #####################################################
 
     # Is is possible to ask the user questions?
-    def interactive?(_message)
+    def interactive?
       not_implemented(__method__)
     end
 


### PR DESCRIPTION
The method shouldn't take any parameters, so this would fail if the subclass doesn't implement the method.