### PR TITLE
Add missing API doc for spaceship::portal

### DIFF
--- a/spaceship/docs/DeveloperPortal.md
+++ b/spaceship/docs/DeveloperPortal.md
@@ -64,6 +64,9 @@ Examples:
 # Find a specific app based on the bundle identifier
 app = Spaceship::Portal.app.find("com.krausefx.app")
 
+# Get detail informations (e.g. see all enabled app services)
+app.details
+
 # Enable HealthKit, but make sure HomeKit is disabled
 app.update_service(Spaceship::Portal.app_service.health_kit.on)
 app.update_service(Spaceship::Portal.app_service.home_kit.off)


### PR DESCRIPTION
I think it's better to add details to let user know that this is the way to get real app details.