### PR TITLE
Version bump to 2.30.2

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.30.1'.freeze
+  VERSION = '2.30.2'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.30.1':**

* Use new `build_failure!` method to report gym failures (#9156) via Mark Pirri
* fix capital f via David Ohayon
* rubo via David Ohayon
* Rescue exception while trying to write the crash report to disk via David Ohayon
* Fix spaceship launcher client login for push certificate (#9090) via Austin Treat Emmons
* [screengrab] Fix metadata directory names when locale country is an empty string (#9094) (#9150) via Josh Snelling
