### PR TITLE
Make build watcher stop watching on compliance-required

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -25,7 +25,7 @@ module FastlaneCore
         elsif matching_build.active?
           UI.success("Build #{matching_build.train_version} - #{matching_build.build_version} is already being tested")
           return matching_build
-        elsif matching_build.ready_to_submit?
+        elsif matching_build.ready_to_submit? || matching_build.export_compliance_missing?
           UI.success("Successfully finished processing the build #{matching_build.train_version} - #{matching_build.build_version}")
           return matching_build
         end

--- a/spaceship/lib/spaceship/test_flight/build.rb
+++ b/spaceship/lib/spaceship/test_flight/build.rb
@@ -121,6 +121,10 @@ module Spaceship::TestFlight
       external_state == BUILD_STATES[:processing]
     end
 
+    def export_compliance_missing?
+      external_state == BUILD_STATES[:export_compliance_missing]
+    end
+
     # Getting builds from BuildTrains only gets a partial Build object
     # We are then requesting the full build from iTC when we need to access
     # any of the variables below, because they are not inlcuded in the partial Build objects


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
The build watcher currently only stops watching when the build becomes `ready`. However, if the build requires compliance information to be set, it doesn't go right to `ready` and instead enters the `export_compliance_missing` state. We will set export compliance as part of making the build available, so we just need to make the build watcher stop waiting when the build reaches `export_compliance_missing`.