### PR TITLE
get reference to fastlane folder the more correct way

### DIFF
--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -135,7 +135,7 @@ module Deliver
           options = FastlaneCore::Configuration.create(deliverfile_options(skip_verification: true), options.__hash__)
           options.load_configuration_file("Deliverfile")
           Deliver::Runner.new(options, skip_version: true) # to login...
-          containing = FastlaneCore::Helper.fastlane_enabled? ? FastlaneCore::FastlaneFolder.path : '.'
+          containing = FastlaneCore::Helper.fastlane_enabled_folder_path
           path = options[:screenshots_path] || File.join(containing, 'screenshots')
           Deliver::DownloadScreenshots.run(options, path)
         end
@@ -151,7 +151,7 @@ module Deliver
           options = FastlaneCore::Configuration.create(deliverfile_options(skip_verification: true), options.__hash__)
           options.load_configuration_file("Deliverfile")
           Deliver::Runner.new(options) # to login...
-          containing = FastlaneCore::Helper.fastlane_enabled? ? FastlaneCore::FastlaneFolder.path : '.'
+          containing = FastlaneCore::Helper.fastlane_enabled_folder_path
           path = options[:metadata_path] || File.join(containing, 'metadata')
           res = Deliver::CommandsGenerator.force_overwrite_metadata?(options, path)
           return 0 unless res

--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -34,8 +34,6 @@ module Deliver
       res ||= UI.confirm("Do you want to overwrite existing metadata on path '#{File.expand_path(path)}'?") if UI.interactive?
       res
     end
-
-    # rubocop:disable Metrics/PerceivedComplexity
     def run
       program :name, 'deliver'
       program :version, Fastlane::VERSION

--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -34,6 +34,7 @@ module Deliver
       res ||= UI.confirm("Do you want to overwrite existing metadata on path '#{File.expand_path(path)}'?") if UI.interactive?
       res
     end
+
     def run
       program :name, 'deliver'
       program :version, Fastlane::VERSION

--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -1,7 +1,9 @@
+require 'fastlane_core'
+
 module Deliver
   class Setup
     def run(options)
-      containing = (File.directory?("fastlane") ? 'fastlane' : '.')
+      containing = FastlaneCore::Helper.fastlane_enabled_folder_path
       file_path = File.join(containing, 'Deliverfile')
       data = generate_deliver_file(containing, options)
       setup_deliver(file_path, data, containing, options)

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -240,6 +240,7 @@ module FastlaneCore
       @enabled ||= !FastlaneCore::FastlaneFolder.path.nil?
     end
 
+    # Checks if fastlane is enabled for this project and returns the folder where the configuration lives
     def self.fastlane_enabled_folder_path
       fastlane_enabled? ? FastlaneCore::FastlaneFolder.path : '.'
     end

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -240,6 +240,10 @@ module FastlaneCore
       @enabled ||= !FastlaneCore::FastlaneFolder.path.nil?
     end
 
+    def self.fastlane_enabled_folder_path
+      fastlane_enabled? ? FastlaneCore::FastlaneFolder.path : '.'
+    end
+
     # <b>DEPRECATED:</b> Use the `ROOT` constant from the appropriate tool module instead
     # e.g. File.join(Sigh::ROOT, 'lib', 'assets', 'resign.sh')
     #

--- a/gym/lib/gym/commands_generator.rb
+++ b/gym/lib/gym/commands_generator.rb
@@ -46,7 +46,7 @@ module Gym
         c.syntax = "fastlane gym init"
         c.description = "Creates a new Gymfile for you"
         c.action do |_args, options|
-          containing = (File.directory?("fastlane") ? 'fastlane' : '.')
+          containing = FastlaneCore::Helper.fastlane_enabled_folder_path
           path = File.join(containing, Gym.gymfile_name)
           UI.user_error! "Gymfile already exists" if File.exist?(path)
           template = File.read("#{Gym::ROOT}/lib/assets/GymfileTemplate")

--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -1,4 +1,5 @@
 require 'commander'
+require 'fastlane_core'
 require 'fastlane/version'
 
 HighLine.track_eof = false
@@ -60,7 +61,7 @@ module Match
         c.syntax = 'fastlane match init'
         c.description = 'Create the Matchfile for you'
         c.action do |args, options|
-          containing = (File.directory?("fastlane") ? 'fastlane' : '.')
+          containing = FastlaneCore::Helper.fastlane_enabled_folder_path
           path = File.join(containing, "Matchfile")
 
           if File.exist?(path)

--- a/scan/lib/scan/commands_generator.rb
+++ b/scan/lib/scan/commands_generator.rb
@@ -45,7 +45,7 @@ module Scan
         c.syntax = "fastlane scan init"
         c.description = "Creates a new Scanfile for you"
         c.action do |_args, options|
-          containing = (Helper.fastlane_enabled? ? 'fastlane' : '.')
+          containing = FastlaneCore::Helper.fastlane_enabled_folder_path
           path = File.join(containing, Scan.scanfile_name)
           UI.user_error!("Scanfile already exists").yellow if File.exist?(path)
           template = File.read("#{Scan::ROOT}/lib/assets/ScanfileTemplate")

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -9,7 +9,7 @@ module Scan
     end
 
     def self.available_options
-      containing = Helper.fastlane_enabled? ? FastlaneCore::FastlaneFolder.path : '.'
+      containing = FastlaneCore::Helper.fastlane_enabled_folder_path
 
       [
         FastlaneCore::ConfigItem.new(key: :workspace,


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Update to get the fastlane folder the more correct way (that will even find it if the folder starts with a .)