### PR TITLE
Print information about dir handling in fastlane on error

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -66,6 +66,13 @@ module Commander
         collector.did_raise_error(@program[:name])
         show_github_issues(e.message) if e.show_github_issues
         display_user_error!(e, e.message)
+      rescue Errno::ENOENT => e
+        # We're also printing the new-lines, as otherwise the message is not very visible in-between the error and the stacktrace
+        puts ""
+        FastlaneCore::UI.important("Error accessing file, this might be due to fastlane's directory handling")
+        FastlaneCore::UI.important("Check out https://docs.fastlane.tools/advanced/#directory-behavior for more details")
+        puts ""
+        raise e
       rescue FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!
         display_user_error!(e, e.to_s)
       rescue Faraday::SSLError => e # SSL issues are very common


### PR DESCRIPTION
This has to wait until https://github.com/fastlane/fastlane/pull/8693 is merged, and also added to fastlane/docs to Advanced.md

This will also allow us to add more exception classes in the future

<img width="1098" alt="screenshot 2017-03-28 06 48 24" src="https://cloud.githubusercontent.com/assets/869950/24434947/585e9318-13e7-11e7-84de-721469d26932.png">
