### PR TITLE
Version bump to 2.22.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.21.0'.freeze
+  VERSION = '2.22.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.21.0':**

* Fix using the Fastfile if parent dir isn't named fastlane (#8593) via Felix Krause
* Raise proper error message in spaceship if bundle_id is nil (#8596) via Felix Krause
* Add --user and -u parameter for `fastlane init` command (#8594) via Felix Krause
* Update messsage when Fastfile can't be found (#8592) via Felix Krause
* Add new `ProgramLicenseAgreementUpdated` class to spaceship (#8595) via Felix Krause
* Remove debug code from gradle tests (#8590) via Felix Krause
