### PR TITLE
Version bump to 2.29.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.28.9'.freeze
+  VERSION = '2.29.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.28.9':**

* [match] Fix not respecting git user options when nuking or changing password (#9120) via Felix Krause
* Fix spelling of default iPad simulators. (#9099) via Zev Eisenberg
* Change metrics collection endpoint  (#9084) via Andrea Falcone
* Respect pilot's wait_processing_interval config option (#9111) via Mark Pirri
* Improve deliver setup detection (#9070) via Felix Krause
* Enable automatic scaling when user doesn't provide all screenshots (#9072) via Felix Krause
* Remove mention of macOS in READMEs (#9107) via Felix Krause
* [match] Add new `clone_branch_directly` option to clone faster (#9102) via Felix Krause
* supply: Allow specifying root url for androidpublisher api (#9075) via Christian Legnitto
