### PR TITLE
Set derived_data_path for slather in setup_jenkins action

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/setup_jenkins.rb
@@ -5,6 +5,7 @@ module Fastlane
         "BACKUP_XCARCHIVE_DESTINATION",
         "DERIVED_DATA_PATH",
         "FL_CARTHAGE_DERIVED_DATA",
+        "FL_SLATHER_BUILD_DIRECTORY",
         "GYM_BUILD_PATH",
         "GYM_CODE_SIGNING_IDENTITY",
         "GYM_DERIVED_DATA_PATH",
@@ -67,6 +68,7 @@ module Fastlane
           ENV['GYM_DERIVED_DATA_PATH'] = derived_data_path
           ENV['SCAN_DERIVED_DATA_PATH'] = derived_data_path
           ENV['FL_CARTHAGE_DERIVED_DATA'] = derived_data_path
+          ENV['FL_SLATHER_BUILD_DIRECTORY'] = derived_data_path
         end
 
         # Set result bundle

--- a/fastlane/spec/actions_specs/setup_jenkins_spec.rb
+++ b/fastlane/spec/actions_specs/setup_jenkins_spec.rb
@@ -20,6 +20,7 @@ describe Fastlane do
         expect(ENV["BACKUP_XCARCHIVE_DESTINATION"]).to be_nil
         expect(ENV["DERIVED_DATA_PATH"]).to be_nil
         expect(ENV["FL_CARTHAGE_DERIVED_DATA"]).to be_nil
+        expect(ENV["FL_SLATHER_BUILD_DIRECTORY"]).to be_nil
         expect(ENV["GYM_BUILD_PATH"]).to be_nil
         expect(ENV["GYM_CODE_SIGNING_IDENTITY"]).to be_nil
         expect(ENV["GYM_DERIVED_DATA_PATH"]).to be_nil
@@ -47,6 +48,7 @@ describe Fastlane do
         expect(ENV["BACKUP_XCARCHIVE_DESTINATION"]).to eq(output)
         expect(ENV["DERIVED_DATA_PATH"]).to eq(derived_data)
         expect(ENV["FL_CARTHAGE_DERIVED_DATA"]).to eq(derived_data)
+        expect(ENV["FL_SLATHER_BUILD_DIRECTORY"]).to eq(derived_data)
         expect(ENV["GYM_BUILD_PATH"]).to eq(output)
         expect(ENV["GYM_CODE_SIGNING_IDENTITY"]).to be_nil
         expect(ENV["GYM_DERIVED_DATA_PATH"]).to eq(derived_data)
@@ -72,6 +74,7 @@ describe Fastlane do
         expect(ENV["BACKUP_XCARCHIVE_DESTINATION"]).to eq(output)
         expect(ENV["DERIVED_DATA_PATH"]).to eq(derived_data)
         expect(ENV["FL_CARTHAGE_DERIVED_DATA"]).to eq(derived_data)
+        expect(ENV["FL_SLATHER_BUILD_DIRECTORY"]).to eq(derived_data)
         expect(ENV["GYM_BUILD_PATH"]).to eq(output)
         expect(ENV["GYM_CODE_SIGNING_IDENTITY"]).to be_nil
         expect(ENV["GYM_DERIVED_DATA_PATH"]).to eq(derived_data)
@@ -171,6 +174,7 @@ describe Fastlane do
 
           expect(ENV["DERIVED_DATA_PATH"]).to eq("/tmp/derived_data")
           expect(ENV["FL_CARTHAGE_DERIVED_DATA"]).to eq("/tmp/derived_data")
+          expect(ENV["FL_SLATHER_BUILD_DIRECTORY"]).to eq("/tmp/derived_data")
           expect(ENV["GYM_DERIVED_DATA_PATH"]).to eq("/tmp/derived_data")
           expect(ENV["SCAN_DERIVED_DATA_PATH"]).to eq("/tmp/derived_data")
           expect(ENV["XCODE_DERIVED_DATA_PATH"]).to eq("/tmp/derived_data")


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
The derived_data_path parameter of `setup_jenkins` set other action's parameter about derived_data_path. But the build_directory parameter of slather action is not set.

### Motivation and Context
I set the build_directory parameter of slather action, although I set the derived_data_path parameter of setup_jenkins action. This PR allow you not to set build_directory parameter of slather action.