### PR TITLE
Add metadataRejected support to app_status

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_status.rb
+++ b/spaceship/lib/spaceship/tunes/app_status.rb
@@ -32,7 +32,7 @@ module Spaceship
       PENDING_DEVELOPER_RELEASE = "Pending Developer Release"
       PROCESSING_FOR_APP_STORE = "Processing for App Store"
       # WAITING_FOR_EXPORT_COMPLIANCE = "Waiting For Export Compliance"
-      # METADATA_REJECTED = "Metadata Rejected"
+      METADATA_REJECTED = "Metadata Rejected"
       # REMOVED_FROM_SALE = "Removed From Sale"
       # INVALID_BINARY = "Invalid Binary"
 
@@ -46,7 +46,8 @@ module Spaceship
           'developerRemovedFromSale' => DEVELOPER_REMOVED_FROM_SALE,
           'waitingForReview' => WAITING_FOR_REVIEW,
           'inReview' => IN_REVIEW,
-          'pendingDeveloperRelease' => PENDING_DEVELOPER_RELEASE
+          'pendingDeveloperRelease' => PENDING_DEVELOPER_RELEASE,
+          'metadataRejected' => METADATA_REJECTED
         }
 
         mapping.each do |k, v|

--- a/spaceship/spec/tunes/app_version_spec.rb
+++ b/spaceship/spec/tunes/app_version_spec.rb
@@ -173,6 +173,10 @@ describe Spaceship::AppVersion, all: true do
       it "parses pendingDeveloperRelease" do
         expect(Spaceship::Tunes::AppStatus.get_from_string('pendingDeveloperRelease')).to eq(Spaceship::Tunes::AppStatus::PENDING_DEVELOPER_RELEASE)
       end
+
+      it "parses metadataRejected" do
+        expect(Spaceship::Tunes::AppStatus.get_from_string('metadataRejected')).to eq(Spaceship::Tunes::AppStatus::METADATA_REJECTED)
+      end
     end
 
     describe "Screenshots" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Add `metadataRejected` support to app_status

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`Spaceship::Tunes::AppStatus` does not support `metadataRejected` right now.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

#### Testing

I recently got Metadata Rejected from Apple
I use custom lane for testing this behavior.

```diff
diff --git a/fastlane/Fastfile b/fastlane/Fastfile
index e945155b3..dd78bbaae 100644
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -320,3 +320,9 @@ lane :donate_food do
     )
   end
 end
+
+lane :spaceship_test do
+  Spaceship::Tunes.login(ENV['USERNAME'], ENV['PASSWORD'])
+  app = Spaceship::Tunes::Application.find(ENV['APP_ID'])
+  puts app.edit_version.app_status
+end
```

And also check the data with charles.

lane :spaceship_test | Charles
--- | ---
<img width="955" alt="screen shot 2017-04-19 at 2 09 59 pm" src="https://cloud.githubusercontent.com/assets/932290/25164932/ae8cd2f8-250e-11e7-9322-4d75a23dd352.png"> | <img width="828" alt="screen shot 2017-04-19 at 12 33 13 am" src="https://cloud.githubusercontent.com/assets/932290/25164959/e351561c-250e-11e7-83c6-adce5332f886.png">
