### PR TITLE
Update update_checker to point to fastlane.tools domain

### DIFF
--- a/fastlane/spec/env_spec.rb
+++ b/fastlane/spec/env_spec.rb
@@ -4,8 +4,8 @@ require "fastlane/cli_tools_distributor"
 describe Fastlane do
   describe Fastlane::EnvironmentPrinter do
     before do
-      stub_request(:post, %r{https:\/\/fastlane-refresher.herokuapp.com\/.*}).
-        with(headers: { 'Host' => 'fastlane-refresher.herokuapp.com:443' }).
+      stub_request(:post, %r{https:\/\/refresher.fastlane.tools\/.*}).
+        with(headers: { 'Host' => 'refresher.fastlane.tools:443' }).
         to_return(status: 200, body: '{"version": "0.16.2",  "status": "ok"}', headers: {})
     end
 

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -7,7 +7,7 @@ module FastlaneCore
   # Verifies, the user runs the latest version of this gem
   class UpdateChecker
     # This web service is fully open source: https://github.com/fastlane/refresher
-    UPDATE_URL = "https://fastlane-refresher.herokuapp.com/"
+    UPDATE_URL = "https://refresher.fastlane.tools/"
 
     def self.start_looking_for_update(gem_name)
       return if Helper.is_test?

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -103,24 +103,24 @@ describe FastlaneCore do
       end
 
       it "generated the correct URL with no parameters, no platform value and no p_hash" do
-        expect(FastlaneCore::UpdateChecker.generate_fetch_url("fastlane")).to eq("https://fastlane-refresher.herokuapp.com/fastlane")
+        expect(FastlaneCore::UpdateChecker.generate_fetch_url("fastlane")).to eq("https://refresher.fastlane.tools/fastlane")
       end
 
       it "uses the bundle identifier and hashes the value if available" do
         ENV["PILOT_APP_IDENTIFIER"] = "com.krausefx.app"
-        expect(FastlaneCore::UpdateChecker.generate_fetch_url("fastlane")).to eq("https://fastlane-refresher.herokuapp.com/fastlane?p_hash=50925b8f18defc356dad507b1729bc185f9582513537346424b0be09b1f12b2f&platform=ios")
+        expect(FastlaneCore::UpdateChecker.generate_fetch_url("fastlane")).to eq("https://refresher.fastlane.tools/fastlane?p_hash=50925b8f18defc356dad507b1729bc185f9582513537346424b0be09b1f12b2f&platform=ios")
       end
 
       describe "#platform" do
         it "ios" do
           FastlaneSpec::Env.with_ARGV(["--app_identifier", "yolo.app"]) do
-            expect(FastlaneCore::UpdateChecker.generate_fetch_url("sigh")).to eq("https://fastlane-refresher.herokuapp.com/sigh?p_hash=52629c9a0eebe49c58db83c94c090bd790a101ff2a70ab9514f6a6427644375a&platform=ios")
+            expect(FastlaneCore::UpdateChecker.generate_fetch_url("sigh")).to eq("https://refresher.fastlane.tools/sigh?p_hash=52629c9a0eebe49c58db83c94c090bd790a101ff2a70ab9514f6a6427644375a&platform=ios")
           end
         end
 
         it "android" do
           FastlaneSpec::Env.with_ARGV(["--app_package_name", "yolo.android.app"]) do
-            expect(FastlaneCore::UpdateChecker.generate_fetch_url("supply")).to eq("https://fastlane-refresher.herokuapp.com/supply?p_hash=6a8b842e4a75d2a2bc4bdf584406a68eab8cabcc7b7a396c283b390fff30b59b&platform=android")
+            expect(FastlaneCore::UpdateChecker.generate_fetch_url("supply")).to eq("https://refresher.fastlane.tools/supply?p_hash=6a8b842e4a75d2a2bc4bdf584406a68eab8cabcc7b7a396c283b390fff30b59b&platform=android")
           end
         end
       end


### PR DESCRIPTION
I tested it locally and it works as expected

<img width="691" alt="screenshot 2017-03-30 11 10 00" src="https://cloud.githubusercontent.com/assets/869950/24519280/7bf33146-1539-11e7-9ad4-33a63cf65e66.png">
