### PR TITLE
Version bump to 2.38.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.37.0'.freeze
+  VERSION = '2.38.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.37.0':**

* #6875 deliver: also use --force as a way to overwrite metadata (#9307) via Jerome Lacoste
* Fix match error message (#9427) via Felix Krause
* LanguageItem keys might be under `localeCode` too (#9421) via Joshua Liebowitz
* iOS 11 Subtitle iTunes Connect support (#9396) via Javier Agüera Cazorla
* Fix headline of "Promotional Text" in summary (#9416) via jnbt
* Update app ratings examples (#9376) via Manuel Martín
* Improve spacing of scan code samples in docs (#9332) via Felix Krause
* Create version.properties (#9412) via Mark Pirri
* Fix Issue 9402: import cert fails if given a password with special chars (#9406) via Lyndsey Ferguson
* [supply] Add check_superseded_tracks option (#9250) via Marcelo Oliveira
* Revert "support new build system (#9377)" (#9404) via Helmut Januschka
* support new build system (#9377) via Helmut Januschka
* fix typo (#9353) via Yuki Yoshioka
