### PR TITLE
Include exception class name in the message for errors of type :excep…

### DIFF
--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
@@ -28,6 +28,8 @@ module FastlaneCore
         sanitized_exception_message = FastlaneCore::CrashReportSanitizer.sanitize_string(string: exception.message)
         if type == :user_error
           message += ': '
+        elsif type == :exception
+          message += ": #{exception.class.name}: #{sanitized_exception_message}"
         else
           message += ": #{sanitized_exception_message}"
         end

--- a/fastlane_core/spec/crash_reporter/crash_report_generator_spec.rb
+++ b/fastlane_core/spec/crash_reporter/crash_report_generator_spec.rb
@@ -45,6 +45,12 @@ describe FastlaneCore::CrashReportGenerator do
       expect(FastlaneCore::CrashReportGenerator.generate(exception: exception)).to eq(expected_body.to_json)
     end
 
+    it 'includes exception class name for exceptions' do
+      setup_sanitizer_expectation(type: :exception)
+      setup_expected_body(type: :exception, message_text: ": #{exception.class.name}: #{exception.message}\n")
+      expect(FastlaneCore::CrashReportGenerator.generate(type: :exception, exception: exception)).to eq(expected_body.to_json)
+    end
+
     it 'includes stack frames in message' do
       setup_sanitizer_expectation
       setup_expected_body(message_text: ": #{exception.message}\n")


### PR DESCRIPTION
…tion

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When the crash reporter logs an crash of type :exception, also include the exception type to reveal a bit more about the failure.