### PR TITLE
Update 'OtherAction' error message to indicate 'other_action' instead

### DIFF
--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -115,7 +115,7 @@ module Fastlane
     # Allows the user to call an action from an action
     def self.method_missing(method_sym, *arguments, &_block)
       UI.error("Unknown method '#{method_sym}'")
-      UI.user_error!("To call another action from an action use `OtherAction.#{method_sym}` instead")
+      UI.user_error!("To call another action from an action use `other_action.#{method_sym}` instead")
     end
 
     # When shelling out from the actoin, should we use `bundle exec`?

--- a/fastlane/spec/action_spec.rb
+++ b/fastlane/spec/action_spec.rb
@@ -91,7 +91,7 @@ describe Fastlane do
         ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileActionFromActionInvalid')
         expect do
           ff.runner.execute(:something, :ios)
-        end.to raise_error("To call another action from an action use `OtherAction.rocket` instead")
+        end.to raise_error("To call another action from an action use `other_action.rocket` instead")
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

The errors that appear when one tries to call another action are confusing and mislead people. This change improves the error message to indicate exactly what to type.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The error message gave incorrect advice on how to fix an issue.

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. --->
I did not test these changes other than running tests.