### PR TITLE
adjusted find build method to exit early if we don't have candidate builds and show a better user error

### DIFF
--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -69,16 +69,15 @@ module Deliver
     end
 
     def find_build(candidate_builds)
-      build = nil
-      candidate_builds.each do |b|
-        if !build or b.upload_date > build.upload_date
-          build = b
-        end
+      if (candidate_builds || []).count == 0
+        UI.user_error!("Could not find any available candidate builds on iTunes Connect to submit")
       end
 
-      unless build
-        UI.error(candidate_builds)
-        UI.crash!("Could not find build")
+      build = candidate_builds.first
+      candidate_builds.each do |b|
+        if b.upload_date > build.upload_date
+          build = b
+        end
       end
 
       return build

--- a/deliver/spec/submit_for_review_spec.rb
+++ b/deliver/spec/submit_for_review_spec.rb
@@ -24,7 +24,9 @@ describe Deliver::SubmitForReview do
     context 'no builds' do
       let(:fake_builds) { make_fake_builds(0) }
       it 'throws a UI error' do
-        expect { review_submitter.find_build(fake_builds) }.to raise_error FastlaneCore::Interface::FastlaneCrash
+        expect do
+          review_submitter.find_build(fake_builds)
+        end.to raise_error FastlaneCore::Interface::FastlaneError, "Could not find any available candidate builds on iTunes Connect to submit"
       end
     end
 


### PR DESCRIPTION

before:
<img width="903" alt="screen shot 2017-06-12 at 6 46 29 pm" src="https://user-images.githubusercontent.com/2445653/27062964-a59dad7e-4fa3-11e7-969c-8d3e4db4eaf5.png">
after:
<img width="449" alt="screen shot 2017-06-12 at 7 04 12 pm" src="https://user-images.githubusercontent.com/2445653/27062967-a84dcac2-4fa3-11e7-8f02-74a31a8eec34.png">
