### PR TITLE
Fix update checker regression in `fastlane env` and `update_fastlane`

### DIFF
--- a/fastlane/lib/fastlane/actions/update_fastlane.rb
+++ b/fastlane/lib/fastlane/actions/update_fastlane.rb
@@ -57,8 +57,7 @@ module Fastlane
         update_needed.each do |tool_info|
           tool = tool_info[0]
           local_version = Gem::Version.new(highest_versions[tool].version)
-          update_url = FastlaneCore::UpdateChecker.generate_fetch_url(tool)
-          latest_version = FastlaneCore::UpdateChecker.fetch_latest(update_url)
+          latest_version = FastlaneCore::UpdateChecker.fetch_latest(tool)
           UI.message("Updating #{tool} from #{local_version} to #{latest_version} ... 🚀")
 
           # Approximate_recommendation will create a string like "~> 0.10" from a version 0.10.0, e.g. one that is valid for versions >= 0.10 and <1.0

--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -63,8 +63,7 @@ module Fastlane
         plugin_manager.available_plugins.each do |plugin|
           begin
           installed_version = Fastlane::ActionCollector.determine_version(plugin)
-          update_url = FastlaneCore::UpdateChecker.generate_fetch_url(plugin)
-          latest_version = FastlaneCore::UpdateChecker.fetch_latest(update_url)
+          latest_version = FastlaneCore::UpdateChecker.fetch_latest(plugin)
           if Gem::Version.new(installed_version) == Gem::Version.new(latest_version)
             update_status = "✅ Up-To-Date"
           else
@@ -107,9 +106,8 @@ module Fastlane
 
         next unless fastlane_tools.include?(current_gem.name.to_sym)
         begin
-          update_url = FastlaneCore::UpdateChecker.generate_fetch_url(current_gem.name)
-          latest_version = FastlaneCore::UpdateChecker.fetch_latest(update_url)
-          if Gem::Version.new(current_gem.version) == Gem::Version.new(latest_version)
+          latest_version = FastlaneCore::UpdateChecker.fetch_latest(current_gem.name)
+          if Gem::Version.new(current_gem.version) >= Gem::Version.new(latest_version)
             update_status = "✅ Up-To-Date"
           else
             update_status = "🚫 Update available"

--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -62,16 +62,16 @@ module Fastlane
         table << "|--------|---------|\n"
         plugin_manager.available_plugins.each do |plugin|
           begin
-          installed_version = Fastlane::ActionCollector.determine_version(plugin)
-          latest_version = FastlaneCore::UpdateChecker.fetch_latest(plugin)
-          if Gem::Version.new(installed_version) == Gem::Version.new(latest_version)
-            update_status = "✅ Up-To-Date"
-          else
-            update_status = "🚫 Update available"
+            installed_version = Fastlane::ActionCollector.determine_version(plugin)
+            latest_version = FastlaneCore::UpdateChecker.fetch_latest(plugin)
+            if Gem::Version.new(installed_version) == Gem::Version.new(latest_version)
+              update_status = "✅ Up-To-Date"
+            else
+              update_status = "🚫 Update available"
+            end
+          rescue
+            update_status = "💥 Check failed"
           end
-        rescue
-          update_status = "💥 Check failed"
-        end
           table << "| #{plugin} | #{installed_version} | #{update_status} |\n"
         end
 

--- a/fastlane/spec/env_spec.rb
+++ b/fastlane/spec/env_spec.rb
@@ -4,9 +4,8 @@ require "fastlane/cli_tools_distributor"
 describe Fastlane do
   describe Fastlane::EnvironmentPrinter do
     before do
-      stub_request(:post, %r{https:\/\/refresher.fastlane.tools\/.*}).
-        with(headers: { 'Host' => 'refresher.fastlane.tools:443' }).
-        to_return(status: 200, body: '{"version": "0.16.2",  "status": "ok"}', headers: {})
+      stub_request(:get, %r{https:\/\/rubygems.org\/api\/v1\/gems\/.*}).
+        to_return(status: 200, body: '{"version": "0.16.2"}', headers: {})
     end
 
     let(:env) { Fastlane::EnvironmentPrinter.get }

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -112,7 +112,11 @@ module FastlaneCore
     end
 
     def self.fetch_latest(gem_name)
-      JSON.parse(Excon.get("https://rubygems.org/api/v1/gems/#{gem_name}.json").body)["version"]
+      JSON.parse(Excon.get(generate_fetch_url(gem_name)).body)["version"]
+    end
+
+    def self.generate_fetch_url(gem_name)
+      "https://rubygems.org/api/v1/gems/#{gem_name}.json"
     end
 
     # (optional) Returns the app identifier for the current tool


### PR DESCRIPTION
This was a regression introduced by https://github.com/fastlane/fastlane/pull/9084, which removed the public facing `generate_fetch_url` method, that was used by the `fastlane env` and `update_fastlane` feature. 

I wonder if it would be possible to detect removing of public Ruby methods using `danger` and automatically search the code base and see if they're used somewhere outside in the future.