### PR TITLE
Removes chomp call to solve issue #9140

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -250,7 +250,7 @@ module Deliver
       UI.user_error!("`trade_representative_contact_information` must be a hash", show_github_issues: true) unless info.kind_of?(Hash)
 
       TRADE_REPRESENTATIVE_CONTACT_INFORMATION_VALUES.each do |key, option_name|
-        v.send("#{key}=", info[option_name].chomp) if info[option_name].chomp
+        v.send("#{key}=", info[option_name].to_s.chomp) if info[option_name]
       end
     end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes `deliver` crash reported in issue #9140 

### Description
The code just remove `chomp` call, following the other methods that are using this same code structure.
