### PR TITLE
Removing all null arguments in install on device

### DIFF
--- a/fastlane/lib/fastlane/actions/install_on_device.rb
+++ b/fastlane/lib/fastlane/actions/install_on_device.rb
@@ -9,13 +9,13 @@ module Fastlane
         end
         taxi_cmd = [
           "ios-deploy",
+          params[:extra],
           "--bundle",
           params[:ipa]
         ]
-
-        taxi_cmd.insert(1, params[:extra]) if params[:extra]
         taxi_cmd << "--no-wifi" if params[:skip_wifi]
         taxi_cmd << ["--id", params[:device_id]] if params[:device_id]
+        taxi_cmd.compact!
         return taxi_cmd.join(" ") if Helper.test?
         Actions.sh(taxi_cmd.join(" "))
         UI.message("Deployed #{params[:ipa]} to device!")

--- a/fastlane/lib/fastlane/actions/install_on_device.rb
+++ b/fastlane/lib/fastlane/actions/install_on_device.rb
@@ -9,10 +9,11 @@ module Fastlane
         end
         taxi_cmd = [
           "ios-deploy",
-          params[:extra],
           "--bundle",
           params[:ipa]
         ]
+
+        taxi_cmd.insert(1, params[:extra]) if params[:extra]
         taxi_cmd << "--no-wifi" if params[:skip_wifi]
         taxi_cmd << ["--id", params[:device_id]] if params[:device_id]
         return taxi_cmd.join(" ") if Helper.test?

--- a/fastlane/spec/actions_specs/install_on_device_spec.rb
+++ b/fastlane/spec/actions_specs/install_on_device_spec.rb
@@ -5,7 +5,7 @@ describe Fastlane do
         result = Fastlane::FastFile.new.parse("lane :test do
           install_on_device(ipa: 'demo.ipa')
         end").runner.execute(:test)
-        expect(result).to eq("ios-deploy  --bundle demo.ipa")
+        expect(result).to eq("ios-deploy --bundle demo.ipa")
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Removing extra space from cmd in install on device action

### Motivation and Context
In another [PR](https://github.com/fastlane/fastlane/pull/8582/files/8afb26ac72b5b5411ec369ce3516ce96f60c0f2f#diff-1fe9a1b6633e51e539b9d1d6a325980a) @giginet related about the extra space in cmd so I've this inside.