### PR TITLE
Removed incorrectly blacklisted entitlement keys

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -729,6 +729,9 @@ function resign {
 
         log "Removing blacklisted keys from patched profile"
         # See https://github.com/facebook/buck/issues/798 and https://github.com/facebook/buck/pull/802/files
+
+        # Update in https://github.com/facebook/buck/commit/99c0fbc3ab5ecf04d186913374f660683deccdef
+        # Update in https://github.com/facebook/buck/commit/36db188da9f6acbb9df419dc1904315ab00c4e19
         BLACKLISTED_KEYS=(\
             "com.apple.developer.icloud-container-development-container-identifiers" \
             "com.apple.developer.icloud-container-environment" \
@@ -741,10 +744,7 @@ function resign {
             "com.apple.developer.homekit" \
             "com.apple.developer.healthkit" \
             "com.apple.developer.in-app-payments" \
-            "com.apple.developer.associated-domains" \
-            "com.apple.security.application-groups" \
             "com.apple.developer.maps" \
-            "com.apple.developer.networking.vpn.api" \
             "com.apple.external-accessory.wireless-configuration"
         )
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
[Similar to Buck](https://github.com/facebook/buck/issues/798), the [resign script](https://github.com/fastlane/fastlane/blob/master/sigh/lib/assets/resign.sh) "Blacklists" certain entitlement keys from being merged.

Since this change was made, Buck has been updated to remove some keys from the blacklist that were added in error. See [here](https://github.com/facebook/buck/commit/99c0fbc3ab5ecf04d186913374f660683deccdef) and [here](https://github.com/facebook/buck/commit/36db188da9f6acbb9df419dc1904315ab00c4e19).

### Motivation and Context
This change allows the resign script to correctly preserve entitlements (when using the `use-app-entitlements` flag during a resign.

Relates to https://github.com/fastlane/fastlane/issues/8307

