### PR TITLE
Make all tables in fastlane more responsive to the terminal width

### DIFF
--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -37,7 +37,7 @@ module Fastlane
       puts Terminal::Table.new(
         title: "Available fastlane actions".green,
         headings: ['Action', 'Description', 'Author'],
-        rows: rows
+        rows: FastlaneCore::PrintTable.transform_output(rows, :newline)
       )
       puts "  Platform filter: #{platform}".magenta if platform
       puts "  Total of #{rows.count} actions"
@@ -108,7 +108,7 @@ module Fastlane
         puts Terminal::Table.new(
           title: "#{name} Options".green,
           headings: ['Key', 'Description', 'Env Var', 'Default'],
-          rows: options
+          rows: FastlaneCore::PrintTable.transform_output(options, :newline)
         )
       else
         puts "No available options".yellow
@@ -123,7 +123,7 @@ module Fastlane
       puts Terminal::Table.new(
         title: "#{name} Output Variables".green,
         headings: ['Key', 'Description'],
-        rows: output.map { |key, desc| [key.yellow, desc] }
+        rows: FastlaneCore::PrintTable.transform_output(output.map { |key, desc| [key.yellow, desc] }, :newline)
       )
       puts "Access the output values using `lane_context[SharedValues::VARIABLE_NAME]`"
       puts ""
@@ -132,7 +132,7 @@ module Fastlane
     def self.print_return_value(action, name)
       return unless action.return_value
 
-      puts Terminal::Table.new(title: "#{name} Return Value".green, rows: [[action.return_value]])
+      puts Terminal::Table.new(title: "#{name} Return Value".green, rows: FastlaneCore::PrintTable.transform_output([[action.return_value]], :newline))
       puts ""
     end
 

--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -37,7 +37,7 @@ module Fastlane
       puts Terminal::Table.new(
         title: "Available fastlane actions".green,
         headings: ['Action', 'Description', 'Author'],
-        rows: FastlaneCore::PrintTable.transform_output(rows, :newline)
+        rows: FastlaneCore::PrintTable.transform_output(rows)
       )
       puts "  Platform filter: #{platform}".magenta if platform
       puts "  Total of #{rows.count} actions"
@@ -97,7 +97,7 @@ module Fastlane
       authors = Array(action.author || action.authors)
       rows << ["Created by #{authors.join(', ').green}"] unless authors.empty?
 
-      puts Terminal::Table.new(title: name.green, rows: rows)
+      puts Terminal::Table.new(title: name.green, rows: FastlaneCore::PrintTable.transform_output(rows))
       puts ""
     end
 
@@ -108,7 +108,7 @@ module Fastlane
         puts Terminal::Table.new(
           title: "#{name} Options".green,
           headings: ['Key', 'Description', 'Env Var', 'Default'],
-          rows: FastlaneCore::PrintTable.transform_output(options, :newline)
+          rows: FastlaneCore::PrintTable.transform_output(options)
         )
       else
         puts "No available options".yellow
@@ -123,7 +123,7 @@ module Fastlane
       puts Terminal::Table.new(
         title: "#{name} Output Variables".green,
         headings: ['Key', 'Description'],
-        rows: FastlaneCore::PrintTable.transform_output(output.map { |key, desc| [key.yellow, desc] }, :newline)
+        rows: FastlaneCore::PrintTable.transform_output(output.map { |key, desc| [key.yellow, desc] })
       )
       puts "Access the output values using `lane_context[SharedValues::VARIABLE_NAME]`"
       puts ""
@@ -132,7 +132,8 @@ module Fastlane
     def self.print_return_value(action, name)
       return unless action.return_value
 
-      puts Terminal::Table.new(title: "#{name} Return Value".green, rows: FastlaneCore::PrintTable.transform_output([[action.return_value]], :newline))
+      puts Terminal::Table.new(title: "#{name} Return Value".green,
+                                rows: FastlaneCore::PrintTable.transform_output([[action.return_value]]))
       puts ""
     end
 

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -115,7 +115,7 @@ module Fastlane
       puts Terminal::Table.new(
         title: "fastlane summary".green,
         headings: ["Step", "Action", "Time (in s)"],
-        rows: rows
+        rows: FastlaneCore::PrintTable.transform_output(rows)
       )
       puts ""
     end
@@ -145,7 +145,7 @@ module Fastlane
       table = Terminal::Table.new(
         title: "Available lanes to run",
         headings: ['Number', 'Lane Name', 'Description'],
-        rows: rows
+        rows: FastlaneCore::PrintTable.transform_output(rows)
       )
 
       UI.message "Welcome to fastlane! Here's what your app is setup to do:"
@@ -232,12 +232,12 @@ module Fastlane
       rows = Actions.lane_context.collect do |key, content|
         [key, content.to_s]
       end
-      rows = FastlaneCore::PrintTable.print_values(config: rows)
 
+      # TODO: do we print twice here?
       require 'terminal-table'
       puts Terminal::Table.new({
         title: "Lane Context".yellow,
-        rows: rows
+        rows: FastlaneCore::PrintTable.transform_output(rows)
       })
     end
   end

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -233,7 +233,6 @@ module Fastlane
         [key, content.to_s]
       end
 
-      # TODO: do we print twice here?
       require 'terminal-table'
       puts Terminal::Table.new({
         title: "Lane Context".yellow,

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -225,7 +225,7 @@ module Fastlane
       rows = Actions.lane_context.collect do |key, content|
         [key, content.to_s]
       end
-      rows = FastlaneCore::PrintTable.limit_row_size(rows)
+      rows = FastlaneCore::PrintTable.print_values(config: rows)
 
       require 'terminal-table'
       puts Terminal::Table.new({

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -315,7 +315,7 @@ module Fastlane
 
       require 'terminal-table'
       puts Terminal::Table.new({
-        rows: rows,
+        rows: FastlaneCore::PrintTable.transform_output(rows),
         title: "Used plugins".green,
         headings: ["Plugin", "Version", "Action"]
       })

--- a/fastlane/lib/fastlane/plugins/plugin_search.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_search.rb
@@ -24,11 +24,10 @@ module Fastlane
       end
 
       params = {
-        rows: rows,
+        rows: FastlaneCore::PrintTable.transform_output(rows),
         title: (search_query ? "fastlane plugins '#{search_query}'" : "Available fastlane plugins").green,
         headings: ["Name", "Description", "Downloads"]
       }
-      params[:rows] = rows
 
       puts ""
       puts Terminal::Table.new(params)

--- a/fastlane/lib/fastlane/plugins/plugin_update_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_update_manager.rb
@@ -42,7 +42,7 @@ module Fastlane
       end
 
       puts Terminal::Table.new({
-        rows: rows,
+        rows: FastlaneCore::PrintTable.transform_output(rows),
         title: "Plugin updates available".yellow,
         headings: ["Plugin", "Your Version", "Latest Version"]
       })

--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -149,7 +149,8 @@ module Fastlane
       rows << [(self.project.is_workspace ? "Workspace" : "Project"), self.project.path]
       require 'terminal-table'
       puts ""
-      puts Terminal::Table.new(rows: rows, title: "Detected Values")
+      puts Terminal::Table.new(rows: FastlaneCore::PrintTable.transform_output(rows),
+                              title: "Detected Values")
       puts ""
 
       unless self.itc_ref || self.project.mac?

--- a/fastlane/spec/fixtures/plist/Info.plist
+++ b/fastlane/spec/fixtures/plist/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -47,7 +47,8 @@ module FastlaneCore
       end.compact
 
       puts ""
-      puts Terminal::Table.new(rows: rows, title: "Detected Values from '#{path}'")
+      puts Terminal::Table.new(rows: FastlaneCore::PrintTable.transform_output(rows),
+                              title: "Detected Values from '#{path}'")
       puts ""
     end
 

--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -52,7 +52,9 @@ module FastlaneCore
       end
 
       def should_transform?
-        return false if (FastlaneCore::Helper.ci? && !FastlaneCore::Helper.test?)
+        if FastlaneCore::Helper.ci? && !FastlaneCore::Helper.test?
+          return false
+        end
         return !FastlaneCore::Env.truthy?("FL_SKIP_TABLE_TRANSFORM")
       end
 

--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -52,6 +52,7 @@ module FastlaneCore
       end
 
       def should_transform?
+        return false if FastlaneCore::Helper.ci?
         return !FastlaneCore::Env.truthy?("FL_SKIP_TABLE_TRANSFORM")
       end
 

--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -24,10 +24,9 @@ module FastlaneCore
         rows = self.collect_rows(options: options, hide_keys: hide_keys.map(&:to_s), mask_keys: mask_keys.map(&:to_s), prefix: '')
 
         params = {}
-        transform = false if FastlaneCore::Env.truthy?("FL_SKIP_TABLE_TRANSFORM")
 
         if transform
-          params[:rows] = transform_output(rows, transform)
+          params[:rows] = transform_output(rows, transform: transform)
         else
           params[:rows] = rows
         end
@@ -52,28 +51,33 @@ module FastlaneCore
         return value
       end
 
-      def transform_output(rows, transform)
+      def should_transform?
+        !FastlaneCore::Env.truthy?("FL_SKIP_TABLE_TRANSFORM")
+      end
+
+      def transform_output(rows, transform: :newline)
+        return rows unless should_transform?
+
         require 'fastlane_core/string_filters'
         require 'tty-screen'
 
-        return_array = []
-        tcols = TTY::Screen.width
+        number_of_cols = TTY::Screen.width
 
         col_count = rows.map(&:length).first || 1
 
         # -4 per column - as tt adds "| " and " |"
         terminal_table_padding = 4
-        max_length = tcols - (col_count * terminal_table_padding)
+        max_length = number_of_cols - (col_count * terminal_table_padding)
 
         max_value_length = (max_length / col_count)
 
-        rows.map do |row|
-          new_row = []
-          row.each do |col|
+        return_array = rows.map do |row|
+          row.map do |col|
             value = col.to_s.dup
+
             if transform == :truncate_middle
               value = value.middle_truncate(max_value_length)
-            elsif transform == :newline && value
+            elsif transform == :newline
               # remove all fixed newlines as it may mess up the output
               value.tr!("\n", " ") if value.kind_of?(String)
               if value.length >= max_value_length
@@ -87,13 +91,12 @@ module FastlaneCore
                 lines = value.wordwrap(max_value_length)
                 value = colorize_array(lines, colors)
               end
+            elsif transform
+              UI.user_error!("Unknown transform value '#{transform}'")
             end
-            new_row << value
+            value
           end
-          return_array << new_row
-          return_array << :separator
         end
-        return_array.pop
         return return_array
       end
 

--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -73,28 +73,32 @@ module FastlaneCore
 
         return_array = rows.map do |row|
           row.map do |col|
-            value = col.to_s.dup
+            if col.nil?
+              col # we want to keep the nil and not convert it to a string
+            else
+              value = col.to_s.dup
 
-            if transform == :truncate_middle
-              value = value.middle_truncate(max_value_length)
-            elsif transform == :newline
-              # remove all fixed newlines as it may mess up the output
-              value.tr!("\n", " ") if value.kind_of?(String)
-              if value.length >= max_value_length
-                colors = value.scan(/(\e\[.*?m)/)
-                if colors && colors.length > 0
-                  colors.each do |color|
-                    value.delete!(color.first)
-                    value.delete!(color.last)
+              if transform == :truncate_middle
+                value = value.middle_truncate(max_value_length)
+              elsif transform == :newline
+                # remove all fixed newlines as it may mess up the output
+                value.tr!("\n", " ") if value.kind_of?(String)
+                if value.length >= max_value_length
+                  colors = value.scan(/(\e\[.*?m)/)
+                  if colors && colors.length > 0
+                    colors.each do |color|
+                      value.delete!(color.first)
+                      value.delete!(color.last)
+                    end
                   end
+                  lines = value.wordwrap(max_value_length)
+                  value = colorize_array(lines, colors)
                 end
-                lines = value.wordwrap(max_value_length)
-                value = colorize_array(lines, colors)
+              elsif transform
+                UI.user_error!("Unknown transform value '#{transform}'")
               end
-            elsif transform
-              UI.user_error!("Unknown transform value '#{transform}'")
+              value
             end
-            value
           end
         end
         return return_array

--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -58,7 +58,7 @@ module FastlaneCore
 
       def transform_row(column, transform, max_value_length)
         return column if column.nil? # we want to keep the nil and not convert it to a string
-        return column if transform.nil? 
+        return column if transform.nil?
 
         value = column.to_s.dup
 

--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -52,7 +52,7 @@ module FastlaneCore
       end
 
       def should_transform?
-        return false if FastlaneCore::Helper.ci?
+        return false if (FastlaneCore::Helper.ci? && !FastlaneCore::Helper.test?)
         return !FastlaneCore::Env.truthy?("FL_SKIP_TABLE_TRANSFORM")
       end
 

--- a/fastlane_core/lib/fastlane_core/string_filters.rb
+++ b/fastlane_core/lib/fastlane_core/string_filters.rb
@@ -31,4 +31,20 @@ class String
 
     "#{self[0, stop]}#{omission}"
   end
+
+  # Base taken from: https://www.ruby-forum.com/topic/57805
+  def wordwrap(length = 80)
+    self.gsub!(/(\S{#{length}})(?=\S)/, '\1 ')
+    self.scan(/.{1,#{length}}(?:\s+|$)/)
+  end
+
+  # Base taken from: http://stackoverflow.com/a/12202205/1945875
+  def middle_truncate(length = 20, options = {})
+    omission = options[:omission] || '...'
+    return self if self.length <= length + omission.length
+    return self[0..length] if length < omission.length
+    len = (length - omission.length) / 2
+    s_len = len - length % 2
+    self[0..s_len] + omission + self[self.length - len..self.length]
+  end
 end

--- a/fastlane_core/spec/configuration_file_spec.rb
+++ b/fastlane_core/spec/configuration_file_spec.rb
@@ -120,7 +120,7 @@ describe FastlaneCore do
 
         it "prints out a table of all the set values" do
           expect(Terminal::Table).to receive(:new).with({
-            rows: [[:app_identifier, "com.krausefx.app"], [:apple_id, "from_le_block"]],
+            rows: [["app_identifier", "com.krausefx.app"], ["apple_id", "from_le_block"]],
             title: "Detected Values from './fastlane_core/spec/fixtures/ConfigFileValid'"
           })
 

--- a/fastlane_core/spec/print_table_spec.rb
+++ b/fastlane_core/spec/print_table_spec.rb
@@ -48,15 +48,17 @@ describe FastlaneCore do
 
       value = FastlaneCore::PrintTable.print_values(config: @config, title: title, hide_keys: [:a_sensitive])
       expect(value[:title]).to eq(title.green)
-      expect(value[:rows]).to eq([["cert_name", "asdf"], :separator, ["output", ".."], :separator, ["a_bool", "true"]])
+      expect(value[:rows]).to eq([["cert_name", "asdf"], ["output", ".."], ["a_bool", "true"]])
     end
+
     it "automatically masks sensitive options" do
       value = FastlaneCore::PrintTable.print_values(config: @config)
-      expect(value[:rows]).to eq([["cert_name", "asdf"], :separator, ["output", ".."], :separator, ["a_bool", "true"], :separator, ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["cert_name", "asdf"], ["output", ".."], ["a_bool", "true"], ["a_sensitive", "********"]])
     end
+
     it "supports mask_keys property with symbols and strings" do
       value = FastlaneCore::PrintTable.print_values(config: @config, mask_keys: [:cert_name, 'a_bool'])
-      expect(value[:rows]).to eq([["cert_name", "********"], :separator, ["output", ".."], :separator, ["a_bool", "********"], :separator, ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["cert_name", "********"], ["output", ".."], ["a_bool", "********"], ["a_sensitive", "********"]])
     end
 
     it "supports hide_keys property with symbols and strings" do
@@ -68,21 +70,21 @@ describe FastlaneCore do
       @config[:a_hash][:foo] = 'bar'
       @config[:a_hash][:bar] = { foo: 'bar' }
       value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:cert_name, :a_bool])
-      expect(value[:rows]).to eq([["output", ".."], :separator, ["a_hash.foo", "bar"], :separator, ["a_hash.bar.foo", "bar"], :separator, ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["output", ".."], ["a_hash.foo", "bar"], ["a_hash.bar.foo", "bar"], ["a_sensitive", "********"]])
     end
 
     it "supports hide_keys property in hashes" do
       @config[:a_hash][:foo] = 'bar'
       @config[:a_hash][:bar] = { foo: 'bar' }
       value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:cert_name, :a_bool, 'a_hash.foo', 'a_hash.bar.foo'])
-      expect(value[:rows]).to eq([["output", ".."], :separator, ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["output", ".."], ["a_sensitive", "********"]])
     end
 
     it "supports printing default values and ignores missing unset ones " do
       @config[:cert_name] = nil # compulsory without default
       @config[:output] = nil    # compulsory with default
       value = FastlaneCore::PrintTable.print_values(config: @config)
-      expect(value[:rows]).to eq([["output", "."], :separator, ["a_bool", "true"], :separator, ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["output", "."], ["a_bool", "true"], ["a_sensitive", "********"]])
     end
 
     describe "Breaks down lines" do

--- a/fastlane_core/spec/print_table_spec.rb
+++ b/fastlane_core/spec/print_table_spec.rb
@@ -84,29 +84,54 @@ describe FastlaneCore do
       value = FastlaneCore::PrintTable.print_values(config: @config)
       expect(value[:rows]).to eq([["output", "."], :separator, ["a_bool", "true"], :separator, ["a_sensitive", "********"]])
     end
+
     describe "Breaks down lines" do
-      let(:long_breakable_text) { 'bar ' * 4000 }
+      let(:long_breakable_text) { 'bar ' * 400 }
+
       before do
         @config[:cert_name] = long_breakable_text
+        allow(TTY::Screen).to receive(:width).and_return(200)
       end
-      it "middle truncate" do
+
+      it "middle truncate", nower: true do
         value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output, :a_bool, :a_sensitive], transform: :truncate_middle)
         expect(value[:rows].count).to eq(1)
-        expect(value[:rows][0][1]).to include "..."
+        expect(value[:rows][0][1]).to include("...")
         expect(value[:rows][0][1].length).to be < long_breakable_text.length
       end
 
       it "newline" do
         value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output, :a_bool, :a_sensitive], transform: :newline)
         expect(value[:rows].count).to eq(1)
-        expect(value[:rows][0][1]).to include "\n"
+        expect(value[:rows][0][1]).to include("\n")
         expect(value[:rows][0][1].length).to be > long_breakable_text.length
       end
 
-      it "no change" do
-        value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output, :a_bool, :a_sensitive], transform: :none)
+      it "no change for `nil`" do
+        value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output, :a_bool, :a_sensitive], transform: nil)
         expect(value[:rows].count).to eq(1)
         expect(value[:rows][0][1].length).to eq(long_breakable_text.length)
+      end
+
+      it "doesn't break with long strings with no space" do
+        rows = [[:git_url, "https" * 100]]
+        value = FastlaneCore::PrintTable.print_values(config: rows, hide_keys: [], transform: :newline)
+        expect(value[:rows].count).to eq(1)
+        expect(value[:rows].first.first).to eq("git_url")
+        expect(value[:rows].first.last).to include("httpshttps")
+      end
+
+      it "doesn't transform if the env variable is set" do
+        with_env_values("FL_SKIP_TABLE_TRANSFORM" => "1") do
+          value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output, :a_bool, :a_sensitive], transform: :truncate_middle)
+          expect(value[:rows][0][1]).to_not include("...")
+        end
+      end
+
+      it "raises an exception for invalid transform" do
+        expect do
+          FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [], transform: :something_random)
+        end.to raise_error("Unknown transform value 'something_random'")
       end
     end
 

--- a/fastlane_core/spec/print_table_spec.rb
+++ b/fastlane_core/spec/print_table_spec.rb
@@ -48,15 +48,15 @@ describe FastlaneCore do
 
       value = FastlaneCore::PrintTable.print_values(config: @config, title: title, hide_keys: [:a_sensitive])
       expect(value[:title]).to eq(title.green)
-      expect(value[:rows]).to eq([['cert_name', "asdf"], ['output', '..'], ["a_bool", true]])
+      expect(value[:rows]).to eq([["cert_name", "asdf"], :separator, ["output", ".."], :separator, ["a_bool", "true"]])
     end
     it "automatically masks sensitive options" do
       value = FastlaneCore::PrintTable.print_values(config: @config)
-      expect(value[:rows]).to eq([["cert_name", "asdf"], ["output", ".."], ["a_bool", true], ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["cert_name", "asdf"], :separator, ["output", ".."], :separator, ["a_bool", "true"], :separator, ["a_sensitive", "********"]])
     end
     it "supports mask_keys property with symbols and strings" do
       value = FastlaneCore::PrintTable.print_values(config: @config, mask_keys: [:cert_name, 'a_bool'])
-      expect(value[:rows]).to eq([["cert_name", "********"], ["output", ".."], ["a_bool", "********"], ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["cert_name", "********"], :separator, ["output", ".."], :separator, ["a_bool", "********"], :separator, ["a_sensitive", "********"]])
     end
 
     it "supports hide_keys property with symbols and strings" do
@@ -68,30 +68,46 @@ describe FastlaneCore do
       @config[:a_hash][:foo] = 'bar'
       @config[:a_hash][:bar] = { foo: 'bar' }
       value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:cert_name, :a_bool])
-      expect(value[:rows]).to eq([["output", ".."], ["a_hash.foo", "bar"], ["a_hash.bar.foo", "bar"], ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["output", ".."], :separator, ["a_hash.foo", "bar"], :separator, ["a_hash.bar.foo", "bar"], :separator, ["a_sensitive", "********"]])
     end
 
     it "supports hide_keys property in hashes" do
       @config[:a_hash][:foo] = 'bar'
       @config[:a_hash][:bar] = { foo: 'bar' }
       value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:cert_name, :a_bool, 'a_hash.foo', 'a_hash.bar.foo'])
-      expect(value[:rows]).to eq([["output", ".."], ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["output", ".."], :separator, ["a_sensitive", "********"]])
     end
 
     it "supports printing default values and ignores missing unset ones " do
       @config[:cert_name] = nil # compulsory without default
       @config[:output] = nil    # compulsory with default
       value = FastlaneCore::PrintTable.print_values(config: @config)
-      expect(value[:rows]).to eq([["output", "."], ["a_bool", true], ["a_sensitive", "********"]])
+      expect(value[:rows]).to eq([["output", "."], :separator, ["a_bool", "true"], :separator, ["a_sensitive", "********"]])
     end
+    describe "Breaks down lines" do
+      let(:long_breakable_text) { 'bar ' * 4000 }
+      before do
+        @config[:cert_name] = long_breakable_text
+      end
+      it "middle truncate" do
+        value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output, :a_bool, :a_sensitive], transform: :truncate_middle)
+        expect(value[:rows].count).to eq(1)
+        expect(value[:rows][0][1]).to include "..."
+        expect(value[:rows][0][1].length).to be < long_breakable_text.length
+      end
 
-    it "breaks down long lines" do
-      long_breakable_text = 'bar ' * 40
-      @config[:cert_name] = long_breakable_text
-      value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output, :a_bool, :a_sensitive])
-      expect(value[:rows].count).to eq(1)
-      expect(value[:rows][0][1]).to end_with '...'
-      expect(value[:rows][0][1].length).to be < long_breakable_text.length
+      it "newline" do
+        value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output, :a_bool, :a_sensitive], transform: :newline)
+        expect(value[:rows].count).to eq(1)
+        expect(value[:rows][0][1]).to include "\n"
+        expect(value[:rows][0][1].length).to be > long_breakable_text.length
+      end
+
+      it "no change" do
+        value = FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [:output, :a_bool, :a_sensitive], transform: :none)
+        expect(value[:rows].count).to eq(1)
+        expect(value[:rows][0][1].length).to eq(long_breakable_text.length)
+      end
     end
 
     it "supports non-Configuration prints" do

--- a/fastlane_core/spec/print_table_spec.rb
+++ b/fastlane_core/spec/print_table_spec.rb
@@ -93,6 +93,7 @@ describe FastlaneCore do
       before do
         @config[:cert_name] = long_breakable_text
         allow(TTY::Screen).to receive(:width).and_return(200)
+        allow(FastlaneCore::Helper).to receive(:ci?).and_return(false) # because we don't transform on CI
       end
 
       it "middle truncate", nower: true do

--- a/fastlane_core/spec/print_table_spec.rb
+++ b/fastlane_core/spec/print_table_spec.rb
@@ -93,7 +93,6 @@ describe FastlaneCore do
       before do
         @config[:cert_name] = long_breakable_text
         allow(TTY::Screen).to receive(:width).and_return(200)
-        allow(FastlaneCore::Helper).to receive(:ci?).and_return(false) # because we don't transform on CI
       end
 
       it "middle truncate", nower: true do

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -59,7 +59,7 @@ module Gym
       puts Terminal::Table.new(
         title: title.green,
         headings: ["Option", "Value"],
-        rows: rows.delete_if { |c| c.to_s.empty? }
+        rows: FastlaneCore::PrintTable.transform_output(rows.delete_if { |c| c.to_s.empty? })
       )
     end
 

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -81,39 +81,42 @@ module Match
     def print_tables
       puts ""
       if self.certs.count > 0
+        rows = self.certs.collect { |c| [c.name, c.id, c.class.to_s.split("::").last, c.expires.strftime("%Y-%m-%d")] }
         puts Terminal::Table.new({
           title: "Certificates that are going to be revoked".green,
           headings: ["Name", "ID", "Type", "Expires"],
-          rows: self.certs.collect { |c| [c.name, c.id, c.class.to_s.split("::").last, c.expires.strftime("%Y-%m-%d")] }
+          rows: FastlaneCore::PrintTable.transform_output(rows)
         })
         puts ""
       end
 
       if self.profiles.count > 0
+        rows = self.profiles.collect do |p|
+          status = p.status == 'Active' ? p.status.green : p.status.red
+
+          [p.name, p.id, status, p.type, p.expires.strftime("%Y-%m-%d")]
+        end
         puts Terminal::Table.new({
           title: "Provisioning Profiles that are going to be revoked".green,
           headings: ["Name", "ID", "Status", "Type", "Expires"],
-          rows: self.profiles.collect do |p|
-            status = p.status == 'Active' ? p.status.green : p.status.red
-
-            [p.name, p.id, status, p.type, p.expires.strftime("%Y-%m-%d")]
-          end
+          rows: FastlaneCore::PrintTable.transform_output(rows)
         })
         puts ""
       end
 
       if self.files.count > 0
+        rows = self.files.collect do |f|
+          components = f.split(File::SEPARATOR)[-3..-1]
+
+          # from "...1o7xtmh/certs/distribution/8K38XUY3AY.cer" to "distribution cert"
+          file_type = components[0..1].reverse.join(" ")[0..-2]
+
+          [file_type, components[2]]
+        end
         puts Terminal::Table.new({
           title: "Files that are going to be deleted".green,
           headings: ["Type", "File Name"],
-          rows: self.files.collect do |f|
-            components = f.split(File::SEPARATOR)[-3..-1]
-
-            # from "...1o7xtmh/certs/distribution/8K38XUY3AY.cer" to "distribution cert"
-            file_type = components[0..1].reverse.join(" ")[0..-2]
-
-            [file_type, components[2]]
-          end
+          rows: rows
         })
         puts ""
       end

--- a/match/lib/match/table_printer.rb
+++ b/match/lib/match/table_printer.rb
@@ -33,7 +33,7 @@ module Match
       end
 
       params = {}
-      params[:rows] = rows
+      params[:rows] = FastlaneCore::PrintTable.transform_output(rows)
       params[:title] = "Installed Provisioning Profile".green
       params[:headings] = ['Parameter', 'Environment Variable', 'Value']
 

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -97,7 +97,7 @@ module Pilot
       puts Terminal::Table.new(
         title: "#{app.name} Builds".green,
         headings: ["Version #", "Build #", "Testing", "Installs", "Sessions"],
-        rows: rows
+        rows: FastlaneCore::PrintTable.transform_output(rows)
       )
     end
 

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -158,10 +158,11 @@ module Pilot
 
     # Requires a block that accepts a tester and returns an array of tester column values
     def list(all_testers, title, headings)
+      rows = all_testers.map { |tester| yield tester }
       puts Terminal::Table.new(
         title: title.green,
         headings: headings,
-        rows: all_testers.map { |tester| yield tester }
+        rows: FastlaneCore::PrintTable.transform_output(rows)
       )
     end
 
@@ -201,7 +202,7 @@ module Pilot
 
       puts Terminal::Table.new(
         title: tester.email.green,
-        rows: rows
+        rows: FastlaneCore::PrintTable.transform_output(rows)
       )
     end
   end

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -67,7 +67,7 @@ describe Pilot::TesterManager do
             tester.last_name,
             tester.email,
             tester.group_names,
-            tester.devices.count,
+            tester.devices.count.to_s,
             tester.full_version,
             tester.pretty_install_date
           ]

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -124,7 +124,7 @@ module Snapshot
       end
 
       params = {
-        rows: rows,
+        rows: FastlaneCore::PrintTable.transform_output(rows),
         headings: ["Device"] + results.values.first.keys,
         title: "snapshot results"
       }


### PR DESCRIPTION
Moved from https://github.com/fastlane/fastlane/pull/7391 by mistake

The design on the top table is the one that's used
<img width="1039" alt="screen shot 2017-04-06 at 7 06 57 pm" src="https://cloud.githubusercontent.com/assets/869950/24783426/200f995a-1b01-11e7-85a8-3fb053efd661.png">
