### PR TITLE
Version bump to 2.31.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.30.2'.freeze
+  VERSION = '2.31.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.30.2':**

* rubocop via David Ohayon
* fastlane exception tests via David Ohayon
* change stack to backtrace via David Ohayon
* truncate the whole message before appending backtrace via David Ohayon
* move new line and truncation back to crash reporter via David Ohayon
* remove unnecessary tests via David Ohayon
* passing crash tests via David Ohayon
* passing generator tests via David Ohayon
* rubocop via David Ohayon
* move crash report message logic to exception types via David Ohayon
* remove type via David Ohayon
* share logic to determine if message should be omitted via David Ohayon
* revert fastfile changes via David Ohayon
* move frame dropping logic to the exception class via David Ohayon
* Move type logic to the crash reporter itself via David Ohayon
* Remove pilot maintenance mode exception (#9189) via Mark Pirri
* Add example of calling Spaceship::Portal::App.details (#9194) via huang-kun
* Adding ability to re-send TestFlight invite to external tester (#9188) via Joel Klabo
* Fix `set_changelog` action for Mac apps (#9183) via Felix Krause
* Small code cleanup for fixes to screengrab's localeToDirName (#9169) via Michael Furtak
* simplify verify! via David Ohayon
* Fix duplicate option listing in the `--help` screen (#9173) via Felix Krause
* Switch Chatwork API endpoint to “v2”. “v1” is no longer available. (#9175) via SAITO Tomomi
* Removed regex from zip action (#9174) via Josh Holtz
* [spaceship] detect non-interactive terminals (team selection) (#9160) via Helmut Januschka
* edit the comment via David Ohayon
* Make sure that valid? raises rather than verify via David Ohayon
* Fix spelling of trade information address files and only create if necessary (#9163) via Felix Krause
* Record scan build failures as just that rather than user_errors via David Ohayon
* zip action not returns output path with zip if not given with one (#9159) via Josh Holtz
