### PR TITLE
Docs: add information about configuration file order

### DIFF
--- a/fastlane/docs/Advanced.md
+++ b/fastlane/docs/Advanced.md
@@ -360,6 +360,55 @@ fastlane-credentials remove --username felix@krausefx.com
 password has been deleted.
 ```
 
+## Control configuration by lane and by platform
+
+In general, configuration files take only the first value given for a particular configuration item. That means that for an `Appfile` like the following:
+
+```ruby
+app_identifier "com.used.id"
+app_identifier "com.ignored.id"
+```
+
+the `app_identfier` will be `"com.used.id"` and the second value will be ignored. The `for_lane` and `for_platform` configuration blocks provide a limited exception to this rule.
+
+All configuration files (Appfile, Matchfile, Screengrabfile, etc.) can use `for_lane` and `for_platform` blocks to control (and override) configuration values for those circumstances.
+
+`for_lane` blocks will be called when the name of lane invoked on the command line matches the one specified by the block. So, given a `Screengrabfile` like:
+
+```ruby
+locales ['en-US', 'fr-FR', 'ja-JP']
+
+for_lane :screenshots_english_only do
+  locales ['en-US']
+end
+
+for_lane :screenshots_french_only do
+  locales ['fr-FR']
+end
+```
+
+`locales` will have the values `['en-US', 'fr-FR', 'ja-JP']` by default, but will only have one value when running the `fastlane screenshots_english_only` or `fastlane screenshots_french_only`.
+
+`for_platform` gives you similar control based on the platform for which you have invoked _fastlane_. So, for an `Appfile` configured like:
+
+```ruby
+app_identifier "com.default.id"
+
+for_lane :enterprise do
+  app_identifier "com.forlane.enterprise"
+end
+
+for_platform :mac do
+  app_identifier "com.forplatform.mac"
+
+  for_lane :release do
+    app_identifier "com.forplatform.mac.forlane.release"
+  end
+end
+```
+
+you can expect the `app_identifier` to equal `"com.forplatform.mac.forlane.release"` when invoking `fastlane mac release`.
+
 ## Gitignore
 
 The documentation was moved to [Gitignore.md](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md).


### PR DESCRIPTION
Taken from Advanced.md from the docs repo