### PR TITLE
Update spaceship to support 2 factor on the new `olympus` API endpoint

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -447,6 +447,7 @@ module Spaceship
           req.body = data.to_json
           req.headers['Content-Type'] = 'application/json'
           req.headers['X-Requested-With'] = 'XMLHttpRequest'
+          req.headers['X-Apple-Widget-Key'] = self.itc_service_key
           req.headers['Accept'] = 'application/json, text/javascript'
           req.headers["Cookie"] = modified_cookie if modified_cookie
         end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -401,7 +401,7 @@ module Spaceship
         if keychain_entry.invalid_credentials
           login(user)
         else
-          puts "Please run this tool again to apply the new password"
+          raise ex
         end
       end
     end

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -22,6 +22,8 @@ class TunesStubbing
         to_return(status: 200, body: "")
       stub_request(:get, "https://olympus.itunes.apple.com/v1/session").
         to_return(status: 200, body: "") # we don't actually care about the body
+      stub_request(:get, "https://olympus.itunes.apple.com/v1/app/config?hostname=itunesconnect.apple.com").
+        to_return(status: 200, body: "{'authServiceKey': 'e0abc'}", headers: { 'Content-Type' => 'application/json' })
 
       # Actual login
       stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin").

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -24,12 +24,12 @@ class TunesStubbing
         to_return(status: 200, body: "") # we don't actually care about the body
 
       # Actual login
-      stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin?widgetKey=1234567890").
+      stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin").
         with(body: { "accountName" => "spaceship@krausefx.com", "password" => "so_secret", "rememberMe" => true }.to_json).
         to_return(status: 200, body: '{}', headers: { 'Set-Cookie' => "myacinfo=abcdef;" })
 
       # Failed login attempts
-      stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin?widgetKey=1234567890").
+      stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin").
         with(body: { "accountName" => "bad-username", "password" => "bad-password", "rememberMe" => true }.to_json).
         to_return(status: 401, body: '{}', headers: { 'Set-Cookie' => 'session=invalid' })
     end

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -23,7 +23,7 @@ class TunesStubbing
       stub_request(:get, "https://olympus.itunes.apple.com/v1/session").
         to_return(status: 200, body: "") # we don't actually care about the body
       stub_request(:get, "https://olympus.itunes.apple.com/v1/app/config?hostname=itunesconnect.apple.com").
-        to_return(status: 200, body: "{'authServiceKey': 'e0abc'}", headers: { 'Content-Type' => 'application/json' })
+        to_return(status: 200, body: {authServiceKey: 'e0abc'}.to_json, headers: { 'Content-Type' => 'application/json' })
 
       # Actual login
       stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin").

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -23,7 +23,7 @@ class TunesStubbing
       stub_request(:get, "https://olympus.itunes.apple.com/v1/session").
         to_return(status: 200, body: "") # we don't actually care about the body
       stub_request(:get, "https://olympus.itunes.apple.com/v1/app/config?hostname=itunesconnect.apple.com").
-        to_return(status: 200, body: {authServiceKey: 'e0abc'}.to_json, headers: { 'Content-Type' => 'application/json' })
+        to_return(status: 200, body: { authServiceKey: 'e0abc' }.to_json, headers: { 'Content-Type' => 'application/json' })
 
       # Actual login
       stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin").


### PR DESCRIPTION
this is an improvement to use a new API endpoint, instead of the old way to use a regex