### PR TITLE
supply: Allow specifying root url for androidpublisher api

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -74,6 +74,11 @@ module Supply
 
       self.android_publisher = Androidpublisher::AndroidPublisherService.new
       self.android_publisher.authorization = auth_client
+      if Supply.config[:root_url]
+        # Google's client expects the root_url string to end with "/".
+        Supply.config[:root_url] << '/' unless Supply.config[:root_url].end_with?('/')
+        self.android_publisher.root_url = Supply.config[:root_url]
+      end
     end
 
     #####################################################

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -3,6 +3,7 @@ require 'credentials_manager'
 
 module Supply
   class Options
+    # rubocop:disable Metrics/PerceivedComplexity
     def self.available_options
       valid_tracks = %w(production beta alpha rollout)
       @options ||= [
@@ -164,9 +165,17 @@ module Supply
                                        value.each do |path|
                                          UI.user_error! "Could not find mapping file at path '#{path}'" unless File.exist?(path)
                                        end
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :root_url,
+                                     env_name: "SUPPLY_ROOT_URL",
+                                     description: "Root URL for the Google Play API. The provided URL will be used for API calls in place of https://www.googleapis.com/",
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       UI.user_error! "Could not parse URL '#{value}'" unless value =~ URI.regexp
                                      end)
 
       ]
     end
+    # rubocop:enable Metrics/PerceivedComplexity
   end
 end


### PR DESCRIPTION
This allows `supply` to override the `root_url` for Google's API client.
This is useful to point at a local server or a proxy.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This allows pointing `supply` at localhost or a proxy. It is useful for debugging, writing tests, or making all api calls go through a proxy.

### Description
Allow `supply` to be configured to point to any URL. This allows pointing `supply` at localhost or a proxy.
