### PR TITLE
Warn user when before_all, after_all or error block overwrite each other

### DIFF
--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -319,14 +319,23 @@ module Fastlane
     end
 
     def set_before_all(platform, block)
+      unless before_all_blocks[platform].nil?
+        UI.error("You defined multiple `before_all` blocks in your `Fastfile`. The last one being set will be used.")
+      end
       before_all_blocks[platform] = block
     end
 
     def set_after_all(platform, block)
+      unless after_all_blocks[platform].nil?
+        UI.error("You defined multiple `after_all` blocks in your `Fastfile`. The last one being set will be used.")
+      end
       after_all_blocks[platform] = block
     end
 
     def set_error(platform, block)
+      unless error_blocks[platform].nil?
+        UI.error("You defined multiple `error` blocks in your `Fastfile`. The last one being set will be used.")
+      end
       error_blocks[platform] = block
     end
 


### PR DESCRIPTION
We don't want to fail, as people probably abuse the system somehow and overwrite those blocks. To not introduce a breaking change, but still help users detect this if they did that by mistake, let's show an error message for those cases.

<img width="891" alt="screenshot 2017-05-25 11 43 21" src="https://cloud.githubusercontent.com/assets/869950/26465386/d20e70b8-413f-11e7-8d62-986fdc9b316c.png">
