### PR TITLE
Update app ratings API examples

### DIFF
--- a/spaceship/docs/iTunesConnect.md
+++ b/spaceship/docs/iTunesConnect.md
@@ -341,16 +341,13 @@ Spaceship::Tunes::SandboxTester.delete_all!
 ratings = app.ratings # => Spaceship::Tunes::AppRatings
 
 # Get the number of 5 star ratings
-five_star_count = ratings.rating_summary.five_star_rating_count
+five_star_count = ratings.five_star_rating_count
 
 # Find the average rating across all stores
-average_rating = ratings.rating_summary.average_rating
-
-# List store fronts the app is available in
-ratings.store_fronts # => Hash of country code to Spaceship::Tunes::AppRatingSummary
+average_rating = ratings.average_rating
 
 # Find the average rating for a given store front
-average_rating = ratings.store_fronts["US"].average_rating
+average_rating = app.ratings(storefront: "US").average_rating
 
 # Get reviews for a given store front
 reviews = ratings.reviews("US") # => Array of hashes representing review data


### PR DESCRIPTION
New app ratings endpoint doesn't have `rating_summary` and `store_fronts` attributes anymore.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Inaccurate documentation.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
I've followed the code in https://github.com/fastlane/fastlane/blob/master/spaceship/spec/tunes/app_ratings_spec.rb to update the examples.

### Description
<!--- Describe your changes in detail -->
Latest `Spaceship::Tunes::AppRatings` doesn't provide `rating_summary` attribute, so the examples of how to use the API were outdated.

`ratings.store_fronts` is also not available, so I've removed line 350.