### PR TITLE
Fix match error message

### DIFF
--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -109,7 +109,7 @@ module Match
         c.syntax = "fastlane match nuke"
         c.description = "Delete all certificates and provisioning profiles from the Apple Dev Portal"
         c.action do |args, options|
-          FastlaneCore::UI.user_error!("Please run `fastlane match nuke [type], allowed values: distribution, enterprise and development. For the 'adhoc' type, please use 'distribution' instead.")
+          FastlaneCore::UI.user_error!("Please run `fastlane match nuke [type], allowed values: distribution and development. For the 'adhoc' type, please use 'distribution' instead.")
         end
       end
 


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/9410

We don't support `match nuke` for enterprise environment as it's too risky