### PR TITLE
Add detection of removedFromSale apps

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_status.rb
+++ b/spaceship/lib/spaceship/tunes/app_status.rb
@@ -33,7 +33,7 @@ module Spaceship
       PROCESSING_FOR_APP_STORE = "Processing for App Store"
       # WAITING_FOR_EXPORT_COMPLIANCE = "Waiting For Export Compliance"
       METADATA_REJECTED = "Metadata Rejected"
-      # REMOVED_FROM_SALE = "Removed From Sale"
+      REMOVED_FROM_SALE = "Removed From Sale"
       # INVALID_BINARY = "Invalid Binary"
 
       # Get the app status matching based on a string (given by iTunes Connect)
@@ -48,7 +48,8 @@ module Spaceship
           'inReview' => IN_REVIEW,
           'rejected' => REJECTED,
           'pendingDeveloperRelease' => PENDING_DEVELOPER_RELEASE,
-          'metadataRejected' => METADATA_REJECTED
+          'metadataRejected' => METADATA_REJECTED,
+          'removedFromSale' => REMOVED_FROM_SALE
         }
 
         mapping.each do |k, v|

--- a/spaceship/spec/tunes/app_version_spec.rb
+++ b/spaceship/spec/tunes/app_version_spec.rb
@@ -181,6 +181,10 @@ describe Spaceship::AppVersion, all: true do
       it "parses metadataRejected" do
         expect(Spaceship::Tunes::AppStatus.get_from_string('metadataRejected')).to eq(Spaceship::Tunes::AppStatus::METADATA_REJECTED)
       end
+
+      it "parses removedFromSale" do
+        expect(Spaceship::Tunes::AppStatus.get_from_string('removedFromSale')).to eq(Spaceship::Tunes::AppStatus::REMOVED_FROM_SALE)
+      end
     end
 
     describe "Screenshots" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->
Add `removedFromSale` support to app_status

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`Spaceship::Tunes::AppStatus` does not support `removedFromSale` right now.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

#### Testing

I have apps that is removed from sale.
I use custom lane for testing this behavior.

```diff
diff --git a/fastlane/Fastfile b/fastlane/Fastfile
index e945155b3..dd78bbaae 100644
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -320,3 +320,9 @@ lane :donate_food do
     )
   end
 end
+
+lane :spaceship_test do
+  Spaceship::Tunes.login(ENV['USERNAME'], ENV['PASSWORD'])
+  app = Spaceship::Tunes::Application.find(ENV['APP_ID'])
+  puts app.live_version.raw_data["status"]
+  puts app.live_version.app_status
+end
```

And also check the data with charles.

lane :spaceship_test | Charles
--- | ---
![image](https://cloud.githubusercontent.com/assets/932290/25554835/a97fd056-2d12-11e7-94da-8c7824285ef2.png) | ![screen_shot_2017-04-15_at_11_46_31_am](https://cloud.githubusercontent.com/assets/932290/25554832/90b799c8-2d12-11e7-8f6b-8e0b9dd0bb99.png)