### PR TITLE
Add a retry option on getting builds for a train

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -30,7 +30,7 @@ module FastlaneCore
       end
 
       def matching_build(watched_build: nil, app_id: nil, platform: nil)
-        matched_builds = Spaceship::TestFlight::Build.builds_for_train(app_id: app_id, platform: platform, train_version: watched_build.train_version)
+        matched_builds = Spaceship::TestFlight::Build.builds_for_train(app_id: app_id, platform: platform, train_version: watched_build.train_version, retry_count: 2)
         matched_builds.find { |build| build.build_version == watched_build.build_version }
       end
 

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -514,7 +514,11 @@ module Spaceship
 
     def with_retry(tries = 5, &_block)
       return yield
-    rescue Faraday::Error::ConnectionFailed, Faraday::Error::TimeoutError, AppleTimeoutError => ex # New Faraday version: Faraday::TimeoutError => ex
+    rescue \
+        Faraday::Error::ConnectionFailed,
+        Faraday::Error::TimeoutError,
+        AppleTimeoutError,
+        InternalServerError => ex # New Faraday version: Faraday::TimeoutError => ex
       tries -= 1
       unless tries.zero?
         logger.warn("Timeout received: '#{ex.message}'. Retrying after 3 seconds (remaining: #{tries})...")

--- a/spaceship/lib/spaceship/test_flight/build.rb
+++ b/spaceship/lib/spaceship/test_flight/build.rb
@@ -86,10 +86,8 @@ module Spaceship::TestFlight
     end
 
     def self.builds_for_train(app_id: nil, platform: nil, train_version: nil, retry_count: 0)
-      client.with_retry(retry_count) do
-        builds_data = client.get_builds_for_train(app_id: app_id, platform: platform, train_version: train_version)
-        builds_data.map { |data| self.new(data) }
-      end
+      builds_data = client.get_builds_for_train(app_id: app_id, platform: platform, train_version: train_version, retry_count: retry_count)
+      builds_data.map { |data| self.new(data) }
     end
 
     # Just the builds, as a flat array, that are still processing

--- a/spaceship/lib/spaceship/test_flight/build.rb
+++ b/spaceship/lib/spaceship/test_flight/build.rb
@@ -85,9 +85,11 @@ module Spaceship::TestFlight
       trains.values.flatten
     end
 
-    def self.builds_for_train(app_id: nil, platform: nil, train_version: nil)
-      builds_data = client.get_builds_for_train(app_id: app_id, platform: platform, train_version: train_version)
-      builds_data.map { |data| self.new(data) }
+    def self.builds_for_train(app_id: nil, platform: nil, train_version: nil, retry_count: 0)
+      client.with_retry(retry_count) do
+        builds_data = client.get_builds_for_train(app_id: app_id, platform: platform, train_version: train_version)
+        builds_data.map { |data| self.new(data) }
+      end
     end
 
     # Just the builds, as a flat array, that are still processing

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -27,11 +27,12 @@ module Spaceship::TestFlight
       handle_response(response)
     end
 
-    def get_builds_for_train(app_id: nil, platform: "ios", train_version: nil)
+    def get_builds_for_train(app_id: nil, platform: "ios", train_version: nil, retry_count: 0)
       assert_required_params(__method__, binding)
-
-      response = request(:get, "providers/#{team_id}/apps/#{app_id}/platforms/#{platform}/trains/#{train_version}/builds")
-      handle_response(response)
+      with_retry(retry_count: retry_count) do
+        response = request(:get, "providers/#{team_id}/apps/#{app_id}/platforms/#{platform}/trains/#{train_version}/builds")
+        handle_response(response)
+      end
     end
 
     ##

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -190,6 +190,8 @@ module Spaceship::TestFlight
         return
       end
 
+      raise InternalServerError, "Server error got #{response.status}" if (500...600).cover?(response.status)
+
       unless response.body.kind_of?(Hash)
         raise UnexpectedResponse, response.body
       end

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -47,10 +47,17 @@ describe Spaceship::TestFlight::Client do
     end
 
     it 'raises an exception on a HTTP error' do
-      response = double('Response', body: '<html>Server Error</html>', status: 500)
+      response = double('Response', body: '<html>Server Error</html>', status: 400)
       expect do
         subject.handle_response(response)
       end.to raise_error(Spaceship::Client::UnexpectedResponse)
+    end
+
+    it 'raises an InternalServerError exception on a HTTP 500 error' do
+      response = double('Response', body: '<html>Server Error</html>', status: 500)
+      expect do
+        subject.handle_response(response)
+      end.to raise_error(Spaceship::Client::InternalServerError)
     end
   end
 


### PR DESCRIPTION
Sometimes intermittent 502s happen while the build watcher is waiting for the build to finish processing and show up in the list of available builds. We shouldnt fail the build watching process for that, we should just try again a couple of times to continue to wait for the build

I tested this locally but can't fudge a 500 in the middle of the waiting process, so assuming no 500's come in, this will continue to work as it always has.