### PR TITLE
Version bump to 2.36.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.35.1'.freeze
+  VERSION = '2.36.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.35.1':**

* Fixed scan results for schemes that contain spaces (#9322) via NachoSoto
* [pilot] Show number of testers on top of table (#9323) via Felix Krause
* Allow for 1% rollouts in supply command (#9296) via Pan Thomakos
* Explicitly crash when the plist cant be parsed for provisioning profile data (#9319) via David Ohayon
* List produce enable_services options in config item (deprecating enabled_features) (#9223) via Josh Holtz
* Fix supply uploading screenshot html (#9297) via Josh Holtz
* Don't log metrics for failures in custom actions and plugins (#9295) via David Ohayon
* Update license copyright to "the fastlane authors" (#9274) via Alex Singer
* Fix encoding error in update_url_schemes fastlane action (#9302) via Jochen Pfeiffer
* uninitialized constant Spaceship::Client::ITunesConnectError fix (#9308) via Murat Çorlu
* Fix scan’s custom report name not working with multiple output types (#9303) via Lyndsey Ferguson
* Don't report crashes from plugins (#9277) via David Ohayon
* Remove version badges from individual tools from pre-mono-gem times (#9255) via Felix Krause
