### PR TITLE
Check for default external group and support :groups option

### DIFF
--- a/pilot/lib/pilot/commands_generator.rb
+++ b/pilot/lib/pilot/commands_generator.rb
@@ -29,9 +29,9 @@ module Pilot
         begin
           mgr.public_send(action, config)
         rescue => ex
-          message = "[#{address}]: #{ex}"
+          # no need to show the email address in the message if only one specified
+          message = (args.count > 1) ? "[#{address}]: #{ex}" : ex
           failures << message
-          UI.error(message)
         end
       end
       UI.user_error!("Some operations failed: #{failures.join(', ')}") unless failures.empty?

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -51,7 +51,7 @@ module Pilot
 
       return if config[:groups].nil?
 
-      groups = TestFlight::Group.filter_groups(app_id: uploaded_build.app_id) do |group|
+      groups = Spaceship::TestFlight::Group.filter_groups(app_id: app.apple_id) do |group|
         config[:groups].include?(group.name)
       end
 

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -17,7 +17,7 @@ module Pilot
           tester = Spaceship::Tunes::Tester::External.create!(email: config[:email],
                                                               first_name: config[:first_name],
                                                               last_name: config[:last_name])
-          UI.success("Successfully invited tester: #{tester.email}")
+          UI.success("Successfully added tester: #{tester.email} to your account")
         end
 
         app_filter = (config[:apple_id] || config[:app_identifier])

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -19,24 +19,24 @@ module Pilot
                                                               last_name: config[:last_name])
           UI.success("Successfully added tester: #{tester.email} to your account")
         end
-
-        app_filter = (config[:apple_id] || config[:app_identifier])
-        if app_filter
-          begin
-            app = Spaceship::Application.find(app_filter)
-            UI.user_error!("Couldn't find app with '#{app_filter}'") unless app
-
-            add_tester_to_groups(tester: tester, app: app, groups: config[:groups])
-
-            UI.success("Successfully added tester to app #{app_filter}")
-          rescue => ex
-            UI.error("Could not add #{tester.email} to app: #{ex}")
-            raise ex
-          end
-        end
       rescue => ex
         UI.error("Could not create tester #{config[:email]}")
         raise ex
+      end
+
+      app_filter = (config[:apple_id] || config[:app_identifier])
+      if app_filter
+        begin
+          app = Spaceship::Application.find(app_filter)
+          UI.user_error!("Couldn't find app with '#{app_filter}'") unless app
+
+          add_tester_to_groups(tester: tester, app: app, groups: config[:groups])
+
+          UI.success("Successfully added tester to app #{app_filter}")
+        rescue => ex
+          UI.error("Could not add #{tester.email} to app: #{app.name}")
+          raise ex
+        end
       end
     end
 

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -43,8 +43,8 @@ module Pilot
     def add_tester_to_groups(tester: nil, app: nil)
       default_external_group = app.default_external_group
       if default_external_group.nil? && config[:groups].nil?
-        UI.error("The app #{app.name} does not have a default external group.")
-        UI.error("Please make sure to pass group names to the `:groups` option.")
+        UI.user_error!("The app #{app.name} does not have a default external group.")
+        UI.user_error!("Please make sure to pass group names to the `:groups` option.")
         return
       end
 

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -107,6 +107,8 @@ module Pilot
         groups.include?(group.name)
       end
 
+      UI.user_error!("There are no groups available matching the names passed to the `:groups` option.") if test_flight_groups.empty?
+
       test_flight_groups.each do |group|
         group.add_tester!(tester)
       end

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -47,7 +47,7 @@ module Pilot
         return
       end
 
-      default_external_group.add_tester!(tester)
+      default_external_group.add_tester!(tester) unless default_external_group.nil?
 
       return if config[:groups].nil?
 

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -43,8 +43,7 @@ module Pilot
     def add_tester_to_groups(tester: nil, app: nil)
       default_external_group = app.default_external_group
       if default_external_group.nil? && config[:groups].nil?
-        UI.user_error!("The app #{app.name} does not have a default external group.")
-        UI.user_error!("Please make sure to pass group names to the `:groups` option.")
+        UI.user_error!("The app #{app.name} does not have a default external group. Please make sure to pass group names to the `:groups` option.")
         return
       end
 


### PR DESCRIPTION
Add support for the `:groups` option in pilot when adding testers. Also this checks to see if there is a group marked as `isDefaultExternalGroup` from the iTC API to add to that if available.