### PR TITLE
Fix crash in scan.rb - no implicit conversion of nil into Array (#8677)

### DIFF
--- a/fastlane/lib/fastlane/actions/scan.rb
+++ b/fastlane/lib/fastlane/actions/scan.rb
@@ -9,6 +9,7 @@ module Fastlane
     class ScanAction < Action
       def self.run(values)
         require 'scan'
+        plist_files_before = []
 
         begin
           destination = values[:destination] # save destination value which can be later overridden


### PR DESCRIPTION
### Checklist
- [ x ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ x ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ x ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ x ] I've updated the documentation if necessary.

### Description

If `plist_files_before` is not initialized in the "begin" block, the "ensure" block will crash trying to calculate `all_test_summaries`.

### Motivation and Context

Fix for the crash described in this issue: 
https://github.com/fastlane/fastlane/issues/8677
