### PR TITLE
Fix pilot stuck on older processing build

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -146,8 +146,8 @@ module Pilot
           UI.message("New application; waiting for build train to appear on iTunes Connect")
         else
           builds = app.all_processing_builds(platform: platform)
-          break if builds.count == 0
-          latest_build = builds.last
+          latest_build = builds.last unless latest_build
+          break unless builds.include?(latest_build)
 
           if latest_build.valid and must_update_build_info
             # Set the changelog and/or description if necessary


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've updated the documentation if necessary.

### Description
This is a new version of #8152, check that PR for more info
This makes pilot only wait for the latest upload when waiting for processing, instead of checking for all builds that might be processing

### Motivation and Context
Fixes the problem where pilot would get stuck waiting for an older build to finish processing by iTunes Connect
This could happen, for example, with a faulty upload. The only way of fixing this currently is by waiting till an Apple script removes the faulty build

This should fix #6069 