### PR TITLE
[supply] Fix Google API timeout option names (#9496)

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -68,8 +68,8 @@ module Supply
 
       Google::Apis::ClientOptions.default.application_name = "fastlane - supply"
       Google::Apis::ClientOptions.default.application_version = Fastlane::VERSION
-      Google::Apis::RequestOptions.default.timeout_sec = 300
-      Google::Apis::RequestOptions.default.open_timeout_sec = 300
+      Google::Apis::ClientOptions.default.read_timeout_sec = 300
+      Google::Apis::ClientOptions.default.open_timeout_sec = 300
       Google::Apis::RequestOptions.default.retries = 5
 
       self.android_publisher = Androidpublisher::AndroidPublisherService.new


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Supply throws an error when attempting to connect to the Google APIs due to a gem update and some setting name changes.

Resolves https://github.com/fastlane/fastlane/issues/9496

### Description

Migration setting updates detailed at https://github.com/google/google-api-ruby-client/blob/8ef5c84c78f6eae4292be8c37ba901a847718dd7/MIGRATING.md#timeouts