### PR TITLE
Update tweet text to use release URL instead of tag URL

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -133,8 +133,8 @@ lane :release do
   donate_food
 
   puts "You can now tweet:".green
-  tag_url = "https://github.com/fastlane/fastlane/releases/tag/fastlane/#{version}"
-  puts "[fastlane] #{github_release['name']} #{tag_url}"
+  releases_url = "https://github.com/fastlane/fastlane/releases/tag/#{version}"
+  puts "[fastlane] #{github_release['name']} #{releases_url}"
 
   update_docs
 end


### PR DESCRIPTION
This way the message is markdown formatted. We used to use tags as they would work better with pre-mono gem releases

I really thought I submitted this exact PR a few days ago, but can't find it 😕