### PR TITLE
[snapshot] Split xcodebuild logs by device name and language

### DIFF
--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -176,7 +176,12 @@ module Snapshot
         FastlaneCore::ConfigItem.new(key: :test_target_name,
                                      env_name: "SNAPSHOT_TEST_TARGET_NAME",
                                      description: "The name of the target you want to test (if you desire to override the Target Application from Xcode)",
-                                     optional: true)
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :namespace_log_files,
+                                     env_name: "SNAPSHOT_NAMESPACE_LOG_FILES",
+                                     description: "Separate the log files per device and per language",
+                                     optional: true,
+                                     is_string: false),
       ]
     end
   end

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -181,7 +181,7 @@ module Snapshot
                                      env_name: "SNAPSHOT_NAMESPACE_LOG_FILES",
                                      description: "Separate the log files per device and per language",
                                      optional: true,
-                                     is_string: false),
+                                     is_string: false)
       ]
     end
   end

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -171,7 +171,7 @@ module Snapshot
 
       open_simulator_for_device(device_type)
 
-      command = TestCommandGenerator.generate(device_type: device_type)
+      command = TestCommandGenerator.generate(device_type: device_type, language: language, locale: locale)
 
       if locale
         UI.header("#{device_type} - #{language} (#{locale})")
@@ -208,7 +208,7 @@ module Snapshot
                                                 end
                                               end)
 
-      raw_output = File.read(TestCommandGenerator.xcodebuild_log_path)
+      raw_output = File.read(TestCommandGenerator.xcodebuild_log_path(device_type: device_type, language: language, locale: locale))
 
       dir_name = locale || language
 

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -63,7 +63,7 @@ module Snapshot
       end
 
       def pipe
-        ["| tee -a #{xcodebuild_log_path.shellescape} | xcpretty #{Snapshot.config[:xcpretty_args]}"]
+        ["| tee #{xcodebuild_log_path.shellescape} | xcpretty #{Snapshot.config[:xcpretty_args]}"]
       end
 
       def find_device(device_name, os_version = Snapshot.config[:ios_version])

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -108,8 +108,13 @@ module Snapshot
         return ["-destination '#{value}'"]
       end
 
-      def xcodebuild_log_path
-        file_name = "#{Snapshot.project.app_name}-#{Snapshot.config[:scheme]}.log"
+      def xcodebuild_log_path(device_type: nil, language: nil, locale: nil)
+        name_components = [ Snapshot.project.app_name, Snapshot.config[:scheme] ]
+        name_components << device_type if device_type
+        name_components << language if language
+        name_components << locale if locale
+        file_name = "#{name_components.join('-')}.log"
+
         containing = File.expand_path(Snapshot.config[:buildlog_path])
         FileUtils.mkdir_p(containing)
 

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -2,7 +2,7 @@ module Snapshot
   # Responsible for building the fully working xcodebuild command
   class TestCommandGenerator
     class << self
-      def generate(device_type: nil)
+      def generate(device_type: nil, language: nil, locale: nil)
         parts = prefix
         parts << "xcodebuild"
         parts += options
@@ -10,7 +10,7 @@ module Snapshot
         parts += build_settings
         parts += actions
         parts += suffix
-        parts += pipe
+        parts += pipe(device_type, language, locale)
 
         parts
       end
@@ -62,8 +62,8 @@ module Snapshot
         []
       end
 
-      def pipe
-        ["| tee #{xcodebuild_log_path.shellescape} | xcpretty #{Snapshot.config[:xcpretty_args]}"]
+      def pipe(device_type, language, locale)
+        ["| tee #{xcodebuild_log_path(device_type: device_type, language: language, locale: locale).shellescape} | xcpretty #{Snapshot.config[:xcpretty_args]}"]
       end
 
       def find_device(device_name, os_version = Snapshot.config[:ios_version])

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -109,7 +109,7 @@ module Snapshot
       end
 
       def xcodebuild_log_path(device_type: nil, language: nil, locale: nil)
-        name_components = [ Snapshot.project.app_name, Snapshot.config[:scheme] ]
+        name_components = [Snapshot.project.app_name, Snapshot.config[:scheme]]
         name_components << device_type if device_type
         name_components << language if language
         name_components << locale if locale

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -63,7 +63,7 @@ module Snapshot
       end
 
       def pipe
-        ["| tee #{xcodebuild_log_path.shellescape} | xcpretty #{Snapshot.config[:xcpretty_args]}"]
+        ["| tee -a #{xcodebuild_log_path.shellescape} | xcpretty #{Snapshot.config[:xcpretty_args]}"]
       end
 
       def find_device(device_name, os_version = Snapshot.config[:ios_version])

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -63,7 +63,8 @@ module Snapshot
       end
 
       def pipe(device_type, language, locale)
-        ["| tee #{xcodebuild_log_path(device_type: device_type, language: language, locale: locale).shellescape} | xcpretty #{Snapshot.config[:xcpretty_args]}"]
+        log_path = xcodebuild_log_path(device_type: device_type, language: language, locale: locale)
+        ["| tee #{log_path.shellescape} | xcpretty #{Snapshot.config[:xcpretty_args]}"]
       end
 
       def find_device(device_name, os_version = Snapshot.config[:ios_version])
@@ -110,9 +111,13 @@ module Snapshot
 
       def xcodebuild_log_path(device_type: nil, language: nil, locale: nil)
         name_components = [Snapshot.project.app_name, Snapshot.config[:scheme]]
-        name_components << device_type if device_type
-        name_components << language if language
-        name_components << locale if locale
+
+        if Snapshot.config[:namespace_log_files]
+          name_components << device_type if device_type
+          name_components << language if language
+          name_components << locale if locale
+        end
+
         file_name = "#{name_components.join('-')}.log"
 
         containing = File.expand_path(Snapshot.config[:buildlog_path])

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -40,7 +40,8 @@ describe Snapshot do
           output_simulator_logs: true,
           devices: ['iPhone 6 (10.1)', 'iPhone 6s'],
           project: './snapshot/example/Example.xcodeproj',
-          scheme: 'ExampleUITests'
+          scheme: 'ExampleUITests',
+          namespace_log_files: true
         })
       end
 
@@ -98,7 +99,7 @@ describe Snapshot do
     end
 
     describe "Valid iOS Configuration" do
-      let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests" } }
+      let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", namespace_log_files: true } }
 
       def configure(options)
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
@@ -187,7 +188,7 @@ describe Snapshot do
     end
 
     describe "Valid macOS Configuration" do
-      let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleMacOS" } }
+      let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleMacOS", namespace_log_files: true } }
 
       it "uses default parameters on macOS" do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options.merge(devices: ["Mac"]))
@@ -211,7 +212,7 @@ describe Snapshot do
     end
 
     describe "Unique logs" do
-      let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests" } }
+      let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", namespace_log_files: true } }
 
       it 'uses correct name and language' do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
@@ -232,6 +233,18 @@ describe Snapshot do
       it 'can work without parameters' do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
         log_path = Snapshot::TestCommandGenerator.xcodebuild_log_path
+        expect(log_path).to eq(
+          File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log").to_s
+        )
+      end
+    end
+
+    describe "Unique logs disabled" do
+      let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests" } }
+
+      it 'uses correct file name' do
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+        log_path = Snapshot::TestCommandGenerator.xcodebuild_log_path(device_type: "iPhone 6", language: "pt", locale: nil)
         expect(log_path).to eq(
           File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log").to_s
         )

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -144,7 +144,7 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
+              "| tee -a #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
             ]
           )
         end
@@ -167,7 +167,7 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee #{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests.log')} | xcpretty "
+              "| tee -a #{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests.log')} | xcpretty "
             ]
           )
         end
@@ -189,7 +189,7 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
+              "| tee -a #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
             ]
           )
         end
@@ -226,7 +226,7 @@ describe Snapshot do
             "FASTLANE_SNAPSHOT=YES",
             :build,
             :test,
-            "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/ExampleMacOS-ExampleMacOS.log")} | xcpretty "
+            "| tee -a #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/ExampleMacOS-ExampleMacOS.log")} | xcpretty "
           ]
         )
       end

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -231,5 +231,33 @@ describe Snapshot do
         )
       end
     end
+
+    describe "Unique logs" do
+      let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests" } }
+
+      it 'uses correct name and language' do
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+        log_path = Snapshot::TestCommandGenerator.xcodebuild_log_path(device_type: "iPhone 6", language: "pt", locale: nil)
+        expect(log_path).to eq(
+          "#{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt.log")}"
+        )
+      end
+
+      it 'uses includes locale if specified' do
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+        log_path = Snapshot::TestCommandGenerator.xcodebuild_log_path(device_type: "iPhone 6", language: "pt", locale: "pt_BR")
+        expect(log_path).to eq(
+          "#{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt-pt_BR.log")}"
+        )
+      end
+
+      it 'can work without parameters' do
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+        log_path = Snapshot::TestCommandGenerator.xcodebuild_log_path
+        expect(log_path).to eq(
+          "#{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")}"
+        )
+      end
+    end
   end
 end

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -130,7 +130,7 @@ describe Snapshot do
         it "uses the default parameters" do
           configure options
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
-          command = Snapshot::TestCommandGenerator.generate(device_type: "iPhone 6")
+          command = Snapshot::TestCommandGenerator.generate(device_type: "iPhone 6", language: "en", locale: nil)
           id = command.join('').match(/id=(.+?),/)[1]
           ios = command.join('').match(/OS=(\d+.\d+)/)[1]
           expect(command).to eq(
@@ -144,7 +144,7 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
+              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone\\ 6-en.log")} | xcpretty "
             ]
           )
         end
@@ -152,7 +152,7 @@ describe Snapshot do
         it "allows to supply custom xcargs" do
           configure options.merge(xcargs: "-only-testing:TestBundle/TestSuite/Screenshots")
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
-          command = Snapshot::TestCommandGenerator.generate(device_type: "iPhone 6")
+          command = Snapshot::TestCommandGenerator.generate(device_type: "iPhone 6", language: "en", locale: nil)
           id = command.join('').match(/id=(.+?),/)[1]
           ios = command.join('').match(/OS=(\d+.\d+)/)[1]
           expect(command).to eq(
@@ -167,7 +167,7 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee #{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests.log')} | xcpretty "
+              "| tee #{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests-iPhone\\ 6-en.log')} | xcpretty "
             ]
           )
         end
@@ -175,7 +175,7 @@ describe Snapshot do
         it "uses the default parameters on tvOS too" do
           configure options.merge(devices: ["Apple TV 1080p"])
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
-          command = Snapshot::TestCommandGenerator.generate(device_type: "Apple TV 1080p")
+          command = Snapshot::TestCommandGenerator.generate(device_type: "Apple TV 1080p", language: "en", locale: nil)
           id = command.join('').match(/id=(.+?),/)[1]
           os = command.join('').match(/OS=(\d+.\d+)/)[1]
           expect(command).to eq(
@@ -189,7 +189,7 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
+              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-Apple\\ TV\\ 1080p-en.log")} | xcpretty "
             ]
           )
         end
@@ -202,7 +202,7 @@ describe Snapshot do
 
         it 'uses the fixed derivedDataPath if given' do
           expect(Dir).not_to receive(:mktmpdir)
-          command = Snapshot::TestCommandGenerator.generate(device_type: "iPhone 6")
+          command = Snapshot::TestCommandGenerator.generate(device_type: "iPhone 6", language: "en", locale: nil)
           expect(command.join('')).to include("-derivedDataPath 'fake/derived/path'")
         end
       end
@@ -214,7 +214,7 @@ describe Snapshot do
       it "uses default parameters on macOS" do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options.merge(devices: ["Mac"]))
         expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
-        command = Snapshot::TestCommandGenerator.generate(device_type: "Mac")
+        command = Snapshot::TestCommandGenerator.generate(device_type: "Mac", language: "en", locale: nil)
         expect(command).to eq(
           [
             "set -o pipefail &&",
@@ -226,7 +226,7 @@ describe Snapshot do
             "FASTLANE_SNAPSHOT=YES",
             :build,
             :test,
-            "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/ExampleMacOS-ExampleMacOS.log")} | xcpretty "
+            "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/ExampleMacOS-ExampleMacOS-Mac-en.log")} | xcpretty "
           ]
         )
       end

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -144,7 +144,7 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee -a #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
+              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
             ]
           )
         end
@@ -167,7 +167,7 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee -a #{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests.log')} | xcpretty "
+              "| tee #{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests.log')} | xcpretty "
             ]
           )
         end
@@ -189,7 +189,7 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee -a #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
+              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")} | xcpretty "
             ]
           )
         end
@@ -226,7 +226,7 @@ describe Snapshot do
             "FASTLANE_SNAPSHOT=YES",
             :build,
             :test,
-            "| tee -a #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/ExampleMacOS-ExampleMacOS.log")} | xcpretty "
+            "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/ExampleMacOS-ExampleMacOS.log")} | xcpretty "
           ]
         )
       end

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -239,7 +239,7 @@ describe Snapshot do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
         log_path = Snapshot::TestCommandGenerator.xcodebuild_log_path(device_type: "iPhone 6", language: "pt", locale: nil)
         expect(log_path).to eq(
-          "#{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt.log")}"
+          File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt.log").to_s
         )
       end
 
@@ -247,7 +247,7 @@ describe Snapshot do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
         log_path = Snapshot::TestCommandGenerator.xcodebuild_log_path(device_type: "iPhone 6", language: "pt", locale: "pt_BR")
         expect(log_path).to eq(
-          "#{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt-pt_BR.log")}"
+          File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt-pt_BR.log").to_s
         )
       end
 
@@ -255,7 +255,7 @@ describe Snapshot do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
         log_path = Snapshot::TestCommandGenerator.xcodebuild_log_path
         expect(log_path).to eq(
-          "#{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log")}"
+          File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log").to_s
         )
       end
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Description
Updated the `xcodebuild_log_file` method to include the device name, language and locale where required. This now means that there is a log file generated per run to prevent logs being overwritten.

#### Before
```
➜  ls -l ~/Library/Logs/snapshot 
-rw-r--r--  1 liamnichols  staff  25912  1 Apr 15:54 ExampleApp-ExampleScheme.log
```

#### After
```
➜  ls -l ~/Library/Logs/snapshot 
-rw-r--r--  1 liamnichols  staff  25912  1 Apr 15:54 ExampleApp-ExampleScheme-iPhone 6-en-US.log
-rw-r--r--  1 liamnichols  staff  25912  1 Apr 15:54 ExampleApp-ExampleScheme-iPhone 6-pt-pt_BR.log
-rw-r--r--  1 liamnichols  staff  25912  1 Apr 15:54 ExampleApp-ExampleScheme-iPhone SE-en-US.log
-rw-r--r--  1 liamnichols  staff  25912  1 Apr 15:54 ExampleApp-ExampleScheme-iPhone SE-pt-pt_BR.log
```

### Motivation and Context
I am currently running snapshot on an array of devices however my ui tests are failing randomly in some runs but not always the final device run. I try to look at the console output from xcpretty however it's not actually giving me anything useful. 

Instead I've tried looking at the output in `~/Library/Logs/snapshot/` however because the `xcodebuild` and in turn the `tee` command gets run multiple times, the log file is overwritten each time the tests run. This means that when the last run succeeds and the failure is before that, I have no way of working out what is going on :/. 

By having a unique filename for each `xcodebuild` command performed, i'm able to look back through the raw logs once `fastlane snapshot` has completed running and the important data wouldn't have been overwritten. This is also favoured over the original approach of appending `-a` to the `tee` command because that approach didn't have any way of keeping the log sizes reasonable.

I've tested this in a sample iOS project with a Snapfile that looks like the following:

```
# A list of devices you want to take the screenshots from
 devices([
   "iPhone 6",
   "iPhone SE"
 ])

languages([
  "en-US",
  ["pt", "pt_BR"] # Portuguese with Brazilian locale
])

# The name of the scheme which contains the UI Tests
 scheme "Example"
```

There are also a couple of extra tests to make sure things are working in all scenarios

-----

<details><summary>Original PR</summary>

### Description
Added the `-a` flag to the `tee` command in order to append the xcodebuild logs to the existing file when running snapshot in the `test_command_generator.rb`.

### Motivation and Context
I am currently running snapshot on an array of devices however my ui tests are failing randomly in some runs but not always the final device run. I try to look at the console output from xcpretty however it's not actually giving me anything useful. 

Instead I've tried looking at the output in `~/Library/Logs/snapshot/` however because the `xcodebuild` and in turn the `tee` command gets run multiple times, the log file is overwritten each time the tests run. This means that when the last run succeeds and the failure is before that, I have no way of working out what is going on :/. 

Adding the `-a` argument to `tee` means that the stream is appended to the end of the file rather than overwriting it each time so this will fix my issue and allow me to see the complete logs and debug further. 

I do have slight concerns about the size of the logs if it is always appending? Would this be an issue? I don't know how cleanup operations work here? I guess another option could be to append the device name to `xcodebuild_log_path` so that there are multiple files created instead however my Ruby knowledge doesn't span much further than being able to add an extra three characters into a string unfortunately. 

In terms of how I have tested it, I haven't yet. I'm not sure how to setup my machine to run from source code so if anybody can help that would be great (ruby/gems aren't my strong point). Thanks.
</details>

Taken from https://github.com/fastlane/fastlane/pull/8725 via @liamnichols