### PR TITLE
Replace test failures with its own class to have more accurate crash metrics

### DIFF
--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -255,6 +255,8 @@ module Fastlane
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         collector.did_raise_error(method_sym)
         raise e
+      rescue FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!
+        raise e
       rescue Exception => e # rubocop:disable Lint/RescueException
         # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
         # Catches all exceptions, since some plugins might use system exits to get out

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -66,6 +66,8 @@ module Commander
         collector.did_raise_error(@program[:name])
         show_github_issues(e.message) if e.show_github_issues
         display_user_error!(e, e.message)
+      rescue FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!
+        display_user_error!(e, e.to_s)
       rescue Faraday::SSLError => e # SSL issues are very common
         handle_ssl_error!(e)
       rescue Faraday::ConnectionFailed => e

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -126,6 +126,10 @@ module FastlaneCore
       end
     end
 
+    # raised from test_failure!
+    class FastlaneTestFailure < StandardError
+    end
+
     # Pass an exception to this method to exit the program
     #   using the given exception
     # Use this method instead of user_error! if this error is
@@ -144,6 +148,15 @@ module FastlaneCore
     # and want to show a nice error message to the user
     def user_error!(error_message, options = {})
       raise FastlaneError.new(options), error_message.to_s
+    end
+
+    # Use this method to exit the program because of a test failure
+    # that's caused by the source code of the user. Example for this
+    # is that scan will fail when the tests fail.
+    # By using this method we'll get more accurate results on the
+    # fastlane failures on enhancer
+    def test_failure!(error_message)
+      raise FastlaneTestFailure.new, error_message
     end
 
     #####################################################

--- a/fastlane_core/spec/fastlane_runner_spec.rb
+++ b/fastlane_core/spec/fastlane_runner_spec.rb
@@ -71,7 +71,8 @@ describe Commander::Runner do
 
     it "calls the tool collector lifecycle methods for a test failure" do
       expect(mock_tool_collector).to receive(:did_launch_action).with("tool_name").and_call_original
-      expect(mock_tool_collector).to receive(:did_raise_error).with("tool_name").and_call_original
+      # Notice how we don't expect `:did_raise_error` to be called here
+      # TestFailures don't count as failures/crashes
 
       stdout, stderr = capture_stds do
         expect do

--- a/fastlane_core/spec/fastlane_runner_spec.rb
+++ b/fastlane_core/spec/fastlane_runner_spec.rb
@@ -68,6 +68,18 @@ describe Commander::Runner do
       end
       expect(stderr).to eq("\n[!] FastlaneCore::Interface::FastlaneError".red + "\n")
     end
+
+    it "calls the tool collector lifecycle methods for a test failure" do
+      expect(mock_tool_collector).to receive(:did_launch_action).with("tool_name").and_call_original
+      expect(mock_tool_collector).to receive(:did_raise_error).with("tool_name").and_call_original
+
+      stdout, stderr = capture_stds do
+        expect do
+          CommandsGenerator.new(raise_error: FastlaneCore::Interface::FastlaneTestFailure).run
+        end.to raise_error(SystemExit)
+      end
+      expect(stderr).to eq("\n[!] FastlaneCore::Interface::FastlaneTestFailure".red + "\n")
+    end
   end
 
   describe '#handle_unknown_error' do

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -83,12 +83,12 @@ module Scan
 
       report_collector.parse_raw_file(TestCommandGenerator.xcodebuild_log_path)
 
-      unless tests_exit_status == 0
-        UI.user_error!("Test execution failed. Exit status: #{tests_exit_status}")
+      if result[:failures] > 0
+        UI.test_failure!("Tests have failed")
       end
 
-      unless result[:failures] == 0
-        UI.user_error!("Tests failed")
+      unless tests_exit_status == 0
+        UI.test_failure!("Test execution failed. Exit status: #{tests_exit_status}")
       end
     end
 

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -38,6 +38,22 @@ describe Scan do
           @scan.handle_results(0)
         end
       end
+
+      describe "Test Failure" do
+        it "raises a FastlaneTestFailure instead of a crash or UserError" do
+          expect do
+            Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+              output_directory: '/tmp/scan_results',
+              project: './scan/examples/standard/app.xcodeproj'
+            })
+            custom_parser = "custom_parser"
+            expect(Scan::TestResultParser).to receive(:new).and_return(custom_parser)
+            expect(custom_parser).to receive(:parse_result).and_return({tests: 5, failures: 3})
+
+            @scan.handle_results(0)
+          end.to raise_error FastlaneCore::Interface::FastlaneTestFailure, "Tests have failed"
+        end
+      end
     end
   end
 end

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -48,7 +48,7 @@ describe Scan do
             })
             custom_parser = "custom_parser"
             expect(Scan::TestResultParser).to receive(:new).and_return(custom_parser)
-            expect(custom_parser).to receive(:parse_result).and_return({tests: 5, failures: 3})
+            expect(custom_parser).to receive(:parse_result).and_return({ tests: 5, failures: 3 })
 
             @scan.handle_results(0)
           end.to raise_error FastlaneCore::Interface::FastlaneTestFailure, "Tests have failed"

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -59,7 +59,7 @@ module Snapshot
 
       print_results(results)
 
-      UI.user_error!(self.collected_errors.join('; ')) if self.collected_errors.count > 0
+      UI.test_failure!(self.collected_errors.join('; ')) if self.collected_errors.count > 0
 
       # Generate HTML report
       ReportsGenerator.new.generate


### PR DESCRIPTION
- This way the user can easily detect why a tool has failed
- Our crash rate for each action is more precise with this change