### PR TITLE
Remove invalid gym xcpretty options verify blocks

### DIFF
--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -259,24 +259,15 @@ module Gym
         FastlaneCore::ConfigItem.new(key: :xcpretty_report_junit,
                                      env_name: "XCPRETTY_REPORT_JUNIT",
                                      description: "Have xcpretty create a JUnit-style XML report at the provided path",
-                                     optional: true,
-                                     verify_block: proc do |value|
-                                       UI.user_error!("Report output location not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
-                                     end),
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :xcpretty_report_html,
                                      env_name: "XCPRETTY_REPORT_HTML",
                                      description: "Have xcpretty create a simple HTML report at the provided path",
-                                     optional: true,
-                                     verify_block: proc do |value|
-                                       UI.user_error!("Report output location not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
-                                     end),
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :xcpretty_report_json,
                                      env_name: "XCPRETTY_REPORT_JSON",
                                      description: "Have xcpretty create a JSON compilation database at the provided path",
-                                     optional: true,
-                                     verify_block: proc do |value|
-                                       UI.user_error!("Report output location not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
-                                     end),
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :analyze_build_time,
                                      env_name: "GYM_ANALYZE_BUILD_TIME",
                                      description: "Analyze the project build time and store the output in culprits.txt file",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Currently to use the gym xcpretty report features an empty file must be created to satisfy the verify block. This is not needed since xcpretty will take care of creating both needed directories and the resulting file as can be seen in [xcpretty reporter.rb](https://github.com/supermarin/xcpretty/blob/36e618611248324b7fdfb9dee818a35ba4c816a8/lib/xcpretty/reporters/reporter.rb#L29). 

### Description
<!--- Describe your changes in detail -->
xcpretty report creates output, don't verify that path exists before