### PR TITLE
Version bump to 2.20.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.19.3'.freeze
+  VERSION = '2.20.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Changes since release 2.19.3:

* Fix tests by mocking FastlaneCore::FastlaneFolder (#8527)
* Use FastlaneFolder.path instead of fixed './fastlane' (#8393)
* Revise FastlaneCore::FastlaneFolder.path (#8484)
* Detect running Ruby version and fail early (#8525)
* Replace `gem update` with `gem install` per @segiddins' request (#8514)
* update header
* Update CONTRIBUTING.md to have information about the Google CLA
* Fix Image File Path (#8513)
* integrate fastlane-plugin-update_project_codesigning (#8417)
* Add missing `ENV.delete` statement after generating test data (#8512)
* Fix Interface `interactive?` method takes no parameters (#8506)
* Specify docs_url via gemspec metadata (#8505)
* Add missing `require` for terminal-table (#8503)
* Update example text to prefix tool commands with 'fastlane' (#8485)
* Add error_callback option to cocoapods action (#8344)
* [deliver] support JPG icons for metadata (#8418)
* Fix regression with delete_keychain(name:) (#8467)
* Check for ENV vars that interfere with local testing (#8462)
* Add "enterprise" reference to the match documentation (#8438)
* Force binary reading/writing when analyzing IPAs (#8455)