### PR TITLE
Action to check Swift version for   platforms

### DIFF
--- a/fastlane/lib/fastlane/actions/check_swift_version.rb
+++ b/fastlane/lib/fastlane/actions/check_swift_version.rb
@@ -1,0 +1,51 @@
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+    class CheckSwiftVersionAction < Action
+      def self.run(params)
+        required_version = params[:version]
+        selected_version = sh("swift -version")
+        if selected_version.include?(required_version)
+          UI.success("Selected Swift version is correct: #{selected_version}")
+        else
+          UI.message("Selected Swift version is not correct: #{selected_version}. You expected #{required_version}.")
+          UI.message("To correct this, make sure you are using right Swift toolchain Or Xcode version")
+          UI.user_error!("Selected Swift version doesn't match your requirement.\nExpected: #{required_version}\nActual: #{selected_version}\n")
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Ensure the selected Swift version is correct"
+      end
+
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       env_name: "FL_ENSURE_SWIFT_VERSION",
+                                       description: "Swift version to verify that is selected",
+                                       is_string: true,
+                                       optional: false)
+        ]
+      end
+
+      def self.authors
+        ["Shashikant86"]
+      end
+
+      def self.example_code
+        ['check_swift_version(version: "Apple Swift version 3.0.2")']
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/check_swift_version.rb
+++ b/fastlane/lib/fastlane/actions/check_swift_version.rb
@@ -38,6 +38,10 @@ module Fastlane
       def self.authors
         ["Shashikant86"]
       end
+      
+      def self.category
+        :building
+      end
 
       def self.example_code
         ['check_swift_version(version: "Apple Swift version 3.0.2")']


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

I read that you don't accept new actions, you can reject this PR straight away  !!

### Checklist
- [x ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Swift is becoming major programming language for developing and iOS and macOS apps. It would be useful to know what version of Swift we are using. Apple 
<!--- If it fixes an open issue, please link to the issue here. -->
New change 
<!--- Please describe in detail how you tested your changes. --->
Using this action for few month and thought it could come from fastlane 

### Description
<!--- Describe your changes in detail -->

This action would be useful to determine what version of Swift we are using for building an app. It would be great idea to check this in the `before_all` step in our build process. 

We can use this action 

` check_swift_version(version: "Apple Swift version 3.0.2")`

You can replace with your version. Check yours using 
` swift -version` 



