### PR TITLE
fix typos

### DIFF
--- a/fastlane/docs/UI.md
+++ b/fastlane/docs/UI.md
@@ -8,7 +8,7 @@ Instead of using `puts`, `raise` and `gets`, please use the helper class `UI` ac
 
 ```ruby
 UI.message "Neutral message (usually white)"
-UI.success "Succesully finished processing (usually green)"
+UI.success "Successfully finished processing (usually green)"
 UI.error "Wahaha, what's going on here! (usually red)"
 UI.important "Make sure to use Windows (usually yellow)"
 

--- a/fastlane/lib/fastlane/actions/appledoc.rb
+++ b/fastlane/lib/fastlane/actions/appledoc.rb
@@ -159,7 +159,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :docset_publisher_id, env_name: "FL_APPLEDOC_DOCSET_PUBLISHER_ID", description: "DocSet publisher identifier", is_string: true, optional: true),
           FastlaneCore::ConfigItem.new(key: :docset_publisher_name, env_name: "FL_APPLEDOC_DOCSET_PUBLISHER_NAME", description: "DocSet publisher name", is_string: true, optional: true),
           FastlaneCore::ConfigItem.new(key: :docset_min_xcode_version, env_name: "FL_APPLEDOC_DOCSET_MIN_XCODE_VERSION", description: "DocSet min. Xcode version", is_string: true, optional: true),
-          FastlaneCore::ConfigItem.new(key: :docset_platform_family, env_name: "FL_APPLEDOC_DOCSET_PLATFORM_FAMILY", description: "DocSet platform familiy", is_string: true, optional: true),
+          FastlaneCore::ConfigItem.new(key: :docset_platform_family, env_name: "FL_APPLEDOC_DOCSET_PLATFORM_FAMILY", description: "DocSet platform family", is_string: true, optional: true),
           FastlaneCore::ConfigItem.new(key: :docset_cert_issuer, env_name: "FL_APPLEDOC_DOCSET_CERT_ISSUER", description: "DocSet certificate issuer", is_string: true, optional: true),
           FastlaneCore::ConfigItem.new(key: :docset_cert_signer, env_name: "FL_APPLEDOC_DOCSET_CERT_SIGNER", description: "DocSet certificate signer", is_string: true, optional: true),
           FastlaneCore::ConfigItem.new(key: :docset_bundle_filename, env_name: "FL_APPLEDOC_DOCSET_BUNDLE_FILENAME", description: "DocSet bundle filename", is_string: true, optional: true),

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -33,10 +33,10 @@ module Fastlane
       def self.validate(params)
         command_name = params[:command]
         if command_name != "archive" && params[:frameworks].count > 0
-          UI.user_error!("Frameworks option is avaialble only for 'archive' command.")
+          UI.user_error!("Frameworks option is available only for 'archive' command.")
         end
         if command_name != "archive" && params[:output]
-          UI.user_error!("Output option is avaialble only for 'archive' command.")
+          UI.user_error!("Output option is available only for 'archive' command.")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -88,7 +88,7 @@ module Fastlane
         unless changed_files_as_expected
           unless params[:force]
             error = [
-              "Found unexpected uncommited changes in the working directory. Expected these files to have ",
+              "Found unexpected uncommitted changes in the working directory. Expected these files to have ",
               "changed: \n#{expected_changed_files.join("\n")}.\nBut found these actual changes: ",
               "#{git_dirty_files.join("\n")}.\nMake sure you have cleaned up the build artifacts and ",
               "are only left with the changed version files at this stage in your lane, and don't touch the ",

--- a/fastlane/lib/fastlane/actions/copy_artifacts.rb
+++ b/fastlane/lib/fastlane/actions/copy_artifacts.rb
@@ -48,7 +48,7 @@ module Fastlane
 
       def self.details
         [
-          "This action copies artifacs to a target directory. It's useful if you have a CI that will pick up these artifacts and attach them to the build. Useful e.g. for storing your `.ipa`s, `.dSYM.zip`s, `.mobileprovision`s, `.cert`s",
+          "This action copies artifacts to a target directory. It's useful if you have a CI that will pick up these artifacts and attach them to the build. Useful e.g. for storing your `.ipa`s, `.dSYM.zip`s, `.mobileprovision`s, `.cert`s",
           "Make sure your target_path is gitignored, and if you use `reset_git_repo`, make sure the artifacts are added to the exclude list"
         ].join("\n")
       end

--- a/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -18,7 +18,7 @@ module Fastlane
       end
 
       def self.description
-        "Raises an exception if there are uncommited git changes"
+        "Raises an exception if there are uncommitted git changes"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
@@ -84,7 +84,7 @@ module Fastlane
         changed_files_as_expected = dirty_set.subset? expected_set
         unless changed_files_as_expected
           unless params[:force]
-            str = ["Found unexpected uncommited changes in the working directory. Expected these files to have changed:",
+            str = ["Found unexpected uncommitted changes in the working directory. Expected these files to have changed:",
                    "#{expected_changed_files.join("\n")}.",
                    "But found these actual changes: \n#{hg_dirty_files.join("\n")}.",
                    "Make sure you have cleaned up the build artifacts and are only left with the changed version files at this",

--- a/fastlane/lib/fastlane/actions/hg_ensure_clean_status.rb
+++ b/fastlane/lib/fastlane/actions/hg_ensure_clean_status.rb
@@ -17,7 +17,7 @@ module Fastlane
       end
 
       def self.description
-        "Raises an exception if there are uncommited hg changes"
+        "Raises an exception if there are uncommitted hg changes"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/ipa.rb
+++ b/fastlane/lib/fastlane/actions/ipa.rb
@@ -76,7 +76,7 @@ module Fastlane
             "-------------------------------------------------------",
             "Original Error:",
             " => " + ex.to_s,
-            "A build error occured. You are using legacy `shenzhen` for building",
+            "A build error occurred. You are using legacy `shenzhen` for building",
             "it is recommended to upgrade to _gym_: ",
             "https://github.com/fastlane/fastlane/tree/master/gym",
             core_command,
@@ -86,7 +86,7 @@ module Fastlane
           end
 
           # Raise a custom exception, as the the normal one is useless for the user
-          UI.user_error!("A build error occured, this is usually related to code signing. Take a look at the error above")
+          UI.user_error!("A build error occurred, this is usually related to code signing. Take a look at the error above")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/oclint.rb
+++ b/fastlane/lib/fastlane/actions/oclint.rb
@@ -26,7 +26,7 @@ module Fastlane
         end
 
         if params[:select_reqex]
-          UI.important("'select_reqex' paramter is deprecated. Please use 'select_regex' instead.")
+          UI.important("'select_reqex' parameter is deprecated. Please use 'select_regex' instead.")
           select_regex = params[:select_reqex]
         end
 

--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -49,7 +49,7 @@ module Fastlane
       def self.check_response_code(response)
         case response.code.to_i
         when 200, 204
-          puts "Succesfully created new OneSignal app".green
+          puts "Successfully created new OneSignal app".green
         else
           UI.user_error!("Unexpected #{response.code} with response: #{response.body}")
         end

--- a/fastlane/lib/fastlane/actions/reset_git_repo.rb
+++ b/fastlane/lib/fastlane/actions/reset_git_repo.rb
@@ -41,7 +41,7 @@ module Fastlane
       end
 
       def self.description
-        "Resets git repo to a clean state by discarding uncommited changes"
+        "Resets git repo to a clean state by discarding uncommitted changes"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/s3.rb
+++ b/fastlane/lib/fastlane/actions/s3.rb
@@ -384,7 +384,7 @@ module Fastlane
                                        default_value: ENV['AWS_REGION']),
           FastlaneCore::ConfigItem.new(key: :path,
                                        env_name: "S3_PATH",
-                                       description: "S3 'path'. Values from Info.plist will be substituded for keys wrapped in {}  ",
+                                       description: "S3 'path'. Values from Info.plist will be substituted for keys wrapped in {}  ",
                                        optional: true,
                                        default_value: 'v{CFBundleShortVersionString}_b{CFBundleVersion}/'),
           FastlaneCore::ConfigItem.new(key: :source,

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -91,7 +91,7 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :payload,
                                        env_name: "FL_SLACK_PAYLOAD",
-                                       description: "Add additional information to this post. payload must be a hash containg any key with any value",
+                                       description: "Add additional information to this post. payload must be a hash containing any key with any value",
                                        default_value: {},
                                        is_string: false),
           FastlaneCore::ConfigItem.new(key: :default_payloads,

--- a/fastlane/lib/fastlane/actions/ssh.rb
+++ b/fastlane/lib/fastlane/actions/ssh.rb
@@ -65,7 +65,7 @@ module Fastlane
           end
         end
         command_word = params[:commands].count == 1 ? "command" : "commands"
-        UI.success("Succesfully executed #{params[:commands].count} #{command_word} on host #{params[:host]}")
+        UI.success("Successfully executed #{params[:commands].count} #{command_word} on host #{params[:host]}")
         Actions.lane_context[SharedValues::SSH_STDOUT_VALUE] = stdout
         Actions.lane_context[SharedValues::SSH_STDERR_VALUE] = stderr
         return { stdout: Actions.lane_context[SharedValues::SSH_STDOUT_VALUE], stderr: Actions.lane_context[SharedValues::SSH_STDERR_VALUE] }

--- a/fastlane/lib/fastlane/actions/tryouts.rb
+++ b/fastlane/lib/fastlane/actions/tryouts.rb
@@ -94,7 +94,7 @@ module Fastlane
                                      optional: true),
           FastlaneCore::ConfigItem.new(key: :notes_path,
                                      env_name: "TRYOUTS_NOTES_PATH",
-                                     description: "Release notes text file path. Overrides the :notes paramether",
+                                     description: "Release notes text file path. Overrides the :notes parameter",
                                      verify_block: proc do |value|
                                        UI.user_error!("Couldn't find notes file at path '#{value}'") unless File.exist?(value)
                                      end,

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
@@ -104,7 +104,7 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :project_slug,
                                        env_name: "SENTRY_PROJECT_SLUG",
-                                       description: "Prgoject slug for Sentry",
+                                       description: "Project slug for Sentry",
                                        verify_block: proc do |value|
                                          UI.user_error!("No project slug for SentryAction given, pass using `project_slug: 'project'`") unless value and !value.empty?
                                        end),

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -136,7 +136,7 @@ module Fastlane
       @runner.set_after_each(@current_platform, block)
     end
 
-    # Is executed if an error occured during fastlane execution
+    # Is executed if an error occurred during fastlane execution
     def error(&block)
       @runner.set_error(@current_platform, block)
     end

--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -84,9 +84,9 @@ module Fastlane
             # Now unzip the file
             Action.sh "unzip '#{zip_path}' -d '#{containing}'"
 
-            UI.user_error!("Coulnd't find 'crashlytics-devtools.jar'") unless File.exist?(jar_path)
+            UI.user_error!("Couldn't find 'crashlytics-devtools.jar'") unless File.exist?(jar_path)
 
-            UI.success "Succesfully downloaded Crashlytics Support Library to '#{jar_path}'"
+            UI.success "Successfully downloaded Crashlytics Support Library to '#{jar_path}'"
           rescue => ex
             UI.user_error!("Error fetching remote file: #{ex}")
           end

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -62,7 +62,7 @@ module Fastlane
             error_blocks[current_platform].call(current_lane, ex, parameters) if current_platform && error_blocks[current_platform]
             error_blocks[nil].call(current_lane, ex, parameters) if error_blocks[nil]
           rescue => error_block_exception
-            UI.error("An error occured while executing the `error` block:")
+            UI.error("An error occurred while executing the `error` block:")
             UI.error(error_block_exception.to_s)
             raise ex # raise the original error message
           end

--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -37,7 +37,7 @@ module Fastlane
           handle_exception(exception: ex)
         else
           UI.error(ex.to_s)
-          UI.error('An error occured during the setup process. Falling back to manual setup!')
+          UI.error('An error occurred during the setup process. Falling back to manual setup!')
           try_manual_setup
         end
       end

--- a/fastlane/lib/fastlane/supported_platforms.rb
+++ b/fastlane/lib/fastlane/supported_platforms.rb
@@ -21,7 +21,7 @@ module Fastlane
     # this will log a warning if the passed platform is not supported
     def self.verify!(platform)
       unless all.include? platform.to_s.to_sym
-        UI.important("Platform '#{platform}' is not officially supported. Currently supported plaforms are #{self.all}.")
+        UI.important("Platform '#{platform}' is not officially supported. Currently supported platforms are #{self.all}.")
       end
     end
   end

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -450,7 +450,7 @@ describe Fastlane do
               Fastlane::FastFile.new.parse("lane :test do
                   carthage(command: '#{command}', frameworks: ['myframework', 'myframework2'])
                 end").runner.execute(:test)
-            end.to raise_error("Frameworks option is avaialble only for 'archive' command.")
+            end.to raise_error("Frameworks option is available only for 'archive' command.")
           end
         end
 
@@ -462,7 +462,7 @@ describe Fastlane do
               Fastlane::FastFile.new.parse("lane :test do
                   carthage(command: '#{command}', frameworks: ['myframework', 'myframework2'])
                 end").runner.execute(:test)
-            end.to raise_error("Frameworks option is avaialble only for 'archive' command.")
+            end.to raise_error("Frameworks option is available only for 'archive' command.")
           end
         end
 
@@ -474,7 +474,7 @@ describe Fastlane do
               Fastlane::FastFile.new.parse("lane :test do
                   carthage(command: '#{command}', frameworks: ['myframework', 'myframework2'])
                 end").runner.execute(:test)
-            end.to raise_error("Frameworks option is avaialble only for 'archive' command.")
+            end.to raise_error("Frameworks option is available only for 'archive' command.")
           end
         end
       end
@@ -499,7 +499,7 @@ describe Fastlane do
               Fastlane::FastFile.new.parse("lane :test do
                   carthage(command: '#{command}', output: 'bla.framework.zip')
                 end").runner.execute(:test)
-            end.to raise_error("Output option is avaialble only for 'archive' command.")
+            end.to raise_error("Output option is available only for 'archive' command.")
           end
         end
 
@@ -511,7 +511,7 @@ describe Fastlane do
               Fastlane::FastFile.new.parse("lane :test do
                   carthage(command: '#{command}', output: 'bla.framework.zip')
                 end").runner.execute(:test)
-            end.to raise_error("Output option is avaialble only for 'archive' command.")
+            end.to raise_error("Output option is available only for 'archive' command.")
           end
         end
 
@@ -523,7 +523,7 @@ describe Fastlane do
               Fastlane::FastFile.new.parse("lane :test do
                   carthage(command: '#{command}', output: 'bla.framework.zip')
                 end").runner.execute(:test)
-            end.to raise_error("Output option is avaialble only for 'archive' command.")
+            end.to raise_error("Output option is available only for 'archive' command.")
           end
         end
       end

--- a/fastlane/spec/actions_specs/default_platform_spec.rb
+++ b/fastlane/spec/actions_specs/default_platform_spec.rb
@@ -26,7 +26,7 @@ describe Fastlane do
         Fastlane::SupportedPlatforms.extra = []
       end
       it "displays a warning if a platform is not supported" do
-        expect(FastlaneCore::UI).to receive(:important).with("Platform 'notSupportedOS' is not officially supported. Currently supported plaforms are [:ios, :mac, :android].")
+        expect(FastlaneCore::UI).to receive(:important).with("Platform 'notSupportedOS' is not officially supported. Currently supported platforms are [:ios, :mac, :android].")
         Fastlane::Actions::DefaultPlatformAction.run(['notSupportedOS'])
       end
 

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -227,7 +227,7 @@ describe Fastlane do
       it "Exception in error block are swallowed and shown, and original exception is re-raised" do
         ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileErrorInError')
 
-        expect(FastlaneCore::UI).to receive(:error).with("An error occured while executing the `error` block:")
+        expect(FastlaneCore::UI).to receive(:error).with("An error occurred while executing the `error` block:")
         expect(FastlaneCore::UI).to receive(:error).with("Error in error")
 
         expect do

--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -27,7 +27,7 @@ module FastlaneCore
       # @param print_all [Boolean] Do we want to print out the command output while running?
       # @param print_command [Boolean] Should we print the command that's being executed
       # @param error [Block] A block that's called if an error occurs
-      # @param prefix [Array] An array containg a prefix + block which might get applied to the output
+      # @param prefix [Array] An array containing a prefix + block which might get applied to the output
       # @param loading [String] A loading string that is shown before the first output
       # @return [String] All the output as string
       def execute(command: nil, print_all: false, print_command: true, error: nil, prefix: nil, loading: nil)

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -1,6 +1,6 @@
 module FastlaneCore
   class ConfigItem
-    # [Symbol] the key which is used as command paramters or key in the fastlane tools
+    # [Symbol] the key which is used as command parameters or key in the fastlane tools
     attr_accessor :key
 
     # [String] the name of the environment variable, which is only used if no other values were found
@@ -40,7 +40,7 @@ module FastlaneCore
     attr_accessor :allow_shell_conversion
 
     # Creates a new option
-    # @param key (Symbol) the key which is used as command paramters or key in the fastlane tools
+    # @param key (Symbol) the key which is used as command parameters or key in the fastlane tools
     # @param env_name (String) the name of the environment variable, which is only used if no other values were found
     # @param description (String) A description shown to the user
     # @param short_option (String) A string of length 1 which is used for the command parameters (e.g. -f)

--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -26,7 +26,7 @@ module Match
         else
           return password
         end
-        UI.error("Passhprases differ. Try again")
+        UI.error("Passphrases differ. Try again")
       end
     end
 

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -56,7 +56,7 @@ module Match
 
       UI.success "All required keys, certificates and provisioning profiles are installed 🙌".green
     rescue Spaceship::Client::UnexpectedResponse, Spaceship::Client::InvalidUserCredentialsError, Spaceship::Client::NoUserCredentialsError => ex
-      UI.error("An error occured while verifying your certificates and profiles with the Apple Developer Portal.")
+      UI.error("An error occurred while verifying your certificates and profiles with the Apple Developer Portal.")
       UI.error("If you already have your certificates stored in git, you can run `fastlane match` in readonly mode")
       UI.error("to just install the certificates and profiles without accessing the Dev Portal.")
       UI.error("To do so, just pass `readonly: true` to your match call.")

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -135,7 +135,7 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :test_without_building,
                                      short_option: "-T",
                                      env_name: "SCAN_TEST_WITHOUT_BUILDING",
-                                     description: "Test without building, requires a derrived data path",
+                                     description: "Test without building, requires a derived data path",
                                      is_string: false,
                                      conflicting_options: [:build_for_testing],
                                      optional: true),

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -197,7 +197,7 @@ module Spaceship
 
         # Create a new provisioning profile
         # @param name (String): The name of the provisioning profile on the Dev Portal
-        # @param bundle_id (String): The app identifier, this paramter is required
+        # @param bundle_id (String): The app identifier, this parameter is required
         # @param certificate (Certificate): The certificate that should be used with this
         #   provisioning profile. You can also pass an array of certificates to this method. This will
         #   only work for development profiles

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -584,7 +584,7 @@ module Spaceship
         lang_details = languages[0]
         display_families = lang_details["displayFamilies"]["value"]
         device_details = display_families.find { |display_family| display_family['name'] == device }
-        raise "Couldn't find device familiy for #{device}" if device_details.nil?
+        raise "Couldn't find device family for #{device}" if device_details.nil?
         raise "Unexpected state: missing device details for #{device}" unless device_details.key?(data_field)
         return device_details[data_field]
       rescue => ex

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -40,7 +40,7 @@ module Supply
     # Initializes the android_publisher and its auth_client using the specified information
     # @param service_account_json: The raw service account Json data
     # @param path_to_key: The path to your p12 file (@deprecated)
-    # @param issuer: Email addresss for oauth (@deprecated)
+    # @param issuer: Email address for oauth (@deprecated)
     def initialize(path_to_key: nil, issuer: nil, service_account_json: nil)
       scope = Androidpublisher::AUTH_ANDROIDPUBLISHER
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
I went over the files with some shellscript and let word have a look at the results. Suspicious typos were fixed.

``` Shell

 grep --include \*.yml --include \*.xml --include \*.txt --include \*.swift --include \*.sample --include \*.rspec --include \*.rb --exclude \*spec.rb --include \*.rake --include \*.properties --include \*.podspec --include \*.md --include \*.markdown --include \*.m  --include \*.js --include \*.java --include \*.html --include \*.gradle --include \*.gemspec --include \*.fastlane --include \*.erb --include \*.env --include \*.bat --include \*.bash --include \*.Appfile --include \*.Brewfile --include \*.Dangerfile --include \*.Deliverfile --include \*.Fastfile --include \*.Gemfile --include \*.Gymfile --include \*.ImportFastfile --include \*.Pluginfile --include \*.Podfile --include \*.Rakefile --include \*.Screengrabfile --include \*.Snapfile --include \*.SwitcherFastfile --include \*.file --include \*.json_file  -hor "\".*\"" . |  sed s/\"//g |  sed -e 's/\([a-z]\)\([A-Z]\)/\1 \2/g' | tr A-Z a-z | gsed 's/\ /\n&/g' |  gsed 's/\\(/\n&/g' |  gsed 's/\\)/\n&/g'|  gsed 's/\:/\n&/g' |  gsed 's/\./\n&/g' |  gsed 's/,/\n&/g' |  sed s/\ //g | sort -u |  grep -v  _ |   grep -v "~" |  grep -v "=" |  grep -v "#"  |  grep -v "http" |  grep -v "\\$" |  grep -v "/" |  grep -v "\\]\\[" |  grep -v "\\\{" |  grep -v "@" |  sed "s/[^[:alpha:]]//g" |  sort -u > ../less.txt

```

### Motivation and Context
Nobody likes typos. Typos are bad for search.