### PR TITLE
Raise exception if AGV is not enabled for increment_build_number

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -16,7 +16,7 @@ module Fastlane
         # https://developer.apple.com/library/ios/qa/qa1827/_index.html
         # Attention: This is NOT the version number - but the build number
         agv_enabled = system('agvtool what-version')
-        raise "Apple Generic Versioning is not enabled." unless agv_enabled || Helper.test?
+        raise "Apple Generic Versioning is not enabled." unless Helper.test? || agv_enabled
 
         folder = params[:xcodeproj] ? File.join(params[:xcodeproj], '..') : '.'
 

--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -15,6 +15,8 @@ module Fastlane
         # More information about how to set up your project and how it works:
         # https://developer.apple.com/library/ios/qa/qa1827/_index.html
         # Attention: This is NOT the version number - but the build number
+        agv_enabled = system('agvtool what-version')
+        raise "Apple Generic Versioning is not enabled." unless agv_enabled
 
         folder = params[:xcodeproj] ? File.join(params[:xcodeproj], '..') : '.'
 
@@ -47,9 +49,8 @@ module Fastlane
 
           return Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number
         end
-      rescue => ex
-        UI.error('Before being able to increment and read the version number from your Xcode project, you first need to setup your project properly. Please follow the guide at https://developer.apple.com/library/content/qa/qa1827/_index.html')
-        raise ex
+      rescue
+        UI.user_error!("Apple Generic Versioning is not enabled in this project.\nBefore being able to increment and read the version number from your Xcode project, you first need to setup your project properly. Please follow the guide at https://developer.apple.com/library/content/qa/qa1827/_index.html")
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -16,7 +16,7 @@ module Fastlane
         # https://developer.apple.com/library/ios/qa/qa1827/_index.html
         # Attention: This is NOT the version number - but the build number
         agv_enabled = system('agvtool what-version')
-        raise "Apple Generic Versioning is not enabled." unless agv_enabled
+        raise "Apple Generic Versioning is not enabled." unless agv_enabled || Helper.test?
 
         folder = params[:xcodeproj] ? File.join(params[:xcodeproj], '..') : '.'
 


### PR DESCRIPTION
This addresses the issue raised in https://github.com/fastlane/fastlane/pull/9258. Even when AGV is not enabled, build numbers can be explicitly set via `increment_build_number` but I don't believe this is intended behavior. People should use `set_plist_value` to set the `CFBundleVersion` if they do not want to use [Apple Generic Versioning](https://developer.apple.com/library/content/qa/qa1827/_index.html).