### PR TITLE
Fix table formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ end
 Then to deploy a new 'beta' version of your app just run
 `fastlane beta` :rocket:
 
-              |  fastlane
---------------------------|------------------------------------------------------------
+
+
+|          |  fastlane  |
+|----------|------------|
 :sparkles: | Connect iOS, Mac, and Android build tools into one workflow (both _fastlane_ tools and third party tools)
 :monorail: | Define different `deployment lanes` for App Store deployment, beta builds, or testing
 :ship: | Deploy from any computer, including a CI server


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
I noticed the formatting of the feature listing table on the README wasn't working. Seems like GitHub no longer likes the header formatting it was using?