### PR TITLE
Fix 9402 import cert not escaping special chars

### DIFF
--- a/fastlane/spec/actions_specs/import_certificate_spec.rb
+++ b/fastlane/spec/actions_specs/import_certificate_spec.rb
@@ -1,6 +1,10 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Import certificate Integration" do
+      before(:each) do
+        allow(FastlaneCore::Helper).to receive(:backticks).with('security -h | grep set-key-partition-list', print: false).and_return('    set-key-partition-list               Set the partition list of a key.')
+      end
+
       it "works with certificate and password" do
         cert_name = "test.cer"
         keychain = 'test.keychain'
@@ -10,7 +14,7 @@ describe Fastlane do
         expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" #{keychain_path.shellescape} &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{keychain_path.shellescape} &> /dev/null"
 
         allow(File).to receive(:exist?).and_return(false)
         allow(File).to receive(:exist?).with(keychain_path).and_return(true)
@@ -27,26 +31,27 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
-      it "works with certificate and password that contain spaces or '\'" do
+      it "works with certificate and password that contain spaces, special chars, or '\'" do
         cert_name = '\" test \".cer'
         keychain = '\" test \".keychain'
-        password = '\"test password\"'
+        password = '\"test pa$$word\"'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_command = "security import #{cert_name.shellescape} -k '#{keychain_path.shellescape}' -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
+        expected_security_import_command = "security import #{cert_name.shellescape} -k '#{keychain_path.shellescape}' -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" #{keychain_path.shellescape} &> /dev/null"
+        expected_set_key_partition_list_command = "security set-key-partition-list -S apple-tool:,apple: -k #{password.shellescape} #{keychain_path.shellescape} &> /dev/null"
 
         allow(File).to receive(:exist?).and_return(false)
         allow(File).to receive(:exist?).with(keychain_path).and_return(true)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
-        allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: false)
-        expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: false)
+        expect(FastlaneCore::Helper).to receive(:backticks).with(expected_set_key_partition_list_command, print: false)
+        expect(FastlaneCore::Helper).to receive(:backticks).with(expected_security_import_command, print: false)
 
         Fastlane::FastFile.new.parse("lane :test do
           import_certificate ({
             keychain_name: '#{keychain}',
+            keychain_password: '#{password}',
             certificate_path: '#{cert_name}',
             certificate_password: '#{password}'
           })
@@ -62,7 +67,7 @@ describe Fastlane do
         expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" #{keychain_path.shellescape}"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{keychain_path.shellescape}"
 
         allow(File).to receive(:exist?).and_return(false)
         allow(File).to receive(:exist?).with(keychain_path).and_return(true)

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -13,10 +13,10 @@ module FastlaneCore
 
       # When security supports partition lists, also add the partition IDs
       # See https://openradar.appspot.com/28524119
-      if `security -h | grep set-key-partition-list`.length > 0
+      if Helper.backticks('security -h | grep set-key-partition-list', print: false).length > 0
         command = "security set-key-partition-list"
         command << " -S apple-tool:,apple:"
-        command << " -k \"#{keychain_password}\""
+        command << " -k #{keychain_password.to_s.shellescape}"
         command << " #{keychain_path.shellescape}"
         command << " &> /dev/null" unless output
 

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -1,11 +1,15 @@
 describe Match do
   describe Match::Utils do
+    before(:each) do
+      allow(FastlaneCore::Helper).to receive(:backticks).with('security -h | grep set-key-partition-list', print: false).and_return('    set-key-partition-list               Set the partition list of a key.')
+    end
+
     describe 'import' do
       it 'finds a normal keychain name relative to ~/Library/Keychains' do
         expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P '' -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" #{Dir.home}/Library/Keychains/login.keychain &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{Dir.home}/Library/Keychains/login.keychain &> /dev/null"
 
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
@@ -21,7 +25,7 @@ describe Match do
         expected_command = "security import item.path -k '/my/special.keychain' -P '' -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" /my/special.keychain &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' /my/special.keychain &> /dev/null"
 
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with('/my/special.keychain').and_return(true)
@@ -45,7 +49,7 @@ describe Match do
         expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain-db' -P '' -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k \"\" #{Dir.home}/Library/Keychains/login.keychain-db &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{Dir.home}/Library/Keychains/login.keychain-db &> /dev/null"
 
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with("#{Dir.home}/Library/Keychains/login.keychain-db").and_return(true)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This fixes https://github.com/fastlane/fastlane/issues/9402

### Description

I updated the code to run `shellescape` on the `keychain_password` so that the password used to create the keychain (which uses `shellescape`) is the same as the password used to import the certificate into the keychain.

I also added a bit of code to aid debugging by printing out the commands when _creating_ the keychain.