### PR TITLE
Set limit on testers request to 10k

### DIFF
--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -36,7 +36,7 @@ module Spaceship::TestFlight
 
     def testers_for_app(app_id: nil)
       assert_required_params(__method__, binding)
-      url = "providers/#{team_id}/apps/#{app_id}/testers"
+      url = "providers/#{team_id}/apps/#{app_id}/testers?limit=10000"
       response = request(:get, url)
       handle_response(response)
     end

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -34,20 +34,6 @@ module Spaceship::TestFlight
       handle_response(response)
     end
 
-    def testers_for_app(app_id: nil)
-      assert_required_params(__method__, binding)
-      url = "providers/#{team_id}/apps/#{app_id}/testers?limit=10000"
-      response = request(:get, url)
-      handle_response(response)
-    end
-
-    def delete_tester_from_app(app_id: nil, tester_id: nil)
-      assert_required_params(__method__, binding)
-      url = "providers/#{team_id}/apps/#{app_id}/testers/#{tester_id}"
-      response = request(:delete, url)
-      handle_response(response)
-    end
-
     ##
     # @!group Builds API
     ##
@@ -110,6 +96,20 @@ module Spaceship::TestFlight
     ##
     # @!group Testers API
     ##
+
+    def testers_for_app(app_id: nil)
+      assert_required_params(__method__, binding)
+      url = "providers/#{team_id}/apps/#{app_id}/testers?limit=10000"
+      response = request(:get, url)
+      handle_response(response)
+    end
+
+    def delete_tester_from_app(app_id: nil, tester_id: nil)
+      assert_required_params(__method__, binding)
+      url = "providers/#{team_id}/apps/#{app_id}/testers/#{tester_id}"
+      response = request(:delete, url)
+      handle_response(response)
+    end
 
     def post_tester(app_id: nil, tester: nil)
       assert_required_params(__method__, binding)

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -123,7 +123,7 @@ describe Spaceship::TestFlight::Client do
     it 'executes the request' do
       MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/testers') {}
       subject.testers_for_app(app_id: app_id)
-      expect(WebMock).to have_requested(:get, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/testers')
+      expect(WebMock).to have_requested(:get, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/testers?limit=10000')
     end
   end
 


### PR DESCRIPTION
This fixes https://github.com/fastlane/fastlane/issues/8979#issuecomment-298905417 where testers may not be found if they are not in the first page of the All Testers list on iTC
