### PR TITLE
TestFairy option checking only checked for symbols, not strings

### DIFF
--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -48,10 +48,10 @@ module Fastlane
 
         options_to_client = lambda do |options|
           options.map do |option|
-            case option
-            when :shake, :anonymous
+            case option.to_s
+            when "shake", "anonymous"
               option.to_s
-            when :video_only_wifi
+            when "video_only_wifi"
               'video-only-wifi'
             else
               UI.user_error!("Unknown option: #{option}")

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -48,10 +48,10 @@ module Fastlane
 
         options_to_client = lambda do |options|
           options.map do |option|
-            case option.to_s
-            when "shake", "anonymous"
+            case option.to_sym
+            when :shake, :anonymous
               option.to_s
-            when "video_only_wifi"
+            when :video_only_wifi
               'video-only-wifi'
             else
               UI.user_error!("Unknown option: #{option}")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid

### Motivation and Context
fixes https://github.com/fastlane/fastlane/issues/9226
Checks the options array items as strings instead of just symbols