### PR TITLE
[match] Check push permission to git repository

### DIFF
--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -7,6 +7,7 @@ module Match
       from ||= ChangePassword.ask_password(message: "Old passphrase for Git Repo: ", confirm: true)
       GitHelper.clear_changes
       workspace = GitHelper.clone(params[:git_url], params[:shallow_clone], manual_password: from, skip_docs: params[:skip_docs], branch: params[:git_branch])
+      GitHelper.check_push_repo_permission(workspace, params[:git_branch])
       Encrypt.new.clear_password(params[:git_url])
       Encrypt.new.store_password(params[:git_url], to)
 

--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -156,5 +156,28 @@ module Match
         end
       end
     end
+
+    # Checks push permission to git repo
+    def self.repo_pushable?(path, branch = "master")
+      Dir.chdir(path) do
+        command = "GIT_TERMINAL_PROMPT=0 git push origin #{branch.shellescape} --dry-run"
+        FastlaneCore::CommandExecutor.execute(command: command,
+                                              print_all: FastlaneCore::Globals.verbose?,
+                                              print_command: FastlaneCore::Globals.verbose?)
+      end
+      return true
+    rescue => ex
+      UI.error("No permission to push...")
+      UI.error(ex)
+      return false
+    end
+
+    def self.check_push_repo_permission(path, branch = "master")
+      unless repo_pushable?(path, branch)
+        UI.error "You do not have push permission to git repository"
+        UI.error "Match will create a new certificate or profiles, but if you do not have permission to puth to git, occur a difference between Apple Developer Portal and git repository."
+        UI.user_error! "Grant push permission to git repository to users who create or update certificates/profiles"
+      end
+    end
   end
 end

--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -174,9 +174,9 @@ module Match
 
     def self.check_push_repo_permission(path, branch = "master")
       unless repo_pushable?(path, branch)
-        UI.error "You do not have push permission to git repository"
-        UI.error "Match will create a new certificate or profiles, but if you do not have permission to puth to git, occur a difference between Apple Developer Portal and git repository."
-        UI.user_error! "Grant push permission to git repository to users who create or update certificates/profiles"
+        UI.error("You do not have push permission to git repository provided")
+        UI.error("_match_ needs to create a new certificate or provisioning profile, however without push access to the git repo, the generated certificate can't be stored properly, resulting in an unused certificate")
+        UI.user_error!("Please grant push access for the current git user to the git repo, so that _match_ can update and create certificates for you")
       end
     end
   end

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -26,6 +26,8 @@ module Match
         UI.user_error!("`fastlane match nuke` doesn't delete anything when running with --readonly enabled")
       end
 
+      GitHelper.check_push_repo_permission(params[:workspace], params[:git_branch])
+
       if (self.certs + self.profiles + self.files).count > 0
         unless params[:skip_confirmation]
           UI.error "---"

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -74,6 +74,7 @@ module Match
       if certs.count == 0 or keys.count == 0
         UI.important "Couldn't find a valid code signing identity in the git repo for #{cert_type}... creating one for you now"
         UI.crash!("No code signing identity found and can not create a new one because you enabled `readonly`") if params[:readonly]
+        GitHelper.check_push_repo_permission(params[:workspace], params[:git_branch])
         cert_path = Generator.generate_certificate(params, cert_type)
         self.changes_to_commit = true
       else
@@ -127,6 +128,8 @@ module Match
           UI.error "If you are certain that a profile should exist, double-check the recent changes to your match repository"
           UI.user_error! "No matching provisioning profiles found and can not create a new one because you enabled `readonly`. Check the output above for more information."
         end
+
+        GitHelper.check_push_repo_permission(params[:workspace], params[:git_branch])
         profile = Generator.generate_provisioning_profile(params: params,
                                                        prov_type: prov_type,
                                                   certificate_id: certificate_id,

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -22,6 +22,7 @@ describe Match do
                                                                        certificate_id: "something",
                                                                        app_identifier: values[:app_identifier]).and_return(profile_path)
       expect(FastlaneCore::ProvisioningProfile).to receive(:install).with(profile_path).and_return(destination)
+      expect(Match::GitHelper).to receive(:check_push_repo_permission).with(repo_dir, "master").twice
       expect(Match::GitHelper).to receive(:commit_changes).with(repo_dir, "[fastlane] Updated appstore and platform ios", git_url, "master")
 
       spaceship = "spaceship"
@@ -59,6 +60,7 @@ describe Match do
 
       expect(Match::GitHelper).to receive(:clone).with(git_url, false, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil).and_return(repo_dir)
       expect(Match::Utils).to receive(:import).with(key_path, keychain, password: nil).and_return(nil)
+      expect(Match::GitHelper).to_not receive(:check_push_repo_permission)
       expect(Match::GitHelper).to_not receive(:commit_changes)
 
       # To also install the certificate, fake that


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Added check of push permission to git repository before changing certificates or profiles using Match.

### Motivation and Context
Match controls authority of certificate with git repository access. If git has only read permission, a certificate is created, but can not update the repository. This makes a difference between Apple Developer Portal and git repository.

Users with only git read permission should be readonly and should not create new certificates or profiles. Deletion is similar.
