### PR TITLE
[pilot] Fix passing paramter as named parameter

### DIFF
--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -29,7 +29,7 @@ module Spaceship::TestFlight
 
     def get_builds_for_train(app_id: nil, platform: "ios", train_version: nil, retry_count: 0)
       assert_required_params(__method__, binding)
-      with_retry(retry_count: retry_count) do
+      with_retry(retry_count) do
         response = request(:get, "providers/#{team_id}/apps/#{app_id}/platforms/#{platform}/trains/#{train_version}/builds")
         handle_response(response)
       end


### PR DESCRIPTION
- Introduced via https://github.com/fastlane/fastlane/commit/1113481ad7b8ca3b76accf432b8e4d5dfb2f2077
- with_retry requires a non-named parameter, it has a default (indicated via the `=`), but doesn't allow named parameters (indicated via the `:`)
- Changing it to a simple parameter should do the trick

Related question: why do we need to pass a custom number here? Looking up the caller stack I couldn't find out why we to a custom number (always 2) instead of using the default for `with_retry` which is 5.

If there is no reason to keep it, I'd be in favor of removing the custom retry number at this point 👍

Fixes https://github.com/fastlane/fastlane/issues/9485