### PR TITLE
Version bump to 2.39.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.38.1'.freeze
+  VERSION = '2.39.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.38.1':**

* Fixes typo. (#9491) via Péter Krassay
* Handle Setting.bundle in a group for commit_version_bump (#9423) via Jimmy Dee
* Add default path for automatic code signing actions (#9465) via Joseph
* Helper.keychain_path heuristic should only search for file to avoid returning directories as false positives (#9462) (#9464) via Jerome Lacoste
* get reference to fastlane folder the more correct way (#9466) via Joshua Liebowitz
* New action to check minimal version of ruby (#9438) via Sebastián Varela
* Catch errors with app names (#9282) via David Ohayon
* Add option for the path to the swiftlint executable (#9451) via David Ohayon
* Update Supply to use 0.12.0 of google-api-client (#9445) via Tom Wilson
* Added platform description for Deliverfile (#9457) via Victor Ronin
* Reference target name instead of product name. (#8988) via Daniel Lee
* Fix crash in crash reporter if backtrace isn't accessible (#9430) via Felix Krause
* Create subkey param for manipulating a dictionary's key-value pair in a plist (#9088) via uwehollatz
* Only use fastlane as the action for the crash reporter (#9452) via David Ohayon
* Dont wrap the terminal table call in a rescue block (#9450) via David Ohayon
* adjusted find build method to exit early if we don't have candidate builds and show a better user error (#9447) via Carola Nitz
* Create YourFirstPR.md (#9446) via Carola Nitz
