### PR TITLE
Improve deliver setup detection

### DIFF
--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -28,6 +28,7 @@ module Deliver
       return available_options
     end
 
+    # rubocop:disable Metrics/PerceivedComplexity
     def run
       program :name, 'deliver'
       program :version, Fastlane::VERSION
@@ -50,7 +51,10 @@ module Deliver
         c.action do |args, options|
           options = FastlaneCore::Configuration.create(deliverfile_options, options.__hash__)
           loaded = options.load_configuration_file("Deliverfile")
-          loaded = true if options[:description] || options[:ipa] || options[:pkg] || File.exist?(File.join(FastlaneCore::FastlaneFolder.path || ".", "metadata")) # do we have *anything* here?
+
+          # Check if we already have a deliver setup in the current directory
+          loaded = true if options[:description] || options[:ipa] || options[:pkg]
+          loaded = true if File.exist?(File.join(FastlaneCore::FastlaneFolder.path || ".", "metadata"))
           unless loaded
             if UI.confirm("No deliver configuration found in the current directory. Do you want to setup deliver?")
               require 'deliver/setup'
@@ -163,5 +167,6 @@ module Deliver
 
       run!
     end
+    # rubocop:enable Metrics/PerceivedComplexity
   end
 end

--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -51,6 +51,7 @@ module Deliver
           options = FastlaneCore::Configuration.create(deliverfile_options, options.__hash__)
           loaded = options.load_configuration_file("Deliverfile")
           loaded = true if options[:description] || options[:ipa] || options[:pkg] # do we have *anything* here?
+          loaded = true if File.exist?(File.join(FastlaneCore::FastlaneFolder.path || ".", "metadata"))
           unless loaded
             if UI.confirm("No deliver configuration found in the current directory. Do you want to setup deliver?")
               require 'deliver/setup'

--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -50,8 +50,7 @@ module Deliver
         c.action do |args, options|
           options = FastlaneCore::Configuration.create(deliverfile_options, options.__hash__)
           loaded = options.load_configuration_file("Deliverfile")
-          loaded = true if options[:description] || options[:ipa] || options[:pkg] # do we have *anything* here?
-          loaded = true if File.exist?(File.join(FastlaneCore::FastlaneFolder.path || ".", "metadata"))
+          loaded = true if options[:description] || options[:ipa] || options[:pkg] || File.exist?(File.join(FastlaneCore::FastlaneFolder.path || ".", "metadata")) # do we have *anything* here?
           unless loaded
             if UI.confirm("No deliver configuration found in the current directory. Do you want to setup deliver?")
               require 'deliver/setup'


### PR DESCRIPTION
If a user has deliver setup without a Deliverfile, and has a `metadata` folder, until now we didn't find it when seeing if deliver is setup for the current project.