### PR TITLE
Improve react-native onboarding

### DIFF
--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -14,6 +14,11 @@ module Fastlane
       elsif is_android?
         UI.message("Detected Android project in current directory...")
         platform = :android
+      elsif is_react_native?
+        UI.important("Detect react-native app. To set up fastlane, please run")
+        UI.command("fastlane init")
+        UI.important("in the sub-folder for each platform (\"ios\" or \"android\")")
+        UI.user_error!("Please navigate to the platform subfolder and run `fastlane init` again")
       else
         UI.message("Couldn't automatically detect the platform")
         val = agree("Is this project an iOS project? (y/n) ".yellow, true)
@@ -35,6 +40,10 @@ module Fastlane
 
     def is_android?
       Dir["*.gradle"].count > 0
+    end
+
+    def is_react_native?
+      SetupIos.new.project_uses_react_native?(path: "./ios")
     end
 
     def show_analytics

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -15,7 +15,7 @@ module Fastlane
         UI.message("Detected Android project in current directory...")
         platform = :android
       elsif is_react_native?
-        UI.important("Detectedj react-native app. To set up fastlane, please run")
+        UI.important("Detected react-native app. To set up fastlane, please run")
         UI.command("fastlane init")
         UI.important("in the sub-folder for each platform (\"ios\" or \"android\")")
         UI.user_error!("Please navigate to the platform subfolder and run `fastlane init` again")

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -15,13 +15,13 @@ module Fastlane
         UI.message("Detected Android project in current directory...")
         platform = :android
       elsif is_react_native?
-        UI.important("Detect react-native app. To set up fastlane, please run")
+        UI.important("Detectedj react-native app. To set up fastlane, please run")
         UI.command("fastlane init")
         UI.important("in the sub-folder for each platform (\"ios\" or \"android\")")
         UI.user_error!("Please navigate to the platform subfolder and run `fastlane init` again")
       else
         UI.message("Couldn't automatically detect the platform")
-        val = agree("Is this project an iOS project? (y/n) ".yellow, true)
+        val = UI.confirm("Is this project an iOS project? (y/n) ")
         platform = (val ? :ios : :android)
       end
 
@@ -43,7 +43,7 @@ module Fastlane
     end
 
     def is_react_native?
-      SetupIos.new.project_uses_react_native?(path: "./ios")
+      SetupIos.project_uses_react_native?(path: "./ios")
     end
 
     def show_analytics

--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -89,8 +89,8 @@ module Fastlane
 
     def self.project_uses_react_native?(path: Dir.pwd)
       package_json = File.join(path, "..", "package.json")
-      return unless File.basename(path) == "ios"
-      return unless File.exist?(package_json)
+      return false unless File.basename(path) == "ios"
+      return false unless File.exist?(package_json)
       package_content = File.read(package_json)
       return true if package_content.include?("react-native")
       false

--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -36,6 +36,7 @@ module Fastlane
           default_setup
         else
           is_manual_setup = true
+          UI.message("Falling back to manual onboarding")
           manual_setup
         end
         UI.success('Successfully finished setting up fastlane')

--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -76,7 +76,7 @@ module Fastlane
     # React Native specific code
     # Make it easy for people to onboard
     def react_native_pre_checks
-      return unless project_uses_react_native?
+      return unless self.class.project_uses_react_native?
       if app_identifier.to_s.length == 0
         error_message = []
         error_message << "Could not detect bundle identifier of your react-native app."
@@ -87,7 +87,7 @@ module Fastlane
       end
     end
 
-    def project_uses_react_native?(path: Dir.pwd)
+    def self.project_uses_react_native?(path: Dir.pwd)
       package_json = File.join(path, "..", "package.json")
       return unless File.basename(path) == "ios"
       return unless File.exist?(package_json)

--- a/fastlane/spec/setup_spec.rb
+++ b/fastlane/spec/setup_spec.rb
@@ -16,14 +16,14 @@ describe Fastlane do
         FileUtils.rm_rf(workspace) if File.directory? workspace
         FileUtils.cp_r(fixtures, File.expand_path('..', workspace)) # copy workspace to work on to /tmp
 
-        expect(FastlaneCore::UI).to receive(:input).and_return("y")
-
         allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(fastlane_folder)
 
         ENV['DELIVER_USER'] = 'felix@sunapps.net'
       end
 
       it "setup is successful and generated inital Fastfile" do
+        expect(FastlaneCore::UI).to receive(:input).and_return("y") # iOS project, yeah
+
         require 'produce'
 
         app = "app"
@@ -70,6 +70,28 @@ describe Fastlane do
           expect(content).to include "team_id \"#{dev_team_id}\""
           expect(content).to include "itc_team_id \"#{itc_team_id}\""
           expect(content).to include "apple_id \"y\""
+        end
+      end
+
+      describe "react-native" do
+        it "tells the user to naviate into the subfolder to run `fastlane init`" do
+          expect do
+            expect(Fastlane::SetupIos).to receive(:project_uses_react_native?).with(path: "./ios").and_return(true)
+
+            setup = Fastlane::Setup.new
+            setup.run
+          end.to raise_error("Please navigate to the platform subfolder and run `fastlane init` again")
+        end
+
+        it "tells the user to set a custom app identifier if none is set yet" do
+          expect do
+            setup = Fastlane::SetupIos.new
+
+            expect(Fastlane::SetupIos).to receive(:project_uses_react_native?).with(no_args).and_return(true)
+            expect(setup).to receive(:setup_project).and_return(nil)
+
+            setup.run
+          end.to raise_error("Could not detect bundle identifier of your react-native app. Make sure to open the Xcode project and update the bundle identifier in the `General` section of your project settings. Restart `fastlane init` once you're done!")
         end
       end
 


### PR DESCRIPTION
- Add custom error handling for react-native projects with no bundle identifier set
- Tell user to navigate to platform subfolder on `fastlane init` for react-native projects
- This PR also moves out 2 method calls that shouldn't be part of the `begin rescue` block