### PR TITLE
Fix tests by mocking FastlaneCore::FastlaneFolder

### DIFF
--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -3,6 +3,10 @@ require "xcodeproj"
 # 77C503031DD3175E00AC8FF0 = today
 describe Fastlane do
   describe "Automatic Code Signing" do
+    before :each do
+      allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+    end
+
     it "enable_automatic_code_signing" do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use ProvisioningStyle 'Automatic'")


### PR DESCRIPTION
This is caused by removing `value = nil if Helper.is_test?` in
FastlaneCore::FastlaneFolder.path.
See more: https://github.com/fastlane/fastlane/pull/8484

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Fix tests by mocking FastlaneCore::FastlaneFolder

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I didn't realize that https://github.com/fastlane/fastlane/pull/8417 is affected with [the change of FastlaneCore::FastlaneFolder](https://github.com/fastlane/fastlane/pull/8484).
I fix the test case to pass correctly.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
