### PR TITLE
Fixes failure to pass launch arguments: Adds scheme to fileURL in SnapshotHelper running on Simulator

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -145,7 +145,7 @@ open class Snapshot: NSObject {
                 print("Can't prepare environment. Simulator home location is inaccessible. Does \(simulatorHostHome) exist?")
                 return nil
             }
-            homeDir = homeDirUrl
+            homeDir = URL(fileURLWithPath: homeDirUrl.path)
         #endif
         return homeDir.appendingPathComponent("Library/Caches/tools.fastlane")
     }


### PR DESCRIPTION
Returns a fileURL with the existing path rather then returning the or…iginal URL, which lacks a scheme.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid 
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->

In Snapshot's SnapshotHelper.swift, I modified the pathPrefix method to return a file scheme URL rather then a url without a scheme when running on the simulator. This fixes an issue where required launch argument resources could failed to be located in the filesystem when running on the simulator.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

After upgrading my Fastlane Snapshot today, I found that none of my associated UITests would complete. I isolated the and described the issue in #8787.

This changes solves the inability to run snapshot in the simulator with launch arguments.

<!--- If it fixes an open issue, please link to the issue here. -->
#8787 

<!--- Please describe in detail how you tested your changes. --->

Snapshot now runs properly in my project.