### PR TITLE
Add shell_error! to help clean up places where we do poor error handling

### DIFF
--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -52,7 +52,7 @@ module Fastlane
           message += "\n#{result}" if print_command_output
 
           error_callback.call(result) if error_callback
-          UI.user_error!(message)
+          UI.shell_error!(message)
         end
       end
 

--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -188,16 +188,16 @@ module FastlaneCore
       end
 
       def trimmed_backtrace
-        trace = trim_backtrace(method_name: 'shell_error!')
+        backtrace = trim_backtrace(method_name: 'shell_error!')
 
         # we also want to trim off the shell invocation itself, which means
         # removing any lines from the backtrace that contain functions
         # in `sh_helper.rb`
-        trace.drop_while { |frame| frame.include?('sh_helper.rb') }
+        backtrace.drop_while { |frame| frame.include?('sh_helper.rb') }
       end
 
       def could_contain_pii?
-        true
+        caused_by_calling_ui_method?(method_name: 'shell_error!')
       end
     end
 

--- a/fastlane_core/spec/fastlane_exception_spec.rb
+++ b/fastlane_core/spec/fastlane_exception_spec.rb
@@ -64,4 +64,25 @@ describe FastlaneCore::Interface::FastlaneException do
       end
     end
   end
+
+  context 'shell error stack trimming' do
+    # testing the shell error stack trimming behavior is complicated, because
+    # the code explicitly only removes frames in sh_helper.rb, but we cannot
+    # actually have those frames in a backtrace in a unit test
+    # so, we will stub the backtrace on the object under test to return a
+    # hard code backtrace, and be sure that is trimmed properly
+    it 'trims backtrace containing sh_helper.rb' do
+      mock_backtrace = ["path/to/sh_helper.rb:55", "path/to/sh_helper.rb:10", "path/to/another/file.rb:1337"]
+      exception = FastlaneCore::Interface::FastlaneShellError.new "SHELL ERROR!!"
+      allow(exception).to receive(:backtrace).and_return(mock_backtrace)
+      expect(exception.trimmed_backtrace).to eq(mock_backtrace.drop(2))
+    end
+
+    it 'does not trim backtrace not containing sh_helper.rb' do
+      mock_backtrace = ["path/to/file.rb:1337", "path/to/file.rb:2001"]
+      exception = FastlaneCore::Interface::FastlaneShellError.new "SHELL ERROR!!"
+      allow(exception).to receive(:backtrace).and_return(mock_backtrace)
+      expect(exception.trimmed_backtrace).to eq(mock_backtrace)
+    end
+  end
 end

--- a/fastlane_core/spec/fastlane_exception_spec.rb
+++ b/fastlane_core/spec/fastlane_exception_spec.rb
@@ -74,14 +74,14 @@ describe FastlaneCore::Interface::FastlaneException do
     it 'trims backtrace containing sh_helper.rb' do
       mock_backtrace = ["path/to/sh_helper.rb:55", "path/to/sh_helper.rb:10", "path/to/another/file.rb:1337"]
       exception = FastlaneCore::Interface::FastlaneShellError.new "SHELL ERROR!!"
-      expect(exception).to receive(:backtrace).at_least(1).and_return(mock_backtrace)
+      expect(exception).to receive(:backtrace).at_least(:once).and_return(mock_backtrace)
       expect(exception.trimmed_backtrace).to eq(mock_backtrace.drop(2))
     end
 
     it 'does not trim backtrace not containing sh_helper.rb' do
       mock_backtrace = ["path/to/file.rb:1337", "path/to/file.rb:2001"]
       exception = FastlaneCore::Interface::FastlaneShellError.new "SHELL ERROR!!"
-      expect(exception).to receive(:backtrace).at_least(1).and_return(mock_backtrace)
+      expect(exception).to receive(:backtrace).at_least(:once).and_return(mock_backtrace)
       expect(exception.trimmed_backtrace).to eq(mock_backtrace)
     end
   end

--- a/fastlane_core/spec/fastlane_exception_spec.rb
+++ b/fastlane_core/spec/fastlane_exception_spec.rb
@@ -74,14 +74,14 @@ describe FastlaneCore::Interface::FastlaneException do
     it 'trims backtrace containing sh_helper.rb' do
       mock_backtrace = ["path/to/sh_helper.rb:55", "path/to/sh_helper.rb:10", "path/to/another/file.rb:1337"]
       exception = FastlaneCore::Interface::FastlaneShellError.new "SHELL ERROR!!"
-      allow(exception).to receive(:backtrace).and_return(mock_backtrace)
+      expect(exception).to receive(:backtrace).at_least(1).and_return(mock_backtrace)
       expect(exception.trimmed_backtrace).to eq(mock_backtrace.drop(2))
     end
 
     it 'does not trim backtrace not containing sh_helper.rb' do
       mock_backtrace = ["path/to/file.rb:1337", "path/to/file.rb:2001"]
       exception = FastlaneCore::Interface::FastlaneShellError.new "SHELL ERROR!!"
-      allow(exception).to receive(:backtrace).and_return(mock_backtrace)
+      expect(exception).to receive(:backtrace).at_least(1).and_return(mock_backtrace)
       expect(exception.trimmed_backtrace).to eq(mock_backtrace)
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently shell errors are all attributed in the crash reporter to `sh_control_output`, particularly when the caller has not done any of their own error handling. This makes it difficult to identify where the errors are actually coming from. As such, we are introducing a new exception type that, when reporting to the crash reporter, does not show any methods in sh_helper, allowing us to see the actual root cause for the issue.