### PR TITLE
[spaceship] detect non-interactive terminals (team selection)

### DIFF
--- a/spaceship/lib/spaceship/portal/ui/select_team.rb
+++ b/spaceship/lib/spaceship/portal/ui/select_team.rb
@@ -32,14 +32,14 @@ module Spaceship
       #   ]
 
       def self.ci?
-        if Object.const_defined?("FastlaneCore")
+        if Object.const_defined?("FastlaneCore") && FastlaneCore.const_defined?("Helper")
           return FastlaneCore::Helper.ci?
         end
         return false
       end
 
       def self.interactive?
-        if Object.const_defined?("FastlaneCore")
+        if Object.const_defined?("FastlaneCore") && FastlaneCore.const_defined?("Helper")
           return FastlaneCore::Helper.interactive?
         end
         return true
@@ -85,7 +85,7 @@ module Spaceship
           teams.each_with_index do |team, i|
             puts "#{i + 1}) #{team['teamId']} \"#{team['name']}\" (#{team['type']})"
           end
-          raise "multiple_teams_no_interactive_shell"
+          raise "Multiple Teams found; unable to choose, terminal not ineractive!"
         end
 
         # User Selection

--- a/spaceship/lib/spaceship/portal/ui/select_team.rb
+++ b/spaceship/lib/spaceship/portal/ui/select_team.rb
@@ -32,18 +32,17 @@ module Spaceship
       #   ]
 
       def self.ci?
-        # Check for Jenkins, Travis CI, ... environment variables
-        ['JENKINS_HOME', 'JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI', 'XCS'].each do |current|
-          return true if ENV.key?(current)
+        if Object.const_defined?("FastlaneCore")
+          return FastlaneCore::Helper.ci?
         end
         return false
       end
 
       def self.interactive?
-        interactive = true
-        interactive = false if $stdout.isatty == false
-        interactive = false if ci?
-        return interactive
+        if Object.const_defined?("FastlaneCore")
+          return FastlaneCore::Helper.interactive?
+        end
+        return true
       end
 
       def select_team

--- a/spaceship/spec/UI/select_team_spec.rb
+++ b/spaceship/spec/UI/select_team_spec.rb
@@ -21,11 +21,13 @@ describe Spaceship::Client do
 
         it "Lets the user select the team if in multiple teams" do
           allow($stdin).to receive(:gets).and_return("2")
+          expect(Spaceship::Client::UserInterface).to receive(:interactive?).and_return(true)
           expect(subject.select_team).to eq("XXXXXXXXXX") # a different team
         end
 
         it "Falls back to user selection if team wasn't found" do
           ENV["FASTLANE_TEAM_ID"] = "Not Here"
+          expect(Spaceship::Client::UserInterface).to receive(:interactive?).and_return(true)
           allow($stdin).to receive(:gets).and_return("2")
           expect(subject.select_team).to eq("XXXXXXXXXX") # a different team
         end
@@ -52,14 +54,23 @@ describe Spaceship::Client do
 
         it "Asks for the team if the name couldn't be found (pick first)" do
           ENV["FASTLANE_TEAM_NAME"] = "NotExistent"
+          expect(Spaceship::Client::UserInterface).to receive(:interactive?).and_return(true)
           allow($stdin).to receive(:gets).and_return("1")
           expect(subject.select_team).to eq("SecondTeam")
         end
 
         it "Asks for the team if the name couldn't be found (pick last)" do
           ENV["FASTLANE_TEAM_NAME"] = "NotExistent"
+          expect(Spaceship::Client::UserInterface).to receive(:interactive?).and_return(true)
           allow($stdin).to receive(:gets).and_return("2")
           expect(subject.select_team).to eq("XXXXXXXXXX")
+        end
+
+        it "Raises an Error if shell is non interactive" do
+          expect(Spaceship::Client::UserInterface).to receive(:interactive?).and_return(false)
+          expect do
+            subject.select_team
+          end.to raise_error("multiple_teams_no_interactive_shell")
         end
 
         after do

--- a/spaceship/spec/UI/select_team_spec.rb
+++ b/spaceship/spec/UI/select_team_spec.rb
@@ -70,7 +70,7 @@ describe Spaceship::Client do
           expect(Spaceship::Client::UserInterface).to receive(:interactive?).and_return(false)
           expect do
             subject.select_team
-          end.to raise_error("multiple_teams_no_interactive_shell")
+          end.to raise_error("Multiple Teams found; unable to choose, terminal not ineractive!")
         end
 
         after do


### PR DESCRIPTION
there is an  endless loop in spaceship when team selection is done, and running in non interactive mode. (aka CI) that almost all tools suffer.

this PR trys to fix this, by providing the 2 missing pieces (`ci?`, `interactive?`)


i know this 2 methods are simple copies from fastlane_core, but as we still have no inter dep. from core to spaceship and vice-a-verse - i think its ok to stay with the couple of duplicated lines. and solving the infinity loop.


can we assume that in fastlane_core, spaceship is available? (then we could remove the methods from fastlane_core, and call the `Spaceship::Client::UserInterface` - or are there any cases where `fastlane_core` is used without `spaceship`?



issues:
#9154, #2798