### PR TITLE
Add new `ProgramLicenseAgreementUpdated` class to spaceship

### DIFF
--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -36,7 +36,15 @@ module Fastlane
           manual_setup
         end
         UI.success('Successfully finished setting up fastlane')
+      rescue Spaceship::Client::InsufficientPermissions, Spaceship::Client::ProgramLicenseAgreementUpdated => ex
+        # We don't want to fallback to manual onboarding for this
+        # as the user needs to first accept the agreement / get more permissions
+        # Let's re-raise the exception to properly show the error message
+        raise ex
       rescue => ex # this will also be caused by Ctrl + C
+        UI.message("Ran into error while trying to connect to iTunes Connect / Dev Portal: #{ex}")
+        UI.message("Falling back to manual onboarding")
+
         if is_manual_setup
           handle_exception(exception: ex)
         else
@@ -45,7 +53,6 @@ module Fastlane
           try_manual_setup
         end
       end
-      # rubocop:enable Lint/RescueException
     end
 
     def handle_exception(exception: nil)


### PR DESCRIPTION
- Detect if the user didn't sign their agreement
- Hide GitHub issues by default if agreement isn't signed
- Refactor spaceship to handle more common errors in the future (is this the future?)
- Show the actual error output nicely when spaceship fails because of permissions or agreement
- Show that automatic detection failed and show error information

<img width="1274" alt="screenshot 2017-03-20 07 22 37" src="https://cloud.githubusercontent.com/assets/869950/24130207/768b9dca-0da4-11e7-8eda-a95a9660a65a.png">
