### PR TITLE
Update fastlane tool collector to work with mono repo change

### DIFF
--- a/fastlane_core/lib/fastlane_core/tool_collector.rb
+++ b/fastlane_core/lib/fastlane_core/tool_collector.rb
@@ -146,9 +146,15 @@ module FastlaneCore
     end
 
     def self.determine_version(name)
-      require 'fastlane'
-      return Fastlane::VERSION if Fastlane::ActionsList.find_action_named(name.to_s)
+      unless name.to_s.start_with?("fastlane-plugin")
+        # In the early days before the mono gem this was more complicated
+        # Now we have a mono version number, which makes this method easy
+        # for all built-in actions and tools
+        require 'fastlane/version'
+        return Fastlane::VERSION
+      end
 
+      # For plugins we still need to load the specific version
       begin
         name = name.to_s.downcase
 


### PR DESCRIPTION
This fixes an issue where the version number of a sub tool wasn't properly recorded when calling `fastlane scan ...` after the mono-gem change