### PR TITLE
Enables App Managers to be able to add external testers to apps

### DIFF
--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -21,6 +21,7 @@ module Pilot
         if tester.kind_of?(Spaceship::Tunes::Tester::Internal)
           UI.success("Successfully added tester to app #{app.name}")
         else
+          # tester was added to the group(s) in the above add_tester_to_groups() call, now we need to let the user know which group(s)
           if config[:groups]
             group_names = groups.map(&:name).join(", ")
             UI.success("Successfully added tester to group(s): #{group_names} in app: #{app.name}")

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -3,6 +3,97 @@ require 'ostruct'
 
 describe Pilot::TesterManager do
   describe "Manages adding/removing/displaying testers" do
+    let(:tester_manager) { Pilot::TesterManager.new }
+
+    let(:global_testers) do
+      [
+        OpenStruct.new(
+          first_name: 'First',
+          last_name: 'Last',
+          email: 'my@email.addr',
+          groups: ['testers'],
+          devices: ["d"],
+          full_version: '1.0 (21)',
+          pretty_install_date: '2016-01-01',
+          something_else: 'blah'
+        ),
+        OpenStruct.new(
+          first_name: 'Fabricio',
+          last_name: 'Devtoolio',
+          email: 'fabric-devtools@gmail.com',
+          groups: ['testers'],
+          devices: ["d", "d2"],
+          full_version: '1.1 (22)',
+          pretty_install_date: '2016-02-02',
+          something_else: 'blah'
+        )
+      ]
+    end
+
+    let(:app_context_testers) do
+      [
+        OpenStruct.new(
+          first_name: 'First',
+          last_name: 'Last',
+          email: 'my@email.addr',
+          something_else: 'blah'
+        ),
+        OpenStruct.new(
+          first_name: 'Fabricio',
+          last_name: 'Devtoolio',
+          email: 'fabric-devtools@gmail.com',
+          something_else: 'blah'
+        )
+      ]
+    end
+
+    let(:custom_tester_group) do
+      OpenStruct.new(
+        id: "CustomID",
+        name: "Test Group",
+        is_internal_group: false,
+        app_id: "com.whatever",
+        is_default_external_group: false
+      )
+    end
+
+    let(:current_user) do
+      Spaceship::Tunes::Member.new({ "firstname": "Josh",
+                           "lastname": "Liebowitz",
+                           "email_address": "taquitos+nospam@gmail.com" })
+    end
+
+    let(:fake_tester) do
+      OpenStruct.new(
+        first_name: 'fake',
+        last_name: 'tester',
+        email: 'fabric-devtools@gmail.com+fake@gmail.com'
+      )
+    end
+
+    let(:default_add_tester_options) do
+      FastlaneCore::Configuration.create(Pilot::Options.available_options, {
+        apple_id: 'com.whatever',
+        email: fake_tester.email,
+        first_name: fake_tester.first_name,
+        last_name: fake_tester.last_name
+      })
+    end
+
+    let(:default_add_tester_options_with_group) do
+      FastlaneCore::Configuration.create(Pilot::Options.available_options, {
+        apple_id: 'com.whatever',
+        email: fake_tester.email,
+        first_name: fake_tester.first_name,
+        last_name: fake_tester.last_name,
+        groups: ["Test Group"]
+      })
+    end
+
+    let(:fake_app) { "fake_app_object" }
+
+    let(:fake_client) { "fake client" }
+
     before(:each) do
       allow(fake_app).to receive(:apple_id).and_return("com.whatever")
       allow(fake_app).to receive(:name).and_return("My Fake App")
@@ -157,97 +248,5 @@ describe Pilot::TesterManager do
         tester_manager.add_tester(default_add_tester_options_with_group)
       end
     end
-
-    # Data and mocks
-    let(:tester_manager) { Pilot::TesterManager.new }
-
-    let(:global_testers) do
-      [
-        OpenStruct.new(
-          first_name: 'First',
-          last_name: 'Last',
-          email: 'my@email.addr',
-          groups: ['testers'],
-          devices: ["d"],
-          full_version: '1.0 (21)',
-          pretty_install_date: '2016-01-01',
-          something_else: 'blah'
-        ),
-        OpenStruct.new(
-          first_name: 'Fabricio',
-          last_name: 'Devtoolio',
-          email: 'fabric-devtools@gmail.com',
-          groups: ['testers'],
-          devices: ["d", "d2"],
-          full_version: '1.1 (22)',
-          pretty_install_date: '2016-02-02',
-          something_else: 'blah'
-        )
-      ]
-    end
-
-    let(:app_context_testers) do
-      [
-        OpenStruct.new(
-          first_name: 'First',
-          last_name: 'Last',
-          email: 'my@email.addr',
-          something_else: 'blah'
-        ),
-        OpenStruct.new(
-          first_name: 'Fabricio',
-          last_name: 'Devtoolio',
-          email: 'fabric-devtools@gmail.com',
-          something_else: 'blah'
-        )
-      ]
-    end
-
-    let(:custom_tester_group) do
-      OpenStruct.new(
-        id: "CustomID",
-        name: "Test Group",
-        is_internal_group: false,
-        app_id: "com.whatever",
-        is_default_external_group: false
-      )
-    end
-
-    let(:current_user) do
-      Spaceship::Tunes::Member.new({ "firstname": "Josh",
-                           "lastname": "Liebowitz",
-                           "email_address": "taquitos+nospam@gmail.com" })
-    end
-
-    let(:fake_tester) do
-      OpenStruct.new(
-        first_name: 'fake',
-        last_name: 'tester',
-        email: 'fabric-devtools@gmail.com+fake@gmail.com'
-      )
-    end
-
-    let(:default_add_tester_options) do
-      FastlaneCore::Configuration.create(Pilot::Options.available_options, {
-        apple_id: 'com.whatever',
-        email: fake_tester.email,
-        first_name: fake_tester.first_name,
-        last_name: fake_tester.last_name
-      })
-    end
-
-    let(:default_add_tester_options_with_group) do
-      FastlaneCore::Configuration.create(Pilot::Options.available_options, {
-        apple_id: 'com.whatever',
-        email: fake_tester.email,
-        first_name: fake_tester.first_name,
-        last_name: fake_tester.last_name,
-        groups: ["Test Group"]
-      })
-    end
-
-    let(:fake_app) { "fake_app_object" }
-
-    let(:fake_client) { "fake client" }
   end
 end

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -2,57 +2,16 @@ require 'colored'
 require 'ostruct'
 
 describe Pilot::TesterManager do
-  describe "prints tester lists" do
-    let(:global_testers) do
-      [
-        OpenStruct.new(
-          first_name: 'First',
-          last_name: 'Last',
-          email: 'my@email.addr',
-          groups: ['testers'],
-          devices: ["d"],
-          full_version: '1.0 (21)',
-          pretty_install_date: '2016-01-01',
-          something_else: 'blah'
-        ),
-        OpenStruct.new(
-          first_name: 'Fabricio',
-          last_name: 'Devtoolio',
-          email: 'fabric-devtools@gmail.com',
-          groups: ['testers'],
-          devices: ["d", "d2"],
-          full_version: '1.1 (22)',
-          pretty_install_date: '2016-02-02',
-          something_else: 'blah'
-        )
-      ]
-    end
-
-    let(:app_context_testers) do
-      [
-        OpenStruct.new(
-          first_name: 'First',
-          last_name: 'Last',
-          email: 'my@email.addr',
-          something_else: 'blah'
-        ),
-        OpenStruct.new(
-          first_name: 'Fabricio',
-          last_name: 'Devtoolio',
-          email: 'fabric-devtools@gmail.com',
-          something_else: 'blah'
-        )
-      ]
-    end
-
-    let(:tester_manager) { Pilot::TesterManager.new }
-
-    let(:fake_app) { "fake_app_object" }
-
+  describe "Manages adding/removing/displaying testers" do
     before(:each) do
-      allow(fake_app).to receive(:apple_id).and_return("whatever")
+      allow(fake_app).to receive(:apple_id).and_return("com.whatever")
+      allow(fake_app).to receive(:name).and_return("My Fake App")
       allow(Spaceship::Application).to receive(:find).and_return(fake_app)
+      allow(Spaceship::Tunes).to receive(:client).and_return(fake_client)
+      allow(Spaceship::Members).to receive(:find).and_return(current_user)
+
       allow(tester_manager).to receive(:login) # prevent attempting to log in with iTC
+      allow(fake_client).to receive(:user).and_return(current_user)
     end
 
     describe "when invoked from a global context" do
@@ -104,5 +63,191 @@ describe Pilot::TesterManager do
         tester_manager.list_testers(app_identifier: 'com.whatever')
       end
     end
+
+    describe "when app manager asks to create new tester in the default group" do
+      it "creates a new tester and adds it to the default group" do
+        allow(current_user).to receive(:roles).and_return(["appmanager"])
+        allow(fake_client).to receive(:testers_by_app).and_return([])
+
+        expect(Spaceship::TestFlight::Tester).to receive(:create_app_level_tester).with(
+          app_id: 'com.whatever',
+          first_name: 'fake',
+          last_name: 'tester',
+          email: 'fabric-devtools@gmail.com+fake@gmail.com'
+        )
+        expect(Spaceship::Tunes::Tester::External).to receive(:find_by_app).and_return(nil) # before creating, no testers
+        expect(Spaceship::TestFlight::Group).to receive(:add_tester_to_groups!)
+        expect(Spaceship::Tunes::Tester::External).to receive(:find_by_app).and_return(fake_tester) # after creating a tester, we return one
+
+        expect(FastlaneCore::UI).to receive(:success).with('Successfully added tester: fabric-devtools@gmail.com+fake@gmail.com to app: My Fake App')
+        expect(FastlaneCore::UI).to receive(:success).with('Successfully added tester to the default tester group in app: My Fake App')
+
+        tester_manager.add_tester(default_add_tester_options)
+      end
+    end
+
+    describe "when admin asks to create new tester in the default group" do
+      it "creates a new tester and adds it to the default group" do
+        allow(current_user).to receive(:roles).and_return(["admin"])
+        allow(tester_manager).to receive(:find_app_tester).and_return(nil)
+
+        expect(Spaceship::Tunes::Tester::External).to receive(:create!).with(
+          email: 'fabric-devtools@gmail.com+fake@gmail.com',
+          first_name: 'fake',
+          last_name: 'tester'
+        )
+        expect(Spaceship::TestFlight::Group).to receive(:add_tester_to_groups!)
+        expect(FastlaneCore::UI).to receive(:success).with('Successfully added tester: fabric-devtools@gmail.com+fake@gmail.com to your account')
+        expect(FastlaneCore::UI).to receive(:success).with('Successfully added tester to the default tester group in app: My Fake App')
+
+        tester_manager.add_tester(default_add_tester_options)
+      end
+    end
+
+    describe "when admin asks to create new tester to a specific existing custom group" do
+      it "creates a new tester and adds it to the default group" do
+        allow(current_user).to receive(:roles).and_return(["admin"])
+        allow(tester_manager).to receive(:find_app_tester).and_return(fake_tester)
+
+        expect(Spaceship::Tunes::Tester::External).to_not receive(:create!)
+        expect(Spaceship::TestFlight::Group).to receive(:add_tester_to_groups!).and_return([custom_tester_group])
+        expect(FastlaneCore::UI).to receive(:success).with('Successfully added tester to group(s): Test Group in app: My Fake App')
+
+        tester_manager.add_tester(default_add_tester_options_with_group)
+      end
+    end
+
+    describe "when asked to add an existing external tester to a specific existing custom group" do
+      it "adds the tester to the custom group" do
+        allow(current_user).to receive(:roles).and_return(["appmanager"])
+        allow(tester_manager).to receive(:find_app_tester).and_return(fake_tester)
+
+        expect(Spaceship::TestFlight::Tester).to_not receive(:create_app_level_tester)
+        expect(Spaceship::TestFlight::Group).to receive(:add_tester_to_groups!).and_return([custom_tester_group])
+        expect(FastlaneCore::UI).to receive(:success).with('Successfully added tester to group(s): Test Group in app: My Fake App')
+
+        tester_manager.add_tester(default_add_tester_options_with_group)
+      end
+    end
+
+    describe "when asked to add an existing internal tester to a specific existing custom group" do
+      it "adds the tester to the custom group" do
+        allow(current_user).to receive(:roles).and_return(["appmanager"])
+        allow(fake_tester).to receive(:kind_of?).with(Spaceship::Tunes::Tester::Internal).and_return(true)
+
+        expect(Spaceship::Tunes::Tester::Internal).to receive(:find_by_app).and_return(fake_tester)
+        expect(Spaceship::TestFlight::Tester).to_not receive(:create_app_level_tester)
+        expect(Spaceship::TestFlight::Group).to receive(:add_tester_to_groups!).and_return([custom_tester_group])
+        expect(FastlaneCore::UI).to receive(:success).with('Found existing tester fabric-devtools@gmail.com+fake@gmail.com')
+        expect(FastlaneCore::UI).to receive(:success).with('Successfully added tester to app My Fake App')
+
+        tester_manager.add_tester(default_add_tester_options_with_group)
+      end
+    end
+
+    describe "when app manager asks to add an existing external tester to a specific existing custom group" do
+      it "adds the tester without calling create" do
+        allow(current_user).to receive(:roles).and_return(["appmanager"])
+        allow(tester_manager).to receive(:find_app_tester).and_return(fake_tester)
+
+        expect(Spaceship::TestFlight::Tester).to_not receive(:create_app_level_tester)
+        expect(Spaceship::TestFlight::Group).to receive(:add_tester_to_groups!).and_return([custom_tester_group])
+        expect(FastlaneCore::UI).to receive(:success).with('Successfully added tester to group(s): Test Group in app: My Fake App')
+
+        tester_manager.add_tester(default_add_tester_options_with_group)
+      end
+    end
+
+    # Data and mocks
+    let(:tester_manager) { Pilot::TesterManager.new }
+
+    let(:global_testers) do
+      [
+        OpenStruct.new(
+          first_name: 'First',
+          last_name: 'Last',
+          email: 'my@email.addr',
+          groups: ['testers'],
+          devices: ["d"],
+          full_version: '1.0 (21)',
+          pretty_install_date: '2016-01-01',
+          something_else: 'blah'
+        ),
+        OpenStruct.new(
+          first_name: 'Fabricio',
+          last_name: 'Devtoolio',
+          email: 'fabric-devtools@gmail.com',
+          groups: ['testers'],
+          devices: ["d", "d2"],
+          full_version: '1.1 (22)',
+          pretty_install_date: '2016-02-02',
+          something_else: 'blah'
+        )
+      ]
+    end
+
+    let(:app_context_testers) do
+      [
+        OpenStruct.new(
+          first_name: 'First',
+          last_name: 'Last',
+          email: 'my@email.addr',
+          something_else: 'blah'
+        ),
+        OpenStruct.new(
+          first_name: 'Fabricio',
+          last_name: 'Devtoolio',
+          email: 'fabric-devtools@gmail.com',
+          something_else: 'blah'
+        )
+      ]
+    end
+
+    let(:custom_tester_group) do
+      OpenStruct.new(
+        id: "CustomID",
+        name: "Test Group",
+        is_internal_group: false,
+        app_id: "com.whatever",
+        is_default_external_group: false
+      )
+    end
+
+    let(:current_user) do
+      Spaceship::Tunes::Member.new({ "firstname": "Josh",
+                           "lastname": "Liebowitz",
+                           "email_address": "taquitos+nospam@gmail.com" })
+    end
+
+    let(:fake_tester) do
+      OpenStruct.new(
+        first_name: 'fake',
+        last_name: 'tester',
+        email: 'fabric-devtools@gmail.com+fake@gmail.com'
+      )
+    end
+
+    let(:default_add_tester_options) do
+      FastlaneCore::Configuration.create(Pilot::Options.available_options, {
+        apple_id: 'com.whatever',
+        email: fake_tester.email,
+        first_name: fake_tester.first_name,
+        last_name: fake_tester.last_name
+      })
+    end
+
+    let(:default_add_tester_options_with_group) do
+      FastlaneCore::Configuration.create(Pilot::Options.available_options, {
+        apple_id: 'com.whatever',
+        email: fake_tester.email,
+        first_name: fake_tester.first_name,
+        last_name: fake_tester.last_name,
+        groups: ["Test Group"]
+      })
+    end
+
+    let(:fake_app) { "fake_app_object" }
+
+    let(:fake_client) { "fake client" }
   end
 end

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -58,9 +58,9 @@ describe Pilot::TesterManager do
     end
 
     let(:current_user) do
-      Spaceship::Tunes::Member.new({ "firstname": "Josh",
-                           "lastname": "Liebowitz",
-                           "email_address": "taquitos+nospam@gmail.com" })
+      Spaceship::Tunes::Member.new({ "firstname" => "Josh",
+                           "lastname" => "Liebowitz",
+                           "email_address" => "taquitos+nospam@gmail.com" })
     end
 
     let(:fake_tester) do

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -110,14 +110,6 @@ module Spaceship::TestFlight
     ##
     # @!group Testers API
     ##
-
-    def post_tester(app_id: nil, tester: nil)
-      return create_app_level_tester(app_id: app_id,
-                                 first_name: tester.first_name,
-                                  last_name: tester.last_name,
-                                      email: tester.email)
-    end
-
     def create_app_level_tester(app_id: nil, first_name: nil, last_name: nil, email: nil)
       assert_required_params(__method__, binding)
       url = "providers/#{team_id}/apps/#{app_id}/testers"

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -112,15 +112,21 @@ module Spaceship::TestFlight
     ##
 
     def post_tester(app_id: nil, tester: nil)
-      assert_required_params(__method__, binding)
+      return create_app_level_tester(app_id: app_id,
+                                 first_name: tester.first_name,
+                                  last_name: tester.last_name,
+                                      email: tester.email)
+    end
 
+    def create_app_level_tester(app_id: nil, first_name: nil, last_name: nil, email: nil)
+      assert_required_params(__method__, binding)
       url = "providers/#{team_id}/apps/#{app_id}/testers"
       response = request(:post) do |req|
         req.url url
         req.body = {
-          "email" => tester.email,
-          "firstName" => tester.first_name,
-          "lastName" => tester.last_name
+          "email" => email,
+          "firstName" => first_name,
+          "lastName" => last_name
         }.to_json
         req.headers['Content-Type'] = 'application/json'
       end

--- a/spaceship/lib/spaceship/test_flight/group.rb
+++ b/spaceship/lib/spaceship/test_flight/group.rb
@@ -46,8 +46,12 @@ module Spaceship::TestFlight
     # is not enough to add the tester to a group. If this isn't done the next request would fail.
     # This is a bug we reported to the iTunes Connect team, as it also happens on the iTunes Connect UI on 18. April 2017
     def add_tester!(tester)
-      # This post request makes the account-level tester available to the app
-      tester_data = client.post_tester(app_id: self.app_id, tester: tester)
+      # This post request creates an account-level tester and then makes it available to the app, or just makes
+      # it available to the app if it already exists
+      tester_data = client.create_app_level_tester(app_id: self.app_id,
+                                               first_name: tester.first_name,
+                                                last_name: tester.last_name,
+                                                    email: tester.email)
       # This put request adds the tester to the group
       client.put_tester_to_group(group_id: self.id, tester_id: tester_data['id'], app_id: self.app_id)
     end

--- a/spaceship/lib/spaceship/test_flight/tester.rb
+++ b/spaceship/lib/spaceship/test_flight/tester.rb
@@ -27,6 +27,13 @@ module Spaceship::TestFlight
       self.all(app_id: app_id).find { |tester| tester.email == email }
     end
 
+    def self.create_app_level_tester(app_id: nil, first_name: nil, last_name: nil, email: nil)
+      client.create_app_level_tester(app_id: app_id,
+                                 first_name: first_name,
+                                  last_name: last_name,
+                                      email: email)
+    end
+
     def remove_from_app!(app_id: nil)
       client.delete_tester_from_app(app_id: app_id, tester_id: self.tester_id)
     end

--- a/spaceship/lib/spaceship/tunes/member.rb
+++ b/spaceship/lib/spaceship/tunes/member.rb
@@ -16,6 +16,15 @@ module Spaceship
         'dsId' => :user_id
       )
 
+      ROLES = {
+        admin: 'admin',
+        app_manager: 'appmanager',
+        sales: 'sales',
+        developer: 'developer',
+        marketing: 'marketing',
+        reports: 'reports'
+      }
+
       def roles
         parsed_roles = []
         raw_data["roles"].each do |role|
@@ -25,11 +34,11 @@ module Spaceship
       end
 
       def admin?
-        roles.include?("admin")
+        roles.include?(ROLES[:admin])
       end
 
       def app_manager?
-        roles.include?("appmanager")
+        roles.include?(ROLES[:app_manager])
       end
 
       def preferred_currency

--- a/spaceship/lib/spaceship/tunes/member.rb
+++ b/spaceship/lib/spaceship/tunes/member.rb
@@ -24,6 +24,14 @@ module Spaceship
         return parsed_roles
       end
 
+      def admin?
+        roles.include?("admin")
+      end
+
+      def app_manager?
+        roles.include?("appmanager")
+      end
+
       def preferred_currency
         currency_base = raw_data["preferredCurrency"]["value"]
         return {

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -135,11 +135,11 @@ describe Spaceship::TestFlight::Client do
     end
   end
 
-  context '#post_tester' do
+  context '#create_app_level_tester' do
     let(:tester) { double('Tester', email: 'fake@email.com', first_name: 'Fake', last_name: 'Name') }
     it 'executes the request' do
       MockAPI::TestFlightServer.post('/testflight/v2/providers/fake-team-id/apps/some-app-id/testers') {}
-      subject.post_tester(app_id: app_id, tester: tester)
+      subject.create_app_level_tester(app_id: app_id, first_name: tester.first_name, last_name: tester.last_name, email: tester.email)
       expect(WebMock).to have_requested(:post, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/testers')
     end
   end

--- a/spaceship/spec/test_flight/group_spec.rb
+++ b/spaceship/spec/test_flight/group_spec.rb
@@ -84,11 +84,13 @@ describe Spaceship::TestFlight::Group do
 
   context 'instances' do
     let(:group) { Spaceship::TestFlight::Group.new('appAdamId' => 1, 'id' => 2, 'isDefaultExternalGroup' => true) }
-    let(:tester) { double('Tester', tester_id: 'some-tester-id') }
+    let(:tester) { double('Tester', tester_id: 'some-tester-id', first_name: 'first name', last_name: 'last name', email: 'some email') }
 
     context '#add_tester!' do
       it 'adds a tester via client' do
-        expect(mock_client).to receive(:post_tester).with(app_id: 1, tester: tester).and_return('id' => 'some-tester-id')
+        expect(mock_client).to receive(:create_app_level_tester)
+          .with(app_id: 1, first_name: tester.first_name, last_name: tester.last_name, email: tester.email)
+          .and_return('id' => 'some-tester-id')
         expect(mock_client).to receive(:put_tester_to_group).with(group_id: 2, tester_id: 'some-tester-id', app_id: 1)
         group.add_tester!(tester)
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Only admins can currently add testers, with this patch, we can now add testers while using an account that only has the "app manager" role
### Description

