### PR TITLE
Stub out env vars that are being set by CircleCI

### DIFF
--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -51,11 +51,16 @@ describe Match do
         git_url: git_url
       }
 
+      keychain = "login.keychain"
+
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('MATCH_KEYCHAIN_NAME').and_return(keychain)
+      allow(ENV).to receive(:[]).with('MATCH_KEYCHAIN_PASSWORD').and_return(nil)
+
       config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
       repo_dir = "./match/spec/fixtures/existing"
       cert_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.cer"
       key_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.p12"
-      keychain = "login.keychain"
 
       expect(Match::GitHelper).to receive(:clone).with(git_url, false, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil, clone_branch_directly: false).and_return(repo_dir)
       expect(Match::Utils).to receive(:import).with(key_path, keychain, password: nil).and_return(nil)

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -1,5 +1,13 @@
 describe Match do
   describe Match::Runner do
+    let(:keychain) { 'login.keychain' }
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('MATCH_KEYCHAIN_NAME').and_return(keychain)
+      allow(ENV).to receive(:[]).with('MATCH_KEYCHAIN_PASSWORD').and_return(nil)
+    end
+
     it "creates a new profile and certificate if it doesn't exist yet" do
       git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
       values = {
@@ -50,12 +58,6 @@ describe Match do
         type: "appstore",
         git_url: git_url
       }
-
-      keychain = "login.keychain"
-
-      allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with('MATCH_KEYCHAIN_NAME').and_return(keychain)
-      allow(ENV).to receive(:[]).with('MATCH_KEYCHAIN_PASSWORD').and_return(nil)
 
       config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
       repo_dir = "./match/spec/fixtures/existing"


### PR DESCRIPTION
CircleCI is now setting some environment variables for _match_ to handle issues in macOS Sierra. This PR stubs out those values to make sure the ones we need are getting returned.