### PR TITLE
Update snapshot launch arguments link

### DIFF
--- a/snapshot/lib/assets/SnapfileTemplate
+++ b/snapshot/lib/assets/SnapfileTemplate
@@ -29,7 +29,7 @@ languages([
 # project "./Project.xcodeproj"
 # workspace "./Project.xcworkspace"
 
-# Arguments to pass to the app on launch. See https://github.com/fastlane/snapshot#launch-arguments
+# Arguments to pass to the app on launch. See https://github.com/fastlane/fastlane/tree/master/snapshot#launch-arguments
 # launch_arguments(["-favColor red"])
 
 # For more information about all available options run


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Description
The snapshot launch arguments link was pointing to the old repo. Changed it to point to the new fastlane mono repo

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
No testing. It's only a link in the Snapfile documentation