### PR TITLE
Use the new UI.test_failure! in screengrab

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -250,10 +250,12 @@ module Screengrab
                                     print_all: true,
                                     print_command: true)
 
-      if @config[:exit_on_test_failure]
-        UI.user_error!("Tests failed", show_github_issues: false) if test_output.include?("FAILURES!!!")
-      else
-        UI.error("Tests failed") if test_output.include?("FAILURES!!!")
+      if test_output.include?("FAILURES!!!")
+        if @config[:exit_on_test_failure]
+          UI.test_failure!("Tests failed for locale #{locale} on device #{device_serial}")
+        else
+          UI.error("Tests failed")
+        end
       end
     end
 

--- a/screengrab/spec/runner_spec.rb
+++ b/screengrab/spec/runner_spec.rb
@@ -54,9 +54,9 @@ describe Screengrab::Runner do
           end
 
           it 'prints an error and exits the program' do
-            expect(ui).to receive(:user_error!).with("Tests failed", show_github_issues: false).and_call_original
+            expect(ui).to receive(:test_failure!).with("Tests failed for locale en-US on device #{device_serial}").and_call_original
 
-            expect { @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, nil) }.to raise_fastlane_error
+            expect { @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, nil) }.to raise_fastlane_test_failure
           end
         end
 

--- a/screengrab/spec/spec_helper.rb
+++ b/screengrab/spec/spec_helper.rb
@@ -27,3 +27,7 @@ end
 def raise_fastlane_error
   raise_error FastlaneCore::Interface::FastlaneError
 end
+
+def raise_fastlane_test_failure
+  raise_error FastlaneCore::Interface::FastlaneTestFailure
+end


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description
Use the new `UI.test_failure!` in _screengrab_ to handle test failures 

### Motivation and Context

To get the better success/failure semantics introduced in #8631
