### PR TITLE
Don't submit non-externally distributed builds for review

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -110,10 +110,10 @@ module Pilot
 
       # This is where we could add a check to see if encryption is required and has been updated
       uploaded_build.export_compliance.encryption_updated = false
-      uploaded_build.beta_review_info.demo_account_required = false
-      uploaded_build.submit_for_testflight_review!
 
       if options[:distribute_external]
+        uploaded_build.beta_review_info.demo_account_required = false
+        uploaded_build.submit_for_testflight_review!
         external_group = Spaceship::TestFlight::Group.default_external_group(app_id: uploaded_build.app_id)
         uploaded_build.add_group!(external_group) unless external_group.nil?
 
@@ -121,14 +121,18 @@ module Pilot
           UI.user_error!("You must specify at least one group using the `:groups` option to distribute externally")
         end
 
-      end
-
-      if options[:groups]
-        groups = Spaceship::TestFlight::Group.filter_groups(app_id: uploaded_build.app_id) do |group|
-          options[:groups].include?(group.name)
+        if options[:groups]
+          groups = Spaceship::TestFlight::Group.filter_groups(app_id: uploaded_build.app_id) do |group|
+            options[:groups].include?(group.name)
+          end
+          groups.each do |group|
+            uploaded_build.add_group!(group)
+          end
         end
-        groups.each do |group|
-          uploaded_build.add_group!(group)
+      else # distribute internally
+        # in case any changes to export_compliance are required
+        if uploaded_build.export_compliance_missing?
+          uploaded_build.save!
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->

Currently `pilot` is submitting all builds for review. Changed to only submit externally distributed (i.e., build where `distribute_external = true`) for review.  For non-external builds, we will save the build info if export compliance needs to be updated.