### PR TITLE
Don't report crashes from plugins

### DIFF
--- a/fastlane/lib/fastlane/actions/badge.rb
+++ b/fastlane/lib/fastlane/actions/badge.rb
@@ -20,6 +20,7 @@ module Fastlane
           Badge::Runner.new.run(params[:path], options)
         rescue => e
           # We want to catch this error and raise our own so that we are not counting this as a crash in our metrics
+          UI.verbose(e.backtrace.join("\n"))
           UI.user_error!("Something went wrong while running badge: #{e}")
         end
       end

--- a/fastlane/lib/fastlane/actions/badge.rb
+++ b/fastlane/lib/fastlane/actions/badge.rb
@@ -16,7 +16,11 @@ module Fastlane
           shield_gravity: params[:shield_gravity],
           shield_no_resize: params[:shield_no_resize]
         }
-        Badge::Runner.new.run(params[:path], options)
+        begin
+          Badge::Runner.new.run(params[:path], options)
+        rescue => e
+          UI.user_error!("Something went wrong while running badge: #{e}")
+        end
       end
 
       #####################################################

--- a/fastlane/lib/fastlane/actions/badge.rb
+++ b/fastlane/lib/fastlane/actions/badge.rb
@@ -19,6 +19,7 @@ module Fastlane
         begin
           Badge::Runner.new.run(params[:path], options)
         rescue => e
+          # We want to catch this error and raise our own so that we are not counting this as a crash in our metrics
           UI.user_error!("Something went wrong while running badge: #{e}")
         end
       end

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
@@ -13,7 +13,7 @@ module FastlaneCore
         backtrace = exception.respond_to?(:trimmed_backtrace) ? exception.trimmed_backtrace : exception.backtrace
         backtrace = FastlaneCore::CrashReportSanitizer.sanitize_backtrace(backtrace: backtrace).join("\n")
 
-        if crash_came_from_plugin?(exception: exception)
+        if exception.fastlane_crash_came_from_plugin?
           message = '[PLUGIN_CRASH]'
         elsif exception.respond_to?(:prefix)
           message = exception.prefix
@@ -33,12 +33,6 @@ module FastlaneCore
         message = message[0..100]
         message += "\n" unless exception.respond_to?(:could_contain_pii?) && exception.could_contain_pii?
         message + backtrace
-      end
-
-      def crash_came_from_plugin?(exception: nil)
-        return false if exception.nil?
-        plugin_frame = exception.backtrace.find { |frame| frame.include?('fastlane-plugin-') }
-        !plugin_frame.nil?
       end
 
       def crash_report_payload(message: '', action: nil)

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
@@ -38,7 +38,7 @@ module FastlaneCore
       def crash_came_from_plugin?(exception: nil)
         return false if exception.nil?
         plugin_frame = exception.backtrace.find { |frame| frame.include?('fastlane-plugin-') }
-        plugin_frame.nil? ? false : true
+        !plugin_frame.nil?
       end
 
       def crash_report_payload(message: '', action: nil)

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
@@ -19,6 +19,7 @@ module FastlaneCore
       def report_crash(exception: nil, action: nil)
         return unless enabled?
         return if @did_report_crash
+        return if crash_came_from_custom_action?(exception: exception)
 
         # Do not run the crash reporter while tests are happening (it might try to send
         # a crash report), unless we have explictly turned on the crash reporter because
@@ -36,6 +37,12 @@ module FastlaneCore
             UI.error("Please open an issue on GitHub if you need help!")
           end
         end
+      end
+
+      def crash_came_from_custom_action?(exception: nil)
+        return false if exception.nil?
+        custom_frame = exception.backtrace.find { |frame| frame.start_with?('actions/') }
+        custom_frame.nil? ? false : true
       end
 
       def reset_crash_reporter_for_testing

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
@@ -19,7 +19,6 @@ module FastlaneCore
       def report_crash(exception: nil, action: nil)
         return unless enabled?
         return if @did_report_crash
-        return if crash_came_from_plugin?(exception: exception)
         # Do not run the crash reporter while tests are happening (it might try to send
         # a crash report), unless we have explictly turned on the crash reporter because
         # we want to test it
@@ -36,12 +35,6 @@ module FastlaneCore
             UI.error("Please open an issue on GitHub if you need help!")
           end
         end
-      end
-
-      def crash_came_from_plugin?(exception: nil)
-        return false if exception.nil?
-        plugin_frame = exception.backtrace.find { |frame| frame.include?('fastlane-plugin-') }
-        plugin_frame.nil? ? false : true
       end
 
       def reset_crash_reporter_for_testing

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
@@ -19,7 +19,7 @@ module FastlaneCore
       def report_crash(exception: nil, action: nil)
         return unless enabled?
         return if @did_report_crash
-        return if crash_came_from_custom_action?(exception: exception)
+        return if exception.fastlane_crash_came_from_custom_action?
 
         # Do not run the crash reporter while tests are happening (it might try to send
         # a crash report), unless we have explictly turned on the crash reporter because
@@ -37,12 +37,6 @@ module FastlaneCore
             UI.error("Please open an issue on GitHub if you need help!")
           end
         end
-      end
-
-      def crash_came_from_custom_action?(exception: nil)
-        return false if exception.nil?
-        custom_frame = exception.backtrace.find { |frame| frame.start_with?('actions/') }
-        !custom_frame.nil?
       end
 
       def reset_crash_reporter_for_testing

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
@@ -19,6 +19,7 @@ module FastlaneCore
       def report_crash(exception: nil, action: nil)
         return unless enabled?
         return if @did_report_crash
+
         # Do not run the crash reporter while tests are happening (it might try to send
         # a crash report), unless we have explictly turned on the crash reporter because
         # we want to test it

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
@@ -42,7 +42,7 @@ module FastlaneCore
       def crash_came_from_custom_action?(exception: nil)
         return false if exception.nil?
         custom_frame = exception.backtrace.find { |frame| frame.start_with?('actions/') }
-        custom_frame.nil? ? false : true
+        !custom_frame.nil?
       end
 
       def reset_crash_reporter_for_testing

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
@@ -19,7 +19,7 @@ module FastlaneCore
       def report_crash(exception: nil, action: nil)
         return unless enabled?
         return if @did_report_crash
-
+        return if crash_came_from_plugin?(exception: exception)
         # Do not run the crash reporter while tests are happening (it might try to send
         # a crash report), unless we have explictly turned on the crash reporter because
         # we want to test it
@@ -36,6 +36,12 @@ module FastlaneCore
             UI.error("Please open an issue on GitHub if you need help!")
           end
         end
+      end
+
+      def crash_came_from_plugin?(exception: nil)
+        return false if exception.nil?
+        plugin_frame = exception.backtrace.find { |frame| frame.include?('fastlane-plugin-') }
+        plugin_frame.nil? ? false : true
       end
 
       def reset_crash_reporter_for_testing

--- a/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
+++ b/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
@@ -23,3 +23,15 @@ module FastlaneCore
     end
   end
 end
+
+class Exception
+  def fastlane_crash_came_from_custom_action?
+    custom_frame = exception.backtrace.find { |frame| frame.start_with?('actions/') }
+    !custom_frame.nil?
+  end
+
+  def fastlane_crash_came_from_plugin?
+    plugin_frame = backtrace.find { |frame| frame.include?('fastlane-plugin-') }
+    !plugin_frame.nil?
+  end
+end

--- a/fastlane_core/spec/crash_reporter/crash_report_generator_spec.rb
+++ b/fastlane_core/spec/crash_reporter/crash_report_generator_spec.rb
@@ -54,6 +54,18 @@ describe FastlaneCore::CrashReportGenerator do
       report = JSON.parse(FastlaneCore::CrashReportGenerator.generate(exception: mock_exception))
       expect(report['message']).to include(mock_exception.backtrace.join("\n"))
     end
+
+    let(:plugin_exception) do
+      double(
+        'Exception',
+        backtrace: ['[gem_home]/gems/fastlane-plugin-appicon-0.6.0/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb:23:in `run'],
+        message: 'plugin exception message'
+      )
+    end
+    it 'has a PLUGIN_CRASH prefix' do
+      setup_expected_body(message_text: "[PLUGIN_CRASH]: #{plugin_exception.class.name}: #{plugin_exception.message}\n", exception: plugin_exception)
+      expect(FastlaneCore::CrashReportGenerator.generate(exception: plugin_exception)).to eq(expected_body.to_json)
+    end
   end
 end
 

--- a/fastlane_core/spec/crash_reporter/crash_report_generator_spec.rb
+++ b/fastlane_core/spec/crash_reporter/crash_report_generator_spec.rb
@@ -7,7 +7,8 @@ describe FastlaneCore::CrashReportGenerator do
           'path/to/fastlane/line/that/crashed',
           'path/to/fastlane/line/that/called/the/crash'
         ],
-        message: 'message goes here'
+        message: 'message goes here',
+        fastlane_crash_came_from_plugin?: false
       )
     end
 
@@ -55,15 +56,10 @@ describe FastlaneCore::CrashReportGenerator do
       expect(report['message']).to include(mock_exception.backtrace.join("\n"))
     end
 
-    let(:plugin_exception) do
-      double(
-        'Exception',
-        backtrace: ['[gem_home]/gems/fastlane-plugin-appicon-0.6.0/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb:23:in `run'],
-        message: 'plugin exception message'
-      )
-    end
     it 'has a PLUGIN_CRASH prefix' do
-      setup_expected_body(message_text: "[PLUGIN_CRASH]: #{plugin_exception.class.name}: #{plugin_exception.message}\n", exception: plugin_exception)
+      plugin_exception = FastlaneCore::Interface::FastlaneError.new
+      plugin_exception.set_backtrace(['[gem_home]/gems/fastlane-plugin-appicon-0.6.0/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb:23:in `run'])
+      setup_expected_body(message_text: "[PLUGIN_CRASH]: #{plugin_exception.class.name}\n", exception: plugin_exception)
       expect(FastlaneCore::CrashReportGenerator.generate(exception: plugin_exception)).to eq(expected_body.to_json)
     end
   end

--- a/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
+++ b/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
@@ -37,6 +37,16 @@ describe FastlaneCore::CrashReporter do
       end
     end
 
+    context 'plugin crashes' do
+      let(:plugin_exception) { double('Plugin_Exception', backtrace: ['[gem_home]/gems/fastlane-plugin-appicon-0.6.0/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb:23:in `run']) }
+
+      it 'does not post crash report if the crash came from a plugin' do
+        expect(FastlaneCore::CrashReportGenerator).to_not receive(:generate)
+        expect(FastlaneCore::CrashReporter.crash_came_from_plugin?(exception: plugin_exception)).to eq(true)
+        FastlaneCore::CrashReporter.report_crash(exception: plugin_exception)
+      end
+    end
+
     context 'opted out of crash reporting' do
       before do
         silence_ui_output

--- a/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
+++ b/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
@@ -37,6 +37,16 @@ describe FastlaneCore::CrashReporter do
       end
     end
 
+    context 'custom action crashes' do
+      let(:custom_action_exception) { double('Custom_Action_Exception', backtrace: ['actions/git_lab:58:in `include?']) }
+
+      it 'does not post crash report if the crash came from a plugin' do
+        expect(FastlaneCore::CrashReportGenerator).to_not receive(:generate)
+        expect(FastlaneCore::CrashReporter.crash_came_from_custom_action?(exception: custom_action_exception)).to eq(true)
+        FastlaneCore::CrashReporter.report_crash(exception: custom_action_exception)
+      end
+    end
+
     context 'opted out of crash reporting' do
       before do
         silence_ui_output

--- a/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
+++ b/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
@@ -11,7 +11,7 @@ describe FastlaneCore::CrashReporter do
       FastlaneCore::CrashReporter.disable_for_testing
     end
 
-    let(:exception) { double('Exception', backtrace: []) }
+    let(:exception) { double('Exception', backtrace: [], fastlane_crash_came_from_custom_action?: false) }
 
     let(:stub_body) do
       {
@@ -38,11 +38,11 @@ describe FastlaneCore::CrashReporter do
     end
 
     context 'custom action crashes' do
-      let(:custom_action_exception) { double('Custom_Action_Exception', backtrace: ['actions/git_lab:58:in `include?']) }
-
-      it 'does not post crash report if the crash came from a plugin' do
+      it 'does not post crash report if the crash came from a custom action' do
+        custom_action_exception = FastlaneCore::Interface::FastlaneError.new
+        custom_action_exception.set_backtrace(['actions/git_lab:58:in `include?'])
         expect(FastlaneCore::CrashReportGenerator).to_not receive(:generate)
-        expect(FastlaneCore::CrashReporter.crash_came_from_custom_action?(exception: custom_action_exception)).to eq(true)
+        expect(custom_action_exception.fastlane_crash_came_from_custom_action?).to eq(true)
         FastlaneCore::CrashReporter.report_crash(exception: custom_action_exception)
       end
     end

--- a/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
+++ b/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
@@ -37,16 +37,6 @@ describe FastlaneCore::CrashReporter do
       end
     end
 
-    context 'plugin crashes' do
-      let(:plugin_exception) { double('Plugin_Exception', backtrace: ['[gem_home]/gems/fastlane-plugin-appicon-0.6.0/lib/fastlane/plugin/appicon/actions/android_appicon_action.rb:23:in `run']) }
-
-      it 'does not post crash report if the crash came from a plugin' do
-        expect(FastlaneCore::CrashReportGenerator).to_not receive(:generate)
-        expect(FastlaneCore::CrashReporter.crash_came_from_plugin?(exception: plugin_exception)).to eq(true)
-        FastlaneCore::CrashReporter.report_crash(exception: plugin_exception)
-      end
-    end
-
     context 'opted out of crash reporting' do
       before do
         silence_ui_output


### PR DESCRIPTION
We are reporting crashes to our crash reporter that come from plugins. We should avoid doing that to keep crash reports to just things that we can manage.