### PR TITLE
[pilot] Show train version and build version while wating for build to re-appear

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -41,9 +41,9 @@ module FastlaneCore
         # As this method is very often used to wait for a build, and then do something
         # with it, we have to be sure that the build actually is ready
         if build.nil?
-          UI.message("Build doesn't show up in the build list any more, waiting for it to appear again")
+          UI.message("Build doesn't show up in the build list any more, waiting for it to appear again (#{build.train_version} - #{build.build_version})")
         elsif build.active?
-          UI.success("Build #{build.train_version} - #{build.build_version} is already being tested")
+          UI.success("Build is already being tested (#{build.train_version} - #{build.build_version})")
         elsif build.ready_to_submit? || build.export_compliance_missing?
           UI.success("Successfully finished processing the build #{build.train_version} - #{build.build_version}")
         else

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -68,7 +68,7 @@ describe FastlaneCore::BuildWatcher do
       expect(Spaceship::TestFlight::Build).to receive(:latest).and_return(active_build)
       expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([active_build])
 
-      expect(UI).to receive(:success).with("Build #{active_build.train_version} - #{active_build.build_version} is already being tested")
+      expect(UI).to receive(:success).with("Build is already being tested (#{active_build.train_version} - #{active_build.build_version})")
       found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
 
       expect(found_build).to eq(active_build)
@@ -113,7 +113,7 @@ describe FastlaneCore::BuildWatcher do
       expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([], [ready_build])
       expect(FastlaneCore::BuildWatcher).to receive(:sleep)
 
-      expect(UI).to receive(:message).with("Build doesn't show up in the build list any more, waiting for it to appear again")
+      expect(UI).to receive(:message).with("Build doesn't show up in the build list any more, waiting for it to appear again (#{ready_build.train_version} - #{ready_build.build_version})")
       expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.train_version} - #{ready_build.build_version}")
       found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
 


### PR DESCRIPTION
<img width="816" alt="screenshot 2017-05-08 02 04 07" src="https://cloud.githubusercontent.com/assets/869950/25786293/ad3d6970-3392-11e7-95fe-447c4e79add1.png">

Unified how the numbers are shown