### PR TITLE
[frameit] Added font_height_factor

### DIFF
--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -59,6 +59,7 @@ module Frameit
     end
 
     # Make sure the paths/colors are valid
+    # rubocop:disable Metrics/PerceivedComplexity
     def validate_values(values)
       values.each do |key, value|
         if value.kind_of?(Hash)
@@ -87,9 +88,12 @@ module Frameit
             UI.user_error! "show_complete_frame must be a Boolean" unless [true, false].include?(value)
           when 'font_scale_factor'
             UI.user_error!("font_scale_factor must be numeric") unless value.kind_of?(Numeric)
+          when 'font_height_factor'
+            UI.user_error!("font_height_factor must be numeric") unless value.kind_of?(Numeric)
           end
         end
       end
     end
+    # rubocop:enable Metrics/PerceivedComplexity
   end
 end

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -217,12 +217,12 @@ module Frameit
       vertical_padding = vertical_frame_padding
       keyword_top_space = vertical_padding
 
-      spacing_between_title_and_keyword = (title.height / 2)
-      title_top_space = vertical_padding + keyword.height + spacing_between_title_and_keyword
+      spacing_between_title_and_keyword = (text_height(title) / 2)
+      title_top_space = vertical_padding + text_height(keyword) + spacing_between_title_and_keyword
       title_left_space = (background.width / 2.0 - title_width / 2.0).round
       keyword_left_space = (background.width / 2.0 - keyword_width / 2.0).round
 
-      self.top_space_above_device += title.height + keyword.height + spacing_between_title_and_keyword + vertical_padding
+      self.top_space_above_device += text_height(title) + text_height(keyword) + spacing_between_title_and_keyword + vertical_padding
       # keyword
       background = background.composite(keyword, "png") do |c|
         c.compose "Over"
@@ -266,7 +266,7 @@ module Frameit
       end
 
       vertical_padding = vertical_frame_padding
-      top_space = vertical_padding + (actual_font_size - title.height) / 2
+      top_space = vertical_padding + (actual_font_size - text_height(title)) / 2
       left_space = (background.width / 2.0 - sum_width / 2.0).round
 
       self.top_space_above_device += actual_font_size + vertical_padding
@@ -292,6 +292,14 @@ module Frameit
     def actual_font_size
       font_scale_factor = fetch_config['font_scale_factor'] || 0.1
       [@image.width * font_scale_factor].max.round
+    end
+
+    def text_height(text)
+      font_height_factor = fetch_config['font_height_factor']
+      if font_height_factor
+        return [actual_font_size * font_height_factor].max.round
+      end
+      text.height
     end
 
     # The space between the keyword and the title


### PR DESCRIPTION
Added `font_height_factor` that allows the title and keyword heights to be a set value so that the devices line up across shots of the same device. Should fix #6116.

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description
Added `font_height_factor` which if defined in the config uses a factor of the calculated font size as the text height instead of calculating the text height which makes the text height equal across all shots of the same device.

### Motivation and Context
If a title that has a lower case g/q/y/j or some other characters is used in one shot but not in another 
 even when using `font_scale_factor` to ensure the same font sizes it results in the example below where the devices don't line up like in issue #6116.
 
![example](https://cloud.githubusercontent.com/assets/701665/24487358/fa257d4c-14dc-11e7-81a6-bc00ae3b8ea0.png)