### PR TITLE
Add 'associated_groups' attribute to Spaceship::Portal::App

### DIFF
--- a/spaceship/lib/spaceship/portal/app.rb
+++ b/spaceship/lib/spaceship/portal/app.rb
@@ -51,6 +51,9 @@ module Spaceship
       # @return (Fixnum) Number of associated identifiers
       attr_accessor :identifiers_count
 
+      # @return (Array of Spaceship::Portal::AppGroup) Associated groups
+      attr_accessor :associated_groups
+
       attr_mapping(
         'appIdId' => :app_id,
         'name' => :name,
@@ -68,6 +71,14 @@ module Spaceship
       )
 
       class << self
+        # Create a new object based on a hash.
+        # This is used to create a new object based on the server response.
+        def factory(attrs)
+          obj = self.new(attrs)
+          obj.unfold_associated_groups(attrs['associatedApplicationGroups'])
+          return obj
+        end
+
         # @param mac [Bool] Fetches Mac apps if true
         # @return (Array) Returns all apps available for this account
         def all(mac: false)
@@ -100,6 +111,12 @@ module Spaceship
             return app if app.bundle_id.casecmp(bundle_id) == 0
           end
         end
+      end
+
+      def unfold_associated_groups(attrs)
+        return unless attrs
+        unfolded_associated_groups = attrs.map { |info| Spaceship::Portal::AppGroup.new(info) }
+        instance_variable_set(:@associated_groups, unfolded_associated_groups)
       end
 
       # Delete this App ID. This action will most likely fail if the App ID is already in the store

--- a/spaceship/spec/portal/app_spec.rb
+++ b/spaceship/spec/portal/app_spec.rb
@@ -51,6 +51,8 @@ describe Spaceship::Portal::App do
       expect(app.app_groups_count).to eq(0)
       expect(app.cloud_containers_count).to eq(0)
       expect(app.identifiers_count).to eq(0)
+      expect(app.associated_groups.length).to eq(1)
+      expect(app.associated_groups[0].group_id).to eq("group.tools.fastlane")
     end
 
     it "allows modification of values and properly retrieving them" do

--- a/spaceship/spec/portal/fixtures/getAppIdDetail.action.json
+++ b/spaceship/spec/portal/fixtures/getAppIdDetail.action.json
@@ -43,6 +43,13 @@
         "isProdPushEnabled": true,
         "associatedApplicationGroupsCount": 0,
         "associatedCloudContainersCount": 0,
-        "associatedIdentifiersCount": 0
+        "associatedIdentifiersCount": 0,
+        "associatedApplicationGroups": [
+            {
+                "name": "Production App Group",
+                "identifier": "group.tools.fastlane",
+                "applicationGroup": "NR5BH6N89Z"
+            }
+        ]
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

`getAppIdDetail.action` API returns the `associatedApplicationGroups` element.
So I added the `associated_groups` attribute to `Spaceship::Portal::App` class.

### Motivation and Context

#8508 
#8143 