### PR TITLE
Revert "[supply] Add check_superseded_tracks option (#9250)"

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
   spec.add_dependency 'fastimage', '>= 1.6' # fetch the image sizes from the screenshots, note: we also support > 2.0
   spec.add_dependency 'gh_inspector', '>= 1.0.1', '< 2.0.0' # search for issues on GitHub when something goes wrong
-  spec.add_dependency 'google-api-client', '~> 0.11' # Google API Client to access Play Publishing API
+  spec.add_dependency 'google-api-client', '~> 0.9.2' # Google API Client to access Play Publishing API
   spec.add_dependency 'highline', '>= 1.7.2', '< 2.0.0' # user inputs (e.g. passwords)
   spec.add_dependency 'json', '< 3.0.0' # Because sometimes it's just not installed
   spec.add_dependency 'mini_magick', '~> 4.5.1' # To open, edit and export PSD files

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -68,9 +68,8 @@ module Supply
 
       Google::Apis::ClientOptions.default.application_name = "fastlane - supply"
       Google::Apis::ClientOptions.default.application_version = Fastlane::VERSION
-      Google::Apis::ClientOptions.default.read_timeout_sec = 300
-      Google::Apis::ClientOptions.default.open_timeout_sec = 300
-      Google::Apis::ClientOptions.default.send_timeout_sec = 300
+      Google::Apis::RequestOptions.default.timeout_sec = 300
+      Google::Apis::RequestOptions.default.open_timeout_sec = 300
       Google::Apis::RequestOptions.default.retries = 5
 
       self.android_publisher = Androidpublisher::AndroidPublisherService.new
@@ -263,17 +262,15 @@ module Supply
     def track_version_codes(track)
       ensure_active_edit!
 
-      begin
-        result = android_publisher.get_track(
+      result = call_google_api do
+        android_publisher.get_track(
           current_package_name,
           current_edit.id,
           track
         )
-        return result.version_codes
-      rescue Google::Apis::ClientError => e
-        return [] if e.status_code == 404 && e.to_s.include?("trackEmpty")
-        raise
       end
+
+      return result.version_codes
     end
 
     def update_apk_listing_for_language(apk_listing)

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -172,13 +172,7 @@ module Supply
                                      optional: true,
                                      verify_block: proc do |value|
                                        UI.user_error! "Could not parse URL '#{value}'" unless value =~ URI.regexp
-                                     end),
-        FastlaneCore::ConfigItem.new(key: :check_superseded_tracks,
-                                     env_name: "SUPPLY_CHECK_SUPERSEDED_TRACKS",
-                                     optional: true,
-                                     description: "Check the other tracks for superseded versions and disable them",
-                                     is_string: false,
-                                     default_value: false)
+                                     end)
 
       ]
     end

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -158,43 +158,7 @@ module Supply
       if Supply.config[:track].eql? "rollout"
         client.update_track(Supply.config[:track], Supply.config[:rollout], apk_version_codes)
       else
-        check_superseded_tracks(apk_version_codes) if Supply.config[:check_superseded_tracks]
         client.update_track(Supply.config[:track], 1.0, apk_version_codes)
-      end
-    end
-
-    # Remove any version codes that is:
-    #  - Lesser than the greatest of any later (i.e. production) track
-    #  - Or lesser than the currently being uploaded if it's in an earlier (i.e. alpha) track
-    def check_superseded_tracks(apk_version_codes)
-      UI.message("Checking superseded tracks...")
-      max_apk_version_code = apk_version_codes.max
-      max_tracks_version_code = nil
-
-      tracks = ["production", "beta", "alpha"]
-      config_track_index = tracks.index(Supply.config[:track])
-
-      tracks.each_index do |track_index|
-        next if track_index.eql? config_track_index
-        track = tracks[track_index]
-
-        track_version_codes = client.track_version_codes(track).sort
-        next if track_version_codes.empty?
-
-        if max_tracks_version_code.nil?
-          max_tracks_version_code = track_version_codes.max
-        else
-          removed_version_codes = track_version_codes.take_while do |v|
-            v < max_tracks_version_code || (v < max_apk_version_code && track_index > config_track_index)
-          end
-
-          unless removed_version_codes.empty?
-            keep_version_codes = track_version_codes - removed_version_codes
-            max_tracks_version_code = keep_version_codes[0] unless keep_version_codes.empty?
-            client.update_track(track, 1.0, keep_version_codes)
-            UI.message("Superseded track '#{track}', removed '#{removed_version_codes}'")
-          end
-        end
       end
     end
 


### PR DESCRIPTION
This reverts commit 73c75d2574ebbcc89046f40045d7f6b2d48a2d48. (https://github.com/fastlane/fastlane/pull/9250)

Caused a few issues:
- https://github.com/fastlane/fastlane/issues/9442
- https://github.com/fastlane/fastlane/issues/9441

and 

```
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/specification.rb:2007:in `raise_if_conflicts': Unable to activate google-api-client-0.12.0, because addressable-2.3.8 conflicts with addressable (>= 2.5.1, ~> 2.5) (Gem::LoadError)
17:38:30     from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/specification.rb:1176:in `activate'
17:38:30     from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/specification.rb:1212:in `block in activate_dependencies'
17:38:30     from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/specification.rb:1198:in `each'
17:38:30     from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/specification.rb:1198:in `activate_dependencies'
17:38:30     from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/specification.rb:1180:in `activate'
17:38:30     from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_gem.rb:48:in `gem'
17:38:30     from /usr/local/bin/fastlane:22:in `<main>'
```