### PR TITLE
Fix scan’s custom report name not working with multiple output types

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -9,6 +9,8 @@ module Scan
       # First, try loading the Scanfile from the current directory
       config.load_configuration_file(Scan.scanfile_name)
 
+      prevalidate
+
       # Detect the project
       FastlaneCore::Project.detect_projects(config)
       Scan.project = FastlaneCore::Project.new(config)
@@ -40,6 +42,14 @@ module Scan
       coerce_to_array_of_strings(:skip_testing)
 
       return config
+    end
+
+    def self.prevalidate
+      output_types = Scan.config[:output_types]
+      has_multiple_report_types = output_types && output_types.split(',').size > 1
+      if has_multiple_report_types && Scan.config[:custom_report_file_name]
+        UI.user_error!("Using a :custom_report_file_name with multiple :output_types (#{output_types}) will lead to unexpected results. Use :output_files instead.")
+      end
     end
 
     def self.coerce_to_array_of_strings(config_key)

--- a/scan/spec/detect_values_spec.rb
+++ b/scan/spec/detect_values_spec.rb
@@ -13,6 +13,28 @@ describe Scan do
       end
     end
 
+    describe "validation" do
+      it "advises of problems with multiple output_types and a custom_report_file_name" do
+        options = {
+          project: "./scan/examples/standard/app.xcodeproj",
+          # use default output types
+          custom_report_file_name: 'report.xml'
+        }
+        expect(FastlaneCore::UI).to receive(:user_error!).with("Using a :custom_report_file_name with multiple :output_types (html,junit) will lead to unexpected results. Use :output_files instead.")
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+      end
+
+      it "does not advise of a problem with one output_type and a custom_report_file_name" do
+        options = {
+          project: "./scan/examples/standard/app.xcodeproj",
+          output_types: 'junit',
+          custom_report_file_name: 'report.xml'
+        }
+        expect(FastlaneCore::UI).not_to receive(:user_error!)
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+      end
+    end
+
     describe "value coercion" do
       it "coerces only_testing to be an array" do
         options = {

--- a/scan/spec/xcpretty_reporter_options_generator_spec.rb
+++ b/scan/spec/xcpretty_reporter_options_generator_spec.rb
@@ -229,7 +229,7 @@ describe Scan do
           options = {
             project: "./scan/examples/standard/app.xcodeproj",
             output_types: "junit,html",
-            custom_report_file_name: "junit.xml",
+            output_files: "junit.xml",
             output_directory: "/test_output"
           }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

Fixes Issue #9293 where `scan`'s custom report filename was being used just for the `html` file and not for the `xml` file as it used to. This ensures that someone will not get a nasty surprise after `scan` completes and provides the report files.

One should use `:output_files` instead and this makes it obvious.


### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

Using the `scan` option without specifying the `output_types` will, by default, try and provide a `html` and `junit` report file. Combined with the `custom_report_file_name` used to yield the `xml` `junit` file with the given name. With a recent update, that stopped working and the `html` file was yielded with the custom name: that is confusing when you want it for the `xml` file.

This change makes it so that if you provide multiple output types, and use this deprecated option, you'll get an error and not accidentally archive the `html` file thinking that you get a `junit` `xml` file.

### Description

This adds a check for the options when generating them to ensure that one is not using options that will cause you problems later on. 
