### PR TITLE
zip action did not return output path with zip if not given with one

### DIFF
--- a/fastlane/lib/fastlane/actions/zip.rb
+++ b/fastlane/lib/fastlane/actions/zip.rb
@@ -4,9 +4,12 @@ module Fastlane
       def self.run(params)
         UI.message "Compressing #{params[:path]}..."
 
-        params[:output_path] ||= "#{params[:path]}.zip"
+        params[:output_path] ||= params[:path]
 
         absolute_output_path = File.expand_path(params[:output_path])
+
+        # Appends ".zip" if path does not end in ".zip"
+        absolute_output_path = absolute_output_path.gsub(/(?<!.zip)$/, ".zip")
 
         absolute_output_dir = File.expand_path("..", absolute_output_path)
         FileUtils.mkdir_p(absolute_output_dir)
@@ -17,8 +20,8 @@ module Fastlane
           Actions.sh "zip -#{zip_options} #{absolute_output_path.shellescape} #{File.basename(params[:path]).shellescape}"
         end
 
-        UI.success "Successfully generated zip file at path '#{File.expand_path(params[:output_path])}'"
-        return File.expand_path(params[:output_path])
+        UI.success "Successfully generated zip file at path '#{File.expand_path(absolute_output_path)}'"
+        return File.expand_path(absolute_output_path)
       end
 
       #####################################################

--- a/fastlane/spec/actions_specs/zip_spec.rb
+++ b/fastlane/spec/actions_specs/zip_spec.rb
@@ -3,6 +3,8 @@ describe Fastlane do
     before do
       allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
       @path = "./fastlane/spec/fixtures/actions/archive.rb"
+      @output_path_with_zip = "./fastlane/spec/fixtures/actions/archive_file.zip"
+      @output_path_without_zip = "./fastlane/spec/fixtures/actions/archive_file"
     end
 
     describe "zip" do
@@ -20,6 +22,30 @@ describe Fastlane do
         result = Fastlane::FastFile.new.parse("lane :test do
           zip(path: '#{@path}', verbose: 'false')
         end").runner.execute(:test)
+      end
+
+      it "generates an output path given no output path" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          zip(path: '#{@path}', output_path: '#{@path}')
+        end").runner.execute(:test)
+
+        expect(result).to eq(File.absolute_path("#{@path}.zip"))
+      end
+
+      it "generates an output path with zip extension (given zip extension)" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          zip(path: '#{@path}', output_path: '#{@output_path_with_zip}')
+        end").runner.execute(:test)
+
+        expect(result).to eq(File.absolute_path(@output_path_with_zip))
+      end
+
+      it "generates an output path with zip extension (not given zip extension)" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          zip(path: '#{@path}', output_path: '#{@output_path_without_zip}')
+        end").runner.execute(:test)
+
+        expect(result).to eq(File.absolute_path(@output_path_with_zip))
       end
     end
   end


### PR DESCRIPTION
`zip` action now will always return an output path with the `.zip` extension 😊 