### PR TITLE
Moves add_tester_to_groups and remove_tester_from_groups to Spaceship::TestFlight::Group

### DIFF
--- a/spaceship/lib/spaceship/test_flight/group.rb
+++ b/spaceship/lib/spaceship/test_flight/group.rb
@@ -48,15 +48,31 @@ module Spaceship::TestFlight
     # This will enable testing for the tester for a given app, as just creating the tester on an account-level
     # is not enough to add the tester to a group. If this isn't done the next request would fail.
     # This is a bug we reported to the iTunes Connect team, as it also happens on the iTunes Connect UI on 18. April 2017
-    def add_tester!(tester)
+    def self.add_tester!(tester)
       # This post request makes the account-level tester available to the app
       tester_data = client.post_tester(app_id: self.app_id, tester: tester)
       # This put request adds the tester to the group
       client.put_tester_to_group(group_id: self.id, tester_id: tester_data['id'], app_id: self.app_id)
     end
 
-    def remove_tester!(tester)
+    def self.remove_tester!(tester)
       client.delete_tester_from_group(group_id: self.id, tester_id: tester.tester_id, app_id: self.app_id)
+    end
+
+    def add_tester_to_groups!(tester: nil, app: nil, groups: nil)
+      if tester.kind_of?(Spaceship::Tunes::Tester::Internal)
+        self.internal_group(app_id: app.apple_id).add_tester!(tester)
+      else
+        self.perform_for_groups_in_app(app: app, groups: groups) { |group| group.add_tester!(tester) }
+      end
+    end
+
+    def remove_tester_from_groups!(tester: nil, app: nil, groups: nil)
+      if tester.kind_of?(Spaceship::Tunes::Tester::Internal)
+        self.internal_group(app_id: app.apple_id).remove_tester!(tester)
+      else
+        self.perform_for_groups_in_app(app: app, groups: groups) { |group| group.remove_tester!(tester) }
+      end
     end
 
     def default_external_group?
@@ -65,6 +81,28 @@ module Spaceship::TestFlight
 
     def internal_group?
       is_internal_group
+    end
+
+    class << self
+      private
+
+      def perform_for_groups_in_app(app: nil, groups: nil, &block)
+        if groups.nil?
+          default_external_group = app.default_external_group
+          if default_external_group.nil?
+            UI.user_error!("The app #{app.name} does not have a default external group. Please make sure to pass group names to the `:groups` option.")
+          end
+          test_flight_groups = [default_external_group]
+        else
+          test_flight_groups = self.filter_groups(app_id: app.apple_id) do |group|
+            groups.include?(group.name)
+          end
+
+          UI.user_error!("There are no groups available matching the names passed to the `:groups` option.") if test_flight_groups.empty?
+        end
+
+        test_flight_groups.each(&block)
+      end
     end
   end
 end


### PR DESCRIPTION
So that it can be reused in fastlane/boarding project

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Adding testers to app groups is shared with boarding, so instead of duplicating logic, I moved it into Spaceship's Application class
