### PR TITLE
Small code cleanup for fixes to screengrab's localeToDirName

### DIFF
--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FileWritingScreenshotCallback.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FileWritingScreenshotCallback.java
@@ -104,13 +104,14 @@ public class FileWritingScreenshotCallback implements ScreenshotCallback {
     }
 
     private static String localeToDirName(Locale locale) {
-        String localeName = locale.getLanguage();
+        StringBuilder sb = new StringBuilder(locale.getLanguage());
+        String localeCountry = locale.getCountry();
 
-        if(locale.getCountry() != null && !locale.getCountry().equals("")) {
-            localeName += "-" + locale.getCountry();
+        if (localeCountry != null && localeCountry.length() != 0) {
+            sb.append("-").append(localeCountry);
         }
 
-        return localeName + "/images/screenshots";
+        return sb.append("/images/screenshots").toString();
     }
 
     private static void createPathTo(File dir) throws IOException {


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Small style changes for the fix provided in #9150
