### PR TITLE
Move type logic to the crash reporter itself

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,7 +2,7 @@ skip_docs
 
 desc "Runs the unit tests and other verifications for the fastlane repo"
 lane :test do |options|
-  snapshot(project: '.')
+  validate_repo
 end
 
 desc "Increment the version number of this gem"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,7 +2,7 @@ skip_docs
 
 desc "Runs the unit tests and other verifications for the fastlane repo"
 lane :test do |options|
-  validate_repo
+  snapshot(project: '.')
 end
 
 desc "Increment the version number of this gem"

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -257,14 +257,14 @@ module Fastlane
         FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!
         raise e
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
-        FastlaneCore::CrashReporter.report_crash(type: :user_error, exception: e, action: method_sym)
+        FastlaneCore::CrashReporter.report_crash(exception: e, action: method_sym)
         collector.did_raise_error(method_sym)
         raise e
       rescue Exception => e # rubocop:disable Lint/RescueException
         # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
         # Catches all exceptions, since some plugins might use system exits to get out
         type = e.kind_of?(FastlaneCore::Interface::FastlaneCrash) ? :crash : :exception
-        FastlaneCore::CrashReporter.report_crash(type: type, exception: e, action: method_sym)
+        FastlaneCore::CrashReporter.report_crash(exception: e, action: method_sym)
         collector.did_crash(method_sym)
         raise e
       end

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -263,7 +263,6 @@ module Fastlane
       rescue Exception => e # rubocop:disable Lint/RescueException
         # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
         # Catches all exceptions, since some plugins might use system exits to get out
-        type = e.kind_of?(FastlaneCore::Interface::FastlaneCrash) ? :crash : :exception
         FastlaneCore::CrashReporter.report_crash(exception: e, action: method_sym)
         collector.did_crash(method_sym)
         raise e

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
@@ -18,7 +18,8 @@ module FastlaneCore
 
       def crash_report_message(type: :exception, exception: nil)
         return if exception.nil?
-        backtrace = FastlaneCore::CrashReportSanitizer.sanitize_backtrace(type: type, backtrace: exception.backtrace).join("\n")
+        stack = exception.respond_to?(:cleaned_backtrace) ? exception.cleaned_backtrace : exception.backtrace
+        backtrace = FastlaneCore::CrashReportSanitizer.sanitize_backtrace(type: type, backtrace: stack).join("\n")
         message = types[type]
         sanitized_exception_message = FastlaneCore::CrashReportSanitizer.sanitize_string(string: exception.message)
         if type == :user_error

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
@@ -1,22 +1,14 @@
 module FastlaneCore
   class CrashReportGenerator
     class << self
-      def types
-        {
-          user_error: '[USER_ERROR]',
-          crash: '[FASTLANE_CRASH]',
-          exception: '[EXCEPTION]'
-        }
-      end
-
-      def generate(type: :exception, exception: nil, action: nil)
-        message = crash_report_message(type: type, exception: exception)
+      def generate(exception: nil, action: nil)
+        message = crash_report_message(exception: exception)
         crash_report_payload(message: message, action: action)
       end
 
       private
 
-      def crash_report_message(type: :exception, exception: nil)
+      def crash_report_message(exception: nil)
         return if exception.nil?
         stack = exception.respond_to?(:cleaned_backtrace) ? exception.cleaned_backtrace : exception.backtrace
         backtrace = FastlaneCore::CrashReportSanitizer.sanitize_backtrace(backtrace: stack).join("\n")

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
@@ -5,23 +5,18 @@ module FastlaneCore
         {
           user_error: '[USER_ERROR]',
           crash: '[FASTLANE_CRASH]',
-          exception: '[EXCEPTION]',
-          connection_failure: '[CONNECTION_FAILURE]',
-          system: '[SYSTEM_ERROR]',
-          option_parser: '[OPTION_PARSER]',
-          invalid_command: '[INVALID_COMMAND]',
-          unknown: '[UNKNOWN]'
+          exception: '[EXCEPTION]'
         }
       end
 
-      def generate(type: :unknown, exception: nil, action: nil)
+      def generate(type: :exception, exception: nil, action: nil)
         message = crash_report_message(type: type, exception: exception)
         crash_report_payload(message: message, action: action)
       end
 
       private
 
-      def crash_report_message(type: :unknown, exception: nil)
+      def crash_report_message(type: :exception, exception: nil)
         return if exception.nil?
         backtrace = FastlaneCore::CrashReportSanitizer.sanitize_backtrace(type: type, backtrace: exception.backtrace).join("\n")
         message = types[type]

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
@@ -19,16 +19,17 @@ module FastlaneCore
       def crash_report_message(type: :exception, exception: nil)
         return if exception.nil?
         stack = exception.respond_to?(:cleaned_backtrace) ? exception.cleaned_backtrace : exception.backtrace
-        backtrace = FastlaneCore::CrashReportSanitizer.sanitize_backtrace(type: type, backtrace: stack).join("\n")
-        message = types[type]
-        sanitized_exception_message = FastlaneCore::CrashReportSanitizer.sanitize_string(string: exception.message)
-        if type == :user_error
+        backtrace = FastlaneCore::CrashReportSanitizer.sanitize_backtrace(backtrace: stack).join("\n")
+        message = exception.respond_to?(:prefix) ? exception.prefix : '[EXCEPTION]'
+
+        if exception.respond_to?(:could_contain_pii?) && exception.could_contain_pii?
           message += ': '
         else
+          sanitized_exception_message = FastlaneCore::CrashReportSanitizer.sanitize_string(string: exception.message)
           message += ": #{sanitized_exception_message}"
         end
         message = message[0..100]
-        message += "\n" unless type == :user_error
+        message += "\n" unless exception.respond_to?(:could_contain_pii?) && exception.could_contain_pii?
         message + backtrace
       end
 

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
@@ -10,8 +10,8 @@ module FastlaneCore
 
       def format_crash_report_message(exception: nil)
         return if exception.nil?
-        stack = exception.respond_to?(:trimmed_backtrace) ? exception.trimmed_backtrace : exception.backtrace
-        backtrace = FastlaneCore::CrashReportSanitizer.sanitize_backtrace(backtrace: stack).join("\n")
+        backtrace = exception.respond_to?(:trimmed_backtrace) ? exception.trimmed_backtrace : exception.backtrace
+        backtrace = FastlaneCore::CrashReportSanitizer.sanitize_backtrace(backtrace: backtrace).join("\n")
         message = exception.respond_to?(:prefix) ? exception.prefix : '[EXCEPTION]'
         message += ': '
 

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
@@ -21,7 +21,8 @@ module FastlaneCore
           exception_message = "#{exception.class.name}: #{FastlaneCore::CrashReportSanitizer.sanitize_string(string: exception.message)}"
         end
 
-        message += exception_message[0..100]
+        message += exception_message
+        message = message[0..100]
         message += "\n" unless exception.respond_to?(:could_contain_pii?) && exception.could_contain_pii?
         message + backtrace
       end

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
@@ -2,13 +2,13 @@ module FastlaneCore
   class CrashReportGenerator
     class << self
       def generate(exception: nil, action: nil)
-        message = crash_report_message(exception: exception)
+        message = format_crash_report_message(exception: exception)
         crash_report_payload(message: message, action: action)
       end
 
       private
 
-      def crash_report_message(exception: nil)
+      def format_crash_report_message(exception: nil)
         return if exception.nil?
         stack = exception.respond_to?(:trimmed_backtrace) ? exception.trimmed_backtrace : exception.backtrace
         backtrace = FastlaneCore::CrashReportSanitizer.sanitize_backtrace(backtrace: stack).join("\n")

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
@@ -16,11 +16,13 @@ module FastlaneCore
         message += ': '
 
         if exception.respond_to?(:crash_report_message)
-          message += FastlaneCore::CrashReportSanitizer.sanitize_string(string: exception.crash_report_message)
+          exception_message = FastlaneCore::CrashReportSanitizer.sanitize_string(string: exception.crash_report_message)
         else
-          message += "#{exception.class.name}: #{FastlaneCore::CrashReportSanitizer.sanitize_string(string: exception.message)[0..100]}\n"
+          exception_message = "#{exception.class.name}: #{FastlaneCore::CrashReportSanitizer.sanitize_string(string: exception.message)}"
         end
 
+        message += exception_message[0..100]
+        message += "\n" unless exception.respond_to?(:could_contain_pii?) && exception.could_contain_pii?
         message + backtrace
       end
 

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_sanitizer.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_sanitizer.rb
@@ -1,7 +1,7 @@
 module FastlaneCore
   class CrashReportSanitizer
     class << self
-      def sanitize_backtrace(backtrace: nil, type: :unknown)
+      def sanitize_backtrace(backtrace: nil, type: :exception)
         if type == :user_error || type == :crash
           # If the crash is from `UI` we only want to include the stack trace
           # up to the point where the crash was initiated.

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_sanitizer.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_sanitizer.rb
@@ -1,7 +1,7 @@
 module FastlaneCore
   class CrashReportSanitizer
     class << self
-      def sanitize_backtrace(backtrace: nil, type: :exception)
+      def sanitize_backtrace(backtrace: nil)
         backtrace.map do |frame|
           sanitize_string(string: frame)
         end

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_sanitizer.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_sanitizer.rb
@@ -2,17 +2,7 @@ module FastlaneCore
   class CrashReportSanitizer
     class << self
       def sanitize_backtrace(backtrace: nil, type: :exception)
-        if type == :user_error || type == :crash
-          # If the crash is from `UI` we only want to include the stack trace
-          # up to the point where the crash was initiated.
-          # The two stack frames we are dropping are `method_missing` and
-          # the call to `crash!` or `user_error!`.
-          stack = backtrace.drop(2)
-        else
-          stack = backtrace
-        end
-
-        stack.map do |frame|
+        backtrace.map do |frame|
           sanitize_string(string: frame)
         end
       end

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
@@ -25,7 +25,7 @@ module FastlaneCore
         # we want to test it
         return if Helper.test? && !@explitly_enabled_for_testing
 
-        payload = CrashReportGenerator.generate(type: type(exception), exception: exception, action: action)
+        payload = CrashReportGenerator.generate(exception: exception, action: action)
         send_report(payload: payload)
         save_file(payload: payload)
         show_message unless did_show_message?
@@ -45,18 +45,6 @@ module FastlaneCore
       end
 
       private
-
-      def type(exception)
-        return :exception if exception.nil? || exception.backtrace.nil? || exception.backtrace[0].nil?
-        first_frame = exception.backtrace[0]
-        if first_frame.include?('user_error!') && first_frame.include?('interface.rb')
-          :user_error
-        elsif first_frame.include?('crash!') && first_frame.include?('interface.rb')
-          :crash
-        else
-          :exception
-        end
-      end
 
       def show_message
         UI.message("Sending crash report...")

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -91,7 +91,6 @@ module Commander
           handle_unknown_error!(e)
         end
       rescue => e # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
-        type = e.kind_of?(FastlaneCore::Interface::FastlaneCrash) ? :crash : :exception
         FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
         collector.did_crash(@program[:name])
         handle_unknown_error!(e)

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -42,7 +42,7 @@ module Commander
         if FastlaneCore::Helper.test?
           raise e
         else
-          FastlaneCore::CrashReporter.report_crash(type: :invalid_command, exception: e, action: @program[:name])
+          FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
           abort "#{e}. Use --help for more information"
         end
       rescue Interrupt => e
@@ -61,7 +61,7 @@ module Commander
         if FastlaneCore::Helper.test?
           raise e
         else
-          FastlaneCore::CrashReporter.report_crash(type: :option_parser, exception: e, action: @program[:name])
+          FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
           abort e.to_s
         end
       rescue \
@@ -71,7 +71,7 @@ module Commander
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         collector.did_raise_error(@program[:name])
         show_github_issues(e.message) if e.show_github_issues
-        FastlaneCore::CrashReporter.report_crash(type: :user_error, exception: e, action: @program[:name])
+        FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
         display_user_error!(e, e.message)
       rescue Errno::ENOENT => e
         # We're also printing the new-lines, as otherwise the message is not very visible in-between the error and the stacktrace
@@ -79,7 +79,7 @@ module Commander
         FastlaneCore::UI.important("Error accessing file, this might be due to fastlane's directory handling")
         FastlaneCore::UI.important("Check out https://docs.fastlane.tools/advanced/#directory-behavior for more details")
         puts ""
-        FastlaneCore::CrashReporter.report_crash(type: :system, exception: e, action: @program[:name])
+        FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
         raise e
       rescue Faraday::SSLError => e # SSL issues are very common
         handle_ssl_error!(e)
@@ -87,12 +87,12 @@ module Commander
         if e.message.include? 'Connection reset by peer - SSL_connect'
           handle_tls_error!(e)
         else
-          FastlaneCore::CrashReporter.report_crash(type: :connection_failure, exception: e, action: @program[:name])
+          FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
           handle_unknown_error!(e)
         end
       rescue => e # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
         type = e.kind_of?(FastlaneCore::Interface::FastlaneCrash) ? :crash : :exception
-        FastlaneCore::CrashReporter.report_crash(type: type, exception: e, action: @program[:name])
+        FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
         collector.did_crash(@program[:name])
         handle_unknown_error!(e)
       ensure

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -111,18 +111,38 @@ module FastlaneCore
     # @!group Errors: Different kinds of exceptions
     #####################################################
 
+    class FastlaneException < StandardError
+        def clean_backtrace(string: nil)
+            return nil if backtrace.nil?
+            return backtrace if backtrace[0].nil?
+            first_frame = backtrace[0]
+            if first_frame.include?(string) || first_frame.include?('interface.rb')
+              backtrace.drop(2)
+            else
+              backtrace
+            end
+        end
+    end
+
     # raised from crash!
-    class FastlaneCrash < StandardError
+    class FastlaneCrash < FastlaneException
+        def cleaned_backtrace
+            clean_backtrace(string: 'crash!')
+        end
     end
 
     # raised from user_error!
-    class FastlaneError < StandardError
+    class FastlaneError < FastlaneException
       attr_reader :show_github_issues
       attr_reader :error_info
 
       def initialize(show_github_issues: false, error_info: nil)
         @show_github_issues = show_github_issues
         @error_info = error_info
+      end
+
+      def cleaned_backtrace
+        clean_backtrace(string: 'crash!')
       end
     end
 

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -140,7 +140,7 @@ module FastlaneCore
 
       def crash_report_message
         return '' if could_contain_pii?
-        "#{exception.message[0..100]}\n"
+        exception.message
       end
     end
 

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -144,7 +144,6 @@ module FastlaneCore
       end
     end
 
-
     # raised from crash!
     class FastlaneCrash < FastlaneException
       def prefix

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -119,7 +119,7 @@ module FastlaneCore
       def caused_by_calling_ui_method?(method_name: nil)
         return false if backtrace.nil? || backtrace[0].nil? || method_name.nil?
         first_frame = backtrace[0]
-        if first_frame.include?(method_name) || first_frame.include?('interface.rb')
+        if first_frame.include?(method_name) && first_frame.include?('interface.rb')
           true
         else
           false
@@ -137,6 +137,11 @@ module FastlaneCore
       def could_contain_pii?
         caused_by_calling_ui_method?
       end
+
+      def crash_report_message
+        return '' if could_contain_pii?
+        "#{exception.message[0..100]}\n"
+      end
     end
 
 
@@ -148,6 +153,10 @@ module FastlaneCore
 
       def trimmed_backtrace
         trim_backtrace(method_name: 'crash!')
+      end
+
+      def could_contain_pii?
+        caused_by_calling_ui_method?(method_name: 'crash!')
       end
     end
 
@@ -166,7 +175,11 @@ module FastlaneCore
       end
 
       def trimmed_backtrace
-        trim_backtrace(method_name: 'crash!')
+        trim_backtrace(method_name: 'user_error!')
+      end
+
+      def could_contain_pii?
+        caused_by_calling_ui_method?(method_name: 'user_error!')
       end
     end
 

--- a/fastlane_core/spec/crash_reporter/crash_report_generator_spec.rb
+++ b/fastlane_core/spec/crash_reporter/crash_report_generator_spec.rb
@@ -54,7 +54,7 @@ describe FastlaneCore::CrashReportGenerator do
   end
 end
 
-def setup_sanitizer_expectation(type: :unknown)
+def setup_sanitizer_expectation(type: :exception)
   expect(FastlaneCore::CrashReportSanitizer).to receive(:sanitize_backtrace).with(
     type: type,
     backtrace: exception.backtrace
@@ -68,6 +68,6 @@ def setup_sanitizer_expectation(type: :unknown)
   end
 end
 
-def setup_expected_body(type: :unknown, message_text: "")
+def setup_expected_body(type: :exception, message_text: "")
   expected_body['message'] = "#{FastlaneCore::CrashReportGenerator.types[type]}#{message_text}#{exception.backtrace.join("\n")}"
 end

--- a/fastlane_core/spec/crash_reporter/crash_report_sanitizer_spec.rb
+++ b/fastlane_core/spec/crash_reporter/crash_report_sanitizer_spec.rb
@@ -27,28 +27,6 @@ describe FastlaneCore::CrashReportSanitizer do
     end
   end
 
-  context 'stack frame dropping' do
-    it 'drops the first two frames from crashes' do
-      expect(FastlaneCore::CrashReportSanitizer.sanitize_backtrace(
-               type: :crash,
-               backtrace: ['frame0', 'frame1', 'frame2']
-      )).to eq(['frame2'])
-    end
-
-    it 'drops the first two frames from user errors' do
-      expect(FastlaneCore::CrashReportSanitizer.sanitize_backtrace(
-               type: :user_error,
-               backtrace: ['frame0', 'frame1', 'frame2']
-      )).to eq(['frame2'])
-    end
-
-    it 'drops no frames from other errors' do
-      expect(FastlaneCore::CrashReportSanitizer.sanitize_backtrace(
-               backtrace: ['frame0', 'frame1', 'frame2']
-      )).to eq(['frame0', 'frame1', 'frame2'])
-    end
-  end
-
   context 'message sanitization' do
     let(:fastlane_spec) { double('Gem::Specification') }
 

--- a/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
+++ b/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
@@ -26,34 +26,6 @@ describe FastlaneCore::CrashReporter do
         supress_opt_out_crash_reporting_file_writing
       end
 
-# These tests might be able to be removed?
-      it 'posts a report to Stackdriver without specified type' do
-        stub_stackdriver_request
-        setup_crash_report_generator_expectation(exception: exception)
-        FastlaneCore::CrashReporter.report_crash(exception: exception)
-      end
-
-      it 'posts a report to Stackdriver with crash type' do
-        stub_stackdriver_request
-        crash_exception = double('Exception', backtrace: ["/fastlane/fastlane_core/lib/fastlane_core/ui/interface.rb:142:in `crash!'"])
-        setup_crash_report_generator_expectation(exception: crash_exception)
-        FastlaneCore::CrashReporter.report_crash(exception: crash_exception)
-      end
-
-      it 'posts a report to Stackdriver with user_error type' do
-        stub_stackdriver_request
-        user_error_exception = double('Exception', backtrace: ["/fastlane/fastlane_core/lib/fastlane_core/ui/interface.rb:152:in `user_error!'"])
-        setup_crash_report_generator_expectation(exception: user_error_exception)
-        FastlaneCore::CrashReporter.report_crash(exception: user_error_exception)
-      end
-
-      it 'posts a report to Stackdriver with specified service' do
-        stub_stackdriver_request
-        setup_crash_report_generator_expectation(action: 'test_action', exception: exception)
-        FastlaneCore::CrashReporter.report_crash(action: 'test_action', exception: exception)
-      end
-# ^^^^^^^^^^
-
       it 'only posts one report' do
         stub_stackdriver_request
         setup_crash_report_generator_expectation(exception: exception)

--- a/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
+++ b/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
@@ -26,6 +26,7 @@ describe FastlaneCore::CrashReporter do
         supress_opt_out_crash_reporting_file_writing
       end
 
+# These tests might be able to be removed?
       it 'posts a report to Stackdriver without specified type' do
         stub_stackdriver_request
         setup_crash_report_generator_expectation(exception: exception)
@@ -35,14 +36,14 @@ describe FastlaneCore::CrashReporter do
       it 'posts a report to Stackdriver with crash type' do
         stub_stackdriver_request
         crash_exception = double('Exception', backtrace: ["/fastlane/fastlane_core/lib/fastlane_core/ui/interface.rb:142:in `crash!'"])
-        setup_crash_report_generator_expectation(type: :crash, exception: crash_exception)
+        setup_crash_report_generator_expectation(exception: crash_exception)
         FastlaneCore::CrashReporter.report_crash(exception: crash_exception)
       end
 
       it 'posts a report to Stackdriver with user_error type' do
         stub_stackdriver_request
         user_error_exception = double('Exception', backtrace: ["/fastlane/fastlane_core/lib/fastlane_core/ui/interface.rb:152:in `user_error!'"])
-        setup_crash_report_generator_expectation(type: :user_error, exception: user_error_exception)
+        setup_crash_report_generator_expectation(exception: user_error_exception)
         FastlaneCore::CrashReporter.report_crash(exception: user_error_exception)
       end
 
@@ -51,6 +52,7 @@ describe FastlaneCore::CrashReporter do
         setup_crash_report_generator_expectation(action: 'test_action', exception: exception)
         FastlaneCore::CrashReporter.report_crash(action: 'test_action', exception: exception)
       end
+# ^^^^^^^^^^
 
       it 'only posts one report' do
         stub_stackdriver_request
@@ -109,9 +111,8 @@ def supress_stackdriver_reporting
   stub_stackdriver_request
 end
 
-def setup_crash_report_generator_expectation(type: :exception, action: nil, exception: nil)
+def setup_crash_report_generator_expectation(action: nil, exception: nil)
   expect(FastlaneCore::CrashReportGenerator).to receive(:generate).with(
-    type: type,
     exception: exception,
     action: action
   ).and_return(stub_body.to_json)

--- a/fastlane_core/spec/fastlane_exception_spec.rb
+++ b/fastlane_core/spec/fastlane_exception_spec.rb
@@ -18,7 +18,7 @@ describe FastlaneCore::Interface::FastlaneException do
 
     it 'properly determines that the exception was raised explicitly' do
       begin
-        raise FastlaneCore::Interface::FastlaneError.new
+        raise FastlaneCore::Interface::FastlaneError.new, 'EXPLICITLY RAISED ERROR'
       rescue => e
         expect(e.caused_by_calling_ui_method?(method_name: 'user_error!')). to be false
       end
@@ -37,7 +37,7 @@ describe FastlaneCore::Interface::FastlaneException do
 
     it 'does not trim backtrace if raised explicitly' do
       begin
-        raise FastlaneCore::Interface::FastlaneError.new
+        raise FastlaneCore::Interface::FastlaneError.new, 'EXPLICITLY RAISED ERROR'
       rescue => e
         expect(e).to respond_to(:trimmed_backtrace)
         expect(e.trimmed_backtrace.count).to eq(e.backtrace.count)
@@ -57,7 +57,7 @@ describe FastlaneCore::Interface::FastlaneException do
 
     it 'returns the original exception message if the message does not contain PII' do
       begin
-        raise FastlaneCore::Interface::FastlaneError.new
+        raise FastlaneCore::Interface::FastlaneError.new, 'EXPLICITLY RAISED ERROR'
       rescue => e
         expect(e).to respond_to(:crash_report_message)
         expect(e.crash_report_message).to eq(e.message)

--- a/fastlane_core/spec/fastlane_exception_spec.rb
+++ b/fastlane_core/spec/fastlane_exception_spec.rb
@@ -1,0 +1,67 @@
+describe FastlaneCore::Interface::FastlaneException do
+  context 'raising fastlane exceptions' do
+    it 'properly determines that it was called via `UI.user_error!`' do
+      begin
+        UI.user_error!('USER ERROR!!')
+      rescue => e
+        expect(e.caused_by_calling_ui_method?(method_name: 'user_error!')).to be true
+      end
+    end
+
+    it 'properly determines that it was called via `UI.crash!`' do
+      begin
+        UI.crash!('CRASH!!')
+      rescue => e
+        expect(e.caused_by_calling_ui_method?(method_name: 'crash!')).to be true
+      end
+    end
+
+    it 'properly determines that the exception was raised explicitly' do
+      begin
+        raise FastlaneCore::Interface::FastlaneError.new
+      rescue => e
+        expect(e.caused_by_calling_ui_method?(method_name: 'user_error!')). to be false
+      end
+    end
+  end
+
+  context 'backtrace trimming' do
+    it 'trims backtrace if called via UI method' do
+      begin
+        UI.user_error!('USER ERROR!!')
+      rescue => e
+        expect(e).to respond_to(:trimmed_backtrace)
+        expect(e.trimmed_backtrace.count).to eq(e.backtrace.count - 2)
+      end
+    end
+
+    it 'does not trim backtrace if raised explicitly' do
+      begin
+        raise FastlaneCore::Interface::FastlaneError.new
+      rescue => e
+        expect(e).to respond_to(:trimmed_backtrace)
+        expect(e.trimmed_backtrace.count).to eq(e.backtrace.count)
+      end
+    end
+  end
+
+  context 'crash report message' do
+    it 'returns an empty string if the message could contain PII' do
+      begin
+        UI.user_error!('USER ERROR!!')
+      rescue => e
+        expect(e).to respond_to(:crash_report_message)
+        expect(e.crash_report_message).to eq('')
+      end
+    end
+
+    it 'returns the original exception message if the message does not contain PII' do
+      begin
+        raise FastlaneCore::Interface::FastlaneError.new
+      rescue => e
+        expect(e).to respond_to(:crash_report_message)
+        expect(e.crash_report_message).to eq(e.message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is intended to remove some of the complex logic in the crash reporter and have some of that handled by the exception types themselves. This is also to make sure that PII is removed from sensitive exception types and to consider the cases where our own exception types are raised through other mechanisms besides through `FastlaneCore::Interface::UI`