### PR TITLE
Remove redundant stub in spec for FastlaneCore::Helper

### DIFF
--- a/fastlane/spec/lane_manager_spec.rb
+++ b/fastlane/spec/lane_manager_spec.rb
@@ -54,8 +54,6 @@ describe Fastlane do
         end
 
         def ensure_dot_env_value_from_folders(folders, envs, expected_values)
-          # current limitation in FastlaneFolder.
-          allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
           folders.each do |dir|
             expected_values.each do |k, v|
               ENV.delete(k.to_s)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Conditional code with `Helper.is_test?` in FastlaneCore::FastlaneFolder.path has already been removed.
See more:
https://github.com/fastlane/fastlane/pull/8484

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It would be better to test real usage in rspec if we don't need stubs, so that we can make sure fastlane works fine.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
