### PR TITLE
Add support for fish tab completions

### DIFF
--- a/fastlane/lib/assets/completions/completion.fish
+++ b/fastlane/lib/assets/completions/completion.fish
@@ -1,5 +1,5 @@
 # This function was taken from https://github.com/Carthage/Carthage/blob/master/Source/Scripts/carthage-fish-completion
-function __fish_prog_needs_subcommand
+function __fish_fastlane_needs_subcommand
   set cmd (commandline -opc)
   if [ (count $cmd) -eq 1 -a $cmd[1] = 'fastlane' ]
     return 0
@@ -34,4 +34,4 @@ for line in $commands
   end
 end
 
-complete -c fastlane -n '__fish_prog_needs_subcommand' -a (string trim $commands_string) -f
+complete -c fastlane -n '__fish_fastlane_needs_subcommand' -a (string trim $commands_string) -f

--- a/fastlane/lib/assets/completions/completion.fish
+++ b/fastlane/lib/assets/completions/completion.fish
@@ -17,7 +17,7 @@ else
   exit 1
 end
 
-set commands (string match --regex '.*lane\ \:([^\s]*)\ do' (cat $file))
+set commands (string match --regex '.*lane\ \:(?!private_)([^\s]*)\ do' (cat $file))
 
 set commands_string
 

--- a/fastlane/lib/assets/completions/completion.fish
+++ b/fastlane/lib/assets/completions/completion.fish
@@ -1,0 +1,37 @@
+# This function was taken from https://github.com/Carthage/Carthage/blob/master/Source/Scripts/carthage-fish-completion
+function __fish_prog_needs_subcommand
+  set cmd (commandline -opc)
+  if [ (count $cmd) -eq 1 -a $cmd[1] = 'fastlane' ]
+    return 0
+  end
+    return 1
+end
+
+if test -e "Fastfile"
+  set file "Fastfile"
+else if test -e "fastlane/Fastfile"
+  set file "fastlane/Fastfile"
+else if test -e ".fastlane/Fastfile"
+  set file ".fastlane/Fastfile"
+else
+  exit 1
+end
+
+set commands (string match --regex '.*lane\ \:([^\s]*)\ do' (cat $file))
+
+set commands_string
+
+# Fish returns the fully matched string, plus the capture group. The actual captured value
+# is every other line, starting at line 2.
+set use_command false
+
+for line in $commands
+  if [ $use_command = true ]
+    set commands_string "$commands_string $line"
+    set use_command false
+  else
+    set use_command true
+  end
+end
+
+complete -c fastlane -n '__fish_prog_needs_subcommand' -a (string trim $commands_string) -f

--- a/fastlane/lib/fastlane/auto_complete.rb
+++ b/fastlane/lib/fastlane/auto_complete.rb
@@ -4,21 +4,39 @@ module Fastlane
   # Enable tab auto completion
   class AutoComplete
     def self.execute
-      fastlane_conf_dir = "~/.fastlane"
-      confirm = UI.confirm "This will copy a shell script into #{fastlane_conf_dir} that provides the command tab completion. Sound good?"
-      return unless confirm
+      shell = ENV['SHELL']
 
-      # create the ~/.fastlane directory
-      fastlane_conf_dir = File.expand_path fastlane_conf_dir
-      FileUtils.mkdir_p fastlane_conf_dir
+      if shell.end_with? "fish"
+        fish_completions_dir = "~/.config/fish/completions"
+        confirm = UI.confirm "This will copy a fish script into #{fish_completions_dir} that provides the command tab completion. If the directory does not exist it will be created. Sound good?"
+        return unless confirm
 
-      # then copy all of the completions files into it from the gem
-      completion_script_path = File.join(Fastlane::ROOT, 'lib', 'assets', 'completions')
-      FileUtils.cp_r completion_script_path, fastlane_conf_dir
+        fish_completions_dir = File.expand_path fish_completions_dir
+        FileUtils.mkdir_p fish_completions_dir
 
-      UI.success "Copied! To use auto complete for fastlane, add the following line to your favorite rc file (e.g. ~/.bashrc)"
-      UI.important "  . ~/.fastlane/completions/completion.sh"
-      UI.success "Don't forget to source that file in your current shell! 🐚"
+        completion_script_path = File.join(Fastlane::ROOT, 'lib', 'assets', 'completions', 'completion.fish')
+        final_completion_script_path = File.join(fish_completions_dir, 'fastlane.fish')
+
+        FileUtils.cp completion_script_path, final_completion_script_path
+
+        UI.success "Copied! You can now use tab completion for lanes"
+      else
+        fastlane_conf_dir = "~/.fastlane"
+        confirm = UI.confirm "This will copy a shell script into #{fastlane_conf_dir} that provides the command tab completion. Sound good?"
+        return unless confirm
+
+        # create the ~/.fastlane directory
+        fastlane_conf_dir = File.expand_path fastlane_conf_dir
+        FileUtils.mkdir_p fastlane_conf_dir
+
+        # then copy all of the completions files into it from the gem
+        completion_script_path = File.join(Fastlane::ROOT, 'lib', 'assets', 'completions')
+        FileUtils.cp_r completion_script_path, fastlane_conf_dir
+
+        UI.success "Copied! To use auto complete for fastlane, add the following line to your favorite rc file (e.g. ~/.bashrc)"
+        UI.important "  . ~/.fastlane/completions/completion.sh"
+        UI.success "Don't forget to source that file in your current shell! 🐚"
+      end
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary (I couldn't find anything that would need updating)

### Description
If the user’s default shell is [fish](https://fishshell.com/) when `fastlane enable_auto_complete` is ran a completion file will be copied to `~/.config/fish/completions`, rather than the user being prompted to add a shell script to their rc file.

### Motivation and Context
Prior to this PR fastlane did not support tab completions with the fish shell, meaning that when running `fastlane enable_auto_complete` users would be provided with instructions that will not work in their shell, and would be left without a way of enabling tab completion.

To test these changes I ran `bundle exec fastlane enable_auto_complete` with fish as my default shell. A `fastlane.fish` file was copied to `~/.config/fish/completions`. I then changed my default shell to bash using `chsh -s /bin/bash`, loaded a new session, and ran `bundle exec fastlane enable_auto_complete` again. This time the old behaviour happened.