### PR TITLE
Refactor fastlane CommanderGenerator usage

### DIFF
--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -91,7 +91,6 @@ module Fastlane
         FastlaneCore::Globals.verbose = true
       end
       global_option('--troubleshoot', 'Enables extended verbose mode. Use with caution, as this even includes ALL sensitive data. Cannot be used on CI.')
-      global_option('--env STRING[,STRING2]', String, 'Add environment(s) to use with `dotenv`')
 
       always_trace!
 

--- a/fastlane/spec/commands_generator_spec.rb
+++ b/fastlane/spec/commands_generator_spec.rb
@@ -1,0 +1,27 @@
+require 'fastlane/commands_generator'
+
+describe Fastlane::CommandsGenerator do
+  before(:each) do
+    ENV['DOTENV'] = nil
+    fastlane_folder = File.absolute_path('./fastlane/spec/fixtures/dotenvs/withFastfiles/parentonly/fastlane')
+    allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(fastlane_folder)
+  end
+
+  describe ":trigger option handling" do
+    it "can use the env flag from tool options" do
+      stub_commander_runner_args(['command_test', '--env', 'DOTENV'])
+      Fastlane::CommandsGenerator.start
+
+      expect(ENV['DOTENV']).to eq('parent')
+    end
+  end
+
+  describe ":list option handling" do
+    it "cannot use the env flag from tool options" do
+      stub_commander_runner_args(['list', '--env', 'DOTENV'])
+      Fastlane::CommandsGenerator.start
+
+      expect(ENV['DOTENV']).to be_nil
+    end
+  end
+end

--- a/fastlane/spec/commands_generator_spec.rb
+++ b/fastlane/spec/commands_generator_spec.rb
@@ -19,7 +19,9 @@ describe Fastlane::CommandsGenerator do
   describe ":list option handling" do
     it "cannot use the env flag from tool options" do
       stub_commander_runner_args(['list', '--env', 'DOTENV'])
-      Fastlane::CommandsGenerator.start
+      expect do
+        Fastlane::CommandsGenerator.start
+      end.to raise_exception(OptionParser::InvalidOption, 'invalid option: --env')
 
       expect(ENV['DOTENV']).to be_nil
     end

--- a/fastlane/spec/fixtures/dotenvs/withFastfiles/parentonly/fastlane/Fastfile
+++ b/fastlane/spec/fixtures/dotenvs/withFastfiles/parentonly/fastlane/Fastfile
@@ -1,0 +1,3 @@
+desc "Empty lane for testing fastlane command"
+lane :command_test do |options|
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Remove --env option from fastlane global_options.

Now `fastlane help` shows correct options.
```bash
  fastlane

  CLI for 'fastlane' - The easiest way to automate beta deployments and releases for your iOS and
Android apps

        Run using `fastlane [platform] [lane_name]`
        To pass values to the lanes use `fastlane [platform] [lane_name] key:value key2:value2`

  Commands: (* default)
    action                 Shows more information for a specific command
    actions                Lists all available fastlane actions
    add_plugin             Add a new plugin to your fastlane setup
    docs                   Generate a markdown based documentation based on the Fastfile
    enable_auto_complete   Enable tab auto completion
    env                    Print your fastlane environment, use this when you submit an issue on
GitHub
    help                   Display global or [command] help documentation
    init                   Helps you with your initial fastlane setup
    install_plugins        Install all plugins for this project
    lanes                  Lists all available lanes and shows their description
    list                   Lists all available lanes without description
    new_action             Create a new custom action for fastlane.
    new_plugin             Create a new plugin that can be used with fastlane
    run                    Run a fastlane one-off action without a full lane
    search_plugins         Search for plugins, search query is optional
    trigger              * Run a specific lane. Pass the lane name and optionally the platform first.
    update_fastlane        Update fastlane to the latest release
    update_plugins         Update all plugin dependencies

  Global Options:
    --verbose
    --capture_output     Captures the output of the current run, and generates a markdown issue
template
    --troubleshoot       Enables extended verbose mode. Use with caution, as this even includes ALL
sensitive data. Cannot be used on CI.
    -h, --help           Display help documentation
    -v, --version        Display version information

  Options for trigger:
    --env STRING[,STRING2] Add environment(s) to use with `dotenv`

  Author:
    Felix Krause <fastlane@krausefx.com>

  Website:
    https://fastlane.tools

  GitHub:
    https://github.com/fastlane/fastlane

```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Because --env option is not actually global_option, it's option for 'fastlane trigger'.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
