### PR TITLE
[screengrab] Fix metadata directory names when locale country is empty

### DIFF
--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FileWritingScreenshotCallback.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FileWritingScreenshotCallback.java
@@ -104,7 +104,13 @@ public class FileWritingScreenshotCallback implements ScreenshotCallback {
     }
 
     private static String localeToDirName(Locale locale) {
-        return locale.getLanguage() + "-" + locale.getCountry() + "/images/screenshots";
+        String localeName = locale.getLanguage();
+
+        if(locale.getCountry() != null && !locale.getCountry().equals("")) {
+            localeName += "-" + locale.getCountry();
+        }
+
+        return localeName + "/images/screenshots";
     }
 
     private static void createPathTo(File dir) throws IOException {


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR fixes #9094.

The changes were tested and verified by building a release AAR file and manually linking to that in an Android project.

### Description
The fix checks to ensure the locale object's country attribute is not NULL and is not empty before using it as part of the screenshot directory name.
