### PR TITLE
Allow `appletvos` platform for dsyms download and upload to Crashlytics

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -166,7 +166,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :appletvos].include?(platform)
       end
 
       def self.example_code

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -128,10 +128,10 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :platform,
                                        env_name: "FL_UPLOAD_SYMBOLS_TO_CRASHLYTICS_PLATFORM",
-                                       description: "The platform of the app (ios, tvos, mac)",
+                                       description: "The platform of the app (ios, appletvos, mac)",
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         available = ['ios', 'tvos', 'mac']
+                                         available = ['ios', 'appletvos', 'mac']
                                          UI.user_error!("Invalid platform '#{value}', must be #{available.join(', ')}") unless available.include?(value)
                                        end)
         ]
@@ -150,7 +150,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :appletvos].include?(platform)
       end
 
       def self.example_code


### PR DESCRIPTION
* Allow `appletvos` platform for download_dsyms action

* Allow `appletvos` platform for upload_symbols_to_crashlytics action

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Currently, `download_dsyms` and `upload_symbold_to_crashlytics` supports only `ios` platform. As long as Fabric already added support for `tvOS`, we can allow the actions to work also with `tvOS` platform.

### Motivation and Context
Allow `download_dsyms` and `upload_symbold_to_crashlytics` to download and upload dsyms also for AppleTV apps.
Tested by creating a test lane which downloads dsyms from iTunesConnect and upload them to Crashlytics.
Everything works fine. 👍 
Also, I changes supported platforms for `tvos` to `appletvos` to match `Spaceship`'s parameter and to not have additional checks.
