### PR TITLE
Update contributing docs to add --path for deps

### DIFF
--- a/YourFirstPR.md
+++ b/YourFirstPR.md
@@ -16,7 +16,7 @@ If you want to work on something else, e.g. new functionality or fixing a bug, i
 - Clone your fork:
   - `git clone git@github.com:<YOUR_GITHUB_USER>/fastlane.git`
 - Install dependencies:
-  - Run `bundle install` in the project root
+  - Run `bundle install --path .bundle` in the project root
   - You also might need to run `bundle install` in each of the tool's subdirectories, e.g. `cd gym && bundle install`
   - If there are dependency errors, you might also need to run `bundle update`
 - Create a new branch to work on:


### PR DESCRIPTION
Following the current directions throws this error:

```
+------+------------------------------+-------------+
|                 fastlane summary                  |
+------+------------------------------+-------------+
| Step | Action                       | Time (in s) |
+------+------------------------------+-------------+
| 1    | Switch to validate_repo lane | 0           |
| 💥   | ensure_no_debug_code         | 0           |
+------+------------------------------+-------------+

[18:16:23]: fastlane finished with errors

[!] Found debug code 'binding.pry': 
```

when running tests on a fresh install. It appears that `.gitignore` and the test runner expects `.bundle` to be the location (and that's what CircleCI does).

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description
Simple documentation fix to help first-time contributors.

### Motivation and Context
Simple documentation fix to help first-time contributors.

