### PR TITLE
Fix typo in plugin docs

### DIFF
--- a/fastlane/docs/Plugins.md
+++ b/fastlane/docs/Plugins.md
@@ -64,7 +64,7 @@ This will:
 #### Plugin Source
 
 Your `fastlane/Pluginfile` contains the list of all `fastlane` plugins your project uses. The `Pluginfile` is a [Gemfile](http://bundler.io/gemfile.html) that gets imported from your main `Gemfile`.
-You specificy all dependencies, including the required version numbers:
+You specify all dependencies, including the required version numbers:
 
 ```ruby
 # Fetched from RubyGems.org


### PR DESCRIPTION
### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

Noticed this in passing today. Quick little typo cleanup.