### PR TITLE
Resolves failure when deliver() called with name: argument and name.txt exists in locale-based metadata.

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -184,7 +184,7 @@ module Deliver
           next unless File.exist?(path)
 
           UI.message("Loading '#{path}'...")
-          options[key] ||= {}
+          options[key] = {}
           options[key][language] ||= File.read(path)
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Resolves an issue that prevents fastlane from submitting to AppStore. Specifically, when metadata/[language]/name.txt exists AND a name is passed to deliver(), fastlane errors with 'string not matched'. Other scenarios may also reproduce this error, but this is mine. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In `load_from_filesystem() ` in `upload_metadata.rb`, the line `options[key][language] ||= File.read(path)` attempts to assign the value of a file to the `options[key][language]` variable. But if `options[key]` already exists, then the prior line, `options[key] ||= {}`, never gets executed and `options[key]` is not an object, thus failing with the error 'string not matched'. There is no doubt a more elegant way to resolve this issue, but this worked for me.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/fastlane/fastlane/issues/8482

<!--- Please describe in detail how you tested your changes. --->
This change was required in order to deliver my app to the AppStore.