### PR TITLE
Fix error handling when Xcode schemes are not shared

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -296,9 +296,16 @@ module FastlaneCore
     # @param [String] The key of which we want the value for (e.g. "PRODUCT_NAME")
     def build_settings(key: nil, optional: true)
       unless @build_settings
+        if is_workspace
+          if schemes.count == 0
+            UI.user_error!("Could not find any schemes for Xcode workspace at path '#{self.path}'. Please make sure that the schemes you want to use are marked as `Shared` from Xcode.")
+          end
+          options[:scheme] ||= schemes.first
+        end
+
         command = build_xcodebuild_showbuildsettings_command
 
-        # xcode might hang here and retrying fixes the problem, see fastlane#4059
+        # Xcode might hang here and retrying fixes the problem, see fastlane#4059
         begin
           timeout = FastlaneCore::Project.xcode_build_settings_timeout
           retries = FastlaneCore::Project.xcode_build_settings_retries
@@ -332,7 +339,7 @@ module FastlaneCore
 
     # Returns the build settings and sets the default scheme to the options hash
     def default_build_settings(key: nil, optional: true)
-      options[:scheme] = schemes.first if is_workspace
+      options[:scheme] ||= schemes.first if is_workspace
       build_settings(key: key, optional: optional)
     end
 


### PR DESCRIPTION
This also fixes the fact that `build_settings` would fetch the project's build settings without fetching the schemes from the Xcode workspace.

<img width="835" alt="screen shot 2017-05-02 at 11 53 08 am" src="https://cloud.githubusercontent.com/assets/869950/25613275/eeb07398-2f2d-11e7-9d1a-dfbf41e16ca6.png">

Fixes https://github.com/fastlane/fastlane/issues/9019