### PR TITLE
Version bump to 2.35.1

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.35.0'.freeze
+  VERSION = '2.35.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.35.0':**

* Add missing new-line after showing code sample (#9281) via Felix Krause
* Update download_dsyms.rb (#9288) via Joshua Liebowitz
* Fix puts crash on linux (#9279) via David Ohayon
* Warn user when before_all, after_all or error block overwrite each other (#9284) via Felix Krause
* Add helpful output when running `pilot` without specifying an action (#9283) via Felix Krause
* Update links to new docs page in crashlytics beta class (#9264) via Felix Krause
