### PR TITLE
Version bump to 2.28.9

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.28.8'.freeze
+  VERSION = '2.28.9'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.28.8':**

* Fix accessing fastlane_core from within spaceship (#9089) via Felix Krause
* Fix iTunesConnect error when not setting changelog (#9085) via Mark Pirri
* Better log message for supply not being able to download screenshots and feature graphics (#9083) via Nathan Broadbent
* Improving the output of EnsureGitStatusCleanAction (#9077) via Anton
* [deliver] Add message when updating the app's age rating (#9071) via Felix Krause
* Artifactory action to return download URL and size after successful upload as shared lane values (#9079) via Tom Meier
* Show line when password was fetched from env variable (#9069) via Felix Krause
* Add a loud reminder to run the Mac App CI job (#9063) via David Ohayon
* Using whitelisted folders for detected languages (#9057) via Arvind Menon
