### PR TITLE
Explicitly crash when the plist cant be parsed for provisioning profile data

### DIFF
--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -28,8 +28,7 @@ module FastlaneCore
         if (plist || []).count > 5
           plist
         else
-          UI.error("Error parsing provisioning profile at path '#{path}'")
-          nil
+          UI.crash!("Error parsing provisioning profile at path '#{path}'")
         end
       end
 


### PR DESCRIPTION
Returning nil from this method was causing a NoMethodError on nil. This PR just makes sure we provide nicer output and log the crash appropriately to our crash reporter.