### PR TITLE
Fix NameError when running single rspec

### DIFF
--- a/fastlane/spec/private_public_fastfile_spec.rb
+++ b/fastlane/spec/private_public_fastfile_spec.rb
@@ -25,6 +25,7 @@ describe Fastlane do
       end
 
       it "doesn't expose the private lanes in `fastlane lanes`" do
+        require 'fastlane/lane_list'
         result = Fastlane::LaneList.generate(path)
         expect(result).to include("such smooth")
         expect(result).to_not include("private call")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Fix error: `NameError: uninitialized constant Fastlane::LaneList`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Running below command cause `NameError: uninitialized constant Fastlane::LaneList`.

```
rspec fastlane/spec/private_public_fastfile_spec.rb
```

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
