### PR TITLE
Use the commander fork from @nafu

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -44,9 +44,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'babosa', '>= 1.0.2', "< 2.0.0"
   spec.add_dependency 'colored' # coloured terminal output
-  spec.add_dependency 'commander', '>= 4.4.0', '< 5.0.0' # CLI parser
+  spec.add_dependency 'commander-fastlane', '>= 4.4.0', '< 5.0.0' # CLI parser
   spec.add_dependency 'excon', '>= 0.45.0', '< 1.0.0' # Great HTTP Client
-  spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'  
+  spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
   spec.add_dependency 'fastimage', '>= 1.6' # fetch the image sizes from the screenshots, note: we also support > 2.0
   spec.add_dependency 'gh_inspector', '>= 1.0.1', '< 2.0.0' # search for issues on GitHub when something goes wrong
   spec.add_dependency 'google-api-client', '~> 0.9.2' # Google API Client to access Play Publishing API


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description

Use the commander fork from @nafu until [the PR](https://github.com/commander-rb/commander/pull/44) gets merged.

### Motivation and Context

The change improves commander's help output to show which command is the default command, and includes the default command's options as part of the top level help.