### PR TITLE
Hockey dSYM upload fix for create_update

### DIFF
--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -88,6 +88,11 @@ module Fastlane
         app_id = options.delete(:public_identifier)
 
         ipaio = Faraday::UploadIO.new(ipa, 'application/octet-stream') if ipa and File.exist?(ipa)
+        dsym = options.delete(:dsym)
+
+        if dsym
+          dsym_io = Faraday::UploadIO.new(dsym, 'application/octet-stream') if dsym and File.exist?(dsym)
+        end
 
         response = connection.get do |req|
           req.url("/api/2/apps/#{app_id}/app_versions/new")
@@ -104,6 +109,10 @@ module Fastlane
         end
 
         options[:ipa] = ipaio
+
+        if dsym
+          options[:dsym] = dsym_io
+        end
 
         connection.put do |req|
           req.url("/api/2/apps/#{app_id}/app_versions/#{app_version_id}")


### PR DESCRIPTION
Unable to send dSYM file to hockey using create_update, that is because the file is not loaded to the hockey PUT body when sending an update.

Please see ticket #8832

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Added the dsym file to the PUT body if the dsym option is available.

### Motivation and Context
Fixed the hockey action dsym upload on create_update. For some reason the dsym was not shipped with the .ipa and Hockey server was throwing an error back.
I tested my changes on the project I am working on and everything worked as expected. Also there is one more person that tried my changes and confirmed the fix :).
