### PR TITLE
Recommend actions when name can't be found

### DIFF
--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -81,7 +81,7 @@ module Fastlane
           all_actions(nil) do |a, action_name|
             candidates << [action_name] if action_name.include? filter
           end
-          puts "Available actions with similar name: #{candidates.join(', ')}".green unless candidates.empty?
+          puts "Available actions with matching name: #{candidates.join(', ')}".green unless candidates.empty?
         end
 
       end

--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -77,11 +77,21 @@ module Fastlane
         print_all # show all available actions instead
 
         if !filter.nil? && filter.length > 1
-          candidates = []
+          action_names = []
           all_actions(nil) do |action_ref, action_name|
-            candidates << action_name if action_name.include? filter
+            action_names << action_name
           end
-          puts "Available actions with matching name: #{candidates.join(', ')}".green unless candidates.empty?
+
+          corrections = []
+
+          if !Gem.loaded_specs["did_you_mean"].nil? && Gem.loaded_specs["did_you_mean"].version >= Gem::Version.new('1.1.0')
+            spell_checker = DidYouMean::SpellChecker.new(dictionary: action_names)
+            corrections << spell_checker.correct(filter).compact
+          end
+
+          corrections << action_names.select { |name| name.include? filter }
+
+          puts "Did you mean: #{corrections.flatten.uniq.join(', ')}".green unless corrections.flatten.empty?
         end
 
       end

--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -95,7 +95,7 @@ module Fastlane
 
         corrections << action_names.select { |name| name.include? filter }
 
-        puts "Did you mean: #{corrections.flatten.uniq.join(', ')} ?".green unless corrections.flatten.empty?
+        puts "Did you mean: #{corrections.flatten.uniq.join(', ')}?".green unless corrections.flatten.empty?
       end
     end
 

--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -79,7 +79,7 @@ module Fastlane
         if !filter.nil? && filter.length > 1
           candidates = []
           all_actions(nil) do |a, action_name|
-            candidates << [action_name] if action_name.include? filter
+            candidates << action_name if action_name.include? filter
           end
           puts "Available actions with matching name: #{candidates.join(', ')}".green unless candidates.empty?
         end

--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -75,25 +75,27 @@ module Fastlane
         puts "==========================================\n".red
 
         print_all # show all available actions instead
+        print_suggestions(filter)
+      end
+    end
 
-        if !filter.nil? && filter.length > 1
-          action_names = []
-          all_actions(nil) do |action_ref, action_name|
-            action_names << action_name
-          end
-
-          corrections = []
-
-          if !Gem.loaded_specs["did_you_mean"].nil? && Gem.loaded_specs["did_you_mean"].version >= Gem::Version.new('1.1.0')
-            spell_checker = DidYouMean::SpellChecker.new(dictionary: action_names)
-            corrections << spell_checker.correct(filter).compact
-          end
-
-          corrections << action_names.select { |name| name.include? filter }
-
-          puts "Did you mean: #{corrections.flatten.uniq.join(', ')}".green unless corrections.flatten.empty?
+    def self.print_suggestions(filter)
+      if !filter.nil? && filter.length > 1
+        action_names = []
+        all_actions(nil) do |action_ref, action_name|
+          action_names << action_name
         end
 
+        corrections = []
+
+        if !Gem.loaded_specs["did_you_mean"].nil? && Gem.loaded_specs["did_you_mean"].version >= Gem::Version.new('1.1.0')
+          spell_checker = DidYouMean::SpellChecker.new(dictionary: action_names)
+          corrections << spell_checker.correct(filter).compact
+        end
+
+        corrections << action_names.select { |name| name.include? filter }
+
+        puts "Did you mean: #{corrections.flatten.uniq.join(', ')} ?".green unless corrections.flatten.empty?
       end
     end
 

--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -73,7 +73,17 @@ module Fastlane
       else
         puts "Couldn't find action for the given filter.".red
         puts "==========================================\n".red
+
         print_all # show all available actions instead
+
+        if !filter.nil? && filter.length > 1
+          candidates = []
+          all_actions(nil) do |a, action_name|
+            candidates << [action_name] if action_name.include? filter
+          end
+          puts "Available actions with similar name: #{candidates.join(', ')}".green unless candidates.empty?
+        end
+
       end
     end
 

--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -78,7 +78,7 @@ module Fastlane
 
         if !filter.nil? && filter.length > 1
           candidates = []
-          all_actions(nil) do |a, action_name|
+          all_actions(nil) do |action_ref, action_name|
             candidates << action_name if action_name.include? filter
           end
           puts "Available actions with matching name: #{candidates.join(', ')}".green unless candidates.empty?

--- a/fastlane/lib/fastlane/one_off.rb
+++ b/fastlane/lib/fastlane/one_off.rb
@@ -33,6 +33,7 @@ module Fastlane
           UI.verbose(caller.join("\n"))
           UI.user_error!("The action '#{action}' is no longer bundled with fastlane. You can install it using `fastlane add_plugin #{action}`")
         else
+          Fastlane::ActionsList.print_suggestions(action)
           UI.user_error!("Action '#{action}' not available, run `fastlane actions` to get a full list")
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description
When running 'fastlane actions xy' without a hit, there now is an additional line at the end with similar actions, e.g. for 'fastlane actions xy':

> Available actions with matching name: hg_add_tag, hg_commit_version_bump, hg_ensure_clean_status, hg_push

### Motivation and Context
This makes it easier to find e.g. all "tag" or "git" related actions, providing a nice shortcut for the user. I like it easy.