### PR TITLE
Enable Resign With Multiple Bundle IDs

### DIFF
--- a/fastlane/lib/fastlane/actions/resign.rb
+++ b/fastlane/lib/fastlane/actions/resign.rb
@@ -112,8 +112,15 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :bundle_id,
                                        env_name: "FL_RESIGN_BUNDLE_ID",
                                        description: "Set new bundle ID during resign (CFBundleIdentifier)",
-                                       is_string: true,
-                                       optional: true),
+                                       is_string: false,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         files = case value
+                                                 when Hash then value.values
+                                                 when Enumerable then value
+                                                 else [value]
+                                                 end
+                                               end),
           FastlaneCore::ConfigItem.new(key: :use_app_entitlements,
                                        env_name: "FL_USE_APP_ENTITLEMENTS",
                                        description: "Extract app bundle codesigning entitlements\nand combine with entitlements from new provisionin profile",

--- a/fastlane/lib/fastlane/actions/resign.rb
+++ b/fastlane/lib/fastlane/actions/resign.rb
@@ -115,12 +115,12 @@ module Fastlane
                                        is_string: false,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         files = case value
-                                                 when Hash then value.values
-                                                 when Enumerable then value
-                                                 else [value]
-                                                 end
-                                               end),
+                                         case value
+                                         when Hash then value.values
+                                         when Enumerable then value
+                                         else [value]
+                                         end
+                                       end),
           FastlaneCore::ConfigItem.new(key: :use_app_entitlements,
                                        env_name: "FL_USE_APP_ENTITLEMENTS",
                                        description: "Extract app bundle codesigning entitlements\nand combine with entitlements from new provisionin profile",

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -476,7 +476,6 @@ function add_new_bundle_id_for_old_bundle_id {
     fi
 
     NEW_BUNDLE_IDENTIFIERS_BY_OLD+=("$OLD_BUNDLE_ID=$NEW_BUNDLE_ID")
-    log "NEW_BUNDLE_IDENTIFIERS_BY_OLD ${NEW_BUNDLE_IDENTIFIERS_BY_OLD[@]}"
 }
 
 # Build list of old to new bundle ids 
@@ -485,6 +484,7 @@ function build_old_new_bundle_id {
     local APP_PATH="$1"
     local APP_NAME=$(basename "$APP_PATH")
     APP_NAME="${APP_NAME%.*}"
+    local NESTED="$2"
     local BUNDLE_IDENTIFIER=$(bundle_id_for_target "$APP_NAME")
 
     if [[ "$BUNDLE_IDENTIFIER" == "" && "$NESTED" != NESTED ]]; then
@@ -688,7 +688,6 @@ function resign {
         then
             # Found a reference bundle id, now get map to the new bundle id
             NEW_REF_BUNDLE_ID=$(new_bundle_id_for_old_bundle_id $OLD_REF_BUNDLE_ID)
-            log "OLD_REF_BUNDLE_ID=$OLD_REF_BUNDLE_ID, NEW_REF_BUNDLE_ID=$NEW_REF_BUNDLE_ID"
             # Change if not the same and if doesn't contain wildcard
             # shellcheck disable=SC2049
             if [[ "$OLD_REF_BUNDLE_ID" != "$NEW_REF_BUNDLE_ID" ]] && ! [[ "$NEW_REF_BUNDLE_ID" =~ \* ]] && [[ "$NEW_REF_BUNDLE_ID" != "" ]];
@@ -905,7 +904,7 @@ function resign {
 build_old_new_bundle_id "$TEMP_DIR/Payload/$APP_NAME"
 while IFS= read -d '' -r app;
 do
-    build_old_new_bundle_id "$app"
+    build_old_new_bundle_id "$app" NESTED
 done < <(find "$TEMP_DIR/Payload/$APP_NAME" -d -mindepth 1 \( -name "*.app" -or -name "*.appex" \) -print0)
 
 # Sign nested applications and app extensions

--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -95,7 +95,8 @@ module Sigh
         c.option '--short_version STRING', String, 'Short version string to force binary and all nested binaries to use (CFBundleShortVersionString).'
         c.option '--bundle_version STRING', String, 'Bundle version to force binary and all nested binaries to use (CFBundleVersion).'
         c.option '--use_app_entitlements', 'Extract app bundle codesigning entitlements and combine with entitlements from new provisionin profile.'
-        c.option '-g', '--new_bundle_id STRING', String, 'New application bundle ID (CFBundleIdentifier)'
+        c.option '-g', '--new_bundle_id STRING', String, 'New application bundle ID (CFBundleIdentifier)', 
+                 &multiple_values_option_proc(c, "bundle_id", &proc { |value| value.split('=', 2) })
         c.option '--keychain_path STRING', String, 'Path to the keychain that /usr/bin/codesign should use'
 
         c.action do |args, options|

--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -95,7 +95,7 @@ module Sigh
         c.option '--short_version STRING', String, 'Short version string to force binary and all nested binaries to use (CFBundleShortVersionString).'
         c.option '--bundle_version STRING', String, 'Bundle version to force binary and all nested binaries to use (CFBundleVersion).'
         c.option '--use_app_entitlements', 'Extract app bundle codesigning entitlements and combine with entitlements from new provisionin profile.'
-        c.option '-g', '--new_bundle_id STRING', String, 'New application bundle ID (CFBundleIdentifier)', 
+        c.option '-g', '--new_bundle_id STRING', String, 'New application bundle ID (CFBundleIdentifier)',
                  &multiple_values_option_proc(c, "bundle_id", &proc { |value| value.split('=', 2) })
         c.option '--keychain_path STRING', String, 'Path to the keychain that /usr/bin/codesign should use'
 

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -156,6 +156,7 @@ module Sigh
           new_app_id = app_name.shellescape
           "-b #{new_app_id}"
         else
+          ""
         end
       end.join(' ')
     end

--- a/sigh/spec/resign_spec.rb
+++ b/sigh/spec/resign_spec.rb
@@ -60,5 +60,21 @@ describe Sigh do
       actualresult = @resign.sha1_for_signing_identity(IDENTITY_1_SHA1)
       expect(actualresult).to eq(IDENTITY_1_SHA1)
     end
+
+    it "Create bundle_id options from hash" do
+      bundle_id_hash = {
+        "My App Name" => "at.fastlane",
+        "My App Ext Name" => "at.fastlane.today"
+      }
+      bundle_id_options = @resign.create_bundle_id_options(bundle_id_hash)
+      expect(bundle_id_options).to eq("-b My\\ App\\ Name=at.fastlane -b My\\ App\\ Ext\\ Name=at.fastlane.today")
+    end
+
+    it "Create bundle_id option from array" do
+      bundle_id = ["at.fastlane"]
+      bundle_id_options = @resign.create_bundle_id_options(bundle_id)
+      expect(bundle_id_options).to eq("-b at.fastlane")
+    end
+
   end
 end

--- a/sigh/spec/resign_spec.rb
+++ b/sigh/spec/resign_spec.rb
@@ -75,6 +75,5 @@ describe Sigh do
       bundle_id_options = @resign.create_bundle_id_options(bundle_id)
       expect(bundle_id_options).to eq("-b at.fastlane")
     end
-
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I have an app that includes multiple, nested apps. I need to resign the app and nested apps with multiple bundle ids to provided testing, QA, and third party validation builds. 

The ability to resign AND update these bundle ids and provisioning profiles reduces the complexity of the Xcode project (I only need 2 configurations) and reduces compile/ipa creation time by a 3rd (e.g. 60+ mins to <20 mins).
<!--- If it fixes an open issue, please link to the issue here. -->
This feature related with #9294 
<!--- Please describe in detail how you tested your changes. --->
I would like feedback on how to better test these changes. 
What I have so far is:
1. This PR adds 2 unit tests for the ruby action code.
2. Test shell scripts (not provided) were used to drive develop of the resign.sh script.
3. This fork was integrated with my app's build and used to compile and resign the app with different bundle ids and provisioning profiles.

### Description

Update the Resign Action to accept a Hash of nested app names (APP_PATH basename) to new bundle ids to allow updating all of the bundle ids within an app. This would work similarly to the current support for multiple provisioning profiles and support for the current bundle_id String would be maintained.

``` 
bundle_id_hash = {
  "My App Name" => "at.fastlane",
  "My App Ext Name" => "at.fastlane.today"
}
 ```

```
resign(
  ipa: newipa_path,
  signing_identity: identity,
  bundle_id: bundle_id_hash
  provisioning_profile: profiles_hash
)
```