### PR TITLE
Improve Deliver languages with config option and other QoL improvements

### DIFF
--- a/deliver/README.md
+++ b/deliver/README.md
@@ -195,7 +195,11 @@ no, en-US, en-CA, fi, ru, zh-Hans, nl-NL, zh-Hant, en-AU, id, de-DE, sv, ko, ms,
 
 Deliver has a special `default` language code which allows you to provide values that are not localised, and which will be used as defaults when you don’t provide a specific localised value.
 
-You can use this either in json within your deliverfile, or as a folder in your metadata file.
+In order to use `default`, you will need tell `deliver` which languages your app all uses. You can do this in either of two ways:
+1. Create the folders named with the language in the metadata folder
+2. Add the following to your deliverfile `languages(['en-US','de-DE'])` 
+
+You can use this either in json within your deliverfile, or as a folder in your metadata folder.
 
 Imagine that you have localised data for the following language codes:  ```en-US, de-DE, el, it```
 

--- a/deliver/README.md
+++ b/deliver/README.md
@@ -195,7 +195,7 @@ no, en-US, en-CA, fi, ru, zh-Hans, nl-NL, zh-Hant, en-AU, id, de-DE, sv, ko, ms,
 
 Deliver has a special `default` language code which allows you to provide values that are not localised, and which will be used as defaults when you don’t provide a specific localised value.
 
-In order to use `default`, you will need to tell `deliver` which languages your app all uses. You can do this in either of two ways:
+In order to use `default`, you will need to tell `deliver` which languages your app uses. You can do this in either of two ways:
 1. Create the folders named with the language in the metadata folder (i.e. fastlane/metadata/en-US or fastlane/metadata/de-DE)
 2. Add the following to your `Deliverfile` `languages(['en-US','de-DE'])` 
 

--- a/deliver/README.md
+++ b/deliver/README.md
@@ -199,11 +199,11 @@ In order to use `default`, you will need tell `deliver` which languages your app
 1. Create the folders named with the language in the metadata folder
 2. Add the following to your deliverfile `languages(['en-US','de-DE'])` 
 
-You can use this either in json within your deliverfile, or as a folder in your metadata folder.
+You can use this either in json within your `Deliverfile` and/or as folders in your metadata folder. `deliver` will take the union of both language sets from the `Deliverfile` and from the metadata folder and create on single set of languages which will be enabled.
 
 Imagine that you have localised data for the following language codes:  ```en-US, de-DE, el, it```
 
-You can set the following in your deliverfile
+You can set the following in your `Deliverfile`
 
 ```ruby
 release_notes({

--- a/deliver/README.md
+++ b/deliver/README.md
@@ -195,9 +195,9 @@ no, en-US, en-CA, fi, ru, zh-Hans, nl-NL, zh-Hant, en-AU, id, de-DE, sv, ko, ms,
 
 Deliver has a special `default` language code which allows you to provide values that are not localised, and which will be used as defaults when you don’t provide a specific localised value.
 
-In order to use `default`, you will need tell `deliver` which languages your app all uses. You can do this in either of two ways:
-1. Create the folders named with the language in the metadata folder
-2. Add the following to your deliverfile `languages(['en-US','de-DE'])` 
+In order to use `default`, you will need to tell `deliver` which languages your app all uses. You can do this in either of two ways:
+1. Create the folders named with the language in the metadata folder (i.e. fastlane/metadata/en-US or fastlane/metadata/de-DE)
+2. Add the following to your `Deliverfile` `languages(['en-US','de-DE'])` 
 
 You can use this either in json within your `Deliverfile` and/or as folders in your metadata folder. `deliver` will take the union of both language sets from the `Deliverfile` and from the metadata folder and create on single set of languages which will be enabled.
 

--- a/deliver/lib/deliver/detect_values.rb
+++ b/deliver/lib/deliver/detect_values.rb
@@ -7,6 +7,8 @@ module Deliver
       find_folders(options)
       ensure_folders_created(options)
       find_version(options) unless skip_params[:skip_version]
+      
+      verify_languages!(options)
     end
 
     def find_app_identifier(options)
@@ -65,6 +67,18 @@ module Deliver
         options[:platform] ||= FastlaneCore::IpaFileAnalyser.fetch_app_platform(options[:ipa])
       elsif options[:pkg]
         options[:platform] = 'osx'
+      end
+    end
+    
+    def verify_languages!(options)
+      languages = options[:languages]
+      return unless languages
+      
+      all_languages = Spaceship::Tunes.client.available_languages
+      diff = languages - all_languages
+       
+      unless diff.empty?
+        UI.user_error!("The following languages are invalid and cannot be activated: #{diff.join(',')}\n\nValid languages are: #{all_languages}")
       end
     end
   end

--- a/deliver/lib/deliver/detect_values.rb
+++ b/deliver/lib/deliver/detect_values.rb
@@ -7,7 +7,7 @@ module Deliver
       find_folders(options)
       ensure_folders_created(options)
       find_version(options) unless skip_params[:skip_version]
-      
+
       verify_languages!(options)
     end
 
@@ -69,14 +69,14 @@ module Deliver
         options[:platform] = 'osx'
       end
     end
-    
+
     def verify_languages!(options)
       languages = options[:languages]
       return unless languages
-      
+
       all_languages = Spaceship::Tunes.client.available_languages
       diff = languages - all_languages
-       
+
       unless diff.empty?
         UI.user_error!("The following languages are invalid and cannot be activated: #{diff.join(',')}\n\nValid languages are: #{all_languages}")
       end

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -316,7 +316,7 @@ module Deliver
                                      optional: true,
                                      verify_block: proc do |languages|
                                        diff = languages - FastlaneCore::Languages::ALL_LANGUAGES
-                                       
+
                                        unless diff.empty?
                                          UI.user_error!("the following languages are not valid: #{diff.join(',')}")
                                        end

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -309,7 +309,17 @@ module Deliver
         FastlaneCore::ConfigItem.new(key: :marketing_url,
                                      description: "Metadata: Localised marketing url",
                                      optional: true,
-                                     is_string: false)
+                                     is_string: false),
+        FastlaneCore::ConfigItem.new(key: :languages,
+                                     description: "Metadata: List of languages to activate",
+                                     type: Array,
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       value.each do |language|
+                                         is_valid_language = FastlaneCore::Languages::ALL_LANGUAGES.include?(language)
+                                         UI.user_error!(":languages was given an invalid lanuage - #{language}") unless is_valid_language
+                                       end
+                                     end)
       ]
     end
   end

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -284,7 +284,7 @@ module Deliver
                                          keywords = keywords.join(", ") if keywords.kind_of?(Array)
                                          value[language] = keywords
 
-                                         UI.user_error!(":keywords must be a hash with all values being strings") unless keywords.kind_of?(String)
+                                         UI.user_error!("keywords must be a hash with all values being strings") unless keywords.kind_of?(String)
                                        end
                                      end),
         FastlaneCore::ConfigItem.new(key: :promotional_text,
@@ -314,10 +314,11 @@ module Deliver
                                      description: "Metadata: List of languages to activate",
                                      type: Array,
                                      optional: true,
-                                     verify_block: proc do |value|
-                                       value.each do |language|
-                                         is_valid_language = FastlaneCore::Languages::ALL_LANGUAGES.include?(language)
-                                         UI.user_error!(":languages was given an invalid lanuage - #{language}") unless is_valid_language
+                                     verify_block: proc do |languages|
+                                       diff = languages - FastlaneCore::Languages::ALL_LANGUAGES
+                                       
+                                       unless diff.empty?
+                                         UI.user_error!("the following languages are not valid: #{diff.join(',')}")
                                        end
                                      end)
       ]

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -310,16 +310,12 @@ module Deliver
                                      description: "Metadata: Localised marketing url",
                                      optional: true,
                                      is_string: false),
+        # The verify_block has been removed from here and verification now happens in Deliver::DetectValues
+        # Verification needed Spaceship::Tunes.client which required the Deliver::Runner to already by started
         FastlaneCore::ConfigItem.new(key: :languages,
                                      description: "Metadata: List of languages to activate",
                                      type: Array,
-                                     optional: true,
-                                     verify_block: proc do |languages|
-                                       diff = languages - FastlaneCore::Languages::ALL_LANGUAGES
-
-                                       unless diff.empty?
-                                         UI.user_error!("the following languages are not valid: #{diff.join(',')}")
-                                       end
+                                     optional: true
                                      end)
       ]
     end

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -315,8 +315,7 @@ module Deliver
         FastlaneCore::ConfigItem.new(key: :languages,
                                      description: "Metadata: List of languages to activate",
                                      type: Array,
-                                     optional: true
-                                     end)
+                                     optional: true)
       ]
     end
   end

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -87,15 +87,15 @@ module Deliver
 
     # Upload all metadata, screenshots, pricing information, etc. to iTunes Connect
     def upload_metadata
+      upload_metadata = UploadMetadata.new
+      upload_screenshots = UploadScreenshots.new
+      
       # First, collect all the things for the HTML Report
       screenshots = UploadScreenshots.new.collect_screenshots(options)
-      UploadMetadata.new.load_from_filesystem(options)
-
-      # Normalizes languages keys from symbols to strings
-      UploadMetadata.new.normalize_language_key(options)
+      upload_metadata.load_from_filesystem(options)
 
       # Assign "default" values to all languages
-      UploadMetadata.new.assign_defaults(options)
+      upload_metadata.assign_defaults(options)
 
       # Handle app icon / watch icon
       prepare_app_icons(options)
@@ -104,7 +104,7 @@ module Deliver
       validate_html(screenshots)
 
       # Commit
-      UploadMetadata.new.upload(options)
+      upload_metadata.upload(options)
       UploadScreenshots.new.upload(options, screenshots)
       UploadPriceTier.new.upload(options)
       UploadAssets.new.upload(options) # e.g. app icon

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -8,7 +8,7 @@ module Deliver
       self.options = options
 
       login
-      
+
       Deliver::DetectValues.new.run!(self.options, skip_auto_detection)
       FastlaneCore::PrintTable.print_values(config: options, hide_keys: [:app], mask_keys: ['app_review_information.demo_password'], title: "deliver #{Fastlane::VERSION} Summary")
     end

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -91,7 +91,7 @@ module Deliver
       upload_screenshots = UploadScreenshots.new
 
       # First, collect all the things for the HTML Report
-      screenshots = UploadScreenshots.new.collect_screenshots(options)
+      screenshots = upload_screenshots.collect_screenshots(options)
       upload_metadata.load_from_filesystem(options)
 
       # Assign "default" values to all languages
@@ -105,7 +105,7 @@ module Deliver
 
       # Commit
       upload_metadata.upload(options)
-      UploadScreenshots.new.upload(options, screenshots)
+      upload_screenshots.upload(options, screenshots)
       UploadPriceTier.new.upload(options)
       UploadAssets.new.upload(options) # e.g. app icon
     end

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -6,7 +6,7 @@ module Deliver
 
     def initialize(options, skip_auto_detection = {})
       self.options = options
-      
+
       login
       Deliver::DetectValues.new.run!(self.options, skip_auto_detection)
       FastlaneCore::PrintTable.print_values(config: options, hide_keys: [:app], mask_keys: ['app_review_information.demo_password'], title: "deliver #{Fastlane::VERSION} Summary")
@@ -90,10 +90,10 @@ module Deliver
       # First, collect all the things for the HTML Report
       screenshots = UploadScreenshots.new.collect_screenshots(options)
       UploadMetadata.new.load_from_filesystem(options)
-      
+
       # Normalizes languages keys from symbols to strings
       UploadMetadata.new.normalize_language_key(options)
-      
+
       # Assign "default" values to all languages
       UploadMetadata.new.assign_defaults(options)
 

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -89,7 +89,7 @@ module Deliver
     def upload_metadata
       upload_metadata = UploadMetadata.new
       upload_screenshots = UploadScreenshots.new
-      
+
       # First, collect all the things for the HTML Report
       screenshots = UploadScreenshots.new.collect_screenshots(options)
       upload_metadata.load_from_filesystem(options)

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -8,6 +8,7 @@ module Deliver
       self.options = options
 
       login
+      
       Deliver::DetectValues.new.run!(self.options, skip_auto_detection)
       FastlaneCore::PrintTable.print_values(config: options, hide_keys: [:app], mask_keys: ['app_review_information.demo_password'], title: "deliver #{Fastlane::VERSION} Summary")
     end

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -6,6 +6,7 @@ module Deliver
 
     def initialize(options, skip_auto_detection = {})
       self.options = options
+      
       login
       Deliver::DetectValues.new.run!(self.options, skip_auto_detection)
       FastlaneCore::PrintTable.print_values(config: options, hide_keys: [:app], mask_keys: ['app_review_information.demo_password'], title: "deliver #{Fastlane::VERSION} Summary")
@@ -89,6 +90,11 @@ module Deliver
       # First, collect all the things for the HTML Report
       screenshots = UploadScreenshots.new.collect_screenshots(options)
       UploadMetadata.new.load_from_filesystem(options)
+      
+      # Normalizes languages keys from symbols to strings
+      UploadMetadata.new.normalize_language_key(options)
+      
+      # Assign "default" values to all languages
       UploadMetadata.new.assign_defaults(options)
 
       # Handle app icon / watch icon

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -96,7 +96,7 @@ module Deliver
           UI.error("Error with provided '#{key}'. Must be a hash, the key being the language.")
           next
         end
-        
+
         current.each do |language, value|
           next unless value.to_s.length > 0
           strip_value = value.to_s.strip
@@ -135,7 +135,7 @@ module Deliver
         end
       end
     end
-    
+
     # Normalizes languages keys from symbols to strings
     def normalize_language_key(options)
       (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES).each do |key|
@@ -146,7 +146,7 @@ module Deliver
           current[key.to_s] = current.delete(key)
         end
       end
-      
+
       options
     end
 
@@ -173,7 +173,7 @@ module Deliver
         language = File.basename(lng_folder)
         enabled_languages << language unless enabled_languages.include?(language)
       end
-      
+
       enabled_languages.uniq!
 
       return unless enabled_languages.include?("default")
@@ -215,7 +215,7 @@ module Deliver
           enabled_languages << language unless enabled_languages.include?(language)
         end
       end
-      
+
       # Reject "default" language from getting enabled
       enabled_languages = enabled_languages.reject! do |lang|
         lang == "default"

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -194,10 +194,10 @@ module Deliver
       end
 
       # Check folder list (an empty folder signifies a language is required)
-      Loader.language_folders(options[:metadata_path]).each do |lng_folder|
-        next unless File.directory?(lng_folder) # We don't want to read txt as they are non localised
+      Loader.language_folders(options[:metadata_path]).each do |lang_folder|
+        next unless File.directory?(lang_folder) # We don't want to read txt as they are non localised
 
-        language = File.basename(lng_folder)
+        language = File.basename(lang_folder)
         enabled_languages << language unless enabled_languages.include?(language)
       end
 
@@ -227,9 +227,9 @@ module Deliver
       end
 
       # Reject "default" language from getting enabled
-      enabled_languages = enabled_languages.reject! do |lang|
+      enabled_languages.reject! do |lang|
         lang == "default"
-      end.uniq
+      end.uniq!
 
       if enabled_languages.count > 0
         v.create_languages(enabled_languages)
@@ -246,10 +246,10 @@ module Deliver
       return if options[:skip_metadata]
 
       # Load localised data
-      Loader.language_folders(options[:metadata_path]).each do |lng_folder|
-        language = File.basename(lng_folder)
+      Loader.language_folders(options[:metadata_path]).each do |lang_folder|
+        language = File.basename(lang_folder)
         (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES).each do |key|
-          path = File.join(lng_folder, "#{key}.txt")
+          path = File.join(lang_folder, "#{key}.txt")
           next unless File.exist?(path)
 
           UI.message("Loading '#{path}'...")
@@ -291,6 +291,20 @@ module Deliver
     end
 
     private
+    
+    # Normalizes languages keys from symbols to strings
+    def normalize_language_key(options)
+      (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES).each do |key|
+        current = options[key]
+        next unless current && current.kind_of?(Hash)
+
+        current.keys.each do |language|
+          current[language.to_s] = current.delete(language)
+        end
+      end
+
+      options
+    end
 
     def set_trade_representative_contact_information(v, options)
       return unless options[:trade_representative_contact_information]

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -142,8 +142,8 @@ module Deliver
         current = options[key]
         next unless current && current.kind_of?(Hash)
 
-        current.keys.each do |key|
-          current[key.to_s] = current.delete(key)
+        current.keys.each do |language|
+          current[language.to_s] = current.delete(language)
         end
       end
 

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -155,26 +155,7 @@ module Deliver
     # If the user is using the 'default' language, then assign values where they are needed
     def assign_defaults(options)
       # Build a complete list of the required languages
-      enabled_languages = options[:languages] || []
-
-      # Get all languages used in existing settings
-      (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES).each do |key|
-        current = options[key]
-        next unless current && current.kind_of?(Hash)
-        current.each do |language, value|
-          enabled_languages << language unless enabled_languages.include?(language)
-        end
-      end
-
-      # Check folder list (an empty folder signifies a language is required)
-      Loader.language_folders(options[:metadata_path]).each do |lng_folder|
-        next unless File.directory?(lng_folder) # We don't want to read txt as they are non localised
-
-        language = File.basename(lng_folder)
-        enabled_languages << language unless enabled_languages.include?(language)
-      end
-
-      enabled_languages.uniq!
+      enabled_languages = detect_languages(options)
 
       return unless enabled_languages.include?("default")
       UI.message("Detected languages: " + enabled_languages.to_s)
@@ -194,6 +175,32 @@ module Deliver
         end
         current.delete("default")
       end
+    end
+    
+    def detect_languages(options)
+      # Build a complete list of the required languages
+      enabled_languages = options[:languages] || []
+
+      # Get all languages used in existing settings
+      (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES).each do |key|
+        current = options[key]
+        next unless current && current.kind_of?(Hash)
+        current.each do |language, value|
+          enabled_languages << language unless enabled_languages.include?(language)
+        end
+      end
+
+      # Check folder list (an empty folder signifies a language is required)
+      Loader.language_folders(options[:metadata_path]).each do |lng_folder|
+        next unless File.directory?(lng_folder) # We don't want to read txt as they are non localised
+
+        language = File.basename(lng_folder)
+        enabled_languages << language unless enabled_languages.include?(language)
+      end
+
+      enabled_languages
+        .map { |s| s.to_s }
+        .uniq
     end
 
     # Makes sure all languages we need are actually created

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -216,9 +216,9 @@ module Deliver
         end
       end
       
-      # Replace :default symbol with "default" string
+      # Reject "default" language from getting enabled
       enabled_languages = enabled_languages.reject! do |lang|
-        lang == :default || lang == "default"
+        lang == "default"
       end.uniq
 
       if enabled_languages.count > 0

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -291,7 +291,7 @@ module Deliver
     end
 
     private
-    
+
     # Normalizes languages keys from symbols to strings
     def normalize_language_key(options)
       (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES).each do |key|

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -159,6 +159,11 @@ module Deliver
         language = File.basename(lng_folder)
         enabled_languages << language unless enabled_languages.include?(language)
       end
+      
+      # Replace :default symbol with "default" string
+      enabled_languages.map do |lang|
+        lang == :default ? "default" : lang
+      end
 
       return unless enabled_languages.include?("default")
       UI.message("Detected languages: " + enabled_languages.to_s)
@@ -198,6 +203,11 @@ module Deliver
           language = language.to_s
           enabled_languages << language unless enabled_languages.include?(language)
         end
+      end
+      
+      # Replace :default symbol with "default" string
+      enabled_languages.reject! do |lang|
+        lang == :default || lang == "default"
       end
 
       if enabled_languages.count > 0

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -154,6 +154,9 @@ module Deliver
 
     # If the user is using the 'default' language, then assign values where they are needed
     def assign_defaults(options)
+      # Normalizes languages keys from symbols to strings
+      normalize_language_key(options)
+
       # Build a complete list of the required languages
       enabled_languages = detect_languages(options)
 
@@ -176,7 +179,7 @@ module Deliver
         current.delete("default")
       end
     end
-    
+
     def detect_languages(options)
       # Build a complete list of the required languages
       enabled_languages = options[:languages] || []
@@ -199,7 +202,7 @@ module Deliver
       end
 
       enabled_languages
-        .map { |s| s.to_s }
+        .map(&:to_s)
         .uniq
     end
 

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -136,26 +136,12 @@ module Deliver
       end
     end
 
-    # Normalizes languages keys from symbols to strings
-    def normalize_language_key(options)
-      (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES).each do |key|
-        current = options[key]
-        next unless current && current.kind_of?(Hash)
-
-        current.keys.each do |language|
-          current[language.to_s] = current.delete(language)
-        end
-      end
-
-      options
-    end
-
     # rubocop:enable Metrics/PerceivedComplexity
 
     # If the user is using the 'default' language, then assign values where they are needed
     def assign_defaults(options)
       # Normalizes languages keys from symbols to strings
-      normalize_language_key(options)
+      normalize_language_keys(options)
 
       # Build a complete list of the required languages
       enabled_languages = detect_languages(options)
@@ -201,6 +187,7 @@ module Deliver
         enabled_languages << language unless enabled_languages.include?(language)
       end
 
+      # Mapping to strings because :default symbol can be passed in
       enabled_languages
         .map(&:to_s)
         .uniq
@@ -227,9 +214,10 @@ module Deliver
       end
 
       # Reject "default" language from getting enabled
-      enabled_languages.reject! do |lang|
+      # because "default" is not an iTC language
+      enabled_languages = enabled_languages.reject do |lang|
         lang == "default"
-      end.uniq!
+      end.uniq
 
       if enabled_languages.count > 0
         v.create_languages(enabled_languages)
@@ -293,7 +281,7 @@ module Deliver
     private
 
     # Normalizes languages keys from symbols to strings
-    def normalize_language_key(options)
+    def normalize_language_keys(options)
       (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES).each do |key|
         current = options[key]
         next unless current && current.kind_of?(Hash)

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -171,9 +171,6 @@ describe Deliver::UploadMetadata do
   end
 
   describe "#languages" do
-    # LOCALISED_VERSION_VALUES = [:description, :keywords, :release_notes, :support_url, :marketing_url]
-    # LOCALISED_APP_VALUES = [:name, :privacy_url]
-
     let(:options) { { metadata_path: tmpdir } }
 
     def create_metadata(path, text)

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -169,102 +169,102 @@ describe Deliver::UploadMetadata do
       end
     end
   end
-  
+
   describe "#languages" do
     # LOCALISED_VERSION_VALUES = [:description, :keywords, :release_notes, :support_url, :marketing_url]
     # LOCALISED_APP_VALUES = [:name, :privacy_url]
-    
+
     let(:options) { { metadata_path: tmpdir } }
-    
+
     def create_metadata(path, text)
       File.open(File.join(path), 'w') do |f|
         f.write(text)
       end
     end
-    
+
     def create_filesystem_language(name)
       require 'fileutils'
-      FileUtils::mkdir_p "#{tmpdir}/#{name}"
+      FileUtils.mkdir_p "#{tmpdir}/#{name}"
     end
-    
+
     context "detected languages with only file system" do
       it "languages are 'de-DE', 'el', 'en-US'" do
         options[:languages] = []
-        
+
         create_filesystem_language('en-US')
         create_filesystem_language('de-DE')
         create_filesystem_language('el')
-        
+
         uploader.load_from_filesystem(options)
         languages = uploader.detect_languages(options)
-        
+
         expect(languages.sort).to eql(['de-DE', 'el', 'en-US'])
       end
     end
-    
+
     context "detected languages with only config options" do
       it "languages are 'en-AU', 'en-CA', 'en-GB'" do
         options[:languages] = ['en-AU', 'en-CA', 'en-GB']
-        
+
         uploader.load_from_filesystem(options)
         languages = uploader.detect_languages(options)
-        
+
         expect(languages.sort).to eql(['en-AU', 'en-CA', 'en-GB'])
       end
     end
-    
+
     context "detected languages with only release notes" do
       it "languages are 'default', 'es-MX'" do
         options[:languages] = []
-        
+
         options[:release_notes] = {
-          'default': 'something',
-          'es-MX': 'something else'
+          'default' => 'something',
+          'es-MX' => 'something else'
         }
-        
+
         uploader.load_from_filesystem(options)
         languages = uploader.detect_languages(options)
-        
+
         expect(languages.sort).to eql(['default', 'es-MX'])
       end
     end
-    
+
     context "detected languages with both file system and config options and release notes" do
       it "languages are 'de-DE', 'default', 'el', 'en-AU', 'en-CA', 'en-GB', 'en-US', 'es-MX'" do
         options[:languages] = ['en-AU', 'en-CA', 'en-GB']
         options[:release_notes] = {
-          'default': 'something',
-          'en-US': 'something else',
-          'es-MX': 'something else else'
+          'default' => 'something',
+          'en-US' => 'something else',
+          'es-MX' => 'something else else'
         }
-        
+
         create_filesystem_language('en-US')
         create_filesystem_language('de-DE')
         create_filesystem_language('el')
-        
+
         uploader.load_from_filesystem(options)
         languages = uploader.detect_languages(options)
-        
+
         expect(languages.sort).to eql(['de-DE', 'default', 'el', 'en-AU', 'en-CA', 'en-GB', 'en-US', 'es-MX'])
       end
     end
-    
+
     context "with localized version values for release notes" do
       it "default value set for unspecified languages" do
         options[:languages] = ['en-AU', 'en-CA', 'en-GB']
         options[:release_notes] = {
-          'default': 'something',
-          'en-US': 'something else',
-          'es-MX': 'something else else'
+          'default' => 'something',
+          'en-US' => 'something else',
+          'es-MX' => 'something else else'
         }
-        
+
         create_filesystem_language('en-US')
         create_filesystem_language('de-DE')
         create_filesystem_language('el')
-        
+
         uploader.load_from_filesystem(options)
         uploader.assign_defaults(options)
-        
+
         expect(options[:release_notes]["en-US"]).to eql('something else')
         expect(options[:release_notes]["es-MX"]).to eql('something else else')
         expect(options[:release_notes]["en-AU"]).to eql('something')

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -169,4 +169,92 @@ describe Deliver::UploadMetadata do
       end
     end
   end
+  
+  describe "#languages" do
+    # LOCALISED_VERSION_VALUES = [:description, :keywords, :release_notes, :support_url, :marketing_url]
+    # LOCALISED_APP_VALUES = [:name, :privacy_url]
+    
+    let(:options) { { metadata_path: tmpdir } }
+    
+    def create_metadata(path, text)
+      File.open(File.join(path), 'w') do |f|
+        f.write(text)
+      end
+    end
+    
+    def create_filesystem_language(name)
+      require 'fileutils'
+      FileUtils::mkdir_p "#{tmpdir}/#{name}"
+    end
+    
+    context "detected languages with only file system" do
+      it "languages are 'de-DE', 'el', 'en-US'" do
+        options[:languages] = []
+        
+        create_filesystem_language('en-US')
+        create_filesystem_language('de-DE')
+        create_filesystem_language('el')
+        
+        uploader.load_from_filesystem(options)
+        languages = uploader.detect_languages(options)
+        
+        expect(languages.sort).to eql(['de-DE', 'el', 'en-US'])
+      end
+    end
+    
+    context "detected languages with only config options" do
+      it "languages are 'en-AU', 'en-CA', 'en-GB'" do
+        options[:languages] = ['en-AU', 'en-CA', 'en-GB']
+        
+        uploader.load_from_filesystem(options)
+        languages = uploader.detect_languages(options)
+        
+        expect(languages.sort).to eql(['en-AU', 'en-CA', 'en-GB'])
+      end
+    end
+    
+    context "detected languages with only release notes" do
+      it "languages are 'default', 'es-MX'" do
+        options[:languages] = []
+        
+        options[:release_notes] = {
+          'default': 'something',
+          'es-MX': 'something else'
+        }
+        
+        uploader.load_from_filesystem(options)
+        languages = uploader.detect_languages(options)
+        
+        expect(languages.sort).to eql(['default', 'es-MX'])
+      end
+    end
+    
+    context "detected languages with both file system and config options and release notes" do
+      it "languages are 'de-DE', 'default', 'el', 'en-AU', 'en-CA', 'en-GB', 'en-US', 'es-MX'" do
+        options[:languages] = ['en-AU', 'en-CA', 'en-GB']
+        options[:release_notes] = {
+          'default': 'something',
+          'en-US': 'something else',
+          'es-MX': 'something else else'
+        }
+        
+        create_filesystem_language('en-US')
+        create_filesystem_language('de-DE')
+        create_filesystem_language('el')
+        
+        uploader.load_from_filesystem(options)
+        languages = uploader.detect_languages(options)
+        
+        expect(languages.sort).to eql(['de-DE', 'default', 'el', 'en-AU', 'en-CA', 'en-GB', 'en-US', 'es-MX'])
+      end
+    end
+    
+    context "with localized version values" do
+      
+    end
+    
+    context "with localized app values" do
+      
+    end
+  end
 end

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -249,12 +249,30 @@ describe Deliver::UploadMetadata do
       end
     end
     
-    context "with localized version values" do
-      
-    end
-    
-    context "with localized app values" do
-      
+    context "with localized version values for release notes" do
+      it "default value set for unspecified languages" do
+        options[:languages] = ['en-AU', 'en-CA', 'en-GB']
+        options[:release_notes] = {
+          'default': 'something',
+          'en-US': 'something else',
+          'es-MX': 'something else else'
+        }
+        
+        create_filesystem_language('en-US')
+        create_filesystem_language('de-DE')
+        create_filesystem_language('el')
+        
+        uploader.load_from_filesystem(options)
+        uploader.assign_defaults(options)
+        
+        expect(options[:release_notes]["en-US"]).to eql('something else')
+        expect(options[:release_notes]["es-MX"]).to eql('something else else')
+        expect(options[:release_notes]["en-AU"]).to eql('something')
+        expect(options[:release_notes]["en-CA"]).to eql('something')
+        expect(options[:release_notes]["en-GB"]).to eql('something')
+        expect(options[:release_notes]["de-DE"]).to eql('something')
+        expect(options[:release_notes]["el"]).to eql('something')
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #9327

### Problem
- Deliver was basing languages off of file system structure
  - In example below it would activate `en-US` and `de-DE`
  - Not everyone uses this kind of file structure and its not great for dynamic setups
    - Would be ideal to define the languages in code
- Also found a deliver bug when the language keys in a `Deliverfile` were passed in as symbols instead of strings

```
- fastlane
  - Fastfile
  - metadata
    - en-US
      - .gitkeep
    - de-DE
      - .gitkeep
```

### Solution
- New `languages` config option to work with the existing file structure way of getting all languages to activate
- Runs a "normalization" method on the options to convert language symbols to string (see examples below of what wouldn't work but now works
  - In that example, `default` and `el` would fail because they get convert to symbols when `deliver` expects those to be strings
  - As a ruby developer, I naturally want to do everything with `:` so it makes sense to normalize the data into strings

#### Deliverfile
```rb
languages(["ex-MX", "en-CA"])
release_notes({
  'default': "the default",
  'el': "heeyyyy el",
  'en-AU' => "doot doot",
  'en-US' => "en bug fixes",
  'de-DE' => "german bug fix",
})
```

#### Output when error
```sh
[!] The following languages are invalid and cannot be activated: pizza

Valid languages are: ["en-CA", "fr-CA", "en-US", "es-MX", "en-GB", "de-DE", "fr-FR", "nl-NL", "el", "tr", "da", "fi", "it", "no", "pt-PT", "ru", "es-ES", "sv", "en-AU", "zh-Hans", "zh-Hant", "id", "ja", "ko", "ms", "th", "vi", "pt-BR"]
```