### PR TITLE
Check to see if frame is method_missing before dropping

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/errors/fastlane_exception.rb
+++ b/fastlane_core/lib/fastlane_core/ui/errors/fastlane_exception.rb
@@ -15,9 +15,20 @@ module FastlaneCore
         end
       end
 
+      def includes_method_missing?
+        return false if backtrace.nil? || backtrace[1].nil?
+        second_frame = backtrace[1]
+        second_frame.include?('method_missing') && second_frame.include?('ui.rb')
+      end
+
       def trim_backtrace(method_name: nil)
         if caused_by_calling_ui_method?(method_name: method_name)
-          backtrace.drop(2)
+          if includes_method_missing?
+            drop_count = 2
+          else
+            drop_count = 1
+          end
+          backtrace.drop(drop_count)
         else
           backtrace
         end

--- a/fastlane_core/spec/fastlane_exception_spec.rb
+++ b/fastlane_core/spec/fastlane_exception_spec.rb
@@ -43,6 +43,20 @@ describe FastlaneCore::Interface::FastlaneException do
         expect(e.trimmed_backtrace.count).to eq(e.backtrace.count)
       end
     end
+
+    it 'does not trim two frames if method_missing not included' do
+      mock_backtrace = ["/path/to/interface.rb:1234:in `user_error!'", "path/to/caller.rb:10: in `hello!'", "path/to/another/file.rb:1337"]
+      exception = FastlaneCore::Interface::FastlaneError.new
+      expect(exception).to receive(:backtrace).at_least(:once).and_return(mock_backtrace)
+      expect(exception.trimmed_backtrace.count).to eq(exception.backtrace.count - 1)
+    end
+
+    it 'does trim two frames if method_messing included' do
+      mock_backtrace = ["/path/to/interface.rb:1234:in `user_error!'", "path/to/ui.rb:10: in `method_missing'", "path/to/caller:10: in `hello!'", "path/to/another/file.rb:1337"]
+      exception = FastlaneCore::Interface::FastlaneError.new
+      expect(exception).to receive(:backtrace).at_least(:once).and_return(mock_backtrace)
+      expect(exception.trimmed_backtrace.count).to eq(exception.backtrace.count - 2)
+    end
   end
 
   context 'crash report message' do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
We drop 2 frames when exception is raised by `error!` or `user_error!`, but there are times when these methods are called from within the interface class and do not use the `method_missing` dispatch. As such, we now check to see if the second stack from contains `method_missing` and don't drop unless it is present.