### PR TITLE
Version bump to 2.26.1

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.26.0'.freeze
+  VERSION = '2.26.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.26.0':**

* Replace export_type with export_method in gym error message (#8816) via Felix Krause
* Update the vision doc to remove Twitter references (#8815) via Andrea Falcone
* Fix typo (#8814) via color_box
