### PR TITLE
Bump podspec version fix

### DIFF
--- a/fastlane/lib/fastlane/actions/version_bump_podspec.rb
+++ b/fastlane/lib/fastlane/actions/version_bump_podspec.rb
@@ -15,7 +15,7 @@ module Fastlane
         if params[:version_number]
           new_version = params[:version_number]
         elsif params[:version_appendix]
-          new_version = version_podspec_file.set_version_appendix(params[:version_appendix])
+          new_version = version_podspec_file.update_version_appendix(params[:version_appendix])
         else
           new_version = version_podspec_file.bump_version(params[:bump_type])
         end

--- a/fastlane/lib/fastlane/actions/version_bump_podspec.rb
+++ b/fastlane/lib/fastlane/actions/version_bump_podspec.rb
@@ -14,6 +14,8 @@ module Fastlane
 
         if params[:version_number]
           new_version = params[:version_number]
+        elsif params[:version_appendix]
+          new_version = version_podspec_file.set_version_appendix(params[:version_appendix])
         else
           new_version = version_podspec_file.bump_version(params[:bump_type])
         end
@@ -34,7 +36,9 @@ module Fastlane
       def self.details
         [
           "You can use this action to manipulate any 'version' variable contained in a ruby file.",
-          "For example, you can use it to bump the version of a cocoapods' podspec file."
+          "For example, you can use it to bump the version of a cocoapods' podspec file.",
+          "It also supports versions that are not semantic: 1.4.14.4.1",
+          "For such versions there is an option to change appendix (4.1)"
         ].join("\n")
       end
 
@@ -57,6 +61,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_number,
                                        env_name: "FL_VERSION_BUMP_PODSPEC_VERSION_NUMBER",
                                        description: "Change to a specific version. This will replace the bump type value",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :version_appendix,
+                                       env_name: "FL_VERSION_BUMP_PODSPEC_VERSION_APPENDIX",
+                                       description: "Change version appendix to a specific value. For example 1.4.14.4.1 -> 1.4.14.5",
                                        optional: true)
         ]
       end

--- a/fastlane/lib/fastlane/helper/podspec_helper.rb
+++ b/fastlane/lib/fastlane/helper/podspec_helper.rb
@@ -28,7 +28,7 @@ module Fastlane
       end
 
       def bump_version(bump_type)
-        UI.user_error!("Do not support bump of 'appendix', please use `set_version_appendix(appendix)` instead") if bump_type == 'appendix'
+        UI.user_error!("Do not support bump of 'appendix', please use `update_version_appendix(appendix)` instead") if bump_type == 'appendix'
 
         major = version_match[:major].to_i
         minor = version_match[:minor].to_i || 0
@@ -49,7 +49,7 @@ module Fastlane
         @version_value = "#{major}.#{minor}.#{patch}"
       end
 
-      def set_version_appendix(appendix = nil)
+      def update_version_appendix(appendix = nil)
         new_appendix = appendix || @version_value[:appendix]
         return if new_appendix.nil?
 

--- a/fastlane/lib/fastlane/helper/podspec_helper.rb
+++ b/fastlane/lib/fastlane/helper/podspec_helper.rb
@@ -9,7 +9,7 @@ module Fastlane
 
       def initialize(path = nil)
         version_var_name = 'version'
-        @version_regex = /^(?<begin>[^#]*#{version_var_name}\s*=\s*['"])(?<value>(?<major>[0-9]+)(\.(?<minor>[0-9]+))?(\.(?<patch>[0-9]+))?)(?<end>['"])/i
+        @version_regex = /^(?<begin>[^#]*#{version_var_name}\s*=\s*['"])(?<value>(?<major>[0-9]+)(\.(?<minor>[0-9]+))?(\.(?<patch>[0-9]+))?(?<appendix>(\.[0-9]+)*)?)(?<end>['"])/i
 
         return unless (path || '').length > 0
         UI.user_error!("Could not find podspec file at path '#{path}'") unless File.exist?(path)

--- a/fastlane/lib/fastlane/helper/podspec_helper.rb
+++ b/fastlane/lib/fastlane/helper/podspec_helper.rb
@@ -28,6 +28,8 @@ module Fastlane
       end
 
       def bump_version(bump_type)
+        UI.user_error!("Do not support bump of 'appendix', please use `set_version_appendix(appendix)` instead") if bump_type == 'appendix'
+
         major = version_match[:major].to_i
         minor = version_match[:minor].to_i || 0
         patch = version_match[:patch].to_i || 0
@@ -45,6 +47,18 @@ module Fastlane
         end
 
         @version_value = "#{major}.#{minor}.#{patch}"
+      end
+
+      def set_version_appendix(appendix = nil)
+        new_appendix = appendix || @version_value[:appendix]
+        return if new_appendix.nil?
+
+        new_appendix = new_appendix.sub(".", "") if new_appendix.start_with?(".")
+        major = version_match[:major].to_i
+        minor = version_match[:minor].to_i || 0
+        patch = version_match[:patch].to_i || 0
+
+        @version_value = "#{major}.#{minor}.#{patch}.#{new_appendix}"
       end
 
       def update_podspec(version = nil)

--- a/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
+++ b/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
@@ -71,7 +71,7 @@ describe Fastlane do
           s.version = "1.3.2"
         end'
           @version_podspec_file.parse(test_content)
-          result = @version_podspec_file.set_version_appendix('5.10')
+          result = @version_podspec_file.update_version_appendix('5.10')
           expect(result).to eq('1.3.2.5.10')
           expect(@version_podspec_file.version_value).to eq('1.3.2.5.10')
         end
@@ -147,7 +147,7 @@ describe Fastlane do
           s.version = "1.3.2.1"
         end'
           @version_podspec_file.parse(test_content)
-          result = @version_podspec_file.set_version_appendix('11.10')
+          result = @version_podspec_file.update_version_appendix('11.10')
           expect(result).to eq('1.3.2.11.10')
           expect(@version_podspec_file.version_value).to eq('1.3.2.11.10')
         end

--- a/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
+++ b/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
@@ -66,6 +66,16 @@ describe Fastlane do
         end')
         end
 
+        it "allows to set a specific appendix" do
+          test_content = 'Pod::Spec.new do |s|
+          s.version = "1.3.2"
+        end'
+          @version_podspec_file.parse(test_content)
+          result = @version_podspec_file.set_version_appendix('5.10')
+          expect(result).to eq('1.3.2.5.10')
+          expect(@version_podspec_file.version_value).to eq('1.3.2.5.10')
+        end
+
         it "allows to set a specific version" do
           test_content = 'Pod::Spec.new do |s|
           s.version = "1.3.2"
@@ -130,6 +140,16 @@ describe Fastlane do
           expect(@version_podspec_file.update_podspec).to eq('Pod::Spec.new do |s|
           s.version = "1.3.2.1"
         end')
+        end
+
+        it "allows to set a specific appendix" do
+          test_content = 'Pod::Spec.new do |s|
+          s.version = "1.3.2.1"
+        end'
+          @version_podspec_file.parse(test_content)
+          result = @version_podspec_file.set_version_appendix('11.10')
+          expect(result).to eq('1.3.2.11.10')
+          expect(@version_podspec_file.version_value).to eq('1.3.2.11.10')
         end
 
         it "allows to set a specific version" do
@@ -231,6 +251,14 @@ describe Fastlane do
 
           expect(result).to eq('2.0.0')
         end
+
+        it "bumps the version when version appendix is given" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            version_bump_podspec(path: '#{@podspec_path}', version_appendix: '5.1')
+          end").runner.execute(:test)
+
+          expect(result).to eq('1.5.1.5.1')
+        end
       end
 
       context "when not semantic version" do
@@ -269,6 +297,14 @@ describe Fastlane do
           end").runner.execute(:test)
 
           expect(result).to eq('2.0.0')
+        end
+
+        it "bumps the version when version appendix is given" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            version_bump_podspec(path: '#{@podspec_path}', version_appendix: '5.1')
+          end").runner.execute(:test)
+
+          expect(result).to eq('1.5.1.5.1')
         end
       end
     end

--- a/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
+++ b/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
@@ -24,68 +24,136 @@ describe Fastlane do
         end.to raise_error("Could not find version in podspec content '#{test_content}'")
       end
 
-      it "returns the current version once parsed" do
-        test_content = 'version = "1.3.2"'
-        result = @version_podspec_file.parse(test_content)
-        expect(result).to eq('1.3.2')
-        expect(@version_podspec_file.version_value).to eq('1.3.2')
+      context "when semantic version" do
+        it "returns the current version once parsed" do
+          test_content = 'version = "1.3.2"'
+          result = @version_podspec_file.parse(test_content)
+          expect(result).to eq('1.3.2')
+          expect(@version_podspec_file.version_value).to eq('1.3.2')
+        end
+
+        it "bumps the patch version when passing 'patch'" do
+          test_content = 'version = "1.3.2"'
+          @version_podspec_file.parse(test_content)
+          result = @version_podspec_file.bump_version('patch')
+          expect(result).to eq('1.3.3')
+          expect(@version_podspec_file.version_value).to eq('1.3.3')
+        end
+
+        it "bumps the minor version when passing 'minor'" do
+          test_content = 'version = "1.3.2"'
+          @version_podspec_file.parse(test_content)
+          result = @version_podspec_file.bump_version('minor')
+          expect(result).to eq('1.4.0')
+          expect(@version_podspec_file.version_value).to eq('1.4.0')
+        end
+
+        it "bumps the major version when passing 'major'" do
+          test_content = 'version = "1.3.2"'
+          @version_podspec_file.parse(test_content)
+          result = @version_podspec_file.bump_version('major')
+          expect(result).to eq('2.0.0')
+          expect(@version_podspec_file.version_value).to eq('2.0.0')
+        end
+
+        it "appears to do nothing if reinjecting the same version number" do
+          test_content = 'Pod::Spec.new do |s|
+          s.version = "1.3.2"
+        end'
+          @version_podspec_file.parse(test_content)
+          expect(@version_podspec_file.update_podspec).to eq('Pod::Spec.new do |s|
+          s.version = "1.3.2"
+        end')
+        end
+
+        it "allows to set a specific version" do
+          test_content = 'Pod::Spec.new do |s|
+          s.version = "1.3.2"
+        end'
+          @version_podspec_file.parse(test_content)
+          expect(@version_podspec_file.update_podspec('2.0.0')).to eq('Pod::Spec.new do |s|
+          s.version = "2.0.0"
+        end')
+        end
+
+        it "updates only the version when updating podspec" do
+          test_content = 'Pod::Spec.new do |s|
+          s.version = "1.3.2"
+        end'
+          @version_podspec_file.parse(test_content)
+          result = @version_podspec_file.bump_version('major')
+          expect(result).to eq('2.0.0')
+          expect(@version_podspec_file.version_value).to eq('2.0.0')
+          expect(@version_podspec_file.update_podspec).to eq('Pod::Spec.new do |s|
+          s.version = "2.0.0"
+        end')
+        end
       end
 
-      it "bumps the patch version when passing 'patch'" do
-        test_content = 'version = "1.3.2"'
-        @version_podspec_file.parse(test_content)
-        result = @version_podspec_file.bump_version('patch')
-        expect(result).to eq('1.3.3')
-        expect(@version_podspec_file.version_value).to eq('1.3.3')
-      end
+      context "when not semantic version" do
+        it "returns the current version once parsed" do
+          test_content = 'version = "1.3.2.5"'
+          result = @version_podspec_file.parse(test_content)
+          expect(result).to eq('1.3.2.5')
+          expect(@version_podspec_file.version_value).to eq('1.3.2.5')
+        end
 
-      it "bumps the minor version when passing 'minor'" do
-        test_content = 'version = "1.3.2"'
-        @version_podspec_file.parse(test_content)
-        result = @version_podspec_file.bump_version('minor')
-        expect(result).to eq('1.4.0')
-        expect(@version_podspec_file.version_value).to eq('1.4.0')
-      end
+        it "bumps the patch version when passing 'patch'" do
+          test_content = 'version = "1.3.2.5"'
+          @version_podspec_file.parse(test_content)
+          result = @version_podspec_file.bump_version('patch')
+          expect(result).to eq('1.3.3')
+          expect(@version_podspec_file.version_value).to eq('1.3.3')
+        end
 
-      it "bumps the major version when passing 'major'" do
-        test_content = 'version = "1.3.2"'
-        @version_podspec_file.parse(test_content)
-        result = @version_podspec_file.bump_version('major')
-        expect(result).to eq('2.0.0')
-        expect(@version_podspec_file.version_value).to eq('2.0.0')
-      end
+        it "bumps the minor version when passing 'minor'" do
+          test_content = 'version = "1.3.2.1"'
+          @version_podspec_file.parse(test_content)
+          result = @version_podspec_file.bump_version('minor')
+          expect(result).to eq('1.4.0')
+          expect(@version_podspec_file.version_value).to eq('1.4.0')
+        end
 
-      it "appears to do nothing if reinjecting the same version number" do
-        test_content = 'Pod::Spec.new do |s|
-        s.version = "1.3.2"
-      end'
-        @version_podspec_file.parse(test_content)
-        expect(@version_podspec_file.update_podspec).to eq('Pod::Spec.new do |s|
-        s.version = "1.3.2"
-      end')
-      end
+        it "bumps the major version when passing 'major'" do
+          test_content = 'version = "1.3.2.3"'
+          @version_podspec_file.parse(test_content)
+          result = @version_podspec_file.bump_version('major')
+          expect(result).to eq('2.0.0')
+          expect(@version_podspec_file.version_value).to eq('2.0.0')
+        end
 
-      it "allows to set a specific version" do
-        test_content = 'Pod::Spec.new do |s|
-        s.version = "1.3.2"
-      end'
-        @version_podspec_file.parse(test_content)
-        expect(@version_podspec_file.update_podspec('2.0.0')).to eq('Pod::Spec.new do |s|
-        s.version = "2.0.0"
-      end')
-      end
+        it "appears to do nothing if reinjecting the same version number" do
+          test_content = 'Pod::Spec.new do |s|
+          s.version = "1.3.2.1"
+        end'
+          @version_podspec_file.parse(test_content)
+          expect(@version_podspec_file.update_podspec).to eq('Pod::Spec.new do |s|
+          s.version = "1.3.2.1"
+        end')
+        end
 
-      it "updates only the version when updating podspec" do
-        test_content = 'Pod::Spec.new do |s|
-        s.version = "1.3.2"
-      end'
-        @version_podspec_file.parse(test_content)
-        result = @version_podspec_file.bump_version('major')
-        expect(result).to eq('2.0.0')
-        expect(@version_podspec_file.version_value).to eq('2.0.0')
-        expect(@version_podspec_file.update_podspec).to eq('Pod::Spec.new do |s|
-        s.version = "2.0.0"
-      end')
+        it "allows to set a specific version" do
+          test_content = 'Pod::Spec.new do |s|
+          s.version = "1.3.2.1"
+        end'
+          @version_podspec_file.parse(test_content)
+          expect(@version_podspec_file.update_podspec('2.0.0.6')).to eq('Pod::Spec.new do |s|
+          s.version = "2.0.0.6"
+        end')
+        end
+
+        it "updates only the version when updating podspec" do
+          test_content = 'Pod::Spec.new do |s|
+          s.version = "1.3.2"
+        end'
+          @version_podspec_file.parse(test_content)
+          result = @version_podspec_file.bump_version('major')
+          expect(result).to eq('2.0.0')
+          expect(@version_podspec_file.version_value).to eq('2.0.0')
+          expect(@version_podspec_file.update_podspec).to eq('Pod::Spec.new do |s|
+          s.version = "2.0.0"
+        end')
+        end
       end
     end
 
@@ -98,7 +166,7 @@ describe Fastlane do
         end.to raise_error("Please pass a path to the `version_get_podspec` action")
       end
 
-      it "gets the version from a podspec file" do
+      it "gets semantic the version from a podspec file" do
         allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         result = Fastlane::FastFile.new.parse("lane :test do
           version_get_podspec(path: './fastlane/spec/fixtures/podspecs/test.podspec')
@@ -106,14 +174,18 @@ describe Fastlane do
 
         expect(result).to eq('1.5.1')
       end
+
+      it "gets not semantic the version from a podspec file" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+        result = Fastlane::FastFile.new.parse("lane :test do
+          version_get_podspec(path: './fastlane/spec/fixtures/podspecs/test_not_semantic.podspec')
+        end").runner.execute(:test)
+
+        expect(result).to eq('1.5.1.3')
+      end
     end
 
     describe "version_bump_podspec" do
-      before do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
-        @podspec_path = './fastlane/spec/fixtures/podspecs/test.podspec'
-      end
-
       it "raises an exception when no path is given" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
@@ -122,36 +194,82 @@ describe Fastlane do
         end.to raise_error("Please pass a path to the `version_bump_podspec` action")
       end
 
-      it "bumps patch version when only the path is given" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          version_bump_podspec(path: '#{@podspec_path}')
-        end").runner.execute(:test)
+      context "when semantic version" do
+        before do
+          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+          @podspec_path = './fastlane/spec/fixtures/podspecs/test.podspec'
+        end
 
-        expect(result).to eq('1.5.2')
+        it "bumps patch version when only the path is given" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            version_bump_podspec(path: '#{@podspec_path}')
+          end").runner.execute(:test)
+
+          expect(result).to eq('1.5.2')
+        end
+
+        it "bumps patch version when bump_type is set to patch the path is given" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            version_bump_podspec(path: '#{@podspec_path}', bump_type: 'patch')
+          end").runner.execute(:test)
+
+          expect(result).to eq('1.5.2')
+        end
+
+        it "bumps minor version when bump_type is set to minor the path is given" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            version_bump_podspec(path: '#{@podspec_path}', bump_type: 'minor')
+          end").runner.execute(:test)
+
+          expect(result).to eq('1.6.0')
+        end
+
+        it "bumps major version when bump_type is set to major the path is given" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            version_bump_podspec(path: '#{@podspec_path}', bump_type: 'major')
+          end").runner.execute(:test)
+
+          expect(result).to eq('2.0.0')
+        end
       end
 
-      it "bumps patch version when bump_type is set to patch the path is given" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          version_bump_podspec(path: '#{@podspec_path}', bump_type: 'patch')
-        end").runner.execute(:test)
+      context "when not semantic version" do
+        before do
+          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+          @podspec_path = './fastlane/spec/fixtures/podspecs/test_not_semantic.podspec'
+        end
 
-        expect(result).to eq('1.5.2')
-      end
+        it "bumps patch version when only the path is given" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            version_bump_podspec(path: '#{@podspec_path}')
+          end").runner.execute(:test)
 
-      it "bumps minor version when bump_type is set to minor the path is given" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          version_bump_podspec(path: '#{@podspec_path}', bump_type: 'minor')
-        end").runner.execute(:test)
+          expect(result).to eq('1.5.2')
+        end
 
-        expect(result).to eq('1.6.0')
-      end
+        it "bumps patch version when bump_type is set to patch the path is given" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            version_bump_podspec(path: '#{@podspec_path}', bump_type: 'patch')
+          end").runner.execute(:test)
 
-      it "bumps major version when bump_type is set to major the path is given" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          version_bump_podspec(path: '#{@podspec_path}', bump_type: 'major')
-        end").runner.execute(:test)
+          expect(result).to eq('1.5.2')
+        end
 
-        expect(result).to eq('2.0.0')
+        it "bumps minor version when bump_type is set to minor the path is given" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            version_bump_podspec(path: '#{@podspec_path}', bump_type: 'minor')
+          end").runner.execute(:test)
+
+          expect(result).to eq('1.6.0')
+        end
+
+        it "bumps major version when bump_type is set to major the path is given" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            version_bump_podspec(path: '#{@podspec_path}', bump_type: 'major')
+          end").runner.execute(:test)
+
+          expect(result).to eq('2.0.0')
+        end
       end
     end
   end

--- a/fastlane/spec/fixtures/podspecs/test_not_semantic.podspec
+++ b/fastlane/spec/fixtures/podspecs/test_not_semantic.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+  s.name         = "SpecName"
+  s.header_dir   = "SuchHeader"
+  s.version      = "1.5.1.3"
+  s.summary      = "With just a few lines of code, your app can add fastlane support."
+
+  s.description  = <<-DESC
+                   Much bla
+                   DESC
+
+  s.homepage          = "https://github.com/fastlane/fastlane"
+  s.license           = { type: 'MIT', file: 'LICENSE.txt' }
+  s.authors           = ["Felix Krause"]
+  s.social_media_url  = "https://twitter.com/FastlaneTools"
+
+  s.source            = { git: "https://github.com/fastlane/fastlane.git", tag: s.version }
+  s.platform          = :ios, 7.0
+  s.source_files      = "*.{h,m}"
+  s.frameworks        = "UIKit"
+  s.weak_framework    = "WebKit"
+  s.exclude_files     = "Demos"
+  s.resource_bundles  = { 'SomeResources' => ['yeah.xcassets/*.imageset/*.png', 'yeah.xcassets'] }
+  s.requires_arc      = true
+end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ x I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
The change is a update of regex in `VersionBumpPodspec` action to support non semantic versions such as `1.2.3.4.5`. The more detailed description is given here #8722 

### Motivation and Context
It solves the problem of setting a new version of Podspec while the previous version was not a semantic. 

The linked issue is #8722 

The spec was updated to test the action against a not semantic version.