### PR TITLE
Remove mention of macOS from main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then to deploy a new 'beta' version of your app just run
 :ghost: | [Jenkins Integration](https://docs.fastlane.tools/best-practices/continuous-integration/#jenkins-integration): Show output directly in test results
 :book: | Automatically generate Markdown documentation of your lane configurations
 :hatching_chick: | Over 170 built-in integrations available
-:computer: | Support for iOS, macOS, and Android apps
+:computer: | Support for iOS and Android apps
 :octocat: | Full Git and Mercurial support
 
 <hr />

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -91,7 +91,7 @@ fastlane release
 :ghost: | [Jenkins Integration](https://docs.fastlane.tools/best-practices/continuous-integration/#jenkins-integration): Show the output directly in the Jenkins test results
 :book: | Automatically generate a markdown documentation of your lane config
 :hatching_chick: | Over 170 built-in integrations available
-:computer: | Support for iOS, macOS and Android apps
+:computer: | Support for iOS and Android apps
 :octocat: | Full git and mercurial support
 
 


### PR DESCRIPTION
Most tools actually don't really support macOS, so we shouldn't list it in our docs as supported platform. Even though partly it might work, it's not our main focus for now, as we want to focus on providing the best tooling for mobile

Triggered by https://github.com/fastlane/fastlane/issues/8969