### PR TITLE
Version bump to 2.39.2

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.39.1'.freeze
+  VERSION = '2.39.2'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.39.1':**

* [supply] Mask json_key_data in summary table (#9507) via Stanislav Shakirov
* [increment_build_number] Check xcodeproj param (#9508) via Hawken Rives
* Show message that Xcode 9 isn't support in snapshot ye (#9468) via Felix Krause
