### PR TITLE
[match] Add new `clone_branch_directly` option to clone faster

### DIFF
--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -1,14 +1,23 @@
 module Match
   class GitHelper
-    def self.clone(git_url, shallow_clone, manual_password: nil, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil)
+    def self.clone(git_url, shallow_clone, manual_password: nil, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil, clone_branch_directly: false)
       return @dir if @dir
 
       @dir = Dir.mktmpdir
 
       command = "git clone '#{git_url}' '#{@dir}'"
-      command << " --depth 1 --no-single-branch" if shallow_clone
+      if shallow_clone
+        command << " --depth 1 --no-single-branch"
+      elsif clone_branch_directly
+        command += " -b #{branch.shellescape} --single-branch"
+      end
 
       UI.message "Cloning remote git repo..."
+
+      if branch && !clone_branch_directly
+        UI.message("If cloning the repo takes too long, you can use the `clone_branch_directly` option in match.")
+      end
+
       begin
         # GIT_TERMINAL_PROMPT will fail the `git clone` command if user credentials are missing
         FastlaneCore::CommandExecutor.execute(command: "GIT_TERMINAL_PROMPT=0 #{command}",

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -106,6 +106,11 @@ module Match
                                      description: "Make a shallow clone of the repository (truncate the history to 1 revision)",
                                      is_string: false,
                                      default_value: false),
+        FastlaneCore::ConfigItem.new(key: :clone_branch_directly,
+                                     env_name: "MATCH_CLONE_BRANCH_DIRECTLY",
+                                     description: "Clone just the branch specified, instead of the whole repo. This requires that the branch already exists. Otherwise the command will fail",
+                                     is_string: false,
+                                     default_value: false),
         FastlaneCore::ConfigItem.new(key: :workspace,
                                      description: nil,
                                      verify_block: proc do |value|

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -8,7 +8,13 @@ module Match
                                          hide_keys: [:workspace],
                                              title: "Summary for match #{Fastlane::VERSION}")
 
-      params[:workspace] = GitHelper.clone(params[:git_url], params[:shallow_clone], skip_docs: params[:skip_docs], branch: params[:git_branch], git_full_name: params[:git_full_name], git_user_email: params[:git_user_email])
+      params[:workspace] = GitHelper.clone(params[:git_url],
+                                           params[:shallow_clone],
+                                           skip_docs: params[:skip_docs],
+                                           branch: params[:git_branch],
+                                           git_full_name: params[:git_full_name],
+                                           git_user_email: params[:git_user_email],
+                                           clone_branch_directly: params[:clone_branch_directly])
 
       unless params[:readonly]
         self.spaceship = SpaceshipEnsure.new(params[:username])

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -15,7 +15,7 @@ describe Match do
       profile_path = "./match/spec/fixtures/test.mobileprovision"
       destination = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision")
 
-      expect(Match::GitHelper).to receive(:clone).with(git_url, true, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil).and_return(repo_dir)
+      expect(Match::GitHelper).to receive(:clone).with(git_url, true, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil, clone_branch_directly: false).and_return(repo_dir)
       expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution).and_return(cert_path)
       expect(Match::Generator).to receive(:generate_provisioning_profile).with(params: config,
                                                                             prov_type: :appstore,
@@ -57,7 +57,7 @@ describe Match do
       key_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.p12"
       keychain = "login.keychain"
 
-      expect(Match::GitHelper).to receive(:clone).with(git_url, false, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil).and_return(repo_dir)
+      expect(Match::GitHelper).to receive(:clone).with(git_url, false, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil, clone_branch_directly: false).and_return(repo_dir)
       expect(Match::Utils).to receive(:import).with(key_path, keychain, password: nil).and_return(nil)
       expect(Match::GitHelper).to_not receive(:commit_changes)
 


### PR DESCRIPTION
When an app developer used their main repo, and selected a different branch for match to store the certificates, it becomes really slow very fast if the `master` branch has bigger resources. In my case it took many minutes already.

This PR adds a parameter that tells match that it should just clone this one branch. Also we'll now show a message that tells users about this new option

<img width="838" alt="screenshot 2017-05-08 01 24 54" src="https://cloud.githubusercontent.com/assets/869950/25786003/aa6ef128-338d-11e7-8c80-2f40761772ef.png">
