### PR TITLE
Allow for case insensitive screenshot directory names

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -32,11 +32,7 @@ module Deliver
         lng_text = "language"
         lng_text += "s" if enabled_languages.count != 1
         UI.message("Activating #{lng_text} #{enabled_languages.join(', ')}...")
-        begin
-          v.save!
-        rescue ITunesConnectError
-          UI.user_error!("Unable to activate languages: #{langs}. Please verify that your language codes are available in iTunesConnect. See https://developer.apple.com/library/content/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/AppStoreTerritories.html for more information.")
-        end
+        v.save!
         # This refreshes the app version from iTC after enabling a localization
         v = app.edit_version
       end
@@ -100,7 +96,12 @@ module Deliver
         UI.important("Framed screenshots are detected! 🖼 Non-framed screenshot files may be skipped. 🏃") if prefer_framed
 
         language_dir_name = File.basename(lng_folder)
-        language = available_languages[language_dir_name.downcase] || language_dir_name
+
+        if available_languages[language_dir_name.downcase].nil?
+          UI.user_error!("#{language_dir_name} is not an available language. Please verify that your language codes are available in iTunesConnect. See https://developer.apple.com/library/content/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/AppStoreTerritories.html for more information.")
+        end
+
+        language = available_languages[language_dir_name.downcase]
 
         files.each do |file_path|
           is_framed = file_path.downcase.include?("_framed.")

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -526,7 +526,9 @@ module Spaceship
     def available_languages
       r = request(:get, "ra/apps/storePreview/regionCountryLanguage")
       response = parse_response(r, 'data')
-      response.flat_map { |region| region["storeFronts"] }.flat_map { |storefront| storefront["supportedLocaleCodes"] }.uniq
+      response.flat_map { |region| region["storeFronts"] }
+              .flat_map { |storefront| storefront["supportedLocaleCodes"] }
+              .uniq
     end
 
     #####################################################

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -523,6 +523,12 @@ module Spaceship
       parse_response(r, 'data')
     end
 
+    def available_languages
+      r = request(:get, "ra/apps/storePreview/regionCountryLanguage")
+      response = parse_response(r, 'data')
+      response.flat_map { |region| region["storeFronts"] }.flat_map { |storefront| storefront["supportedLocaleCodes"] }.uniq
+    end
+
     #####################################################
     # @!group App Icons
     #####################################################


### PR DESCRIPTION
If directories containing screenshots are named with improper cases in the language codes, this will correct them based on languages available in iTC.

This should be followed up with similar logic in the `upload_metadata` situation where languages are being activated.