### PR TITLE
Use all commits instead of current HEAD in `number_of_commits`.

### DIFF
--- a/fastlane/lib/fastlane/actions/number_of_commits.rb
+++ b/fastlane/lib/fastlane/actions/number_of_commits.rb
@@ -10,7 +10,10 @@ module Fastlane
 
       def self.run(params)
         if is_git?
-          command = 'git rev-list --all --count'
+          if params[:all]
+            command = 'git rev-list --all --count'
+          else
+            command = 'git rev-list HEAD --count'
         else
           UI.user_error!("Not in a git repository.")
         end
@@ -22,15 +25,15 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Return the total number of all commits in current git repo"
+        "Return the total number of all commits in current git branch"
       end
 
       def self.return_value
-        "The total number of all commits in current git repo"
+        "The total number of all commits in current git branch"
       end
 
       def self.details
-        "You can use this action to get the number of commits of this repo. This is useful if you want to set the build number to the number of commits."
+        "You can use this action to get the number of commits of this branch. This is useful if you want to set the build number to the number of commits. If you want all the commits in the current repo, set the `all` parameter to true."
       end
 
       def self.authors
@@ -43,8 +46,9 @@ module Fastlane
 
       def self.example_code
         [
-          'build_number = number_of_commits
-          increment_build_number(build_number: build_number)'
+          'increment_build_number(build_number: number_of_commits)',
+          'build_number = number_of_commits(all: true)
+          increment_build_number(build_number: number_of_commits)',
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/number_of_commits.rb
+++ b/fastlane/lib/fastlane/actions/number_of_commits.rb
@@ -49,7 +49,7 @@ module Fastlane
         [
           'increment_build_number(build_number: number_of_commits)',
           'build_number = number_of_commits(all: true)
-          increment_build_number(build_number: number_of_commits)',
+          increment_build_number(build_number: number_of_commits)'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/number_of_commits.rb
+++ b/fastlane/lib/fastlane/actions/number_of_commits.rb
@@ -26,15 +26,25 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Return the total number of all commits in current git branch"
+        "See number_of_commits --help for details"
       end
 
       def self.return_value
         "The total number of all commits in current git branch"
       end
 
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :all,
+                                       env_name: "FL_NUMBER_OF_COMMITS_ALL",
+                                       optional: true,
+                                       is_string: false,
+                                       description: "Returns number of all commits instead of current branch")
+        ]
+      end
+
       def self.details
-        "You can use this action to get the number of commits of this branch. This is useful if you want to set the build number to the number of commits. If you want all the commits in the current repo, set the `all` parameter to true."
+        "You can use this action to get the number of commits of this branch. This is useful if you want to set the build number to the number of commits. See number_of_commits --help for more details"
       end
 
       def self.authors

--- a/fastlane/lib/fastlane/actions/number_of_commits.rb
+++ b/fastlane/lib/fastlane/actions/number_of_commits.rb
@@ -14,6 +14,7 @@ module Fastlane
             command = 'git rev-list --all --count'
           else
             command = 'git rev-list HEAD --count'
+          end
         else
           UI.user_error!("Not in a git repository.")
         end

--- a/fastlane/lib/fastlane/actions/number_of_commits.rb
+++ b/fastlane/lib/fastlane/actions/number_of_commits.rb
@@ -34,7 +34,7 @@ module Fastlane
       end
 
       def self.authors
-        ["onevcat"]
+        ["onevcat", "samuelbeek"]
       end
 
       def self.is_supported?(platform)

--- a/fastlane/lib/fastlane/actions/number_of_commits.rb
+++ b/fastlane/lib/fastlane/actions/number_of_commits.rb
@@ -26,7 +26,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "See number_of_commits --help for details"
+        "Return the number of commits in current git branch"
       end
 
       def self.return_value
@@ -44,7 +44,7 @@ module Fastlane
       end
 
       def self.details
-        "You can use this action to get the number of commits of this branch. This is useful if you want to set the build number to the number of commits. See number_of_commits --help for more details"
+        "You can use this action to get the number of commits of this branch. This is useful if you want to set the build number to the number of commits. See `faslane actions number_of_commits` for more details"
       end
 
       def self.authors

--- a/fastlane/lib/fastlane/actions/number_of_commits.rb
+++ b/fastlane/lib/fastlane/actions/number_of_commits.rb
@@ -10,7 +10,7 @@ module Fastlane
 
       def self.run(params)
         if is_git?
-          command = 'git rev-list HEAD --count'
+          command = 'git rev-list --all --count'
         else
           UI.user_error!("Not in a git repository.")
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description
Fixes https://github.com/fastlane/fastlane/issues/5376. 

### Motivation and Context
The documentation described the `number_of_commits` command as `The total number of all commits in current git repo`. But it was the total number of commits on the current branch. This PR fixes that.  