### PR TITLE
Fix spaceship launcher client login for push certificate

### DIFF
--- a/spaceship/lib/spaceship/portal/certificate.rb
+++ b/spaceship/lib/spaceship/portal/certificate.rb
@@ -287,7 +287,7 @@ module Spaceship
 
           # look up the app_id by the bundle_id
           if bundle_id
-            app = Spaceship::App.find(bundle_id)
+            app = Spaceship::App.set_client(client).find(bundle_id)
             raise "Could not find app with bundle id '#{bundle_id}'" unless app
             app_id = app.app_id
           end

--- a/spaceship/spec/launcher_spec.rb
+++ b/spaceship/spec/launcher_spec.rb
@@ -59,6 +59,18 @@ describe Spaceship do
         clean_launcher.login(username, password)
         expect(clean_launcher.provisioning_profile.all.count).to eq(6)
       end
+
+      it "shouldn't fail if trying to create new apns_certificate before app is invoked" do
+        bundle_id = 'net.sunapps.151'
+
+        clean_launcher = Spaceship::Launcher.new
+        clean_launcher.login(username, password)
+        csr = PortalStubbing.adp_read_fixture_file('certificateSigningRequest.certSigningRequest')
+
+        expect {
+          clean_launcher.certificate.development_push.create!(csr: csr, bundle_id: bundle_id)
+        }.to_not raise_error
+      end
     end
   end
 end

--- a/spaceship/spec/launcher_spec.rb
+++ b/spaceship/spec/launcher_spec.rb
@@ -61,14 +61,17 @@ describe Spaceship do
       end
 
       it "shouldn't fail if trying to create new apns_certificate before app is invoked" do
-        bundle_id = 'net.sunapps.151'
 
         clean_launcher = Spaceship::Launcher.new
         clean_launcher.login(username, password)
-        csr = PortalStubbing.adp_read_fixture_file('certificateSigningRequest.certSigningRequest')
 
+        expect(clean_launcher.client).to receive(:create_certificate!).with('BKLRAVXMGM', /BEGIN CERTIFICATE REQUEST/, 'B7JBD8LHAA', false) {
+          JSON.parse(PortalStubbing.adp_read_fixture_file('certificateCreate.certRequest.json'))
+        }
+
+        csr, pkey = Spaceship::Portal::Certificate.create_certificate_signing_request
         expect do
-          clean_launcher.certificate.development_push.create!(csr: csr, bundle_id: bundle_id)
+          clean_launcher.certificate.development_push.create!(csr: csr, bundle_id: 'net.sunapps.151')
         end.to_not raise_error
       end
     end

--- a/spaceship/spec/launcher_spec.rb
+++ b/spaceship/spec/launcher_spec.rb
@@ -61,13 +61,12 @@ describe Spaceship do
       end
 
       it "shouldn't fail if trying to create new apns_certificate before app is invoked" do
-
         clean_launcher = Spaceship::Launcher.new
         clean_launcher.login(username, password)
 
-        expect(clean_launcher.client).to receive(:create_certificate!).with('BKLRAVXMGM', /BEGIN CERTIFICATE REQUEST/, 'B7JBD8LHAA', false) {
+        expect(clean_launcher.client).to receive(:create_certificate!).with('BKLRAVXMGM', /BEGIN CERTIFICATE REQUEST/, 'B7JBD8LHAA', false) do
           JSON.parse(PortalStubbing.adp_read_fixture_file('certificateCreate.certRequest.json'))
-        }
+        end
 
         csr, pkey = Spaceship::Portal::Certificate.create_certificate_signing_request
         expect do

--- a/spaceship/spec/launcher_spec.rb
+++ b/spaceship/spec/launcher_spec.rb
@@ -67,9 +67,9 @@ describe Spaceship do
         clean_launcher.login(username, password)
         csr = PortalStubbing.adp_read_fixture_file('certificateSigningRequest.certSigningRequest')
 
-        expect {
+        expect do
           clean_launcher.certificate.development_push.create!(csr: csr, bundle_id: bundle_id)
-        }.to_not raise_error
+        end.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
🔑

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I found what I believe is a bug when using `Spaceship::Launcher` and trying to create push certificates for an app. What I've found is that the call to `launcher.certificate.development_push.create!` would throw a RuntimeError. 

After inspecting the code I realized this is because the `Spaceship::Certificate.create!` method is  checking for the app in the portal, to do this it calls out to the `Spaceship::App` portal client. Because this method does not pass the client along, and the default `Spaceship::Portal.client` is nil because I'm using `Spaceship::Launcher`, I receive a RuntimeError telling me to log in. This would only affect Push Certificates as they require the app to exist.


<!--- If it fixes an open issue, please link to the issue here. -->
#### Related Github Issue
I didn't find any open issues and am going to forego opening one myself as I believe the fix is pretty small (and more descriptive of the issue)

<!--- Please describe in detail how you tested your changes. --->
#### How I tested my changes
I tested my changes by patching my local fastlane gem with the fix. Unfortunately, I tried to add a spec in launcher_spec to describe what I was seeing but I'm running into some issues with WebMock. Rspec will fail for this PR currently and am **looking for help to resolve this testing issue**. 

What I believe is happening is the `Spaceship::Client#request` method is encoding the body (headers, params) of POST requests. This doesn't seem to match the stubbed request bodies. I'm unsure why this doesn't affect any other POST request specs.

### Description
<!--- Describe your changes in detail -->

I've added a call to `with_client` to the `create!` method. This passes along the client object from the `Spaceship::Portal::Certificate`. 

Another approach I tried was to set the `Spaceship::Portal.client` inside the `Spaceship::Launcher` initializer, but this is incorrect because it'd break the ability to have two spaceships running side by side.

