### PR TITLE
Catch Xcode 8.3 legacy API while patching Xcode PackageApplication script

### DIFF
--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -143,7 +143,9 @@ module Gym
       def raise_legacy_build_api_error(output)
         UI.error("You enabled the legacy build API in _gym_")
         UI.error("This option has been deprecated for about a year")
-        UI.error("and broke with one of the most recent Xcode releases")
+        UI.error("and was removed with Xcode 8.3")
+        UI.error("Please update your Fastfile to include the export_type too")
+        UI.error("more information about how to migrate away: https://github.com/fastlane/fastlane/releases/tag/2.24.0")
         UI.user_error!("Build failed. Please remove the `use_legacy_build_api` option in your Fastfile and try again", error_info: output)
       end
 

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -104,6 +104,15 @@ module Gym
         return File.join(m[1], 'IDEDistribution.standard.log') unless m.nil?
       end
 
+      def raise_legacy_build_api_error(output)
+        UI.error("You enabled the legacy build API in _gym_")
+        UI.error("This option has been deprecated for about a year")
+        UI.error("and was removed with Xcode 8.3")
+        UI.error("Please update your Fastfile to include the export_type too")
+        UI.error("more information about how to migrate away: https://github.com/fastlane/fastlane/releases/tag/2.24.0")
+        UI.user_error!("Build failed. Please remove the `use_legacy_build_api` option in your Fastfile and try again", error_info: output)
+      end
+
       private
 
       def read_standard_output(output)
@@ -138,15 +147,6 @@ module Gym
         FastlaneCore::PrintTable.print_values(config: values,
                                            hide_keys: [],
                                                title: "Build environment".yellow)
-      end
-
-      def raise_legacy_build_api_error(output)
-        UI.error("You enabled the legacy build API in _gym_")
-        UI.error("This option has been deprecated for about a year")
-        UI.error("and was removed with Xcode 8.3")
-        UI.error("Please update your Fastfile to include the export_type too")
-        UI.error("more information about how to migrate away: https://github.com/fastlane/fastlane/releases/tag/2.24.0")
-        UI.user_error!("Build failed. Please remove the `use_legacy_build_api` option in your Fastfile and try again", error_info: output)
       end
 
       def print_xcode_path_instructions

--- a/gym/lib/gym/xcodebuild_fixes/package_application_fix.rb
+++ b/gym/lib/gym/xcodebuild_fixes/package_application_fix.rb
@@ -20,6 +20,10 @@ module Gym
           # If that location changes, search it using xcrun --sdk iphoneos -f PackageApplication
           package_application_path = "#{Xcode.xcode_path}/Platforms/iPhoneOS.platform/Developer/usr/bin/PackageApplication"
 
+          unless File.exist?(package_application_path)
+            ErrorHandler.raise_legacy_build_api_error("")
+          end
+
           UI.crash!("Unable to patch the `PackageApplication` script bundled in Xcode. This is not supported.") unless expected_md5_hashes.include?(Digest::MD5.file(package_application_path).hexdigest)
 
           # Duplicate PackageApplication script to PackageApplication4Gym


### PR DESCRIPTION
- This will show an appropriate error message for Xcode 8.3 users that still have the legacy build API enabled. We want to migrate 100% of the users away from it, as it was now officially removed from Xcode
- Also link to the release that contains the migration information