### PR TITLE
Revise action alias handling

### DIFF
--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -101,6 +101,17 @@ module Fastlane
       nil
     end
 
+    # Pass a action alias symbol (e.g. :enable_automatic_code_signing)
+    # and this method will return a reference to the action class
+    # if it exists. In case the action with this alias can't be found
+    # this method will return nil.
+    def class_reference_from_action_alias(method_sym)
+      alias_found = find_alias(method_sym.to_s)
+      return nil unless alias_found
+
+      class_reference_from_action_name(alias_found.to_sym)
+    end
+
     # lookup if an alias exists
     def find_alias(action_name)
       Actions.alias_actions.each do |key, v|
@@ -119,15 +130,12 @@ module Fastlane
       # First, check if there is a predefined method in the actions folder
       class_ref = class_reference_from_action_name(method_sym)
       unless class_ref
-        alias_found = find_alias(method_sym.to_s)
-        if alias_found
+        class_ref = class_reference_from_action_alias(method_sym)
+        # notify action that it has been used by alias
+        if class_ref.respond_to?(:alias_used)
           orig_action = method_sym.to_s
-          class_ref = class_reference_from_action_name(alias_found.to_sym)
-          # notify action that it has been used by alias
-          if class_ref.respond_to?(:alias_used)
-            arguments = [{}] if arguments.empty?
-            class_ref.alias_used(orig_action, arguments.first)
-          end
+          arguments = [{}] if arguments.empty?
+          class_ref.alias_used(orig_action, arguments.first)
         end
       end
 

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -125,6 +125,7 @@ module Fastlane
           class_ref = class_reference_from_action_name(alias_found.to_sym)
           # notify action that it has been used by alias
           if class_ref.respond_to?(:alias_used)
+            arguments = [{}] if arguments.empty?
             class_ref.alias_used(orig_action, arguments.first)
           end
         end

--- a/fastlane/spec/action_spec.rb
+++ b/fastlane/spec/action_spec.rb
@@ -21,6 +21,14 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "alias does not crash with no param" do
+        Fastlane::Actions.load_external_actions("./fastlane/spec/fixtures/actions")
+        expect(UI).to receive(:important).with("modified")
+        result = Fastlane::FastFile.new.parse("lane :test do
+          somealias
+        end").runner.execute(:test)
+      end
+
       it "alias can override option" do
         Fastlane::Actions.load_external_actions("./fastlane/spec/fixtures/actions")
         expect(UI).to receive(:important).with("modified")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Revise action alias handling if no params are passed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

When you use params inside `alias_used` but not passed any params, that cause NoMethodError.

```
Failures:

  1) Fastlane Fastlane::Action can call alias action alias does not crash with no param
     Failure/Error:
       result = Fastlane::FastFile.new.parse("lane :test do
         somealias
       end").runner.execute(:test)

     NoMethodError:
       undefined method `[]=' for nil:NilClass
```

You can check this behavior with [this commit](https://github.com/nafu/fastlane/commit/36c1e6c144ec79670cccbc97f5c46e82161911c1).
