### PR TITLE
Allow for 1% rollouts in supply command

### DIFF
--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -26,7 +26,7 @@ module Supply
                                      description: "The percentage of the user fraction when uploading to the rollout track",
                                      default_value: '0.1',
                                      verify_block: proc do |value|
-                                       min = 0.05
+                                       min = 0.01
                                        max = 0.5
                                        UI.user_error! "Invalid value '#{value}', must be between #{min} and #{max}" unless value.to_f.between?(min, max)
                                      end),

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -41,7 +41,7 @@ module Supply
     def promote_track
       version_codes = client.track_version_codes(Supply.config[:track])
       # the actual value passed for the rollout argument does not matter because it will be ignored by the Google Play API
-      # but it has to be between 0.05 and 0.5 to pass the validity check. So we are passing the default value 0.1
+      # but it has to be between 0.01 and 0.5 to pass the validity check. So we are passing the default value 0.1
       client.update_track(Supply.config[:track], 0.1, nil)
       client.update_track(Supply.config[:track_promote_to], Supply.config[:rollout], version_codes)
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation, Context, Description
The Google Play API allows values below `0.05`. For instance, a `0.01`
value can be used to rollout to 1% of users. This change allows `supply`
to be run with a rollout value as low as `0.01`.

Example:

    +-------------------------+--------------------------------+
    |                Summary for supply 2.35.2                 |
    +-------------------------+--------------------------------+
    | package_name            | *********************          |
    | json_key                | /usr/src/app/key.json          |
    | track                   | beta                           |
    | track_promote_to        | rollout                        |
    | rollout                 | 0.01                           |
    | metadata_path           | /usr/src/app/fastlane/metadata |
    | skip_upload_apk         | true                           |
    | apk                     | release.apk                    |
    | skip_upload_metadata    | false                          |
    | skip_upload_images      | false                          |
    | skip_upload_screenshots | false                          |
    | validate_only           | false                          |
    +-------------------------+--------------------------------+

    [18:44:42]: Preparing to upload for language 'en-US'...
    [18:44:43]: Updating changelog for code version '12100' and language 'en-US'...
    [18:45:00]: Uploading all changes to Google Play...
    [18:45:03]: Successfully finished the upload to Google Play