### PR TITLE
Add rejected support to app_status

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_status.rb
+++ b/spaceship/lib/spaceship/tunes/app_status.rb
@@ -46,6 +46,7 @@ module Spaceship
           'developerRemovedFromSale' => DEVELOPER_REMOVED_FROM_SALE,
           'waitingForReview' => WAITING_FOR_REVIEW,
           'inReview' => IN_REVIEW,
+          'rejected' => REJECTED,
           'pendingDeveloperRelease' => PENDING_DEVELOPER_RELEASE,
           'metadataRejected' => METADATA_REJECTED
         }

--- a/spaceship/spec/tunes/app_version_spec.rb
+++ b/spaceship/spec/tunes/app_version_spec.rb
@@ -170,6 +170,10 @@ describe Spaceship::AppVersion, all: true do
         expect(Spaceship::Tunes::AppStatus.get_from_string('prepareForUpload')).to eq(Spaceship::Tunes::AppStatus::PREPARE_FOR_SUBMISSION)
       end
 
+      it "parses rejected" do
+        expect(Spaceship::Tunes::AppStatus.get_from_string('rejected')).to eq(Spaceship::Tunes::AppStatus::REJECTED)
+      end
+
       it "parses pendingDeveloperRelease" do
         expect(Spaceship::Tunes::AppStatus.get_from_string('pendingDeveloperRelease')).to eq(Spaceship::Tunes::AppStatus::PENDING_DEVELOPER_RELEASE)
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Add `rejected` support to app_status

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`Spaceship::Tunes::AppStatus` does not support `rejected` right now.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

#### Testing

I recently Rejected from Apple.
I use custom lane for testing this behavior.

```diff
diff --git a/fastlane/Fastfile b/fastlane/Fastfile
index e945155b3..dd78bbaae 100644
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -320,3 +320,9 @@ lane :donate_food do
     )
   end
 end
+
+lane :spaceship_test do
+  Spaceship::Tunes.login(ENV['USERNAME'], ENV['PASSWORD'])
+  app = Spaceship::Tunes::Application.find(ENV['APP_ID'])
+  puts app.edit_version.app_status
+end
```

And also check the data with charles.

lane :spaceship_test | Charles
--- | ---
<img width="828" src="https://cloud.githubusercontent.com/assets/932290/25397502/6c999ad8-2a23-11e7-95bd-2b8419e73122.png"> | <img width="806" alt="screen shot 2017-04-19 at 12 21 33 am" src="https://cloud.githubusercontent.com/assets/932290/25397542/8e82f11c-2a23-11e7-9f46-7e45c658e2e7.png">
