### PR TITLE
Change metrics collection endpoint 

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ In addition to `fastlane`'s commands, you also have access to these `fastlane` t
 - [`match`](https://github.com/fastlane/fastlane/tree/master/match): Easily sync your certificates and profiles across your team using Git
 - [`scan`](https://github.com/fastlane/fastlane/tree/master/scan): The easiest way to run tests for your iOS and Mac apps
 
+## Statistics
+
+`fastlane` tracks the number of errors for each action to detect integration issues.
+
+You can easily opt-out by adding `opt_out_usage` to your `Fastfile` or by setting the environment variable `FASTLANE_OPT_OUT_USAGE`. To also disable update checks, set the `FASTLANE_SKIP_UPDATE_CHECK` variable.
+
 ## Need Help?
 
 Please [submit an issue](https://github.com/fastlane/fastlane/issues) on GitHub and provide information about your setup.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ _fastlane_ tracks a few key metrics to understand how developers are using the t
 
 We have recently changed the destination service to which these metrics are reported, as well as the format of the data, but the data that is collected has not changed.
 
-You can easily opt-out of metrics collection by adding `opt_out_usage` to your `Fastfile` or by setting the environment variable `FASTLANE_OPT_OUT_USAGE`. Participating helps us provide the best possible support for _fastlane_, so we hope you'll consider it a plus! :heavy_plus_sign:
+You can easily opt-out of metrics collection by adding `opt_out_usage` at the top of your `Fastfile` or by setting the environment variable `FASTLANE_OPT_OUT_USAGE`. Participating helps us provide the best possible support for _fastlane_, so we hope you'll consider it a plus! :heavy_plus_sign:
 
 ## Need Help?
 

--- a/README.md
+++ b/README.md
@@ -139,11 +139,20 @@ In addition to `fastlane`'s commands, you also have access to these `fastlane` t
 - [`match`](https://github.com/fastlane/fastlane/tree/master/match): Easily sync your certificates and profiles across your team using Git
 - [`scan`](https://github.com/fastlane/fastlane/tree/master/scan): The easiest way to run tests for your iOS and Mac apps
 
-## Statistics
+## Metrics
 
-`fastlane` tracks the number of errors for each action to detect integration issues.
+_fastlane_ tracks a few key metrics to understand how developers are using the tool and to help us know what areas need improvement. No personal/sensitive information is ever collected. Metrics that are collected include: 
 
-You can easily opt-out by adding `opt_out_usage` to your `Fastfile` or by setting the environment variable `FASTLANE_OPT_OUT_USAGE`. To also disable update checks, set the `FASTLANE_SKIP_UPDATE_CHECK` variable.
+* The number of successes, errors, and crashes for _fastlane_ and each action run in a Fastfile
+* The running time of _fastlane_
+* The method by which _fastlane_ was installed
+* Whether _fastlane_ is being run on CI
+* The platform (e.g. iOS, Android) for which _fastlane_ is run
+* A hash of the app identifier or package name, which helps us anonymously identify unique usage of _fastlane_
+
+We have recently changed the destination service to which these metrics are reported, as well as the format of the data, but the data that is collected has not changed.
+
+You can easily opt-out of metrics collection by adding `opt_out_usage` to your `Fastfile` or by setting the environment variable `FASTLANE_OPT_OUT_USAGE`. Participating helps us provide the best possible support for _fastlane_, so we hope you'll consider it a plus! :heavy_plus_sign:
 
 ## Need Help?
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,10 +5,6 @@ lane :test do |options|
   validate_repo
 end
 
-lane :andrea_test do |options|
-  puts "testing"
-end
-
 desc "Increment the version number of this gem"
 lane :bump do |options|
   ensure_git_branch(branch: "master")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,6 +5,10 @@ lane :test do |options|
   validate_repo
 end
 
+lane :andrea_test do |options|
+  puts "testing"
+end
+
 desc "Increment the version number of this gem"
 lane :bump do |options|
   ensure_git_branch(branch: "master")

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -186,7 +186,7 @@ See how [Wikipedia](https://github.com/fastlane/examples#wikipedia-by-wikimedia-
 
 ## Statistics
 
-`fastlane` tracks the number of errors for each action to detect integration issues. The data will be sent to [fastlane-enhancer](https://github.com/fastlane/enhancer).
+`fastlane` tracks the number of errors for each action to detect integration issues.
 
 You can easily opt-out by adding `opt_out_usage` to your `Fastfile` or by setting the environment variable `FASTLANE_OPT_OUT_USAGE`. To also disable update checks, set the `FASTLANE_SKIP_UPDATE_CHECK` variable.
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -184,12 +184,6 @@ See how [Wikipedia](https://github.com/fastlane/examples#wikipedia-by-wikimedia-
 - [`gym`](https://github.com/fastlane/fastlane/tree/master/gym): Building your iOS apps has never been easier
 - [`match`](https://github.com/fastlane/fastlane/tree/master/match): Easily sync your certificates and profiles across your team using git
 
-## Statistics
-
-`fastlane` tracks the number of errors for each action to detect integration issues.
-
-You can easily opt-out by adding `opt_out_usage` to your `Fastfile` or by setting the environment variable `FASTLANE_OPT_OUT_USAGE`. To also disable update checks, set the `FASTLANE_SKIP_UPDATE_CHECK` variable.
-
 ## Credentials
 A detailed description about how `fastlane` stores your credentials is available on a [separate repo](https://github.com/fastlane/fastlane/tree/master/credentials_manager).
 

--- a/fastlane/lib/assets/DefaultFastfileTemplate
+++ b/fastlane/lib/assets/DefaultFastfileTemplate
@@ -70,4 +70,4 @@ end
 # All available actions: https://docs.fastlane.tools/actions
 
 # fastlane reports which actions are used. No personal data is recorded. 
-# Learn more at https://github.com/fastlane/fastlane/tree/master/fastlane#statistics
+# Learn more at https://github.com/fastlane/fastlane#statistics

--- a/fastlane/lib/assets/DefaultFastfileTemplate
+++ b/fastlane/lib/assets/DefaultFastfileTemplate
@@ -69,5 +69,5 @@ end
 # More information about multiple platforms in fastlane: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Platforms.md
 # All available actions: https://docs.fastlane.tools/actions
 
-# fastlane reports which actions are used
-# No personal data is recorded. Learn more at https://github.com/fastlane/enhancer
+# fastlane reports which actions are used. No personal data is recorded. 
+# Learn more at https://github.com/fastlane/fastlane/tree/master/fastlane#statistics

--- a/fastlane/lib/assets/DefaultFastfileTemplate
+++ b/fastlane/lib/assets/DefaultFastfileTemplate
@@ -70,4 +70,4 @@ end
 # All available actions: https://docs.fastlane.tools/actions
 
 # fastlane reports which actions are used. No personal data is recorded. 
-# Learn more at https://github.com/fastlane/fastlane#statistics
+# Learn more at https://github.com/fastlane/fastlane#metrics

--- a/fastlane/lib/assets/FastfileTemplateAndroid
+++ b/fastlane/lib/assets/FastfileTemplateAndroid
@@ -62,5 +62,5 @@ end
 # More information about multiple platforms in fastlane: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Platforms.md
 # All available actions: https://docs.fastlane.tools/actions
 
-# fastlane reports which actions are used
-# No personal data is sent or shared. Learn more at https://github.com/fastlane/enhancer
+# fastlane reports which actions are used. No personal data is recorded. 
+# Learn more at https://github.com/fastlane/fastlane/tree/master/fastlane#statistics

--- a/fastlane/lib/assets/FastfileTemplateAndroid
+++ b/fastlane/lib/assets/FastfileTemplateAndroid
@@ -63,4 +63,4 @@ end
 # All available actions: https://docs.fastlane.tools/actions
 
 # fastlane reports which actions are used. No personal data is recorded. 
-# Learn more at https://github.com/fastlane/fastlane/tree/master/fastlane#statistics
+# Learn more at https://github.com/fastlane/fastlane#metrics

--- a/fastlane/lib/fastlane/action_collector.rb
+++ b/fastlane/lib/fastlane/action_collector.rb
@@ -19,7 +19,7 @@ module Fastlane
     end
 
     def show_message
-      UI.message("Sending Crash/Success information. Learn more at https://github.com/fastlane/fastlane/tree/master/fastlane#statistics")
+      UI.message("Sending Crash/Success information. Learn more at https://github.com/fastlane/fastlane#metrics")
       UI.message("No personal/sensitive data is sent. Only sharing the following:")
       UI.message(launches)
       UI.message(@error) if @error

--- a/fastlane/lib/fastlane/action_collector.rb
+++ b/fastlane/lib/fastlane/action_collector.rb
@@ -19,7 +19,7 @@ module Fastlane
     end
 
     def show_message
-      UI.message("Sending Crash/Success information. More information on: https://github.com/fastlane/enhancer")
+      UI.message("Sending Crash/Success information. Learn more at https://github.com/fastlane/fastlane/tree/master/fastlane#statistics")
       UI.message("No personal/sensitive data is sent. Only sharing the following:")
       UI.message(launches)
       UI.message(@error) if @error

--- a/fastlane/lib/fastlane/action_collector.rb
+++ b/fastlane/lib/fastlane/action_collector.rb
@@ -24,7 +24,7 @@ module Fastlane
       UI.message(launches)
       UI.message(@error) if @error
       UI.message("This information is used to fix failing actions and improve integrations that are often used.")
-      UI.message("You can disable this by adding `opt_out_usage` to your Fastfile")
+      UI.message("You can disable this by adding `opt_out_usage` at the top of your Fastfile")
     end
 
     def determine_version(name)

--- a/fastlane/lib/fastlane/actions/opt_out_usage.rb
+++ b/fastlane/lib/fastlane/actions/opt_out_usage.rb
@@ -13,7 +13,8 @@ module Fastlane
       def self.details
         [
           "By default, fastlane will track what actions are being used",
-          "No personal information is shared.",
+          "No personal/sensitive information is recorded.",
+          "Learn more at https://github.com/fastlane/fastlane#metrics"
           "Add `opt_out_usage` at the top of your Fastfile to disable metrics collection"
         ].join(' ')
       end

--- a/fastlane/lib/fastlane/actions/opt_out_usage.rb
+++ b/fastlane/lib/fastlane/actions/opt_out_usage.rb
@@ -13,9 +13,8 @@ module Fastlane
       def self.details
         [
           "By default, fastlane will track what actions are being used",
-          "No personal information is shared. More information available on",
-          "https://github.com/fastlane/enhancer",
-          "Add `opt_out_usage` at the top of your Fastfile"
+          "No personal information is shared.",
+          "Add `opt_out_usage` at the top of your Fastfile to disable metrics collection"
         ].join(' ')
       end
 

--- a/fastlane/lib/fastlane/actions/opt_out_usage.rb
+++ b/fastlane/lib/fastlane/actions/opt_out_usage.rb
@@ -14,7 +14,7 @@ module Fastlane
         [
           "By default, fastlane will track what actions are being used",
           "No personal/sensitive information is recorded.",
-          "Learn more at https://github.com/fastlane/fastlane#metrics"
+          "Learn more at https://github.com/fastlane/fastlane#metrics",
           "Add `opt_out_usage` at the top of your Fastfile to disable metrics collection"
         ].join(' ')
       end

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -49,6 +49,7 @@ module Fastlane
     def show_analytics
       UI.message("fastlane will collect the number of errors for each action to detect integration issues")
       UI.message("No sensitive/private information will be uploaded")
+      UI.message("Learn more at https://github.com/fastlane/fastlane#metrics")
     end
   end
 end

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -47,8 +47,7 @@ module Fastlane
     end
 
     def show_analytics
-      UI.message("fastlane will send the number of errors for each action to")
-      UI.message("https://github.com/fastlane/enhancer to detect integration issues")
+      UI.message("fastlane will collect the number of errors for each action to detect integration issues")
       UI.message("No sensitive/private information will be uploaded")
     end
   end

--- a/fastlane_core/lib/fastlane_core/tool_collector.rb
+++ b/fastlane_core/lib/fastlane_core/tool_collector.rb
@@ -62,7 +62,7 @@ module FastlaneCore
       end
 
       require 'excon'
-      url = ENV["ANALYTIC_INGESTER_URL"] || "https://ana-ing.fabric.io/public"
+      url = ENV["FASTLANE_METRICS_URL"] || "https://fastlane-metrics.fabric.io/public"
 
       analytic_event_body = create_analytic_event_body
 

--- a/fastlane_core/lib/fastlane_core/tool_collector.rb
+++ b/fastlane_core/lib/fastlane_core/tool_collector.rb
@@ -1,5 +1,7 @@
 module FastlaneCore
   class ToolCollector
+    # Learn more at https://github.com/fastlane/fastlane#metrics
+
     # This is the original error reporting mechanism, which has always represented
     # either controlled (UI.user_error!), or uncontrolled (UI.crash!, anything else)
     # exceptions.
@@ -119,6 +121,7 @@ module FastlaneCore
 
     def show_message
       UI.message("Sending Crash/Success information")
+      UI.message("Learn more at https://github.com/fastlane/fastlane#metrics")
       UI.message("No personal/sensitive data is sent. Only sharing the following:")
       UI.message(launches)
       UI.message(@error) if @error

--- a/fastlane_core/lib/fastlane_core/tool_collector.rb
+++ b/fastlane_core/lib/fastlane_core/tool_collector.rb
@@ -126,7 +126,7 @@ module FastlaneCore
       UI.message(launches)
       UI.message(@error) if @error
       UI.message("This information is used to fix failing tools and improve those that are most often used.")
-      UI.message("You can disable this by setting the environment variable: FASTLANE_OPT_OUT_USAGE=1")
+      UI.message("You can disable this by adding `opt_out_usage` at the top of your Fastfile")
     end
 
     def launches

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -153,8 +153,8 @@ module FastlaneCore
     # Use this method to exit the program because of a test failure
     # that's caused by the source code of the user. Example for this
     # is that scan will fail when the tests fail.
-    # By using this method we'll get more accurate results on the
-    # fastlane failures on enhancer
+    # By using this method we'll have more accurate results about
+    # fastlane failures
     def test_failure!(error_message)
       raise FastlaneTestFailure.new, error_message
     end

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -287,7 +287,7 @@ module FastlaneCore
     def self.send_events(analytics)
       analytic_event_body = { analytics: analytics }.to_json
 
-      url = ENV["ANALYTIC_INGESTER_URL"] || "https://ana-ing.fabric.io/public"
+      url = ENV["FASTLANE_METRICS_URL"] || "https://fastlane-metrics.fabric.io/public"
       Excon.post(url,
                  body: analytic_event_body,
                  headers: { "Content-Type" => 'application/json' })

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -192,7 +192,7 @@ module FastlaneCore
     end
 
     def self.send_launch_analytic_events_for(gem_name)
-      return if ENV["FASTLANE_OPT_OUT_USAGE"]
+      return if FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
 
       ci = Helper.is_ci?.to_s
       project_hash = p_hash(ARGV, gem_name)
@@ -261,7 +261,7 @@ module FastlaneCore
     end
 
     def self.send_completion_events_for(gem_name)
-      return if ENV["FASTLANE_OPT_OUT_USAGE"]
+      return if FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
 
       ci = Helper.is_ci?.to_s
       install_method = if Helper.rubygems?
@@ -287,7 +287,6 @@ module FastlaneCore
       analytic_event_body = { analytics: analytics }.to_json
 
       url = ENV["ANALYTIC_INGESTER_URL"] || "https://ana-ing.fabric.io/public"
-
       Excon.post(url,
                 :body => analytic_event_body,
                 :headers => { "Content-Type" => 'application/json' })

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -15,11 +15,19 @@ module FastlaneCore
 
       @start_time = Time.now
 
-      url = generate_fetch_url(gem_name)
       Thread.new do
         begin
-          server_results[gem_name] = fetch_latest(url)
+          send_launch_analytic_events_for(gem_name)
         rescue
+          # we don't want to show a stack trace if something goes wrong
+        end
+      end
+
+      Thread.new do
+        begin
+          server_results[gem_name] = fetch_latest(gem_name)
+        rescue
+          # we don't want to show a stack trace if something goes wrong
         end
       end
     end
@@ -36,7 +44,7 @@ module FastlaneCore
     def self.show_update_status(gem_name, current_version)
       fork do
         begin
-          finished_running(gem_name)
+          send_completion_events_for(gem_name)
         rescue
           # we don't want to show a stack trace if something goes wrong
         end
@@ -102,38 +110,8 @@ module FastlaneCore
       UI.command("gem sources --add https://rubygems.org")
     end
 
-    # Generate the URL on the main thread (since we're switching directory)
-    def self.generate_fetch_url(gem_name)
-      url = UPDATE_URL + gem_name
-      params = {}
-      params["ci"] = "1" if Helper.is_ci?
-
-      project_hash = p_hash(ARGV, gem_name)
-      params["p_hash"] = project_hash if project_hash
-      params["platform"] = @platform if @platform # this has to be called after `p_hash`
-
-      url += "?" + URI.encode_www_form(params) if params.count > 0
-      return url
-    end
-
-    def self.fetch_latest(url)
-      JSON.parse(Excon.post(url).body).fetch("version", nil)
-    end
-
-    def self.finished_running(gem_name)
-      return if ENV["FASTLANE_OPT_OUT_USAGE"]
-
-      time = (Time.now - @start_time).to_i
-      url = UPDATE_URL + "time/#{gem_name}"
-      url += "?time=#{time}"
-      url += "&ci=1" if Helper.ci?
-      url += "&gem=1" if Helper.rubygems?
-      url += "&bundler=1" if Helper.bundler?
-      url += "&mac_app=1" if Helper.mac_app?
-      url += "&standalone=1" if Helper.contained_fastlane?
-      url += "&homebrew=1" if Helper.homebrew?
-
-      Excon.post(url)
+    def self.fetch_latest(gem_name)
+      JSON.parse(Excon.get("https://rubygems.org/api/v1/gems/#{gem_name}.json").body)["version"]
     end
 
     # (optional) Returns the app identifier for the current tool
@@ -211,6 +189,168 @@ module FastlaneCore
       return nil
     rescue
       return nil
+    end
+
+    def self.send_launch_analytic_events_for(gem_name)
+      return if ENV["FASTLANE_OPT_OUT_USAGE"]
+
+      ci = Helper.is_ci?.to_s
+      project_hash = p_hash(ARGV, gem_name)
+      p_hash = project_hash if project_hash
+      platform = @platform if @platform # this has to be called after `p_hash`
+
+      send_launch_analytic_events(p_hash, gem_name, platform, ci)
+    end
+
+    def self.send_launch_analytic_events(p_hash, tool, platform, ci)
+      timestamp_seconds = Time.now.to_i
+
+      analytics = []
+      analytics << event_for_p_hash(p_hash, tool, platform, timestamp_seconds) if p_hash
+      analytics << event_for_launch(tool, ci, timestamp_seconds)
+
+      send_events(analytics)
+    end
+
+    def self.event_for_p_hash(p_hash, tool, platform, timestamp_seconds)
+      {
+        event_source: {
+          oauth_app_name: 'fastlane-refresher',
+          product: 'fastlane'
+        },
+        actor: {
+          name:'project',
+          detail: p_hash
+        },
+        action: {
+          name: 'update_checked'
+        },
+        primary_target: {
+          name: 'tool',
+          detail: tool || 'unknown'
+        },
+        secondary_target: {
+          name: 'platform',
+          detail: platform || 'unknown'
+        },
+        millis_since_epoch: timestamp_seconds * 1000,
+        version: 1
+      }
+    end
+
+    def self.event_for_launch(tool, ci, timestamp_seconds)
+      {
+        event_source: {
+          oauth_app_name: 'fastlane-refresher',
+          product: 'fastlane'
+        },
+        actor: {
+          name:'tool',
+          detail: tool || 'unknown'
+        },
+        action: {
+          name: 'launched'
+        },
+        primary_target: {
+          name: 'ci',
+          detail: ci
+        },
+        millis_since_epoch: timestamp_seconds * 1000,
+        version: 1
+      }
+    end
+
+    def self.send_completion_events_for(gem_name)
+      return if ENV["FASTLANE_OPT_OUT_USAGE"]
+
+      ci = Helper.is_ci?.to_s
+      install_method = if Helper.rubygems?
+                         'gem'
+                       elsif Helper.bundler?
+                         'bundler'
+                       elsif Helper.mac_app?
+                         'mac_app'
+                       elsif Helper.contained_fastlane?
+                         'standalone'
+                       elsif Helper.homebrew?
+                         'homebrew'
+                       else
+                         'unknown'
+                       end
+      duration = (Time.now - @start_time).to_i
+      timestamp_seconds = Time.now.to_i
+
+      send_completion_events(gem_name, ci, install_method, duration, timestamp_seconds)
+    end
+
+    def self.send_events(analytics)
+      analytic_event_body = { analytics: analytics }.to_json
+
+      url = ENV["ANALYTIC_INGESTER_URL"] || "https://ana-ing.fabric.io/public"
+
+      Excon.post(url,
+                :body => analytic_event_body,
+                :headers => { "Content-Type" => 'application/json' })
+    end
+
+    def self.event_for_completion(tool, ci, duration, timestamp_seconds)
+      {
+        event_source: {
+          oauth_app_name: 'fastlane-refresher',
+          product: 'fastlane'
+        },
+        actor: {
+          name:'tool',
+          detail: tool || 'unknown'
+        },
+        action: {
+          name: 'completed_with_duration'
+        },
+        primary_target: {
+          name: 'duration',
+          detail: duration.to_s
+        },
+        secondary_target: {
+          name: 'ci',
+          detail: ci
+        },
+        millis_since_epoch: timestamp_seconds * 1000,
+        version: 1
+      }
+    end
+
+    def self.event_for_install_method(tool, ci, install_method, timestamp_seconds)
+      {
+        event_source: {
+          oauth_app_name: 'fastlane-refresher',
+          product: 'fastlane'
+        },
+        actor: {
+          name:'tool',
+          detail: tool || 'unknown'
+        },
+        action: {
+          name: 'completed_with_install_method'
+        },
+        primary_target: {
+          name: 'install_method',
+          detail: install_method
+        },
+        secondary_target: {
+          name: 'ci',
+          detail: ci
+        },
+        millis_since_epoch: timestamp_seconds * 1000,
+        version: 1
+      }
+    end
+
+    def self.send_completion_events(tool, ci, install_method, duration, timestamp_seconds)
+      analytics = []
+      analytics << event_for_completion(tool, ci, duration, timestamp_seconds)
+      analytics << event_for_install_method(tool, ci, install_method, timestamp_seconds)
+
+      send_events(analytics)
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -6,9 +6,6 @@ require 'fastlane_core/update_checker/changelog'
 module FastlaneCore
   # Verifies, the user runs the latest version of this gem
   class UpdateChecker
-    # This web service is fully open source: https://github.com/fastlane/refresher
-    UPDATE_URL = "https://refresher.fastlane.tools/"
-
     def self.start_looking_for_update(gem_name)
       return if Helper.is_test?
       return if FastlaneCore::Env.truthy?("FASTLANE_SKIP_UPDATE_CHECK")
@@ -169,7 +166,7 @@ module FastlaneCore
     end
 
     # To not count the same projects multiple time for the number of launches
-    # More information: https://github.com/fastlane/refresher
+    # Learn more at https://github.com/fastlane/fastlane#metrics
     # Use the `FASTLANE_OPT_OUT_USAGE` variable to opt out
     # The resulting value is e.g. ce12f8371df11ef6097a83bdf2303e4357d6f5040acc4f76019489fa5deeae0d
     def self.p_hash(args, gem_name)

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -36,8 +36,8 @@ module FastlaneCore
       @results ||= {}
     end
 
-    def self.start_time
-      @start_time
+    class << self
+      attr_reader :start_time
     end
 
     def self.update_available?(gem_name, current_version)
@@ -223,7 +223,7 @@ module FastlaneCore
           product: 'fastlane'
         },
         actor: {
-          name:'project',
+          name: 'project',
           detail: p_hash
         },
         action: {
@@ -249,7 +249,7 @@ module FastlaneCore
           product: 'fastlane'
         },
         actor: {
-          name:'tool',
+          name: 'tool',
           detail: tool || 'unknown'
         },
         action: {
@@ -292,8 +292,8 @@ module FastlaneCore
 
       url = ENV["ANALYTIC_INGESTER_URL"] || "https://ana-ing.fabric.io/public"
       Excon.post(url,
-                :body => analytic_event_body,
-                :headers => { "Content-Type" => 'application/json' })
+                 body: analytic_event_body,
+                 headers: { "Content-Type" => 'application/json' })
     end
 
     def self.event_for_completion(tool, ci, duration, timestamp_seconds)
@@ -303,7 +303,7 @@ module FastlaneCore
           product: 'fastlane'
         },
         actor: {
-          name:'tool',
+          name: 'tool',
           detail: tool || 'unknown'
         },
         action: {
@@ -329,7 +329,7 @@ module FastlaneCore
           product: 'fastlane'
         },
         actor: {
-          name:'tool',
+          name: 'tool',
           detail: tool || 'unknown'
         },
         action: {

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -36,6 +36,10 @@ module FastlaneCore
       @results ||= {}
     end
 
+    def self.start_time
+      @start_time
+    end
+
     def self.update_available?(gem_name, current_version)
       latest = server_results[gem_name]
       return (latest and Gem::Version.new(latest) > Gem::Version.new(current_version))
@@ -277,7 +281,7 @@ module FastlaneCore
                        else
                          'unknown'
                        end
-      duration = (Time.now - @start_time).to_i
+      duration = (Time.now - start_time).to_i
       timestamp_seconds = Time.now.to_i
 
       send_completion_events(gem_name, ci, install_method, duration, timestamp_seconds)

--- a/fastlane_core/spec/tool_collector_spec.rb
+++ b/fastlane_core/spec/tool_collector_spec.rb
@@ -1,6 +1,6 @@
 describe FastlaneCore::ToolCollector do
   before(:all) { ENV.delete("FASTLANE_OPT_OUT_USAGE") }
-
+  
   let(:collector) { FastlaneCore::ToolCollector.new }
 
   it "keeps track of what tools get invoked" do
@@ -42,23 +42,82 @@ describe FastlaneCore::ToolCollector do
     end
   end
 
-  it "posts the collected data when finished" do
+  it "posts the collected data with a crash when finished" do
     collector.did_launch_action(:gym)
     collector.did_launch_action(:scan)
     collector.did_crash(:scan)
-    url = collector.did_finish
 
-    form = Hash[URI.decode_www_form(url.split("?")[1])]
-    form["steps"] = JSON.parse form["steps"]
-    form["versions"] = JSON.parse form["versions"]
+    analytic_event_body = collector.create_analytic_event_body
+    analytics = JSON.parse(analytic_event_body)['analytics']
+    
+    expect(analytics.size).to eq(4)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'scan'}.size).to eq(1)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'gym'}.size).to eq(1)
+    expect(analytics.find_all { |a| a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'scan'}.size).to eq(2)
+    expect(analytics.find_all { |a| a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'gym'}.size).to eq(2)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == 'crash' && a['actor']['detail'] == 'scan'}.size).to eq(1)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == 'success' && a['actor']['detail'] == 'gym'}.size).to eq(1)
+  end
 
-    expect(form["steps"]["gym"]).to eq(1)
-    expect(form["steps"]["scan"]).to eq(1)
+  it "posts the collected data with an error when finished" do
+    collector.did_launch_action(:gym)
+    collector.did_launch_action(:scan)
+    collector.did_raise_error(:scan)
 
-    expect(form["versions"]["gym"]).to eq(Fastlane::VERSION)
-    expect(form["versions"]["scan"]).to eq(Fastlane::VERSION)
+    analytic_event_body = collector.create_analytic_event_body
+    analytics = JSON.parse(analytic_event_body)['analytics']
+    
+    expect(analytics.size).to eq(4)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'scan'}.size).to eq(1)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'gym'}.size).to eq(1)
+    expect(analytics.find_all { |a| a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'scan'}.size).to eq(2)
+    expect(analytics.find_all { |a| a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'gym'}.size).to eq(2)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == 'error' && a['actor']['detail'] == 'scan'}.size).to eq(1)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == 'success' && a['actor']['detail'] == 'gym'}.size).to eq(1)
+  end
 
-    expect(form["error"]).to eq("scan")
-    expect(form["crash"]).to eq("scan")
+  it "posts the web onboarding data with a success when finished" do
+    with_env_values('GENERATED_FASTFILE_ID' => 'fastfile_id') do
+      collector.did_launch_action(:fastlane)
+
+      analytic_event_body = collector.create_analytic_event_body
+      analytics = JSON.parse(analytic_event_body)['analytics']
+      
+      expect(analytics.size).to eq(3)
+      expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'fastlane'}.size).to eq(1)
+      expect(analytics.find_all { |a| a['event_source']['product'] != 'fastlane_web_onboarding' && a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'fastlane'}.size).to eq(2)
+      expect(analytics.find_all { |a| a['primary_target']['detail'] == 'success' && a['actor']['detail'] == 'fastlane'}.size).to eq(1)
+      expect(analytics.find_all { |a| a['action']['name'] == 'fastfile_executed' && a['actor']['detail'] == 'fastfile_id' && a['primary_target']['detail'] == 'success'}.size).to eq(1)
+    end
+  end
+
+  it "posts the web onboarding data with an crash when finished" do
+    with_env_values('GENERATED_FASTFILE_ID' => 'fastfile_id') do
+      collector.did_launch_action(:fastlane)
+      collector.did_crash(:gym)
+
+      analytic_event_body = collector.create_analytic_event_body
+      analytics = JSON.parse(analytic_event_body)['analytics']
+      
+      expect(analytics.size).to eq(3)
+      expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'fastlane'}.size).to eq(1)
+      expect(analytics.find_all { |a| a['event_source']['product'] != 'fastlane_web_onboarding' && a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'fastlane'}.size).to eq(2)
+      expect(analytics.find_all { |a| a['action']['name'] == 'fastfile_executed' && a['primary_target']['detail'] == 'crash' && a['actor']['detail'] == 'fastfile_id'}.size).to eq(1)
+    end
+  end
+
+  it "posts the web onboarding data with an error when finished" do
+    with_env_values('GENERATED_FASTFILE_ID' => 'fastfile_id') do
+      collector.did_launch_action(:fastlane)
+      collector.did_raise_error(:gym)
+
+      analytic_event_body = collector.create_analytic_event_body
+      analytics = JSON.parse(analytic_event_body)['analytics']
+      
+      expect(analytics.size).to eq(3)
+      expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'fastlane'}.size).to eq(1)
+      expect(analytics.find_all { |a| a['event_source']['product'] != 'fastlane_web_onboarding' && a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'fastlane'}.size).to eq(2)
+      expect(analytics.find_all { |a| a['action']['name'] == 'fastfile_executed' && a['primary_target']['detail'] == 'error' && a['actor']['detail'] == 'fastfile_id'}.size).to eq(1)
+    end
   end
 end

--- a/fastlane_core/spec/tool_collector_spec.rb
+++ b/fastlane_core/spec/tool_collector_spec.rb
@@ -1,6 +1,6 @@
 describe FastlaneCore::ToolCollector do
   before(:all) { ENV.delete("FASTLANE_OPT_OUT_USAGE") }
-  
+
   let(:collector) { FastlaneCore::ToolCollector.new }
 
   it "keeps track of what tools get invoked" do
@@ -49,14 +49,14 @@ describe FastlaneCore::ToolCollector do
 
     analytic_event_body = collector.create_analytic_event_body
     analytics = JSON.parse(analytic_event_body)['analytics']
-    
+
     expect(analytics.size).to eq(4)
-    expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'scan'}.size).to eq(1)
-    expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'gym'}.size).to eq(1)
-    expect(analytics.find_all { |a| a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'scan'}.size).to eq(2)
-    expect(analytics.find_all { |a| a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'gym'}.size).to eq(2)
-    expect(analytics.find_all { |a| a['primary_target']['detail'] == 'crash' && a['actor']['detail'] == 'scan'}.size).to eq(1)
-    expect(analytics.find_all { |a| a['primary_target']['detail'] == 'success' && a['actor']['detail'] == 'gym'}.size).to eq(1)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'scan' }.size).to eq(1)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'gym' }.size).to eq(1)
+    expect(analytics.find_all { |a| a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'scan' }.size).to eq(2)
+    expect(analytics.find_all { |a| a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'gym' }.size).to eq(2)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == 'crash' && a['actor']['detail'] == 'scan' }.size).to eq(1)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == 'success' && a['actor']['detail'] == 'gym' }.size).to eq(1)
   end
 
   it "posts the collected data with an error when finished" do
@@ -66,14 +66,14 @@ describe FastlaneCore::ToolCollector do
 
     analytic_event_body = collector.create_analytic_event_body
     analytics = JSON.parse(analytic_event_body)['analytics']
-    
+
     expect(analytics.size).to eq(4)
-    expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'scan'}.size).to eq(1)
-    expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'gym'}.size).to eq(1)
-    expect(analytics.find_all { |a| a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'scan'}.size).to eq(2)
-    expect(analytics.find_all { |a| a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'gym'}.size).to eq(2)
-    expect(analytics.find_all { |a| a['primary_target']['detail'] == 'error' && a['actor']['detail'] == 'scan'}.size).to eq(1)
-    expect(analytics.find_all { |a| a['primary_target']['detail'] == 'success' && a['actor']['detail'] == 'gym'}.size).to eq(1)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'scan' }.size).to eq(1)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'gym' }.size).to eq(1)
+    expect(analytics.find_all { |a| a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'scan' }.size).to eq(2)
+    expect(analytics.find_all { |a| a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'gym' }.size).to eq(2)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == 'error' && a['actor']['detail'] == 'scan' }.size).to eq(1)
+    expect(analytics.find_all { |a| a['primary_target']['detail'] == 'success' && a['actor']['detail'] == 'gym' }.size).to eq(1)
   end
 
   it "posts the web onboarding data with a success when finished" do
@@ -82,12 +82,12 @@ describe FastlaneCore::ToolCollector do
 
       analytic_event_body = collector.create_analytic_event_body
       analytics = JSON.parse(analytic_event_body)['analytics']
-      
+
       expect(analytics.size).to eq(3)
-      expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'fastlane'}.size).to eq(1)
-      expect(analytics.find_all { |a| a['event_source']['product'] != 'fastlane_web_onboarding' && a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'fastlane'}.size).to eq(2)
-      expect(analytics.find_all { |a| a['primary_target']['detail'] == 'success' && a['actor']['detail'] == 'fastlane'}.size).to eq(1)
-      expect(analytics.find_all { |a| a['action']['name'] == 'fastfile_executed' && a['actor']['detail'] == 'fastfile_id' && a['primary_target']['detail'] == 'success'}.size).to eq(1)
+      expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'fastlane' }.size).to eq(1)
+      expect(analytics.find_all { |a| a['event_source']['product'] != 'fastlane_web_onboarding' && a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'fastlane' }.size).to eq(2)
+      expect(analytics.find_all { |a| a['primary_target']['detail'] == 'success' && a['actor']['detail'] == 'fastlane' }.size).to eq(1)
+      expect(analytics.find_all { |a| a['action']['name'] == 'fastfile_executed' && a['actor']['detail'] == 'fastfile_id' && a['primary_target']['detail'] == 'success' }.size).to eq(1)
     end
   end
 
@@ -98,11 +98,11 @@ describe FastlaneCore::ToolCollector do
 
       analytic_event_body = collector.create_analytic_event_body
       analytics = JSON.parse(analytic_event_body)['analytics']
-      
+
       expect(analytics.size).to eq(3)
-      expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'fastlane'}.size).to eq(1)
-      expect(analytics.find_all { |a| a['event_source']['product'] != 'fastlane_web_onboarding' && a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'fastlane'}.size).to eq(2)
-      expect(analytics.find_all { |a| a['action']['name'] == 'fastfile_executed' && a['primary_target']['detail'] == 'crash' && a['actor']['detail'] == 'fastfile_id'}.size).to eq(1)
+      expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'fastlane' }.size).to eq(1)
+      expect(analytics.find_all { |a| a['event_source']['product'] != 'fastlane_web_onboarding' && a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'fastlane' }.size).to eq(2)
+      expect(analytics.find_all { |a| a['action']['name'] == 'fastfile_executed' && a['primary_target']['detail'] == 'crash' && a['actor']['detail'] == 'fastfile_id' }.size).to eq(1)
     end
   end
 
@@ -113,11 +113,11 @@ describe FastlaneCore::ToolCollector do
 
       analytic_event_body = collector.create_analytic_event_body
       analytics = JSON.parse(analytic_event_body)['analytics']
-      
+
       expect(analytics.size).to eq(3)
-      expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'fastlane'}.size).to eq(1)
-      expect(analytics.find_all { |a| a['event_source']['product'] != 'fastlane_web_onboarding' && a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'fastlane'}.size).to eq(2)
-      expect(analytics.find_all { |a| a['action']['name'] == 'fastfile_executed' && a['primary_target']['detail'] == 'error' && a['actor']['detail'] == 'fastfile_id'}.size).to eq(1)
+      expect(analytics.find_all { |a| a['primary_target']['detail'] == '1' && a['actor']['detail'] == 'fastlane' }.size).to eq(1)
+      expect(analytics.find_all { |a| a['event_source']['product'] != 'fastlane_web_onboarding' && a['secondary_target']['detail'] == Fastlane::VERSION && a['actor']['detail'] == 'fastlane' }.size).to eq(2)
+      expect(analytics.find_all { |a| a['action']['name'] == 'fastfile_executed' && a['primary_target']['detail'] == 'error' && a['actor']['detail'] == 'fastfile_id' }.size).to eq(1)
     end
   end
 end

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -115,9 +115,9 @@ describe FastlaneCore do
       it "has no p_hash event when no project defined" do
         expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|
           expect(analytics.size).to eq(1)
-          expect(analytics.find_all { |a| a[:actor][:detail] == 'fastlane' && a[:action][:name] == 'launched'}.size).to eq(1)
+          expect(analytics.find_all { |a| a[:actor][:detail] == 'fastlane' && a[:action][:name] == 'launched' }.size).to eq(1)
         end
-        
+
         FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
       end
 
@@ -126,9 +126,9 @@ describe FastlaneCore do
 
         expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|
           expect(analytics.size).to eq(1)
-          expect(analytics.find_all { |a| a[:primary_target][:detail] == 'true' && a[:action][:name] == 'launched'}.size).to eq(1)
+          expect(analytics.find_all { |a| a[:primary_target][:detail] == 'true' && a[:action][:name] == 'launched' }.size).to eq(1)
         end
-        
+
         FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
       end
 
@@ -138,10 +138,10 @@ describe FastlaneCore do
 
         expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|
           expect(analytics.size).to eq(2)
-          expect(analytics.find_all { |a| a[:actor][:detail] == 'fastlane' && a[:action][:name] == 'launched'}.size).to eq(1)
+          expect(analytics.find_all { |a| a[:actor][:detail] == 'fastlane' && a[:action][:name] == 'launched' }.size).to eq(1)
           expect(analytics.find_all { |a| a[:actor][:name] == 'project' && a[:action][:name] == 'update_checked' && a[:actor][:detail] == p_hashed_id }.size).to eq(1)
         end
-        
+
         FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
       end
 
@@ -152,7 +152,7 @@ describe FastlaneCore do
               expect(analytics.size).to eq(2)
               expect(analytics.find_all { |a| a[:action][:name] == 'update_checked' && a[:secondary_target][:detail] == :ios }.size).to eq(1)
             end
-          
+
             FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
           end
         end
@@ -163,7 +163,7 @@ describe FastlaneCore do
               expect(analytics.size).to eq(2)
               expect(analytics.find_all { |a| a[:action][:name] == 'update_checked' && a[:secondary_target][:detail] == :android }.size).to eq(1)
             end
-          
+
             FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
           end
         end
@@ -191,7 +191,7 @@ describe FastlaneCore do
           expect(analytics.find_all { |a| a[:actor][:detail] == 'fastlane' && a[:action][:name] == 'completed_with_duration' && a[:primary_target][:detail] }.size).to eq(1)
           expect(analytics.find_all { |a| a[:action][:name] == 'completed_with_install_method' && a[:primary_target][:detail] == 'gem' && a[:secondary_target][:detail] == 'false' }.size).to eq(1)
         end
-        
+
         FastlaneCore::UpdateChecker.send_completion_events_for("fastlane")
       end
     end

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -3,6 +3,13 @@ require 'fastlane_core/update_checker/update_checker'
 describe FastlaneCore do
   describe FastlaneCore::UpdateChecker do
     let (:name) { 'fastlane' }
+    def android_hash_of(value)
+      hash_of("android_project_#{value}")
+    end
+
+    def hash_of(value)
+      Digest::SHA256.hexdigest("p#{value}fastlan3_SAlt")
+    end
 
     describe "#update_available?" do
       it "no update is available" do
@@ -72,12 +79,8 @@ describe FastlaneCore do
     describe "#p_hash?" do
       let (:package_name) { 'com.test.app' }
 
-      def android_hash_of(value)
-        hash_of("android_project_#{value}")
-      end
-
-      def hash_of(value)
-        Digest::SHA256.hexdigest("p#{value}fastlan3_SAlt")
+      before do
+        ENV.delete("FASTLANE_OPT_OUT_USAGE")
       end
 
       it "chooses the correct param for package name for supply" do
@@ -96,31 +99,65 @@ describe FastlaneCore do
       end
     end
 
-    describe "#generate_fetch_url" do
+    describe "#send_launch_analytic_events_for" do
       before do
         ENV.delete("FASTLANE_OPT_OUT_USAGE")
-        expect(FastlaneCore::Helper).to receive(:is_ci?).and_return(false)
+        allow(FastlaneCore::Helper).to receive(:is_ci?).and_return(false)
       end
 
-      it "generated the correct URL with no parameters, no platform value and no p_hash" do
-        expect(FastlaneCore::UpdateChecker.generate_fetch_url("fastlane")).to eq("https://refresher.fastlane.tools/fastlane")
+      it "has no p_hash event when no project defined" do
+        expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|
+          expect(analytics.size).to eq(1)
+          expect(analytics.find_all { |a| a[:actor][:detail] == 'fastlane' && a[:action][:name] == 'launched'}.size).to eq(1)
+        end
+        
+        FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
       end
 
-      it "uses the bundle identifier and hashes the value if available" do
+      it "identifies CI correctly" do
+        allow(FastlaneCore::Helper).to receive(:is_ci?).and_return(true)
+
+        expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|
+          expect(analytics.size).to eq(1)
+          expect(analytics.find_all { |a| a[:primary_target][:detail] == 'true' && a[:action][:name] == 'launched'}.size).to eq(1)
+        end
+        
+        FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
+      end
+
+      it "contains p_hash event and uses the bundle identifier and hashes the value if available" do
         ENV["PILOT_APP_IDENTIFIER"] = "com.krausefx.app"
-        expect(FastlaneCore::UpdateChecker.generate_fetch_url("fastlane")).to eq("https://refresher.fastlane.tools/fastlane?p_hash=50925b8f18defc356dad507b1729bc185f9582513537346424b0be09b1f12b2f&platform=ios")
+        p_hashed_id = hash_of(ENV["PILOT_APP_IDENTIFIER"])
+
+        expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|
+          expect(analytics.size).to eq(2)
+          expect(analytics.find_all { |a| a[:actor][:detail] == 'fastlane' && a[:action][:name] == 'launched'}.size).to eq(1)
+          expect(analytics.find_all { |a| a[:actor][:name] == 'project' && a[:action][:name] == 'update_checked' && a[:actor][:detail] == p_hashed_id}.size).to eq(1)
+        end
+        
+        FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
       end
 
       describe "#platform" do
         it "ios" do
           FastlaneSpec::Env.with_ARGV(["--app_identifier", "yolo.app"]) do
-            expect(FastlaneCore::UpdateChecker.generate_fetch_url("sigh")).to eq("https://refresher.fastlane.tools/sigh?p_hash=52629c9a0eebe49c58db83c94c090bd790a101ff2a70ab9514f6a6427644375a&platform=ios")
+            expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|
+              expect(analytics.size).to eq(2)
+              expect(analytics.find_all { |a| a[:action][:name] == 'update_checked' && a[:secondary_target][:detail] == :ios}.size).to eq(1)
+            end
+          
+            FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
           end
         end
 
         it "android" do
           FastlaneSpec::Env.with_ARGV(["--app_package_name", "yolo.android.app"]) do
-            expect(FastlaneCore::UpdateChecker.generate_fetch_url("supply")).to eq("https://refresher.fastlane.tools/supply?p_hash=6a8b842e4a75d2a2bc4bdf584406a68eab8cabcc7b7a396c283b390fff30b59b&platform=android")
+            expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|
+              expect(analytics.size).to eq(2)
+              expect(analytics.find_all { |a| a[:action][:name] == 'update_checked' && a[:secondary_target][:detail] == :android}.size).to eq(1)
+            end
+          
+            FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
           end
         end
       end

--- a/screengrab/example/fastlane/Fastfile
+++ b/screengrab/example/fastlane/Fastfile
@@ -66,5 +66,5 @@ end
 # More information about multiple platforms in fastlane: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Platforms.md
 # All available actions: https://docs.fastlane.tools/actions
 
-# fastlane reports which actions are used. No personal data is recorded. 
+# fastlane reports which actions are used. No personal data is recorded.
 # Learn more at https://github.com/fastlane/fastlane/tree/master/fastlane#statistics

--- a/screengrab/example/fastlane/Fastfile
+++ b/screengrab/example/fastlane/Fastfile
@@ -67,4 +67,4 @@ end
 # All available actions: https://docs.fastlane.tools/actions
 
 # fastlane reports which actions are used. No personal data is recorded.
-# Learn more at https://github.com/fastlane/fastlane/tree/master/fastlane#statistics
+# Learn more at https://github.com/fastlane/fastlane#metrics

--- a/screengrab/example/fastlane/Fastfile
+++ b/screengrab/example/fastlane/Fastfile
@@ -66,5 +66,5 @@ end
 # More information about multiple platforms in fastlane: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Platforms.md
 # All available actions: https://docs.fastlane.tools/actions
 
-# fastlane reports which actions are used
-# No personal data is recorded. Learn more at https://github.com/fastlane/enhancer
+# fastlane reports which actions are used. No personal data is recorded. 
+# Learn more at https://github.com/fastlane/fastlane/tree/master/fastlane#statistics


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
The metrics information that is collected is not changing, simply the destination of the data. We no longer want to operate services in Heroku to simplify the architecture and to increase reliability of the data. Metrics collection is important to us because it tells us which actions are used the most and where improvements are needed. The opt out behavior via `FASTLANE_OPT_OUT_USAGE` remains unchanged. 

### Description
<!--- Describe your changes in detail -->
Stop sending metrics events to _refresher_ and _enhancer_. _fastlane_ will check for updates from rubygems.org directly and metrics events will be sent directly to the Fabric analytic ingester. This behavior was previously inside [_refresher_](https://github.com/fastlane/refresher) and [_enhancer_](https://github.com/fastlane/enhancer).

Documentation has been updated to reflect these changes.