### PR TITLE
Adding ability to re-send TestFlight invite to external tester

### DIFF
--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -111,6 +111,13 @@ module Spaceship::TestFlight
       handle_response(response)
     end
 
+    def resend_invite_to_external_tester(app_id: nil, tester_id: nil)
+      assert_required_params(__method__, binding)
+      url = "/testflight/v1/invites/#{app_id}/resend?testerId=#{tester_id}"
+      response = request(:post, url)
+      handle_response(response)
+    end
+
     def create_app_level_tester(app_id: nil, first_name: nil, last_name: nil, email: nil)
       assert_required_params(__method__, binding)
       url = "providers/#{team_id}/apps/#{app_id}/testers"

--- a/spaceship/lib/spaceship/test_flight/tester.rb
+++ b/spaceship/lib/spaceship/test_flight/tester.rb
@@ -37,5 +37,9 @@ module Spaceship::TestFlight
     def remove_from_app!(app_id: nil)
       client.delete_tester_from_app(app_id: app_id, tester_id: self.tester_id)
     end
+
+    def resend_invite(app_id: nil)
+      client.resend_invite_to_external_tester(app_id: app_id, tester_id: self.tester_id)
+    end
   end
 end

--- a/spaceship/spec/test_flight/tester_spec.rb
+++ b/spaceship/spec/test_flight/tester_spec.rb
@@ -71,8 +71,7 @@ describe Spaceship::TestFlight::Tester do
   end
 
   context 'invites' do
-
-    let(:tester) { Spaceship::TestFlight::Tester.new('id' => 'tester-id')}
+    let(:tester) { Spaceship::TestFlight::Tester.new('id' => 'tester-id') }
 
     context '.resend_invite' do
       it 'suceeds' do

--- a/spaceship/spec/test_flight/tester_spec.rb
+++ b/spaceship/spec/test_flight/tester_spec.rb
@@ -69,4 +69,16 @@ describe Spaceship::TestFlight::Tester do
       end
     end
   end
+
+  context 'invites' do
+
+    let(:tester) { Spaceship::TestFlight::Tester.new('id' => 'tester-id')}
+
+    context '.resend_invite' do
+      it 'suceeds' do
+        expect(mock_client).to receive(:resend_invite_to_external_tester).with(app_id: 'app-id', tester_id: 'tester-id')
+        tester.resend_invite(app_id: 'app-id')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Added client method for API call and convenience method on
Spaceship::TestFlight::Tester

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass *(I have run the tests from the spaceship directory but the root directory tests aren't working for me. See here: https://github.com/fastlane/fastlane/issues/9177*
- [ x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ x] I've updated the documentation if necessary.

### Motivation and Context

The issue this is trying to fix is that there is no way to re-send invites to people who have already signed up with TestFlight. Issue here: https://github.com/fastlane/fastlane/issues/8970

In the linked issue the original report mentions that there is an API for this. So, I added the API call the the TestFlight client. I added the use of this new API to the Tester class.

New call:
`Spaceship::TestFlight::Tester::resend_invite` now exists

I also added a simple test.