### PR TITLE
created subkey param for manipulating key value in a dict

### DIFF
--- a/fastlane/lib/fastlane/actions/set_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/set_info_plist_value.rb
@@ -11,7 +11,12 @@ module Fastlane
           path = File.expand_path(params[:path])
           plist = Plist.parse_xml(path)
           if params[:subkey]
-            plist[params[:key]][params[:subkey]] = params[:value]
+          	if !plist[params[:key]]
+          		UI.message "Key doesn't exist, going to create new one ..."
+          		plist[params[:key]] = {params[:subkey] => params[:value]}
+          	else
+            	plist[params[:key]][params[:subkey]] = params[:value]
+            end
           else
             plist[params[:key]] = params[:value]
           end

--- a/fastlane/lib/fastlane/actions/set_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/set_info_plist_value.rb
@@ -11,11 +11,11 @@ module Fastlane
           path = File.expand_path(params[:path])
           plist = Plist.parse_xml(path)
           if params[:subkey]
-          	if !plist[params[:key]]
-          		UI.message "Key doesn't exist, going to create new one ..."
-          		plist[params[:key]] = {params[:subkey] => params[:value]}
-          	else
-            	plist[params[:key]][params[:subkey]] = params[:value]
+            if !plist[params[:key]]
+              UI.message "Key doesn't exist, going to create new one ..."
+              plist[params[:key]] = { params[:subkey] => params[:value] }
+            else
+              plist[params[:key]][params[:subkey]] = params[:value]
             end
           else
             plist[params[:key]] = params[:value]

--- a/fastlane/lib/fastlane/actions/set_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/set_info_plist_value.rb
@@ -11,11 +11,11 @@ module Fastlane
           path = File.expand_path(params[:path])
           plist = Plist.parse_xml(path)
           if params[:subkey]
-            if !plist[params[:key]]
+            if plist[params[:key]]
+              plist[params[:key]][params[:subkey]] = params[:value]
+            else
               UI.message "Key doesn't exist, going to create new one ..."
               plist[params[:key]] = { params[:subkey] => params[:value] }
-            else
-              plist[params[:key]][params[:subkey]] = params[:value]
             end
           else
             plist[params[:key]] = params[:value]

--- a/fastlane/lib/fastlane/actions/set_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/set_info_plist_value.rb
@@ -10,7 +10,11 @@ module Fastlane
         begin
           path = File.expand_path(params[:path])
           plist = Plist.parse_xml(path)
-          plist[params[:key]] = params[:value]
+          if params[:subkey]
+            plist[params[:key]][params[:subkey]] = params[:value]
+          else
+            plist[params[:key]] = params[:value]
+          end
           new_plist = Plist::Emit.dump(plist)
           File.write(path, new_plist)
 
@@ -31,6 +35,10 @@ module Fastlane
                                        env_name: "FL_SET_INFO_PLIST_PARAM_NAME",
                                        description: "Name of key in plist",
                                        optional: false),
+          FastlaneCore::ConfigItem.new(key: :subkey,
+                                       env_name: "FL_SET_INFO_PLIST_SUBPARAM_NAME",
+                                       description: "Name of subkey in plist",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :value,
                                        env_name: "FL_SET_INFO_PLIST_PARAM_VALUE",
                                        description: "Value to setup",
@@ -47,7 +55,7 @@ module Fastlane
       end
 
       def self.authors
-        ["kohtenko"]
+        ["kohtenko", "uwehollatz"]
       end
 
       def self.is_supported?(platform)
@@ -56,7 +64,8 @@ module Fastlane
 
       def self.example_code
         [
-          'set_info_plist_value(path: "./Info.plist", key: "CFBundleIdentifier", value: "com.krausefx.app.beta")'
+          'set_info_plist_value(path: "./Info.plist", key: "CFBundleIdentifier", value: "com.krausefx.app.beta")',
+          'set_info_plist_value(path: "./MyApp-Info.plist", key: "NSAppTransportSecurity", subkey: "NSAllowsArbitraryLoads", value: true)'
         ]
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x ] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I need to manipulate a key inside dictionary in plist, in detail the NSAllowsArbitraryLoads key. By adding an optional param this is now possible.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
I have made a clone of fastlane project and incorporated the change already in my project

### Description
<!--- Describe your changes in detail -->
I have added optional parameter FL_SET_INFO_PLIST_SUBPARAM_NAME to be able to provide a key and a subkey when the subkey needs modification.