### PR TITLE
Add a nil check before asking for the shell-escaped version of path in create_keychain

### DIFF
--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -8,13 +8,17 @@ module Fastlane
 
     class CreateKeychainAction < Action
       def self.run(params)
+        if params[:password].nil?
+          UI.user_error!("You have to pass a non-nil value to :password")
+        end
+
         escaped_password = params[:password].shellescape
 
         if params[:name]
           escaped_name = params[:name].shellescape
           keychain_path = "~/Library/Keychains/#{escaped_name}"
         else
-          keychain_path = params[:path].shellescape
+          keychain_path = params[:path] && params[:path].shellescape
         end
 
         if keychain_path.nil?


### PR DESCRIPTION
Someone, _myself_, set up the ENV vars wrong on our CI. More importantly, this passed nil into the values for create_keychain. Which crashes the action as it assumes non-nil values. I ended up digging around in a bunch of the wrong places before deciding to consult the code instead.

So, I gave it a quick look over for the potential of `nil` values 👍 

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've once read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [n/a] I've updated the documentation if necessary.
