### PR TITLE
Fix Markdown formatting throughout project

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ end
 Then to deploy a new 'beta' version of your app just run
 `fastlane beta` :rocket:
 
-              |  fastlane
---------------------------|------------------------------------------------------------
+
+
+|          |  fastlane  |
+|----------|------------|
 :sparkles: | Connect iOS, Mac, and Android build tools into one workflow (both _fastlane_ tools and third party tools)
 :monorail: | Define different `deployment lanes` for App Store deployment, beta builds, or testing
 :ship: | Deploy from any computer, including a CI server

--- a/cert/README.md
+++ b/cert/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 <p align="center">

--- a/deliver/README.md
+++ b/deliver/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 <p align="center">
@@ -40,6 +41,7 @@ deliver
 Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.com/FastlaneTools)
 
 -------
+
 <p align="center">
     <a href="#features">Features</a> &bull;
     <a href="#installation">Installation</a> &bull;

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -16,6 +16,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 fastlane
@@ -25,11 +26,12 @@ fastlane
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/fastlane/fastlane/blob/master/fastlane/LICENSE)
 [![Gem](https://img.shields.io/gem/v/fastlane.svg?style=flat)](https://rubygems.org/gems/fastlane)
 
-######*fastlane* lets you define and run your deployment pipelines for different environments. It helps you unify your apps release process and automate the whole process. fastlane connects all fastlane tools and third party tools, like [CocoaPods](https://cocoapods.org/) and [Slack](https://slack.com).
+###### *fastlane* lets you define and run your deployment pipelines for different environments. It helps you unify your apps release process and automate the whole process. fastlane connects all fastlane tools and third party tools, like [CocoaPods](https://cocoapods.org/) and [Slack](https://slack.com).
 
 Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.com/FastlaneTools)
 
 -------
+
 <p align="center">
     <a href="#features">Features</a> &bull;
     <a href="#installation">Installation</a> &bull;
@@ -73,8 +75,8 @@ To launch the `appstore` lane, just run:
 fastlane release
 ```
 
-              |  fastlane
---------------------------|------------------------------------------------------------
+|          |  fastlane  |
+|----------|------------|
 :sparkles: | Connect all iOS and Android build tools into one workflow (both `fastlane` tools and third party tools)
 :monorail: | Define different `deployment lanes` for App Store deployment, beta builds or testing
 :ship: | Deploy from any computer, including a CI-server

--- a/fastlane/docs/Bamboo.md
+++ b/fastlane/docs/Bamboo.md
@@ -36,7 +36,7 @@ sh(git_remote_cmd)
 ```
 
 
-##Speeding up build times with carthage
+## Speeding up build times with carthage
 
 Carthage is a wonderful dependency manager but once you are start using a large number of frameworks, things can start to slow down, especially if your CI server has to run `carthage` EVERY time you check in a small line of code.
 
@@ -45,17 +45,17 @@ One way to make build times faster is to break your work up into two separate bu
 The general idea is to make a build plan: **Project - Artifacts** that builds the `Carthage` directory and stores it as a shared artifact.  Then you create a second build plan **Project - Fastlane** that pulls down the `Carthage` directory and runs `fastlane`.  
 
 
-###Artifact Plan
+### Artifact Plan
 
 Use a very simple setup to create this build plan.  First off you want to make sure this plan is manually triggered only - because you only need to run it whenever the `Cartfile` changes as opposed to after ever single commit.  It could also be on a nightly build perhaps if you desire.
 
-####Stages / Jobs / Tasks
+#### Stages / Jobs / Tasks
 This plan consists of 1 Job, 1 Stage and 2 Tasks
 
 * Task 1: **Source Code Checkout**
 * Task 2: **Script** (`carthage update`)
 
-####Artifact definitions
+#### Artifact definitions
 
 Create a shared artifact with the following info:
 
@@ -80,7 +80,7 @@ ensure_git_status_clean
 
 as these calls will either fail the build or delete the `Carthage` directory.  Additionally you want to remove any `carthage` tasks from inside your `Fastfile` as `carthage` is now happening externally to the build.
 
-####Build plan setup
+#### Build plan setup
 
 What this build plan does is it checks out the source code, then it downloads the entire `Carthage/Build/` directory into your local project - which is exactly what would be created from `carthage bootstrap` and then it runs `fastlane`
 

--- a/fastlane/docs/Guide.md
+++ b/fastlane/docs/Guide.md
@@ -1,12 +1,14 @@
 This guide will help you get started with `fastlane` in no time :rocket:
 
 -------
+
 <p align="center">
     <a href="#installation">Installation</a> &bull;
     <a href="#setting-up-fastlane">Setting up</a> &bull;
     <a href="#example-projects">Example Projects</a> &bull;
     <a href="#help">Help</a>
 </p>
+
 -------
 
 ## Notes about this guide

--- a/fastlane_core/README.md
+++ b/fastlane_core/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 FastlaneCore

--- a/frameit/README.md
+++ b/frameit/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 <p align="center">
@@ -40,8 +41,8 @@ frameit
 
 Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.com/FastlaneTools)
 
-
 -------
+
 <p align="center">
     <a href="#features">Features</a> &bull;
     <a href="#installation">Installation</a> &bull;
@@ -51,6 +52,7 @@ Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.c
 </p>
 
 -------
+
 <h5 align="center"><code>frameit</code> is part of <a href="https://fastlane.tools">fastlane</a>: The easiest way to automate beta deployments and releases for your iOS and Android apps.</h5>
 
 

--- a/gym/README.md
+++ b/gym/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 <p align="center">
@@ -38,6 +39,7 @@ gym
 Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.com/FastlaneTools)
 
 -------
+
 <p align="center">
     <a href="#whats-gym">Features</a> &bull;
     <a href="#installation">Installation</a> &bull;
@@ -78,8 +80,8 @@ fastlane gym
 
 `gym` uses the latest APIs to build and sign your application which results in much faster build times.
 
-              |  Gym Features
---------------------------|------------------------------------------------------------
+|          |  Gym Features  |
+|----------|----------------|
 :rocket:            | `gym` builds 30% faster than other build tools like [shenzhen](https://github.com/nomad/shenzhen)
 :checkered_flag: | Beautiful inline build output
 :book:     | Helps you resolve common build errors like code signing issues

--- a/gym/examples/cocoapods/Pods/HexColors/README.md
+++ b/gym/examples/cocoapods/Pods/HexColors/README.md
@@ -6,10 +6,10 @@ HexColors
 
 HexColors is drop in category for HexColor Support for NSColor and UIColor. Support for HexColors with prefixed # and without.
 
-#RELEASE 2.3.0
+# RELEASE 2.3.0
 Attention the API has changed!
 
-#Example iOS
+# Example iOS
 ``` objective-c
 // with hash
 UIColor *colorWithHex = [UIColor colorWithHexString:@"#ff8942"];
@@ -21,7 +21,7 @@ UIColor *secondColorWithHex = [UIColor colorWithHexString:@"ff8942"];
 UIColor *shortColorWithHex = [UIColor colorWithHexString:@"fff"];
 ```
 
-#Example macOS
+# Example macOS
 ``` objective-c
 // with hash
 NSColor *colorWithHex = [NSColor colorWithHexString:@"#ff8942"];
@@ -33,21 +33,21 @@ NSColor *secondColorWithHex = [NSColor colorWithHexString:@"ff8942"];
 NSColor *shortColorWithHex = [NSColor colorWithHexString:@"fff"];
 ```
 
-#Installation
+# Installation
 * `#import "HexColors.h"` where you want to use easy as pie HexColors
 * `pod install HexColors`
 * or just drag the source files in your project
 
-##Requirements
+## Requirements
 HexColors requires [iOS 5.0](http://developer.apple.com/library/ios/#releasenotes/General/WhatsNewIniPhoneOS/Articles/iPhoneOS4.html) and above, and Mac OS X 10.6
 
-##Credits
+## Credits
 HexColors was created by [Marius Landwehr](https://github.com/mRs-) because of the pain recalculating Hex values to RGB.
 
 HexColors was ported to macOS by [holgersindbaek](https://github.com/holgersindbaek).
 
-##Creator
+## Creator
 [Marius Landwehr](https://github.com/mRs-) [@mariusLAN](https://twitter.com/mariusLAN)
 
-##License
+## License
 HexColors is available underthe MIT license. See the LICENSE file for more info.

--- a/match/README.md
+++ b/match/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <b>match</b>
 </p>
+
 -------
 
 <p align="center">
@@ -42,6 +43,7 @@ A new approach to iOS code signing: Share one code signing identity across your 
 [More information on how to get started with codesigning](/fastlane/docs/Codesigning)
 
 -------
+
 <p align="center">
     <a href="#why-match">Why?</a> &bull;
     <a href="#installation">Installation</a> &bull;
@@ -77,8 +79,8 @@ Before starting to use `match`, make sure to read the [codesigning.guide](https:
 
 ### What does `match` do for you?
 
-              |  match
---------------------------|------------------------------------------------------------
+|          |  match  |
+|----------|---------|
 :arrows_counterclockwise:  | Automatically sync your iOS keys and profiles across all your team members using git
 :package:  | Handle all the heavy lifting of creating and storing your certificates and profiles
 :computer:  | Setup codesigning on a new machine in under a minute

--- a/pem/README.md
+++ b/pem/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 <p align="center">
@@ -44,6 +45,7 @@ Tired of manually creating and maintaining your push notification profiles for y
 To automate iOS Provisioning profiles you can use [match](https://github.com/fastlane/fastlane/tree/master/match).
 
 -------
+
 <p align="center">
     <a href="#features">Features</a> &bull;
     <a href="#installation">Installation</a> &bull;

--- a/pilot/README.md
+++ b/pilot/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 <p align="center">
@@ -47,6 +48,7 @@ Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.c
 `pilot` uses [spaceship.airforce](https://spaceship.airforce) to interact with iTunes Connect :rocket:
 
 -------
+
 <p align="center">
     <a href="#installation">Installation</a> &bull;
     <a href="#usage">Usage</a> &bull;

--- a/produce/README.md
+++ b/produce/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 <p align="center">
@@ -40,6 +41,7 @@ produce
 Get in contact with the developers on Twitter: [@FastlaneTools](https://twitter.com/FastlaneTools)
 
 -------
+
 <p align="center">
     <a href="#features">Features</a> &bull;
     <a href="#installation">Installation</a> &bull;

--- a/scan/README.md
+++ b/scan/README.md
@@ -20,6 +20,7 @@
   <b>scan</b> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 <p align="center">
@@ -40,6 +41,7 @@ scan
 Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.com/FastlaneTools)
 
 -------
+
 <p align="center">
     <a href="#whats-scan">Features</a> &bull;
     <a href="#installation">Installation</a> &bull;
@@ -101,8 +103,8 @@ scan
 
 `scan` uses the latest APIs and tools to make running tests plain simple and offer a great integration into your existing workflow, like [fastlane](https://fastlane.tools) or Jenkins.
 
-              |  scan Features
---------------------------|------------------------------------------------------------
+|          |  scan Features  |
+|----------|-----------------|
 :checkered_flag: | Beautiful inline build output while running the tests
 :mountain_cableway: | Sensible defaults: Automatically detect the project, schemes and more
 :bar_chart: | Support for HTML, JSON and JUnit reports

--- a/screengrab/README.md
+++ b/screengrab/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 <p align="center">

--- a/sigh/README.md
+++ b/sigh/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 <p align="center">
@@ -40,6 +41,7 @@ sigh
 Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.com/FastlaneTools)
 
 -------
+
 <p align="center">
     <a href="#features">Features</a> &bull;
     <a href="#installation">Installation</a> &bull;

--- a/snapshot/README.md
+++ b/snapshot/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 <p align="center">
@@ -60,6 +61,7 @@ _snapshot_ runs completely in the background - you can do something else, while 
 Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.com/FastlaneTools)
 
 -------
+
 <p align="center">
     <a href="#features">Features</a> &bull;
     <a href="#installation">Installation</a> &bull;

--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -20,11 +20,13 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 <p align="center">
   <img src="assets/spaceship.png" width="470">
 </p>
+
 -------
 
 [![Twitter: @FastlaneTools](https://img.shields.io/badge/contact-@FastlaneTools-blue.svg?style=flat)](https://twitter.com/FastlaneTools)
@@ -36,6 +38,7 @@
 Get in contact with the creators on Twitter: [@FastlaneTools](https://twitter.com/fastlanetools)
 
 -------
+
 <p align="center">
     <a href="#whats-spaceship">Why?</a> &bull;
     <a href="#usage">Usage</a> &bull;

--- a/supply/README.md
+++ b/supply/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
   <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a>
 </p>
+
 -------
 
 <p align="center">
@@ -41,6 +42,7 @@ Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.c
 
 
 -------
+
 <p align="center">
     <a href="#features">Features</a> &bull;
     <a href="#installation">Installation</a> &bull;


### PR DESCRIPTION
Following up on #8547, scrubbed thru the `*.md` files and fixed a handful of rendering errors I spotted. Seems like GitHub (recently?) is more picky about whitespace.