### PR TITLE
Fix error installing the AppleWWDRCA certificate on multiuser systems

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -1,3 +1,5 @@
+require 'tempfile'
+
 module FastlaneCore
   # This class checks if a specific certificate is installed on the current mac
   class CertChecker
@@ -54,14 +56,13 @@ module FastlaneCore
     end
 
     def self.install_wwdr_certificate
-      Dir.chdir('/tmp') do
-        url = 'https://developer.apple.com/certificationauthority/AppleWWDRCA.cer'
-        filename = File.basename(url)
-        keychain = wwdr_keychain
-        keychain = "-k #{keychain.shellescape}" unless keychain.empty?
-        Helper.backticks("curl -O #{url} && security import #{filename} #{keychain}", print: FastlaneCore::Globals.verbose?)
-        UI.user_error!("Could not install WWDR certificate") unless $?.success?
-      end
+      url = 'https://developer.apple.com/certificationauthority/AppleWWDRCA.cer'
+      file = Tempfile.new('AppleWWDRCA')
+      filename = file.path
+      keychain = wwdr_keychain
+      keychain = "-k #{keychain.shellescape}" unless keychain.empty?
+      Helper.backticks("curl -o #{filename} #{url} && security import #{filename} #{keychain}", print: FastlaneCore::Globals.verbose?)
+      UI.user_error!("Could not install WWDR certificate") unless $?.success?
     end
 
     def self.wwdr_keychain

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -34,8 +34,7 @@ describe FastlaneCore do
         # We have to execute *something* using ` since otherwise we set expectations to `nil`, which is not healthy
         `ls`
 
-        cmd = "curl -O https://developer.apple.com/certificationauthority/AppleWWDRCA.cer "
-        cmd += "&& security import AppleWWDRCA.cer -k keychain\\ with\\ spaces.keychain"
+        cmd = %r{curl -o (/.+?) https://developer\.apple\.com/certificationauthority/AppleWWDRCA.cer && security import \1 -k keychain\\ with\\ spaces\.keychain}
 
         expect(FastlaneCore::Helper).to receive(:backticks).with(cmd, { print: nil }).and_return("")
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)


### PR DESCRIPTION


<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Download AppleWWDRCA.cer as a Tempfile rather than to a specific filename.
Using Tempfile also means that ruby automatically removes the file from the system.

### Motivation and Context

It can happen that the file /tmp/AppleWWDRCA.cer already exists, this
causes the install to fail because the file cannot be created as the
current user. Using a random temp file prevents this issue.

This happens on my CI server, which is a single mac with multiple users as
separate runners, the first to create the file `/tmp/AppleWWDRCA.cer` works,
all the other runners fail to run `match`.
