### PR TITLE
Version bump to 2.27.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.26.1'.freeze
+  VERSION = '2.27.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.26.1':**

* Improve docs around env variables in credentials_manager (#8882) via Felix Krause
* Fix broken plugins link (#8718) via Aaron Brager
* Fix logarchive collection on Xcode 8.3 (#8848) via Danielle Tomlinson
* Remove ActiveSupport, Bump Xcodeproj to no longer require it (#8802) via Julian Nadeau
* Revert " Remove copyright" (#8849) via Michael Furtak
* Update the simulators snapshot uses by default (#8843) via Felix Krause
* Fix maximum width calculations for 1 column layouts (#8842) via Felix Krause
* Insert a line before h1 (#8844) via Takeru Chuganji
* Fix LoadError catching when it's not related to CommandsGenerator (#8831) via Felix Krause
* Update 'OtherAction' error message to indicate 'other_action' instead (#8840) via Lyndsey Ferguson
* Update Actions.md plugin generation to include plugins with not high usage numbers (#8835) via Felix Krause
* Remove copyright (#8437) via Andrea Falcone
* Add nice error message when crashlytics action can't find its .framework (#8807) via Felix Krause
* Set derived_data_path for slather in setup_jenkins action (#8826) via Takashi Hasegawa
* Make all tables in fastlane more responsive to the terminal width (#8830) via Helmut Januschka
* Skip legacy build API spec on Xcode 8.3 (#8828) via Felix Krause
