### PR TITLE
Don't log metrics for failures in custom actions and plugins

### DIFF
--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -258,17 +258,13 @@ module Fastlane
         raise e
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         FastlaneCore::CrashReporter.report_crash(exception: e, action: method_sym)
-        unless e.fastlane_crash_came_from_custom_action? || e.fastlane_crash_came_from_plugin?
-          collector.did_raise_error(method_sym)
-        end
+        collector.did_raise_error(method_sym) if e.fastlane_should_report_metrics?
         raise e
       rescue Exception => e # rubocop:disable Lint/RescueException
         # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
         # Catches all exceptions, since some plugins might use system exits to get out
         FastlaneCore::CrashReporter.report_crash(exception: e, action: method_sym)
-        unless e.fastlane_crash_came_from_custom_action? || e.fastlane_crash_came_from_plugin?
-          collector.did_crash(method_sym)
-        end
+        collector.did_crash(method_sym) if e.fastlane_should_report_metrics?
         raise e
       end
     end

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -258,13 +258,17 @@ module Fastlane
         raise e
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
         FastlaneCore::CrashReporter.report_crash(exception: e, action: method_sym)
-        collector.did_raise_error(method_sym)
+        unless e.fastlane_crash_came_from_custom_action? || e.fastlane_crash_came_from_plugin?
+          collector.did_raise_error(method_sym)
+        end
         raise e
       rescue Exception => e # rubocop:disable Lint/RescueException
         # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
         # Catches all exceptions, since some plugins might use system exits to get out
         FastlaneCore::CrashReporter.report_crash(exception: e, action: method_sym)
-        collector.did_crash(method_sym)
+        unless e.fastlane_crash_came_from_custom_action? || e.fastlane_crash_came_from_plugin?
+          collector.did_crash(method_sym)
+        end
         raise e
       end
     end

--- a/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
+++ b/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
@@ -36,10 +36,10 @@ class Exception
   end
 
   def fastlane_should_report_metrics?
-    if !fastlane_crash_came_from_plugin? && !fastlane_crash_came_from_custom_action
-      true
-    else
+    if fastlane_crash_came_from_plugin? || fastlane_crash_came_from_custom_action
       false
+    else
+      true
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
+++ b/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
@@ -34,4 +34,12 @@ class Exception
     plugin_frame = backtrace.find { |frame| frame.include?('fastlane-plugin-') }
     !plugin_frame.nil?
   end
+
+  def fastlane_should_report_metrics?
+    if !fastlane_crash_came_from_plugin? && !fastlane_crash_came_from_custom_action
+      true
+    else
+      false
+    end
+  end
 end

--- a/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
+++ b/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
@@ -36,7 +36,7 @@ class Exception
   end
 
   def fastlane_should_report_metrics?
-    if fastlane_crash_came_from_plugin? || fastlane_crash_came_from_custom_action
+    if fastlane_crash_came_from_plugin? || fastlane_crash_came_from_custom_action?
       false
     else
       true

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -115,16 +115,12 @@ module Commander
 
     def rescue_unknown_error(e)
       FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
-      unless e.fastlane_crash_came_from_custom_action? || e.fastlane_crash_came_from_plugin?
-        @collector.did_crash(@program[:name])
-      end
+      @collector.did_crash(@program[:name]) if e.fastlane_should_report_metrics?
       handle_unknown_error!(e)
     end
 
     def rescue_fastlane_error(e)
-      unless e.fastlane_crash_came_from_custom_action? || e.fastlane_crash_came_from_plugin?
-        @collector.did_raise_error(@program[:name])
-      end
+      @collector.did_raise_error(@program[:name]) if e.fastlane_should_report_metrics?
       show_github_issues(e.message) if e.show_github_issues
       FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
       display_user_error!(e, e.message)

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -31,10 +31,10 @@ module Commander
       parse_global_options
       remove_global_options options, @args
 
-      collector = FastlaneCore::ToolCollector.new
+      @collector = FastlaneCore::ToolCollector.new
 
       begin
-        collector.did_launch_action(@program[:name])
+        @collector.did_launch_action(@program[:name])
         run_active_command
       rescue InvalidCommandError => e
         # calling `abort` makes it likely that tests stop without failing, so
@@ -80,34 +80,54 @@ module Commander
       rescue FastlaneCore::Interface::FastlaneCommonException => e # these are exceptions that we dont count as crashes
         display_user_error!(e, e.to_s)
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
-        collector.did_raise_error(@program[:name])
-        show_github_issues(e.message) if e.show_github_issues
-        FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
-        display_user_error!(e, e.message)
+        rescue_fastlane_error(e)
       rescue Errno::ENOENT => e
-        # We're also printing the new-lines, as otherwise the message is not very visible in-between the error and the stacktrace
-        puts ""
-        FastlaneCore::UI.important("Error accessing file, this might be due to fastlane's directory handling")
-        FastlaneCore::UI.important("Check out https://docs.fastlane.tools/advanced/#directory-behavior for more details")
-        puts ""
-        FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
-        raise e
+        rescue_file_error(e)
       rescue Faraday::SSLError => e # SSL issues are very common
         handle_ssl_error!(e)
       rescue Faraday::ConnectionFailed => e
-        if e.message.include? 'Connection reset by peer - SSL_connect'
-          handle_tls_error!(e)
-        else
-          FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
-          handle_unknown_error!(e)
-        end
+        rescue_connection_failed_error(e)
       rescue => e # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
-        FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
-        collector.did_crash(@program[:name])
-        handle_unknown_error!(e)
+        rescue_unknown_error(e)
       ensure
-        collector.did_finish
+        @collector.did_finish
       end
+    end
+
+    def rescue_file_error(e)
+      # We're also printing the new-lines, as otherwise the message is not very visible in-between the error and the stacktrace
+      puts ""
+      FastlaneCore::UI.important("Error accessing file, this might be due to fastlane's directory handling")
+      FastlaneCore::UI.important("Check out https://docs.fastlane.tools/advanced/#directory-behavior for more details")
+      puts ""
+      FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
+      raise e
+    end
+
+    def rescue_connection_failed_error(e)
+      if e.message.include? 'Connection reset by peer - SSL_connect'
+        handle_tls_error!(e)
+      else
+        FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
+        handle_unknown_error!(e)
+      end
+    end
+
+    def rescue_unknown_error(e)
+      FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
+      unless e.fastlane_crash_came_from_custom_action? || e.fastlane_crash_came_from_plugin?
+        @collector.did_crash(@program[:name])
+      end
+      handle_unknown_error!(e)
+    end
+
+    def rescue_fastlane_error(e)
+      unless e.fastlane_crash_came_from_custom_action? || e.fastlane_crash_came_from_plugin?
+        @collector.did_raise_error(@program[:name])
+      end
+      show_github_issues(e.message) if e.show_github_issues
+      FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
+      display_user_error!(e, e.message)
     end
 
     def handle_tls_error!(e)


### PR DESCRIPTION
We are currently docking our metrics when there is a failure in a _fastlane-plugin_ or in custom actions though these are out of our control. We should only be recording failures that happen within our codebase where possible.