### PR TITLE
change the zip output path from relative to absolute

### DIFF
--- a/fastlane/lib/fastlane/actions/zip.rb
+++ b/fastlane/lib/fastlane/actions/zip.rb
@@ -6,10 +6,15 @@ module Fastlane
 
         params[:output_path] ||= "#{params[:path]}.zip"
 
+        absolute_output_path = File.expand_path(params[:output_path])
+
+        absolute_output_dir = File.expand_path("..", absolute_output_path)
+        FileUtils.mkdir_p(absolute_output_dir)
+
         Dir.chdir(File.expand_path("..", params[:path])) do # required to properly zip
           zip_options = params[:verbose] ? "r" : "rq"
 
-          Actions.sh "zip -#{zip_options} #{params[:output_path].shellescape} #{File.basename(params[:path]).shellescape}"
+          Actions.sh "zip -#{zip_options} #{absolute_output_path.shellescape} #{File.basename(params[:path]).shellescape}"
         end
 
         UI.success "Successfully generated zip file at path '#{File.expand_path(params[:output_path])}'"

--- a/fastlane/spec/actions_specs/zip_spec.rb
+++ b/fastlane/spec/actions_specs/zip_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane do
 
     describe "zip" do
       it "generates a valid zip command" do
-        expect(Fastlane::Actions).to receive(:sh).with("zip -r #{@path}.zip archive.rb")
+        expect(Fastlane::Actions).to receive(:sh).with("zip -r #{File.expand_path(@path)}.zip archive.rb")
 
         result = Fastlane::FastFile.new.parse("lane :test do
           zip(path: '#{@path}')
@@ -15,7 +15,7 @@ describe Fastlane do
       end
 
       it "generates a valid zip command without verbose output" do
-        expect(Fastlane::Actions).to receive(:sh).with("zip -rq #{@path}.zip archive.rb")
+        expect(Fastlane::Actions).to receive(:sh).with("zip -rq #{File.expand_path(@path)}.zip archive.rb")
 
         result = Fastlane::FastFile.new.parse("lane :test do
           zip(path: '#{@path}', verbose: 'false')


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

I changed the zip output path from relative path to absolute path.
Because `zip` action changes directory (via `Dir.chidir`) to `../params[:path]` and trying to output to `output_path` by relative path from there.

### Motivation and Context

#8620 
