### PR TITLE
Raise exception if no match password is provided

### DIFF
--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -18,7 +18,7 @@ module Match
         if !UI.interactive?
           UI.error "Neither the MATCH_PASSWORD environment variable nor the local keychain contained a password."
           UI.error "Bailing out instead of asking for a password, since this is non-interactive mode."
-          UI.error "Try setting the MATCH_PASSWORD environment variable, or temporarily enable interactive mode to store a password."
+          UI.user_error!("Try setting the MATCH_PASSWORD environment variable, or temporarily enable interactive mode to store a password.")
         else
           UI.important "Enter the passphrase that should be used to encrypt/decrypt your certificates"
           UI.important "This passphrase is specific per repository and will be stored in your local keychain"


### PR DESCRIPTION
- Fixes https://github.com/fastlane/fastlane/issues/9126
- This was added via https://github.com/fastlane/fastlane/pull/7561
- Error message was improved just now via https://github.com/fastlane/fastlane/pull/9130
- I think the intent was raise an exception and bail out, as the error message says it, so this PR updates it