### PR TITLE
showBuildSettings does not require to call clean

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -214,10 +214,10 @@ module FastlaneCore
     end
 
     # @return true if XCode version is higher than 8.3
-    def self.xcode_higher_than_8_3?
+    def self.xcode_atleast?(version)
       FastlaneCore::UI.user_error!("Unable to locate Xcode. Please make sure to have Xcode installed on your machine") if xcode_version.nil?
       v = xcode_version
-      Gem::Version.new(v) >= Gem::Version.new('8.3.0')
+      Gem::Version.new(v) >= Gem::Version.new(version)
     end
 
     # @return the full path to the iTMSTransporter executable

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -214,7 +214,7 @@ module FastlaneCore
     end
 
     # @return true if XCode version is higher than 8.3
-    def self.xcode_atleast?(version)
+    def self.xcode_at_least?(version)
       FastlaneCore::UI.user_error!("Unable to locate Xcode. Please make sure to have Xcode installed on your machine") if xcode_version.nil?
       v = xcode_version
       Gem::Version.new(v) >= Gem::Version.new(version)

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -213,6 +213,13 @@ module FastlaneCore
       keychain_path
     end
 
+    # @return true if XCode version is higher than 8.3
+    def self.xcode_higher_than_8_3?
+      FastlaneCore::UI.user_error!("Unable to locate Xcode. Please make sure to have Xcode installed on your machine") if xcode_version.nil?
+      v = xcode_version
+      Gem::Version.new(v) >= Gem::Version.new('8.3.0')
+    end
+
     # @return the full path to the iTMSTransporter executable
     def self.itms_path
       return ENV["FASTLANE_ITUNES_TRANSPORTER_PATH"] if FastlaneCore::Env.truthy?("FASTLANE_ITUNES_TRANSPORTER_PATH")

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -277,11 +277,11 @@ module FastlaneCore
     #####################################################
 
     def build_xcodebuild_showbuildsettings_command
-      # We also need to pass the workspace and scheme to this command.
-      #
-      # The 'clean' portion of this command is a workaround for an xcodebuild bug with Core Data projects.
-      # See: https://github.com/fastlane/fastlane/pull/5626
-      command = "xcodebuild clean -showBuildSettings #{xcodebuild_parameters.join(' ')}"
+      if FastlaneCore::Helper.xcode_higher_than_8_3?
+        command = "xcodebuild -showBuildSettings #{xcodebuild_parameters.join(' ')}"
+      else
+        command = "xcodebuild clean -showBuildSettings #{xcodebuild_parameters.join(' ')}"
+      end
       command += " 2> /dev/null" if xcodebuild_suppress_stderr
       command
     end

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -277,7 +277,7 @@ module FastlaneCore
     #####################################################
 
     def build_xcodebuild_showbuildsettings_command
-      if FastlaneCore::Helper.xcode_higher_than_8_3?
+      if FastlaneCore::Helper.xcode_atleast?('8.3')
         command = "xcodebuild -showBuildSettings #{xcodebuild_parameters.join(' ')}"
       else
         command = "xcodebuild clean -showBuildSettings #{xcodebuild_parameters.join(' ')}"

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -277,7 +277,12 @@ module FastlaneCore
     #####################################################
 
     def build_xcodebuild_showbuildsettings_command
-      if FastlaneCore::Helper.xcode_atleast?('8.3')
+      # We also need to pass the workspace and scheme to this command.
+      #
+      # The 'clean' portion of this command was a workaround for an xcodebuild bug with Core Data projects.
+      # This xcodebuild bug is fixed in Xcode 8.3 so 'clean' it's not necessary
+      # See: https://github.com/fastlane/fastlane/pull/5626
+      if FastlaneCore::Helper.xcode_at_least?('8.3')
         command = "xcodebuild -showBuildSettings #{xcodebuild_parameters.join(' ')}"
       else
         command = "xcodebuild clean -showBuildSettings #{xcodebuild_parameters.join(' ')}"

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -280,7 +280,7 @@ module FastlaneCore
       # We also need to pass the workspace and scheme to this command.
       #
       # The 'clean' portion of this command was a workaround for an xcodebuild bug with Core Data projects.
-      # This xcodebuild bug is fixed in Xcode 8.3 so 'clean' it's not necessary
+      # This xcodebuild bug is fixed in Xcode 8.3 so 'clean' it's not necessary anymore
       # See: https://github.com/fastlane/fastlane/pull/5626
       if FastlaneCore::Helper.xcode_at_least?('8.3')
         command = "xcodebuild -showBuildSettings #{xcodebuild_parameters.join(' ')}"

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -296,16 +296,23 @@ describe FastlaneCore do
     end
 
     describe "build_settings() can handle empty lines" do
-      it "SUPPORTED_PLATFORMS should be iphonesimulator iphoneos" do
+      it "SUPPORTED_PLATFORMS should be iphonesimulator iphoneos on XCode >= 8.3" do
         options = { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" }
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
-        if FastlaneCore::Helper.xcode_higher_than_8_3?
-          command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
-        else
-          command = "xcodebuild clean -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
-        end
+        allow(FastlaneCore::Helper).to receive(:xcode_atleast).and_return(true)
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
         expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
         expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")
+      end
+      unless FastlaneCore::Helper.xcode_atleast?('8.3')
+        it "SUPPORTED_PLATFORMS should be iphonesimulator iphoneos on XCode < 8.3" do
+          options = { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" }
+          @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
+          allow(FastlaneCore::Helper).to receive(:xcode_atleast?).and_return(false)
+          command = "xcodebuild clean -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
+          expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
+          expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")
+        end
       end
     end
 

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -296,19 +296,19 @@ describe FastlaneCore do
     end
 
     describe "build_settings() can handle empty lines" do
-      it "SUPPORTED_PLATFORMS should be iphonesimulator iphoneos on XCode >= 8.3" do
+      it "SUPPORTED_PLATFORMS should be iphonesimulator iphoneos on Xcode >= 8.3" do
         options = { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" }
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
-        expect(FastlaneCore::Helper).to receive(:xcode_atleast?).and_return(true)
+        expect(FastlaneCore::Helper).to receive(:xcode_at_least?).and_return(true)
         command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
         expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
         expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")
       end
 
-      it "SUPPORTED_PLATFORMS should be iphonesimulator iphoneos on XCode < 8.3" do
+      it "SUPPORTED_PLATFORMS should be iphonesimulator iphoneos on Xcode < 8.3" do
         options = { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" }
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
-        expect(FastlaneCore::Helper).to receive(:xcode_atleast?).and_return(false)
+        expect(FastlaneCore::Helper).to receive(:xcode_at_least?).and_return(false)
         command = "xcodebuild clean -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
         expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
         expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -299,20 +299,19 @@ describe FastlaneCore do
       it "SUPPORTED_PLATFORMS should be iphonesimulator iphoneos on XCode >= 8.3" do
         options = { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" }
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
-        allow(FastlaneCore::Helper).to receive(:xcode_atleast?).and_return(true)
+        expect(FastlaneCore::Helper).to receive(:xcode_atleast?).and_return(true)
         command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
         expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
         expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")
       end
-      unless FastlaneCore::Helper.xcode_atleast?('8.3')
-        it "SUPPORTED_PLATFORMS should be iphonesimulator iphoneos on XCode < 8.3" do
-          options = { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" }
-          @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
-          allow(FastlaneCore::Helper).to receive(:xcode_atleast?).and_return(false)
-          command = "xcodebuild clean -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
-          expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
-          expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")
-        end
+
+      it "SUPPORTED_PLATFORMS should be iphonesimulator iphoneos on XCode < 8.3" do
+        options = { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" }
+        @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
+        expect(FastlaneCore::Helper).to receive(:xcode_atleast?).and_return(false)
+        command = "xcodebuild clean -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
+        expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
+        expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")
       end
     end
 

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -299,7 +299,12 @@ describe FastlaneCore do
       it "SUPPORTED_PLATFORMS should be iphonesimulator iphoneos" do
         options = { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" }
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
-        expect(FastlaneCore::Project).to receive(:run_command).with("xcodebuild clean -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null", { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
+        if FastlaneCore::Helper.xcode_higher_than_8_3?
+          command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
+        else
+          command = "xcodebuild clean -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
+        end
+        expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
         expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")
       end
     end

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -299,7 +299,7 @@ describe FastlaneCore do
       it "SUPPORTED_PLATFORMS should be iphonesimulator iphoneos on XCode >= 8.3" do
         options = { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" }
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
-        allow(FastlaneCore::Helper).to receive(:xcode_atleast).and_return(true)
+        allow(FastlaneCore::Helper).to receive(:xcode_atleast?).and_return(true)
         command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
         expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
         expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")

--- a/gym/lib/gym/xcode.rb
+++ b/gym/lib/gym/xcode.rb
@@ -18,9 +18,7 @@ module Gym
       end
 
       def legacy_api_deprecated?
-        UI.user_error!("Unable to locate Xcode. Please make sure to have Xcode installed on your machine") if xcode_version.nil?
-        v = xcode_version
-        Gem::Version.new(v) >= Gem::Version.new('8.3.0')
+        FastlaneCore::Helper.xcode_higher_than_8_3?
       end
     end
   end

--- a/gym/lib/gym/xcode.rb
+++ b/gym/lib/gym/xcode.rb
@@ -18,7 +18,7 @@ module Gym
       end
 
       def legacy_api_deprecated?
-        FastlaneCore::Helper.xcode_higher_than_8_3?
+        FastlaneCore::Helper.xcode_atleast?('8.3')
       end
     end
   end

--- a/gym/lib/gym/xcode.rb
+++ b/gym/lib/gym/xcode.rb
@@ -18,7 +18,7 @@ module Gym
       end
 
       def legacy_api_deprecated?
-        FastlaneCore::Helper.xcode_atleast?('8.3')
+        FastlaneCore::Helper.xcode_at_least?('8.3')
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ x] I've updated the documentation if necessary.

### Description
In show building settings, don't call xcodebuild clean, because it's not a necessary workaround anymore. 


### Motivation and Context
This change will allow the user to do not clean the build (unless specified in the following commands). 
Previously for example event setting clean: false, will result in callling clean because of the generated  
xcodebuild clean -showBuildSettings

As stated in the comment this was a workaround for an xcodebuild bug. But this bug has being fixed in 8.3 so it's not necessary anymore. https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html
As huge benefit, I can keep using fastlane with my CI, and for example, caching pod builds, and reduce my build time significantly. 
 
This pull request also fixes https://github.com/fastlane/fastlane/issues/8099