### PR TITLE
[scan] Use pre-2.34.0 strategy if temp junit output is missing

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -96,7 +96,7 @@ module Scan
       reporter_options = reporter_options_generator.generate_reporter_options
       cmd = "cat #{@test_command_generator.xcodebuild_log_path} | xcpretty #{reporter_options.join(' ')} &> /dev/null"
       system(cmd)
-      return File.read(Scan.cache[:temp_junit_report])
+      File.read(Scan.cache[:temp_junit_report])
     end
 
     def copy_simulator_logs

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -91,9 +91,12 @@ module Scan
       # We'll have to regenerate from the xcodebuild log, like we did before version 2.34.0.
       UI.message("Generating test results. This may take a while for large projects.")
       output_file = Tempfile.new("junit_report")
-      cmd = "cat #{@test_command_generator.xcodebuild_log_path} | xcpretty --report junit --output #{output_file.path} &> /dev/null"
+
+      reporter_options_generator = XCPrettyReporterOptionsGenerator.new(false, [], [], "", false)
+      reporter_options = reporter_options_generator.generate_reporter_options
+      cmd = "cat #{@test_command_generator.xcodebuild_log_path} | xcpretty #{reporter_options.join(' ')} &> /dev/null"
       system(cmd)
-      output_file.read
+      return File.read(Scan.cache[:temp_junit_report])
     end
 
     def copy_simulator_logs

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -90,7 +90,6 @@ module Scan
       # Something went wrong with the temp junit report for the test success/failures count.
       # We'll have to regenerate from the xcodebuild log, like we did before version 2.34.0.
       UI.message("Generating test results. This may take a while for large projects.")
-      output_file = Tempfile.new("junit_report")
 
       reporter_options_generator = XCPrettyReporterOptionsGenerator.new(false, [], [], "", false)
       reporter_options = reporter_options_generator.generate_reporter_options

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -5,6 +5,10 @@ require 'terminal-table'
 
 module Scan
   class Runner
+    def initialize
+      @test_command_generator = TestCommandGenerator.new
+    end
+
     def run
       handle_results(test_app)
     end
@@ -16,7 +20,7 @@ module Scan
       # This way it's okay to just call it for the first simulator we're using for
       # the first test run
       open_simulator_for_device(Scan.devices.first) if Scan.devices
-      command = TestCommandGenerator.generate
+      command = @test_command_generator.generate
       prefix_hash = [
         {
           prefix: "Running Tests: ",
@@ -87,7 +91,7 @@ module Scan
       # We'll have to regenerate from the xcodebuild log, like we did before version 2.34.0.
       UI.message("Generating test results. This may take a while for large projects.")
       output_file = Tempfile.new("junit_report")
-      cmd = "cat #{TestCommandGenerator.xcodebuild_log_path} | xcpretty --report junit --output #{output_file.path} &> /dev/null"
+      cmd = "cat #{@test_command_generator.xcodebuild_log_path} | xcpretty --report junit --output #{output_file.path} &> /dev/null"
       system(cmd)
       output_file.read
     end

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -1,149 +1,147 @@
 module Scan
   # Responsible for building the fully working xcodebuild command
   class TestCommandGenerator
-    class << self
-      def generate
-        parts = prefix
-        parts << "env NSUnbufferedIO=YES xcodebuild"
-        parts += options
-        parts += actions
-        parts += suffix
-        parts += pipe
+    def generate
+      parts = prefix
+      parts << "env NSUnbufferedIO=YES xcodebuild"
+      parts += options
+      parts += actions
+      parts += suffix
+      parts += pipe
 
-        parts
+      parts
+    end
+
+    def prefix
+      ["set -o pipefail &&"]
+    end
+
+    # Path to the project or workspace as parameter
+    # This will also include the scheme (if given)
+    # @return [Array] The array with all the components to join
+    def project_path_array
+      proj = Scan.project.xcodebuild_parameters
+      return proj if proj.count > 0
+      UI.user_error!("No project/workspace found")
+    end
+
+    def options
+      config = Scan.config
+
+      options = []
+      options += project_path_array unless config[:xctestrun]
+      options << "-sdk '#{config[:sdk]}'" if config[:sdk]
+      options << destination # generated in `detect_values`
+      options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]
+      options << "-derivedDataPath '#{config[:derived_data_path]}'" if config[:derived_data_path]
+      options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
+      options << "-enableCodeCoverage #{config[:code_coverage] ? 'YES' : 'NO'}" unless config[:code_coverage].nil?
+      options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
+      options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?
+      options << "-xcconfig '#{config[:xcconfig]}'" if config[:xcconfig]
+      options << "-xctestrun '#{config[:xctestrun]}'" if config[:xctestrun]
+      options << config[:xcargs] if config[:xcargs]
+
+      # detect_values will ensure that these values are present as Arrays if
+      # they are present at all
+      options += config[:only_testing].map { |test_id| "-only-testing:#{test_id}" } if config[:only_testing]
+      options += config[:skip_testing].map { |test_id| "-skip-testing:#{test_id}" } if config[:skip_testing]
+
+      options
+    end
+
+    def actions
+      config = Scan.config
+
+      actions = []
+      actions << :clean if config[:clean]
+
+      if config[:build_for_testing]
+        actions << "build-for-testing"
+      elsif config[:test_without_building] || config[:xctestrun]
+        actions << "test-without-building"
+      else
+        actions << :build unless config[:skip_build]
+        actions << :test
       end
 
-      def prefix
-        ["set -o pipefail &&"]
+      actions
+    end
+
+    def suffix
+      suffix = []
+      suffix
+    end
+
+    def pipe
+      pipe = ["| tee '#{xcodebuild_log_path}'"]
+
+      if Scan.config[:output_style] == 'raw'
+        return pipe
       end
 
-      # Path to the project or workspace as parameter
-      # This will also include the scheme (if given)
-      # @return [Array] The array with all the components to join
-      def project_path_array
-        proj = Scan.project.xcodebuild_parameters
-        return proj if proj.count > 0
-        UI.user_error!("No project/workspace found")
+      formatter = []
+      if Scan.config[:formatter]
+        formatter << "-f `#{Scan.config[:formatter]}`"
+      elsif FastlaneCore::Env.truthy?("TRAVIS")
+        formatter << "-f `xcpretty-travis-formatter`"
+        UI.success("Automatically switched to Travis formatter")
       end
 
-      def options
-        config = Scan.config
-
-        options = []
-        options += project_path_array unless config[:xctestrun]
-        options << "-sdk '#{config[:sdk]}'" if config[:sdk]
-        options << destination # generated in `detect_values`
-        options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]
-        options << "-derivedDataPath '#{config[:derived_data_path]}'" if config[:derived_data_path]
-        options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
-        options << "-enableCodeCoverage #{config[:code_coverage] ? 'YES' : 'NO'}" unless config[:code_coverage].nil?
-        options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
-        options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?
-        options << "-xcconfig '#{config[:xcconfig]}'" if config[:xcconfig]
-        options << "-xctestrun '#{config[:xctestrun]}'" if config[:xctestrun]
-        options << config[:xcargs] if config[:xcargs]
-
-        # detect_values will ensure that these values are present as Arrays if
-        # they are present at all
-        options += config[:only_testing].map { |test_id| "-only-testing:#{test_id}" } if config[:only_testing]
-        options += config[:skip_testing].map { |test_id| "-skip-testing:#{test_id}" } if config[:skip_testing]
-
-        options
+      if Helper.colors_disabled?
+        formatter << "--no-color"
       end
 
-      def actions
-        config = Scan.config
-
-        actions = []
-        actions << :clean if config[:clean]
-
-        if config[:build_for_testing]
-          actions << "build-for-testing"
-        elsif config[:test_without_building] || config[:xctestrun]
-          actions << "test-without-building"
-        else
-          actions << :build unless config[:skip_build]
-          actions << :test
-        end
-
-        actions
+      if Scan.config[:output_style] == 'basic'
+        formatter << "--no-utf"
       end
 
-      def suffix
-        suffix = []
-        suffix
+      if Scan.config[:output_style] == 'rspec'
+        formatter << "--test"
       end
 
-      def pipe
-        pipe = ["| tee '#{xcodebuild_log_path}'"]
+      @reporter_options_generator = XCPrettyReporterOptionsGenerator.new(Scan.config[:open_report],
+                                                                         Scan.config[:output_types],
+                                                                         Scan.config[:output_files] || Scan.config[:custom_report_file_name],
+                                                                         Scan.config[:output_directory],
+                                                                         Scan.config[:use_clang_report_name])
+      reporter_options = @reporter_options_generator.generate_reporter_options
+      return pipe << "| xcpretty #{formatter.join(' ')} #{reporter_options.join(' ')}"
+    end
 
-        if Scan.config[:output_style] == 'raw'
-          return pipe
-        end
+    # Store the raw file
+    def xcodebuild_log_path
+      file_name = "#{Scan.project.app_name}-#{Scan.config[:scheme]}.log"
+      containing = File.expand_path(Scan.config[:buildlog_path])
+      FileUtils.mkdir_p(containing)
 
-        formatter = []
-        if Scan.config[:formatter]
-          formatter << "-f `#{Scan.config[:formatter]}`"
-        elsif FastlaneCore::Env.truthy?("TRAVIS")
-          formatter << "-f `xcpretty-travis-formatter`"
-          UI.success("Automatically switched to Travis formatter")
-        end
+      return File.join(containing, file_name)
+    end
 
-        if Helper.colors_disabled?
-          formatter << "--no-color"
-        end
-
-        if Scan.config[:output_style] == 'basic'
-          formatter << "--no-utf"
-        end
-
-        if Scan.config[:output_style] == 'rspec'
-          formatter << "--test"
-        end
-
-        reporter_options_generator = XCPrettyReporterOptionsGenerator.new(Scan.config[:open_report],
-                                                                          Scan.config[:output_types],
-                                                                          Scan.config[:output_files] || Scan.config[:custom_report_file_name],
-                                                                          Scan.config[:output_directory],
-                                                                          Scan.config[:use_clang_report_name])
-        reporter_options = reporter_options_generator.generate_reporter_options
-        return pipe << "| xcpretty #{formatter.join(' ')} #{reporter_options.join(' ')}"
+    # Generate destination parameters
+    def destination
+      unless Scan.cache[:destination]
+        Scan.cache[:destination] = [*Scan.config[:destination]].map { |dst| "-destination '#{dst}'" }.join(' ')
       end
+      Scan.cache[:destination]
+    end
 
-      # Store the raw file
-      def xcodebuild_log_path
-        file_name = "#{Scan.project.app_name}-#{Scan.config[:scheme]}.log"
-        containing = File.expand_path(Scan.config[:buildlog_path])
-        FileUtils.mkdir_p(containing)
+    # The path to set the Derived Data to
+    def build_path
+      unless Scan.cache[:build_path]
+        day = Time.now.strftime("%F") # e.g. 2015-08-07
 
-        return File.join(containing, file_name)
+        Scan.cache[:build_path] = File.expand_path("~/Library/Developer/Xcode/Archives/#{day}/")
+        FileUtils.mkdir_p Scan.cache[:build_path]
       end
+      Scan.cache[:build_path]
+    end
 
-      # Generate destination parameters
-      def destination
-        unless Scan.cache[:destination]
-          Scan.cache[:destination] = [*Scan.config[:destination]].map { |dst| "-destination '#{dst}'" }.join(' ')
-        end
-        Scan.cache[:destination]
+    def result_bundle_path
+      unless Scan.cache[:result_bundle_path]
+        Scan.cache[:result_bundle_path] = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ".test_result"
       end
-
-      # The path to set the Derived Data to
-      def build_path
-        unless Scan.cache[:build_path]
-          day = Time.now.strftime("%F") # e.g. 2015-08-07
-
-          Scan.cache[:build_path] = File.expand_path("~/Library/Developer/Xcode/Archives/#{day}/")
-          FileUtils.mkdir_p Scan.cache[:build_path]
-        end
-        Scan.cache[:build_path]
-      end
-
-      def result_bundle_path
-        unless Scan.cache[:result_bundle_path]
-          Scan.cache[:result_bundle_path] = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ".test_result"
-        end
-        return Scan.cache[:result_bundle_path]
-      end
+      return Scan.cache[:result_bundle_path]
     end
   end
 end

--- a/scan/lib/scan/test_result_parser.rb
+++ b/scan/lib/scan/test_result_parser.rb
@@ -14,7 +14,7 @@ module Scan
         }
       else
         UI.error("Couldn't parse the number of tests from the output")
-        return { 
+        return {
           tests: 0,
           failures: 0
         }

--- a/scan/lib/scan/test_result_parser.rb
+++ b/scan/lib/scan/test_result_parser.rb
@@ -14,7 +14,10 @@ module Scan
         }
       else
         UI.error("Couldn't parse the number of tests from the output")
-        return {}
+        return { 
+          tests: 0,
+          failures: 0
+        }
       end
     end
   end

--- a/scan/lib/scan/xcpretty_reporter_options_generator.rb
+++ b/scan/lib/scan/xcpretty_reporter_options_generator.rb
@@ -58,7 +58,7 @@ module Scan
       @temp_junit_report = Tempfile.new("junit_report")
       Scan.cache[:temp_junit_report] = @temp_junit_report.path
       reporter << "--report junit"
-      reporter << "--output #{Scan.cache[:temp_junit_report]}"
+      reporter << "--output '#{Scan.cache[:temp_junit_report]}'"
       return reporter
     end
 

--- a/scan/lib/scan/xcpretty_reporter_options_generator.rb
+++ b/scan/lib/scan/xcpretty_reporter_options_generator.rb
@@ -55,7 +55,8 @@ module Scan
       # adds another junit reporter in case the user does not specify one
       # this will be used to generate a results table and then discarded
       require 'tempfile'
-      Scan.cache[:temp_junit_report] = Tempfile.new("junit_report").path
+      @temp_junit_report = Tempfile.new("junit_report")
+      Scan.cache[:temp_junit_report] = @temp_junit_report.path
       reporter << "--report junit"
       reporter << "--output #{Scan.cache[:temp_junit_report]}"
       return reporter

--- a/scan/lib/scan/xcpretty_reporter_options_generator.rb
+++ b/scan/lib/scan/xcpretty_reporter_options_generator.rb
@@ -45,7 +45,7 @@ module Scan
         type = raw_type.strip
         output_path = File.join(File.expand_path(@output_directory), determine_output_file_name(type))
         reporter << "--report #{type}"
-        reporter << "--output #{output_path}"
+        reporter << "--output '#{output_path}'"
 
         if type == "html" && @open_report
           Scan.cache[:open_html_report_path] = output_path

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -99,7 +99,7 @@ describe Scan do
             include_simulator_logs: false,
             output_style: "raw"
           })
-          
+
           Scan.cache[:temp_junit_report] = '/var/folders/non_existent_file.junit'
           expect(@scan.test_results).to_not be_nil
           expect(Scan.cache[:temp_junit_report]).to_not eq('/var/folders/non_existent_file.junit')

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -90,6 +90,21 @@ describe Scan do
         expect(@scan.test_results).to_not be_nil
         expect(Scan.cache[:temp_junit_report]).to_not eq('/var/folders/non_existent_file.junit')
       end
+
+      describe "when output_style is raw" do
+        it "still proceeds successfully and generates a temp junit report" do
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            output_directory: '/tmp/scan_results',
+            project: './scan/examples/standard/app.xcodeproj',
+            include_simulator_logs: false,
+            output_style: "raw"
+          })
+          
+          Scan.cache[:temp_junit_report] = '/var/folders/non_existent_file.junit'
+          expect(@scan.test_results).to_not be_nil
+          expect(Scan.cache[:temp_junit_report]).to_not eq('/var/folders/non_existent_file.junit')
+        end
+      end
     end
   end
 end

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -7,7 +7,10 @@ describe Scan do
         mock_slack_poster = Object.new
         allow(Scan::SlackPoster).to receive(:new).and_return(mock_slack_poster)
         allow(mock_slack_poster).to receive(:run)
-        allow(Scan::TestCommandGenerator).to receive(:xcodebuild_log_path).and_return('./scan/spec/fixtures/boring.log')
+
+        mock_test_command_generator = Object.new
+        allow(Scan::TestCommandGenerator).to receive(:new).and_return(mock_test_command_generator)
+        allow(mock_test_command_generator).to receive(:xcodebuild_log_path).and_return('./scan/spec/fixtures/boring.log')
 
         mock_test_result_parser = Object.new
         allow(Scan::TestResultParser).to receive(:new).and_return(mock_test_result_parser)

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -69,6 +69,10 @@ describe Scan do
   end
 
   describe Scan::TestCommandGenerator do
+    before(:each) do
+      @test_command_generator = Scan::TestCommandGenerator.new
+    end
+
     it "raises an exception when project path wasn't found" do
       expect do
         options = { project: "/notExistent" }
@@ -94,7 +98,7 @@ describe Scan do
         options = { project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0", toolchain: "com.apple.dt.toolchain.Swift_2_3" }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
         expect(result).to start_with([
                                        "set -o pipefail &&",
                                        "env NSUnbufferedIO=YES xcodebuild",
@@ -117,7 +121,7 @@ describe Scan do
       options = { project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0", xcargs: xcargs }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-      result = Scan::TestCommandGenerator.generate
+      result = @test_command_generator.generate
       expect(result).to start_with([
                                      "set -o pipefail &&",
                                      "env NSUnbufferedIO=YES xcodebuild",
@@ -136,7 +140,7 @@ describe Scan do
       options = { formatter: "custom-formatter", project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-      result = Scan::TestCommandGenerator.generate
+      result = @test_command_generator.generate
       expect(result.last).to include("| xcpretty -f `custom-formatter`")
     end
 
@@ -149,7 +153,7 @@ describe Scan do
       it "uses the correct build command with the example project with no additional parameters" do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
         expect(result).to start_with([
                                        "set -o pipefail &&",
                                        "env NSUnbufferedIO=YES xcodebuild",
@@ -163,12 +167,12 @@ describe Scan do
       end
 
       it "#project_path_array" do
-        result = Scan::TestCommandGenerator.project_path_array
+        result = @test_command_generator.project_path_array
         expect(result).to eq(["-scheme app", "-project ./scan/examples/standard/app.xcodeproj"])
       end
 
       it "#build_path" do
-        result = Scan::TestCommandGenerator.build_path
+        result = @test_command_generator.build_path
         regex = %r{Library/Developer/Xcode/Archives/\d\d\d\d\-\d\d\-\d\d}
         expect(result).to match(regex)
       end
@@ -176,12 +180,12 @@ describe Scan do
       it "#buildlog_path is used when provided" do
         options = { project: "./scan/examples/standard/app.xcodeproj", buildlog_path: "/tmp/my/path" }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
-        result = Scan::TestCommandGenerator.xcodebuild_log_path
+        result = @test_command_generator.xcodebuild_log_path
         expect(result).to include("/tmp/my/path")
       end
 
       it "#buildlog_path is not used when not provided" do
-        result = Scan::TestCommandGenerator.xcodebuild_log_path
+        result = @test_command_generator.xcodebuild_log_path
         expect(result.to_s).to include(File.expand_path("#{FastlaneCore::Helper.buildlog_path}/scan"))
       end
     end
@@ -195,7 +199,7 @@ describe Scan do
       it "uses the correct build command with the example project" do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
         expect(result).to start_with([
                                        "set -o pipefail &&",
                                        "env NSUnbufferedIO=YES xcodebuild",
@@ -235,7 +239,10 @@ describe Scan do
           mock_slack_poster = Object.new
           allow(Scan::SlackPoster).to receive(:new).and_return(mock_slack_poster)
           allow(mock_slack_poster).to receive(:run)
-          allow(Scan::TestCommandGenerator).to receive(:xcodebuild_log_path).and_return('./scan/spec/fixtures/boring.log')
+
+          mock_test_command_generator = Object.new
+          allow(Scan::TestCommandGenerator).to receive(:new).and_return(mock_test_command_generator)
+          allow(mock_test_command_generator).to receive(:xcodebuild_log_path).and_return('./scan/spec/fixtures/boring.log')
 
           Scan::Runner.new.handle_results(0)
         end
@@ -249,7 +256,7 @@ describe Scan do
         options = { project: "./scan/examples/standard/app.xcodeproj", result_bundle: true, scheme: 'app' }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
         expect(result).to start_with([
                                        "set -o pipefail &&",
                                        "env NSUnbufferedIO=YES xcodebuild",
@@ -272,7 +279,7 @@ describe Scan do
                     only_testing: %w(TestBundleA/TestSuiteB TestBundleC) }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
 
         expect(result).to start_with([
                                        "set -o pipefail &&",
@@ -295,7 +302,7 @@ describe Scan do
                     only_testing: 'TestBundleA/TestSuiteB' }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
 
         expect(result).to start_with([
                                        "set -o pipefail &&",
@@ -317,7 +324,7 @@ describe Scan do
                     skip_testing: %w(TestBundleA/TestSuiteB TestBundleC) }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
 
         expect(result).to start_with([
                                        "set -o pipefail &&",
@@ -340,7 +347,7 @@ describe Scan do
                     skip_testing: 'TestBundleA/TestSuiteB' }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
 
         expect(result).to start_with([
                                        "set -o pipefail &&",
@@ -360,7 +367,7 @@ describe Scan do
       options = { project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 6s" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-      result = Scan::TestCommandGenerator.generate
+      result = @test_command_generator.generate
       expect(result).to start_with([
                                      "set -o pipefail &&",
                                      "env NSUnbufferedIO=YES xcodebuild",
@@ -378,7 +385,7 @@ describe Scan do
       options = { project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 5 (8.4)" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-      result = Scan::TestCommandGenerator.generate
+      result = @test_command_generator.generate
       # FIXME: expect UI error starting "No simulators found that are equal to the version of specifier"
     end
 
@@ -393,7 +400,7 @@ describe Scan do
 
       it "should build-for-testing" do
         Scan.config[:build_for_testing] = true
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
         expect(result).to start_with([
                                        "set -o pipefail &&",
                                        "env NSUnbufferedIO=YES xcodebuild",
@@ -407,7 +414,7 @@ describe Scan do
       end
       it "should test-without-building" do
         Scan.config[:test_without_building] = true
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
         expect(result).to start_with([
                                        "set -o pipefail &&",
                                        "env NSUnbufferedIO=YES xcodebuild",
@@ -434,7 +441,7 @@ describe Scan do
 
       it "should run tests from xctestrun file" do
         Scan.config[:xctestrun] = "/folder/mytests.xctestrun"
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
         expect(result).to start_with([
                                        "set -o pipefail &&",
                                        "env NSUnbufferedIO=YES xcodebuild",
@@ -455,7 +462,7 @@ describe Scan do
         ] }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
         expect(result).to start_with([
                                        "set -o pipefail &&",
                                        "env NSUnbufferedIO=YES xcodebuild",
@@ -476,7 +483,7 @@ describe Scan do
         ] }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
         expect(result).to start_with([
                                        "set -o pipefail &&",
                                        "env NSUnbufferedIO=YES xcodebuild",
@@ -497,7 +504,7 @@ describe Scan do
         ] }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-        result = Scan::TestCommandGenerator.generate
+        result = @test_command_generator.generate
         expect(result).to start_with([
                                        "set -o pipefail &&",
                                        "env NSUnbufferedIO=YES xcodebuild",

--- a/scan/spec/xcpretty_reporter_options_generator_spec.rb
+++ b/scan/spec/xcpretty_reporter_options_generator_spec.rb
@@ -15,7 +15,7 @@ describe Scan do
         expect(temp_junit_report).not_to be_nil
         expect(reporter_options).to end_with([
                                                "--report junit",
-                                               "--output #{temp_junit_report}"
+                                               "--output '#{temp_junit_report}'"
                                              ])
       end
 
@@ -25,7 +25,7 @@ describe Scan do
 
         expect(reporter_options).to start_with([
                                                  "--report junit",
-                                                 "--output /test_output/report.junit"
+                                                 "--output '/test_output/report.junit'"
                                                ])
       end
 
@@ -35,7 +35,7 @@ describe Scan do
 
         expect(reporter_options).to start_with([
                                                  "--report junit",
-                                                 "--output /test_output/junit.xml"
+                                                 "--output '/test_output/junit.xml'"
                                                ])
       end
 
@@ -45,7 +45,7 @@ describe Scan do
 
         expect(reporter_options).to start_with([
                                                  "--report html",
-                                                 "--output /test_output/report.html"
+                                                 "--output '/test_output/report.html'"
                                                ])
       end
 
@@ -55,7 +55,7 @@ describe Scan do
 
         expect(reporter_options).to start_with([
                                                  "--report html",
-                                                 "--output /test_output/custom_report.html"
+                                                 "--output '/test_output/custom_report.html'"
                                                ])
       end
 
@@ -65,7 +65,7 @@ describe Scan do
 
         expect(reporter_options).to start_with([
                                                  "--report json-compilation-database",
-                                                 "--output /test_output/report.json-compilation-database"
+                                                 "--output '/test_output/report.json-compilation-database'"
                                                ])
       end
 
@@ -75,7 +75,7 @@ describe Scan do
 
         expect(reporter_options).to start_with([
                                                  "--report json-compilation-database",
-                                                 "--output /test_output/custom_report.json"
+                                                 "--output '/test_output/custom_report.json'"
                                                ])
       end
 
@@ -85,7 +85,7 @@ describe Scan do
 
         expect(reporter_options).to start_with([
                                                  "--report json-compilation-database",
-                                                 "--output /test_output/compile_commands.json"
+                                                 "--output '/test_output/compile_commands.json'"
                                                ])
       end
 
@@ -95,9 +95,9 @@ describe Scan do
 
         expect(reporter_options).to start_with([
                                                  "--report html",
-                                                 "--output /test_output/report.html",
+                                                 "--output '/test_output/report.html'",
                                                  "--report junit",
-                                                 "--output /test_output/report.junit"
+                                                 "--output '/test_output/report.junit'"
                                                ])
       end
 
@@ -107,9 +107,9 @@ describe Scan do
 
         expect(reporter_options).to start_with([
                                                  "--report html",
-                                                 "--output /test_output/custom_report.html",
+                                                 "--output '/test_output/custom_report.html'",
                                                  "--report junit",
-                                                 "--output /test_output/junit.xml"
+                                                 "--output '/test_output/junit.xml'"
                                                ])
       end
 
@@ -122,7 +122,7 @@ describe Scan do
           expect(temp_junit_report).not_to be_nil
           expect(reporter_options).to end_with([
                                                  "--report junit",
-                                                 "--output #{temp_junit_report}"
+                                                 "--output '#{temp_junit_report}'"
                                                ])
         end
 
@@ -132,7 +132,7 @@ describe Scan do
 
           expect(reporter_options).to start_with([
                                                    "--report junit",
-                                                   "--output /test_output/report.junit"
+                                                   "--output '/test_output/report.junit'"
                                                  ])
         end
 
@@ -142,7 +142,7 @@ describe Scan do
 
           expect(reporter_options).to start_with([
                                                    "--report junit",
-                                                   "--output /test_output/junit.xml"
+                                                   "--output '/test_output/junit.xml'"
                                                  ])
         end
 
@@ -152,7 +152,7 @@ describe Scan do
 
           expect(reporter_options).to start_with([
                                                    "--report html",
-                                                   "--output /test_output/report.html"
+                                                   "--output '/test_output/report.html'"
                                                  ])
         end
 
@@ -162,7 +162,7 @@ describe Scan do
 
           expect(reporter_options).to start_with([
                                                    "--report html",
-                                                   "--output /test_output/custom_report.html"
+                                                   "--output '/test_output/custom_report.html'"
                                                  ])
         end
 
@@ -172,7 +172,7 @@ describe Scan do
 
           expect(reporter_options).to start_with([
                                                    "--report json-compilation-database",
-                                                   "--output /test_output/report.json-compilation-database"
+                                                   "--output '/test_output/report.json-compilation-database'"
                                                  ])
         end
 
@@ -182,7 +182,7 @@ describe Scan do
 
           expect(reporter_options).to start_with([
                                                    "--report json-compilation-database",
-                                                   "--output /test_output/custom_report.json"
+                                                   "--output '/test_output/custom_report.json'"
                                                  ])
         end
 
@@ -191,11 +191,11 @@ describe Scan do
           reporter_options = generator.generate_reporter_options
 
           expect(reporter_options).to include("--report json-compilation-database")
-          expect(reporter_options).to include("--output /test_output/compile_commands.json")
+          expect(reporter_options).to include("--output '/test_output/compile_commands.json'")
 
           expect(reporter_options).to start_with([
                                                    "--report json-compilation-database",
-                                                   "--output /test_output/compile_commands.json"
+                                                   "--output '/test_output/compile_commands.json'"
                                                  ])
         end
 
@@ -205,9 +205,9 @@ describe Scan do
 
           expect(reporter_options).to start_with([
                                                    "--report html",
-                                                   "--output /test_output/report.html",
+                                                   "--output '/test_output/report.html'",
                                                    "--report junit",
-                                                   "--output /test_output/report.junit"
+                                                   "--output '/test_output/report.junit'"
                                                  ])
         end
 
@@ -217,9 +217,9 @@ describe Scan do
 
           expect(reporter_options).to start_with([
                                                    "--report html",
-                                                   "--output /test_output/custom_report.html",
+                                                   "--output '/test_output/custom_report.html'",
                                                    "--report junit",
-                                                   "--output /test_output/junit.xml"
+                                                   "--output '/test_output/junit.xml'"
                                                  ])
         end
       end
@@ -241,11 +241,11 @@ describe Scan do
           reporter_options = Scan::XCPrettyReporterOptionsGenerator.generate_from_scan_config.generate_reporter_options
           expect(reporter_options).to eq([
                                            "--report junit",
-                                           "--output /test_output/junit.xml",
+                                           "--output '/test_output/junit.xml'",
                                            "--report html",
-                                           "--output /test_output/report.html",
+                                           "--output '/test_output/report.html'",
                                            "--report junit",
-                                           "--output #{Scan.cache[:temp_junit_report]}"
+                                           "--output '#{Scan.cache[:temp_junit_report]}'"
                                          ])
         end
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #9268.
Edit 1: Also fixes an issue reported in the comments, where paths were not wrapped in single quotes, causing issues for paths with spaces in them.

### Description
The fix I implemented in #7365 was to optimize the runtime of `scan` by consolidating all instances of `xcpretty --report #{report} --output #{output}`. One of the `xcpretty` calls is a temp file we use to generate the test output table (# of tests and # of failures). In the case of the issue above, the user's temp file is apparently missing.

The solution is to add a backup plan: If the temp_junit_report file is not found, just rerun
`cat #{xcodebuild_log_file} | xcpretty --report junit ...`
for a new file. This is basically just re-adding the logic from before my fix. Again, `cat` will be slow for large xcodebuild logs, but I suppose we have no other choice at this point.

### Reviewer notes
Since I made a change involving a big indentation (class methods > instance methods), I recommend reading without whitespace changes: https://github.com/fastlane/fastlane/pull/9276/files?w=1.
