### PR TITLE
Improving the output of EnsureGitStatusCleanAction

### DIFF
--- a/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -7,13 +7,16 @@ module Fastlane
     # Raises an exception and stop the lane execution if the repo is not in a clean state
     class EnsureGitStatusCleanAction < Action
       def self.run(params)
-        repo_clean = `git status --porcelain`.empty?
+        repo_status = Actions.sh("git status --porcelain")
+        repo_clean = repo_status.empty?
 
         if repo_clean
           UI.success('Git status is clean, all good! 💪')
           Actions.lane_context[SharedValues::GIT_REPO_WAS_CLEAN_ON_START] = true
         else
-          UI.user_error!("Git repository is dirty! Please ensure the repo is in a clean state by committing/stashing/discarding all changes first.")
+          error_message = "Git repository is dirty! Please ensure the repo is in a clean state by committing/stashing/discarding all changes first."
+          error_message += "\nUncommitted changes:\n#{repo_status}" if params[:show_uncommitted_changes]
+          UI.user_error!(error_message)
         end
       end
 
@@ -43,6 +46,18 @@ module Fastlane
 
       def self.example_code
         ['ensure_git_status_clean']
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :show_uncommitted_changes,
+                                       env_name: "FL_ENSURE_GIT_STATUS_CLEAN_SHOW_UNCOMMITTED_CHANGES",
+                                       description: "The flag whether to show uncommitted changes if the repo is dirty",
+                                       optional: true,
+                                       default_value: false,
+                                       is_string: false
+                                       )
+        ]
       end
 
       def self.category

--- a/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -41,7 +41,7 @@ module Fastlane
       end
 
       def self.author
-        "lmirosevic"
+        ["lmirosevic", "antondomashnev"]
       end
 
       def self.example_code
@@ -55,8 +55,7 @@ module Fastlane
                                        description: "The flag whether to show uncommitted changes if the repo is dirty",
                                        optional: true,
                                        default_value: false,
-                                       is_string: false
-                                       )
+                                       is_string: false)
         ]
       end
 

--- a/fastlane/spec/actions_specs/ensure_git_status_clean_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_git_status_clean_spec.rb
@@ -1,0 +1,58 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "ensure_git_status_clean" do
+      before :each do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+        allow(FastlaneCore::UI).to receive(:success).with("Driving the lane 'test' 🚀")
+      end
+
+      context "when git status is clean" do
+        before :each do
+          allow(Fastlane::Actions).to receive(:sh).with("git status --porcelain").and_return("")
+        end
+
+        it "outputs success message" do
+          expect(FastlaneCore::UI).to receive(:success).with("Git status is clean, all good! 💪")
+          Fastlane::FastFile.new.parse("lane :test do
+            ensure_git_status_clean
+          end").runner.execute(:test)
+        end
+      end
+
+      context "when git status is not clean" do
+        before :each do
+          allow(Fastlane::Actions).to receive(:sh).with("git status --porcelain").and_return("M fastlane/lib/fastlane/actions/ensure_git_status_clean.rb")
+        end
+
+        context "with show_uncommitted_changes flag" do
+          context "true" do
+            it "outputs reach error message" do
+              expect(FastlaneCore::UI).to receive(:user_error!).with("Git repository is dirty! Please ensure the repo is in a clean state by committing/stashing/discarding all changes first.\nUncommitted changes:\nM fastlane/lib/fastlane/actions/ensure_git_status_clean.rb")
+              Fastlane::FastFile.new.parse("lane :test do
+                ensure_git_status_clean(show_uncommitted_changes: true)
+              end").runner.execute(:test)
+            end
+          end
+
+          context "false" do
+            it "outputs short error message" do
+              expect(FastlaneCore::UI).to receive(:user_error!).with("Git repository is dirty! Please ensure the repo is in a clean state by committing/stashing/discarding all changes first.")
+              Fastlane::FastFile.new.parse("lane :test do
+                ensure_git_status_clean(show_uncommitted_changes: false)
+              end").runner.execute(:test)
+            end
+          end
+        end
+
+        context "without show_uncommitted_changes flag" do
+          it "outputs short error message" do
+            expect(FastlaneCore::UI).to receive(:user_error!).with("Git repository is dirty! Please ensure the repo is in a clean state by committing/stashing/discarding all changes first.")
+            Fastlane::FastFile.new.parse("lane :test do
+              ensure_git_status_clean
+            end").runner.execute(:test)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This is a PR with the implementation of proposal in #9049 issue.

### Description
- [x] Added new flag `show_uncommitted_changes` to output status message in case if the repo is not clean
- [x] Added spec for the `EnsureGitStatusCleanAction`
