### PR TITLE
List produce enable_services options in config item (deprecating enabled_features)

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
@@ -13,6 +13,7 @@ module FastlaneCore
       used_switches = []
       options.each do |option|
         next if option.description.to_s.empty? # "private" options
+        next unless option.allow_shell
 
         short_switch = option.short_option
         key = option.key

--- a/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
@@ -13,7 +13,7 @@ module FastlaneCore
       used_switches = []
       options.each do |option|
         next if option.description.to_s.empty? # "private" options
-        next unless option.allow_shell
+        next unless option.display_in_shell
 
         short_switch = option.short_option
         key = option.key

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -40,7 +40,7 @@ module FastlaneCore
     attr_accessor :allow_shell_conversion
     
     # [Boolean] Set if the variable can be used from shell
-    attr_accessor :allow_shell
+    attr_accessor :display_in_shell
 
     # Creates a new option
     # @param key (Symbol) the key which is used as command parameters or key in the fastlane tools
@@ -58,8 +58,8 @@ module FastlaneCore
     # @param conflict_block an optional block which is called when options conflict happens
     # @param deprecated (String) Set if the option is deprecated. A deprecated option should be optional and is made optional if the parameter isn't set, and fails otherwise
     # @param sensitive (Boolean) Set if the variable is sensitive, such as a password or API token, to prevent echoing when prompted for the parameter
-    # @param allow_shell (Boolean) Set if the variable can be used from shell
-    def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, type: nil, optional: nil, conflicting_options: nil, conflict_block: nil, deprecated: nil, sensitive: nil, allow_shell: nil)
+    # @param display_in_shell (Boolean) Set if the variable can be used from shell
+    def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, type: nil, optional: nil, conflicting_options: nil, conflict_block: nil, deprecated: nil, sensitive: nil, display_in_shell: nil)
       UI.user_error!("key must be a symbol") unless key.kind_of? Symbol
       UI.user_error!("env_name must be a String") unless (env_name || '').kind_of? String
 
@@ -89,7 +89,7 @@ module FastlaneCore
 
       sensitive = false if sensitive.nil?
       
-      allow_shell = true if allow_shell.nil?
+      display_in_shell = true if display_in_shell.nil?
 
       @key = key
       @env_name = env_name
@@ -106,7 +106,7 @@ module FastlaneCore
       @deprecated = deprecated
       @sensitive = sensitive
       @allow_shell_conversion = (type == :shell_string)
-      @allow_shell = allow_shell
+      @display_in_shell = display_in_shell
     end
 
     def verify!(value)

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -98,6 +98,10 @@ module FastlaneCore
         # deprecated options are marked deprecated in their description
         description = "[DEPRECATED!] #{deprecated} - #{description}"
       end
+      
+      optional = false if optional.nil?
+      sensitive = false if sensitive.nil?
+      display_in_shell = true if display_in_shell.nil?
 
       @key = key
       @env_name = env_name
@@ -108,13 +112,13 @@ module FastlaneCore
       @is_string = is_string
       @data_type = type
       @data_type = String if type == :shell_string
-      @optional = false if optional.nil?
+      @optional = optional
       @conflicting_options = conflicting_options
       @conflict_block = conflict_block
       @deprecated = deprecated
-      @sensitive = false if sensitive.nil?
+      @sensitive = sensitive
       @allow_shell_conversion = (type == :shell_string)
-      @display_in_shell = true if display_in_shell.nil?
+      @display_in_shell = display_in_shell
     end
 
     def verify!(value)

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -38,7 +38,7 @@ module FastlaneCore
     # [Boolean] Set if the variable is to be converted to a shell-escaped String when provided as a Hash or Array
     # Allows items expected to be strings used in shell arguments to be alternatively provided as a Hash or Array for better readability and auto-escaped for us.
     attr_accessor :allow_shell_conversion
-    
+
     # [Boolean] Set if the variable can be used from shell
     attr_accessor :display_in_shell
 
@@ -88,7 +88,7 @@ module FastlaneCore
       optional = false if optional.nil?
 
       sensitive = false if sensitive.nil?
-      
+
       display_in_shell = true if display_in_shell.nil?
 
       @key = key

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -98,7 +98,7 @@ module FastlaneCore
         # deprecated options are marked deprecated in their description
         description = "[DEPRECATED!] #{deprecated} - #{description}"
       end
-      
+
       optional = false if optional.nil?
       sensitive = false if sensitive.nil?
       display_in_shell = true if display_in_shell.nil?

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -72,7 +72,7 @@ module FastlaneCore
                    conflict_block: nil,
                    deprecated: nil,
                    sensitive: nil,
-                   display_in_shell: nil)
+                   display_in_shell: true)
       UI.user_error!("key must be a symbol") unless key.kind_of? Symbol
       UI.user_error!("env_name must be a String") unless (env_name || '').kind_of? String
 
@@ -101,7 +101,6 @@ module FastlaneCore
 
       optional = false if optional.nil?
       sensitive = false if sensitive.nil?
-      display_in_shell = true if display_in_shell.nil?
 
       @key = key
       @env_name = env_name

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -59,7 +59,20 @@ module FastlaneCore
     # @param deprecated (String) Set if the option is deprecated. A deprecated option should be optional and is made optional if the parameter isn't set, and fails otherwise
     # @param sensitive (Boolean) Set if the variable is sensitive, such as a password or API token, to prevent echoing when prompted for the parameter
     # @param display_in_shell (Boolean) Set if the variable can be used from shell
-    def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, type: nil, optional: nil, conflicting_options: nil, conflict_block: nil, deprecated: nil, sensitive: nil, display_in_shell: nil)
+    def initialize(key: nil,
+                   env_name: nil,
+                   description: nil,
+                   short_option: nil,
+                   default_value: nil,
+                   verify_block: nil,
+                   is_string: true,
+                   type: nil,
+                   optional: nil,
+                   conflicting_options: nil,
+                   conflict_block: nil,
+                   deprecated: nil,
+                   sensitive: nil,
+                   display_in_shell: nil)
       UI.user_error!("key must be a symbol") unless key.kind_of? Symbol
       UI.user_error!("env_name must be a String") unless (env_name || '').kind_of? String
 
@@ -85,11 +98,6 @@ module FastlaneCore
         # deprecated options are marked deprecated in their description
         description = "[DEPRECATED!] #{deprecated} - #{description}"
       end
-      optional = false if optional.nil?
-
-      sensitive = false if sensitive.nil?
-
-      display_in_shell = true if display_in_shell.nil?
 
       @key = key
       @env_name = env_name
@@ -100,13 +108,13 @@ module FastlaneCore
       @is_string = is_string
       @data_type = type
       @data_type = String if type == :shell_string
-      @optional = optional
+      @optional = false if optional.nil?
       @conflicting_options = conflicting_options
       @conflict_block = conflict_block
       @deprecated = deprecated
-      @sensitive = sensitive
+      @sensitive = false if sensitive.nil?
       @allow_shell_conversion = (type == :shell_string)
-      @display_in_shell = display_in_shell
+      @display_in_shell = true if display_in_shell.nil?
     end
 
     def verify!(value)

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -38,6 +38,9 @@ module FastlaneCore
     # [Boolean] Set if the variable is to be converted to a shell-escaped String when provided as a Hash or Array
     # Allows items expected to be strings used in shell arguments to be alternatively provided as a Hash or Array for better readability and auto-escaped for us.
     attr_accessor :allow_shell_conversion
+    
+    # [Boolean] Set if the variable can be used from shell
+    attr_accessor :allow_shell
 
     # Creates a new option
     # @param key (Symbol) the key which is used as command parameters or key in the fastlane tools
@@ -55,7 +58,8 @@ module FastlaneCore
     # @param conflict_block an optional block which is called when options conflict happens
     # @param deprecated (String) Set if the option is deprecated. A deprecated option should be optional and is made optional if the parameter isn't set, and fails otherwise
     # @param sensitive (Boolean) Set if the variable is sensitive, such as a password or API token, to prevent echoing when prompted for the parameter
-    def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, type: nil, optional: nil, conflicting_options: nil, conflict_block: nil, deprecated: nil, sensitive: nil)
+    # @param allow_shell (Boolean) Set if the variable can be used from shell
+    def initialize(key: nil, env_name: nil, description: nil, short_option: nil, default_value: nil, verify_block: nil, is_string: true, type: nil, optional: nil, conflicting_options: nil, conflict_block: nil, deprecated: nil, sensitive: nil, allow_shell: nil)
       UI.user_error!("key must be a symbol") unless key.kind_of? Symbol
       UI.user_error!("env_name must be a String") unless (env_name || '').kind_of? String
 
@@ -84,6 +88,8 @@ module FastlaneCore
       optional = false if optional.nil?
 
       sensitive = false if sensitive.nil?
+      
+      allow_shell = true if allow_shell.nil?
 
       @key = key
       @env_name = env_name
@@ -100,6 +106,7 @@ module FastlaneCore
       @deprecated = deprecated
       @sensitive = sensitive
       @allow_shell_conversion = (type == :shell_string)
+      @allow_shell = allow_shell
     end
 
     def verify!(value)

--- a/produce/README.md
+++ b/produce/README.md
@@ -78,31 +78,37 @@ Get in contact with the developers on Twitter: [@FastlaneTools](https://twitter.
 To get a list of all available parameters:
 
     fastlane produce --help
-
+    
 ```
-  Commands:
-    associate_group  Associate with a group, which is created if needed or simply located otherwise
-    create           Creates a new app on iTunes Connect and the Apple Developer Portal
-    disable_services Disable specific Application Services for a specific app on the Apple Developer Portal
-    enable_services  Enable specific Application Services for a specific app on the Apple Developer Portal
-    group            Ensure that a specific App Group exists
-    help             Display global or [command] help documentation
+  Commands: (* default)
+    associate_group    Associate with a group, which is created if needed or simply located otherwise
+    create           * Creates a new app on iTunes Connect and the Apple Developer Portal
+    disable_services   Disable specific Application Services for a specific app on the Apple Developer Portal
+    enable_services    Enable specific Application Services for a specific app on the Apple Developer Portal
+    group              Ensure that a specific App Group exists
+    help               Display global or [command] help documentation
 
   Global Options:
+    --verbose
+    -h, --help           Display help documentation
+    -v, --version        Display version information
+
+  Options for create:
     -u, --username STRING Your Apple ID Username (PRODUCE_USERNAME)
     -a, --app_identifier STRING App Identifier (Bundle ID, e.g. com.krausefx.app) (PRODUCE_APP_IDENTIFIER)
     -e, --bundle_identifier_suffix STRING App Identifier Suffix (Ignored if App Identifier does not ends with .*) (PRODUCE_APP_IDENTIFIER_SUFFIX)
     -q, --app_name STRING App Name (PRODUCE_APP_NAME)
     -z, --app_version STRING Initial version number (e.g. '1.0') (PRODUCE_VERSION)
     -y, --sku STRING     SKU Number (e.g. '1234') (PRODUCE_SKU)
+    -j, --platform STRING The platform to use (optional) (PRODUCE_PLATFORM)
     -m, --language STRING Primary Language (e.g. 'English', 'German') (PRODUCE_LANGUAGE)
     -c, --company_name STRING The name of your company. Only required if it's the first app you create (PRODUCE_COMPANY_NAME)
-    -i, --skip_itc       Skip the creation of the app on iTunes Connect (PRODUCE_SKIP_ITC)
-    -d, --skip_devcenter  Skip the creation of the app on the Apple Developer Portal (PRODUCE_SKIP_DEVCENTER)
-    -b, --team_id STRING The ID of your team if you're in multiple teams (PRODUCE_TEAM_ID)
-    -l, --team_name STRING The name of your team if you're in multiple teams (PRODUCE_TEAM_NAME)
-    -h, --help           Display help documentation
-    -v, --version        Display version information
+    -i, --skip_itc [VALUE] Skip the creation of the app on iTunes Connect (PRODUCE_SKIP_ITC)
+    -d, --skip_devcenter [VALUE] Skip the creation of the app on the Apple Developer Portal (PRODUCE_SKIP_DEVCENTER)
+    -b, --team_id STRING The ID of your Developer Portal team if you're in multiple teams (PRODUCE_TEAM_ID)
+    -l, --team_name STRING The name of your Developer Portal team if you're in multiple teams (PRODUCE_TEAM_NAME)
+    -k, --itc_team_id [VALUE] The ID of your iTunes Connect team if you're in multiple teams (PRODUCE_ITC_TEAM_ID)
+    -p, --itc_team_name STRING The name of your iTunes Connect team if you're in multiple teams (PRODUCE_ITC_TEAM_NAME)
 ```
 
 ## Enabling / Disabling Application Services
@@ -184,6 +190,26 @@ lane :release do
     app_version: '1.0',
     sku: '123',
     team_name: 'SunApps GmbH' # only necessary when in multiple teams
+    
+    # Optional
+    # App services can be enabled during app creation
+    enable_services: {
+      app_group: "on"               # Valid values: "on", "off"
+      apple_pay: "on"               # Valid values: "on", "off"
+      associated_domains: "on"      # Valid values: "on", "off"
+      data_protection: "complete"   # Valid values: "complete", "unlessopen", "untilfirstauth"
+      game_center: "on"             # Valid values: "on", "off"
+      health_kit: "on"              # Valid values: "on", "off"
+      home_kit: "on"                # Valid values: "on", "off"
+      wireless_accessory: "on"      # Valid values: "on", "off"
+      icloud: "cloudkit"            # Valid values: "legacy", "cloudkit"
+      in_app_purchase: "on"         # Valid values: "on", "off"
+      inter_app_audio: "on"         # Valid values: "on", "off"
+      passbook: "on"                # Valid values: "on", "off"
+      push_notification: "on"       # Valid values: "on", "off"
+      siri_kit: "on"                # Valid values: "on", "off"
+      vpn_configuration: "on"       # Valid values: "on", "off"
+    }
   )
 
   deliver

--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -2,6 +2,10 @@ require 'spaceship'
 
 module Produce
   class DeveloperCenter
+    ALLOWED_FEATURES =[:app_group, :apple_pay, :associated_domains, :data_protection, :game_center, :health_kit,
+                       :home_kit, :wireless_accessory, :icloud, :in_app_purchase, :inter_app_audio, :passbook, 
+                       :push_notification, :siri_kit, :vpn_configuration]
+    
     def run
       login
       create_new_app
@@ -43,6 +47,7 @@ module Produce
     def enabled_features
       app_service = Spaceship.app_service
       enabled_clean_options = {}
+      
       Produce.config[:enabled_features].each do |k, v|
         if k.to_sym == :data_protection
           case v

--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -1,10 +1,36 @@
 require 'spaceship'
 
 module Produce
-  class DeveloperCenter
-    ALLOWED_SERVICES = [:app_group, :apple_pay, :associated_domains, :data_protection, :game_center, :health_kit,
-                       :home_kit, :wireless_accessory, :icloud, :in_app_purchase, :inter_app_audio, :passbook, 
-                       :push_notification, :siri_kit, :vpn_configuration]
+  class DeveloperCenter    
+    SERVICE_ON = "on"
+    SERVICE_OFF = "off"
+    SERVICE_COMPLETE = "complete"
+    SERVICE_UNLESS_OPEN = "unlessopen"
+    SERVICE_UNTIL_FIRST_LAUNCH = "untilfirstauth"
+    SERVICE_LEGACY = "legacy"
+    SERVICE_CLOUDKIT = "cloudkit"
+    
+    ALLOWED_SERVICES = {
+      app_group: [SERVICE_ON, SERVICE_OFF],
+      apple_pay: [SERVICE_ON, SERVICE_OFF],
+      associated_domains: [SERVICE_ON, SERVICE_OFF],
+      data_protection: [
+        SERVICE_COMPLETE,
+        SERVICE_UNLESS_OPEN,
+        SERVICE_UNTIL_FIRST_LAUNCH
+      ],
+      game_center: [SERVICE_ON, SERVICE_OFF],
+      health_kit: [SERVICE_ON, SERVICE_OFF],
+      home_kit: [SERVICE_ON, SERVICE_OFF],
+      wireless_accessory: [SERVICE_ON, SERVICE_OFF],
+      icloud: [SERVICE_LEGACY, SERVICE_CLOUDKIT],
+      in_app_purchase: [SERVICE_ON, SERVICE_OFF],
+      inter_app_audio: [SERVICE_ON, SERVICE_OFF],
+      passbook: [SERVICE_ON, SERVICE_OFF],
+      push_notification: [SERVICE_ON, SERVICE_OFF],
+      siri_kit: [SERVICE_ON, SERVICE_OFF],
+      vpn_configuration: [SERVICE_ON, SERVICE_OFF],
+    }
     
     def run
       login
@@ -54,24 +80,24 @@ module Produce
       config_enabled_services.each do |k, v|
         if k.to_sym == :data_protection
           case v
-          when "complete"
+          when SERVICE_COMPLETE
             enabled_clean_options[app_service.data_protection.complete.service_id] = app_service.data_protection.complete
-          when "unlessopen"
+          when SERVICE_UNLESS_OPEN
             enabled_clean_options[app_service.data_protection.unlessopen.service_id] = app_service.data_protection.unlessopen
-          when "untilfirstauth"
+          when SERVICE_UNTIL_FIRST_LAUNCH
             enabled_clean_options[app_service.data_protection.untilfirstauth.service_id] = app_service.data_protection.untilfirstauth
           end
         elsif k.to_sym == :icloud
           case v
-          when "legacy"
+          when SERVICE_LEGACY
             enabled_clean_options[app_service.icloud.on.service_id] = app_service.icloud.on
             enabled_clean_options[app_service.cloud_kit.xcode5_compatible.service_id] = app_service.cloud_kit.xcode5_compatible
-          when "cloudkit"
+          when SERVICE_CLOUDKIT
             enabled_clean_options[app_service.icloud.on.service_id] = app_service.icloud.on
             enabled_clean_options[app_service.cloud_kit.cloud_kit.service_id] = app_service.cloud_kit.cloud_kit
           end
         else
-          if v == "on"
+          if v == SERVICE_ON
             enabled_clean_options[app_service.send(k.to_s).on.service_id] = app_service.send(k.to_s).on
           else
             enabled_clean_options[app_service.send(k.to_s).off.service_id] = app_service.send(k.to_s).off

--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -2,7 +2,7 @@ require 'spaceship'
 
 module Produce
   class DeveloperCenter
-    ALLOWED_FEATURES =[:app_group, :apple_pay, :associated_domains, :data_protection, :game_center, :health_kit,
+    ALLOWED_SERVICES = [:app_group, :apple_pay, :associated_domains, :data_protection, :game_center, :health_kit,
                        :home_kit, :wireless_accessory, :icloud, :in_app_purchase, :inter_app_audio, :passbook, 
                        :push_notification, :siri_kit, :vpn_configuration]
     
@@ -23,7 +23,7 @@ module Produce
 
         app = Spaceship.app.create!(bundle_id: app_identifier,
                                          name: app_name,
-                                         enabled_features: enabled_features,
+                                         enable_services: enable_services,
                                          mac: Produce.config[:platform] == "osx")
 
         if app.name != Produce.config[:app_name]
@@ -44,11 +44,14 @@ module Produce
       return true
     end
 
-    def enabled_features
+    def enable_services
       app_service = Spaceship.app_service
       enabled_clean_options = {}
       
-      Produce.config[:enabled_features].each do |k, v|
+      # "enable_services" was deprecated in favor of "enable_services"
+      config_enabled_services = Produce.config[:enable_services] || Produce.config[:enable_services]
+      
+      config_enabled_services.each do |k, v|
         if k.to_sym == :data_protection
           case v
           when "complete"

--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -1,7 +1,7 @@
 require 'spaceship'
 
 module Produce
-  class DeveloperCenter    
+  class DeveloperCenter
     SERVICE_ON = "on"
     SERVICE_OFF = "off"
     SERVICE_COMPLETE = "complete"
@@ -9,7 +9,7 @@ module Produce
     SERVICE_UNTIL_FIRST_LAUNCH = "untilfirstauth"
     SERVICE_LEGACY = "legacy"
     SERVICE_CLOUDKIT = "cloudkit"
-    
+
     ALLOWED_SERVICES = {
       app_group: [SERVICE_ON, SERVICE_OFF],
       apple_pay: [SERVICE_ON, SERVICE_OFF],
@@ -29,9 +29,9 @@ module Produce
       passbook: [SERVICE_ON, SERVICE_OFF],
       push_notification: [SERVICE_ON, SERVICE_OFF],
       siri_kit: [SERVICE_ON, SERVICE_OFF],
-      vpn_configuration: [SERVICE_ON, SERVICE_OFF],
+      vpn_configuration: [SERVICE_ON, SERVICE_OFF]
     }
-    
+
     def run
       login
       create_new_app
@@ -73,10 +73,10 @@ module Produce
     def enable_services
       app_service = Spaceship.app_service
       enabled_clean_options = {}
-      
+
       # "enable_services" was deprecated in favor of "enable_services"
       config_enabled_services = Produce.config[:enable_services] || Produce.config[:enable_services]
-      
+
       config_enabled_services.each do |k, v|
         if k.to_sym == :data_protection
           case v

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -67,7 +67,7 @@ module Produce
                                      default_value: false),
 
         FastlaneCore::ConfigItem.new(key: :enabled_features,
-                                     allow_shell: false,
+                                     display_in_shell: false,
                                      env_name: "PRODUCE_ENABLED_FEATURES",
                                      description: "Array with Spaceship App Features (e.g. #{Produce::DeveloperCenter::ALLOWED_FEATURES.join(", ")})",
                                      is_string: false,

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -68,14 +68,14 @@ module Produce
 
         # Deprecating this in favor of a rename from "enabled_features" to "enable_services"
         FastlaneCore::ConfigItem.new(key: :enabled_features,
-                                     deprecated: true,
+                                     deprecated: "Please use `enable_services` instead",
                                      display_in_shell: false,
                                      env_name: "PRODUCE_ENABLED_FEATURES",
-                                     description: "Array with Spaceship App Features (e.g. #{Produce::DeveloperCenter::ALLOWED_SERVICES.join(", ")})",
+                                     description: "Array with Spaceship App Services",
                                      is_string: false,
                                      default_value: {},
                                      verify_block: proc do |value|
-                                                     allowed_keys = Produce::DeveloperCenter::ALLOWED_SERVICES
+                                                     allowed_keys = Produce::DeveloperCenter::ALLOWED_SERVICES.all_keys
                                                      UI.user_error!("enabled_features has to be of type Hash") unless value.kind_of?(Hash)
                                                      value.each do |key, v|
                                                        UI.user_error!("The key: '#{key}' is not supported in `enabled_features' - following keys are available: [#{allowed_keys.join(',')}]") unless allowed_keys.include? key.to_sym
@@ -84,11 +84,11 @@ module Produce
         FastlaneCore::ConfigItem.new(key: :enable_services,
                                      display_in_shell: false,
                                      env_name: "PRODUCE_ENABLE_SERVICES",
-                                     description: "Array with Spaceship App Services (e.g. #{Produce::DeveloperCenter::ALLOWED_SERVICES.join(", ")})",
+                                     description: "Array with Spaceship App Services (e.g. #{allowed_services_description})",
                                      is_string: false,
                                      default_value: {},
                                      verify_block: proc do |value|
-                                                     allowed_keys = Produce::DeveloperCenter::ALLOWED_SERVICES
+                                                     allowed_keys = Produce::DeveloperCenter::ALLOWED_SERVICES.all_keys
                                                      UI.user_error!("enable_services has to be of type Hash") unless value.kind_of?(Hash)
                                                      value.each do |key, v|
                                                        UI.user_error!("The key: '#{key}' is not supported in `enable_services' - following keys are available: [#{allowed_keys.join(',')}]") unless allowed_keys.include? key.to_sym
@@ -139,6 +139,12 @@ module Produce
                                        ENV["FASTLANE_ITC_TEAM_NAME"] = value.to_s
                                      end)
       ]
+    end
+    
+    def self.allowed_services_description
+      return Produce::DeveloperCenter::ALLOWED_SERVICES.map do |k,v|
+        "#{k.to_s}: (#{v.join('|')})"
+      end.join(", ")
     end
   end
 end

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -66,17 +66,32 @@ module Produce
                                      is_string: false,
                                      default_value: false),
 
+        # Deprecating this in favor of a rename from "enabled_features" to "enable_services"
         FastlaneCore::ConfigItem.new(key: :enabled_features,
+                                     deprecated: true,
                                      display_in_shell: false,
                                      env_name: "PRODUCE_ENABLED_FEATURES",
-                                     description: "Array with Spaceship App Features (e.g. #{Produce::DeveloperCenter::ALLOWED_FEATURES.join(", ")})",
+                                     description: "Array with Spaceship App Features (e.g. #{Produce::DeveloperCenter::ALLOWED_SERVICES.join(", ")})",
                                      is_string: false,
                                      default_value: {},
                                      verify_block: proc do |value|
-                                                     allowed_keys = Produce::DeveloperCenter::ALLOWED_FEATURES
+                                                     allowed_keys = Produce::DeveloperCenter::ALLOWED_SERVICES
                                                      UI.user_error!("enabled_features has to be of type Hash") unless value.kind_of?(Hash)
                                                      value.each do |key, v|
                                                        UI.user_error!("The key: '#{key}' is not supported in `enabled_features' - following keys are available: [#{allowed_keys.join(',')}]") unless allowed_keys.include? key.to_sym
+                                                     end
+                                                   end),
+        FastlaneCore::ConfigItem.new(key: :enable_services,
+                                     display_in_shell: false,
+                                     env_name: "PRODUCE_ENABLE_SERVICES",
+                                     description: "Array with Spaceship App Services (e.g. #{Produce::DeveloperCenter::ALLOWED_SERVICES.join(", ")})",
+                                     is_string: false,
+                                     default_value: {},
+                                     verify_block: proc do |value|
+                                                     allowed_keys = Produce::DeveloperCenter::ALLOWED_SERVICES
+                                                     UI.user_error!("enable_services has to be of type Hash") unless value.kind_of?(Hash)
+                                                     value.each do |key, v|
+                                                       UI.user_error!("The key: '#{key}' is not supported in `enable_services' - following keys are available: [#{allowed_keys.join(',')}]") unless allowed_keys.include? key.to_sym
                                                      end
                                                    end),
 

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -67,14 +67,13 @@ module Produce
                                      default_value: false),
 
         FastlaneCore::ConfigItem.new(key: :enabled_features,
-                                     short_option: "-P",
+                                     allow_shell: false,
                                      env_name: "PRODUCE_ENABLED_FEATURES",
-                                     description: "Array with Spaceship App Features (e.g. app_group,apple_pay, associated_domains, data_protection, game_center, health_kit, home_kit, wireless_accessory, icloud, in_app_purchase, inter_app_audio, passbook, push_notification, siri_kit, vpn_configuration)",
+                                     description: "Array with Spaceship App Features (e.g. #{Produce::DeveloperCenter::ALLOWED_FEATURES.join(", ")})",
                                      is_string: false,
                                      default_value: {},
                                      verify_block: proc do |value|
-                                                     allowed_keys = [:app_group, :apple_pay, :associated_domains, :data_protection, :game_center, :health_kit, :home_kit,
-                                                                     :wireless_accessory, :icloud, :in_app_purchase, :inter_app_audio, :passbook, :push_notification, :siri_kit, :vpn_configuration]
+                                                     allowed_keys = Produce::DeveloperCenter::ALLOWED_FEATURES
                                                      UI.user_error!("enabled_features has to be of type Hash") unless value.kind_of?(Hash)
                                                      value.each do |key, v|
                                                        UI.user_error!("The key: '#{key}' is not supported in `enabled_features' - following keys are available: [#{allowed_keys.join(',')}]") unless allowed_keys.include? key.to_sym

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -69,7 +69,7 @@ module Produce
         FastlaneCore::ConfigItem.new(key: :enabled_features,
                                      short_option: "-P",
                                      env_name: "PRODUCE_ENABLED_FEATURES",
-                                     description: "Array with Spaceship App Features",
+                                     description: "Array with Spaceship App Features (e.g. app_group,apple_pay, associated_domains, data_protection, game_center, health_kit, home_kit, wireless_accessory, icloud, in_app_purchase, inter_app_audio, passbook, push_notification, siri_kit, vpn_configuration)",
                                      is_string: false,
                                      default_value: {},
                                      verify_block: proc do |value|

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -75,7 +75,7 @@ module Produce
                                      is_string: false,
                                      default_value: {},
                                      verify_block: proc do |value|
-                                                     allowed_keys = Produce::DeveloperCenter::ALLOWED_SERVICES.all_keys
+                                                     allowed_keys = Produce::DeveloperCenter::ALLOWED_SERVICES.keys
                                                      UI.user_error!("enabled_features has to be of type Hash") unless value.kind_of?(Hash)
                                                      value.each do |key, v|
                                                        UI.user_error!("The key: '#{key}' is not supported in `enabled_features' - following keys are available: [#{allowed_keys.join(',')}]") unless allowed_keys.include? key.to_sym
@@ -88,7 +88,7 @@ module Produce
                                      is_string: false,
                                      default_value: {},
                                      verify_block: proc do |value|
-                                                     allowed_keys = Produce::DeveloperCenter::ALLOWED_SERVICES.all_keys
+                                                     allowed_keys = Produce::DeveloperCenter::ALLOWED_SERVICES.keys
                                                      UI.user_error!("enable_services has to be of type Hash") unless value.kind_of?(Hash)
                                                      value.each do |key, v|
                                                        UI.user_error!("The key: '#{key}' is not supported in `enable_services' - following keys are available: [#{allowed_keys.join(',')}]") unless allowed_keys.include? key.to_sym
@@ -140,10 +140,10 @@ module Produce
                                      end)
       ]
     end
-    
+
     def self.allowed_services_description
-      return Produce::DeveloperCenter::ALLOWED_SERVICES.map do |k,v|
-        "#{k.to_s}: (#{v.join('|')})"
+      return Produce::DeveloperCenter::ALLOWED_SERVICES.map do |k, v|
+        "#{k}: (#{v.join('|')})"
       end.join(", ")
     end
   end

--- a/produce/spec/manager_spec.rb
+++ b/produce/spec/manager_spec.rb
@@ -3,24 +3,24 @@ describe Produce do
     it "should auto convert string hash keys to symbol keys" do
       Produce.config = FastlaneCore::Configuration.create(Produce::Options.available_options, {
           username: "helmut@januschka.com",
-          enabled_features: { "data_protection" => "complete" },
+          enable_services: { "data_protection" => "complete" },
           skip_itc: true
       })
 
       instance = Produce::DeveloperCenter.new
-      features = instance.enabled_features
+      features = instance.enable_services
       expect(features["dataProtection"].value).to eq("complete")
     end
 
     it "accepts symbol'd hash" do
       Produce.config = FastlaneCore::Configuration.create(Produce::Options.available_options, {
         username: "helmut@januschka.com",
-        enabled_features: { data_protection: "complete" },
+        enable_services: { data_protection: "complete" },
         skip_itc: true
       })
 
       instance = Produce::DeveloperCenter.new
-      features = instance.enabled_features
+      features = instance.enable_services
       expect(features["dataProtection"].value).to eq("complete")
     end
   end

--- a/spaceship/lib/spaceship/portal/app.rb
+++ b/spaceship/lib/spaceship/portal/app.rb
@@ -33,8 +33,8 @@ module Spaceship
       # @return (Hash) Feature details
       attr_accessor :features
 
-      # @return (Array) List of enabled features
-      attr_accessor :enabled_features
+      # @return (Array) List of enabled services
+      attr_accessor :enable_services
 
       # @return (Bool) Development Push Enabled?
       attr_accessor :dev_push_enabled
@@ -62,7 +62,7 @@ module Spaceship
         'identifier' => :bundle_id,
         'isWildCard' => :is_wildcard,
         'features' => :features,
-        'enabledFeatures' => :enabled_features,
+        'enabledFeatures' => :enable_services,
         'isDevPushEnabled' => :dev_push_enabled,
         'isProdPushEnabled' => :prod_push_enabled,
         'associatedApplicationGroupsCount' => :app_groups_count,
@@ -92,14 +92,14 @@ module Spaceship
         # @param name [String] the name of the App
         # @param mac [Bool] is this a Mac app?
         # @return (App) The app you just created
-        def create!(bundle_id: nil, name: nil, mac: false, enabled_features: {})
+        def create!(bundle_id: nil, name: nil, mac: false, enable_services: {})
           if bundle_id.end_with?('*')
             type = :wildcard
           else
             type = :explicit
           end
 
-          new_app = client.create_app!(type, name, bundle_id, mac: mac, enabled_features: enabled_features)
+          new_app = client.create_app!(type, name, bundle_id, mac: mac, enable_services: enable_services)
           self.new(new_app)
         end
 

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -144,7 +144,7 @@ module Spaceship
       latinized
     end
 
-    def create_app!(type, name, bundle_id, mac: false, enabled_features: {})
+    def create_app!(type, name, bundle_id, mac: false, enable_services: {})
       # We moved the ensure_csrf to the top of this method
       # as we got some users with issues around creating new apps
       # https://github.com/fastlane/fastlane/issues/5813
@@ -171,7 +171,7 @@ module Spaceship
         teamId: team_id
       }
       params.merge!(ident_params)
-      enabled_features.each do |k, v|
+      enable_services.each do |k, v|
         params[v.service_id.to_sym] = v.value
       end
       r = request(:post, "account/#{platform_slug(mac)}/identifiers/addAppId.action", params)

--- a/spaceship/spec/portal/app_spec.rb
+++ b/spaceship/spec/portal/app_spec.rb
@@ -45,7 +45,7 @@ describe Spaceship::Portal::App do
       expect(app.is_wildcard).to eq(false)
 
       expect(app.features).to include("push" => true)
-      expect(app.enabled_features).to include("push")
+      expect(app.enable_services).to include("push")
       expect(app.dev_push_enabled).to eq(false)
       expect(app.prod_push_enabled).to eq(true)
       expect(app.app_groups_count).to eq(0)
@@ -88,7 +88,7 @@ describe Spaceship::Portal::App do
 
   describe '#create' do
     it 'creates an app id with an explicit bundle_id' do
-      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, enabled_features: {}) {
+      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, enable_services: {}) {
         { 'isWildCard' => true }
       }
       app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App')
@@ -96,15 +96,15 @@ describe Spaceship::Portal::App do
     end
 
     it 'creates an app id with an explicit bundle_id and no push notifications' do
-      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, enabled_features: { push_notification: "off" }) {
+      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false, enable_services: { push_notification: "off" }) {
         { 'enabledFeatures' => ["inAppPurchase"] }
       }
-      app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App', enabled_features: { push_notification: "off" })
-      expect(app.enabled_features).not_to include("push")
+      app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App', enable_services: { push_notification: "off" })
+      expect(app.enable_services).not_to include("push")
     end
 
     it 'creates an app id with a wildcard bundle_id' do
-      expect(client).to receive(:create_app!).with(:wildcard, 'Development App', 'tools.fastlane.spaceship.*', mac: false, enabled_features: {}) {
+      expect(client).to receive(:create_app!).with(:wildcard, 'Development App', 'tools.fastlane.spaceship.*', mac: false, enable_services: {}) {
         { 'isWildCard' => false }
       }
       app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.*', name: 'Development App')

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -122,7 +122,7 @@ describe Spaceship::Client do
       it 'should make a request create an explicit app id with no push feature' do
         payload = {}
         payload[Spaceship.app_service.push_notification.on.service_id] = Spaceship.app_service.push_notification.on
-        response = subject.create_app!(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', enabled_features: payload)
+        response = subject.create_app!(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', enable_services: payload)
         expect(response['enabledFeatures']).to_not include("push")
         expect(response['identifier']).to eq('tools.fastlane.spaceship.some-explicit-app')
       end


### PR DESCRIPTION
Fixes #9209 

## Problem
The `enabled_features` command was not self documented enough to show how to properly use. Keys were given but not values and did not explain how to use for either CLI or Fastfile. Using via CLI was "technically" not even supported due to `enabled_features` needing to be a hash. Also, the command `fastlane produce enabled_services` already existed which did a similar thing but had different naming patterns. 

## Solution
The solution was to add documentation to the config item to show what the accepted keys and values are along with hiding the `enabled_features` from showing up when `fastlane produce --help` is being run
- Added `display_in_shell` as `FastlaneCore::ConfigItem` param
  - Some "hash" config items aren't meant to be entered in via CLI
- In `produce`...
  - Deprecating `enabled_features` in favor of `enable_services` to be consistent with `fastlane produce enable_services` command
  - Created constants for service values
  - Created a list of valid service keys and values that are displayed in `fastlane action produce`

```sh
| enabled_features         | [DEPRECATED!] Please use `enable_services`  | PRODUCE_ENABLED_FEATURES      | {}         |
|                          | instead - Array with Spaceship App Services |                               |            |
| enable_services          | Array with Spaceship App Services (e.g.     | PRODUCE_ENABLE_SERVICES       | {}         |
|                          | app_group: (on|off), apple_pay: (on|off),   |                               |            |
|                          | associated_domains: (on|off),               |                               |            |
|                          | data_protection:                            |                               |            |
|                          | (complete|unlessopen|untilfirstauth),       |                               |            |
|                          | game_center: (on|off), health_kit:          |                               |            |
|                          | (on|off), home_kit: (on|off),               |                               |            |
|                          | wireless_accessory: (on|off), icloud:       |                               |            |
|                          | (legacy|cloudkit), in_app_purchase:         |                               |            |
|                          | (on|off), inter_app_audio: (on|off),        |                               |            |
|                          | passbook: (on|off), push_notification:      |                               |            |
|                          | (on|off), siri_kit: (on|off),               |                               |            |
|                          | vpn_configuration: (on|off))                |                               |            |
```