### PR TITLE
Handle exit status of error_callback

### DIFF
--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -51,8 +51,10 @@ module Fastlane
                     end
           message += "\n#{result}" if print_command_output
 
-          error_callback.call(result) if error_callback
-          UI.user_error!(message)
+          callback_exit_status = error_callback.call(result) if error_callback
+          if callback_exit_status != 0
+            UI.user_error!(message)
+          end
         end
       end
 


### PR DESCRIPTION

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

If executing external commands is failed and recover in error callbacks, lane should be succeed.
However, `user_error!` is always called.

This PR make if callbacks return exit code 0, then `user_error!` is not called. In other words, lane become succeed.

```ruby
sh "./failure", error_callback: lambda { |result|
  sh "./success"
  next 0
}
```

If no value is returned from the callback. `sh` action should be failed. (same as until now.)
