### PR TITLE
Fixed scan results for schemes that contain spaces

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -2,6 +2,7 @@ require 'pty'
 require 'open3'
 require 'fileutils'
 require 'terminal-table'
+require 'shellwords'
 
 module Scan
   class Runner
@@ -93,7 +94,7 @@ module Scan
 
       reporter_options_generator = XCPrettyReporterOptionsGenerator.new(false, [], [], "", false)
       reporter_options = reporter_options_generator.generate_reporter_options
-      cmd = "cat #{@test_command_generator.xcodebuild_log_path} | xcpretty #{reporter_options.join(' ')} &> /dev/null"
+      cmd = "cat #{@test_command_generator.xcodebuild_log_path.shellescape} | xcpretty #{reporter_options.join(' ')} &> /dev/null"
       system(cmd)
       File.read(Scan.cache[:temp_junit_report])
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prior to this change, `scan` was failing to `cat` the results for my scheme, because the full path was something like `~/Library/Logs/scan/My Scheme-All Tests.log`
<!--- Please describe in detail how you tested your changes. --->
Full disclosure: I haven't tested this change, but I'm 99% sure it's correct (and @taquitos's help provides the last 1% of confidence)