### PR TITLE
[screengrab] Use abort_with_message! to report no screenshots found

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -292,7 +292,7 @@ module Screengrab
       # success based on whether there are more screenshots there than when we started.
       if starting_screenshot_count == ending_screenshot_count
         UI.error "Make sure you've used Screengrab.screenshot() in your tests and that your expected tests are being run."
-        UI.user_error! "No screenshots were detected 📷❌"
+        UI.abort_with_message! "No screenshots were detected 📷❌"
       end
 
       ending_screenshot_count - starting_screenshot_count


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Replace `user_error!` with `abort_with_message!` so that this common situation is not tracked as a failure for fastlane stability.

This is part of our larger effort to understand and improve _fastlane_'s stability.

