### PR TITLE
Create log archive directory in case it doesn’t exist

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -254,6 +254,7 @@ module FastlaneCore
 
         logarchive_dst = Shellwords.escape(File.join(logs_destination_dir, "system_logs-#{log_identity}.logarchive"))
         FileUtils.rm_rf(logarchive_dst)
+        FileUtils.mkdir_p(logarchive_dst)
         command = "xcrun simctl spawn #{device.udid} log collect --output #{logarchive_dst} 2>/dev/null"
         FastlaneCore::CommandExecutor.execute(command: command, print_all: false, print_command: true)
       end


### PR DESCRIPTION
Fixes #8909: the `xcrun` command will fail if the `—output` directory does not exist.  We create it to ensure success.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Scan can fail when collecting logs when the directory that the logs are being expanded to does not exist. See Issue #8909.

### Description

This change uses the mkdir -p command via `FileUtils` to ensure that the destination directory exists. Tested locally with a job that was failing due to this issue.