### PR TITLE
Fix string handling in print_table wrapping

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 Style/PercentLiteralDelimiters:
   Enabled: false
-  
+
 # kind_of? is a good way to check a type
 Style/ClassCheck:
   EnforcedStyle: kind_of?
@@ -16,6 +16,12 @@ Style/SafeNavigation:
 Performance/RegexpMatch:
   Enabled: false
 
+# This suggests use of `tr` instead of `gsub`. While this might be more performant,
+# these methods are not at all interchangable, and behave very differently. This can
+# lead to people making the substitution without considering the differences.
+Performance/StringReplacement:
+  Enabled: false
+
 # .length == 0 is also good, we don't always want .zero?
 Style/NumericPredicate:
   Enabled: false
@@ -23,7 +29,7 @@ Style/NumericPredicate:
 # this would cause errors with long lanes
 Metrics/BlockLength:
   Enabled: false
-  
+
 # this is a bit buggy
 Metrics/ModuleLength:
   Enabled: false
@@ -36,23 +42,23 @@ Style/VariableNumber:
 Style/MethodMissing:
   Enabled: false
 
-# 
+#
 #   File.chmod(0777, f)
-# 
+#
 # is easier to read than
-# 
+#
 #   File.chmod(0o777, f)
-# 
+#
 Style/NumericLiteralPrefix:
   Enabled: false
 
-# 
+#
 # command = (!clean_expired.nil? || !clean_pattern.nil?) ? CLEANUP : LIST
-# 
+#
 # is easier to read than
-# 
+#
 # command = !clean_expired.nil? || !clean_pattern.nil? ? CLEANUP : LIST
-# 
+#
 Style/TernaryParentheses:
   Enabled: false
 

--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -44,7 +44,7 @@ module FastlaneCore
         value = ""
         array.each do  |l|
           colored_line = l
-          colored_line = "#{colors.first[0]}#{l}#{colors.last[0]}" if colors.length > 0
+          colored_line = "#{colors.first}#{l}#{colors.last}" if colors.length > 0
           value << colored_line
           value << "\n"
         end
@@ -68,15 +68,10 @@ module FastlaneCore
           return value.middle_truncate(max_value_length)
         elsif transform == :newline
           # remove all fixed newlines as it may mess up the output
-          value.tr!("\n", " ") if value.kind_of?(String)
+          value.gsub!("\n", " ") if value.kind_of?(String)
           if value.length >= max_value_length
-            colors = value.scan(/(\e\[.*?m)/)
-            if colors && colors.length > 0
-              colors.each do |color|
-                value.delete!(color.first)
-                value.delete!(color.last)
-              end
-            end
+            colors = value.scan(/\e\[.*?m/)
+            colors.each { |color| value.gsub!(color, '') }
             lines = value.wordwrap(max_value_length)
             return  colorize_array(lines, colors)
           end


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Description

The fix replaces use of some string manipulation methods that have surprising behavior, with use of ones that are easier to use and understand. It also simplifies the data a little by removing nested arrays.

The main problem is that `delete!` does not act like a simple string replacement. It actually acts by remove all characters found in the input string from the target. This behavior can be seen by examining some of the code in question

```
irb(main):003:0> require 'colored'
=> true
irb(main):004:0> value = 'team_name'.yellow
=> "\e[33mteam_name\e[0m"
irb(main):005:0> value.scan(/(\e\[.*?m)/)
=> [["\e[33m"], ["\e[0m"]]
irb(main):006:0> colors = value.scan(/(\e\[.*?m)/)
=> [["\e[33m"], ["\e[0m"]]
irb(main):007:0> if colors && colors.length > 0
irb(main):008:1>   colors.each do |color|
irb(main):009:2*     value.delete!(color.first)
irb(main):010:2>     value.delete!(color.last)
irb(main):011:2>   end
irb(main):012:1> end
=> [["\e[33m"], ["\e[0m"]]
irb(main):013:0> value
=> "tea_nae"
```

Another simplification I've made is a small change to the usage of `scan`. As written, this returns an array of arrays, this makes later handling a little trickier.

```
irb(main):029:0> value = 'team_name'.yellow
=> "\e[33mteam_name\e[0m"
irb(main):030:0> colors = value.scan(/(\e\[.*?m)/)
=> [["\e[33m"], ["\e[0m"]]
```

According to the documentation, if we omit the capture group from the regex, then we won't get the array of arrays, instead getting a flat array of strings.

```
irb(main):039:0> value = 'team_name'.yellow
=> "\e[33mteam_name\e[0m"
irb(main):040:0> colors = value.scan(/\e\[.*?m/)
=> ["\e[33m", "\e[0m"]
```

I've also disabled a RuboCop check that I think gives advice that could easily lead to a bad decision.

### Motivation and Context

This fixes #8947 

The current implementation is causing 'm' chars to get dropped from the table values whenever newline wrapping occurs.