### PR TITLE
Commit version bump bug fix and enhancements

### DIFF
--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -63,12 +63,8 @@ module Fastlane
           end
         end
 
-        # returns an array (empty if params[:include] is nil) or nil for invalid argument
-        extra_files = include_list_from_param params[:include]
-        UI.user_error! ":include must specify a string array or a comma-separated string" if extra_files.nil?
-
         # create our list of files that we expect to have changed, they should all be relative to the project root, which should be equal to the git workdir root
-        expected_changed_files = extra_files
+        expected_changed_files = []
         expected_changed_files << pbxproj_path
         expected_changed_files << info_plist_files
 
@@ -160,11 +156,6 @@ module Fastlane
                                        description: "A regular expression used to filter matched plist files to be modified",
                                        optional: true,
                                        default_value: nil,
-                                       is_string: false),
-          FastlaneCore::ConfigItem.new(key: :include,
-                                       description: "A list of extra files to be included in the version bump (string array or comma-separated string)",
-                                       optional: true,
-                                       default_value: nil,
                                        is_string: false)
         ]
       end
@@ -210,31 +201,15 @@ module Fastlane
       class << self
         def settings_plists_from_param(param)
           if param.kind_of? String
-            # commit_version_bump settings: "About.plist"
-            [param]
+            # commit_version_bump xcodeproj: "MyProject.xcodeproj", settings: "About.plist"
+            return [param]
           elsif param.kind_of? Array
-            # commit_version_bump settings: ["Root.plist", "About.plist"]
-            param
-          else
-            # commit_version_bump settings: true # Root.plist
-            ["Root.plist"]
+            # commit_version_bump xcodeproj: "MyProject.xcodeproj", settings: [ "Root.plist", "About.plist" ]
+            return param
           end
-        end
 
-        def include_list_from_param(param)
-          return [] if param.nil?
-
-          if param.kind_of? String
-            # commit_version_bump include: "package.json,custom.cfg"
-            # This can be useful for environment variables, but there's no env. var. for :ignore,
-            # so not adding for :include for now.
-            param.split(",")
-          elsif param.kind_of? Array
-            # commit_version_bump include: %w{package.json custom.cfg}
-            param
-          else
-            nil
-          end
+          # commit_version_bump xcodeproj: "MyProject.xcodeproj", settings: true # Root.plist
+          ["Root.plist"]
         end
 
         def settings_bundle_file_path(project, settings_file_name)

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -190,6 +190,15 @@ module Fastlane
           'commit_version_bump(
             message: "Version Bump",                    # create a commit with a custom message
             xcodeproj: "./path/to/MyProject.xcodeproj", # optional, if you have multiple Xcode project files, you must specify your main project here
+          )',
+          'commit_version_bump(
+            settings: true # Include Settings.bundle/Root.plist
+          )',
+          'commit_version_bump(
+            settings: "About.plist" # Include Settings.bundle/About.plist
+          )',
+          'commit_version_bump(
+            settings: %w[About.plist Root.plist] # Include more than one plist from Settings.bundle
           )'
         ]
       end

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -251,8 +251,6 @@ module Fastlane
           elsif param.kind_of? Array
             # commit_version_bump include: %w{package.json custom.cfg}
             param
-          else
-            nil
           end
         end
 
@@ -268,7 +266,7 @@ module Fastlane
 
           root_pathname = Pathname.new repo_root
           Actions.lane_context[SharedValues::MODIFIED_FILES].map do |path|
-            next path unless path =~ /^\//
+            next path unless path =~ %r{^/}
             Pathname.new(path).relative_path_from(root_pathname).to_s
           end.uniq
         end

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -218,12 +218,7 @@ module Fastlane
           'commit_version_bump(
             message: "Version Bump",                    # create a commit with a custom message
             xcodeproj: "./path/to/MyProject.xcodeproj", # optional, if you have multiple Xcode project files, you must specify your main project here
-          )',
-          'commit_version_bump settings: true # include Settings.bundle/Root.plist',
-          'commit_version_bump settings: "About.plist" # include Settings.bundle/About.plist',
-          'commit_version_bump settings: %w[About.plist Root.plist] # include multiple files from Settings.bundle',
-          'commit_version_bump include: %w[package.json custom.cfg] # include other updated files as part of the version bump',
-          'commit_version_bump ignore: /OtherProject/ # ignore files matching a regular expression'
+          )'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -1,27 +1,10 @@
-require 'pathname'
-
 module Fastlane
   module Actions
-    module SharedValues
-      MODIFIED_FILES = :MODIFIED_FILES
-    end
-
-    class << self
-      # Add an array of paths relative to the repo root or absolute paths that have been modified by
-      # an action.
-      #
-      # :files: An array of paths relative to the repo root or absolute paths
-      def add_modified_files(files)
-        modified_files = lane_context[SharedValues::MODIFIED_FILES] || Set.new
-        modified_files += files
-        lane_context[SharedValues::MODIFIED_FILES] = modified_files
-      end
-    end
-
     # Commits the current changes in the repo as a version bump, checking to make sure only files which contain version information have been changed.
     class CommitVersionBumpAction < Action
       def self.run(params)
         require 'xcodeproj'
+        require 'pathname'
         require 'set'
         require 'shellwords'
 
@@ -83,8 +66,6 @@ module Fastlane
         # returns an array (empty if params[:include] is nil) or nil for invalid argument
         extra_files = include_list_from_param params[:include]
         UI.user_error! ":include must specify a string array or a comma-separated string" if extra_files.nil?
-
-        extra_files += modified_files_relative_to_repo_root repo_path
 
         # create our list of files that we expect to have changed, they should all be relative to the project root, which should be equal to the git workdir root
         expected_changed_files = extra_files
@@ -261,16 +242,6 @@ module Fastlane
           raise "No Settings.bundle in project" if settings_bundle.nil?
 
           File.join settings_bundle.real_path, settings_file_name
-        end
-
-        def modified_files_relative_to_repo_root(repo_root)
-          return [] if Actions.lane_context[SharedValues::MODIFIED_FILES].nil?
-
-          root_pathname = Pathname.new repo_root
-          Actions.lane_context[SharedValues::MODIFIED_FILES].map do |path|
-            next path unless path =~ /^\//
-            Pathname.new(path).relative_path_from(root_pathname).to_s
-          end.uniq
         end
       end
     end

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -216,8 +216,7 @@ module Fastlane
           settings_bundle = project.files.find { |f| f.path =~ /Settings.bundle/ }
           raise "No Settings.bundle in project" if settings_bundle.nil?
 
-          project_parent = File.dirname project.path
-          File.join(project_parent, settings_bundle.path, settings_file_name)
+          File.join settings_bundle.real_path, settings_file_name
         end
       end
     end

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -251,6 +251,8 @@ module Fastlane
           elsif param.kind_of? Array
             # commit_version_bump include: %w{package.json custom.cfg}
             param
+          else
+            nil
           end
         end
 
@@ -266,7 +268,7 @@ module Fastlane
 
           root_pathname = Pathname.new repo_root
           Actions.lane_context[SharedValues::MODIFIED_FILES].map do |path|
-            next path unless path =~ %r{^/}
+            next path unless path =~ /^\//
             Pathname.new(path).relative_path_from(root_pathname).to_s
           end.uniq
         end

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -218,7 +218,12 @@ module Fastlane
           'commit_version_bump(
             message: "Version Bump",                    # create a commit with a custom message
             xcodeproj: "./path/to/MyProject.xcodeproj", # optional, if you have multiple Xcode project files, you must specify your main project here
-          )'
+          )',
+          'commit_version_bump settings: true # include Settings.bundle/Root.plist',
+          'commit_version_bump settings: "About.plist" # include Settings.bundle/About.plist',
+          'commit_version_bump settings: %w[About.plist Root.plist] # include multiple files from Settings.bundle',
+          'commit_version_bump include: %w[package.json custom.cfg] # include other updated files as part of the version bump',
+          'commit_version_bump ignore: /OtherProject/ # ignore files matching a regular expression'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -1,10 +1,27 @@
+require 'pathname'
+
 module Fastlane
   module Actions
+    module SharedValues
+      MODIFIED_FILES = :MODIFIED_FILES
+    end
+
+    class << self
+      # Add an array of paths relative to the repo root or absolute paths that have been modified by
+      # an action.
+      #
+      # :files: An array of paths relative to the repo root or absolute paths
+      def add_modified_files(files)
+        modified_files = lane_context[SharedValues::MODIFIED_FILES] || Set.new
+        modified_files += files
+        lane_context[SharedValues::MODIFIED_FILES] = modified_files
+      end
+    end
+
     # Commits the current changes in the repo as a version bump, checking to make sure only files which contain version information have been changed.
     class CommitVersionBumpAction < Action
       def self.run(params)
         require 'xcodeproj'
-        require 'pathname'
         require 'set'
         require 'shellwords'
 
@@ -66,6 +83,8 @@ module Fastlane
         # returns an array (empty if params[:include] is nil) or nil for invalid argument
         extra_files = include_list_from_param params[:include]
         UI.user_error! ":include must specify a string array or a comma-separated string" if extra_files.nil?
+
+        extra_files += modified_files_relative_to_repo_root repo_path
 
         # create our list of files that we expect to have changed, they should all be relative to the project root, which should be equal to the git workdir root
         expected_changed_files = extra_files
@@ -242,6 +261,16 @@ module Fastlane
           raise "No Settings.bundle in project" if settings_bundle.nil?
 
           File.join settings_bundle.real_path, settings_file_name
+        end
+
+        def modified_files_relative_to_repo_root(repo_root)
+          return [] if Actions.lane_context[SharedValues::MODIFIED_FILES].nil?
+
+          root_pathname = Pathname.new repo_root
+          Actions.lane_context[SharedValues::MODIFIED_FILES].map do |path|
+            next path unless path =~ /^\//
+            Pathname.new(path).relative_path_from(root_pathname).to_s
+          end.uniq
         end
       end
     end

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -225,7 +225,7 @@ module Fastlane
           settings_bundle = project.files.find { |f| f.path =~ /Settings.bundle/ }
           raise "No Settings.bundle in project" if settings_bundle.nil?
 
-          File.join settings_bundle.real_path, settings_file_name
+          File.join(settings_bundle.real_path, settings_file_name)
         end
       end
     end

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -63,8 +63,12 @@ module Fastlane
           end
         end
 
+        # returns an array (empty if params[:include] is nil) or nil for invalid argument
+        extra_files = include_list_from_param params[:include]
+        UI.user_error! ":include must specify a string array or a comma-separated string" if extra_files.nil?
+
         # create our list of files that we expect to have changed, they should all be relative to the project root, which should be equal to the git workdir root
-        expected_changed_files = []
+        expected_changed_files = extra_files
         expected_changed_files << pbxproj_path
         expected_changed_files << info_plist_files
 
@@ -156,6 +160,11 @@ module Fastlane
                                        description: "A regular expression used to filter matched plist files to be modified",
                                        optional: true,
                                        default_value: nil,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :include,
+                                       description: "A list of extra files to be included in the version bump (string array or comma-separated string)",
+                                       optional: true,
+                                       default_value: nil,
                                        is_string: false)
         ]
       end
@@ -201,15 +210,31 @@ module Fastlane
       class << self
         def settings_plists_from_param(param)
           if param.kind_of? String
-            # commit_version_bump xcodeproj: "MyProject.xcodeproj", settings: "About.plist"
-            return [param]
+            # commit_version_bump settings: "About.plist"
+            [param]
           elsif param.kind_of? Array
-            # commit_version_bump xcodeproj: "MyProject.xcodeproj", settings: [ "Root.plist", "About.plist" ]
-            return param
+            # commit_version_bump settings: ["Root.plist", "About.plist"]
+            param
+          else
+            # commit_version_bump settings: true # Root.plist
+            ["Root.plist"]
           end
+        end
 
-          # commit_version_bump xcodeproj: "MyProject.xcodeproj", settings: true # Root.plist
-          ["Root.plist"]
+        def include_list_from_param(param)
+          return [] if param.nil?
+
+          if param.kind_of? String
+            # commit_version_bump include: "package.json,custom.cfg"
+            # This can be useful for environment variables, but there's no env. var. for :ignore,
+            # so not adding for :include for now.
+            param.split(",")
+          elsif param.kind_of? Array
+            # commit_version_bump include: %w{package.json custom.cfg}
+            param
+          else
+            nil
+          end
         end
 
         def settings_bundle_file_path(project, settings_file_name)

--- a/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
+++ b/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
@@ -20,12 +20,12 @@ describe Fastlane::Actions::CommitVersionBumpAction do
 
   describe 'settings_bundle_file_path' do
     it 'returns the path of a file in the settings bundle from an Xcodeproj::Project' do
-      settings_bundle = double "file", path: "MyApp/Settings.bundle"
-      xcodeproj = double "xcodeproj", files: [settings_bundle], path: "./MyApp.xcodeproj"
+      settings_bundle = double "file", path: "Settings.bundle", real_path: "/path/to/MyApp/Settings.bundle"
+      xcodeproj = double "xcodeproj", files: [settings_bundle]
 
       file_path = action.settings_bundle_file_path xcodeproj, "Root.plist"
 
-      expect(file_path).to eq "./MyApp/Settings.bundle/Root.plist"
+      expect(file_path).to eq "/path/to/MyApp/Settings.bundle/Root.plist"
     end
 
     it 'raises if no settings bundle in the project' do

--- a/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
+++ b/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
@@ -59,4 +59,41 @@ describe Fastlane::Actions::CommitVersionBumpAction do
       end.to raise_error RuntimeError
     end
   end
+
+  describe 'modified_files_relative_to_repo_root' do
+    it 'returns an empty array if modified_files is nil' do
+      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] = nil
+      expect(action.modified_files_relative_to_repo_root "/path/to/repo/root").to be_empty
+    end
+
+    it 'returns a list of relative paths given a list of possibly absolute paths' do
+      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] =
+        Set.new %w{relative/path1 /path/to/repo/root/relative/path2}
+      relative_paths = action.modified_files_relative_to_repo_root "/path/to/repo/root"
+      expect(relative_paths).to eq %w{relative/path1 relative/path2}
+    end
+
+    it 'removes duplicates' do
+      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] =
+        Set.new %w{relative/path /path/to/repo/root/relative/path}
+        relative_paths = action.modified_files_relative_to_repo_root "/path/to/repo/root"
+        expect(relative_paths).to eq ["relative/path"]
+    end
+  end
+
+  describe 'Actions::add_modified_files' do
+    it 'adds an array of paths to the list, initializing to [] if nil' do
+      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] = nil
+      Fastlane::Actions.add_modified_files %w{relative/path1 /path/to/repo/root/relative/path2}
+      expected = Set.new %w{relative/path1 /path/to/repo/root/relative/path2}
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES]).to eq expected
+    end
+
+    it 'ignores duplicates' do
+      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] = Set.new ["relative/path"]
+      Fastlane::Actions.add_modified_files ["relative/path"]
+      expected = Set.new ["relative/path"]
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES]).to eq expected
+    end
+  end
 end

--- a/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
+++ b/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
@@ -8,36 +8,13 @@ describe Fastlane::Actions::CommitVersionBumpAction do
     end
 
     it 'returns the param if an Array' do
-      settings_plists = action.settings_plists_from_param %w{About.plist Root.plist}
-      expect(settings_plists).to eq %w{About.plist Root.plist}
+      settings_plists = action.settings_plists_from_param ["About.plist", "Root.plist"]
+      expect(settings_plists).to eq ["About.plist", "Root.plist"]
     end
 
     it 'returns ["Root.plist"] for any other input' do
       settings_plists = action.settings_plists_from_param true
       expect(settings_plists).to eq ["Root.plist"]
-    end
-  end
-
-  describe 'include_list_from_param' do
-    it 'returns an empty array for a nil argument' do
-      include_list = action.include_list_from_param nil
-      expect(include_list).to be_an Array
-      expect(include_list).to be_empty
-    end
-
-    it 'splits a comma-separated String into an Array' do
-      include_list = action.include_list_from_param "relative/path1,relative/path2"
-      expect(include_list).to eq %w{relative/path1 relative/path2}
-    end
-
-    it 'returns the param if an Array' do
-      include_list = action.include_list_from_param %w{relative/path1 relative/path2}
-      expect(include_list).to eq %w{relative/path1 relative/path2}
-    end
-
-    it 'returns nil for any other type' do
-      include_list = action.include_list_from_param true
-      expect(include_list).to be_nil
     end
   end
 

--- a/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
+++ b/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
@@ -63,7 +63,7 @@ describe Fastlane::Actions::CommitVersionBumpAction do
   describe 'modified_files_relative_to_repo_root' do
     it 'returns an empty array if modified_files is nil' do
       Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] = nil
-      expect(action.modified_files_relative_to_repo_root("/path/to/repo/root")).to be_empty
+      expect(action.modified_files_relative_to_repo_root "/path/to/repo/root").to be_empty
     end
 
     it 'returns a list of relative paths given a list of possibly absolute paths' do
@@ -76,8 +76,8 @@ describe Fastlane::Actions::CommitVersionBumpAction do
     it 'removes duplicates' do
       Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] =
         Set.new %w{relative/path /path/to/repo/root/relative/path}
-      relative_paths = action.modified_files_relative_to_repo_root "/path/to/repo/root"
-      expect(relative_paths).to eq ["relative/path"]
+        relative_paths = action.modified_files_relative_to_repo_root "/path/to/repo/root"
+        expect(relative_paths).to eq ["relative/path"]
     end
   end
 

--- a/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
+++ b/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
@@ -63,7 +63,7 @@ describe Fastlane::Actions::CommitVersionBumpAction do
   describe 'modified_files_relative_to_repo_root' do
     it 'returns an empty array if modified_files is nil' do
       Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] = nil
-      expect(action.modified_files_relative_to_repo_root "/path/to/repo/root").to be_empty
+      expect(action.modified_files_relative_to_repo_root("/path/to/repo/root")).to be_empty
     end
 
     it 'returns a list of relative paths given a list of possibly absolute paths' do
@@ -76,8 +76,8 @@ describe Fastlane::Actions::CommitVersionBumpAction do
     it 'removes duplicates' do
       Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] =
         Set.new %w{relative/path /path/to/repo/root/relative/path}
-        relative_paths = action.modified_files_relative_to_repo_root "/path/to/repo/root"
-        expect(relative_paths).to eq ["relative/path"]
+      relative_paths = action.modified_files_relative_to_repo_root "/path/to/repo/root"
+      expect(relative_paths).to eq ["relative/path"]
     end
   end
 

--- a/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
+++ b/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
@@ -59,41 +59,4 @@ describe Fastlane::Actions::CommitVersionBumpAction do
       end.to raise_error RuntimeError
     end
   end
-
-  describe 'modified_files_relative_to_repo_root' do
-    it 'returns an empty array if modified_files is nil' do
-      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] = nil
-      expect(action.modified_files_relative_to_repo_root "/path/to/repo/root").to be_empty
-    end
-
-    it 'returns a list of relative paths given a list of possibly absolute paths' do
-      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] =
-        Set.new %w{relative/path1 /path/to/repo/root/relative/path2}
-      relative_paths = action.modified_files_relative_to_repo_root "/path/to/repo/root"
-      expect(relative_paths).to eq %w{relative/path1 relative/path2}
-    end
-
-    it 'removes duplicates' do
-      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] =
-        Set.new %w{relative/path /path/to/repo/root/relative/path}
-        relative_paths = action.modified_files_relative_to_repo_root "/path/to/repo/root"
-        expect(relative_paths).to eq ["relative/path"]
-    end
-  end
-
-  describe 'Actions::add_modified_files' do
-    it 'adds an array of paths to the list, initializing to [] if nil' do
-      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] = nil
-      Fastlane::Actions.add_modified_files %w{relative/path1 /path/to/repo/root/relative/path2}
-      expected = Set.new %w{relative/path1 /path/to/repo/root/relative/path2}
-      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES]).to eq expected
-    end
-
-    it 'ignores duplicates' do
-      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES] = Set.new ["relative/path"]
-      Fastlane::Actions.add_modified_files ["relative/path"]
-      expected = Set.new ["relative/path"]
-      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES]).to eq expected
-    end
-  end
 end

--- a/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
+++ b/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
@@ -8,13 +8,36 @@ describe Fastlane::Actions::CommitVersionBumpAction do
     end
 
     it 'returns the param if an Array' do
-      settings_plists = action.settings_plists_from_param ["About.plist", "Root.plist"]
-      expect(settings_plists).to eq ["About.plist", "Root.plist"]
+      settings_plists = action.settings_plists_from_param %w{About.plist Root.plist}
+      expect(settings_plists).to eq %w{About.plist Root.plist}
     end
 
     it 'returns ["Root.plist"] for any other input' do
       settings_plists = action.settings_plists_from_param true
       expect(settings_plists).to eq ["Root.plist"]
+    end
+  end
+
+  describe 'include_list_from_param' do
+    it 'returns an empty array for a nil argument' do
+      include_list = action.include_list_from_param nil
+      expect(include_list).to be_an Array
+      expect(include_list).to be_empty
+    end
+
+    it 'splits a comma-separated String into an Array' do
+      include_list = action.include_list_from_param "relative/path1,relative/path2"
+      expect(include_list).to eq %w{relative/path1 relative/path2}
+    end
+
+    it 'returns the param if an Array' do
+      include_list = action.include_list_from_param %w{relative/path1 relative/path2}
+      expect(include_list).to eq %w{relative/path1 relative/path2}
+    end
+
+    it 'returns nil for any other type' do
+      include_list = action.include_list_from_param true
+      expect(include_list).to be_nil
     end
   end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This is motivated by Issue #9341. The problem is that the `:settings` option to `commit_version_bump` doesn't work if the Settings.bundle is in a group in the Xcode project. This option has been there for some time, but it was broken when I first tried to use it. I "fixed" that bug at some point, resulting in the faulty code that's there now. This originally showed up as a bug in my settings_bundle plugin. That has been fixed but not yet released, pending resolution of the issue with `commit_version_bump`.

(_Edited_) To produce the bug:

```
git clone https://github.com/jdee/settings-bundle
cd settings-bundle
git checkout commit-version-bump-bug
bundle install
bundle exec fastlane group_test
```

To test the fix:

```
git checkout -- .
git checkout commit-version-bump-bug-fixed
bundle install
bundle exec fastlane group_test
```

Note that `bundle exec fastlane test` will succeed in both branches. The difference between SettingsBundleExample and SettingsBundleGroupExample is that in the former, the Settings.bundle is at the root of the project in Xcode, but in the latter it's under the SettingsBundleGroupExample group. The `#path` method used [here](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/commit_version_bump.rb#L220) returns a value relative to the group, not the project root.

But a bigger issue is that this logic belongs in the plugin, not in this action. I suggested two options in the issue. I've implemented both. There are three stages to the fix, represented by different commits.

1. Fix the broken logic in `settings_bundle_file_path`.
2. Add an `:include` option to specify arbitrary files to include.
3. Add `lane_context[SharedValues::MODIFIED_FILES]` and `Actions::add_modified_files`.

If only some of these changes should be merged, they can easily be reverted or removed.

### Description

1. Fix the broken logic in `settings_bundle_file_path`:
  Use the `#real_path` method, which returns the absolute path to the file. This fixes the original
  bug with a tiny change.
2. Add an `:include` option to specify arbitrary files to include.
  This allows explicit inclusion of an array of relative file paths. This has the virtue that there is no
  mystery if a file is included, but more parameters are required, and the correct path has to be
  explicitly supplied. There is already an `:ignore` parameter. This parameter seems to complement
  it.
3. Add `lane_context[SharedValues::MODIFIED_FILES]` and `Actions::add_modified_files`.
  This allows any action that modifies files to be included in a commit to pass them directly to
  the `commit_version_bump` action via the lane_context. It allows the context to accumulate
  the unique results of all actions. It eliminates the need for any additional parameters to support
  plugins that make modifications to include in a version bump. It could easily be used to support
  Android as well, rewrite `commit_version_bump` and obviate the `:xcodeproj` and `:settings`
  parameters.

I mentioned in the issue that it's possible for a settings bundle to have a custom name other than Settings.bundle. This is and isn't true. It's possible to create such a thing, but it doesn't show up in the Settings app unless the name is Settings.bundle. So that's not a concern, and the first commit is enough to fix the issue and probably put the question of settings bundles to rest.

But it seems plausible that there may be other cases where a lane might modify files other than the Xcode project and Info.plist as part of a version bump. Or I might have to fix another bug in my plugin and have to change `commit_version_bump` again. A more extensible approach seems like a good idea. The other two options are presented for consideration.

(_Edited_) To try out these options, use the `commit-version-bump-bug-fixed` branch in the plugin repo above. See the [Fastfile](https://github.com/jdee/settings-bundle/blob/commit-version-bump-bug-fixed/fastlane/Fastfile) there, which has three lanes that demonstrate the three different methods.

Using the `:include` option:
```
bundle exec fastlane test
```

Using the corrected `:settings` option:
```
bundle exec fastlane group_test
```

Using the lane_context (no `:include` or `:settings` option):
```
bundle exec fastlane library_test
```

Note: `git reset --hard HEAD^` erases the last commit in the current branch and is useful for testing this action.