### PR TITLE
Version bump to 2.28.4

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.28.3'.freeze
+  VERSION = '2.28.4'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.28.3':**

* Deprecate update_build_info_on_upload as it is not supported by new iTC/TF (#8994) via Mark Pirri
* Don't submit non-externally distributed builds for review (#8984) via Mark Pirri
* Remove testers from apps when no groups are specified (#8983) via David Ohayon
* Make build watcher stop watching on compliance-required (#8980) via Mark Pirri
* Direct users of pilot to open issues on github. (#8966) via Mark Pirri
* Pilot: Add missing Spaceship::TestFlight to filter_groups call (#8974) via Erik Kerber
* Align messages telling people to search the issues (#8968) via Orta
* Returns a fileURL with the existing path rather then returning the original URL, which lacks a scheme. (#8791) via Isaac Schmidt
* support required named parameter checking for Ruby 2.0 (#8963) via Stefan Natchev
