### PR TITLE
Version bump to 2.24.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.23.0'.freeze
+  VERSION = '2.24.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.23.0':**

* Update snapshot launch arguments link (#8706) via Marius Ciocanel
* Add documentation about the fastlane directory behavior (#8693) via Felix Krause
* Convince people to disable legacy build API (#8692) via Felix Krause
* Italicize instances of fastlane in README template (#8697) via David Ohayon
* Remove duplicate Advanced.md entry (#8687) via Felix Krause
* Fix crash in scan.rb - no implicit conversion of nil into Array (#8677) (#8678) via battlmonstr
* Fix hardcoded fastlane paths (#8380) via Maksym Grebenets
* macOS support for snapshot (#8668) via David Ohayon
* Add support for fish tab completions (#8558) via Joseph Duffy
* Revert "Add macOS support to snapshot (#8468)" (#8667) via David Ohayon
* Add macOS support to snapshot (#8468) via David Ohayon
* Upgrade rubocop to 0.48 (#8652) via Kohki Miki
* Fix spelling mistake (#8657) via Fumiya Nakamura
* Specify rubocop version to ~> 0.47.0 (#8650) via Fumiya Nakamura
* Fix NameError when running single rspec (#8634) via Fumiya Nakamura
* [match] Check push permission to git repository (#8643) via Econa77
* Replace test failures with its own class to have more accurate crash metrics (#8631) via Felix Krause
* Update tweet text to use release URL instead of tag URL (#8633) via Felix Krause
* Improve react-native onboarding (#8605) via Felix Krause
* Update fastlane tool collector to work with mono repo change (#8632) via Felix Krause
* Add `commander-fastlane` fork to list of gems (#8642) via Felix Krause
* Clarify the fastlane docs message (#8641) via David Ohayon
* change the zip output path from relative to absolute (#8637) via yukiasai
