### PR TITLE
go into the xcodeproj's folder, if given

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -12,12 +12,6 @@ module Fastlane
       end
 
       def self.run(params)
-        # More information about how to set up your project and how it works:
-        # https://developer.apple.com/library/ios/qa/qa1827/_index.html
-        # Attention: This is NOT the version number - but the build number
-        agv_enabled = system('agvtool what-version')
-        raise "Apple Generic Versioning is not enabled." unless Helper.test? || agv_enabled
-
         folder = params[:xcodeproj] ? File.join(params[:xcodeproj], '..') : '.'
 
         command_prefix = [
@@ -31,6 +25,12 @@ module Fastlane
           'cd',
           '-'
         ].join(' ')
+
+        # More information about how to set up your project and how it works:
+        # https://developer.apple.com/library/ios/qa/qa1827/_index.html
+        # Attention: This is NOT the version number - but the build number
+        agv_enabled = system([command_prefix, 'agvtool what-version', command_suffix].join(' '))
+        raise "Apple Generic Versioning is not enabled." unless Helper.test? || agv_enabled
 
         command = [
           command_prefix,


### PR DESCRIPTION
🔑

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#9474 checks if `agvtool` is enabled, but doesn't change directories to the xcodeproj file if you give `:xcodeproj` as an argument.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/fastlane/fastlane/issues/9506.
<!--- Please describe in detail how you tested your changes. --->
I cloned my fork locally, updated my project's Gemfile to use it, ran `bundle show fastlane` to verify that bundler was using my clone and not the installed version, and then ran my action that uses `increment_build_number`. And it passed!

### Description
<!--- Describe your changes in detail -->
I moved the `agv what-version` call down to after we've discovered the folder of the .xcodeproj, and made us `cd` into the folder before running `agvtool`.