### PR TITLE
Directory ordering of default values for .ipa and . pkg files

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -37,7 +37,7 @@ module Deliver
                                      optional: true,
                                      env_name: "DELIVER_IPA_PATH",
                                      description: "Path to your ipa file",
-                                     default_value: Dir["*.ipa"].first,
+                                     default_value: Dir["*.ipa"].sort_by { |x| File.mtime(x) }.last,
                                      verify_block: proc do |value|
                                        UI.user_error!("Could not find ipa file at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                        UI.user_error!("'#{value}' doesn't seem to be an ipa file") unless value.end_with?(".ipa")
@@ -51,7 +51,7 @@ module Deliver
                                      optional: true,
                                      env_name: "DELIVER_PKG_PATH",
                                      description: "Path to your pkg file",
-                                     default_value: Dir["*.pkg"].first,
+                                     default_value: Dir["*.ipa"].sort_by { |x| File.mtime(x) }.last,
                                      verify_block: proc do |value|
                                        UI.user_error!("Could not find pkg file at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                        UI.user_error!("'#{value}' doesn't seem to be a pkg file") unless value.end_with?(".pkg")

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -51,7 +51,7 @@ module Deliver
                                      optional: true,
                                      env_name: "DELIVER_PKG_PATH",
                                      description: "Path to your pkg file",
-                                     default_value: Dir["*.ipa"].sort_by { |x| File.mtime(x) }.last,
+                                     default_value: Dir["*.pkg"].sort_by { |x| File.mtime(x) }.last,
                                      verify_block: proc do |value|
                                        UI.user_error!("Could not find pkg file at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                        UI.user_error!("'#{value}' doesn't seem to be a pkg file") unless value.end_with?(".pkg")

--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -65,7 +65,7 @@ module Fastlane
         platform = Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
 
         if platform == :ios or platform.nil?
-          ipa_path_default = Dir["*.ipa"].last
+          ipa_path_default = Dir["*.ipa"].sort_by { |x| File.mtime(x) }.last
         end
 
         if platform == :android

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -32,7 +32,7 @@ module Pilot
                                      optional: true,
                                      env_name: "PILOT_IPA",
                                      description: "Path to the ipa file to upload",
-                                     default_value: Dir["*.ipa"].first,
+                                     default_value: Dir["*.ipa"].sort_by { |x| File.mtime(x) }.last,
                                      verify_block: proc do |value|
                                        UI.user_error!("Could not find ipa file at path '#{value}'") unless File.exist? value
                                        UI.user_error!("'#{value}' doesn't seem to be an ipa file") unless value.end_with? ".ipa"


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines]
- [x] I've updated the documentation if necessary.

### Motivation and Context
When a project has multiple targets, an error could occur when there are .ipa files present for different targets having different bundle ids. The Ruby DIR command in some fastlane command default settings might not select the last .ipa file created. for example, when this occurred with pilot, it would result with the wrong .ipa file being uploaded to ITC, which would fail with an error stating that the bundle id changed. The same was noted for the .pkg option for deliver.

### Description
Replaced the default DIR ordering that was not guaranteed with a time ordered sort, which plucks the most recent ipa or pkg file for the default value. 