### PR TITLE
Corrected an error message which is shown when a CD session cookie is expired.

### DIFF
--- a/spaceship/lib/spaceship/two_step_client.rb
+++ b/spaceship/lib/spaceship/two_step_client.rb
@@ -45,8 +45,14 @@ module Spaceship
     def handle_two_factor(response)
       two_factor_url = "https://github.com/fastlane/fastlane/tree/master/spaceship#2-step-verification"
       puts "Two Factor Authentication for account '#{self.user}' is enabled"
-      puts "If you're running this in a non-interactive session (e.g. server or CI)"
-      puts "check out #{two_factor_url}"
+
+      if !File.exist?(persistent_cookie_path) && self.class.spaceship_session_env.to_s.length.zero?
+        puts "If you're running this in a non-interactive session (e.g. server or CI)"
+        puts "check out #{two_factor_url}"
+      else
+        # If the cookie is set but still required, the cookie is expired
+        puts "Your session cookie has been expired."
+      end
 
       security_code = response.body["securityCode"]
       # {"length"=>6,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Corrected an error message which is shown when a CD session cookie is expired.

### Motivation and Context
When we do CD on our CI servers while a session cookie is expired, we currently see an error message like "If you're running this in a non-interactive session (e.g. server or CI)..." which appears to be incorrect. So I’ve corrected the error message.
