### PR TITLE
Version bump to 2.32.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.31.0'.freeze
+  VERSION = '2.32.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.31.0':**

* Create a new error super class to represent failures that should not be logged as crashes (#9211) via David Ohayon
* Add a comment to the interruption rescue block via David Ohayon
* just reraise via David Ohayon
* reraise the exception to make sure fastlane execution stops via David Ohayon
* rubo via David Ohayon
* Stop reporting interruptions as crashes via David Ohayon
* Allow to retrieve the actual prices for in-app purchases (#9180) via Max Mulatz
* Fixes incorrect comment via Joshua Liebowitz
* Forces find_app to return nil via Joshua Liebowitz
* fixes test failing in CI via Joshua Liebowitz
* Adds regression test via Joshua Liebowitz
* Removing tester from Users and Roles (not specifying app) crashes Fixes: if no app, returns after deleting user via Joshua Liebowitz
