### PR TITLE
Update the simulators snapshot uses by default

### DIFF
--- a/snapshot/lib/snapshot/detect_values.rb
+++ b/snapshot/lib/snapshot/detect_values.rb
@@ -43,8 +43,9 @@ module Snapshot
 
           # Filter iPhones
           # Full list: ["iPhone 4s", "iPhone 5", "iPhone 5s", "iPhone 6", "iPhone 6 Plus", "iPhone 6s", "iPhone 6s Plus"]
-          next if sim.name.include?("6s") # same screen resolution as iPhone 6, or iPhone 6s Plus
           next if sim.name.include?("5s") # same screen resolution as iPhone 5
+          next if sim.name.include?("SE") # duplicate of iPhone 5
+          next if sim.name.include?("iPhone 6") # same as iPhone 7
 
           next if sim.name.include?("Apple TV")
 


### PR DESCRIPTION
Until now this would result in duplicate screenshots for all iPhone 6/7, even triple with the SE. 

By default this will now run on 

```
=> ["iPhone 5",  "iPhone 7", "iPhone 7 Plus", "iPad Pro (9.7 inch)", "iPad Pro (12.9 inch)"]
```