### PR TITLE
Add git_user_name and git_user_email option to match

### DIFF
--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -145,8 +145,9 @@ module Match
       commands << "git config user.name \"#{user_name}\"" unless user_name.nil?
       commands << "git config user.email \"#{user_email}\"" unless user_email.nil?
 
-      UI.message "Add git user config to local git repo..." unless commands.empty?
+      return if commands.empty?
 
+      UI.message "Add git user config to local git repo..."
       Dir.chdir(@dir) do
         commands.each do |command|
           FastlaneCore::CommandExecutor.execute(command: command,

--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -1,6 +1,6 @@
 module Match
   class GitHelper
-    def self.clone(git_url, shallow_clone, manual_password: nil, skip_docs: false, branch: "master", git_user_name: nil, git_user_email: nil)
+    def self.clone(git_url, shallow_clone, manual_password: nil, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil)
       return @dir if @dir
 
       @dir = Dir.mktmpdir
@@ -21,7 +21,7 @@ module Match
         UI.user_error!("Error cloning certificates git repo, please make sure you have access to the repository - see instructions above")
       end
 
-      add_user_config(git_user_name, git_user_email)
+      add_user_config(git_full_name, git_user_email)
 
       UI.user_error!("Error cloning repo, make sure you have access to it '#{git_url}'") unless File.directory?(@dir)
 

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -64,6 +64,16 @@ module Match
                                      verify_block: proc do |value|
                                        ENV["FASTLANE_TEAM_ID"] = value.to_s
                                      end),
+        FastlaneCore::ConfigItem.new(key: :git_user_name,
+                                     env_name: "MATCH_GIT_USER_NAME",
+                                     description: "git user name to commit",
+                                     optional: true,
+                                     default_value: nil),
+        FastlaneCore::ConfigItem.new(key: :git_user_email,
+                                     env_name: "MATCH_GIT_USER_EMAIL",
+                                     description: "git user email to commit",
+                                     optional: true,
+                                     default_value: nil),
         FastlaneCore::ConfigItem.new(key: :team_name,
                                      short_option: "-l",
                                      env_name: "FASTLANE_TEAM_NAME",

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -64,9 +64,9 @@ module Match
                                      verify_block: proc do |value|
                                        ENV["FASTLANE_TEAM_ID"] = value.to_s
                                      end),
-        FastlaneCore::ConfigItem.new(key: :git_user_name,
-                                     env_name: "MATCH_GIT_USER_NAME",
-                                     description: "git user name to commit",
+        FastlaneCore::ConfigItem.new(key: :git_full_name,
+                                     env_name: "MATCH_GIT_FULL_NAME",
+                                     description: "git user full name to commit",
                                      optional: true,
                                      default_value: nil),
         FastlaneCore::ConfigItem.new(key: :git_user_email,

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -8,7 +8,7 @@ module Match
                                          hide_keys: [:workspace],
                                              title: "Summary for match #{Fastlane::VERSION}")
 
-      params[:workspace] = GitHelper.clone(params[:git_url], params[:shallow_clone], skip_docs: params[:skip_docs], branch: params[:git_branch])
+      params[:workspace] = GitHelper.clone(params[:git_url], params[:shallow_clone], skip_docs: params[:skip_docs], branch: params[:git_branch], git_user_name: params[:git_user_name], git_user_email: params[:git_user_email])
 
       unless params[:readonly]
         self.spaceship = SpaceshipEnsure.new(params[:username])

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -8,7 +8,7 @@ module Match
                                          hide_keys: [:workspace],
                                              title: "Summary for match #{Fastlane::VERSION}")
 
-      params[:workspace] = GitHelper.clone(params[:git_url], params[:shallow_clone], skip_docs: params[:skip_docs], branch: params[:git_branch], git_user_name: params[:git_user_name], git_user_email: params[:git_user_email])
+      params[:workspace] = GitHelper.clone(params[:git_url], params[:shallow_clone], skip_docs: params[:skip_docs], branch: params[:git_branch], git_full_name: params[:git_full_name], git_user_email: params[:git_user_email])
 
       unless params[:readonly]
         self.spaceship = SpaceshipEnsure.new(params[:username])

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -15,7 +15,7 @@ describe Match do
       profile_path = "./match/spec/fixtures/test.mobileprovision"
       destination = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision")
 
-      expect(Match::GitHelper).to receive(:clone).with(git_url, true, skip_docs: false, branch: "master").and_return(repo_dir)
+      expect(Match::GitHelper).to receive(:clone).with(git_url, true, skip_docs: false, branch: "master", git_user_name: nil, git_user_email: nil).and_return(repo_dir)
       expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution).and_return(cert_path)
       expect(Match::Generator).to receive(:generate_provisioning_profile).with(params: config,
                                                                             prov_type: :appstore,
@@ -57,7 +57,7 @@ describe Match do
       key_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.p12"
       keychain = "login.keychain"
 
-      expect(Match::GitHelper).to receive(:clone).with(git_url, false, skip_docs: false, branch: "master").and_return(repo_dir)
+      expect(Match::GitHelper).to receive(:clone).with(git_url, false, skip_docs: false, branch: "master", git_user_name: nil, git_user_email: nil).and_return(repo_dir)
       expect(Match::Utils).to receive(:import).with(key_path, keychain, password: nil).and_return(nil)
       expect(Match::GitHelper).to_not receive(:commit_changes)
 

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -15,7 +15,7 @@ describe Match do
       profile_path = "./match/spec/fixtures/test.mobileprovision"
       destination = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision")
 
-      expect(Match::GitHelper).to receive(:clone).with(git_url, true, skip_docs: false, branch: "master", git_user_name: nil, git_user_email: nil).and_return(repo_dir)
+      expect(Match::GitHelper).to receive(:clone).with(git_url, true, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil).and_return(repo_dir)
       expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution).and_return(cert_path)
       expect(Match::Generator).to receive(:generate_provisioning_profile).with(params: config,
                                                                             prov_type: :appstore,
@@ -57,7 +57,7 @@ describe Match do
       key_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.p12"
       keychain = "login.keychain"
 
-      expect(Match::GitHelper).to receive(:clone).with(git_url, false, skip_docs: false, branch: "master", git_user_name: nil, git_user_email: nil).and_return(repo_dir)
+      expect(Match::GitHelper).to receive(:clone).with(git_url, false, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil).and_return(repo_dir)
       expect(Match::Utils).to receive(:import).with(key_path, keychain, password: nil).and_return(nil)
       expect(Match::GitHelper).to_not receive(:commit_changes)
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Add new option to match `git_user_name` and `git_user_email` to set git config to match's git repository.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
If using useConfigOnly option (and global name or email settings is not set) in gitconfig, match fails to commit to git repository
Add new two option for name and email and fix it.

The reason which the git option needs is followed by [this page](https://collectiveidea.com/blog/archives/2016/04/04/multiple-personalities-in-git)