### PR TITLE
-showBuildSettings does not require to call clean

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -277,11 +277,7 @@ module FastlaneCore
     #####################################################
 
     def build_xcodebuild_showbuildsettings_command
-      # We also need to pass the workspace and scheme to this command.
-      #
-      # The 'clean' portion of this command is a workaround for an xcodebuild bug with Core Data projects.
-      # See: https://github.com/fastlane/fastlane/pull/5626
-      command = "xcodebuild clean -showBuildSettings #{xcodebuild_parameters.join(' ')}"
+      command = "xcodebuild -showBuildSettings #{xcodebuild_parameters.join(' ')}"
       command += " 2> /dev/null" if xcodebuild_suppress_stderr
       command
     end

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -299,7 +299,7 @@ describe FastlaneCore do
       it "SUPPORTED_PLATFORMS should be iphonesimulator iphoneos" do
         options = { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" }
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
-        expect(FastlaneCore::Project).to receive(:run_command).with("xcodebuild clean -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null", { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
+        expect(FastlaneCore::Project).to receive(:run_command).with("xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null", { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
         expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ x] I've updated the documentation if necessary.

### Description
In show building settings, don't call xcodebuild clean, because it's not a necessary workaround anymore. 


### Motivation and Context
This change will allow the user to do not clean the build (unless specified in the following commands). 
Previously for example event setting clean: false, will result in callling clean because of the generated  
xcodebuild clean -showBuildSettings

As stated in the comment this was a workaround for an xcodebuild bug. But this bug has being fixed in 8.3 so it's not necessary anymore. https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html
As huge benefit, I can keep using fastlane with my CI, and for example, caching pod builds, and reduce my build time significantly. 
 
This pull request also fixes https://github.com/fastlane/fastlane/issues/8099
 