### PR TITLE
Provided an option to restrict fastlane version to a fixed version in addition to minimum version check

### DIFF
--- a/fastlane/lib/fastlane/actions/fastlane_version.rb
+++ b/fastlane/lib/fastlane/actions/fastlane_version.rb
@@ -7,33 +7,42 @@ module Fastlane
       def self.run(params)
         params = nil unless params.kind_of?(Array)
         value = (params || []).first
+        options = (params and params.size > 1) ? params.last : {}
+        lock = options[:lock] || false
         defined_version = Gem::Version.new(value) if value
 
-        UI.user_error!("Please pass minimum fastlane version as parameter to fastlane_version") unless defined_version
-
-        if Gem::Version.new(Fastlane::VERSION) < defined_version
-          FastlaneCore::UpdateChecker.show_update_message('fastlane', Fastlane::VERSION)
-          error_message = "The Fastfile requires a fastlane version of >= #{defined_version}. You are on #{Fastlane::VERSION}."
-          UI.user_error!(error_message)
+        UI.user_error!("Please pass minimum/required fastlane version as parameter to fastlane_version") unless defined_version
+        if lock
+          if Gem::Version.new(Fastlane::VERSION) != defined_version
+            FastlaneCore::UpdateChecker.show_update_message('fastlane', Fastlane::VERSION)
+            error_message = "The Fastfile requires a fastlane version of #{defined_version}. You are on #{Fastlane::VERSION}."
+            UI.user_error!(error_message)
+          end
+        else
+          if Gem::Version.new(Fastlane::VERSION) < defined_version
+            FastlaneCore::UpdateChecker.show_update_message('fastlane', Fastlane::VERSION)
+            error_message = "The Fastfile requires a fastlane version of >= #{defined_version}. You are on #{Fastlane::VERSION}."
+            UI.user_error!(error_message)
+          end
         end
 
-        UI.message("Your fastlane version #{Fastlane::VERSION} matches the minimum requirement of #{defined_version}  ✅")
+        UI.message("Your fastlane version #{Fastlane::VERSION} matches the requirement of #{defined_version}  ✅")
       end
 
       def self.step_text
         "Verifying required fastlane version"
       end
 
-      def self.author
-        "KrauseFx"
+      def self.authors
+        ["KrauseFx", "Karthik Krishnan"]
       end
 
       def self.description
-        "Verifies the minimum fastlane version required"
+        "Verifies the minimum/exact fastlane version required"
       end
 
       def self.example_code
-        ['fastlane_version "1.50.0"']
+        ['fastlane_version "1.50.0"', 'fastlane_version "1.50.0", :lock => true']
       end
 
       def self.details

--- a/fastlane/spec/actions_specs/fastlane_version_spec.rb
+++ b/fastlane/spec/actions_specs/fastlane_version_spec.rb
@@ -7,6 +7,14 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "works as expected with options" do
+        allow(FastlaneCore::Changelog).to receive(:show_changes).with("fastlane", '0.1')
+        stub_const('Fastlane::VERSION', '0.1')
+        Fastlane::FastFile.new.parse("lane :test do
+          fastlane_version '0.1', lock: true
+        end").runner.execute(:test)
+      end
+
       it "raises an exception if it's an old version" do
         expect do
           expect(FastlaneCore::Changelog).to receive(:show_changes).with("fastlane", Fastlane::VERSION)
@@ -14,6 +22,15 @@ describe Fastlane do
             fastlane_version '9999'
           end").runner.execute(:test)
         end.to raise_error(/The Fastfile requires a fastlane version of >= 9999./)
+      end
+
+      it "raises an exception if it's not an exact version" do
+        expect do
+          expect(FastlaneCore::Changelog).to receive(:show_changes).with("fastlane", Fastlane::VERSION)
+          Fastlane::FastFile.new.parse("lane :test do
+            fastlane_version '9999', lock: true
+          end").runner.execute(:test)
+        end.to raise_error(/The Fastfile requires a fastlane version of 9999./)
       end
 
       it "raises an exception if it's an old version in a non-bundler environement" do
@@ -45,7 +62,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             fastlane_version
           end").runner.execute(:test)
-        end.to raise_error("Please pass minimum fastlane version as parameter to fastlane_version")
+        end.to raise_error("Please pass minimum/required fastlane version as parameter to fastlane_version")
       end
     end
   end


### PR DESCRIPTION
Provided an option to restrict fastlane version to a fixed version in addition to minimum version check

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently we can mandate minimum version of fastlane required for the project.  However, if the teams want to be able to mandate a very specific version of fastlane in the environment, there is no way out for them.

### Description
I have now enhanced the fastlane_version action to allow an option to specific if fastlane should lock to a specific version.   For instance, instead of 

> fastlane_version 1.3

one can mention 
> fastlane_version 1.3, :lock => true

I have updated the unit tests as well.
