### PR TITLE
Rescue exceptions when crash reporter cannot write out status file

### DIFF
--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
@@ -62,11 +62,7 @@ module FastlaneCore
 
         return did_show if did_show
 
-        begin
-          File.write(path, '1')
-        rescue
-          # don't show the user a message, since there is no functionality lost when this happens
-        end
+        File.write(path, '1') rescue nil
         false
       end
 

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
@@ -62,7 +62,11 @@ module FastlaneCore
 
         return did_show if did_show
 
-        File.write(path, '1')
+        begin
+          File.write(path, '1')
+        rescue
+          # don't show the user a message, since there is no functionality lost when this happens
+        end
         false
       end
 

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
@@ -62,7 +62,14 @@ module FastlaneCore
 
         return did_show if did_show
 
-        File.write(path, '1') rescue nil
+        begin
+          File.write(path, '1')
+        rescue
+          if FastlaneCore::Globals.verbose?
+            UI.error("Cannot write out file indicating that crash report announcement has been displayed.")
+            UI.error("The following message will be displayed on the next crash as well:")
+          end
+        end
         false
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The crash reporter notifies the user that it is sending a crash report on the first crash; it writes a file to the `.fastlane` directory after doing this so that it doesn't overwhelm the user with this message after each crash. However, if the `.fastlane` directory is not writable, the crash reporter currently crashes, and records the file write error as the crash. This is not ideal, as it hides the actual cause of the original crash. So, this change `rescue`s that exception on writing the file.

The downside is that for users in this scenario they will see the crash report message over and over, but we will address that issue if it becomes a problem for the relatively small number of users seeing this issue.