### PR TITLE
Specify rubocop version to ~> 0.47.0

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -75,7 +75,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard', '~> 0.8.7.4'
   spec.add_development_dependency 'webmock', '~> 2.3.2'
   spec.add_development_dependency 'coveralls', '~> 0.8.13'
-  spec.add_development_dependency 'rubocop', '~> 0.47'
+  spec.add_development_dependency 'rubocop', '~> 0.47.0'
   spec.add_development_dependency 'rb-readline' # https://github.com/deivid-rodriguez/byebug/issues/289#issuecomment-251383465
   spec.add_development_dependency 'rest-client', '~> 1.6.7'
   spec.add_development_dependency 'fakefs', '~> 0.8.1'


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Specify rubocop version to ~> 0.47.0

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Rubocop 0.48.0 has been released https://github.com/bbatsov/rubocop/releases/tag/v0.48.0
They includes Fastfile and fastlane related files as default.
https://github.com/bbatsov/rubocop/pull/3997/commits/78730a7a65397e94b0e0ad042e3e9b7c982cb96b#diff-af441552566679e9498e0a466229a484R32
So this is hotfix for the changes.
