### PR TITLE
fix uninitialized constant Spaceship::Client::ITunesConnectError

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -213,7 +213,7 @@ module Spaceship
       end
 
       unless result
-        raise ITunesConnectError.new, "Could not set team ID to '#{team_id}', only found the following available teams: #{available_teams.join(', ')}"
+        raise TunesClient::ITunesConnectError.new, "Could not set team ID to '#{team_id}', only found the following available teams: #{available_teams.join(', ')}"
       end
 
       response = request(:post) do |req|


### PR DESCRIPTION
This pull request fixes `uninitialized constant Spaceship::Client::ITunesConnectError` error on  `spaceship/lib/spaceship/client.rb` file.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I'm trying to use Fastlane with one of my Ionic/Cordova applications. When I tried to generate a build for ios, I get an error as `uninitialized constant Spaceship::Client::ITunesConnectError`. 

```
+-------------------+-----------+
|         Lane Context          |
+-------------------+-----------+
| DEFAULT_PLATFORM  | ios       |
| PLATFORM_NAME     | ios       |
| LANE_NAME         | ios beta  |
| SIGH_PROFILE_TYPE | app-store |
+-------------------+-----------+
[12:12:07]: uninitialized constant Spaceship::Client::ITunesConnectError

+------+------------------------+-------------+
|              fastlane summary               |
+------+------------------------+-------------+
| Step | Action                 | Time (in s) |
+------+------------------------+-------------+
| 1    | Verifying required     | 0           |
|      | fastlane version       |             |
| 2    | default_platform       | 0           |
| 3    | match                  | 8           |
| 4    | update_project_codesi  | 0           |
|      | gning                  |             |
| 💥   | latest_testflight_bui  | 2           |
|      | ld_number              |             |
+------+------------------------+-------------+

[12:12:07]: fastlane finished with errors

Looking for related GitHub issues on fastlane/fastlane...

➡️  getting uninitialized constant Spaceship::Client::ITunesConnectError while running cert
    https://github.com/fastlane/fastlane/issues/4633 [closed] 4 💬
    12 Nov 2016

➡️  pilot Beta App Description is required.
    https://github.com/fastlane/fastlane/issues/6351 [closed] 13 💬
    16 Jan 2017

➡️  Deliver fails after iTunes connect updated yesterday (9/24)
    https://github.com/fastlane/fastlane/issues/2224 [closed] 94 💬
    22 Sep 2016

🔗  You can ⌘ + double-click on links to open them directly in your browser.
/Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/spaceship/lib/spaceship/client.rb:217:in `team_id=': [!] uninitialized constant Spaceship::Client::ITunesConnectError (NameError)
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/spaceship/lib/spaceship/tunes/tunes_client.rb:68:in `select_team'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/spaceship/lib/spaceship/tunes/spaceship.rb:30:in `select_team'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/actions/app_store_build_number.rb:13:in `run'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb:11:in `run'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/runner.rb:252:in `block (2 levels) in execute_action'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/actions/actions_helper.rb:50:in `execute_action'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/runner.rb:230:in `block in execute_action'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/runner.rb:226:in `chdir'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/runner.rb:226:in `execute_action'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/runner.rb:148:in `trigger_action_by_name'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/fast_file.rb:146:in `method_missing'
	from Fastfile:58:in `block (2 levels) in parsing_binding'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/lane.rb:33:in `call'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/lane.rb:33:in `call'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/runner.rb:49:in `block in execute'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/runner.rb:45:in `chdir'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/runner.rb:45:in `execute'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/lane_manager.rb:52:in `cruise_lane'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/command_line_handler.rb:30:in `handle'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/commands_generator.rb:104:in `block (2 levels) in run'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/commander-fastlane-4.4.4/lib/commander/command.rb:178:in `call'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/commander-fastlane-4.4.4/lib/commander/command.rb:178:in `call'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/commander-fastlane-4.4.4/lib/commander/command.rb:153:in `run'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/commander-fastlane-4.4.4/lib/commander/runner.rb:476:in `run_active_command'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:38:in `run!'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/commander-fastlane-4.4.4/lib/commander/delegates.rb:15:in `run!'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/commands_generator.rb:303:in `run'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/commands_generator.rb:42:in `start'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/fastlane/lib/fastlane/cli_tools_distributor.rb:66:in `take_off'
	from /Users/murat.corlu/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.35.1/bin/fastlane:20:in `<top (required)>'
	from /Users/murat.corlu/.fastlane/bin/bundle/bin/fastlane:22:in `load'
	from /Users/murat.corlu/.fastlane/bin/bundle/bin/fastlane:22:in `<main>'
```

I looked at suggested issues but none of them solved. Then I tried to understand the problem as debugging `spaceship/lib/spaceship/client.rb` file. I realized that the problem is about `ITunesConnectError`. I searched another usage of that class and saw that there is another usage like `TunesClient::ITunesConnectError.new` instead of `ITunesConnectError.new`. Then I tried it like that and it worked. (By the way, I don't know ruby)

### Description
Maybe it would be better to have a test for that issue. But unfortunately I'm not familiar with ruby.