### PR TITLE
Artifactory action to return shared lane values

### DIFF
--- a/fastlane/lib/fastlane/actions/artifactory.rb
+++ b/fastlane/lib/fastlane/actions/artifactory.rb
@@ -1,5 +1,10 @@
 module Fastlane
   module Actions
+    module SharedValues
+      ARTIFACTORY_DOWNLOAD_URL = :ARTIFACTORY_DOWNLOAD_URL
+      ARTIFACTORY_DOWNLOAD_SIZE = :ARTIFACTORY_DOWNLOAD_SIZE
+    end
+
     class ArtifactoryAction < Action
       def self.run(params)
         Actions.verify_gem!('artifactory')
@@ -17,6 +22,10 @@ module Fastlane
           }
           UI.message("Uploading file: #{artifact.local_path} ...")
           upload = artifact.upload(params[:repo], params[:repo_path], params[:properties])
+
+          Actions.lane_context[SharedValues::ARTIFACTORY_DOWNLOAD_URL] = upload.uri
+          Actions.lane_context[SharedValues::ARTIFACTORY_DOWNLOAD_SIZE] = upload.size
+
           UI.message("Uploaded Artifact:")
           UI.message("Repo: #{upload.repo}")
           UI.message("URI: #{upload.uri}")
@@ -44,7 +53,14 @@ module Fastlane
       end
 
       def self.author
-        ["koglinjg"]
+        ["koglinjg", "tommeier"]
+      end
+
+      def self.output
+        [
+          ['ARTIFACTORY_DOWNLOAD_URL', 'The download url for file uploaded'],
+          ['ARTIFACTORY_DOWNLOAD_SIZE', 'The reported file size for file uploaded']
+        ]
       end
 
       def self.example_code


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

The existing `Artifactory` action only prints the result to `UI.message`, it would be useful to have the download URL generated from the uploaded artefact to use in the current lane context, I've also added `size` as that is the only other bit of useful info gleaned from the artifactory result.