### PR TITLE
Fix snapshot creating file path url for simulatorHostHome

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -141,11 +141,11 @@ open class Snapshot: NSObject {
                 print("Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable.")
                 return nil
             }
-            guard let homeDirUrl = URL(string: simulatorHostHome) else {
+            guard FileManager.default.fileExists(atPath: simulatorHostHome) else {
                 print("Can't prepare environment. Simulator home location is inaccessible. Does \(simulatorHostHome) exist?")
                 return nil
             }
-            homeDir = homeDirUrl
+            homeDir = URL(fileURLWithPath: simulatorHostHome)
         #endif
         return homeDir.appendingPathComponent("Library/Caches/tools.fastlane")
     }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
The issue is that `URL(string: simulatorHostHome)` will only generate for example `/users/myuser`. It is therefor  missing `file://` that it is getting from `URL(fileURLWithPath: simulatorHostHome)`.

If you add `URL(string: "file://\(simulatorHostHome)")` it will work as expected. But I will recommend to use `URL(fileURLWithPath: simulatorHostHome)`. That way we don't need to handle the `file://` our self.

I have added a small test to check if the `simulatorHostHome` actually exists. Since there was added a check for this in the previous commit.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Fixes issue described in #8895 