### PR TITLE
Wrap the call to puts Terminal::Table in a rescue block

### DIFF
--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -111,13 +111,19 @@ module Fastlane
         rows << [index, name, current[:time].to_i]
       end
 
-      puts ""
-      puts Terminal::Table.new(
-        title: "fastlane summary".green,
-        headings: ["Step", "Action", "Time (in s)"],
-        rows: FastlaneCore::PrintTable.transform_output(rows)
-      )
-      puts ""
+      begin
+        require 'terminal-table'
+        puts ""
+        puts Terminal::Table.new(
+          title: "fastlane summary".green,
+          headings: ["Step", "Action", "Time (in s)"],
+          rows: FastlaneCore::PrintTable.transform_output(rows)
+        )
+        puts ""
+      rescue
+        os = Helper.linux? ? 'linux' : 'mac'
+        UI.crash!("Something went wrong trying to print the lane context on #{os}")
+      end
     end
 
     # Lane chooser if user didn't provide a lane


### PR DESCRIPTION
I fixed a crash just like this last week and it looks like there is another one. This just wraps it in a rescue block so we can get more information about the crash as it happens https://github.com/fastlane/fastlane/pull/9279