### PR TITLE
Handle case of Info.plist path prepended by $(SRCROOT)

### DIFF
--- a/fastlane/lib/fastlane/actions/update_app_identifier.rb
+++ b/fastlane/lib/fastlane/actions/update_app_identifier.rb
@@ -23,7 +23,7 @@ module Fastlane
           configs = project.objects.select { |obj| obj.isa == 'XCBuildConfiguration' && !obj.build_settings[identifier_key].nil? }
           UI.user_error!("Info plist uses $(#{identifier_key}), but xcodeproj does not") unless configs.count > 0
 
-          configs = configs.select { |obj| obj.build_settings[info_plist_key] == params[:plist_path] }
+          configs = configs.select { |obj| obj.build_settings[info_plist_key] == params[:plist_path] || obj.build_settings[info_plist_key] == "$(SRCROOT)/"+params[:plist_path] }
           UI.user_error!("Xcodeproj doesn't have configuration with info plist #{params[:plist_path]}.") unless configs.count > 0
 
           # For each of the build configurations, set app identifier

--- a/fastlane/lib/fastlane/actions/update_app_identifier.rb
+++ b/fastlane/lib/fastlane/actions/update_app_identifier.rb
@@ -23,7 +23,8 @@ module Fastlane
           configs = project.objects.select { |obj| obj.isa == 'XCBuildConfiguration' && !obj.build_settings[identifier_key].nil? }
           UI.user_error!("Info plist uses $(#{identifier_key}), but xcodeproj does not") unless configs.count > 0
 
-          configs = configs.select { |obj| obj.build_settings[info_plist_key] == params[:plist_path] || obj.build_settings[info_plist_key] == "$(SRCROOT)/" + params[:plist_path] }
+          possible_plist_paths = ["", "$(SRCROOT)/"].map { |x| x + params[:plist_path] }
+          configs = configs.select { |obj| possible_plist_paths.include? obj.build_settings[info_plist_key] }
           UI.user_error!("Xcodeproj doesn't have configuration with info plist #{params[:plist_path]}.") unless configs.count > 0
 
           # For each of the build configurations, set app identifier

--- a/fastlane/lib/fastlane/actions/update_app_identifier.rb
+++ b/fastlane/lib/fastlane/actions/update_app_identifier.rb
@@ -23,7 +23,7 @@ module Fastlane
           configs = project.objects.select { |obj| obj.isa == 'XCBuildConfiguration' && !obj.build_settings[identifier_key].nil? }
           UI.user_error!("Info plist uses $(#{identifier_key}), but xcodeproj does not") unless configs.count > 0
 
-          configs = configs.select { |obj| obj.build_settings[info_plist_key] == params[:plist_path] || obj.build_settings[info_plist_key] == "$(SRCROOT)/"+params[:plist_path] }
+          configs = configs.select { |obj| obj.build_settings[info_plist_key] == params[:plist_path] || obj.build_settings[info_plist_key] == "$(SRCROOT)/" + params[:plist_path] }
           UI.user_error!("Xcodeproj doesn't have configuration with info plist #{params[:plist_path]}.") unless configs.count > 0
 
           # For each of the build configurations, set app identifier


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The Fastlane action is unable to find the Info.plist for my newly created target.

### Description
The action when checking xcodeproj for validity of given plist path, would now handle the case of `$(SRCROOT)` prepended to it.