### PR TITLE
Update download_dsyms.rb

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -112,7 +112,7 @@ module Fastlane
                                        short_option: "-a",
                                        env_name: "DOWNLOAD_DSYMS_APP_IDENTIFIER",
                                        description: "The bundle identifier of your app",
-                                       optional: true,
+                                       optional: false,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)),
           FastlaneCore::ConfigItem.new(key: :team_id,
                                        short_option: "-k",


### PR DESCRIPTION
Makes app identifier a required option, so we catch stuff like https://github.com/fastlane/fastlane/issues/9275