### PR TITLE
Add Image Path for Locale Folders to Supply README File

### DIFF
--- a/supply/README.md
+++ b/supply/README.md
@@ -141,7 +141,7 @@ Expansion files (obbs) found under the same directory as your APK will also be u
 
 After running `fastlane supply init`, you will have a metadata directory. This directory contains one or more locale directories (e.g. en-US, en-GB, etc.), and inside this directory are text files such as `title.txt` and `short_description.txt`.
 
-Here you can supply images with the following file names (extension can be png, jpg or jpeg):
+Inside of a given locale directory is a folder called `images`. Here you can supply images with the following file names (extension can be png, jpg or jpeg):
 
 - `featureGraphic`
 - `icon`


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Updates `supply` README to include folder structure for `images` folder underneath locale directory. The grammar of the current documentation implies that images should be stored at the top level locale directory and not in the folder `images` underneath the locale directory.

### Motivation and Context
I was trying to debug why my images were not being picked up by `supply`, printed out what folder it was looking into, and was surprised to find that it was looking under a folder of `images` for each locale directory. Specifying this in the documentation will hopefully prevent others from having the same confusion. This might seem obvious if you've run `fastlane supply init` in your project, but I was developing off of the documentation before running `init` on my project.