### PR TITLE
Only set test_info values that aren't nil

### DIFF
--- a/spaceship/lib/spaceship/test_flight/build.rb
+++ b/spaceship/lib/spaceship/test_flight/build.rb
@@ -168,9 +168,9 @@ module Spaceship::TestFlight
     end
 
     def update_build_information!(description: nil, feedback_email: nil, whats_new: nil)
-      test_info.description = description
-      test_info.feedback_email = feedback_email
-      test_info.whats_new = whats_new
+      test_info.description = description if description
+      test_info.feedback_email = feedback_email if feedback_email
+      test_info.whats_new = whats_new if whats_new
       save!
     end
 

--- a/spaceship/lib/spaceship/test_flight/test_info.rb
+++ b/spaceship/lib/spaceship/test_flight/test_info.rb
@@ -30,5 +30,9 @@ module Spaceship::TestFlight
     def whats_new=(value)
       raw_data.each { |locale| locale['whatsNew'] = value }
     end
+
+    def deep_copy
+      TestInfo.new(raw_data.map(&:dup))
+    end
   end
 end

--- a/spaceship/spec/test_flight/build_spec.rb
+++ b/spaceship/spec/test_flight/build_spec.rb
@@ -221,5 +221,48 @@ describe Spaceship::TestFlight::Build do
         build.save!
       end
     end
+
+    RSpec::Matchers.define :same_test_info do |other_test_info|
+      match do |args|
+        args[:build].test_info.to_s == other_test_info.to_s
+      end
+    end
+
+    context '#update_build_information!' do
+      it 'updates description' do
+        updated_test_info = build.test_info.deep_copy
+        updated_test_info.description = 'a newer description'
+
+        expect(build.client).to receive(:put_build).with(same_test_info(updated_test_info))
+
+        build.update_build_information!(description: 'a newer description')
+      end
+
+      it 'updates feedback_email' do
+        updated_test_info = build.test_info.deep_copy
+        updated_test_info.feedback_email = 'new_email@example.com'
+
+        expect(build.client).to receive(:put_build).with(same_test_info(updated_test_info))
+
+        build.update_build_information!(feedback_email: 'new_email@example.com')
+      end
+
+      it 'updates whats_new' do
+        updated_test_info = build.test_info.deep_copy
+        updated_test_info.whats_new = 'this fixture data is new'
+
+        expect(build.client).to receive(:put_build).with(same_test_info(updated_test_info))
+
+        build.update_build_information!(whats_new: 'this fixture data is new')
+      end
+
+      it 'does nothing if nothing is passed' do
+        updated_test_info = build.test_info.deep_copy
+
+        expect(build.client).to receive(:put_build).with(same_test_info(updated_test_info))
+
+        build.update_build_information!
+      end
+    end
   end
 end

--- a/spaceship/spec/test_flight/test_info_spec.rb
+++ b/spaceship/spec/test_flight/test_info_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require_relative '../mock_servers'
 
 describe Spaceship::TestFlight::TestInfo do
   let(:test_info) do
@@ -24,6 +25,13 @@ describe Spaceship::TestFlight::TestInfo do
                                         ])
   end
 
+  let(:mock_client) { double('MockClient') }
+
+  before do
+    # Use a simple client for all data models
+    Spaceship::TestFlight::Base.client = mock_client
+  end
+
   it 'gets the value from the first locale' do
     expect(test_info.feedback_email).to eq('enUS@email.com')
     expect(test_info.description).to eq('en-US description')
@@ -33,5 +41,18 @@ describe Spaceship::TestFlight::TestInfo do
   it 'sets values to all locales' do
     test_info.whats_new = 'News!'
     expect(test_info.raw_data.all? { |locale| locale['whatsNew'] == 'News!' }).to eq(true)
+  end
+
+  it 'copies its contents' do
+    new_test_info = test_info.deep_copy
+    expect(new_test_info.object_id).to_not eq(test_info.object_id)
+
+    # make sure it is a deep copy, but the contents are the same
+    new_test_info.raw_data.zip(test_info.raw_data).each do |sub_array|
+      new_item = sub_array.first
+      item = sub_array.last
+      expect(new_item.object_id).to_not eq(item.object_id)
+      expect(new_item.to_s).to eq(item.to_s)
+    end
   end
 end

--- a/spaceship/spec/test_flight/test_info_spec.rb
+++ b/spaceship/spec/test_flight/test_info_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require_relative '../mock_servers'
 
 describe Spaceship::TestFlight::TestInfo do
   let(:test_info) do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
When doing `update_build_information!`, do not set `test_info` fields that do not change. Also add `deep_copy` method on `Spaceship::TestFlight::TestInfo` to allow easier testing.