### PR TITLE
Replace `gem update` with `gem install` per @segiddins' request

### DIFF
--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -84,7 +84,7 @@ module FastlaneCore
       elsif Helper.mac_app?
         "the Fabric app. Launch the app and navigate to the fastlane tab to get the most recent version."
       else
-        "sudo gem update #{gem_name.downcase}"
+        "sudo gem install #{gem_name.downcase}"
       end
     end
 

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -43,11 +43,11 @@ describe FastlaneCore do
       end
 
       it "works a custom gem name" do
-        expect(FastlaneCore::UpdateChecker.update_command(gem_name: "gym")).to eq("sudo gem update gym")
+        expect(FastlaneCore::UpdateChecker.update_command(gem_name: "gym")).to eq("sudo gem install gym")
       end
 
       it "works with system ruby" do
-        expect(FastlaneCore::UpdateChecker.update_command).to eq("sudo gem update fastlane")
+        expect(FastlaneCore::UpdateChecker.update_command).to eq("sudo gem install fastlane")
       end
 
       it "works with bundler" do


### PR DESCRIPTION
This will make the update process faster, and is the recommended way to update gems if the user isn't using bundler