### PR TITLE
Only use fastlane as the action for the crash reporter

### DIFF
--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -257,13 +257,13 @@ module Fastlane
       rescue FastlaneCore::Interface::FastlaneCommonException => e # these are exceptions that we dont count as crashes
         raise e
       rescue FastlaneCore::Interface::FastlaneError => e # user_error!
-        FastlaneCore::CrashReporter.report_crash(exception: e, action: method_sym)
+        FastlaneCore::CrashReporter.report_crash(exception: e)
         collector.did_raise_error(method_sym) if e.fastlane_should_report_metrics?
         raise e
       rescue Exception => e # rubocop:disable Lint/RescueException
         # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
         # Catches all exceptions, since some plugins might use system exits to get out
-        FastlaneCore::CrashReporter.report_crash(exception: e, action: method_sym)
+        FastlaneCore::CrashReporter.report_crash(exception: e)
         collector.did_crash(method_sym) if e.fastlane_should_report_metrics?
         raise e
       end

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_report_generator.rb
@@ -1,9 +1,9 @@
 module FastlaneCore
   class CrashReportGenerator
     class << self
-      def generate(exception: nil, action: nil)
+      def generate(exception: nil)
         message = format_crash_report_message(exception: exception)
-        crash_report_payload(message: message, action: action)
+        crash_report_payload(message: message)
       end
 
       private
@@ -35,11 +35,11 @@ module FastlaneCore
         message + backtrace
       end
 
-      def crash_report_payload(message: '', action: nil)
+      def crash_report_payload(message: '')
         {
           'eventTime' => Time.now.utc.to_datetime.rfc3339,
           'serviceContext' => {
-            'service' => action || 'fastlane',
+            'service' => 'fastlane',
             'version' => Fastlane::VERSION
           },
           'message' => message

--- a/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
+++ b/fastlane_core/lib/fastlane_core/crash_reporter/crash_reporter.rb
@@ -16,7 +16,7 @@ module FastlaneCore
         !FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_CRASH_REPORTING")
       end
 
-      def report_crash(exception: nil, action: nil)
+      def report_crash(exception: nil)
         return unless enabled?
         return if @did_report_crash
         return if exception.fastlane_crash_came_from_custom_action?
@@ -26,7 +26,7 @@ module FastlaneCore
         # we want to test it
         return if Helper.test? && !@explicitly_enabled_for_testing
         begin
-          payload = CrashReportGenerator.generate(exception: exception, action: action)
+          payload = CrashReportGenerator.generate(exception: exception)
           send_report(payload: payload)
           save_file(payload: payload)
           show_message unless did_show_message?

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -43,7 +43,7 @@ module Commander
         if FastlaneCore::Helper.test?
           raise e
         else
-          FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
+          FastlaneCore::CrashReporter.report_crash(exception: e)
           abort "#{e}. Use --help for more information"
         end
       rescue Interrupt => e
@@ -62,7 +62,7 @@ module Commander
         if FastlaneCore::Helper.test?
           raise e
         else
-          FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
+          FastlaneCore::CrashReporter.report_crash(exception: e)
           if self.active_command.name == "help" && @default_command == :help # need to access directly via @
             # This is a special case, for example for pilot
             # when the user runs `fastlane pilot -u user@google.com`
@@ -105,7 +105,7 @@ module Commander
       FastlaneCore::UI.important("Error accessing file, this might be due to fastlane's directory handling")
       FastlaneCore::UI.important("Check out https://docs.fastlane.tools/advanced/#directory-behavior for more details")
       puts ""
-      FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
+      FastlaneCore::CrashReporter.report_crash(exception: e)
       raise e
     end
 
@@ -113,13 +113,13 @@ module Commander
       if e.message.include? 'Connection reset by peer - SSL_connect'
         handle_tls_error!(e)
       else
-        FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
+        FastlaneCore::CrashReporter.report_crash(exception: e)
         handle_unknown_error!(e)
       end
     end
 
     def rescue_unknown_error(e)
-      FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
+      FastlaneCore::CrashReporter.report_crash(exception: e)
       collector.did_crash(@program[:name]) if e.fastlane_should_report_metrics?
       handle_unknown_error!(e)
     end
@@ -127,7 +127,7 @@ module Commander
     def rescue_fastlane_error(e)
       collector.did_raise_error(@program[:name]) if e.fastlane_should_report_metrics?
       show_github_issues(e.message) if e.show_github_issues
-      FastlaneCore::CrashReporter.report_crash(exception: e, action: @program[:name])
+      FastlaneCore::CrashReporter.report_crash(exception: e)
       display_user_error!(e, e.message)
     end
 

--- a/fastlane_core/spec/crash_reporter/crash_report_generator_spec.rb
+++ b/fastlane_core/spec/crash_reporter/crash_report_generator_spec.rb
@@ -27,12 +27,6 @@ describe FastlaneCore::CrashReportGenerator do
       allow(Time).to receive(:now).and_return(Time.utc(0))
     end
 
-    it 'sets service to the action that crashed' do
-      setup_sanitizer_expectation
-      report = JSON.parse(FastlaneCore::CrashReportGenerator.generate(exception: mock_exception, action: 'test_action'))
-      expect(report['serviceContext']['service']).to eq('test_action')
-    end
-
     it 'omits a message for type user_error' do
       begin
         UI.user_error!('Some User Error')

--- a/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
+++ b/fastlane_core/spec/crash_reporter/crash_reporter_spec.rb
@@ -95,8 +95,7 @@ end
 
 def setup_crash_report_generator_expectation(action: nil, exception: nil)
   expect(FastlaneCore::CrashReportGenerator).to receive(:generate).with(
-    exception: exception,
-    action: action
+    exception: exception
   ).and_return(stub_body.to_json)
 end
 


### PR DESCRIPTION
We have been hitting limits in our crash reporter for having too many versions and actions being recorded. This PR makes sure that all errors/crashes are being logged under the _fastlane_ action. This is okay because the stack traces show from which action the error is coming anyways.