### PR TITLE
Version bump to 2.26.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.25.0'.freeze
+  VERSION = '2.26.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.25.0':**

* Remove some entitlement keys from the blacklist (#8774) via Andy Drizen
* Fix typos (#8786) via Wolfgang Lutz
* Bump podspec version fix (#8762) via Anton
* [cert] Add generate_p12 & p12_password options to export p12 file (#8440) via gaosen
* Fix typo in Advanced.md (#8783) via color_box
* Optional use all commits instead of current HEAD in `number_of_commits`. (#8769) via Samuel Beek
* [gym] hard error on xcode 8.3 with legacy api (#8747) via Helmut Januschka
* [deliver] Improve description of the -z option (#8771) via Krzysztof Romanowski
* fix output of 'fastlane' for multiple platforms without default. (#8302) via Wolfgang Lutz
* Corrected an error message which is shown when a CD session cookie is expired. (#8764) via Taichirou Suzuki
* Add cache_builds option to carthage action (#8504) via Luke
* Remove duplicate space in default Appfile (#8746) via Felix Krause
