### PR TITLE
Use new `build_failure!` method to report gym failures

### DIFF
--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -252,11 +252,13 @@ module Fastlane
             class_ref.run(arguments)
           end
         end
+      rescue \
+        FastlaneCore::Interface::FastlaneBuildFailure,    # build_failure!
+        FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!
+        raise e
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         FastlaneCore::CrashReporter.report_crash(type: :user_error, exception: e, action: method_sym)
         collector.did_raise_error(method_sym)
-        raise e
-      rescue FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!
         raise e
       rescue Exception => e # rubocop:disable Lint/RescueException
         # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -70,6 +70,10 @@ module Commander
           FastlaneCore::CrashReporter.report_crash(type: :option_parser, exception: e, action: @program[:name])
           abort e.to_s
         end
+      rescue \
+        FastlaneCore::Interface::FastlaneBuildFailure,    # build_failure!
+        FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!
+        display_user_error!(e, e.to_s)
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         collector.did_raise_error(@program[:name])
         show_github_issues(e.message) if e.show_github_issues
@@ -83,8 +87,6 @@ module Commander
         puts ""
         FastlaneCore::CrashReporter.report_crash(type: :system, exception: e, action: @program[:name])
         raise e
-      rescue FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!
-        display_user_error!(e, e.to_s)
       rescue Faraday::SSLError => e # SSL issues are very common
         handle_ssl_error!(e)
       rescue Faraday::ConnectionFailed => e

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -126,6 +126,10 @@ module FastlaneCore
       end
     end
 
+    # raised from build_failure!
+    class FastlaneBuildFailure < FastlaneError
+    end
+
     # raised from test_failure!
     class FastlaneTestFailure < StandardError
     end
@@ -148,6 +152,16 @@ module FastlaneCore
     # and want to show a nice error message to the user
     def user_error!(error_message, options = {})
       raise FastlaneError.new(options), error_message.to_s
+    end
+
+    # Use this method to exit the program because of a build failure
+    # that's caused by the source code of the user. Example for this
+    # is that gym will fail when the code doesn't compile or because
+    # settings for the project are incorrect.
+    # By using this method we'll have more accurate results about
+    # fastlane failures
+    def build_failure!(error_message, options = {})
+      raise FastlaneBuildFailure.new(options), error_message.to_s
     end
 
     # Use this method to exit the program because of a test failure

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -55,7 +55,7 @@ module Gym
         print_xcode_path_instructions
         print_xcode_version
         raise_legacy_build_api_error(output) if Gym.config[:use_legacy_build_api]
-        UI.user_error!("Error building the application - see the log above", error_info: output)
+        UI.build_failure!("Error building the application - see the log above", error_info: output)
       end
 
       # @param [Array] The output of the errored build (line by line)
@@ -86,7 +86,7 @@ module Gym
           print "provisioning profile and code signing identity."
         end
         print_full_log_path
-        UI.user_error!("Error packaging up the application", error_info: output)
+        UI.build_failure!("Error packaging up the application", error_info: output)
       end
 
       def handle_empty_archive
@@ -96,7 +96,7 @@ module Gym
         print "Also, make sure to have a valid code signing identity and provisioning profile installed"
         print "Follow this guide to setup code signing https://docs.fastlane.tools/codesigning/GettingStarted/"
         print "If your intention was only to export an ipa be sure to provide a valid archive at the archive path."
-        UI.user_error!("Archive invalid")
+        UI.build_failure!("Archive invalid")
       end
 
       def find_standard_output_path(output)
@@ -110,7 +110,7 @@ module Gym
         UI.error("and was removed with Xcode 8.3")
         UI.error("Please update your Fastfile to include the export_method too")
         UI.error("more information about how to migrate away: https://github.com/fastlane/fastlane/releases/tag/2.24.0")
-        UI.user_error!("Build failed. Please remove the `use_legacy_build_api` option in your Fastfile and try again", error_info: output)
+        UI.build_failure!("Build failed. Please remove the `use_legacy_build_api` option in your Fastfile and try again", error_info: output)
       end
 
       private


### PR DESCRIPTION
These failures will not be counted by metrics or recorded by crash reporter

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently, code compilation errors are reported via `user_error!`, even though these sorts of errors are not actually the result of a user misusing _fastlane_ but just natural errors in software development lifecycle.  Since we do not want to report these sorts of errors to our crash reporter (and don't want to count them as user failures in metrics), we have introduced a new failure type to handle these exceptions without any sort of logging.