### PR TITLE
Update Actions.md plugin generation to include plugins with not high usage numbers

### DIFF
--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -94,7 +94,7 @@ module Fastlane
         conn = Faraday.new(ENHANCER_URL)
         conn.basic_auth(ENV["ENHANCER_USER"], ENV["ENHANCER_PASSWORD"])
         begin
-          @launches = JSON.parse(conn.get('/index.json').body)
+          @launches = JSON.parse(conn.get('/index.json?minimum_launches=0').body)
         rescue
           UI.user_error!("Couldn't fetch usage data, make sure to have ENHANCER_USER and ENHANCER_PASSWORD")
         end


### PR DESCRIPTION
With a recent change in enhancer we excluded many actions to only show the top actions. However for generating the docs, we want to include all the plugins