### PR TITLE
Skip the upload success message when skipping the upload

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -25,7 +25,7 @@ module Deliver
         upload_binary
       end
 
-      UI.success("Finished the upload to iTunes Connect")
+      UI.success("Finished the upload to iTunes Connect") unless options[:skip_binary_upload]
 
       submit_for_review if options[:submit_for_review]
     end


### PR DESCRIPTION
We shouldnt be printing a success message that the binary was successfully updated if `skip_upload_binary == true`