### PR TITLE
Fix actions install on device

### DIFF
--- a/fastlane/lib/fastlane/actions/install_on_device.rb
+++ b/fastlane/lib/fastlane/actions/install_on_device.rb
@@ -11,7 +11,7 @@ module Fastlane
           "ios-deploy",
           params[:extra],
           "--bundle",
-          params[:ipa]
+          params[:ipa].gsub(/ /, '\ ')
         ]
         taxi_cmd << "--no-wifi" if params[:skip_wifi]
         taxi_cmd << ["--id", params[:device_id]] if params[:device_id]

--- a/fastlane/lib/fastlane/actions/install_on_device.rb
+++ b/fastlane/lib/fastlane/actions/install_on_device.rb
@@ -11,7 +11,7 @@ module Fastlane
           "ios-deploy",
           params[:extra],
           "--bundle",
-          params[:ipa].gsub(/ /, '\ ')
+          params[:ipa].shellescape
         ]
         taxi_cmd << "--no-wifi" if params[:skip_wifi]
         taxi_cmd << ["--id", params[:device_id]] if params[:device_id]

--- a/fastlane/spec/actions_specs/install_on_device_spec.rb
+++ b/fastlane/spec/actions_specs/install_on_device_spec.rb
@@ -7,6 +7,13 @@ describe Fastlane do
         end").runner.execute(:test)
         expect(result).to eq("ios-deploy  --bundle demo.ipa")
       end
+
+      it "generates a valid command using app name with space" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          install_on_device(ipa: 'demo app.ipa')
+        end").runner.execute(:test)
+        expect(result).to eq("ios-deploy  --bundle demo\\ app.ipa")
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Escape ipa path to compile using ios-deploy at action install on device

### Motivation and Context
My app name consists of two words and it was necessary to escape the same to use the function (action) install on device
