### PR TITLE
[WIP] Improve device matching so it includes sims with (xyz) in the names

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -34,9 +34,9 @@ module FastlaneCore
             if line.include?("inch)")
               # For Xcode 8, where sometimes we have the # of inches in ()
               # iPad Pro (12.9 inch) (CEF11EB3-79DF-43CB-896A-0F33916C8BDE) (Shutdown)
-              match = line.match(/\s+([^\(]+ \(.*inch\)) \(([-0-9A-F]+)\) \(([^\(]+)\)(.*unavailable.*)?/)
+              match = line.match(/\s+(.+ \(.*inch\)) \(([-0-9A-F]+)\) \(([^\(]+)\)(.*unavailable.*)?/)
             else
-              match = line.match(/\s+([^\(]+) \(([-0-9A-F]+)\) \(([^\(]+)\)(.*unavailable.*)?/)
+              match = line.match(/\s+(.+) \(([-0-9A-F]+)\) \(([^\(]+)\)(.*unavailable.*)?/)
             end
 
             if match && !match[4] && (os_type == requested_os_type || requested_os_type == "")

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -29,7 +29,7 @@ describe FastlaneCore do
         expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
 
         devices = FastlaneCore::Simulator.all
-        expect(devices.count).to eq(6)
+        expect(devices.count).to eq(7)
 
         expect(devices[0]).to have_attributes(
           name: "iPhone 4s", os_type: "iOS", os_version: "8.1",
@@ -44,24 +44,30 @@ describe FastlaneCore do
           is_simulator: true
         )
         expect(devices[2]).to have_attributes(
+          name: "iPhone 5s (9.1)", os_type: "iOS", os_version: "9.1",
+          udid: "23DE091F-34F4-48B6-B51A-231F2CEAB055",
+          state: "Shutdown",
+          is_simulator: true
+        )
+        expect(devices[3]).to have_attributes(
           name: "iPhone 6s Plus", os_type: "iOS", os_version: "9.1",
           udid: "BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0",
           state: "Shutdown",
           is_simulator: true
         )
-        expect(devices[3]).to have_attributes(
+        expect(devices[4]).to have_attributes(
           name: "iPad Air", os_type: "iOS", os_version: "9.1",
           udid: "B61CB41D-354B-4991-992A-80AFFF1062E6",
           state: "Shutdown",
           is_simulator: true
         )
-        expect(devices[4]).to have_attributes(
+        expect(devices[5]).to have_attributes(
           name: "iPad Air 2", os_type: "iOS", os_version: "9.1",
           udid: "57836FE1-5443-4433-B164-A6C9EADAB3F9",
           state: "Shutdown",
           is_simulator: true
         )
-        expect(devices[5]).to have_attributes(
+        expect(devices[6]).to have_attributes(
           name: "iPad Pro", os_type: "iOS", os_version: "9.1",
           udid: "B1DDED8D-E449-461A-94A5-4146A1F58B20",
           state: "Shutdown",
@@ -143,7 +149,7 @@ describe FastlaneCore do
       expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
 
       devices = FastlaneCore::DeviceManager.simulators
-      expect(devices.count).to eq(9)
+      expect(devices.count).to eq(10)
 
       expect(devices[0]).to have_attributes(
         name: "iPhone 4s", os_type: "iOS", os_version: "8.1",
@@ -158,30 +164,48 @@ describe FastlaneCore do
         is_simulator: true
       )
       expect(devices[2]).to have_attributes(
+        name: "iPhone 5s (9.1)", os_type: "iOS", os_version: "9.1",
+        udid: "23DE091F-34F4-48B6-B51A-231F2CEAB055",
+        state: "Shutdown",
+        is_simulator: true
+      )
+      expect(devices[3]).to have_attributes(
         name: "iPhone 6s Plus", os_type: "iOS", os_version: "9.1",
         udid: "BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0",
         state: "Shutdown",
         is_simulator: true
       )
-      expect(devices[3]).to have_attributes(
+      expect(devices[4]).to have_attributes(
         name: "iPad Air", os_type: "iOS", os_version: "9.1",
         udid: "B61CB41D-354B-4991-992A-80AFFF1062E6",
         state: "Shutdown",
         is_simulator: true
       )
+      expect(devices[5]).to have_attributes(
+        name: "iPad Air 2", os_type: "iOS", os_version: "9.1",
+        udid: "57836FE1-5443-4433-B164-A6C9EADAB3F9",
+        state: "Shutdown",
+        is_simulator: true
+      )
       expect(devices[6]).to have_attributes(
+        name: "iPad Pro", os_type: "iOS", os_version: "9.1",
+        udid: "B1DDED8D-E449-461A-94A5-4146A1F58B20",
+        state: "Shutdown",
+        is_simulator: true
+      )
+      expect(devices[7]).to have_attributes(
         name: "Apple TV 1080p", os_type: "tvOS", os_version: "9.0",
         udid: "D239A51B-A61C-4B60-B4D6-B7EC16595128",
         state: "Shutdown",
         is_simulator: true
       )
-      expect(devices[7]).to have_attributes(
+      expect(devices[8]).to have_attributes(
         name: "Apple Watch - 38mm", os_type: "watchOS", os_version: "2.0",
         udid: "FE0C82A5-CDD2-4062-A62C-21278EEE32BB",
         state: "Shutdown",
         is_simulator: true
       )
-      expect(devices[8]).to have_attributes(
+      expect(devices[9]).to have_attributes(
         name: "Apple Watch - 38mm", os_type: "watchOS", os_version: "2.0",
         udid: "66D1BF17-3003-465F-A165-E6E3A565E5EB",
         state: "Booted",
@@ -266,7 +290,7 @@ describe FastlaneCore do
       expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
 
       devices = FastlaneCore::DeviceManager.all('iOS')
-      expect(devices.count).to eq(7)
+      expect(devices.count).to eq(8)
 
       expect(devices[0]).to have_attributes(
         name: "Matthew's iPhone", os_type: "iOS", os_version: "9.3",
@@ -287,12 +311,18 @@ describe FastlaneCore do
         is_simulator: true
       )
       expect(devices[3]).to have_attributes(
+        name: "iPhone 5s (9.1)", os_type: "iOS", os_version: "9.1",
+        udid: "23DE091F-34F4-48B6-B51A-231F2CEAB055",
+        state: "Shutdown",
+        is_simulator: true
+      )
+      expect(devices[4]).to have_attributes(
         name: "iPhone 6s Plus", os_type: "iOS", os_version: "9.1",
         udid: "BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0",
         state: "Shutdown",
         is_simulator: true
       )
-      expect(devices[4]).to have_attributes(
+      expect(devices[5]).to have_attributes(
         name: "iPad Air", os_type: "iOS", os_version: "9.1",
         udid: "B61CB41D-354B-4991-992A-80AFFF1062E6",
         state: "Shutdown",

--- a/fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode7
+++ b/fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode7
@@ -6,6 +6,7 @@
     iPhone 4s (DBABD2A2-0144-44B0-8F93-263EB656FC13) (Shutdown)
     iPhone 5 (0D80C781-8702-4156-855E-A9B737FF92D3) (Booted)
 -- iOS 9.1 --
+    iPhone 5s (9.1) (23DE091F-34F4-48B6-B51A-231F2CEAB055) (Shutdown)
     iPhone 6s Plus (BB65C267-FAE9-4CB7-AE31-A5D9BA393AF0) (Shutdown)
     Resizable iPad (B323CCB4-840B-4B26-B57B-71681D6C30C2) (Shutdown) (unavailable, device type profile not found)
     iPad Air (B61CB41D-354B-4991-992A-80AFFF1062E6) (Shutdown)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->

Change the regex for device manager so that it can find simulators that have parenthesis `(` in the name.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We were naming our simulators on our CI slaves, `iPhone 5s (9.1)`, `iPhone 7 (10.2)`, etc. so we could differentiate between them. `scan` was unable to find any devices because none of those matched in device manager's regex.

<!--- If it fixes an open issue, please link to the issue here. -->
I did not open an issue.

<!--- Please describe in detail how you tested your changes. --->
_pending_: I tested by specifying my branch of fastlane in our build system and running `scan` with the simulators in the name.