### PR TITLE
Move `processed?` to instance and add unit tests

### DIFF
--- a/spaceship/lib/spaceship/test_flight/build.rb
+++ b/spaceship/lib/spaceship/test_flight/build.rb
@@ -130,7 +130,7 @@ module Spaceship::TestFlight
       external_state == BUILD_STATES[:export_compliance_missing]
     end
 
-    def self.processed?
+    def processed?
       active? || ready_to_submit? || export_compliance_missing?
     end
 

--- a/spaceship/spec/test_flight/build_spec.rb
+++ b/spaceship/spec/test_flight/build_spec.rb
@@ -190,6 +190,33 @@ describe Spaceship::TestFlight::Build do
         end
         expect(build).to be_export_compliance_missing
       end
+
+      it 'is processed on active' do
+        mock_client_response(:get_build) do
+          {
+            'externalState' => 'testflight.build.state.testing.active'
+          }
+        end
+        expect(build).to be_processed
+      end
+
+      it 'is processed on ready to submit' do
+        mock_client_response(:get_build) do
+          {
+            'externalState' => 'testflight.build.state.submit.ready'
+          }
+        end
+        expect(build).to be_processed
+      end
+
+      it 'is processed on export compliance missing' do
+        mock_client_response(:get_build) do
+          {
+            'externalState' => 'testflight.build.state.export.compliance.missing'
+          }
+        end
+        expect(build).to be_processed
+      end
     end
 
     context '#upload_date' do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->

`processed?` was accidentally defined on the class (i.e., `self.processed?`) not on the instance. There were no unit tests that detected this.  Fixed the method definition and added unit tests.