### PR TITLE
Fix match passphrase issue

### DIFF
--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -24,6 +24,7 @@ module Match
       elsif clone_branch_directly
         command += " -b #{branch.shellescape} --single-branch"
       end
+      command << " --verbose" if FastlaneCore::Globals.verbose?
 
       UI.message "Cloning remote git repo..."
 

--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -33,9 +33,8 @@ module Match
 
       begin
         # GIT_TERMINAL_PROMPT will fail the `git clone` command if user credentials are missing
-        FastlaneCore::CommandExecutor.execute(command: "GIT_TERMINAL_PROMPT=0 #{command}",
-                                            print_all: FastlaneCore::Globals.verbose?,
-                                        print_command: FastlaneCore::Globals.verbose?)
+        Kernel.`("GIT_TERMINAL_PROMPT=0 #{command}")
+
       rescue
         UI.error("Error cloning certificates repo, please make sure you have read access to the repository you want to use")
         UI.error("Run the following command manually to make sure you're properly authenticated:")

--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -35,7 +35,6 @@ module Match
       begin
         # GIT_TERMINAL_PROMPT will fail the `git clone` command if user credentials are missing
         Kernel.`("GIT_TERMINAL_PROMPT=0 #{command}")
-
       rescue
         UI.error("Error cloning certificates repo, please make sure you have read access to the repository you want to use")
         UI.error("Run the following command manually to make sure you're properly authenticated:")

--- a/match/spec/git_helper_spec.rb
+++ b/match/spec/git_helper_spec.rb
@@ -25,10 +25,10 @@ describe Match do
           print_command: nil
         }
 
-        expect(FastlaneCore::CommandExecutor).
-          to receive(:execute).
-          with(to_params).
-          and_return(nil)
+        expect(Kernel).
+            to receive(:`).
+                with(command).
+                and_return(nil)
 
         result = Match::GitHelper.clone(git_url, shallow_clone, skip_docs: true)
         expect(File.directory?(result)).to eq(true)
@@ -47,10 +47,10 @@ describe Match do
           print_command: nil
         }
 
-        expect(FastlaneCore::CommandExecutor).
-          to receive(:execute).
-          with(to_params).
-          and_return(nil)
+        expect(Kernel).
+            to receive(:`).
+                with(command).
+                and_return(nil)
 
         result = Match::GitHelper.clone(git_url, shallow_clone)
         expect(File.directory?(result)).to eq(true)
@@ -69,10 +69,10 @@ describe Match do
           print_command: nil
         }
 
-        expect(FastlaneCore::CommandExecutor).
-          to receive(:execute).
-          with(to_params).
-          and_return(nil)
+        expect(Kernel).
+            to receive(:`).
+                with(command).
+                and_return(nil)
 
         result = Match::GitHelper.clone(git_url, shallow_clone)
         expect(File.directory?(result)).to eq(true)
@@ -92,10 +92,10 @@ describe Match do
           print_command: nil
         }
 
-        expect(FastlaneCore::CommandExecutor).
-          to receive(:execute).
-          with(to_params).
-          and_return(nil)
+        expect(Kernel).
+            to receive(:`).
+                with(command).
+                and_return(nil)
 
         command = "git branch --list origin/#{git_branch} --no-color -r"
         to_params = {

--- a/match/spec/git_helper_spec.rb
+++ b/match/spec/git_helper_spec.rb
@@ -26,9 +26,9 @@ describe Match do
         }
 
         expect(Kernel).
-            to receive(:`).
-                with(command).
-                and_return(nil)
+          to receive(:`).
+          with(command).
+          and_return(nil)
 
         result = Match::GitHelper.clone(git_url, shallow_clone, skip_docs: true)
         expect(File.directory?(result)).to eq(true)
@@ -48,9 +48,9 @@ describe Match do
         }
 
         expect(Kernel).
-            to receive(:`).
-                with(command).
-                and_return(nil)
+          to receive(:`).
+          with(command).
+          and_return(nil)
 
         result = Match::GitHelper.clone(git_url, shallow_clone)
         expect(File.directory?(result)).to eq(true)
@@ -70,9 +70,9 @@ describe Match do
         }
 
         expect(Kernel).
-            to receive(:`).
-                with(command).
-                and_return(nil)
+          to receive(:`).
+          with(command).
+          and_return(nil)
 
         result = Match::GitHelper.clone(git_url, shallow_clone)
         expect(File.directory?(result)).to eq(true)
@@ -93,9 +93,9 @@ describe Match do
         }
 
         expect(Kernel).
-            to receive(:`).
-                with(command).
-                and_return(nil)
+          to receive(:`).
+          with(command).
+          and_return(nil)
 
         command = "git branch --list origin/#{git_branch} --no-color -r"
         to_params = {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

Match action does not show anything when git asking passphrase.
This behavior seems something like buggy, that fastlane command hang up.
So, I change this behavior to accept passphrase input. 😃 

maybe related issue -> #5537

### Description
<!--- Describe your changes in detail -->

I replaced command executor to Kernel , only `git clone`.

