### PR TITLE
Helper.keychain_path heuristic should only search for file to avoid returning directories as false positives (#9462)

### DIFF
--- a/fastlane/lib/fastlane/actions/unlock_keychain.rb
+++ b/fastlane/lib/fastlane/actions/unlock_keychain.rb
@@ -22,6 +22,8 @@ module Fastlane
         escaped_path = keychain_path.shellescape
         escaped_password = params[:password].shellescape
 
+        # Log the full path, useful for troubleshooting
+        UI.message("Unlocking keychain at path: #{escaped_path}")
         # unlock given keychain and disable lock and timeout
         commands << Fastlane::Actions.sh("security unlock-keychain -p #{escaped_password} #{escaped_path}", log: false)
         commands << Fastlane::Actions.sh("security set-keychain-settings #{escaped_path}", log: false)

--- a/fastlane/spec/actions_specs/delete_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/delete_keychain_spec.rb
@@ -2,14 +2,14 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Delete keychain Integration" do
       before :each do
-        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:file?).and_return(false)
       end
 
       it "works with keychain name found locally" do
         allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         keychain = File.expand_path('test.keychain')
-        allow(File).to receive(:exist?).and_return(false)
-        allow(File).to receive(:exist?).with(keychain).and_return(true)
+        allow(File).to receive(:file?).and_return(false)
+        allow(File).to receive(:file?).with(keychain).and_return(true)
 
         result = Fastlane::FastFile.new.parse("lane :test do
           delete_keychain ({
@@ -22,8 +22,8 @@ describe Fastlane do
 
       it "works with keychain name found in ~/Library/Keychains" do
         keychain = File.expand_path('~/Library/Keychains/test.keychain')
-        allow(File).to receive(:exist?).and_return(false)
-        allow(File).to receive(:exist?).with(keychain).and_return(true)
+        allow(File).to receive(:file?).and_return(false)
+        allow(File).to receive(:file?).with(keychain).and_return(true)
 
         result = Fastlane::FastFile.new.parse("lane :test do
           delete_keychain ({
@@ -36,8 +36,8 @@ describe Fastlane do
 
       it "works with keychain name found in ~/Library/Keychains with -db" do
         keychain = File.expand_path('~/Library/Keychains/test.keychain-db')
-        allow(File).to receive(:exist?).and_return(false)
-        allow(File).to receive(:exist?).with(keychain).and_return(true)
+        allow(File).to receive(:file?).and_return(false)
+        allow(File).to receive(:file?).with(keychain).and_return(true)
 
         result = Fastlane::FastFile.new.parse("lane :test do
           delete_keychain ({
@@ -50,7 +50,7 @@ describe Fastlane do
 
       it "works with keychain name that contain spaces and `\"`" do
         allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
-        allow(File).to receive(:exist?).with(File.expand_path('" test ".keychain')).and_return(true)
+        allow(File).to receive(:file?).with(File.expand_path('" test ".keychain')).and_return(true)
 
         result = Fastlane::FastFile.new.parse("lane :test do
           delete_keychain ({
@@ -63,7 +63,9 @@ describe Fastlane do
       end
 
       it "works with absolute keychain path" do
+        allow(File).to receive(:exist?).and_return(false)
         allow(File).to receive(:exist?).with('/projects/test.keychain').and_return(true)
+        allow(File).to receive(:file?).with('/projects/test.keychain').and_return(true)
 
         result = Fastlane::FastFile.new.parse("lane :test do
           delete_keychain ({

--- a/fastlane/spec/actions_specs/import_certificate_spec.rb
+++ b/fastlane/spec/actions_specs/import_certificate_spec.rb
@@ -16,8 +16,9 @@ describe Fastlane do
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{keychain_path.shellescape} &> /dev/null"
 
+        allow(File).to receive(:file?).and_return(false)
+        allow(File).to receive(:file?).with(keychain_path).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
-        allow(File).to receive(:exist?).with(keychain_path).and_return(true)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
         allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: false)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: false)
@@ -42,8 +43,9 @@ describe Fastlane do
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         expected_set_key_partition_list_command = "security set-key-partition-list -S apple-tool:,apple: -k #{password.shellescape} #{keychain_path.shellescape} &> /dev/null"
 
+        allow(File).to receive(:file?).and_return(false)
+        allow(File).to receive(:file?).with(keychain_path).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
-        allow(File).to receive(:exist?).with(keychain_path).and_return(true)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_set_key_partition_list_command, print: false)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_security_import_command, print: false)
@@ -69,8 +71,9 @@ describe Fastlane do
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{keychain_path.shellescape}"
 
+        allow(File).to receive(:file?).and_return(false)
+        allow(File).to receive(:file?).with(keychain_path).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
-        allow(File).to receive(:exist?).with(keychain_path).and_return(true)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
         allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: true)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: true)

--- a/fastlane/spec/actions_specs/setup_jenkins_spec.rb
+++ b/fastlane/spec/actions_specs/setup_jenkins_spec.rb
@@ -106,6 +106,7 @@ describe Fastlane do
           ENV["KEYCHAIN_PATH"] = keychain_path
 
           expect(UI).to receive(:message).with("Unlocking keychain: \"#{keychain_path}\".")
+          expect(UI).to receive(:message).with("Unlocking keychain at path: #{File.expand_path(keychain_path).shellescape}")
           expect(UI).to receive(:message).with(/Set output directory path to:/)
           expect(UI).to receive(:message).with(/Set derived data path to:/)
           expect(UI).to receive(:message).with("Set result bundle.")

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -208,7 +208,7 @@ module FastlaneCore
         keychain_paths << "#{location}.keychain"
       end
 
-      keychain_path = keychain_paths.find { |path| File.exist?(path) }
+      keychain_path = keychain_paths.find { |path| File.file?(path) }
       UI.user_error!("Could not locate the provided keychain. Tried:\n\t#{keychain_paths.join("\n\t")}") unless keychain_path
       keychain_path
     end

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -60,28 +60,28 @@ describe FastlaneCore do
 
     describe "#keychain_path" do
       it "finds file in current directory" do
-        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:file?).and_return(false)
 
         found = File.expand_path("test.keychain")
-        allow(File).to receive(:exist?).with(found).and_return(true)
+        allow(File).to receive(:file?).with(found).and_return(true)
 
         expect(FastlaneCore::Helper.keychain_path("test.keychain")).to eq File.expand_path(found)
       end
 
       it "finds file in current directory with -db" do
-        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:file?).and_return(false)
 
         found = File.expand_path("test-db")
-        allow(File).to receive(:exist?).with(found).and_return(true)
+        allow(File).to receive(:file?).with(found).and_return(true)
 
         expect(FastlaneCore::Helper.keychain_path("test.keychain")).to eq File.expand_path(found)
       end
 
       it "finds file in current directory with spaces and \"" do
-        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:file?).and_return(false)
 
         found = File.expand_path('\\"\\ test\\ \\".keychain')
-        allow(File).to receive(:exist?).with(found).and_return(true)
+        allow(File).to receive(:file?).with(found).and_return(true)
 
         expect(FastlaneCore::Helper.keychain_path('\\"\\ test\\ \\".keychain')).to eq File.expand_path(found)
       end

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -11,8 +11,9 @@ describe Match do
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{Dir.home}/Library/Keychains/login.keychain &> /dev/null"
 
+        allow(File).to receive(:file?).and_return(false)
+        expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
         allow(File).to receive(:exist?).and_return(false)
-        expect(File).to receive(:exist?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
         expect(File).to receive(:exist?).with('item.path').and_return(true)
 
         allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: FastlaneCore::Globals.verbose?)
@@ -27,8 +28,9 @@ describe Match do
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' /my/special.keychain &> /dev/null"
 
+        allow(File).to receive(:file?).and_return(false)
+        expect(File).to receive(:file?).with('/my/special.keychain').and_return(true)
         allow(File).to receive(:exist?).and_return(false)
-        expect(File).to receive(:exist?).with('/my/special.keychain').and_return(true)
         expect(File).to receive(:exist?).with('item.path').and_return(true)
 
         allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: FastlaneCore::Globals.verbose?)
@@ -51,8 +53,9 @@ describe Match do
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{Dir.home}/Library/Keychains/login.keychain-db &> /dev/null"
 
+        allow(File).to receive(:file?).and_return(false)
+        expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain-db").and_return(true)
         allow(File).to receive(:exist?).and_return(false)
-        expect(File).to receive(:exist?).with("#{Dir.home}/Library/Keychains/login.keychain-db").and_return(true)
         expect(File).to receive(:exist?).with("item.path").and_return(true)
 
         allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: FastlaneCore::Globals.verbose?)


### PR DESCRIPTION
See #9462 for details