### PR TITLE
Remove ActiveSupport, Bump Xcodeproj to no longer require it

### DIFF
--- a/deliver/spec/submit_for_review_spec.rb
+++ b/deliver/spec/submit_for_review_spec.rb
@@ -1,6 +1,4 @@
 require 'deliver/submit_for_review'
-require 'active_support/core_ext/numeric/time.rb'
-require 'active_support/core_ext/time/calculations.rb'
 require 'ostruct'
 
 describe Deliver::SubmitForReview do
@@ -10,7 +8,7 @@ describe Deliver::SubmitForReview do
   # the builds will be in date ascending order
   def make_fake_builds(number_of_builds)
     (0...number_of_builds).map do |num|
-      OpenStruct.new({ upload_date: num.minutes.from_now })
+      OpenStruct.new({ upload_date: Time.now.utc + 60 * num }) # minutes_from_now
     end
   end
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = Dir["*/lib"]
 
   spec.add_dependency 'slack-notifier', '>= 1.3', '< 2.0.0' # Slack notifications
-  spec.add_dependency 'xcodeproj', '>= 0.20', '< 2.0.0' # Needed for commit_version_bump action
+  spec.add_dependency 'xcodeproj', '>= 1.4.4', '< 2.0.0' # Needed for commit_version_bump action
   spec.add_dependency 'xcpretty', '>= 0.2.4', '< 1.0.0' # prettify xcodebuild output
   spec.add_dependency 'terminal-notifier', '>= 1.6.2', '< 2.0.0' # macOS notifications
   spec.add_dependency 'terminal-table', '>= 1.4.5', '< 2.0.0' # Actions documentation

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -64,9 +64,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.9' # Used for deploygate, hockey and testfairy actions
   spec.add_dependency 'faraday_middleware', '~> 0.9' # same as faraday
 
-  # Lock `activesupport` (transitive dependency via `xcodeproj`) to keep supporting system ruby
-  spec.add_dependency 'activesupport', '< 5'
-
   # Development only
   spec.add_development_dependency 'rake', '< 12'
   spec.add_development_dependency 'rspec', '~> 3.5.0'

--- a/screengrab/spec/runner_spec.rb
+++ b/screengrab/spec/runner_spec.rb
@@ -103,7 +103,7 @@ describe Screengrab::Runner do
 
     context 'no devices' do
       it 'does not find any active devices' do
-        adb_response = <<-ADB_OUTPUT.strip_heredoc
+        adb_response = strip_heredoc <<-ADB_OUTPUT
         List of devices attached
 
         ADB_OUTPUT
@@ -117,7 +117,7 @@ describe Screengrab::Runner do
 
     context 'one device with spurious ADB output mixed in' do
       it 'finds an active device' do
-        adb_response = <<-ADB_OUTPUT.strip_heredoc
+        adb_response = strip_heredoc <<-ADB_OUTPUT
           List of devices attached
           adb server version (39) doesn't match this client (36); killing...
           * daemon started successfully
@@ -133,7 +133,7 @@ describe Screengrab::Runner do
 
     context 'one device' do
       it 'finds an active device' do
-        adb_response = <<-ADB_OUTPUT.strip_heredoc
+        adb_response = strip_heredoc <<-ADB_OUTPUT
           List of devices attached
           T065002LTT             device usb:437387264X product:ghost_retail model:XT1053 device:ghost
 
@@ -147,7 +147,7 @@ describe Screengrab::Runner do
 
     context 'multiple devices' do
       it 'finds an active device' do
-        adb_response = <<-ADB_OUTPUT.strip_heredoc
+        adb_response = strip_heredoc <<-ADB_OUTPUT
           List of devices attached
           emulator-5554          device product:sdk_phone_x86_64 model:Android_SDK_built_for_x86_64 device:generic_x86_64
           T065002LTT             device usb:437387264X product:ghost_retail model:XT1053 device:ghost
@@ -161,7 +161,7 @@ describe Screengrab::Runner do
 
     context 'one device booting' do
       it 'finds an active device' do
-        adb_response = <<-ADB_OUTPUT.strip_heredoc
+        adb_response = strip_heredoc <<-ADB_OUTPUT
           List of devices attached
           emulator-5554 offline
           T065002LTT  device
@@ -177,7 +177,7 @@ describe Screengrab::Runner do
 
   describe :run_adb_command do
     it 'filters out lines which are ADB warnings' do
-      adb_response = <<-ADB_OUTPUT.strip_heredoc
+      adb_response = strip_heredoc <<-ADB_OUTPUT
             adb: /home/me/rubystack-2.3.1-4/common/lib/libcrypto.so.1.0.0: no version information available (required by adb)
             List of devices attached
             e1dbf228               device usb:1-1.2 product:a33gdd model:SM_A300H device:a33g

--- a/screengrab/spec/spec_helper.rb
+++ b/screengrab/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/string/strip'
-
 # Executes the provided block after adjusting the ENV to have the
 # provided keys and values set as defined in hash. After the block
 # completes, restores the ENV to its previous state.
@@ -30,4 +28,15 @@ end
 
 def raise_fastlane_test_failure
   raise_error FastlaneCore::Interface::FastlaneTestFailure
+end
+
+# The following methods is taken from activesupport,
+#
+# https://github.com/rails/rails/blob/d66e7835bea9505f7003e5038aa19b6ea95ceea1/activesupport/lib/active_support/core_ext/string/strip.rb
+#
+# All credit for this method goes to the original authors.
+# The code is used under the MIT license.
+#
+def strip_heredoc(str)
+  str.gsub(/^#{str.scan(/^[ \t]*(?=\S)/).min}/, "".freeze)
 end

--- a/screengrab/spec/spec_helper.rb
+++ b/screengrab/spec/spec_helper.rb
@@ -37,6 +37,8 @@ end
 # All credit for this method goes to the original authors.
 # The code is used under the MIT license.
 #
+# Strips indentation by removing the amount of leading whitespace in the least indented non-empty line in the whole string
+#
 def strip_heredoc(str)
   str.gsub(/^#{str.scan(/^[ \t]*(?=\S)/).min}/, "".freeze)
 end


### PR DESCRIPTION
### Description
In https://github.com/fastlane/fastlane/pull/5298 ActiveSupport (a dep added by XcodeProj) was locked to ActiveSupport < 5 to continue to support older ruby versions. This becomes a problem when running in tandem with other applications which have higher requirements for ActiveSupport.

### Solution
My solution was to only lock ActiveSupport on an installation to <5 if your RUBY_VERSION is less than 2.2.2 (the minimum requirement for ActiveSupport 5).

cc @KrauseFx @neonichu (original PR and Reviewer)