### PR TITLE
Fix deliver preview layout

### DIFF
--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -107,6 +107,9 @@
               margin-left: 10px;
               margin-right: 10px;
           }
+          .app-icons {
+            overflow: hidden;
+          }
           .app-icons img {
             width: 150px;
           }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Fix deliver preview layout when there is no watch_icon.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

Preview.html layout is broken when there is only one app_icon without apple_watch_app_icon.

### Without apple_watch_app_icon

The layout is fixed.

without this patch | with this patch
--- | ---
![image](https://cloud.githubusercontent.com/assets/932290/25259871/9a7d58ac-2683-11e7-80d4-253cf5428c46.png) | ![image](https://cloud.githubusercontent.com/assets/932290/25259879/a5fb5cc4-2683-11e7-9059-188267fef9ff.png)

### With apple_watch_app_icon

It looks same.

without this patch | with this patch
--- | ---
![image](https://cloud.githubusercontent.com/assets/932290/25259935/0b7aa0d2-2684-11e7-9454-02b660de2a77.png) | ![image](https://cloud.githubusercontent.com/assets/932290/25259892/c04e82ea-2683-11e7-9688-1f97458f646f.png)
