### PR TITLE
LanguageItem keys might be under `localeCode` too

### DIFF
--- a/spaceship/lib/spaceship/tunes/language_item.rb
+++ b/spaceship/lib/spaceship/tunes/language_item.rb
@@ -31,7 +31,7 @@ module Spaceship
 
       # @return (Array) An array containing all languages that are already available
       def keys
-        self.original_array.collect { |l| l.fetch('language') }
+        return self.original_array.map { |current| current['language'] ||= current['localeCode'] } # Apple being consistent
       end
 
       # @return (Array) An array containing all languages that are already available
@@ -43,7 +43,7 @@ module Spaceship
       def inspect
         result = ""
         self.original_array.collect do |current|
-          result += "#{current.fetch('language')}: #{current.fetch(identifier, {}).fetch('value')}\n"
+          result += "#{current['language'] ||= current['localeCode']}: #{current.fetch(identifier, {}).fetch('value')}\n"
         end
         result
       end

--- a/spaceship/spec/tunes/language_item_spec.rb
+++ b/spaceship/spec/tunes/language_item_spec.rb
@@ -3,10 +3,41 @@ describe Spaceship::Tunes::LanguageItem do
     Spaceship::Tunes.login
   end
 
-  describe "#inspect" do
+  describe "language code inspection" do
     it "prints out all languages with their values" do
       str = Spaceship::Application.all.first.edit_version.description.inspect
       expect(str).to eq("German: My title\nEnglish: Super Description here\n")
+    end
+
+    it "localCode is also used for language keys" do
+      # details.name uses `localCode` instead of `languages`
+      keys = Spaceship::Application.all.first.details.name.keys
+      expect(keys).to eq(["en-US", "de-DE"])
+    end
+
+    it "localCode is also used for inspect method" do
+      # details.name uses `localeCode` instead of `languages`
+      inspect_string = Spaceship::Application.all.first.details.name.inspect
+      expect(inspect_string).to eq("en-US: Updated by fastlane\nde-DE: why new itc 2\n")
+    end
+
+    it "localCode is also used for get_lang method" do
+      # details.name uses `localeCode` instead of `languages`
+      english_name = Spaceship::Application.all.first.details.name["en-US"]
+      expect(english_name).to eq("Updated by fastlane")
+    end
+
+    it "ensure test data is setup as expected" do
+      # details.name uses `localeCode` instead of `languages`, so no nodes should exist for `languages`
+      original_array = Spaceship::Application.all.first.details.name.original_array
+      locale_node = original_array.flat_map { |value| value["localeCode"] }
+      languages_node = original_array.each_with_object([]) do |value, languages|
+        language = value["languages"]
+        languages << language unless language.nil?
+      end
+
+      expect(locale_node).to eq(["en-US", "de-DE"])
+      expect(languages_node).to be_empty
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

Some properties that use LanguageItem aren't properly returning their :keys because they are stored under `localeCode` instead of `languages`


