### PR TITLE
Add support for enabling/disabling phased release

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -174,7 +174,7 @@ module Spaceship
       attr_reader :trailers
 
       # @return (Hash) Represents the phased_release hash (read-only)
-      #   For now, please use the `set_phased_release` method and call `.save!`
+      #   For now, please use the `toggle_phased_release` method and call `.save!`
       #   as the API will probably change in the future
       attr_reader :phased_release
 
@@ -189,7 +189,7 @@ module Spaceship
       #        "dayPercentageMap"=>{"1"=>1, "2"=>2, "3"=>5, "4"=>10, "5"=>20, "6"=>50, "7"=>100},
       #        "isEnabled"=>true}
       #
-      def set_phased_release(enabled: false)
+      def toggle_phased_release(enabled: false)
         state = (enabled ? "INACTIVE" : "NOT_STARTED")
 
         self.phased_release["state"]["value"] = state

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -173,6 +173,28 @@ module Spaceship
       # @return (Hash) Represents the trailers of this app version (read-only)
       attr_reader :trailers
 
+      # @return (Hash) Represents the phased_release hash (read-only)
+      #   For now, please use the `set_phased_release` method and call `.save!`
+      #   as the API will probably change in the future
+      attr_reader :phased_release
+
+      # Currently phased_release doesn't seem to have all the features enabled
+      #
+      #     => {"state"=>{"value"=>"NOT_STARTED", "isEditable"=>true, "isRequired"=>false, "errorKeys"=>nil},
+      #        "startDate"=>nil,
+      #        "lastPaused"=>nil,
+      #        "pausedDuration"=>nil,
+      #        "totalPauseDays"=>30,
+      #        "currentDayNumber"=>nil,
+      #        "dayPercentageMap"=>{"1"=>1, "2"=>2, "3"=>5, "4"=>10, "5"=>20, "6"=>50, "7"=>100},
+      #        "isEnabled"=>true}
+      #
+      def set_phased_release(enabled: false)
+        state = (enabled ? "INACTIVE" : "NOT_STARTED")
+
+        self.phased_release["state"]["value"] = state
+      end
+
       attr_mapping({
         'appType' => :app_type,
         'platform' => :platform,
@@ -191,6 +213,7 @@ module Spaceship
         'supportsAppleWatch' => :supports_apple_watch,
         'versionId' => :version_id,
         'version.value' => :version,
+        'phasedRelease' => :phased_release,
 
         # GeoJson
         # 'transitAppFile.value' => :transit_app_file


### PR DESCRIPTION
This PR adds support for toggling phased rollouts for releases in _spaceship_, next step is to add support for it as part _deliver_ 🚀

Also it looks like we have even more control about the rollout plan, like the # of days of the rollout

<img width="882" alt="screen shot 2017-06-05 at 3 43 57 pm" src="https://cloud.githubusercontent.com/assets/869950/26807229/2933f4b2-4a0a-11e7-817f-e994481bdc2e.png">

<img width="863" alt="screen shot 2017-06-05 at 3 44 35 pm" src="https://cloud.githubusercontent.com/assets/869950/26807232/2c9daa1c-4a0a-11e7-87e5-2e538a04a573.png">
