### PR TITLE
Fix iTunesConnect error when not setting changelog

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -121,7 +121,7 @@ module Pilot
     end
 
     def should_update_build_information(options)
-      options[:changelog].to_s.length
+      options[:changelog].to_s.length > 0
     end
 
     def should_update_app_test_information(options)

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -51,7 +51,7 @@ module Pilot
         UI.user_error!("No build to distribute!")
       end
 
-      if should_update_app_test_information(options)
+      if should_update_app_test_information?(options)
         app_test_info = Spaceship::TestFlight::AppTestInfo.find(app_id: build.app_id)
         app_test_info.test_info.feedback_email = options[:beta_app_feedback_email] if options[:beta_app_feedback_email]
         app_test_info.test_info.description = options[:beta_app_description] if options[:beta_app_description]
@@ -63,7 +63,7 @@ module Pilot
         end
       end
 
-      if should_update_build_information(options)
+      if should_update_build_information?(options)
         begin
           build.update_build_information!(whats_new: options[:changelog])
           UI.success "Successfully set the changelog for build"
@@ -120,11 +120,11 @@ module Pilot
       return row
     end
 
-    def should_update_build_information(options)
+    def should_update_build_information?(options)
       options[:changelog].to_s.length > 0
     end
 
-    def should_update_app_test_information(options)
+    def should_update_app_test_information?(options)
       options[:beta_app_description].to_s.length > 0 || options[:beta_app_feedback_email].to_s.length > 0
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

When running `pilot` without a changelog, feedback email, or app description and no beta information set on iTunesConnect, iTC was returning an error. This fixes that issue.