### PR TITLE
Add Gitlab 9.0+ ENV variable for branch detection.

### DIFF
--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     module SharedValues
-      GIT_BRANCH_ENV_VARS = %w(GIT_BRANCH BRANCH_NAME TRAVIS_BRANCH BITRISE_GIT_BRANCH CI_BUILD_REF_NAME).freeze
+      GIT_BRANCH_ENV_VARS = %w(GIT_BRANCH BRANCH_NAME TRAVIS_BRANCH BITRISE_GIT_BRANCH CI_BUILD_REF_NAME CI_COMMIT_REF_NAME).freeze
     end
 
     class GitBranchAction < Action


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Added another ENV variable.
More information can be found here: https://docs.gitlab.com/ce/ci/variables/#9-0-renaming

### Motivation and Context
To support future gitlab-ci with versions >= 9.0
