### PR TITLE
Add support for Xcode 9 by automatically using the right profile for each bundle identifier

### DIFF
--- a/fastlane/lib/fastlane/actions/gym.rb
+++ b/fastlane/lib/fastlane/actions/gym.rb
@@ -19,7 +19,7 @@ module Fastlane
         values[:export_method] ||= Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE]
 
         if Actions.lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING]
-          # Since Xcode 9 you need to provide the explicit provisioning profile per app target
+          # Since Xcode 9 you need to explicitly provide the provisioning profile per app target
           # If the user is smart and uses match and gym together with fastlane, we can do all
           # the heavy lifting for them
           values[:export_options] ||= {}

--- a/fastlane/lib/fastlane/actions/match.rb
+++ b/fastlane/lib/fastlane/actions/match.rb
@@ -1,5 +1,9 @@
 module Fastlane
   module Actions
+    module SharedValues
+      MATCH_PROVISIONING_PROFILE_MAPPING = :MATCH_PROVISIONING_PROFILE_MAPPING
+    end
+
     class MatchAction < Action
       def self.run(params)
         require 'match'
@@ -8,17 +12,36 @@ module Fastlane
         Match::Runner.new.run(params)
 
         define_profile_type(params)
+        define_provisioning_profile_mapping(params)
       end
 
-      def self.define_profile_type(values)
+      def self.define_profile_type(params)
         profile_type = "app-store"
-        profile_type = "ad-hoc" if values[:type] == 'adhoc'
-        profile_type = "development" if values[:type] == 'development'
-        profile_type = "enterprise" if values[:type] == 'enterprise'
+        profile_type = "ad-hoc" if params[:type] == 'adhoc'
+        profile_type = "development" if params[:type] == 'development'
+        profile_type = "enterprise" if params[:type] == 'enterprise'
 
         UI.message("Setting Provisioning Profile type to '#{profile_type}'")
 
         Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE] = profile_type
+      end
+
+      # Maps the bundle identifier to the appropriate provisioning profile
+      # This is used in the _gym_ action as part of the export options
+      # e.g.
+      #
+      #   export_options: {
+      #     provisioningProfiles: { "me.themoji.app.beta": "match AppStore me.themoji.app.beta" }
+      #   }
+      #
+      def self.define_provisioning_profile_mapping(params)
+        env_variable_name = Match::Utils.environment_variable_name_profile_name(app_identifier: params[:app_identifier],
+                                                                                          type: Match.profile_type_sym(params[:type]),
+                                                                                      platform: params[:platform])
+
+        mapping = Actions.lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING] || {}
+        mapping[params[:app_identifier]] = ENV[env_variable_name]
+        Actions.lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING] = mapping
       end
 
       #####################################################


### PR DESCRIPTION
If you're using _match_ and _gym_ together with _fastlane_, you can already use Xcode 9 out of the box 🚀

I still want a fallback for this, if the user just uses gym (why would you do that even....), because right now we're failing (see https://github.com/fastlane/fastlane/issues/9380), instead we should try to automatically determine the profile to use based on the Xcode project settings. Using match + fastlane is the recommended way as we can be 100% certain the profiles are correct, but we should still support other ways too

Fixes https://github.com/fastlane/fastlane/issues/9380