### PR TITLE
Add UI.abort_with_message! for aborting in non-exceptional circumstances

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/interface.rb
+++ b/fastlane_core/lib/fastlane_core/ui/interface.rb
@@ -107,6 +107,10 @@ module FastlaneCore
       not_implemented(__method__)
     end
 
+    #####################################################
+    # @!group Abort helper methods
+    #####################################################
+
     # Pass an exception to this method to exit the program
     #   using the given exception
     # Use this method instead of user_error! if this error is
@@ -156,6 +160,18 @@ module FastlaneCore
     # fastlane failures
     def test_failure!(error_message)
       raise FastlaneTestFailure.new, error_message
+    end
+
+    # Use this method to exit the program because of terminal state
+    # that is neither the fault of fastlane, nor a problem with the
+    # user's input. Using this method instead of user_error! will
+    # avoid tracking this outcome as a fastlane failure.
+    #
+    #   e.g. tests ran successfully, but no screenshots were found
+    #
+    # This will show the message, but hide the full stack trace.
+    def abort_with_message!(message)
+      raise FastlaneCommonException.new, message
     end
 
     #####################################################

--- a/fastlane_core/spec/interface_spec.rb
+++ b/fastlane_core/spec/interface_spec.rb
@@ -1,0 +1,11 @@
+describe FastlaneCore::Interface do
+  describe "Abort helper methods" do
+    describe "#abort_with_message!" do
+      it "raises FastlaneCommonException" do
+        expect do
+          FastlaneCore::Interface.new.abort_with_message!("Yup")
+        end.to raise_error(FastlaneCore::Interface::FastlaneCommonException, "Yup")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Add `abort_with_message!` to `FastlaneCore::Interface` as a convenience method for raising a `FastlaneCore::Interface::FastlaneCommonException`