### PR TITLE
Fix keyword / string correspondence table

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -503,8 +503,8 @@ module Spaceship
         {
           keywords: :keywords,
           description: :description,
-          supportURL: :support_url,
-          marketingURL: :marketing_url,
+          supportUrl: :support_url,
+          marketingUrl: :marketing_url,
           releaseNotes: :release_notes
         }.each do |json, attribute|
           instance_variable_set("@#{attribute}".to_sym, LanguageItem.new(json, languages))


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Since there was a change in the capitalize of the keyword, we modified the correspondence table between the keyword and the string accordingly.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Error occurs when downloading metadata from itunes connect with fastlane deliver.
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/fastlane/fastlane/issues/8924
https://github.com/fastlane/fastlane/issues/8922
<!--- Please describe in detail how you tested your changes. --->
Corrected the corresponding part, and downloaded metadata from itunes connect with fastlane deliver and confirmed that no error occurred.