### PR TITLE
Make scan's slack_url ignore empty strings

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -223,7 +223,9 @@ module Scan
                                      description: "Create an Incoming WebHook for your Slack group to post results there",
                                      optional: true,
                                      verify_block: proc do |value|
-                                       UI.user_error!("Invalid URL, must start with https://") unless value.start_with? "https://"
+                                       if !value.to_s.empty? && !value.start_with?("https://")
+                                         UI.user_error!("Invalid URL, must start with https://")
+                                       end
                                      end),
         FastlaneCore::ConfigItem.new(key: :slack_channel,
                                      short_option: "-e",

--- a/scan/lib/scan/slack_poster.rb
+++ b/scan/lib/scan/slack_poster.rb
@@ -3,7 +3,7 @@ module Scan
     def run(results)
       return if Scan.config[:skip_slack]
       return if Scan.config[:slack_only_on_failure] && results[:failures] == 0
-      return if Scan.config[:slack_url].nil?
+      return if Scan.config[:slack_url].to_s.empty?
 
       require 'slack-notifier'
       notifier = Slack::Notifier.new(Scan.config[:slack_url])

--- a/scan/spec/slack_poster_spec.rb
+++ b/scan/spec/slack_poster_spec.rb
@@ -1,0 +1,122 @@
+require 'scan'
+require 'slack-notifier'
+
+describe Scan::SlackPoster do
+  describe "slack_url handling" do
+    describe "without a slack_url set" do
+      it "skips Slack posting" do
+        # ensures that people's local environment variable doesn't interfere with this test
+        with_env_values('SLACK_URL' => nil) do
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            project: './scan/examples/standard/app.xcodeproj'
+          })
+
+          expect(Slack::Notifier).not_to receive(:new)
+
+          Scan::SlackPoster.new.run({ tests: 0, failures: 0 })
+        end
+      end
+    end
+
+    describe "with the slack_url option set but skip_slack set to true" do
+      it "skips Slack posting" do
+        # ensures that people's local environment variable doesn't interfere with this test
+        with_env_values('SLACK_URL' => nil) do
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            project: './scan/examples/standard/app.xcodeproj',
+            slack_url: 'https://slack/hook/url',
+            skip_slack: true
+          })
+
+          expect(Slack::Notifier).not_to receive(:new)
+
+          Scan::SlackPoster.new.run({ tests: 0, failures: 0 })
+        end
+      end
+    end
+
+    describe "with the SLACK_URL ENV var set but skip_slack set to true" do
+      it "skips Slack posting" do
+        with_env_values('SLACK_URL' => 'https://slack/hook/url') do
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            project: './scan/examples/standard/app.xcodeproj',
+            skip_slack: true
+          })
+
+          expect(Slack::Notifier).not_to receive(:new)
+
+          Scan::SlackPoster.new.run({ tests: 0, failures: 0 })
+        end
+      end
+    end
+
+    describe "with the SLACK_URL ENV var set to empty string" do
+      it "skips Slack posting" do
+        with_env_values('SLACK_URL' => '') do
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            project: './scan/examples/standard/app.xcodeproj'
+          })
+
+          expect(Slack::Notifier).not_to receive(:new)
+
+          Scan::SlackPoster.new.run({ tests: 0, failures: 0 })
+        end
+      end
+    end
+
+    describe "with the slack_url option set to empty string" do
+      it "skips Slack posting" do
+        # ensures that people's local environment variable doesn't interfere with this test
+        with_env_values('SLACK_URL' => nil) do
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            project: './scan/examples/standard/app.xcodeproj',
+            slack_url: ''
+          })
+
+          expect(Slack::Notifier).not_to receive(:new)
+
+          Scan::SlackPoster.new.run({ tests: 0, failures: 0 })
+        end
+      end
+    end
+
+    def expect_slack_posting
+      fake_notifier = "fake_notifier"
+      fake_result = "fake_result"
+      expect(Slack::Notifier).to receive(:new).and_return(fake_notifier)
+      expect(fake_notifier).to receive(:username=)
+      expect(fake_notifier).to receive(:ping).and_return(fake_result)
+      expect(fake_result).to receive(:code).and_return(200)
+    end
+
+    describe "with slack_url option set to a URL value" do
+      it "does Slack posting" do
+        expect_slack_posting
+
+        # ensures that people's local environment variable doesn't interfere with this test
+        with_env_values('SLACK_URL' => nil) do
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            project: './scan/examples/standard/app.xcodeproj',
+            slack_url: 'https://slack/hook/url'
+          })
+
+          Scan::SlackPoster.new.run({ tests: 0, failures: 0 })
+        end
+      end
+    end
+
+    describe "with SLACK_URL ENV var set to a URL value" do
+      it "does Slack posting" do
+        expect_slack_posting
+
+        with_env_values('SLACK_URL' => 'https://slack/hook/url') do
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            project: './scan/examples/standard/app.xcodeproj'
+          })
+
+          Scan::SlackPoster.new.run({ tests: 0, failures: 0 })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description

Adjust _scan_'s handling of the `slack_url` parameter, to treat empty strings as it would a `nil` value. i.e. it will skip sending Slack notifications.

### Motivation and Context

[This issue](https://github.com/fastlane/fastlane/issues/8583) showed confusion about the correct way to specify that _scan_ should not send notifications. While the code is behaving as expected for the way that it is written, I think this change makes it a little more tolerant for people's intent.

