### PR TITLE
Ignore newline of demo user information

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -220,7 +220,7 @@ module Deliver
       REVIEW_INFORMATION_VALUES.each do |key, option_name|
         v.send("#{key}=", info[option_name]) if info[option_name]
       end
-      v.review_user_needed = (v.review_demo_user.to_s + v.review_demo_password.to_s).length > 0
+      v.review_user_needed = (v.review_demo_user.to_s.chomp + v.review_demo_password.to_s.chomp).length > 0
     end
 
     def set_app_rating(v, options)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Ignore newline string of `demo_user` and `demo_password` of review information.

And use this opportunity to increase code coverage of `upload_metadata`.

### Motivation and Context

If `demo_user` or `demo_password` contains newline(`\n`), `review_user_needed` become `true` and following error is raised from iTunes Connect.

<img width="692" alt="screen shot 2017-03-20 at 1 50 53" src="https://cloud.githubusercontent.com/assets/147051/24082868/b7a55304-0d0f-11e7-9f3b-43b567b54119.png">

```
[!] The request could not be completed because:
        Enter a demo account user name. Enter a demo account password.
```

So it ignores newline of `metadata/app_review_information/demo_user` and `metadata/app_review_information/demo_password`
