### PR TITLE
Better log message for supply not being able to download screenshots

### DIFF
--- a/supply/lib/supply/setup.rb
+++ b/supply/lib/supply/setup.rb
@@ -44,7 +44,7 @@ module Supply
       IMAGES_TYPES.each do |image_type|
         if ['featureGraphic'].include?(image_type)
           # we don't get all files in full resolution :(
-          UI.message("Due to the limit of the Google Play API `supply` can't download your existing feature graphics...")
+          UI.message("Due to a limitation of the Google Play API, there is no way for `supply` to download your existing feature graphics. Please copy your feature graphics into `metadata/android/en-US/images/`")
           next
         end
 
@@ -71,7 +71,7 @@ module Supply
         FileUtils.mkdir_p(File.join(containing, IMAGES_FOLDER_NAME, screenshot_type))
       end
 
-      UI.message("Due to the limit of the Google Play API `supply` can't download your existing screenshots...")
+      UI.message("Due to a limitation of the Google Play API, there is no way for `supply` to download your existing screenshots. Please copy your screenshots into `metadata/android/en-US/images/`")
     end
 
     def store_apk_listing(apk_listing)


### PR DESCRIPTION
See: #9076

I think this log message would clear up some confusion about the API limitation.