### PR TITLE
Fix using the Fastfile if parent dir isn't named fastlane

### DIFF
--- a/fastlane_core/lib/fastlane_core/fastlane_folder.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_folder.rb
@@ -13,7 +13,9 @@ module FastlaneCore
 
     # Path to the Fastfile inside the fastlane folder. This is nil when none is available
     def self.fastfile_path
-      path = File.join(self.path || '.', 'Fastfile')
+      return nil if self.path.nil?
+
+      path = File.join(self.path, 'Fastfile')
       return path if File.exist?(path)
       return nil
     end

--- a/fastlane_core/spec/fastlane_folder_spec.rb
+++ b/fastlane_core/spec/fastlane_folder_spec.rb
@@ -1,0 +1,45 @@
+describe FastlaneCore::FastlaneFolder do
+  let (:fastfile_name) { "Fastfile" }
+  describe "#path" do
+    it "returns the fastlane path if it exists" do
+      expect(FastlaneCore::FastlaneFolder.path).to eq("./fastlane/")
+    end
+
+    it "returns nil if the fastlane path isn't available" do
+      Dir.chdir("/") do
+        expect(FastlaneCore::FastlaneFolder.path).to eq(nil)
+      end
+    end
+
+    it "returns the path if fastlane is being executed from the fastlane directory" do
+      Dir.chdir("fastlane") do
+        expect(FastlaneCore::FastlaneFolder.path).to eq('./')
+      end
+    end
+  end
+
+  describe "#fastfile_path" do
+    it "uses a Fastfile that's inside a fastlane directory" do
+      expect(FastlaneCore::FastlaneFolder.fastfile_path).to eq(File.join(".", "fastlane", fastfile_name))
+    end
+
+    it "uses a Fastfile that's inside a fastlane directory if cd is inside a fastlane dir" do
+      Dir.chdir("fastlane") do
+        expect(FastlaneCore::FastlaneFolder.fastfile_path).to eq(File.join(".", fastfile_name))
+      end
+    end
+
+    it "doesn't try to use a Fastfile if it's not inside a fastlane folder" do
+      Dir.chdir("sigh") do
+        File.write(fastfile_name, "")
+        begin
+          expect(FastlaneCore::FastlaneFolder.fastfile_path).to eq(nil)
+        rescue RSpec::Expectations::ExpectationNotMetError => ex
+          raise ex
+        ensure
+          File.delete(fastfile_name)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add tests for all those cases, and ensured that tests fail without this patch

Fixes https://github.com/fastlane/fastlane/issues/8532