### PR TITLE
Add feature to set env variables on Fastfile

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -116,6 +116,11 @@ module Fastlane
       self.current_platform = nil
     end
 
+    # Define environment variables
+    def env(name, value)
+      @runner.add_env(self.current_platform, name, value)
+    end
+
     # Is executed before each test run
     def before_all(&block)
       @runner.set_before_all(@current_platform, block)

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -9,6 +9,9 @@ module Fastlane
     # @return [Hash] All the lanes available, first the platform, then the lane
     attr_accessor :lanes
 
+    # @return [Hash] All the environment variables to set, first the platform, then the variable name
+    attr_accessor :environment_variables
+
     def full_lane_name
       [current_platform, current_lane].reject(&:nil?).join(' ')
     end
@@ -43,6 +46,10 @@ module Fastlane
       parameters ||= {}
       begin
         Dir.chdir(path_to_use) do # the file is located in the fastlane folder
+          environment_variables[current_platform] ||= {}
+          environment_variables[current_platform].each do |name, key|
+            ENV[name] = key
+          end
           execute_flow_block(before_all_blocks, current_platform, current_lane, parameters)
           execute_flow_block(before_each_blocks, current_platform, current_lane, parameters)
 
@@ -306,6 +313,11 @@ module Fastlane
       lanes[lane.platform][lane.name] = lane
     end
 
+    def add_env(platform, name, value)
+      environment_variables[platform] ||= {}
+      environment_variables[platform][name] = value
+    end
+
     def set_before_each(platform, block)
       before_each_blocks[platform] = block
     end
@@ -328,6 +340,10 @@ module Fastlane
 
     def lanes
       @lanes ||= {}
+    end
+
+    def environment_variables
+      @environment_variables ||= {}
     end
 
     def before_each_blocks

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -65,6 +65,14 @@ describe Fastlane do
             expect(ENV["FASTLANE_TEST_ENV_PLATFORM"]).to eq("android")
           end
         end
+
+        context "with environment variable in lane" do
+          it "Do not set environment variable" do
+            expect(ENV["FASTLANE_INNER_ENV"]).to be_nil
+            @ff.runner.execute('inner_env', 'ios')
+            expect(ENV["FASTLANE_INNER_ENV"]).to be_nil
+          end
+        end
       end
     end
 

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -33,6 +33,41 @@ describe Fastlane do
       end
     end
 
+    describe "#env" do
+      before do
+        @ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileEnv')
+      end
+
+      after do
+        ENV["FASTLANE_TEST_ENV_GLOBAL"] = nil
+        ENV["FASTLANE_TEST_ENV_PLATFORM"] = nil
+      end
+
+      it "Set environment variable" do
+        expect(ENV["FASTLANE_TEST_ENV_GLOBAL"]).to be_nil
+        @ff.runner.execute('echo')
+        expect(ENV["FASTLANE_TEST_ENV_GLOBAL"]).to eq("foobar")
+      end
+
+      context "with platform" do
+        context "with ios" do
+          it "Set environment variable on specific platforms" do
+            expect(ENV["FASTLANE_TEST_ENV_PLATFORM"]).to be_nil
+            @ff.runner.execute('echo', 'ios')
+            expect(ENV["FASTLANE_TEST_ENV_PLATFORM"]).to eq("ios")
+          end
+        end
+
+        context "with android" do
+          it "Set environment variable on specific platforms" do
+            expect(ENV["FASTLANE_TEST_ENV_PLATFORM"]).to be_nil
+            @ff.runner.execute('echo', 'android')
+            expect(ENV["FASTLANE_TEST_ENV_PLATFORM"]).to eq("android")
+          end
+        end
+      end
+    end
+
     describe "#lane_name" do
       before do
         @ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/Fastfile1')

--- a/fastlane/spec/fixtures/fastfiles/FastfileEnv
+++ b/fastlane/spec/fixtures/fastfiles/FastfileEnv
@@ -10,6 +10,10 @@ platform :ios do
   lane :echo do
     puts 'ios'
   end
+
+  lane :inner_env do
+    env 'FASTLANE_INNER_ENV', true
+  end
 end
 
 platform :android do

--- a/fastlane/spec/fixtures/fastfiles/FastfileEnv
+++ b/fastlane/spec/fixtures/fastfiles/FastfileEnv
@@ -1,0 +1,21 @@
+env 'FASTLANE_TEST_ENV_GLOBAL', 'foobar'
+
+lane :echo do
+  puts 'global'
+end
+
+platform :ios do
+  env 'FASTLANE_TEST_ENV_PLATFORM', 'ios'
+
+  lane :echo do
+    puts 'ios'
+  end
+end
+
+platform :android do
+  env 'FASTLANE_TEST_ENV_PLATFORM', 'android'
+
+  lane :echo do
+    puts 'android'
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Introduce new feature to set environment variables on `Fastfile`.

You can use `env` to define environment variables on DSL.

```ruby
env 'FASTLANE_TEST_ENV_GLOBAL', 'foobar'

lane :echo do
  puts 'global'
end

platform :ios do
  env 'FASTLANE_TEST_ENV_PLATFORM', 'ios'

  lane :echo do
    puts 'ios'
  end
end

platform :android do
  env 'FASTLANE_TEST_ENV_PLATFORM', 'android'

  lane :echo do
    puts 'android'
  end
end
```

### Motivation and Context

If we want to set environment variables, we should use `before_all`.

```ruby
before_all do
  ENV["FASTLANE_HIDE_CHANGELOG"] = "1"
end
```

It is not readable.
For example, you can set the environment variable like following.

```ruby
env 'FASTLANE_HIDE_CHANGELOG', '1'
```