### PR TITLE
Add nice error message when crashlytics action can't find its .framework

### DIFF
--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -5,7 +5,7 @@ module Fastlane
         def discover_default_crashlytics_path
           path = Dir["./Pods/iOS/Crashlytics/Crashlytics.framework"].last || Dir["./**/Crashlytics.framework"].last
           unless path
-            UI.user_error!("Couldn't find Crashlytics.framework in current directory. Make sure to add the 'Crashlytics' pod to your 'Gemfile' and run `pod update`")
+            UI.user_error!("Couldn't find Crashlytics.framework in current directory. Make sure to add the 'Podfile' pod to your 'Gemfile' and run `pod update`")
           end
           return path
         end

--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -5,7 +5,7 @@ module Fastlane
         def discover_default_crashlytics_path
           path = Dir["./Pods/iOS/Crashlytics/Crashlytics.framework"].last || Dir["./**/Crashlytics.framework"].last
           unless path
-            UI.user_error!("Couldn't find Crashlytics.framework in current directory. Make sure to add the 'Podfile' pod to your 'Gemfile' and run `pod update`")
+            UI.user_error!("Couldn't find Crashlytics.framework in current directory. Make sure to add the 'Crashlytics' pod to your 'Podfile' and run `pod update`")
           end
           return path
         end

--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -3,13 +3,15 @@ module Fastlane
     class CrashlyticsHelper
       class << self
         def discover_default_crashlytics_path
-          Dir["./Pods/iOS/Crashlytics/Crashlytics.framework"].last || Dir["./**/Crashlytics.framework"].last
+          path = Dir["./Pods/iOS/Crashlytics/Crashlytics.framework"].last || Dir["./**/Crashlytics.framework"].last
+          unless path
+            UI.user_error!("Couldn't find Crashlytics.framework in current directory. Make sure to add the 'Crashlytics' pod to your 'Gemfile' and run `pod update`")
+          end
+          return path
         end
 
         def generate_ios_command(params)
-          unless params[:crashlytics_path]
-            params[:crashlytics_path] = discover_default_crashlytics_path
-          end
+          params[:crashlytics_path] ||= discover_default_crashlytics_path
 
           UI.user_error!("No value found for 'crashlytics_path'") unless params[:crashlytics_path]
           submit_binary = Dir[File.join(params[:crashlytics_path], '**', 'submit')].last


### PR DESCRIPTION
This happened when the user didn't have Crashlytics set up for their app

<img width="1001" alt="screen shot 2017-04-06 at 6 19 41 pm" src="https://cloud.githubusercontent.com/assets/869950/24781623/c8b91092-1af5-11e7-9f58-451d1ff8af63.png">
