### PR TITLE
Address delete_keychain regression for -db keychains

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -177,7 +177,7 @@ module FastlaneCore
       return File.join(self.itms_path, 'bin', 'iTMSTransporter')
     end
 
-    def self.keychain_path(name)
+    def self.possible_keychain_paths(name)
       # Existing code expects that a keychain name will be expanded into a default path to Libary/Keychains
       # in the user's home directory. However, this will not allow the user to pass an absolute path
       # for the keychain value
@@ -207,7 +207,11 @@ module FastlaneCore
         keychain_paths << location
         keychain_paths << "#{location}.keychain"
       end
+      keychain_paths
+    end
 
+    def self.keychain_path(name)
+      keychain_paths = possible_keychain_paths(name)
       keychain_path = keychain_paths.find { |path| File.exist?(path) }
       UI.user_error!("Could not locate the provided keychain. Tried:\n\t#{keychain_paths.join("\n\t")}") unless keychain_path
       keychain_path


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description

For the keychain name 'example', `create_keychain` makes a keychain at:

```
/Users/mfurtak/Library/Keychains/example-db
```

The `-db` suffix is a new wrinkle in recent macOS versions. We've been fixing places where this has broken our keychain handling, but these fixes had not yet reached `delete_keychain`.

So, in the previous version, for the keychain name 'example', `delete_keychain` would generate the command:

```
security delete-keychain /Users/mfurtak/Library/Keychains/example
```

Assuming you ran `create_keychain` and got the keychain as described above, this path doesn't exist. However, `security delete-keychain` doesn't care, and helpfully deletes `example-db` for you. So, the previous version was working somewhat by coincidence.

The most recent version of `delete_keychain` attempted to be better about searching in more places for the keychain to delete, but it also added checks to make sure that the keychains exist before trying to ask `security` to delete them. This broke the working situation above.

My proposed fix is to make `delete_keychain` use the shared utility `FastlaneCore::Helper.keychain_path` to take advantage of its shared keychain locating checks.

### Motivation and Context

#8543 reported a regression introduced by #8467 while fixing the regression caused by #8003 