### PR TITLE
Add custom error message when receive an internal server error

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -97,6 +97,9 @@ module Spaceship
     # Raised when 401 is received from portal request
     class UnauthorizedAccessError < BasicPreferredInfoError; end
 
+    # Raised when 500 is received from iTunes Connect
+    class InternalServerError < BasicPreferredInfoError; end
+
     # Authenticates with Apple's web services. This method has to be called once
     # to generate a valid session. The session will automatically be used from then
     # on.
@@ -477,7 +480,7 @@ module Spaceship
       if body["messages"] && body["messages"]["error"].include?("Forbidden")
         raise_insuffient_permission_error!
       elsif body.to_s.include?("Internal Server Error - Read")
-        raise AppleTimeoutError, "Received an internal server error from iTunes Connect / Developer Portal, please try again later"
+        raise InternalServerError, "Received an internal server error from iTunes Connect / Developer Portal, please try again later"
       elsif (body["resultString"] || "").include?("Program License Agreement")
         raise ProgramLicenseAgreementUpdated, "#{body['userString']} Please manually log into iTunes Connect to review and accept the updated agreement."
       end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -476,6 +476,8 @@ module Spaceship
       # Check if the failure is due to missing permissions (iTunes Connect)
       if body["messages"] && body["messages"]["error"].include?("Forbidden")
         raise_insuffient_permission_error!
+      elsif body.to_s.include?("Internal Server Error - Read")
+        raise AppleTimeoutError, "Received an internal server error from iTunes Connect / Developer Portal, please try again later"
       elsif (body["resultString"] || "").include?("Program License Agreement")
         raise ProgramLicenseAgreementUpdated, "#{body['userString']} Please manually log into iTunes Connect to review and accept the updated agreement."
       end


### PR DESCRIPTION
Unfortunately I couldn't find a way to test this. I did receive the following stack traces:

**error message (body)**
```
**<HTML><HEAD>
<TITLE>Internal Server Error</TITLE>
</HEAD><BODY>
<H1>Internal Server Error - Read</H1>
The server encountered an internal error or misconfiguration and was unable to
complete your request.<P>
Reference&#32;&#35;3&#46;7a6533b8&#46;1490604875&#46;742473b8
</BODY></HTML>
```
**stack trace**
```
fastlane-2.19.3/spaceship/lib/spaceship/client.rb:453:in 
fastlane-2.19.3/spaceship/lib/spaceship/tunes/tunes_client.rb:339:in 
fastlane-2.19.3/spaceship/lib/spaceship/tunes/app_version.rb:183:in 
fastlane-2.19.3/spaceship/lib/spaceship/tunes/application.rb:111:in `edit_version'
```

I'd be ok with merging this without having a way to reproduce this locally, and see if that fixes the issue, and see if still get people reporting this issue. 

By showing a more clear error message, it should make sense for the user that the issue isn't related to their setup, but has something to do with the web-services.