### PR TITLE
Dont drop frames on non-user_errors

### DIFF
--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -257,8 +257,7 @@ module Fastlane
         FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!
         raise e
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
-        type = e.backtrace[0].include?('user_error!') ? :user_error : :exception
-        FastlaneCore::CrashReporter.report_crash(type: type, exception: e, action: method_sym)
+        FastlaneCore::CrashReporter.report_crash(type: e.type, exception: e, action: method_sym)
         collector.did_raise_error(method_sym)
         raise e
       rescue Exception => e # rubocop:disable Lint/RescueException

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -257,7 +257,8 @@ module Fastlane
         FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!
         raise e
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
-        FastlaneCore::CrashReporter.report_crash(type: :user_error, exception: e, action: method_sym)
+        type = e.backtrace[0].include?('user_error!') ? :user_error : :exception
+        FastlaneCore::CrashReporter.report_crash(type: type, exception: e, action: method_sym)
         collector.did_raise_error(method_sym)
         raise e
       rescue Exception => e # rubocop:disable Lint/RescueException

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -77,7 +77,8 @@ module Commander
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         collector.did_raise_error(@program[:name])
         show_github_issues(e.message) if e.show_github_issues
-        FastlaneCore::CrashReporter.report_crash(type: :user_error, exception: e, action: @program[:name])
+        type = e.backtrace[0].include?('user_error!') ? :user_error : :crash
+        FastlaneCore::CrashReporter.report_crash(type: type, exception: e, action: @program[:name])
         display_user_error!(e, e.message)
       rescue Errno::ENOENT => e
         # We're also printing the new-lines, as otherwise the message is not very visible in-between the error and the stacktrace

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -77,7 +77,7 @@ module Commander
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         collector.did_raise_error(@program[:name])
         show_github_issues(e.message) if e.show_github_issues
-        type = e.backtrace[0].include?('user_error!') ? :user_error : :crash
+        type = e.backtrace[0].include?('user_error!') ? :user_error : :exception
         FastlaneCore::CrashReporter.report_crash(type: type, exception: e, action: @program[:name])
         display_user_error!(e, e.message)
       rescue Errno::ENOENT => e

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -77,8 +77,7 @@ module Commander
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         collector.did_raise_error(@program[:name])
         show_github_issues(e.message) if e.show_github_issues
-        type = e.backtrace[0].include?('user_error!') ? :user_error : :exception
-        FastlaneCore::CrashReporter.report_crash(type: type, exception: e, action: @program[:name])
+        FastlaneCore::CrashReporter.report_crash(type: e.type, exception: e, action: @program[:name])
         display_user_error!(e, e.message)
       rescue Errno::ENOENT => e
         # We're also printing the new-lines, as otherwise the message is not very visible in-between the error and the stacktrace

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -124,6 +124,18 @@ module FastlaneCore
         @show_github_issues = show_github_issues
         @error_info = error_info
       end
+
+      def type
+        return :unknown if backtrace[0].nil?
+        first_frame = backtrace[0]
+        if first_frame.include?('user_error!') && first_frame.include?('interface.rb')
+          :user_error
+        elsif first_frame.include?('crash!') && first_frame.include?('interface.rb')
+          :crash
+        else
+          :exception
+        end
+      end
     end
 
     # raised from build_failure!


### PR DESCRIPTION
This is to make sure that we are not dropping the first two frames on crashes that are not explicitly called from `UI.crash!` and `UI.user_error!`.