### PR TITLE
Add regex version check

### DIFF
--- a/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
+++ b/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
@@ -8,15 +8,27 @@ module Fastlane
       def self.run(params)
         Actions.verify_gem!('xcode-install')
         required_version = params[:version]
+        match_version = params[:match]
         selected_version = sh("xcversion selected").match(/^Xcode (.*)$/)[1]
 
-        if selected_version == required_version
-          UI.success("Selected Xcode version is correct: #{selected_version}")
-        else
-          UI.message("Selected Xcode version is not correct: #{selected_version}. You expected #{required_version}.")
-          UI.message("To correct this, use: `xcode_select(version: #{required_version})`.")
+        if required_version
+          if selected_version == required_version
+            UI.success("Selected Xcode version is correct: #{selected_version}")
+          else
+            UI.message("Selected Xcode version is not correct: #{selected_version}. You expected #{required_version}.")
+            UI.message("To correct this, use: `xcode_select(version: #{required_version})`.")
 
-          UI.user_error!("Selected Xcode version doesn't match your requirement.\nExpected: Xcode #{required_version}\nActual: #{selected_version}\n")
+            UI.user_error!("Selected Xcode version doesn't match your requirement.\nExpected: Xcode #{required_version}\nActual: #{selected_version}\n")
+          end
+        elsif match_version
+          if selected_version =~ /^#{match_version}/
+            UI.success("Selected Xcode version: #{selected_version}, match: #{match_version}")
+          else
+            UI.success("Selected Xcode version: #{selected_version}, doesn't match: #{match_version}")
+            UI.user_error!("Selected Xcode version doesn't match your requirement.\nExpected: Xcode #{match_version}\nActual: #{selected_version}\n")
+          end
+        else
+          UI.user_error!("You have to either pass a 'required_version' or a 'match_version' to the action")
         end
       end
 
@@ -39,7 +51,12 @@ module Fastlane
                                        env_name: "FL_ENSURE_XCODE_VERSION",
                                        description: "Xcode version to verify that is selected",
                                        is_string: true,
-                                       optional: false)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :match,
+                                      env_name: "FL_ENSURE_XCODE_VERSION_MATCH",
+                                      description: "Regular expression matching selected Xcode version",
+                                      is_string: true,
+                                      optional: true)
         ]
       end
 
@@ -57,7 +74,10 @@ module Fastlane
       end
 
       def self.example_code
-        ['ensure_xcode_version(version: "7.2")']
+        [
+          'ensure_xcode_version(version: "7.2")',
+          'ensure_xcode_version(match: "8")'
+        ]
       end
 
       def self.category


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Added a more convenient method to check the Xcode version & ability to check the major version of Xcode

### Motivation and Context
Frequent Xcode update requires Fastfile update to change the required Xcode version
We just want to check the major version of Xcode (8, or 8.3.x)