### PR TITLE
Fixed issue where deliver would not print appropriate error messages after failing to upload metadata

### DIFF
--- a/.assets/Gemfile
+++ b/.assets/Gemfile
@@ -2,4 +2,4 @@
 
 source "https://rubygems.org"
 
-gemspec path: File.expand_path("/Users/colinmcd94/Projects/fastlane")
+gemspec path: File.expand_path("<PATH_TO_YOUR_LOCAL_FASTLANE_CLONE>")

--- a/.assets/Gemfile
+++ b/.assets/Gemfile
@@ -2,4 +2,4 @@
 
 source "https://rubygems.org"
 
-gemspec path: File.expand_path("<PATH_TO_YOUR_LOCAL_FASTLANE_CLONE>")
+gemspec path: File.expand_path("/Users/colinmcd94/Projects/fastlane")

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -121,7 +121,7 @@ module Deliver
       begin
         details.save!
         UI.success("Successfully uploaded set of metadata to iTunes Connect")
-      rescue Spaceship::ITunesConnectError => e
+      rescue Spaceship::TunesClient::ITunesConnectError => e
         # This makes sure that we log invalid app names as user errors
         # If another string needs to be checked here we should
         # figure out a more generic way to handle these cases.


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x ] I've updated the documentation if necessary.

### Motivation and Context
While trying to use deliver to upload metadata to an iOS app I'm building I repeatedly saw this non-informative error message:
`/Users/colinmcd94/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.39.1/deliver/lib/deliver/upload_metadata.rb:124:in `rescue in upload': [!] uninitialized constant Spaceship::ITunesConnectError (NameError)`

It turns out the bundle ID I was trying to use was already in use, but that error wasn't printed because of a bug in upload_metadata.rb. 

### Description
I assume at some point the error constant ITunesConnectError was moved from being a property of `Spaceship` to a property of `Spaceship::TunesClient`. I just replaced `Spaceship` with `Spaceship::TunesClient` in the file and the error messages began printing out as expected.


