### PR TITLE
Version bump to 2.25.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.24.0'.freeze
+  VERSION = '2.25.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.24.0':**

* [snapshot] add option to skip helper version check (#8751) via Helmut Januschka
* Update Your First PR instructions post monogem (#8754) via Andrea Falcone
* Pin the rubocop version to prevent reactive fixing (#8753) via Michael Furtak
* rubocop disable PercentLiteralDelimiters rule (#8752) via Helmut Januschka
* Add a tip about using QuickDemo for clean status bar (#8739) via Andrea Falcone
* Do not change or generate README.md after running rspec (#8629) via Fumiya Nakamura
* Use the new UI.test_failure! in screengrab (#8736) via Michael Furtak
* Add another ADB status phrase to reject (#8732) via Michael Furtak
* Add Gitlab 9.0+ ENV variable for branch detection. (#8707) via Peter Spiess-Knafl
* Fix pilot stuck waiting for multitple builds. Only wait for latest (current upload) (#8640) via Nicolás Gebauer
* Modernize action to action call to resolved configurations (#8719) via Todd Brannam
* Catch Xcode 8.3 legacy API while patching Xcode PackageApplication script (#8717) via Felix Krause
* Print information about dir handling in fastlane on error (#8694) via Felix Krause
* Show information about how to share schemes (#8714) via Felix Krause
* Add more tests for ConfigItem and clarify error message (#8711) via Felix Krause
