### PR TITLE
Version bump to 2.28.3

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.28.2'.freeze
+  VERSION = '2.28.3'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.28.2':**

* Reject internal testers (#8959) via Mark Pirri
* Removing testers from multiple groups (#8957) via Mark Pirri
* showBuildSettings does not require to call clean on Xcode >= 8.3 (#8921) via punty
* Check for default external group and support :groups option (#8943) via David Ohayon
* Fix string handling in print_table wrapping (#8951) via Michael Furtak
* Put motivation and context above description (#8953) via Michael Furtak
* Fix deliver preview layout (#8945) via Fumiya Nakamura
* Add skip_package_ipa option to Gym Sometimes you don’t want an ipa but rather, just the xcarchive. via taquitos
