### PR TITLE
Version bump to 2.28.6

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.28.5'.freeze
+  VERSION = '2.28.6'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.28.5':**

* Only set test_info values that aren't nil (#9020) via Mark Pirri
* Update DOCTYPE to Apple so that rspec stops doing that (#9021) via Mark Pirri
* Remove iterm? helper method that isn't used anymore (#9017) via Felix Krause
* Directory ordering of default values for .ipa and . pkg files (#8982) via Chris Graham
* Add tests for TestFlight methods in spaceship and fastlane_core (#8962) via Stefan Natchev
* Fix `pilot distribute` to be called without uploading a build (#9005) via Aman Gupta
* Updated class method vs instance method via Joshua Liebowitz
* Rebased on most recent changes Moved add/remove users to/from group logic to class methods in Spaceship::TestFlight::Group via Joshua Liebowitz
