### PR TITLE
Error when description is less than 10 chars

### DIFF
--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -46,7 +46,11 @@ module Pilot
                                      short_option: "-d",
                                      optional: true,
                                      env_name: "PILOT_BETA_APP_DESCRIPTION",
-                                     description: "Provide the beta app description when uploading a new build"),
+                                     description: "Provide the beta app description when uploading a new build",
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Beta App Description must be at least 10 characters long.") unless value.to_s.length >= 10
+                                       UI.user_error!("Beta App Description must be less than 4000 characters long.") unless value.to_s.length <= 4000
+                                     end),
         FastlaneCore::ConfigItem.new(key: :beta_app_feedback_email,
                                      short_option: "-n",
                                      optional: true,


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Description
Give Warning when Beta Description is less than 10 characters or greater than 4000

### Motivation and Context
Bumper to get denied after the upload is successful.
If I could be pointed in the right direction for a test case of pilot update build info

```
[16:32:36]: Successfully finished processing the build
[16:32:36]: You can now tweet: 
[16:32:36]: iTunes Connect #iosprocessingtime 10 minutes
*snip lane context*
[16:32:37]: [English]: Beta App Description must be at least 10 characters long. Beta App Description must be at least 10 characters long.
```