### PR TITLE
Add a loud reminder to run the Mac App CI job

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -209,7 +209,6 @@ lane :update_docs do
 end
 
 def send_mac_app_ci_reminder
-  # require 'pry'; binding.pry
   if ENV['FABRIC_SLACK_URL']
     slack(
       slack_url: ENV['FABRIC_SLACK_URL'],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -244,7 +244,7 @@ private_lane :send_mac_app_ci_reminder do
       channel: 'deployment-tools',
       default_payloads: [],
       message: "Please run the Fastlane Mac App Package CI job in TeamCity\n#{ENV['FABRIC_MAC_APP_CI_JOB_URL']}"
-      )
+    )
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -208,17 +208,6 @@ lane :update_docs do
   end
 end
 
-def send_mac_app_ci_reminder
-  if ENV['FABRIC_SLACK_URL']
-    slack(
-      slack_url: ENV['FABRIC_SLACK_URL'],
-      channel: 'deployment-tools',
-      default_payloads: [],
-      message: "Please run the Fastlane Mac App Package CI job in TeamCity\n#{ENV['FABRIC_MAC_APP_CI_JOB_URL']}"
-      )
-  end
-end
-
 def generate_markdown_docs
   require 'fastlane/documentation/markdown_docs_generator'
   actions_md_path = File.expand_path("docs/actions.md")
@@ -246,6 +235,17 @@ error do |lane, exception|
     slack(channel: "testing", message: exception.to_s, success: false)
   end
   slack_train_crash
+end
+
+private_lane :send_mac_app_ci_reminder do
+  if ENV['FABRIC_SLACK_URL']
+    slack(
+      slack_url: ENV['FABRIC_SLACK_URL'],
+      channel: 'deployment-tools',
+      default_payloads: [],
+      message: "Please run the Fastlane Mac App Package CI job in TeamCity\n#{ENV['FABRIC_MAC_APP_CI_JOB_URL']}"
+      )
+  end
 end
 
 desc "Verifies all tests pass and the current state of the repo is valid"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -142,7 +142,7 @@ lane :release do
   releases_url = "https://github.com/fastlane/fastlane/releases/tag/#{version}"
   puts "[fastlane] #{github_release['name']} #{releases_url}"
 
-  print_mac_app_ci_reminder
+  send_mac_app_ci_reminder
 
   update_docs
   slack_train
@@ -208,10 +208,16 @@ lane :update_docs do
   end
 end
 
-def print_mac_app_ci_reminder
-  UI.header "IMPORTANT"
-  UI.important "Please run the Fabric Mac App Package CI job!"
-  UI.header "IMPORTANT"
+def send_mac_app_ci_reminder
+  # require 'pry'; binding.pry
+  if ENV['FABRIC_SLACK_URL']
+    slack(
+      slack_url: ENV['FABRIC_SLACK_URL'],
+      channel: 'deployment-tools',
+      default_payloads: [],
+      message: "Please run the Fastlane Mac App Package CI job in TeamCity\n#{ENV['FABRIC_MAC_APP_CI_JOB_URL']}"
+      )
+  end
 end
 
 def generate_markdown_docs

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -142,6 +142,8 @@ lane :release do
   releases_url = "https://github.com/fastlane/fastlane/releases/tag/#{version}"
   puts "[fastlane] #{github_release['name']} #{releases_url}"
 
+  print_mac_app_ci_reminder
+
   update_docs
   slack_train
 end
@@ -204,6 +206,12 @@ lane :update_docs do
       end
     end
   end
+end
+
+def print_mac_app_ci_reminder
+  UI.header "IMPORTANT"
+  UI.important "Please run the Fabric Mac App Package CI job!"
+  UI.header "IMPORTANT"
 end
 
 def generate_markdown_docs


### PR DESCRIPTION
This is a reminder at the end of a deployment to run the CI job that builds the _packaged-fastlane_ for the Fabric Mac app.