### PR TITLE
Version bump to 2.28.8

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.28.7'.freeze
+  VERSION = '2.28.8'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.28.7':**

* Add support for app-level test_info (#9055) via Mark Pirri
* docs: add remark about token (#9053) via Daniel Schmidt
* Set limit on testers request to 10k (#9054) via David Ohayon
* Fix error handling when schemes are not shared (#9037) via Felix Krause
* Gym option build time (#9034) via Rishabh Tayal
* [spaceship] enhance review fetching 📢 (#8701) via Helmut Januschka
* Remove mention of macOS from main README (#9032) via Felix Krause
* Setup fastlane train for fastlane deployment (#8836) via Felix Krause
* fix IAP modify (#8367) via Helmut Januschka
* Allow `appletvos` platform for dsyms download and upload to Crashlytics (#8588) via Seremet Mihai
* Replace stub with allow to fix deprecation warnings (#9027) via Fumiya Nakamura
* Add detection of removedFromSale apps (#9028) via Fumiya Nakamura
* Replace outdated Guide.md with links to new docs page (#9030) via Felix Krause
* Fix not disabling colors properly when using the `FASTLANE_DISABLE_COLORS` env variable (#9016) via Felix Krause
