### PR TITLE
Fix LoadError catching when it's not related to CommandsGenerator

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -48,13 +48,14 @@ module Fastlane
             require File.join(tool_name, "commands_generator")
 
             # Call the tool's CommandsGenerator class and let it do its thing
-            Object.const_get(tool_name.fastlane_module)::CommandsGenerator.start
+            commands_generator_ref = Object.const_get(tool_name.fastlane_module)::CommandsGenerator
           rescue LoadError
             # This will only happen if the tool we call here, doesn't provide
             # a CommandsGenerator class yet
             # When we launch this feature, this should never be the case
             abort("#{tool_name} can't be called via `fastlane #{tool_name}`, run '#{tool_name}' directly instead".red)
           end
+          commands_generator_ref.start
         elsif tool_name == "fastlane-credentials"
           require 'credentials_manager'
           ARGV.shift

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -48,14 +48,14 @@ module Fastlane
             require File.join(tool_name, "commands_generator")
 
             # Call the tool's CommandsGenerator class and let it do its thing
-            commands_generator_ref = Object.const_get(tool_name.fastlane_module)::CommandsGenerator
+            commands_generator = Object.const_get(tool_name.fastlane_module)::CommandsGenerator
           rescue LoadError
             # This will only happen if the tool we call here, doesn't provide
             # a CommandsGenerator class yet
             # When we launch this feature, this should never be the case
             abort("#{tool_name} can't be called via `fastlane #{tool_name}`, run '#{tool_name}' directly instead".red)
           end
-          commands_generator_ref.start
+          commands_generator.start
         elsif tool_name == "fastlane-credentials"
           require 'credentials_manager'
           ARGV.shift


### PR DESCRIPTION
We rescue `LoadError` so that we tell users to run the tool directly if CommandsGenerator is not available. However since we call `.start` inside that `begin` `rescue` block we'd catch all LoadErrors from within fastlane, and then show the confusing error message of

```
pilot can't be called via `fastlane pilot`, run 'pilot' directly instead
```