### PR TITLE
Fix logarchive collection on Xcode 8.3

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -250,20 +250,12 @@ module FastlaneCore
       end
 
       def copy_logarchive(device, log_identity, logs_destination_dir)
-        sim_resource_dir = FastlaneCore::CommandExecutor.execute(command: "xcrun simctl getenv #{device.udid} SIMULATOR_SHARED_RESOURCES_DIRECTORY 2>/dev/null", print_all: false, print_command: true)
-        logarchive_src = File.join(sim_resource_dir, "system_logs.logarchive")
-        logarchive_dst = File.join(logs_destination_dir, "system_logs-#{log_identity}.logarchive")
+        require 'shellwords'
 
-        # if logarchive already exists it fails as the .logarchive is a directory, so delete it. to be sure its gone
-        FileUtils.rm_rf(logarchive_src)
+        logarchive_dst = Shellwords.escape(File.join(logs_destination_dir, "system_logs-#{log_identity}.logarchive"))
         FileUtils.rm_rf(logarchive_dst)
-
-        command = "xcrun simctl spawn #{device.udid} log collect 2>/dev/null"
+        command = "xcrun simctl spawn #{device.udid} log collect --output #{logarchive_dst} 2>/dev/null"
         FastlaneCore::CommandExecutor.execute(command: command, print_all: false, print_command: true)
-
-        FileUtils.mkdir_p(logarchive_dst)
-        FileUtils.cp_r("#{logarchive_src}/.", logarchive_dst)
-        UI.success "Copying file '#{logarchive_src}' to '#{logarchive_dst}'..."
       end
     end
   end

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -218,28 +218,14 @@ describe Scan do
             devices: ["iPhone 6s", "iPad Air"],
             project: './scan/examples/standard/app.xcodeproj'
           })
-          expect(FileUtils).to receive(:cp_r).with(/.*/, /system_logs-iPhone 6s_iOS_10.0.logarchive/)
-          expect(FileUtils).to receive(:cp_r).with(/.*/, /system_logs-iPad Air_iOS_10.0.logarchive/)
 
           expect(FastlaneCore::CommandExecutor).
             to receive(:execute).
-            with(command: "xcrun simctl getenv 021A465B-A294-4D9E-AD07-6BDC8E186343 SIMULATOR_SHARED_RESOURCES_DIRECTORY 2>/dev/null", print_all: false, print_command: true).
-            and_return("/tmp/folder")
+            with(command: "xcrun simctl spawn 021A465B-A294-4D9E-AD07-6BDC8E186343 log collect --output /tmp/scan_results/system_logs-iPhone\ 6s_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
 
           expect(FastlaneCore::CommandExecutor).
             to receive(:execute).
-            with(command: "xcrun simctl spawn 021A465B-A294-4D9E-AD07-6BDC8E186343 log collect 2>/dev/null", print_all: false, print_command: true).
-            and_return("/tmp/folder")
-
-          expect(FastlaneCore::CommandExecutor).
-            to receive(:execute).
-            with(command: "xcrun simctl getenv 2ABEAF08-E480-4617-894F-6BAB587E7963 SIMULATOR_SHARED_RESOURCES_DIRECTORY 2>/dev/null", print_all: false, print_command: true).
-            and_return("/tmp/folder")
-
-          expect(FastlaneCore::CommandExecutor).
-            to receive(:execute).
-            with(command: "xcrun simctl spawn 2ABEAF08-E480-4617-894F-6BAB587E7963 log collect 2>/dev/null", print_all: false, print_command: true).
-            and_return("/tmp/folder")
+            with(command: "xcrun simctl spawn 2ABEAF08-E480-4617-894F-6BAB587E7963 log collect --output /tmp/scan_results/system_logs-iPad\ Air_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
 
           mock_slack_poster = Object.new
           allow(Scan::SlackPoster).to receive(:new).and_return(mock_slack_poster)

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -221,11 +221,11 @@ describe Scan do
 
           expect(FastlaneCore::CommandExecutor).
             to receive(:execute).
-            with(command: "xcrun simctl spawn 021A465B-A294-4D9E-AD07-6BDC8E186343 log collect --output /tmp/scan_results/system_logs-iPhone\ 6s_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
+            with(command: "xcrun simctl spawn 021A465B-A294-4D9E-AD07-6BDC8E186343 log collect --output /tmp/scan_results/system_logs-iPhone\\ 6s_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
 
           expect(FastlaneCore::CommandExecutor).
             to receive(:execute).
-            with(command: "xcrun simctl spawn 2ABEAF08-E480-4617-894F-6BAB587E7963 log collect --output /tmp/scan_results/system_logs-iPad\ Air_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
+            with(command: "xcrun simctl spawn 2ABEAF08-E480-4617-894F-6BAB587E7963 log collect --output /tmp/scan_results/system_logs-iPad\\ Air_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
 
           mock_slack_poster = Object.new
           allow(Scan::SlackPoster).to receive(:new).and_return(mock_slack_poster)

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -47,16 +47,6 @@ describe Snapshot do
       it 'copies all device log archives to the output directory on macOS 10.12 (Siera)' do
         Snapshot.config = @config
 
-        expect(FileUtils).
-          to receive(:cp_r).
-          with(/.*/, %r{de-DE/system_logs-cfcd208495d565ef66e7dff9f98764da.logarchive}).
-          and_return(true)
-
-        expect(FileUtils).
-          to receive(:cp_r).
-          with(/.*/, %r{en-US/system_logs-cfcd208495d565ef66e7dff9f98764da.logarchive}).
-          and_return(true)
-
         allow(FastlaneCore::CommandExecutor).
           to receive(:execute).
           with(command: "sw_vers -productVersion", print_all: false, print_command: false).
@@ -64,23 +54,11 @@ describe Snapshot do
 
         expect(FastlaneCore::CommandExecutor).
           to receive(:execute).
-          with(command: "xcrun simctl getenv 33333 SIMULATOR_SHARED_RESOURCES_DIRECTORY 2>/dev/null", print_all: false, print_command: true).
-          and_return("/tmp/folder")
+          with(command: "xcrun simctl spawn 33333 log collect --output /tmp/scan_results/de-DE/system_logs-cfcd208495d565ef66e7dff9f98764da.logarchive 2>/dev/null", print_all: false, print_command: true)
 
         expect(FastlaneCore::CommandExecutor).
           to receive(:execute).
-          with(command: "xcrun simctl spawn 33333 log collect 2>/dev/null", print_all: false, print_command: true).
-          and_return("/tmp/folder")
-
-        expect(FastlaneCore::CommandExecutor).
-          to receive(:execute).
-          with(command: "xcrun simctl getenv 98765 SIMULATOR_SHARED_RESOURCES_DIRECTORY 2>/dev/null", print_all: false, print_command: true).
-          and_return("/tmp/folder")
-
-        expect(FastlaneCore::CommandExecutor).
-          to receive(:execute).
-          with(command: "xcrun simctl spawn 98765 log collect 2>/dev/null", print_all: false, print_command: true).
-          and_return("/tmp/folder")
+          with(command: "xcrun simctl spawn 98765 log collect --output /tmp/scan_results/en-US/system_logs-cfcd208495d565ef66e7dff9f98764da.logarchive 2>/dev/null", print_all: false, print_command: true)
 
         Snapshot::Runner.new.copy_simulator_logs("iPhone 6 (10.1)", "de-DE", nil, 0)
         Snapshot::Runner.new.copy_simulator_logs("iPhone 6s (10.1)", "en-US", nil, 0)


### PR DESCRIPTION
This changes log archive collection to specify the `--output` parameter on
`simctl spawn {id} log collect` to fix an issue where the log archive would be
written to an incorrect path when running undner Xcode 8.3

- Does this parameter exist on 8.x < 8.3? (if this PR passes, then it works at least on 8.2)

8.3 PR Failing because of this here:
- https://github.com/fastlane/fastlane/pull/8829

Example project:
- https://circleci.com/gh/DanToml/Lock.swift/tree/dani_8.3_fl