### PR TITLE
Revert #9279.

### DIFF
--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -233,16 +233,11 @@ module Fastlane
         [key, content.to_s]
       end
 
-      begin
-        require 'terminal-table'
-        puts Terminal::Table.new({
-          title: "Lane Context".yellow,
-          rows: FastlaneCore::PrintTable.transform_output(rows)
-        })
-      rescue
-        os = Helper.linux? ? 'linux' : 'mac'
-        UI.crash!("Something went wrong trying to print the lane context on #{os}")
-      end
+      require 'terminal-table'
+      puts Terminal::Table.new({
+        title: "Lane Context".yellow,
+        rows: FastlaneCore::PrintTable.transform_output(rows)
+      })
     end
   end
 end


### PR DESCRIPTION
We should look into the root cause of the crash happening when `Terminal::Table` prints out in the `LaneManager`