### PR TITLE
Insert a line before h1

### DIFF
--- a/fastlane/lib/fastlane/documentation/docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/docs_generator.rb
@@ -33,7 +33,7 @@ module Fastlane
       output << "<td width=\"33%\"><code>sudo gem install fastlane -NV</code></td>"
       output << "</tr>"
       output << "</table>"
-
+      output << ""
       output << "# Available Actions"
 
       all_keys = ff.runner.lanes.keys.reject(&:nil?)


### PR DESCRIPTION
### Description

Since it is broken with GitHub markdown viewer like following screenshot.

![screen shot 2017-04-11 at 14 11 08](https://cloud.githubusercontent.com/assets/2619092/24893786/e1d608fe-1ec0-11e7-8351-0b8a9e31d73a.png)
