### PR TITLE
Add "--new-comment" / "--base" / "--head" support to Danger action

### DIFF
--- a/fastlane/lib/fastlane/actions/danger.rb
+++ b/fastlane/lib/fastlane/actions/danger.rb
@@ -11,9 +11,14 @@ module Fastlane
 
         danger_id = params[:danger_id]
         dangerfile = params[:dangerfile]
+        base = params[:base]
+        head = params[:head]
         cmd << "--danger_id=#{danger_id}" if danger_id
         cmd << "--dangerfile=#{dangerfile}" if dangerfile
         cmd << "--fail-on-errors=true" if params[:fail_on_errors]
+        cmd << "--new-comment" if params[:new_comment]
+        cmd << "--base=#{base}" if base
+        cmd << "--head=#{head}" if head
 
         ENV['DANGER_GITHUB_API_TOKEN'] = params[:github_api_token] if params[:github_api_token]
 
@@ -64,7 +69,23 @@ module Fastlane
                                        description: "Should always fail the build process, defaults to false",
                                        is_string: false,
                                        optional: true,
-                                       default_value: false)
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :new_comment,
+                                       env_name: "FL_DANGER_NEW_COMMENT",
+                                       description: "Makes Danger post a new comment instead of editing its previous one",
+                                       is_string: false,
+                                       optional: true,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :base,
+                                       env_name: "FL_DANGER_BASE",
+                                       description: "A branch/tag/commit to use as the base of the diff. [master|dev|stable]",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :head,
+                                       env_name: "FL_DANGER_HEAD",
+                                       description: "A branch/tag/commit to use as the head. [master|dev|stable]",
+                                       is_string: true,
+                                       optional: true)
         ]
       end
 

--- a/fastlane/spec/actions_specs/danger_spec.rb
+++ b/fastlane/spec/actions_specs/danger_spec.rb
@@ -69,6 +69,38 @@ describe Fastlane do
 
         expect(result).to eq("bundle exec danger")
       end
+
+      it "appends new-comment flag when set" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          danger(new_comment: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec danger --new-comment")
+      end
+
+      it "does not append new-comment flag when unset" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          danger(new_comment: false)
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec danger")
+      end
+
+      it "appends base" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          danger(base: 'master')
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec danger --base=master")
+      end
+
+      it "appends head" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          danger(head: 'master')
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec danger --head=master")
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
I added [Danger parameters](https://github.com/danger/danger/blob/v4.2.2/lib/danger/commands/runner.rb#L56-L61) that are not  supported yet.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I want to use `--new-comment` option on fastlane Danger action :D
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
