### PR TITLE
[spaceship] rework reviews  📢

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_ratings.rb
+++ b/spaceship/lib/spaceship/tunes/app_ratings.rb
@@ -50,7 +50,7 @@ module Spaceship
       # @return (Array) of Review Objects
       def reviews(store_front, versionId = '')
         raw_reviews = client.get_reviews(application.apple_id, application.platform, store_front, versionId)
-        reviews = raw_reviews.map do |review|
+        raw_reviews.map do |review|
           review["value"]["application"] = self.application
           AppReview.factory(review["value"])
         end
@@ -129,6 +129,7 @@ module Spaceship
 
       def responded?
         return true if raw_developer_response
+        false
       end
     end
 

--- a/spaceship/lib/spaceship/tunes/app_ratings.rb
+++ b/spaceship/lib/spaceship/tunes/app_ratings.rb
@@ -50,12 +50,10 @@ module Spaceship
       # @return (Array) of Review Objects
       def reviews(store_front, versionId = '')
         raw_reviews = client.get_reviews(application.apple_id, application.platform, store_front, versionId)
-        reviews = []
-        raw_reviews.each do |review|
+        reviews = raw_reviews.map do |review|
           review["value"]["application"] = self.application
-          reviews << AppReview.factory(review["value"])
+          AppReview.factory(review["value"])
         end
-        reviews
       end
     end
 
@@ -77,11 +75,11 @@ module Spaceship
       })
 
       def create!(text)
-        client.create_developer_response(app_id: application.apple_id, platform: application.platform, review_id: review_id, response: text)
+        client.create_developer_response!(app_id: application.apple_id, platform: application.platform, review_id: review_id, response: text)
       end
 
-      def update(text)
-        client.update_developer_response(app_id: application.apple_id, platform: application.platform, review_id: review_id, response_id: id, response: text)
+      def update!(text)
+        client.update_developer_response!(app_id: application.apple_id, platform: application.platform, review_id: review_id, response_id: id, response: text)
       end
     end
 
@@ -102,10 +100,10 @@ module Spaceship
       attr_accessor :developer_response
 
       attr_mapping({
-        'id'       => :id,
-        'rating'   => :rating,
-        'title'    => :title,
-        'review'   => :review,
+        'id' => :id,
+        'rating' => :rating,
+        'title' => :title,
+        'review' => :review,
         'nickname' => :nickname,
         'storeFront' => :store_front,
         'appVersionString' => :app_version,
@@ -121,10 +119,7 @@ module Spaceship
         def factory(attrs)
           obj = self.new(attrs)
           response_attrs = {}
-
-          if obj.raw_developer_response
-            response_attrs = obj.raw_developer_response
-          end
+          response_attrs = obj.raw_developer_response if obj.raw_developer_response
           response_attrs[:application] = obj.application
           response_attrs[:review_id] = obj.id
           obj.developer_response = DeveloperResponse.factory(response_attrs)
@@ -132,9 +127,8 @@ module Spaceship
         end
       end
 
-      def response?
+      def responded?
         return true if raw_developer_response
-        return false
       end
     end
 

--- a/spaceship/lib/spaceship/tunes/app_ratings.rb
+++ b/spaceship/lib/spaceship/tunes/app_ratings.rb
@@ -105,6 +105,7 @@ module Spaceship
         'id'       => :id,
         'rating'   => :rating,
         'title'    => :title,
+        'review'   => :review,
         'nickname' => :nickname,
         'storeFront' => :store_front,
         'appVersionString' => :app_version,

--- a/spaceship/lib/spaceship/tunes/app_ratings.rb
+++ b/spaceship/lib/spaceship/tunes/app_ratings.rb
@@ -47,9 +47,93 @@ module Spaceship
         instance_variable_set(:@store_fronts, unfolded_store_fronts)
       end
 
-      # @return (Array) of raw hashes representing user reviews for the given store front (and optional versionId)
+      # @return (Array) of Review Objects
       def reviews(store_front, versionId = '')
-        client.get_reviews(application.apple_id, application.platform, store_front, versionId)
+        raw_reviews = client.get_reviews(application.apple_id, application.platform, store_front, versionId)
+        reviews = []
+        raw_reviews.each do |review|
+          review["value"]["application"] = self.application
+          reviews << AppReview.factory(review["value"])
+        end
+        reviews
+      end
+    end
+
+    class DeveloperResponse < TunesBase
+      attr_reader :id
+      attr_reader :response
+      attr_reader :last_modified
+      attr_reader :hidden
+      attr_reader :state
+      attr_accessor :application
+      attr_accessor :review_id
+
+      attr_mapping({
+        'responseId' => :id,
+        'response' => :response,
+        'lastModified' => :last_modified,
+        'isHidden' => :hidden,
+        'pendingState' => :state
+      })
+
+      def create!(text)
+        client.create_developer_response(app_id: application.apple_id, platform: application.platform, review_id: review_id, response: text)
+      end
+
+      def update(text)
+        client.update_developer_response(app_id: application.apple_id, platform: application.platform, review_id: review_id, response_id: id, response: text)
+      end
+    end
+
+    class AppReview < TunesBase
+      attr_accessor :application
+      attr_reader :rating
+      attr_reader :id
+      attr_reader :title
+      attr_reader :review
+      attr_reader :nickname
+      attr_reader :store_front
+      attr_reader :app_version
+      attr_reader :last_modified
+      attr_reader :helpful_views
+      attr_reader :total_views
+      attr_reader :edited
+      attr_reader :raw_developer_response
+      attr_accessor :developer_response
+
+      attr_mapping({
+        'id'       => :id,
+        'rating'   => :rating,
+        'title'    => :title,
+        'nickname' => :nickname,
+        'storeFront' => :store_front,
+        'appVersionString' => :app_version,
+        'lastModified' => :last_modified,
+        'helpfulViews' => :helpful_views,
+        'totalViews' => :total_views,
+        'developerResponse' => :raw_developer_response,
+        'edited' => :edited
+      })
+      class << self
+        # Create a new object based on a hash.
+        # This is used to create a new object based on the server response.
+        def factory(attrs)
+          obj = self.new(attrs)
+          response_attrs = {}
+
+          if obj.raw_developer_response
+            response_attrs = obj.raw_developer_response
+          end
+          response_attrs[:application] = obj.application
+          response_attrs[:review_id] = obj.id
+          obj.developer_response = DeveloperResponse.factory(response_attrs)
+          return obj
+        end
+      end
+
+      def response?
+        return true if raw_developer_response
+        return false
       end
     end
 

--- a/spaceship/lib/spaceship/tunes/app_ratings.rb
+++ b/spaceship/lib/spaceship/tunes/app_ratings.rb
@@ -73,14 +73,6 @@ module Spaceship
         'isHidden' => :hidden,
         'pendingState' => :state
       })
-
-      def create!(text)
-        client.create_developer_response!(app_id: application.apple_id, platform: application.platform, review_id: review_id, response: text)
-      end
-
-      def update!(text)
-        client.update_developer_response!(app_id: application.apple_id, platform: application.platform, review_id: review_id, response_id: id, response: text)
-      end
     end
 
     class AppReview < TunesBase

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -323,7 +323,7 @@ module Spaceship
       parse_response(r, 'data')
     end
 
-    def create_developer_response(app_id: nil, platform: nil, review_id: nil, response: "")
+    def create_developer_response!(app_id: nil, platform: nil, review_id: nil, response: "")
       data = {
         responseText: response,
         reviewId: review_id
@@ -336,7 +336,7 @@ module Spaceship
       parse_response(r, 'data')
     end
 
-    def update_developer_response(app_id: nil, platform: "ios", review_id: nil, response_id: nil, response: "")
+    def update_developer_response!(app_id: nil, platform: "ios", review_id: nil, response_id: nil, response: "")
       data = {
         responseText: response
       }
@@ -353,13 +353,13 @@ module Spaceship
       per_page = 100 # apple default
       all_fetched = false
       all_reviews = []
-      until all_fetched
+      loop do
         r = request(:get, "ra/apps/#{app_id}/platforms/#{platform}/reviews?storefront=#{storefront}&versionId=#{versionId}&index=#{index}")
         all_reviews.concat(parse_response(r, 'data')['reviews'])
         if all_reviews.count < parse_response(r, 'data')['reviewCount']
           index += per_page
         else
-          all_fetched = true
+          break
         end
       end
       all_reviews

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -349,7 +349,6 @@ module Spaceship
     def get_reviews(app_id, platform, storefront, versionId = '')
       index = 0
       per_page = 100 # apple default
-      all_fetched = false
       all_reviews = []
       loop do
         r = request(:get, "ra/apps/#{app_id}/platforms/#{platform}/reviews?storefront=#{storefront}&versionId=#{versionId}&index=#{index}")

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -328,7 +328,7 @@ module Spaceship
         responseText: response,
         reviewId: review_id
       }
-      r = request(:post) do |req|
+      request(:post) do |req|
         req.url "ra/apps/#{app_id}/platforms/#{platform}/reviews/#{review_id}/responses"
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
@@ -339,7 +339,7 @@ module Spaceship
       data = {
         responseText: response
       }
-      r = request(:put) do |req|
+      request(:put) do |req|
         req.url "ra/apps/#{app_id}/platforms/#{platform}/reviews/#{review_id}/responses/#{response_id}"
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -323,9 +323,46 @@ module Spaceship
       parse_response(r, 'data')
     end
 
+    def create_developer_response(app_id: nil, platform: nil, review_id: nil, response: "")
+      data = {
+        responseText: response,
+        reviewId: review_id
+      }
+      r = request(:post) do |req|
+        req.url "ra/apps/#{app_id}/platforms/#{platform}/reviews/#{review_id}/responses"
+        req.body = data.to_json
+        req.headers['Content-Type'] = 'application/json'
+      end
+      parse_response(r, 'data')
+    end
+
+    def update_developer_response(app_id: nil, platform: "ios", review_id: nil, response_id: nil, response: "")
+      data = {
+        responseText: response
+      }
+      r = request(:put) do |req|
+        req.url "ra/apps/#{app_id}/platforms/#{platform}/reviews/#{review_id}/responses/#{response_id}"
+        req.body = data.to_json
+        req.headers['Content-Type'] = 'application/json'
+      end
+      parse_response(r, 'data')
+    end
+
     def get_reviews(app_id, platform, storefront, versionId = '')
-      r = request(:get, "ra/apps/#{app_id}/reviews?platform=#{platform}&storefront=#{storefront}&versionId=#{versionId}")
-      parse_response(r, 'data')['reviews']
+      index = 0
+      per_page = 100 # apple default
+      all_fetched = false
+      all_reviews = []
+      until all_fetched
+        r = request(:get, "ra/apps/#{app_id}/platforms/#{platform}/reviews?storefront=#{storefront}&versionId=#{versionId}&index=#{index}")
+        all_reviews.concat(parse_response(r, 'data')['reviews'])
+        if all_reviews.count < parse_response(r, 'data')['reviewCount']
+          index += per_page
+        else
+          all_fetched = true
+        end
+      end
+      all_reviews
     end
 
     #####################################################

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -333,7 +333,6 @@ module Spaceship
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
       end
-      parse_response(r, 'data')
     end
 
     def update_developer_response!(app_id: nil, platform: "ios", review_id: nil, response_id: nil, response: "")
@@ -345,7 +344,6 @@ module Spaceship
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
       end
-      parse_response(r, 'data')
     end
 
     def get_reviews(app_id, platform, storefront, versionId = '')

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -323,7 +323,11 @@ module Spaceship
       parse_response(r, 'data')
     end
 
-    def create_developer_response!(app_id: nil, platform: nil, review_id: nil, response: "")
+    def create_developer_response!(app_id: nil, platform: "ios", review_id: nil, response: nil)
+      raise "app_id is required" unless app_id
+      raise "review_id is required" unless review_id
+      raise "response is required" unless response
+
       data = {
         responseText: response,
         reviewId: review_id
@@ -335,7 +339,12 @@ module Spaceship
       end
     end
 
-    def update_developer_response!(app_id: nil, platform: "ios", review_id: nil, response_id: nil, response: "")
+    def update_developer_response!(app_id: nil, platform: "ios", review_id: nil, response_id: nil, response: nil)
+      raise "app_id is required" unless app_id
+      raise "review_id is required" unless review_id
+      raise "response_id is required" unless response_id
+      raise "response is required" unless response
+
       data = {
         responseText: response
       }

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -323,38 +323,6 @@ module Spaceship
       parse_response(r, 'data')
     end
 
-    def create_developer_response!(app_id: nil, platform: "ios", review_id: nil, response: nil)
-      raise "app_id is required" unless app_id
-      raise "review_id is required" unless review_id
-      raise "response is required" unless response
-
-      data = {
-        responseText: response,
-        reviewId: review_id
-      }
-      request(:post) do |req|
-        req.url "ra/apps/#{app_id}/platforms/#{platform}/reviews/#{review_id}/responses"
-        req.body = data.to_json
-        req.headers['Content-Type'] = 'application/json'
-      end
-    end
-
-    def update_developer_response!(app_id: nil, platform: "ios", review_id: nil, response_id: nil, response: nil)
-      raise "app_id is required" unless app_id
-      raise "review_id is required" unless review_id
-      raise "response_id is required" unless response_id
-      raise "response is required" unless response
-
-      data = {
-        responseText: response
-      }
-      request(:put) do |req|
-        req.url "ra/apps/#{app_id}/platforms/#{platform}/reviews/#{review_id}/responses/#{response_id}"
-        req.body = data.to_json
-        req.headers['Content-Type'] = 'application/json'
-      end
-    end
-
     def get_reviews(app_id, platform, storefront, versionId = '')
       index = 0
       per_page = 100 # apple default

--- a/spaceship/spec/tunes/app_ratings_spec.rb
+++ b/spaceship/spec/tunes/app_ratings_spec.rb
@@ -1,6 +1,7 @@
 describe Spaceship::Tunes::AppRatings do
   before { Spaceship::Tunes.login }
   let(:app) { Spaceship::Application.all.first }
+  let(:client) { Spaceship::Application.client }
 
   describe "successfully loads rating summary" do
     it "contains the right information" do
@@ -45,6 +46,29 @@ describe Spaceship::Tunes::AppRatings do
       expect(reviews.first.review).to eq("Review 1")
       expect(reviews.first.last_modified).to eq(1_463_887_020_000)
       expect(reviews.first.nickname).to eq("Reviewer1")
+    end
+  end
+
+  describe "Manages Developer Response" do
+    it "Can Read Response" do
+      TunesStubbing.itc_stub_ratings
+      review = app.ratings.reviews("US").first
+      expect(review.response?).to eq(true)
+      expect(review.developer_response.response).to eq("Thank You")
+    end
+
+    it "Can edit a response" do
+      TunesStubbing.itc_stub_ratings
+      expect(client).to receive(:update_developer_response).with(app_id: app.apple_id, platform: app.platform, review_id: 1_000_000_000, response_id: 28_516, response: "Awesome")
+      review = app.ratings.reviews("US").first
+      review.developer_response.update("Awesome")
+    end
+
+    it "Can add a response" do
+      TunesStubbing.itc_stub_ratings
+      expect(client).to receive(:create_developer_response).with(app_id: app.apple_id, platform: app.platform, review_id: 1_000_000_000, response: "Awesome Dude")
+      review = app.ratings.reviews("US").first
+      review.developer_response.create!("Awesome Dude")
     end
   end
 end

--- a/spaceship/spec/tunes/app_ratings_spec.rb
+++ b/spaceship/spec/tunes/app_ratings_spec.rb
@@ -38,15 +38,13 @@ describe Spaceship::Tunes::AppRatings do
       reviews = ratings.reviews("US")
 
       expect(reviews.count).to eq(4)
-      expect(reviews.first).to eq({
-        "id" => 1_000_000_000,
-        "rating" => 2,
-        "title" => "Title 1",
-        "review" => "Review 1",
-        "created" => 1_463_887_020_000,
-        "nickname" => "Reviewer1",
-        "storeFront" => "NZ"
-      })
+      expect(reviews.first.store_front).to eq("NZ")
+      expect(reviews.first.id).to eq(1_000_000_000)
+      expect(reviews.first.rating).to eq(2)
+      expect(reviews.first.title).to eq("Title 1")
+      expect(reviews.first.review).to eq("Review 1")
+      expect(reviews.first.last_modified).to eq(1_463_887_020_000)
+      expect(reviews.first.nickname).to eq("Reviewer1")
     end
   end
 end

--- a/spaceship/spec/tunes/app_ratings_spec.rb
+++ b/spaceship/spec/tunes/app_ratings_spec.rb
@@ -53,20 +53,20 @@ describe Spaceship::Tunes::AppRatings do
     it "Can Read Response" do
       TunesStubbing.itc_stub_ratings
       review = app.ratings.reviews("US").first
-      expect(review.response?).to eq(true)
+      expect(review.responded?).to eq(true)
       expect(review.developer_response.response).to eq("Thank You")
     end
 
     it "Can edit a response" do
       TunesStubbing.itc_stub_ratings
-      expect(client).to receive(:update_developer_response).with(app_id: app.apple_id, platform: app.platform, review_id: 1_000_000_000, response_id: 28_516, response: "Awesome")
+      expect(client).to receive(:update_developer_response!).with(app_id: app.apple_id, platform: app.platform, review_id: 1_000_000_000, response_id: 28_516, response: "Awesome")
       review = app.ratings.reviews("US").first
-      review.developer_response.update("Awesome")
+      review.developer_response.update!("Awesome")
     end
 
     it "Can add a response" do
       TunesStubbing.itc_stub_ratings
-      expect(client).to receive(:create_developer_response).with(app_id: app.apple_id, platform: app.platform, review_id: 1_000_000_000, response: "Awesome Dude")
+      expect(client).to receive(:create_developer_response!).with(app_id: app.apple_id, platform: app.platform, review_id: 1_000_000_000, response: "Awesome Dude")
       review = app.ratings.reviews("US").first
       review.developer_response.create!("Awesome Dude")
     end

--- a/spaceship/spec/tunes/app_ratings_spec.rb
+++ b/spaceship/spec/tunes/app_ratings_spec.rb
@@ -56,19 +56,5 @@ describe Spaceship::Tunes::AppRatings do
       expect(review.responded?).to eq(true)
       expect(review.developer_response.response).to eq("Thank You")
     end
-
-    it "Can edit a response" do
-      TunesStubbing.itc_stub_ratings
-      expect(client).to receive(:update_developer_response!).with(app_id: app.apple_id, platform: app.platform, review_id: 1_000_000_000, response_id: 28_516, response: "Awesome")
-      review = app.ratings.reviews("US").first
-      review.developer_response.update!("Awesome")
-    end
-
-    it "Can add a response" do
-      TunesStubbing.itc_stub_ratings
-      expect(client).to receive(:create_developer_response!).with(app_id: app.apple_id, platform: app.platform, review_id: 1_000_000_000, response: "Awesome Dude")
-      review = app.ratings.reviews("US").first
-      review.developer_response.create!("Awesome Dude")
-    end
   end
 end

--- a/spaceship/spec/tunes/fixtures/review_by_storefront.json
+++ b/spaceship/spec/tunes/fixtures/review_by_storefront.json
@@ -1,19 +1,25 @@
 {
     "data": {
         "reviewCount": 4,
-        "reviews": [
-          {
-          "value": {
+        "reviews": [{
+            "value": {
                 "id": 1000000000,
                 "rating": 2,
                 "title": "Title 1",
                 "review": "Review 1",
                 "lastModified": 1463887020000,
                 "nickname": "Reviewer1",
-                "storeFront": "NZ"
+                "storeFront": "NZ",
+                "developerResponse": {
+                    "isHidden": false,
+                    "lastModified": 1490782551000,
+                    "pendingState": "CREATE",
+                    "response": "Thank You",
+                    "responseId": 28516
+                }
+ 
             }
-        },
-        {
+        }, {
             "value": {
                 "id": 1000000001,
                 "rating": 2,
@@ -22,9 +28,8 @@
                 "lastModified": 1459152540000,
                 "nickname": "Reviewer2",
                 "storeFront": "NZ"
-            }
-        },
-        {
+           }
+        }, {
             "value": {
                 "id": 1000000002,
                 "rating": 4,
@@ -34,8 +39,7 @@
                 "nickname": "Reviewer3",
                 "storeFront": "NZ"
             }
-        },
-        {
+        }, {
             "value": {
                 "id": 1000000003,
                 "rating": 5,
@@ -46,11 +50,11 @@
                 "storeFront": "NZ"
             }
         }]
-},
-"messages": {
-    "warn": null,
-    "error": null,
-    "info": null
-},
-"statusCode": "SUCCESS"
+    },
+    "messages": {
+        "warn": null,
+        "error": null,
+        "info": null
+    },
+    "statusCode": "SUCCESS"
 }

--- a/spaceship/spec/tunes/fixtures/review_by_storefront.json
+++ b/spaceship/spec/tunes/fixtures/review_by_storefront.json
@@ -1,43 +1,56 @@
 {
-	"data": {
-		"reviews": [{
-			"id": 1000000000,
-			"rating": 2,
-			"title": "Title 1",
-			"review": "Review 1",
-			"created": 1463887020000,
-			"nickname": "Reviewer1",
-			"storeFront": "NZ"
-		}, {
-			"id": 1000000001,
-			"rating": 2,
-			"title": "Title 2",
-			"review": "Review 2",
-			"created": 1459152540000,
-			"nickname": "Reviewer2",
-			"storeFront": "NZ"
-		}, {
-			"id": 1000000002,
-			"rating": 4,
-			"title": "Title 3",
-			"review": "Review 3",
-			"created": 1455870780000,
-			"nickname": "Reviewer3",
-			"storeFront": "NZ"
-		}, {
-			"id": 1000000003,
-			"rating": 5,
-			"title": "Title 4",
-			"review": "Review 4",
-			"created": 1453490460000,
-			"nickname": "Reviewer4",
-			"storeFront": "NZ"
-		}]
-	},
-	"messages": {
-		"warn": null,
-		"error": null,
-		"info": null
-	},
-	"statusCode": "SUCCESS"
+    "data": {
+        "reviewCount": 4,
+        "reviews": [
+          {
+          "value": {
+                "id": 1000000000,
+                "rating": 2,
+                "title": "Title 1",
+                "review": "Review 1",
+                "lastModified": 1463887020000,
+                "nickname": "Reviewer1",
+                "storeFront": "NZ"
+            }
+        },
+        {
+            "value": {
+                "id": 1000000001,
+                "rating": 2,
+                "title": "Title 2",
+                "review": "Review 2",
+                "lastModified": 1459152540000,
+                "nickname": "Reviewer2",
+                "storeFront": "NZ"
+            }
+        },
+        {
+            "value": {
+                "id": 1000000002,
+                "rating": 4,
+                "title": "Title 3",
+                "review": "Review 3",
+                "lastModified": 1455870780000,
+                "nickname": "Reviewer3",
+                "storeFront": "NZ"
+            }
+        },
+        {
+            "value": {
+                "id": 1000000003,
+                "rating": 5,
+                "title": "Title 4",
+                "review": "Review 4",
+                "lastModified": 1453490460000,
+                "nickname": "Reviewer4",
+                "storeFront": "NZ"
+            }
+        }]
+},
+"messages": {
+    "warn": null,
+    "error": null,
+    "info": null
+},
+"statusCode": "SUCCESS"
 }

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -76,7 +76,7 @@ class TunesStubbing
       stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/reviews/summary?platform=ios&versionId=").
         to_return(status: 200, body: itc_read_fixture_file('ratings_summary.json'), headers: { 'Content-Type' => 'application/json' })
 
-      stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/reviews?platform=ios&storefront=US&versionId=").
+      stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/platforms/ios/reviews?index=0&storefront=US&versionId=").
         to_return(status: 200, body: itc_read_fixture_file('review_by_storefront.json'), headers: { 'Content-Type' => 'application/json' })
     end
 


### PR DESCRIPTION
reworks interface for retreiving app store reviews.

```ruby
require "spaceship"
Spaceship::Tunes.login("helmut@januschka.com")
app = Spaceship::Application.find("krone.at-fivexfive")


# get all reviews from AT
reviews = app.ratings.reviews("AT")

reviews.each do | review |
  puts "#{review.rating}"
  if review.responded? 
    puts "Already been responed to"
  end
end
