### PR TITLE
Add full support for new promotional text support in iTC

### DIFF
--- a/deliver/Deliverfile.md
+++ b/deliver/Deliverfile.md
@@ -179,6 +179,17 @@ keywords(
 )
 ```
 
+##### promotional_text
+
+Localised promotional text
+
+```ruby
+promotional_text(
+  "en-US" => "Hey, you should totally buy our app, it's the best",
+  "de-DE" => "App kaufen bitte"
+)
+```
+
 ##### app_icon
 A path to a new app icon, which must be exactly 1024x1024px
 ```ruby

--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -195,6 +195,13 @@
               <%= (@options[:release_notes][language] || '').gsub("\n", "<br />") %>
           </div>
         <% end %>
+
+        <% if @options[:promotional_text] %>
+          <div class="app-changelog">
+              <div class="cat-headline">Changelog</div>
+              <%= (@options[:promotional_text][language] || '').gsub("\n", "<br />") %>
+          </div>
+        <% end %>
         
         <div class="app-screenshots">
           <div class="cat-headline">Screenshots</div>

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -259,6 +259,13 @@ module Deliver
                                          UI.user_error!(":keywords must be a hash with all values being strings") unless keywords.kind_of?(String)
                                        end
                                      end),
+        FastlaneCore::ConfigItem.new(key: :promotional_text,
+                                     description: "Metadata: An array of localised promotional texts",
+                                     optional: true,
+                                     is_string: false,
+                                     verify_block: proc do |value|
+                                       UI.user_error!(":keywords must be a Hash, with the language being the key") unless value.kind_of?(Hash)
+                                     end),
         FastlaneCore::ConfigItem.new(key: :release_notes,
                                      description: "Metadata: Localised release notes for this version",
                                      optional: true,

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -2,7 +2,7 @@ module Deliver
   # upload description, rating, etc.
   class UploadMetadata
     # All the localised values attached to the version
-    LOCALISED_VERSION_VALUES = [:description, :keywords, :release_notes, :support_url, :marketing_url]
+    LOCALISED_VERSION_VALUES = [:description, :keywords, :release_notes, :support_url, :marketing_url, :promotional_text]
 
     # Everything attached to the version but not being localised
     NON_LOCALISED_VERSION_VALUES = [:copyright]

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -152,6 +152,9 @@ module Spaceship
       # @return (Hash) A hash representing the keywords in all languages
       attr_reader :keywords
 
+      # @return (Hash) A hash representing the promotionalText in all languages
+      attr_reader :promotional_text
+
       # @return (Hash) A hash representing the description in all languages
       attr_reader :description
 
@@ -563,7 +566,8 @@ module Spaceship
           description: :description,
           supportUrl: :support_url,
           marketingUrl: :marketing_url,
-          releaseNotes: :release_notes
+          releaseNotes: :release_notes,
+          promotionalText: :promotional_text
         }.each do |json, attribute|
           instance_variable_set("@#{attribute}".to_sym, LanguageItem.new(json, languages))
         end


### PR DESCRIPTION
This was introduced at WWDC 2017

This PR adds support for this new feature on _spaceship_ and _deliver_ 🚀

<img width="698" alt="screen shot 2017-06-05 at 3 34 47 pm" src="https://cloud.githubusercontent.com/assets/869950/26806214/8ae3c904-4a04-11e7-8650-031aaf36988d.png">
