### PR TITLE
Stop reporting interruptions as crashes

### DIFF
--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -252,6 +252,8 @@ module Fastlane
             class_ref.run(arguments)
           end
         end
+      rescue Interrupt => e
+        UI.error('fastlane was interrupted. We hope you give it another try!')
       rescue \
         FastlaneCore::Interface::FastlaneBuildFailure,    # build_failure!
         FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -253,7 +253,6 @@ module Fastlane
           end
         end
       rescue Interrupt => e
-        UI.error('fastlane was interrupted. We hope you give it another try!')
         raise e
       rescue \
         FastlaneCore::Interface::FastlaneBuildFailure,    # build_failure!

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -252,7 +252,7 @@ module Fastlane
             class_ref.run(arguments)
           end
         end
-      rescue Interrupt => e
+      rescue Interrupt
         UI.error('fastlane was interrupted. We hope you give it another try!')
       rescue \
         FastlaneCore::Interface::FastlaneBuildFailure,    # build_failure!

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -252,8 +252,9 @@ module Fastlane
             class_ref.run(arguments)
           end
         end
-      rescue Interrupt
+      rescue Interrupt => e
         UI.error('fastlane was interrupted. We hope you give it another try!')
+        raise e
       rescue \
         FastlaneCore::Interface::FastlaneBuildFailure,    # build_failure!
         FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!


### PR DESCRIPTION
We don't want to be recording failures that come from users interrupting/cancelling their _fastlane_ executions.