### PR TITLE
Add support for app-level test_info

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -56,7 +56,8 @@ module Pilot
         app_test_info.test_info.feedback_email = options[:beta_app_feedback_email] if options[:beta_app_feedback_email]
         app_test_info.test_info.description = options[:beta_app_description] if options[:beta_app_description]
         begin
-          app_test_info.save_for_app(app_id: build.app_id)
+          app_test_info.save_for_app!(app_id: build.app_id)
+          UI.success "Successfully set the beta_app_feedback_email and/or beta_app_description"
         rescue => ex
           UI.user_error!("Could not set beta_app_feedback_email and/or beta_app_description: #{ex}")
         end
@@ -65,10 +66,10 @@ module Pilot
       if should_update_build_information(options)
         begin
           build.update_build_information!(whats_new: options[:changelog])
+          UI.success "Successfully set the changelog for build"
         rescue => ex
           UI.user_error!("Could not set changelog: #{ex}")
         end
-        UI.success "Successfully set the changelog for build"
       end
 
       return if config[:skip_submission]

--- a/spaceship/lib/spaceship/test_flight.rb
+++ b/spaceship/lib/spaceship/test_flight.rb
@@ -1,6 +1,7 @@
 
 require 'spaceship/test_flight/client'
 require 'spaceship/test_flight/base'
+require 'spaceship/test_flight/app_test_info'
 require 'spaceship/test_flight/build'
 require 'spaceship/test_flight/build_trains'
 require 'spaceship/test_flight/beta_review_info'

--- a/spaceship/lib/spaceship/test_flight/app_test_info.rb
+++ b/spaceship/lib/spaceship/test_flight/app_test_info.rb
@@ -20,7 +20,7 @@ module Spaceship::TestFlight
     end
 
     # saves the changes to the App Test Info object to TestFlight
-    def save_for_app(app_id: nil)
+    def save_for_app!(app_id: nil)
       client.put_app_test_info(app_id: app_id, app_test_info: self)
     end
   end

--- a/spaceship/lib/spaceship/test_flight/app_test_info.rb
+++ b/spaceship/lib/spaceship/test_flight/app_test_info.rb
@@ -1,0 +1,27 @@
+module Spaceship::TestFlight
+  class AppTestInfo < Base
+    # AppTestInfo wraps a test_info and beta_review_info in the format required to manage test_info
+    # for an application. Note that this structure, although looking similar to build test_info
+    # is test information about the application
+
+    attr_accessor :test_info
+
+    def self.find(app_id: nil)
+      raw_app_test_info = client.get_app_test_info(app_id: app_id)
+      self.new(raw_app_test_info)
+    end
+
+    def test_info
+      Spaceship::TestFlight::TestInfo.new(raw_data['details'])
+    end
+
+    def test_info=(value)
+      raw_data.set(['details'], value.raw_data)
+    end
+
+    # saves the changes to the App Test Info object to TestFlight
+    def save_for_app(app_id: nil)
+      client.put_app_test_info(app_id: app_id, app_test_info: self)
+    end
+  end
+end

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -156,15 +156,22 @@ module Spaceship::TestFlight
     end
 
     ##
-    # @!group TestInfo
+    # @!group AppTestInfo
     ##
 
-    def put_testinfo(app_id: nil, testinfo: nil)
+    def get_app_test_info(app_id: nil)
+      assert_required_params(__method__, binding)
+
+      response = request(:get, "providers/#{team_id}/apps/#{app_id}/testInfo")
+      handle_response(response)
+    end
+
+    def put_app_test_info(app_id: nil, app_test_info: nil)
       assert_required_params(__method__, binding)
 
       response = request(:put) do |req|
         req.url "providers/#{team_id}/apps/#{app_id}/testInfo"
-        req.body = testinfo.to_json
+        req.body = app_test_info.to_json
         req.headers['Content-Type'] = 'application/json'
       end
       handle_response(response)

--- a/spaceship/spec/test_flight/app_test_info_spec.rb
+++ b/spaceship/spec/test_flight/app_test_info_spec.rb
@@ -86,7 +86,7 @@ describe Spaceship::TestFlight::AppTestInfo do
 
     it 'updates app test info on the server' do
       expect(app_test_info.client).to receive(:put_app_test_info).with(same_app_test_info(app_test_info))
-      app_test_info.save_for_app(app_id: 'app-id')
+      app_test_info.save_for_app!(app_id: 'app-id')
     end
   end
 end

--- a/spaceship/spec/test_flight/app_test_info_spec.rb
+++ b/spaceship/spec/test_flight/app_test_info_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+describe Spaceship::TestFlight::AppTestInfo do
+  let(:app_test_info) do
+    Spaceship::TestFlight::AppTestInfo.new({
+                                            'primaryLocale' => 'en-US',
+                                            'details' => [{
+                                              'locale' => 'en-US',
+                                              'feedbackEmail' => 'feedback@email.com',
+                                              'description' => 'Beta app description',
+                                              'whatsNew' => 'What is new'
+                                            }],
+                                            'betaReviewInfo' => {
+                                              'contactFirstName' => 'First',
+                                              'contactLastName' => 'Last',
+                                              'contactPhone' => '1234567890',
+                                              'contactEmail' => 'contact@email.com',
+                                              'demoAccountName' => 'User Name',
+                                              'demoAccountPassword' => 'Password',
+                                              'demoAccountRequired' => false,
+                                              'notes' => 'notes!!'
+                                            }
+                                          })
+  end
+
+  let(:test_info) do
+    Spaceship::TestFlight::TestInfo.new([
+                                          {
+                                            'locale' => 'en-US',
+                                            'description' => 'en-US description',
+                                            'feedbackEmail' => 'enUS@email.com',
+                                            'whatsNew' => 'US News'
+                                          },
+                                          {
+                                            'locale' => 'de-DE',
+                                            'description' => 'de-DE description',
+                                            'feedbackEmail' => 'deDE@email.com',
+                                            'whatsNew' => 'German News'
+                                          },
+                                          {
+                                            'locale' => 'de-AT',
+                                            'description' => 'de-AT description',
+                                            'feedbackEmail' => 'deAT@email.com',
+                                            'whatsNew' => 'Austrian News'
+                                          }
+                                        ])
+  end
+
+  let(:mock_client) { double('MockClient') }
+
+  before do
+    # Use a simple client for all data models
+    Spaceship::TestFlight::Base.client = mock_client
+  end
+
+  it 'gets the TestInfo' do
+    expect(app_test_info.test_info).to be_instance_of(Spaceship::TestFlight::TestInfo)
+    expect(app_test_info.test_info.feedback_email).to eq("feedback@email.com")
+    expect(app_test_info.test_info.description).to eq("Beta app description")
+    expect(app_test_info.test_info.whats_new).to eq('What is new')
+  end
+
+  it 'sets the TestInfo' do
+    app_test_info.test_info = test_info
+    expect(app_test_info.raw_data['details']).to eq(test_info.raw_data)
+  end
+
+  context 'client interactions' do
+    it 'find app test info on the server' do
+      mock_client_response(:get_app_test_info, with: hash_including(app_id: 'app-id')) do
+        app_test_info.raw_data
+      end
+
+      found_app_test_info = Spaceship::TestFlight::AppTestInfo.find(app_id: 'app-id')
+      expect(found_app_test_info).to be_instance_of(Spaceship::TestFlight::AppTestInfo)
+
+      # use to_h.to_s to compare raw_data, since they are different instances
+      expect(found_app_test_info.raw_data.to_h.to_s).to eq(app_test_info.raw_data.to_h.to_s)
+    end
+
+    RSpec::Matchers.define :same_app_test_info do |other_app_test_info|
+      match do |args|
+        args[:app_test_info].raw_data.to_h.to_s == other_app_test_info.raw_data.to_h.to_s
+      end
+    end
+
+    it 'updates app test info on the server' do
+      expect(app_test_info.client).to receive(:put_app_test_info).with(same_app_test_info(app_test_info))
+      app_test_info.save_for_app(app_id: 'app-id')
+    end
+  end
+end

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -161,14 +161,22 @@ describe Spaceship::TestFlight::Client do
   end
 
   ##
-  # @!group TestInfo
+  # @!group AppTestInfo
   ##
 
-  context '#put_testinfo' do
-    let(:testinfo) { double('TestInfo', to_json: '') }
+  context '#get_app_test_info' do
+    it 'executes the request' do
+      MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/testInfo') {}
+      subject.get_app_test_info(app_id: app_id)
+      expect(WebMock).to have_requested(:get, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/testInfo')
+    end
+  end
+
+  context '#put_app_test_info' do
+    let(:app_test_info) { double('AppTestInfo', to_json: '') }
     it 'executes the request' do
       MockAPI::TestFlightServer.put('/testflight/v2/providers/fake-team-id/apps/some-app-id/testInfo') {}
-      subject.put_testinfo(app_id: app_id, testinfo: testinfo)
+      subject.put_app_test_info(app_id: app_id, app_test_info: app_test_info)
       expect(WebMock).to have_requested(:put, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/testInfo')
     end
   end


### PR DESCRIPTION
So that we can set beta_app_feedback_email and beta_app_description

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

Add support for setting TestFlight app-level test info. Previously we had tried to set the beta feedback email and app description through build-level test-info, but this does not work. As such, when specifying feedback email and app description through `pilot`, we now set the app-level test info.