### PR TITLE
Align messages telling people to search the issues

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/github_issue_inspector_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/ui/github_issue_inspector_reporter.rb
@@ -45,8 +45,8 @@ module Fastlane
       status = (resolved ? issue.state.green : issue.state.red)
 
       puts "➡️  #{issue.title.yellow}"
-      puts "   #{issue.html_url} [#{status}] #{issue.comments} 💬"
-      puts "   #{Time.parse(issue.updated_at).to_pretty}"
+      puts "    #{issue.html_url} [#{status}] #{issue.comments} 💬"
+      puts "    #{Time.parse(issue.updated_at).to_pretty}"
       puts ""
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [N/A] I've updated the documentation if necessary.

### Motivation and Context

I saw this [in our CI](https://circleci.com/gh/artsy/eigen/4080),

<img width="758" alt="screen shot 2017-04-22 at 16 36 10" src="https://cloud.githubusercontent.com/assets/49038/25308091/618da562-277b-11e7-8ffb-ea92301ebd26.png">

I felt I could improve the situation.

### Description

I'm not _actually_ sure that this will align them perfectly. As emoji may not fit into 2 fixed-width boxes, but it would be closer to aligning. 