### PR TITLE
Feature/snapshot test without building

### DIFF
--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -170,7 +170,21 @@ module Snapshot
         FastlaneCore::ConfigItem.new(key: :test_target_name,
                                      env_name: "SNAPSHOT_TEST_TARGET_NAME",
                                      description: "The name of the target you want to test (if you desire to override the Target Application from Xcode)",
-                                     optional: true)
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :test_without_building,
+                                     short_option: "-T",
+                                     env_name: "SNAPSHOT_TEST_WITHOUT_BUILDING",
+                                     description: "Test without building the project",
+                                     is_string: false,
+                                     default_value: false,
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :xctestrun,
+                                     short_option: "-R",
+                                     env_name: "SCAN_XCTESTRUN",
+                                     description: "Run tests using the provided .xctestrun file",
+                                     is_string: true,
+                                     optional: true
+                                     )
       ]
     end
   end

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -183,8 +183,7 @@ module Snapshot
                                      env_name: "SCAN_XCTESTRUN",
                                      description: "Run tests using the provided .xctestrun file",
                                      is_string: true,
-                                     optional: true
-                                     )
+                                     optional: true)
       ]
     end
   end

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -32,7 +32,11 @@ module Snapshot
         config = Snapshot.config
 
         options = []
-        options += project_path_array
+        if config[:xctestrun]
+          options << "-xctestrun '#{config[:xctestrun]}'"
+        else
+          options += project_path_array
+        end
         options << "-sdk '#{config[:sdk]}'" if config[:sdk]
         options << "-derivedDataPath '#{derived_data_path}'"
         options << config[:xcargs] if config[:xcargs]
@@ -50,10 +54,16 @@ module Snapshot
       end
 
       def actions
+        config = Snapshot.config
+
         actions = []
         actions << :clean if Snapshot.config[:clean]
-        actions << :build # https://github.com/fastlane/snapshot/issues/246
-        actions << :test
+        if config[:test_without_building] || config[:xctestrun]
+          actions << "test-without-building"
+        else
+          actions << :build # https://github.com/fastlane/snapshot/issues/246
+          actions << :test
+        end
 
         actions
       end

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -207,5 +207,40 @@ describe Snapshot do
         end
       end
     end
+
+    describe 'test-without-building' do
+      before (:each) do
+        @config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, {
+          output_directory: '/tmp/scan_results',
+          output_simulator_logs: true,
+          derived_data_path: 'fake/derived/path',
+          devices: ['iPhone 6 (10.1)', 'iPhone 6s'],
+          test_without_building: true,
+          project: './snapshot/example/Example.xcodeproj',
+          scheme: 'ExampleUITests',
+          xctestrun: './snapshot/example/Example.xctestrun'
+        })
+      end
+
+      it "should test xctestruns" do
+        Snapshot.config = @config
+
+        command = Snapshot::TestCommandGenerator.generate(device_type: "iPhone 6")
+          id = command.join('').match(/id=(.+?),/)[1]
+          ios = command.join('').match(/OS=(\d+.\d+)/)[1]
+          expect(command).to eq(
+            [
+              "set -o pipefail &&",
+              "xcodebuild",
+              "-xctestrun './snapshot/example/Example.xctestrun'",
+              "-derivedDataPath 'fake/derived/path'",
+              "-destination 'platform=iOS Simulator,id=#{id},OS=#{ios}'",
+              "FASTLANE_SNAPSHOT=YES",
+              "test-without-building",
+              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
+            ]
+          )
+      end
+    end
   end
 end

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -226,20 +226,20 @@ describe Snapshot do
         Snapshot.config = @config
 
         command = Snapshot::TestCommandGenerator.generate(device_type: "iPhone 6")
-          id = command.join('').match(/id=(.+?),/)[1]
-          ios = command.join('').match(/OS=(\d+.\d+)/)[1]
-          expect(command).to eq(
-            [
-              "set -o pipefail &&",
-              "xcodebuild",
-              "-xctestrun './snapshot/example/Example.xctestrun'",
-              "-derivedDataPath 'fake/derived/path'",
-              "-destination 'platform=iOS Simulator,id=#{id},OS=#{ios}'",
-              "FASTLANE_SNAPSHOT=YES",
-              "test-without-building",
-              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
-            ]
-          )
+        id = command.join('').match(/id=(.+?),/)[1]
+        ios = command.join('').match(/OS=(\d+.\d+)/)[1]
+        expect(command).to eq(
+          [
+            "set -o pipefail &&",
+            "xcodebuild",
+            "-xctestrun './snapshot/example/Example.xctestrun'",
+            "-derivedDataPath 'fake/derived/path'",
+            "-destination 'platform=iOS Simulator,id=#{id},OS=#{ios}'",
+            "FASTLANE_SNAPSHOT=YES",
+            "test-without-building",
+            "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
+          ]
+        )
       end
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
This adds the capability to run snapshot via .xctestruns built with build-for-testing, which saves repetitive project compilations.

### Motivation and Context
This adds similar support as included in https://github.com/fastlane/fastlane/pull/7130. Xcode 8 added a few additional commands to xcodebuild, which can speed up and simplify deployment.
