### PR TITLE
Add last_git_commit_hash to git_helper

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -230,7 +230,7 @@ module Fastlane
         if Actions.last_git_commit_hash(true) && should_add_payload[:last_git_commit_hash]
           slack_attachment[:fields] << {
             title: 'Git Commit Hash',
-            value: Actions.last_git_commit_hash(true),
+            value: Actions.last_git_commit_hash(short: true),
             short: false
           }
         end

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -129,7 +129,7 @@ module Fastlane
               "Built by" => "Jenkins",
             },
             default_payloads: [:git_branch, :git_author], # Optional, lets you specify a whitelist of default payloads to include. Pass an empty array to suppress all the default payloads.
-                                                          # Don\'t add this key, or pass nil, if you want all the default payloads. The available default payloads are: `lane`, `test_result`, `git_branch`, `git_author`, `last_git_commit_message`.
+                                                          # Don\'t add this key, or pass nil, if you want all the default payloads. The available default payloads are: `lane`, `test_result`, `git_branch`, `git_author`, `last_git_commit_message`, `last_git_commit_hash`.
             attachment_properties: { # Optional, lets you specify any other properties available for attachments in the slack API (see https://api.slack.com/docs/attachments).
                                      # This hash is deep merged with the existing properties set using the other properties above. This allows your own fields properties to be appended to the existing fields that were created using the `payload` property for instance.
               thumb_url: "http://example.com/path/to/thumb.png",
@@ -222,6 +222,15 @@ module Fastlane
           slack_attachment[:fields] << {
             title: 'Git Commit',
             value: Actions.last_git_commit_message,
+            short: false
+          }
+        end
+
+        # last_git_commit_hash
+        if Actions.last_git_commit_hash(true) && should_add_payload[:last_git_commit_hash]
+          slack_attachment[:fields] << {
+            title: 'Git Commit Hash',
+            value: Actions.last_git_commit_hash(true),
             short: false
           }
         end

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -88,12 +88,9 @@ module Fastlane
 
     # Get the hash of the last commit
     def self.last_git_commit_hash(short)
-      if short
-        s = last_git_commit_formatted_with('%h')
-      else
-        s = last_git_commit_formatted_with('%H')
-      end
-      return s if s.to_s.length > 0
+      format_specifier = short ? '%h' : '%H'
+      string = last_git_commit_formatted_with(format_specifier).to_s
+      return string unless string.empty?
       return nil
     end
 

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -86,6 +86,17 @@ module Fastlane
       nil
     end
 
+    # Get the hash of the last commit
+    def self.last_git_commit_hash(short)
+      if short
+        s = last_git_commit_formatted_with('%h')
+      else
+        s = last_git_commit_formatted_with('%H')
+      end
+      return s if s.to_s.length > 0
+      return nil
+    end
+
     # Returns the current git branch - can be replaced using the environment variable `GIT_BRANCH`
     def self.git_branch
       return ENV['GIT_BRANCH'] if ENV['GIT_BRANCH'].to_s.length > 0 # set by Jenkins

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -27,7 +27,7 @@ describe Fastlane do
             'Build Date' => Time.new.to_s,
             'Built by' => 'Jenkins'
           },
-          default_payloads: [:lane, :test_result, :git_branch, :git_author]
+          default_payloads: [:lane, :test_result, :git_branch, :git_author, :last_git_commit_hash]
         })
 
         notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Adding the last git commit to the slack message provides useful information to those seeing the message. It identifies the exact commit by its identifier than just the commit message (ex: a1b2c3 vs "hot fix")

### Description
<!--- Describe your changes in detail -->

1. I added a last_git_commit_hash function to the git_helper. If given a boolean true it returns the short hash of the last commit, if not, it returns the full hash. 
2. Used the last_git_commit_hash to add the short hash to the default slack function message. 