### PR TITLE
Replace stub with allow to fix deprecation warnings

### DIFF
--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -29,7 +29,7 @@ describe Spaceship::TestFlight::Client do
   context '#handle_response' do
     it 'handles successful responses with json' do
       response = double('Response', status: 200)
-      response.stub(:body).and_return({ 'data' => 'value' })
+      allow(response).to receive(:body).and_return({ 'data' => 'value' })
       expect(subject.handle_response(response)).to eq('value')
     end
 
@@ -40,7 +40,7 @@ describe Spaceship::TestFlight::Client do
 
     it 'raises an exception on an API error' do
       response = double('Response', status: 400)
-      response.stub(:body).and_return({ 'data' => nil, 'error' => 'Bad Request' })
+      allow(response).to receive(:body).and_return({ 'data' => nil, 'error' => 'Bad Request' })
       expect do
         subject.handle_response(response)
       end.to raise_error(Spaceship::Client::UnexpectedResponse)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There is Deprecation Warnings about using `stub`.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
When you run:
```
be rspec spaceship/spec/test_flight/client_spec.rb
```

The message are shown without this patch.
This patch remove below warnings.

```
Deprecation Warnings:

Using `stub` from rspec-mocks' old `:should` syntax without explicitly
enabling the syntax is deprecated. Use the new `:expect` syntax or
explicitly enable `:should` instead. Called from
/Users/nafu/Projects/fastlane/spaceship/spec/test_flight/client_spec.rb:32:in
`block (3 levels) in <top (required)>'.

If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total
```
