### PR TITLE
Version bump to 2.30.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.29.1'.freeze
+  VERSION = '2.30.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.29.1':**

* Set the service field to the action name (#9145) via David Ohayon
* Removes chomp call to solve issue #9140 (#9144) via Gérson Mendes de Souza
* Raise exception if no match password is provided (#9137) via Felix Krause
* Show warning when no value is provided for option in config files (#9108) via Felix Krause
* Fix mismatched version breaking test (#9143) via David Ohayon
* Add Stackdriver crash reporting (#9113) via David Ohayon
* Tell users about new SnapshotHelper.swift (#9138) via Felix Krause
* Add note in SnapshotHelper.swift about increment the version number (#9139) via Felix Krause
