### PR TITLE
Fix `pilot distribute`

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -37,10 +37,10 @@ module Pilot
       UI.message("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
       latest_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: app.apple_id, platform: platform)
 
-      distribute(options, latest_build)
+      distribute(options, build: latest_build)
     end
 
-    def distribute(options, build = nil)
+    def distribute(options, build: nil)
       start(options)
       if config[:apple_id].to_s.length == 0 and config[:app_identifier].to_s.length == 0
         config[:app_identifier] = UI.input("App Identifier: ")

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -40,10 +40,15 @@ module Pilot
       distribute(options, latest_build)
     end
 
-    def distribute(options, build)
+    def distribute(options, build = nil)
       start(options)
       if config[:apple_id].to_s.length == 0 and config[:app_identifier].to_s.length == 0
         config[:app_identifier] = UI.input("App Identifier: ")
+      end
+
+      build ||= Spaceship::TestFlight::Build.latest(app_id: app.apple_id, platform: fetch_app_platform)
+      if build.nil?
+        UI.user_error!("No build to distribute!")
       end
 
       if should_update_build_information(options)

--- a/spaceship/lib/spaceship/test_flight/build.rb
+++ b/spaceship/lib/spaceship/test_flight/build.rb
@@ -67,7 +67,8 @@ module Spaceship::TestFlight
     BUILD_STATES = {
       processing: 'testflight.build.state.processing',
       active: 'testflight.build.state.testing.active',
-      ready: 'testflight.build.state.testing.ready',
+      ready_to_submit: 'testflight.build.state.submit.ready',
+      ready_to_test: 'testflight.build.state.testing.ready',
       export_compliance_missing: 'testflight.build.state.export.compliance.missing'
     }
 
@@ -110,7 +111,11 @@ module Spaceship::TestFlight
     end
 
     def ready_to_submit?
-      external_state == BUILD_STATES[:ready]
+      external_state == BUILD_STATES[:ready_to_submit]
+    end
+
+    def ready_to_test?
+      external_state == BUILD_STATES[:ready_to_test]
     end
 
     def active?
@@ -166,7 +171,7 @@ module Spaceship::TestFlight
     end
 
     def submit_for_testflight_review!
-      return if ready_to_submit?
+      return if ready_to_test?
       client.post_for_testflight_review(app_id: app_id, build_id: id, build: self)
     end
 

--- a/spaceship/lib/spaceship/test_flight/build.rb
+++ b/spaceship/lib/spaceship/test_flight/build.rb
@@ -67,7 +67,7 @@ module Spaceship::TestFlight
     BUILD_STATES = {
       processing: 'testflight.build.state.processing',
       active: 'testflight.build.state.testing.active',
-      ready: 'testflight.build.state.submit.ready',
+      ready: 'testflight.build.state.testing.ready',
       export_compliance_missing: 'testflight.build.state.export.compliance.missing'
     }
 
@@ -166,6 +166,7 @@ module Spaceship::TestFlight
     end
 
     def submit_for_testflight_review!
+      return if ready_to_submit?
       client.post_for_testflight_review(app_id: app_id, build_id: id, build: self)
     end
 


### PR DESCRIPTION
This makes `fastlane pilot distribute --distribute_external` work again on my app.

```
ArgumentError: [!] wrong number of arguments (given 1, expected 2)
gems/ruby/2.3.0/gems/fastlane-2.28.5/pilot/lib/pilot/build_manager.rb:43:in `distribute'
gems/ruby/2.3.0/gems/fastlane-2.28.5/pilot/lib/pilot/commands_generator.rb:72:in `block (2 levels) in run'
gems/ruby/2.3.0/gems/commander-fastlane-4.4.4/lib/commander/command.rb:178:in `call'
```