### PR TITLE
FIX escape ipa path to compile using ios-deploy

### DIFF
--- a/fastlane/lib/fastlane/actions/install_on_device.rb
+++ b/fastlane/lib/fastlane/actions/install_on_device.rb
@@ -11,7 +11,7 @@ module Fastlane
           "ios-deploy",
           params[:extra],
           "--bundle",
-          params[:ipa]
+          params[:ipa].gsub(/ /, '\ ')
         ]
         taxi_cmd << "--no-wifi" if params[:skip_wifi]
         taxi_cmd << ["--id", params[:device_id]] if params[:device_id]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
