### PR TITLE
mute `[!] Original Error` console output from test

### DIFF
--- a/fastlane/spec/cli_tools_distributor_spec.rb
+++ b/fastlane/spec/cli_tools_distributor_spec.rb
@@ -47,6 +47,7 @@ describe Fastlane::CLIToolsDistributor do
       expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileErrorInError").at_least(:once)
       expect(FastlaneCore::UpdateChecker).to receive(:start_looking_for_update).with('fastlane')
       expect(FastlaneCore::UpdateChecker).to receive(:show_update_status).with('fastlane', Fastlane::VERSION)
+      expect_any_instance_of(Commander::Runner).to receive(:abort).with("\n[!] Original error".red).and_raise(SystemExit) # mute console output from `abort`
       expect do
         Fastlane::CLIToolsDistributor.take_off
       end.to raise_error(SystemExit)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When one runs `bundle exec rspec`, as one does before each and every commit, one expects to get a very neat line of green `.`s.  Except, NO! Without warning, a single, glaring, bright-red `[!] Original error` breaks the peaceful continuity of passing tests.

![image](https://cloud.githubusercontent.com/assets/1190389/26375135/c0a0f320-3fd5-11e7-8d6c-3cf2c5cea1d2.png)
The HORROR!

This shall not stand!

Using an rspec mock as our lever, we shall move the world[*](https://www.brainyquote.com/quotes/quotes/a/archimedes101761.html) to trap this pesky crimson affront to common sense. We then devour it before it has the opportunity to offend our orderly dot sensibilities any further.