### PR TITLE
Add missing `ENV.delete` statement after generating test data

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -156,6 +156,7 @@ desc "This SHOULD only be used for testing changes to the docs"
 lane :test_generate_docs do
   ENV['USE_ENHANCE_TEST_DATA'] = "true"
   generate_markdown_docs
+  ENV.delete("USE_ENHANCE_TEST_DATA")
 end
 
 desc "Update the actions.md on https://docs.fastlane.tools"


### PR DESCRIPTION
This would cause the `USE_ENHANCE_TEST_DATA` environment variable to be set while verifying the repo is valid, however it's still being active *after* pushing the fastlane release, when generating the final docs, causing the order of the actions to be wrong, and the plugins to be hidden