### PR TITLE
Italicize instances of fastlane in README template

### DIFF
--- a/fastlane/lib/fastlane/plugins/template/README.md.erb
+++ b/fastlane/lib/fastlane/plugins/template/README.md.erb
@@ -4,7 +4,7 @@
 
 ## Getting Started
 
-This project is a [fastlane](https://github.com/fastlane/fastlane) plugin. To get started with `<%= gem_name %>`, add it to your project by running:
+This project is a [_fastlane_](https://github.com/fastlane/fastlane) plugin. To get started with `<%= gem_name %>`, add it to your project by running:
 
 ```bash
 fastlane add_plugin <%= plugin_name %>
@@ -43,10 +43,10 @@ For any other issues and feedback about this plugin, please submit it to this re
 
 If you have trouble using plugins, check out the [Plugins Troubleshooting](https://docs.fastlane.tools/plugins/plugins-troubleshooting/) guide.
 
-## Using `fastlane` Plugins
+## Using _fastlane_ Plugins
 
 For more information about how the `fastlane` plugin system works, check out the [Plugins documentation](https://docs.fastlane.tools/plugins/create-plugin/).
 
-## About `fastlane`
+## About _fastlane_
 
-`fastlane` is the easiest way to automate beta deployments and releases for your iOS and Android apps. To learn more, check out [fastlane.tools](https://fastlane.tools).
+_fastlane_ is the easiest way to automate beta deployments and releases for your iOS and Android apps. To learn more, check out [fastlane.tools](https://fastlane.tools).


### PR DESCRIPTION
Update the plugin README template to read: _fastlane_ instead of `fastlane`.