### PR TITLE
Skip error message when no simulator is provided

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -153,7 +153,7 @@ module Scan
       end
 
       default = lambda do
-        UI.error("Couldn't find any matching simulators for '#{devices}' - falling back to default simulator")
+        UI.error("Couldn't find any matching simulators for '#{devices}' - falling back to default simulator") if (devices || []).count > 0
 
         result = Array(
           simulators
@@ -163,7 +163,7 @@ module Scan
             .last || simulators.first
         )
 
-        UI.error("Found simulator \"#{result.first.name} (#{result.first.os_version})\"") if result.first
+        UI.message("Found simulator \"#{result.first.name} (#{result.first.os_version})\"") if result.first
 
         result
       end


### PR DESCRIPTION
We've shown error messages for cases that aren't actually errors