### PR TITLE
fix method return value is the error log issue

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -45,6 +45,12 @@ module Fastlane
           # Store the new number in the shared hash
           build_number = `#{command_prefix} agvtool what-version`.split("\n").last.strip
 
+          # if agvtool not enabled and user specified build_number, which means only modify plist build number
+          if $?.exitstatus != 0 and params[:build_number]
+            UI.important("only modify plist build number to specifed '#{params[:build_number]}'")
+            build_number = params[:build_number]
+          end
+          
           return Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number
         end
       rescue => ex
@@ -60,7 +66,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :build_number,
                                        env_name: "FL_BUILD_NUMBER_BUILD_NUMBER",
-                                       description: "Change to a specific version",
+                                       description: "Change to a specific version. If you did not set Versioning System in Xcode, it would only modify build number in .plist file",
                                        optional: true,
                                        is_string: false),
           FastlaneCore::ConfigItem.new(key: :xcodeproj,

--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -50,7 +50,7 @@ module Fastlane
             UI.important("only modify plist build number to specifed '#{params[:build_number]}'")
             build_number = params[:build_number]
           end
-          
+
           return Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number
         end
       rescue => ex


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
bug

### Description
when not set apple versioning system following https://developer.apple.com/library/content/qa/qa1827/_index.html and user passed "build_number" argument, the shell command would return 0 instead of 6. but the command to get `build_number` would return the error log string with "There does not seem to be a CURRENT_PROJECT_VERSION key set for this project.  Add this key to your target's expert build settings."
