### PR TITLE
Fix headline of "Promotional Text" in summary

### DIFF
--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -198,7 +198,7 @@
 
         <% if @options[:promotional_text] %>
           <div class="app-changelog">
-              <div class="cat-headline">Changelog</div>
+              <div class="cat-headline">Promotional Text</div>
               <%= (@options[:promotional_text][language] || '').gsub("\n", "<br />") %>
           </div>
         <% end %>


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

The newly introduced option `promotional_text` had the wrong headline in the HTML summary.
I've tested the HTML preview in my project.

### Description

Replaces the wrongly copied headline "Changelog" with "Promotional Texts"