### PR TITLE
Fixes fastlane init failing with interactive bug

### DIFF
--- a/spaceship/lib/spaceship/portal/ui/select_team.rb
+++ b/spaceship/lib/spaceship/portal/ui/select_team.rb
@@ -39,8 +39,8 @@ module Spaceship
       end
 
       def self.interactive?
-        if Object.const_defined?("FastlaneCore") && FastlaneCore.const_defined?("Helper")
-          return FastlaneCore::Helper.interactive?
+        if Object.const_defined?("FastlaneCore") && FastlaneCore.const_defined?("UI")
+          return FastlaneCore::UI.interactive?
         end
         return true
       end


### PR DESCRIPTION
Fixes #9203 

Getting following output with `fastlane init` when having multiple teams
```
[13:10:43]: Ran into error while trying to connect to iTunes Connect / Dev Portal: undefined method interactive?' for FastlaneCore::Helper:Module [13:10:43]: Falling back to manual onboarding [13:10:43]: undefined methodinteractive?' for FastlaneCore::Helper:Module
[13:10:43]: An error occurred during the setup process. Falling back to manual setup!
```