### PR TITLE
Appaloosa action proxy support

### DIFF
--- a/fastlane/lib/fastlane/actions/appaloosa.rb
+++ b/fastlane/lib/fastlane/actions/appaloosa.rb
@@ -24,16 +24,19 @@ module Fastlane
         uri = URI("#{APPALOOSA_SERVER}/upload_services/presign_form")
         params = { file: file_name, store_id: store_id, group_ids: group_ids }
         uri.query = URI.encode_www_form(params)
-        presign_form_response = Net::HTTP.get_response(uri)
+        http = Net::HTTP.new(uri.host)
+        presign_form_response = http.request(Net::HTTP::Get.new(uri.request_uri))
         json_res = JSON.parse(presign_form_response.body)
         return if error_detected json_res['errors']
         s3_sign = json_res['s3_sign']
         path = json_res['path']
         uri = URI.parse(Base64.decode64(s3_sign))
         File.open(file, 'rb') do |f|
-          Net::HTTP.start(uri.host) do |http|
-            http.send_request('PUT', uri.request_uri, f.read, 'content-type' => '')
-          end
+          http = Net::HTTP.new(uri.host)
+          put = Net::HTTP::Put.new(uri.request_uri)
+          put.body = f.read
+          put['content-type'] = ''
+          http.request(put)
         end
         path
       end
@@ -42,7 +45,8 @@ module Fastlane
         uri = URI("#{APPALOOSA_SERVER}/#{store_id}/upload_services/url_for_download")
         params = { store_id: store_id, api_key: api_key, key: path }
         uri.query = URI.encode_www_form(params)
-        url_for_download_response = Net::HTTP.get_response(uri)
+        http = Net::HTTP.new(uri.host)
+        url_for_download_response = http.request(Net::HTTP::Get.new(uri.request_uri))
         if invalid_response?(url_for_download_response)
           UI.user_error!("ERROR: A problem occurred with your API token and your store id. Please try again.")
         end

--- a/fastlane/lib/fastlane/actions/appaloosa.rb
+++ b/fastlane/lib/fastlane/actions/appaloosa.rb
@@ -24,7 +24,8 @@ module Fastlane
         uri = URI("#{APPALOOSA_SERVER}/upload_services/presign_form")
         params = { file: file_name, store_id: store_id, group_ids: group_ids }
         uri.query = URI.encode_www_form(params)
-        http = Net::HTTP.new(uri.host)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
         presign_form_response = http.request(Net::HTTP::Get.new(uri.request_uri))
         json_res = JSON.parse(presign_form_response.body)
         return if error_detected json_res['errors']
@@ -45,7 +46,8 @@ module Fastlane
         uri = URI("#{APPALOOSA_SERVER}/#{store_id}/upload_services/url_for_download")
         params = { store_id: store_id, api_key: api_key, key: path }
         uri.query = URI.encode_www_form(params)
-        http = Net::HTTP.new(uri.host)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
         url_for_download_response = http.request(Net::HTTP::Get.new(uri.request_uri))
         if invalid_response?(url_for_download_response)
           UI.user_error!("ERROR: A problem occurred with your API token and your store id. Please try again.")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The Appaloosa action uses `send_request` which apparently doesn't take into account http proxy env settings.

### Description
Changed `send_request` calls to `http.request` calls.

**However**, I see some Appaloosa tests failing with:
`       expected FastlaneCore::Interface::FastlaneError, got #<WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: GET h...sconnect.apple.com\/testflight\/v2/")`

I'm not that familiar with Ruby: can someone point me in the right direction?