### PR TITLE
Respect pilot's wait_processing_interval config option

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -2,7 +2,7 @@ module FastlaneCore
   class BuildWatcher
     class << self
       # @return The build we waited for. This method will always return a build
-      def wait_for_build_processing_to_be_complete(app_id: nil, platform: nil)
+      def wait_for_build_processing_to_be_complete(app_id: nil, platform: nil, poll_interval: 10)
         # First, find the train and build version we want to watch for
         watched_build = watching_build(app_id: app_id, platform: platform)
         UI.crash!("Could not find a build for app: #{app_id} on platform: #{platform}") if watched_build.nil?
@@ -16,7 +16,7 @@ module FastlaneCore
             return matched_build
           end
 
-          sleep 10
+          sleep poll_interval
         end
       end
 

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -150,5 +150,25 @@ describe FastlaneCore::BuildWatcher do
       expect(UI).to receive(:crash!).with("Could not find a build for app: some-app-id on platform: ios").and_call_original
       expect { FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios) }.to raise_error(FastlaneCore::Interface::FastlaneCrash)
     end
+
+    it 'sleeps 10 seconds by default' do
+      expect(Spaceship::TestFlight::Build).to receive(:all_processing_builds).and_return([processing_build])
+      expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([], [ready_build])
+      expect(FastlaneCore::BuildWatcher).to receive(:sleep).with(10)
+
+      allow(UI).to receive(:message)
+      allow(UI).to receive(:success)
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
+    end
+
+    it 'sleeps for the amount of time specified in poll_interval' do
+      expect(Spaceship::TestFlight::Build).to receive(:all_processing_builds).and_return([processing_build])
+      expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([], [ready_build])
+      expect(FastlaneCore::BuildWatcher).to receive(:sleep).with(123)
+
+      allow(UI).to receive(:message)
+      allow(UI).to receive(:success)
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, poll_interval: 123)
+    end
   end
 end

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -35,7 +35,7 @@ module Pilot
       end
 
       UI.message("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-      latest_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: app.apple_id, platform: platform)
+      latest_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: app.apple_id, platform: platform, poll_interval: config[:wait_processing_interval])
 
       distribute(options, build: latest_build)
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When rewriting `pilot`'s iTunesConnect interactions, we extracted the `build_watcher` class to be shared between multiple _fastlane_ tools. In doing so, we removed the ability for it to choose how long to wait between polls.  This adds the ability back (and, as such, re-enables `pilot`'s `wait_processing_interval` config option.

This was created in response to issue #9110 