### PR TITLE
Update webmock dependency to work with latest Ruby

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -73,7 +73,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'yard', '~> 0.8.7.4'
-  spec.add_development_dependency 'webmock', '~> 1.19.0'
+  spec.add_development_dependency 'webmock', '~> 2.3.2'
   spec.add_development_dependency 'coveralls', '~> 0.8.13'
   spec.add_development_dependency 'rubocop', '~> 0.47'
   spec.add_development_dependency 'rb-readline' # https://github.com/deivid-rodriguez/byebug/issues/289#issuecomment-251383465

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -595,7 +595,7 @@ describe FastlaneCore do
           it "throws an error if it's invalid" do
             expect do
               @config.set(:output, 132)
-            end.to raise_error("'output' value must be a String! Found Integer instead.")
+            end.to raise_error("'output' value must be a String! Found #{123.class} instead.")
             expect do
               @config.set(:wait_processing_interval, -1)
             end.to raise_error("Please enter a valid positive number of seconds")

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -595,7 +595,7 @@ describe FastlaneCore do
           it "throws an error if it's invalid" do
             expect do
               @config.set(:output, 132)
-            end.to raise_error("'output' value must be a String! Found Fixnum instead.")
+            end.to raise_error("'output' value must be a String! Found Integer instead.")
             expect do
               @config.set(:wait_processing_interval, -1)
             end.to raise_error("Please enter a valid positive number of seconds")

--- a/spaceship/spec/portal/app_spec.rb
+++ b/spaceship/spec/portal/app_spec.rb
@@ -124,7 +124,7 @@ describe Spaceship::Portal::App do
     it 'updates the name of the app by given bundle_id' do
       stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/updateAppIdName.action").
         with(body: { "appIdId" => "B7JBD8LHAA", "name" => "The New Name", "teamId" => "XXXXXXXXXX" }).
-        to_return(status: 200, body: JSON.parse(PortalStubbing.adp_read_fixture_file('updateAppIdName.action.json')), headers: {})
+        to_return(status: 200, body: PortalStubbing.adp_read_fixture_file('updateAppIdName.action.json'), headers: { 'Content-Type' => 'application/json' })
 
       app = subject.update_name!('The New Name')
       expect(app.app_id).to eq('B7JBD8LHAA')


### PR DESCRIPTION
This caused issues running the tests on a new Mac with the latest Ruby via rbenv