### PR TITLE
Catch errors with language activation

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -184,11 +184,7 @@ module Deliver
       end
 
       if enabled_languages.count > 0
-        v.create_languages(enabled_languages)
-        lng_text = "language"
-        lng_text += "s" if enabled_languages.count != 1
-        UI.message("Activating #{lng_text} #{enabled_languages.join(', ')}...")
-        v.save!
+        v.activate_languages(enabled_languages)
       end
       true
     end

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -28,11 +28,7 @@ module Deliver
 
       enabled_languages = screenshots_per_language.keys
       if enabled_languages.count > 0
-        v.create_languages(enabled_languages)
-        lng_text = "language"
-        lng_text += "s" if enabled_languages.count != 1
-        UI.message("Activating #{lng_text} #{enabled_languages.join(', ')}...")
-        v.save!
+        v.activate_languages(enabled_languages)
         # This refreshes the app version from iTC after enabling a localization
         v = app.edit_version
       end

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -282,6 +282,19 @@ module Spaceship
         nil
       end
 
+      def activate_languages(languages)
+        create_languages(enabled_languages)
+        lng_text = "language"
+        lng_text += "s" if enabled_languages.count != 1
+        langs = enabled_languages.join(', ')
+        UI.message("Activating #{lng_text} #{langs}...")
+        save!
+      rescue ITunesConnectError
+        UI.user_error!("Unable to activate languages: #{langs}. Please verify that your language codes have the appropriate cases. See http://data.okfn.org/data/core/language-codes#resource-ietf-language-tags for a list of available codes.")
+      rescue => e
+        raise e
+      end
+
       def current_build_number
         if self.is_live?
           build_version


### PR DESCRIPTION
Apple has changed the case sensitivity of it's language codes. This makes sure to print out a better error message.