### PR TITLE
Make sure that valid? raises rather than verify

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -103,7 +103,7 @@ module FastlaneCore
     end
 
     def verify!(value)
-      true if valid?(value)
+      valid?(value)
     end
 
     # Make sure, the value is valid (based on the verify block)

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -102,13 +102,12 @@ module FastlaneCore
       @allow_shell_conversion = (type == :shell_string)
     end
 
-    # This will raise an exception if the value is not valid
     def verify!(value)
       true if valid?(value)
     end
 
     # Make sure, the value is valid (based on the verify block)
-    # Returns false if that's not the case
+    # Raises an exception if the value is invalid
     def valid?(value)
       # we also allow nil values, which do not have to be verified.
       if value

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -104,8 +104,7 @@ module FastlaneCore
 
     # This will raise an exception if the value is not valid
     def verify!(value)
-      UI.user_error!("Invalid value '#{value}' for option '#{self}'") unless valid?(value)
-      true
+      true if valid?(value)
     end
 
     # Make sure, the value is valid (based on the verify block)


### PR DESCRIPTION
Saw a crash in Stackdriver that showed a lot of failures in the `verify` method, but it calls into `valid?` which should be responsible for raising exceptions.