### PR TITLE
Update lane scope whenever changing lanes

### DIFF
--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -1,13 +1,21 @@
 module Fastlane
   class Runner
     # Symbol for the current lane
-    attr_accessor :current_lane
+    attr_reader :current_lane
 
     # Symbol for the current platform
     attr_accessor :current_platform
 
     # @return [Hash] All the lanes available, first the platform, then the lane
     attr_accessor :lanes
+
+    # Update lane scope whenever current changes
+    def current_lane=(value)
+      @current_lane = value
+      ENV["FASTLANE_LANE_NAME"] = value.to_s
+      Actions.lane_context[Actions::SharedValues::LANE_NAME] = full_lane_name
+      @current_lane
+    end
 
     def full_lane_name
       [current_platform, current_lane].reject(&:nil?).join(' ')


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I'm not sure if this is an issue for others, or if it would cause more problems for the majority of cases, but this is the scenario I've faced today (feel free to close and :fire: this PR - I have a strong feeling this was locked for a reason).

For one client, we have to package two completely different apps at the same time, with the majority of the same code, but two targets. As such, I've wrapped it into one lane `client_release` which calls two other lanes `build_target_one` + `build_target_two`. The wrapping lane then can use all the usual shared lane contexts from the likes of `gym` to manage what to next.

Unfortunately, when switching to `build_target_one` the lane context remains as the `client_release` lane, so any calls to things such as `CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)` will fail, as it is looking for the default, and not using the `AppFile` scope for `build_target_one` that I would expect (this could be designed behaviour for a reason though).

I don't believe there is a way for private/sub lanes to scope `AppFileConfig` calls to the particular lane context it is being written in.

### Description

Whenever `Fastlane::Runner` assigns a new `current_lane` the scope should be altered for the ENV and the shared lane context. 

With this value updated on every assignment of `current_lane`, any dependencies such as `CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)` will always use the `AppFile` reference relevent to the inner context of the lane (or private lane) it is in.

The drawbacks of this is any existing projects relying on the outer wrapping lane context for their `AppFile` references, this will not work, they will need additional references in the `AppFile` to default for even private lanes. I imagine this could be an issue? I'm not sure how to solve this, and really wanted to propose this solution and see if there were any other alternatives thought about.

In the meantime, my workaround is to be very specific in the sub/private lanes to specify every attribute and not rely on default values gleaned from `Appfile`.
