### PR TITLE
Update Supply to use 0.12.0 of google-api-client

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
   spec.add_dependency 'fastimage', '>= 1.6' # fetch the image sizes from the screenshots, note: we also support > 2.0
   spec.add_dependency 'gh_inspector', '>= 1.0.1', '< 2.0.0' # search for issues on GitHub when something goes wrong
-  spec.add_dependency 'google-api-client', '~> 0.11' # Google API Client to access Play Publishing API
+  spec.add_dependency 'google-api-client', '>= 0.12.0', '< 0.13.0' # Google API Client to access Play Publishing API
   spec.add_dependency 'highline', '>= 1.7.2', '< 2.0.0' # user inputs (e.g. passwords)
   spec.add_dependency 'json', '< 3.0.0' # Because sometimes it's just not installed
   spec.add_dependency 'mini_magick', '~> 4.5.1' # To open, edit and export PSD files

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -131,7 +131,7 @@ module Supply
     def listings
       ensure_active_edit!
 
-      result = call_google_api { android_publisher.list_listings(current_package_name, current_edit.id) }
+      result = call_google_api { android_publisher.list_edit_listings(current_package_name, current_edit.id) }
 
       return result.listings.map do |row|
         Listing.new(self, row.language, row)
@@ -143,7 +143,7 @@ module Supply
       ensure_active_edit!
 
       begin
-        result = android_publisher.get_listing(
+        result = android_publisher.get_edit_listing(
           current_package_name,
           current_edit.id,
           language
@@ -160,7 +160,7 @@ module Supply
     def apks_version_codes
       ensure_active_edit!
 
-      result = call_google_api { android_publisher.list_apks(current_package_name, current_edit.id) }
+      result = call_google_api { android_publisher.list_edit_apks(current_package_name, current_edit.id) }
 
       return result.apks.map(&:version_code)
     end
@@ -170,7 +170,7 @@ module Supply
       ensure_active_edit!
 
       result = call_google_api do
-        android_publisher.list_apk_listings(
+        android_publisher.list_edit_apklistings(
           current_package_name,
           current_edit.id,
           apk_version_code
@@ -199,7 +199,7 @@ module Supply
       })
 
       call_google_api do
-        android_publisher.update_listing(
+        android_publisher.update_edit_listing(
           current_package_name,
           current_edit.id,
           language,
@@ -212,7 +212,7 @@ module Supply
       ensure_active_edit!
 
       result_upload = call_google_api do
-        android_publisher.upload_apk(
+        android_publisher.upload_edit_apk(
           current_package_name,
           current_edit.id,
           upload_source: path_to_apk
@@ -250,7 +250,7 @@ module Supply
       })
 
       call_google_api do
-        android_publisher.update_track(
+        android_publisher.update_edit_track(
           current_package_name,
           current_edit.id,
           track,
@@ -264,7 +264,7 @@ module Supply
       ensure_active_edit!
 
       begin
-        result = android_publisher.get_track(
+        result = android_publisher.get_edit_track(
           current_package_name,
           current_edit.id,
           track
@@ -285,7 +285,7 @@ module Supply
       })
 
       call_google_api do
-        android_publisher.update_apk_listing(
+        android_publisher.update_edit_apklisting(
           current_package_name,
           current_edit.id,
           apk_listing.apk_version_code,
@@ -303,7 +303,7 @@ module Supply
       ensure_active_edit!
 
       result = call_google_api do
-        android_publisher.list_images(
+        android_publisher.list_edit_images(
           current_package_name,
           current_edit.id,
           language,
@@ -319,7 +319,7 @@ module Supply
       ensure_active_edit!
 
       call_google_api do
-        android_publisher.upload_image(
+        android_publisher.upload_edit_image(
           current_package_name,
           current_edit.id,
           language,
@@ -334,7 +334,7 @@ module Supply
       ensure_active_edit!
 
       call_google_api do
-        android_publisher.delete_all_images(
+        android_publisher.deleteall_edit_images(
           current_package_name,
           current_edit.id,
           language,
@@ -347,7 +347,7 @@ module Supply
       ensure_active_edit!
 
       call_google_api do
-        android_publisher.upload_expansion_file(
+        android_publisher.upload_edit_expansionfile(
           current_package_name,
           current_edit.id,
           apk_version_code,

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -334,7 +334,7 @@ module Supply
       ensure_active_edit!
 
       call_google_api do
-        android_publisher.deleteall_edit_images(
+        android_publisher.deleteall_edit_image(
           current_package_name,
           current_edit.id,
           language,


### PR DESCRIPTION

### Checklist
- [ X ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [  X ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ X ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ X ] I've updated the documentation if necessary.

### Motivation and Context

The problem is pretty simple: version 0.12.0 of the API has breaking changes. Without this change, unless developers know to manually lock their google-api-gem to 0.11.x, supply will not work for them.

### Description

Version 0.12.0 of the Google API Client gem has breaking API changes. Unfortunately, the previous gemspec requirement (~> 0.11) was slightly too permissive, and allowed the new version to be pulled in accidentally. This PR fixes this by upgrading to the new gem explicitly and updating the API calls.

This was generated by following the API diffs here (https://github.com/google/google-api-ruby-client/commit/3f26743ef728466c7f3edfe8dfb1224122c596b5#diff-215abaa8c4101dcb8977c43a24964183) and changing all calls in client.rb. I've validated by running my local project against this version of fastlane, and it seems to work as expected.

While I'm in here, it seemed like a good idea to update to 0.12.0 and fix the breakages. But the simplest possible fix would just be to lock the gem to 0.11.0 < 0.12.0 if someone else wants to do the upgrade later.
