### PR TITLE
Implement Reports Generator for Screengrab

### DIFF
--- a/screengrab/build.gradle
+++ b/screengrab/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.2'
     }
 }
 

--- a/screengrab/gradle/wrapper/gradle-wrapper.properties
+++ b/screengrab/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 26 13:15:01 EDT 2016
+#Mon May 15 20:52:31 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/screengrab/lib/screengrab.rb
+++ b/screengrab/lib/screengrab.rb
@@ -4,6 +4,7 @@ require 'fileutils'
 require 'fastlane_core'
 
 require 'screengrab/runner'
+require 'screengrab/reports_generator'
 require 'screengrab/detect_values'
 require 'screengrab/dependency_checker'
 require 'screengrab/options'

--- a/screengrab/lib/screengrab/reports_generator.rb
+++ b/screengrab/lib/screengrab/reports_generator.rb
@@ -1,0 +1,36 @@
+require 'erb'
+require 'fastimage'
+
+module Screengrab
+  class ReportsGenerator
+    def generate
+      UI.message "Generating HTML Report"
+
+      screens_path = Screengrab.config[:output_directory]
+
+      @data = {}
+
+      Dir[File.join(screens_path, "*")].sort.each do |language_folder|
+        language = File.basename(language_folder)
+        Dir[File.join(language_folder, 'images', '*', '*.png')].sort.each do |screenshot|
+          device_type_folder = File.basename(File.dirname(screenshot))
+          p device_type_folder
+          @data[language] ||= {}
+          @data[language][device_type_folder] ||= []
+          resulting_path = File.join('.', language, 'images', device_type_folder, File.basename(screenshot))
+          @data[language][device_type_folder] << resulting_path
+        end
+      end
+
+      html_path = File.join(Screengrab::ROOT, "lib", "screengrab/page.html.erb")
+      html = ERB.new(File.read(html_path)).result(binding) # http://www.rrn.dk/rubys-erb-templating-system
+
+      export_path = "#{screens_path}/screenshots.html"
+      File.write(export_path, html)
+
+      export_path = File.expand_path(export_path)
+      UI.success "Successfully created HTML file with an overview of all the screenshots: '#{export_path}'"
+      system("open '#{export_path}'") unless Screengrab.config[:skip_open_summary]
+    end
+  end
+end

--- a/screengrab/lib/screengrab/reports_generator.rb
+++ b/screengrab/lib/screengrab/reports_generator.rb
@@ -1,5 +1,4 @@
 require 'erb'
-require 'fastimage'
 
 module Screengrab
   class ReportsGenerator
@@ -14,7 +13,6 @@ module Screengrab
         language = File.basename(language_folder)
         Dir[File.join(language_folder, 'images', '*', '*.png')].sort.each do |screenshot|
           device_type_folder = File.basename(File.dirname(screenshot))
-          p device_type_folder
           @data[language] ||= {}
           @data[language][device_type_folder] ||= []
           resulting_path = File.join('.', language, 'images', device_type_folder, File.basename(screenshot))

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -69,6 +69,8 @@ module Screengrab
 
       open_screenshots_summary(device_type_dir_name)
 
+      ReportsGenerator.new.generate
+
       UI.success "Captured #{number_of_screenshots} screenshots! 📷✨"
     end
 

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -67,8 +67,6 @@ module Screengrab
 
       number_of_screenshots = pull_screenshots_from_device(device_serial, device_screenshots_paths, device_type_dir_name)
 
-      open_screenshots_summary(device_type_dir_name)
-
       ReportsGenerator.new.generate
 
       UI.success "Captured #{number_of_screenshots} screenshots! 📷✨"
@@ -343,16 +341,6 @@ module Screengrab
     rescue
       # Some versions of ADB will have a non-zero exit status for this, which will cause the executor to raise.
       # We can safely ignore that and treat it as if it returned 'No such file'
-    end
-
-    def open_screenshots_summary(device_type_dir_name)
-      unless @config[:skip_open_summary]
-        UI.message "Opening screenshots summary"
-        # MCF: this isn't OK on any platform except Mac
-        run_adb_command("open #{@config[:output_directory]}/*/images/#{device_type_dir_name}/*.png",
-                        print_all: false,
-                        print_command: true)
-      end
     end
 
     def run_adb_command(command, print_all: false, print_command: false)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
! some tests, not related to feature, were not passing
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In this feature you will find implementation of Report Generator for `Screengrab`. It is based on similar implementation of reports for `Snapshot`. 
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/fastlane/fastlane/issues/9161
<!--- Please describe in detail how you tested your changes. --->
I tested it on 2 different devices (Nexus 5X and Samsung S6) and on emulator. I was using project `example` from `screengrab` module. 

### Description
<!--- Describe your changes in detail -->
I used implementation of reports from `Snapshot` and adapted it to `Screengrab`.
- modified `screengrab/lib/screengrab.rb` to import reports
- created `screengrab/lib/screengrab/reports_generator.rb` which contains implementation of reports
- modified `screengrab/lib/screengrab/runner.rb` to run reports, after screenshots are created
- updated Android files
