### PR TITLE
Fix crash in crash reporter if backtrace isn't accessible

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
+++ b/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
@@ -31,7 +31,7 @@ class Exception
   end
 
   def fastlane_crash_came_from_plugin?
-    plugin_frame = backtrace && backtrace.find { |frame| frame.include?('fastlane-plugin-') }
+    plugin_frame = exception && exception.backtrace && exception.backtrace.find { |frame| frame.include?('fastlane-plugin-') }
     !plugin_frame.nil?
   end
 

--- a/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
+++ b/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
@@ -26,12 +26,12 @@ end
 
 class Exception
   def fastlane_crash_came_from_custom_action?
-    custom_frame = exception.backtrace.find { |frame| frame.start_with?('actions/') }
+    custom_frame = exception && exception.backtrace && exception.backtrace.find { |frame| frame.start_with?('actions/') }
     !custom_frame.nil?
   end
 
   def fastlane_crash_came_from_plugin?
-    plugin_frame = backtrace.find { |frame| frame.include?('fastlane-plugin-') }
+    plugin_frame = backtrace && backtrace.find { |frame| frame.include?('fastlane-plugin-') }
     !plugin_frame.nil?
   end
 


### PR DESCRIPTION
There is cases where the backtrace can't be accessed. We don't want to crash the crash reporter, which would then shadow the actual stack trace + error message

Crash + Stack trace with this patch applied
<img width="1012" alt="screenshot 2017-06-11 07 52 15" src="https://user-images.githubusercontent.com/869950/27017751-a70c0ea4-4edf-11e7-8190-a1e43e6e0652.png">

Without this patch, we shadow the actual crash.
<img width="1059" alt="screenshot 2017-06-11 07 52 20" src="https://user-images.githubusercontent.com/869950/27017752-a8255e58-4edf-11e7-9671-9899377262dd.png">

I'm wondering if we can design/refactor the crash reporter in a way that it can't shadow the actual crash in any case? 