### PR TITLE
Fix issue #8600.

### DIFF
--- a/spaceship/lib/spaceship/helper/plist_middleware.rb
+++ b/spaceship/lib/spaceship/helper/plist_middleware.rb
@@ -7,6 +7,7 @@ module FaradayMiddleware
     end
 
     define_parser do |body|
+      body = body.force_encoding("UTF-8")
       Plist.parse_xml(body)
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)

### Description

* Fix Issue #8600
  * Replace ASCII-8BIT string to UTF-8 string.

### Motivation and Context
 
* Reference #8600 
  * plist can not scan @xml when it is ASCII-8BIT string.
  * abort line: /gems/plist-3.2.0/lib/plist/parser.rb:91

* This problem is occurred using Japanese name provisioning and so on.
* Maybe, Apple server changed response.
  * no problem until yesterday
  * the problem is occurred since today
