### PR TITLE
Fix link to troubleshooting on new docs site

### DIFF
--- a/fastlane/docs/Codesigning/Troubleshooting.md
+++ b/fastlane/docs/Codesigning/Troubleshooting.md
@@ -1,3 +1,3 @@
 # Codesigning
 
-Moved to [docs.fastlane.tools](https://docs.fastlane.tools/codesigning/Troubleshooting/)
+Moved to [docs.fastlane.tools](https://docs.fastlane.tools/codesigning/troubleshooting/)


### PR DESCRIPTION
This redirect wasn't working because of the uppercase `Troubleshooting`
