### PR TITLE
Enhancing app_store_build_number action’s build number sort

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -15,7 +15,7 @@ module Fastlane
         VERSION_PATTERN = /^(\.?[0-9]+)+$/
 
         def self.correct?(version)
-          (version.to_s !~ VERSION_PATTERN).nil?
+          version.to_s.match(VERSION_PATTERN)
         end
 
         def initialize(version)

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -30,6 +30,10 @@ module Fastlane
           @build_numbers.join(".")
         end
 
+        def to_f
+          @build_numbers.first(2).join(".").to_f
+        end
+
         def to_i
           @build_numbers.first
         end
@@ -45,7 +49,7 @@ module Fastlane
         end
 
         def +(other)
-          return build_numbers.first + other
+          return self.to_i + othser
         end
       end
 

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -12,7 +12,7 @@ module Fastlane
 
         public
 
-        VERSION_PATTERN = /^(\.?[0-9]+)+$/
+        VERSION_PATTERN = /^([0-9])+(\.[0-9]+)*$/
 
         def self.correct?(version)
           version.to_s.match(VERSION_PATTERN)

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -49,7 +49,7 @@ module Fastlane
         end
 
         def +(other)
-          return self.to_i + othser
+          return self.to_i + other
         end
       end
 

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -39,7 +39,7 @@ module Fastlane
 
           begin
             train = app.build_trains[version_number]
-            build_nr = train.builds.map(&:build_version).map(&:to_i).sort.last
+            build_nr = train.builds.map(&:build_version).map { |s| Gem::Version.new(s) }.sort.last.to_s
           rescue
             UI.user_error!("could not find a build on iTC - and 'initial_build_number' option is not set") unless params[:initial_build_number]
             build_nr = params[:initial_build_number]

--- a/fastlane/spec/actions_specs/app_store_build_number_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_build_number_spec.rb
@@ -1,6 +1,14 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe Fastlane::Actions::AppStoreBuildNumberAction::BuildNumber do
+      it "Should works adding by int" do
+        build_number = Fastlane::Actions::AppStoreBuildNumberAction::BuildNumber.new("3.9.1")
+
+        result = build_number + 1
+
+        expect(result).to eq(4)
+      end
+
       it "Should sorted fine in mixed types" do
         build_number1 = Fastlane::Actions::AppStoreBuildNumberAction::BuildNumber.new("3")
         build_number2 = Fastlane::Actions::AppStoreBuildNumberAction::BuildNumber.new("3.9")

--- a/fastlane/spec/actions_specs/app_store_build_number_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_build_number_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::AppStoreBuildNumberAction do
+  it "Should return latest build in integer" do
+    # Mock Builds
+    build1 = OpenStruct.new
+    build1.build_version = "3"
+
+    build2 = OpenStruct.new
+    build2.build_version = "2"
+
+    builds = OpenStruct.new
+    builds.builds = [build1, build2]
+
+    # Mock App with Buildtrain
+    spec_app = OpenStruct.new
+    spec_app.build_trains = {
+      "1.0" => builds
+    }
+
+    # Mock Spaceship
+    expect(Spaceship::Tunes).to receive(:login).and_return(true)
+    expect(Spaceship::Tunes).to receive(:select_team).and_return(true)
+    expect(Spaceship::Application).to receive(:find).and_return(spec_app)
+
+    result = Fastlane::FastFile.new.parse("lane :test do
+      app_store_build_number(username:'demo@demo.com', app_identifier: 'demo.app', live: false, version: '1.0')
+    end").runner.execute(:test)
+
+    expect(result).to eq(3)
+  end
+
+  it "Should return latest build in mixed type" do
+    # Mock Builds
+    build1 = OpenStruct.new
+    build1.build_version = "3"
+
+    build2 = OpenStruct.new
+    build2.build_version = "2"
+
+    build3 = OpenStruct.new
+    build3.build_version = "3.9"
+
+    builds = OpenStruct.new
+    builds.builds = [build1, build2, build3]
+
+    # Mock App with Buildtrain
+    spec_app = OpenStruct.new
+    spec_app.build_trains = {
+      "1.0" => builds
+    }
+
+    # Mock Spaceship
+    expect(Spaceship::Tunes).to receive(:login).and_return(true)
+    expect(Spaceship::Tunes).to receive(:select_team).and_return(true)
+    expect(Spaceship::Application).to receive(:find).and_return(spec_app)
+
+    result = Fastlane::FastFile.new.parse("lane :test do
+      app_store_build_number(username:'demo@demo.com', app_identifier: 'demo.app', live: false, version: '1.0')
+    end").runner.execute(:test)
+
+    expect(result).to eq(3.9)
+  end
+end

--- a/fastlane/spec/actions_specs/app_store_build_number_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_build_number_spec.rb
@@ -1,64 +1,82 @@
-require 'spec_helper'
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe Fastlane::Actions::AppStoreBuildNumberAction::BuildNumber do
+      it "Should sorted fine in mixed types" do
+        build_number1 = Fastlane::Actions::AppStoreBuildNumberAction::BuildNumber.new("3")
+        build_number2 = Fastlane::Actions::AppStoreBuildNumberAction::BuildNumber.new("3.9")
+        build_number3 = Fastlane::Actions::AppStoreBuildNumberAction::BuildNumber.new("3.9.1")
+        build_number4 = Fastlane::Actions::AppStoreBuildNumberAction::BuildNumber.new("39")
 
-describe Fastlane::Actions::AppStoreBuildNumberAction do
-  it "Should return latest build in integer" do
-    # Mock Builds
-    build1 = OpenStruct.new
-    build1.build_version = "3"
+        build_numbers = [build_number1, build_number2, build_number3, build_number4]
 
-    build2 = OpenStruct.new
-    build2.build_version = "2"
+        shuffled_build_numbers = build_numbers.shuffle
+        result = shuffled_build_numbers.sort
 
-    builds = OpenStruct.new
-    builds.builds = [build1, build2]
+        expect(result).to eq(build_numbers)
+      end
+    end
 
-    # Mock App with Buildtrain
-    spec_app = OpenStruct.new
-    spec_app.build_trains = {
-      "1.0" => builds
-    }
+    describe Fastlane::Actions::AppStoreBuildNumberAction do
+      it "Should return latest build in integer" do
+        # Mock Builds
+        build1 = OpenStruct.new
+        build1.build_version = "3"
 
-    # Mock Spaceship
-    expect(Spaceship::Tunes).to receive(:login).and_return(true)
-    expect(Spaceship::Tunes).to receive(:select_team).and_return(true)
-    expect(Spaceship::Application).to receive(:find).and_return(spec_app)
+        build2 = OpenStruct.new
+        build2.build_version = "2"
 
-    result = Fastlane::FastFile.new.parse("lane :test do
-      app_store_build_number(username:'demo@demo.com', app_identifier: 'demo.app', live: false, version: '1.0')
-    end").runner.execute(:test)
+        builds = OpenStruct.new
+        builds.builds = [build1, build2]
 
-    expect(result).to eq(3)
-  end
+        # Mock App with Buildtrain
+        spec_app = OpenStruct.new
+        spec_app.build_trains = {
+          "1.0" => builds
+        }
 
-  it "Should return latest build in mixed type" do
-    # Mock Builds
-    build1 = OpenStruct.new
-    build1.build_version = "3"
+        # Mock Spaceship
+        expect(Spaceship::Tunes).to receive(:login).and_return(true)
+        expect(Spaceship::Tunes).to receive(:select_team).and_return(true)
+        expect(Spaceship::Application).to receive(:find).and_return(spec_app)
 
-    build2 = OpenStruct.new
-    build2.build_version = "2"
+        result = Fastlane::FastFile.new.parse("lane :test do
+          app_store_build_number(username:'demo@demo.com', app_identifier: 'demo.app', live: false, version: '1.0')
+        end").runner.execute(:test)
 
-    build3 = OpenStruct.new
-    build3.build_version = "3.9"
+        expect(result).to eq(3)
+      end
 
-    builds = OpenStruct.new
-    builds.builds = [build1, build2, build3]
+      it "Should return latest build in mixed type" do
+        # Mock Builds
+        build1 = OpenStruct.new
+        build1.build_version = "3"
 
-    # Mock App with Buildtrain
-    spec_app = OpenStruct.new
-    spec_app.build_trains = {
-      "1.0" => builds
-    }
+        build2 = OpenStruct.new
+        build2.build_version = "2"
 
-    # Mock Spaceship
-    expect(Spaceship::Tunes).to receive(:login).and_return(true)
-    expect(Spaceship::Tunes).to receive(:select_team).and_return(true)
-    expect(Spaceship::Application).to receive(:find).and_return(spec_app)
+        build3 = OpenStruct.new
+        build3.build_version = "3.9"
 
-    result = Fastlane::FastFile.new.parse("lane :test do
-      app_store_build_number(username:'demo@demo.com', app_identifier: 'demo.app', live: false, version: '1.0')
-    end").runner.execute(:test)
+        builds = OpenStruct.new
+        builds.builds = [build1, build2, build3]
 
-    expect(result).to eq(3.9)
+        # Mock App with Buildtrain
+        spec_app = OpenStruct.new
+        spec_app.build_trains = {
+          "1.0" => builds
+        }
+
+        # Mock Spaceship
+        expect(Spaceship::Tunes).to receive(:login).and_return(true)
+        expect(Spaceship::Tunes).to receive(:select_team).and_return(true)
+        expect(Spaceship::Application).to receive(:find).and_return(spec_app)
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          app_store_build_number(username:'demo@demo.com', app_identifier: 'demo.app', live: false, version: '1.0')
+        end").runner.execute(:test)
+
+        expect(result).to eq(3.9)
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
I'm using build number as x.y format, and app_store_build_number doesn't support that.
So... This will fixes #1178

### Description
<!--- Describe your changes in detail -->
I use ~~Gem::Version~~ custom type to sort build numbers as semver, after that it will convert to string.