### PR TITLE
[slack] Fix crash when defining FL_SLACK_DEFAULT_PAYLOADS

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -98,7 +98,7 @@ module Fastlane
                                        env_name: "FL_SLACK_DEFAULT_PAYLOADS",
                                        description: "Remove some of the default payloads. More information about the available payloads on GitHub",
                                        optional: true,
-                                       is_string: false),
+                                       type: Array),
           FastlaneCore::ConfigItem.new(key: :attachment_properties,
                                        env_name: "FL_SLACK_ATTACHMENT_PROPERTIES",
                                        description: "Merge additional properties in the slack attachment, see https://api.slack.com/docs/attachments",

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -100,16 +100,16 @@ describe Fastlane do
           message: message,
           success: false,
           channel: channel,
-          default_payloads: "lane,test_result",
+          default_payloads: "lane,test_result"
         })
 
         notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
-      
+
         fields = attachments[:fields]
 
         expect(fields[0][:title]).to eq('Lane')
         expect(fields[0][:value]).to eq(lane_name)
-        
+
         expect(fields[1][:title]).to eq('Result')
         expect(fields[1][:value]).to eq('Error')
       end

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -86,6 +86,33 @@ describe Fastlane do
 
         expect(attachments[:thumb_url]).to eq('https://example.com/path/to/thumb.png')
       end
+
+      it "parses default_payloads from a comma delimited string" do
+        channel = "#myChannel"
+        message = "Custom Message"
+        lane_name = "lane_name"
+
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
+
+        require 'fastlane/actions/slack'
+        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+          slack_url: 'https://127.0.0.1',
+          message: message,
+          success: false,
+          channel: channel,
+          default_payloads: "lane,test_result",
+        })
+
+        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+      
+        fields = attachments[:fields]
+
+        expect(fields[0][:title]).to eq('Lane')
+        expect(fields[0][:value]).to eq(lane_name)
+        
+        expect(fields[1][:title]).to eq('Result')
+        expect(fields[1][:value]).to eq('Error')
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I never actually want to use any of the default payloads in my project when sending Slack message so to clean up my `Fastfile` I attempted to define `FL_SLACK_DEFAULT_PAYLOADS` as an empty string so that I could remove the parameter each time I used `slack` however this appeared to crash with the following error:

```
NoMethodError: [!] undefined method `join' for "":String
```  

(The env var parsed as a `String` and not an `Array` as expected)

### Description

This PR simply updates the `:default_payloads` config item and sets its `type` to `Array` so that [`auto_convert_value`](https://github.com/fastlane/fastlane/blob/master/fastlane_core/lib/fastlane_core/configuration/config_item.rb#L133) can correctly parse the environment variable rather than failing and just returning the original string.  

I wasn't sure if a simple one line config item change warranted any unit tests so haven't added any yet but let me know if you think it does (and a heads up on how to approach testing this in a nice way would also be appreciated as well) ✌️ 
