### PR TITLE
Correct usage of screengrab

### DIFF
--- a/screengrab/README.md
+++ b/screengrab/README.md
@@ -83,9 +83,9 @@ Ensure that the following permissions exist in your **src/debug/AndroidManifest.
 2.  To capture screenshots, add the following to your tests `Screengrab.screenshot("name_of_screenshot_here");` on the appropriate screens
 
 # Generating Screenshots with Screengrab
-- Then, before running `screengrab` you'll need a debug and test apk
+- Then, before running `fastlane screengrab` you'll need a debug and test apk
   - You can create your APKs with `./gradlew assembleDebug assembleAndroidTest`
-- Once complete run `screengrab` in your app project directory to generate screenshots
+- Once complete run `fastlane screengrab` in your app project directory to generate screenshots
     - You will be prompted to provide any required parameters which are not in your **Screengrabfile** or provided as command line arguments
 - Your screenshots will be saved to `fastlane/metadata/android` in the directory where you ran `screengrab`
 


### PR DESCRIPTION
Just `screengrab` is not found.