### PR TITLE
react-native: tell user to navigate to platform subfolder on `fastlane init`

### DIFF
--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -14,6 +14,11 @@ module Fastlane
       elsif is_android?
         UI.message("Detected Android project in current directory...")
         platform = :android
+      elsif is_react_native?
+        UI.important("Detect react-native app. To set up fastlane, please run")
+        UI.command("fastlane init")
+        UI.important("in the sub-folder for each platform (\"ios\" or \"android\")")
+        UI.user_error!("Please navigate to the platform subfolder and run `fastlane init` again")
       else
         UI.message("Couldn't automatically detect the platform")
         val = agree("Is this project an iOS project? (y/n) ".yellow, true)
@@ -35,6 +40,10 @@ module Fastlane
 
     def is_android?
       Dir["*.gradle"].count > 0
+    end
+
+    def is_react_native?
+      SetupIos.new.project_uses_react_native?(path: "./ios")
     end
 
     def show_analytics


### PR DESCRIPTION
<img width="715" alt="screenshot 2017-03-21 06 12 16" src="https://cloud.githubusercontent.com/assets/869950/24177830/55b3412a-0e62-11e7-9eee-f46923e1da9e.png">

This will show an appropriate error message when running `fastlane init` in the root of the react-native project. The Xcode and the Android project are in the subfolders.