### PR TITLE
Version bump to 2.39.1

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.39.0'.freeze
+  VERSION = '2.39.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.39.0':**

* Raise exception if AGV is not enabled for increment_build_number (#9474) via David Ohayon
* [supply] Fix Google API timeout option names (#9496) (#9499) via Eric McNiece
* [pilot] Fix passing paramter as named parameter (#9495) via Felix Krause
