### PR TITLE
Fix maximum width calculations for 1 column layouts

### DIFF
--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -97,10 +97,10 @@ module FastlaneCore
         col_count = rows.map(&:length).first || 1
 
         # -4 per column - as tt adds "| " and " |"
-        terminal_table_padding = 0
+        terminal_table_padding = 4
         max_length = number_of_cols - (col_count * terminal_table_padding)
 
-        max_value_length = (max_length / col_count)
+        max_value_length = (max_length / col_count) - 1
 
         return_array = rows.map do |row|
           row.map do |column|


### PR DESCRIPTION
Note the 1 column table at the top part of the output: 

<img width="1046" alt="screenshot 2017-04-10 07 42 08" src="https://cloud.githubusercontent.com/assets/869950/24890639/e691345e-1e25-11e7-9e9c-90d46dd3c88e.png">
