### PR TITLE
Removing tester from Users and Roles (not specifying app) crashes

### DIFF
--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -57,7 +57,8 @@ module Pilot
       app = find_app(app_filter: config[:apple_id] || config[:app_identifier])
       unless app
         tester.delete!
-        UI.success("Successfully removed tester #{tester.email}")
+        UI.success("Successfully removed tester #{tester.email} from Users and Roles")
+        return
       end
 
       begin

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -263,7 +263,7 @@ describe Pilot::TesterManager do
         allow(Spaceship::Application).to receive(:find).and_return(nil)
         allow(tester_manager).to receive(:find_app).and_return(nil)
 
-        expect(Spaceship::Tunes::Tester::External).to receive(:find).and_return(fake_tester) # before creating, no testers
+        expect(Spaceship::Tunes::Tester::External).to receive(:find).and_return(fake_tester)
         expect(Spaceship::TestFlight::Group).to_not receive(:remove_tester_from_groups!)
         expect(FastlaneCore::UI).to receive(:success).with('Successfully removed tester fabric-devtools@gmail.com+fake@gmail.com from Users and Roles')
 

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -260,6 +260,8 @@ describe Pilot::TesterManager do
     describe "when external tester is removed without providing app" do
       it "removes the tester without error" do
         allow(current_user).to receive(:roles).and_return(["admin"])
+        allow(Spaceship::Application).to receive(:find).and_return(nil)
+
         expect(Spaceship::Tunes::Tester::External).to receive(:find).and_return(fake_tester) # before creating, no testers
         expect(Spaceship::TestFlight::Group).to_not receive(:remove_tester_from_groups!)
         expect(FastlaneCore::UI).to receive(:success).with('Successfully removed tester fabric-devtools@gmail.com+fake@gmail.com from Users and Roles')

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -80,6 +80,14 @@ describe Pilot::TesterManager do
       })
     end
 
+    let(:remove_tester_options) do
+      FastlaneCore::Configuration.create(Pilot::Options.available_options, {
+        email: fake_tester.email,
+        first_name: fake_tester.first_name,
+        last_name: fake_tester.last_name
+      })
+    end
+
     let(:default_add_tester_options_with_group) do
       FastlaneCore::Configuration.create(Pilot::Options.available_options, {
         apple_id: 'com.whatever',
@@ -246,6 +254,17 @@ describe Pilot::TesterManager do
         expect(FastlaneCore::UI).to receive(:success).with('Successfully added tester to group(s): Test Group in app: My Fake App')
 
         tester_manager.add_tester(default_add_tester_options_with_group)
+      end
+    end
+
+    describe "when external tester is removed without providing app" do
+      it "removes the tester without error" do
+        allow(current_user).to receive(:roles).and_return(["admin"])
+        expect(Spaceship::Tunes::Tester::External).to receive(:find).and_return(fake_tester) # before creating, no testers
+        expect(Spaceship::TestFlight::Group).to_not receive(:remove_tester_from_groups!)
+        expect(FastlaneCore::UI).to receive(:success).with('Successfully removed tester fabric-devtools@gmail.com+fake@gmail.com from Users and Roles')
+
+        tester_manager.remove_tester(remove_tester_options)
       end
     end
   end

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -261,6 +261,7 @@ describe Pilot::TesterManager do
       it "removes the tester without error" do
         allow(current_user).to receive(:roles).and_return(["admin"])
         allow(Spaceship::Application).to receive(:find).and_return(nil)
+        allow(tester_manager).to receive(:find_app).and_return(nil)
 
         expect(Spaceship::Tunes::Tester::External).to receive(:find).and_return(fake_tester) # before creating, no testers
         expect(Spaceship::TestFlight::Group).to_not receive(:remove_tester_from_groups!)


### PR DESCRIPTION
Fixes: if no app, returns after deleting user

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

https://github.com/fastlane/fastlane/issues/9023
