### PR TITLE
Create a new error super class to represent failures that should not be logged as crashes

### DIFF
--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -254,9 +254,7 @@ module Fastlane
         end
       rescue Interrupt => e
         raise e # reraise the interruption to avoid logging this as a crash
-      rescue \
-        FastlaneCore::Interface::FastlaneBuildFailure,    # build_failure!
-        FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!
+      rescue FastlaneCore::Interface::FastlaneNotCountedFailure => e # these are exceptions that we dont count as crashes
         raise e
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         FastlaneCore::CrashReporter.report_crash(exception: e, action: method_sym)

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -254,7 +254,7 @@ module Fastlane
         end
       rescue Interrupt => e
         raise e # reraise the interruption to avoid logging this as a crash
-      rescue FastlaneCore::Interface::FastlaneNotCountedFailure => e # these are exceptions that we dont count as crashes
+      rescue FastlaneCore::Interface::FastlaneCommonException => e # these are exceptions that we dont count as crashes
         raise e
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         FastlaneCore::CrashReporter.report_crash(exception: e, action: method_sym)

--- a/fastlane_core/lib/fastlane_core.rb
+++ b/fastlane_core/lib/fastlane_core.rb
@@ -38,6 +38,7 @@ require 'fastlane_core/ui/errors/fastlane_exception'
 require 'fastlane_core/ui/errors/fastlane_error'
 require 'fastlane_core/ui/errors/fastlane_crash'
 require 'fastlane_core/ui/errors/fastlane_shell_error'
+require 'fastlane_core/ui/errors/fastlane_not_counted_error'
 
 # Third Party code
 require 'colored'

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -314,7 +314,7 @@ module FastlaneCore
             UI.error("Could not read build settings. Make sure that the scheme \"#{options[:scheme]}\" is configured for running by going to Product → Scheme → Edit Scheme…, selecting the \"Build\" section, checking the \"Run\" checkbox and closing the scheme window.")
           end
         rescue Timeout::Error
-          raise FastlaneCore::Interface::FastlaneDependencyError.new, "xcodebuild -showBuildSettings timed-out after #{timeout} seconds and #{retries} retries." \
+          raise FastlaneCore::Interface::FastlaneDependencyCausedException.new, "xcodebuild -showBuildSettings timed-out after #{timeout} seconds and #{retries} retries." \
             " You can override the timeout value with the environment variable FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT," \
             " and the number of retries with the environment variable FASTLANE_XCODEBUILD_SETTINGS_RETRIES ".red
         end

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -314,9 +314,9 @@ module FastlaneCore
             UI.error("Could not read build settings. Make sure that the scheme \"#{options[:scheme]}\" is configured for running by going to Product → Scheme → Edit Scheme…, selecting the \"Build\" section, checking the \"Run\" checkbox and closing the scheme window.")
           end
         rescue Timeout::Error
-          UI.crash!("xcodebuild -showBuildSettings timed-out after #{timeout} seconds and #{retries} retries." \
+          raise FastlaneCore::Interface::FastlaneDependencyError.new, "xcodebuild -showBuildSettings timed-out after #{timeout} seconds and #{retries} retries." \
             " You can override the timeout value with the environment variable FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT," \
-            " and the number of retries with the environment variable FASTLANE_XCODEBUILD_SETTINGS_RETRIES ")
+            " and the number of retries with the environment variable FASTLANE_XCODEBUILD_SETTINGS_RETRIES ".red
         end
       end
 

--- a/fastlane_core/lib/fastlane_core/ui/errors/fastlane_exception.rb
+++ b/fastlane_core/lib/fastlane_core/ui/errors/fastlane_exception.rb
@@ -32,10 +32,5 @@ module FastlaneCore
         exception.message
       end
     end
-    class FastlaneBuildFailure < FastlaneException
-    end
-
-    class FastlaneTestFailure < FastlaneException
-    end
   end
 end

--- a/fastlane_core/lib/fastlane_core/ui/errors/fastlane_not_counted_error.rb
+++ b/fastlane_core/lib/fastlane_core/ui/errors/fastlane_not_counted_error.rb
@@ -1,11 +1,17 @@
 module FastlaneCore
   class Interface
+    # Super class for exception types that we do not want to record
+    # explictly as crashes or user errors
     class FastlaneCommonException < FastlaneException; end
 
+    # Raised when there is a build failure in xcodebuild
     class FastlaneBuildFailure < FastlaneCommonException; end
 
+    # Raised when a test fails when being run by tools such as scan or snapshot
     class FastlaneTestFailure < FastlaneCommonException; end
 
-    class FastlaneDependencyError < FastlaneCommonException; end
+    # Raise this type of exception when a failure caused by a third party
+    # dependency (i.e. xcodebuild, gradle, slather) happens.
+    class FastlaneDependencyCausedException < FastlaneCommonException; end
   end
 end

--- a/fastlane_core/lib/fastlane_core/ui/errors/fastlane_not_counted_error.rb
+++ b/fastlane_core/lib/fastlane_core/ui/errors/fastlane_not_counted_error.rb
@@ -1,0 +1,11 @@
+module FastlaneCore
+  class Interface
+    class FastlaneNotCountedFailure < FastlaneException; end
+
+    class FastlaneBuildFailure < FastlaneNotCountedFailure; end
+
+    class FastlaneTestFailure < FastlaneNotCountedFailure; end
+
+    class FastlaneDependencyError < FastlaneNotCountedFailure; end
+  end
+end

--- a/fastlane_core/lib/fastlane_core/ui/errors/fastlane_not_counted_error.rb
+++ b/fastlane_core/lib/fastlane_core/ui/errors/fastlane_not_counted_error.rb
@@ -1,11 +1,11 @@
 module FastlaneCore
   class Interface
-    class FastlaneNotCountedFailure < FastlaneException; end
+    class FastlaneCommonException < FastlaneException; end
 
-    class FastlaneBuildFailure < FastlaneNotCountedFailure; end
+    class FastlaneBuildFailure < FastlaneCommonException; end
 
-    class FastlaneTestFailure < FastlaneNotCountedFailure; end
+    class FastlaneTestFailure < FastlaneCommonException; end
 
-    class FastlaneDependencyError < FastlaneNotCountedFailure; end
+    class FastlaneDependencyError < FastlaneCommonException; end
   end
 end

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -64,7 +64,7 @@ module Commander
           FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
           abort e.to_s
         end
-      rescue FastlaneCore::Interface::FastlaneNotCountedFailure => e # these are exceptions that we dont count as crashes
+      rescue FastlaneCore::Interface::FastlaneCommonException => e # these are exceptions that we dont count as crashes
         display_user_error!(e, e.to_s)
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         collector.did_raise_error(@program[:name])

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -64,7 +64,7 @@ module Commander
           FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
           abort e.to_s
         end
-      rescue FastlaneCore::Interface::FastlaneNotCountedFailure => e # test_failure!
+      rescue FastlaneCore::Interface::FastlaneNotCountedFailure => e # these are exceptions that we dont count as crashes
         display_user_error!(e, e.to_s)
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         collector.did_raise_error(@program[:name])

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -64,9 +64,7 @@ module Commander
           FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
           abort e.to_s
         end
-      rescue \
-        FastlaneCore::Interface::FastlaneBuildFailure,    # build_failure!
-        FastlaneCore::Interface::FastlaneTestFailure => e # test_failure!
+      rescue FastlaneCore::Interface::FastlaneNotCountedFailure => e # test_failure!
         display_user_error!(e, e.to_s)
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         collector.did_raise_error(@program[:name])


### PR DESCRIPTION
There are places in our code where we depend on other tools/scripts, we want to stop counting these as crashes.