### PR TITLE
Find and delete keychains with -db extension

### DIFF
--- a/fastlane/lib/fastlane/actions/delete_keychain.rb
+++ b/fastlane/lib/fastlane/actions/delete_keychain.rb
@@ -6,19 +6,16 @@ module Fastlane
       def self.run(params)
         original = Actions.lane_context[Actions::SharedValues::ORIGINAL_DEFAULT_KEYCHAIN]
 
-        search_paths = []
-        search_paths << File.expand_path(params[:name]) if params[:name]
-        search_paths << File.expand_path(File.join("~", "Library", "Keychains", params[:name])) if params[:name]
-        search_paths << File.expand_path(params[:keychain_path]) if params[:keychain_path]
-
-        if search_paths.empty?
+        if params[:keychain_path]
+          if File.exist?(params[:keychain_path])
+            keychain_path = params[:keychain_path]
+          else
+            UI.user_error!("Unable to find the specified keychain.")
+          end
+        elsif params[:name]
+          keychain_path = FastlaneCore::Helper.keychain_path(params[:name])
+        else
           UI.user_error!("You either have to set :name or :keychain_path")
-        end
-
-        keychain_path = search_paths.find { |path| File.exist?(path) }
-
-        if keychain_path.nil?
-          UI.user_error!("Unable to find the specified keychain. Looked in:\n\t" + search_paths.join("\n\t"))
         end
 
         Fastlane::Actions.sh("security default-keychain -s #{original}", log: false) unless original.nil?

--- a/fastlane/lib/fastlane/actions/import_certificate.rb
+++ b/fastlane/lib/fastlane/actions/import_certificate.rb
@@ -4,7 +4,7 @@ module Fastlane
   module Actions
     class ImportCertificateAction < Action
       def self.run(params)
-        keychain_path = File.expand_path(File.join("~", "Library", "Keychains", params[:keychain_name]))
+        keychain_path = FastlaneCore::Helper.keychain_path(params[:keychain_name])
 
         FastlaneCore::KeychainImporter.import_file(params[:certificate_path], keychain_path, keychain_password: params[:keychain_password], certificate_password: params[:certificate_password], output: params[:log_output])
       end

--- a/fastlane/spec/actions_specs/import_certificate_spec.rb
+++ b/fastlane/spec/actions_specs/import_certificate_spec.rb
@@ -13,6 +13,7 @@ describe Fastlane do
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" #{keychain_path.shellescape} &> /dev/null"
 
         allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?).with(keychain_path).and_return(true)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
         allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: false)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: false)
@@ -38,6 +39,7 @@ describe Fastlane do
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" #{keychain_path.shellescape} &> /dev/null"
 
         allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?).with(keychain_path).and_return(true)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
         allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: false)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: false)
@@ -63,6 +65,7 @@ describe Fastlane do
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" #{keychain_path.shellescape}"
 
         allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?).with(keychain_path).and_return(true)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
         allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: true)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: true)

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -58,6 +58,35 @@ describe FastlaneCore do
       end
     end
 
+    describe "#keychain_path" do
+      it "finds file in current directory" do
+        allow(File).to receive(:exist?).and_return(false)
+
+        found = File.expand_path("test.keychain")
+        allow(File).to receive(:exist?).with(found).and_return(true)
+
+        expect(FastlaneCore::Helper.keychain_path("test.keychain")).to eq File.expand_path(found)
+      end
+
+      it "finds file in current directory with -db" do
+        allow(File).to receive(:exist?).and_return(false)
+
+        found = File.expand_path("test-db")
+        allow(File).to receive(:exist?).with(found).and_return(true)
+
+        expect(FastlaneCore::Helper.keychain_path("test.keychain")).to eq File.expand_path(found)
+      end
+
+      it "finds file in current directory with spaces and \"" do
+        allow(File).to receive(:exist?).and_return(false)
+
+        found = File.expand_path('\\"\\ test\\ \\".keychain')
+        allow(File).to receive(:exist?).with(found).and_return(true)
+
+        expect(FastlaneCore::Helper.keychain_path('\\"\\ test\\ \\".keychain')).to eq File.expand_path(found)
+      end
+    end
+
     # macOS only (to work on Linux)
     if FastlaneCore::Helper.is_mac?
       describe "Xcode" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
When deleting keychains, search for files with `-db` at the end of the file name.

### Motivation and Context
Since macOS Sierra keychain creates files with an extra -db extension, which delete_keychain action would fail to find.
