### PR TITLE
Fix accessing fastlane_core from within spaceship

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -249,7 +249,7 @@ private_lane :send_mac_app_ci_reminder do
 end
 
 desc "Verifies all tests pass and the current state of the repo is valid"
-lane :validate_repo do
+private_lane :validate_repo do
   # Verifying that no debug code is in the code base
   #
   ensure_no_debug_code(text: "binding.pry", extension: ".rb", exclude: "playground.rb", exclude_dirs: ["\.bundle"]) # debugging code

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -249,13 +249,17 @@ private_lane :send_mac_app_ci_reminder do
 end
 
 desc "Verifies all tests pass and the current state of the repo is valid"
-private_lane :validate_repo do
+lane :validate_repo do
   # Verifying that no debug code is in the code base
   #
   ensure_no_debug_code(text: "binding.pry", extension: ".rb", exclude: "playground.rb", exclude_dirs: ["\.bundle"]) # debugging code
   ensure_no_debug_code(text: "# TODO", extension: ".rb", exclude_dirs: ["\.bundle"]) # TODOs
   ensure_no_debug_code(text: "now: ", extension: ".rb", exclude_dirs: ["\.bundle"]) # rspec focus
   ensure_no_debug_code(text: "<<<<<<<", extension: ".rb", exclude_dirs: ["\.bundle"]) # Merge conflict
+
+  # spaceship and credentials_manager don't have access to fastlane_core
+  ensure_no_debug_code(text: " UI\\.", path: "spaceship/lib", extension: ".rb", exclude_dirs: ["\.bundle"])
+  ensure_no_debug_code(text: " UI\\.", path: "credentials_manager/lib", extension: ".rb", exclude_dirs: ["\.bundle"])
 
   rubocop
 

--- a/spaceship/lib/spaceship/spaceauth_runner.rb
+++ b/spaceship/lib/spaceship/spaceauth_runner.rb
@@ -22,7 +22,7 @@ module Spaceship
         puts "This could be an issue with iTunes Connect,".yellow
         puts "Please try unsetting the FASTLANE_SESSION environment variable".yellow
         puts "and re-run `fastlane spaceauth`".yellow
-        UI.crash!("Problem connecting to iTunes Connect")
+        raise "Problem connecting to iTunes Connect"
       end
 
       itc_cookie_content = Spaceship::Tunes.client.store_cookie

--- a/spaceship/lib/spaceship/test_flight/group.rb
+++ b/spaceship/lib/spaceship/test_flight/group.rb
@@ -84,7 +84,7 @@ module Spaceship::TestFlight
       if groups.nil?
         default_external_group = app.default_external_group
         if default_external_group.nil?
-          UI.user_error!("The app #{app.name} does not have a default external group. Please make sure to pass group names to the `:groups` option.")
+          raise "The app #{app.name} does not have a default external group. Please make sure to pass group names to the `:groups` option."
         end
         test_flight_groups = [default_external_group]
       else
@@ -92,7 +92,7 @@ module Spaceship::TestFlight
           groups.include?(group.name)
         end
 
-        UI.user_error!("There are no groups available matching the names passed to the `:groups` option.") if test_flight_groups.empty?
+        raise "There are no groups available matching the names passed to the `:groups` option." if test_flight_groups.empty?
       end
 
       test_flight_groups.each(&block)

--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -78,7 +78,7 @@ module Spaceship
         #  should it be an ios or an osx app
 
         def create!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil)
-          UI.deprecated("The `version` parameter is deprecated. Use `ensure_version!` method instead") if version
+          puts "The `version` parameter is deprecated. Use `ensure_version!` method instead" if version
           client.create_application!(name: name,
                          primary_language: primary_language,
                                       sku: sku,

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -265,7 +265,7 @@ module Spaceship
     # @param bundle_id (String): The bundle ID must match the one you used in Xcode. It
     #   can't be changed after you submit your first build.
     def create_application!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil)
-      UI.deprecated("The `version` parameter is deprecated. Use `Spaceship::Tunes::Application.ensure_version!` method instead") if version
+      puts "The `version` parameter is deprecated. Use `Spaceship::Tunes::Application.ensure_version!` method instead" if version
 
       # First, we need to fetch the data from Apple, which we then modify with the user's values
       primary_language ||= "English"


### PR DESCRIPTION
Also adds tests so that never happens again

with the recent TestFlight changes, multiple `UI.something` calls went into _spaceship_ causing crashes if that part of the code is reached. Currently _spaceship_ doesn't have access to _fastlane_core_. I'm updating our build scripts to automatically detect those errors in the future :+1: