### PR TITLE
Pilot: Add missing Spaceship::TestFlight to filter_groups call

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -124,7 +124,7 @@ module Pilot
       end
 
       if options[:groups]
-        groups = Group.filter_groups(app_id: uploaded_build.app_id) do |group|
+        groups = Spaceship::TestFlight::Group.filter_groups(app_id: uploaded_build.app_id) do |group|
           options[:groups].include?(group.name)
         end
         groups.each do |group|


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This resolves https://github.com/fastlane/fastlane/issues/8964

I originally experienced this issue myself, and verified that this corrects the issue by successfully distributing external builds with Pilot.

```bash
[23:14:30]: Waiting for iTunes Connect to finish processing the new build (8.19.0 - 8.19.0.47)
[23:14:32]: Successfully finished processing the build 8.19.0 - 8.19.0.47
[23:14:35]: Successfully set the changelog and/or description for build
[23:14:35]: Distributing new build to testers: 8.19.0 - 8.19.0.47
[23:14:58]: Successfully distributed build to External testers 🚀
```

### Description
I fixed what appeared to be a typo by adding `Spaceship::TestFlight::` to the `Groups.filter_groups` call. I mirrored what was already in `tester_manager.rb` https://github.com/fastlane/fastlane/blob/1751e1eb00c202e0795a7f504322f9b55b0f12ec/pilot/lib/pilot/tester_manager.rb#L108