### PR TITLE
Using whitelisted folders for detected languages

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -116,7 +116,7 @@ module Deliver
       end
 
       # Check folder list (an empty folder signifies a language is required)
-      Dir.glob(File.join(options[:metadata_path], "*")).each do |lng_folder|
+      Loader.language_folders(options[:metadata_path]).each do |lng_folder|
         next unless File.directory?(lng_folder) # We don't want to read txt as they are non localised
 
         language = File.basename(lng_folder)


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
This PR fixes the bug https://github.com/fastlane/fastlane/issues/9050 by essentially only looking for whitelisted language folders.

### Description
`FastlaneCore` already has a whitelist of languages supported by iTunes. This change ensures that it only uses the whitelisted folders list for language detection during a metadata upload to iTC using `deliver`.