### PR TITLE
Add another ADB status phrase to reject

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -77,11 +77,12 @@ module Screengrab
       # the first output by adb devices is "List of devices attached" so remove that and any adb startup output
       devices.reject! do |device|
         [
-          'server is out of date',   # The adb server is out of date and must be restarted
-          'unauthorized',            # The device has not yet accepted ADB control
-          'offline',                 # The device is offline, skip it
-          '* daemon',                # Messages printed when the daemon is starting up
-          'List of devices attached' # Header of table for data we want
+          'server is out of date',    # The adb server is out of date and must be restarted
+          'unauthorized',             # The device has not yet accepted ADB control
+          'offline',                  # The device is offline, skip it
+          '* daemon',                 # Messages printed when the daemon is starting up
+          'List of devices attached', # Header of table for data we want
+          "doesn't match this client" # Message printed when there is an ADB client/server version mismatch
         ].any? { |status| device.include? status }
       end
 

--- a/screengrab/spec/runner_spec.rb
+++ b/screengrab/spec/runner_spec.rb
@@ -115,6 +115,22 @@ describe Screengrab::Runner do
       end
     end
 
+    context 'one device with spurious ADB output mixed in' do
+      it 'finds an active device' do
+        adb_response = <<-ADB_OUTPUT.strip_heredoc
+          List of devices attached
+          adb server version (39) doesn't match this client (36); killing...
+          * daemon started successfully
+          T065002LTT             device usb:437387264X product:ghost_retail model:XT1053 device:ghost
+
+
+        ADB_OUTPUT
+        mock_adb_response_for_command(adb_list_devices_command, adb_response)
+
+        expect(@runner.select_device).to eq('T065002LTT')
+      end
+    end
+
     context 'one device' do
       it 'finds an active device' do
         adb_response = <<-ADB_OUTPUT.strip_heredoc


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description

ADB can print, `adb server version (39) doesn't match this client (36); killing...` when the client and server versions don't match. We need to ignore that during devices detection.

### Motivation and Context

Reported in #8731
