### PR TITLE
Duplicate swiftlint custom executable parameter, so it doesn't get corrupted

### DIFF
--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -11,7 +11,7 @@ module Fastlane
           UI.user_error!("Your version of swiftlint (#{version}) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
         end
 
-        command = params[:executable].nil? ? "swiftlint" : params[:executable]
+        command = params[:executable].nil? ? "swiftlint" : params[:executable].dup
         command << " #{params[:mode]}"
         command << supported_option_switch(params, :strict, "0.9.2", true)
         command << " --config #{params[:config_file].shellescape}" if params[:config_file]

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -11,7 +11,7 @@ module Fastlane
           UI.user_error!("Your version of swiftlint (#{version}) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
         end
 
-        command = params[:executable].nil? ? "swiftlint" : params[:executable].dup
+        command = (params[:executable] || "swiftlint").dup
         command << " #{params[:mode]}"
         command << supported_option_switch(params, :strict, "0.9.2", true)
         command << " --config #{params[:config_file].shellescape}" if params[:config_file]
@@ -39,7 +39,7 @@ module Fastlane
 
       # Get current SwiftLint version
       def self.swiftlint_version(executable: nil)
-        binary = executable.nil? ? 'swiftlint' : executable
+        binary = executable || 'swiftlint'
         Gem::Version.new(`#{binary} version`.chomp)
       end
 

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -29,6 +29,26 @@ describe Fastlane do
 
           expect(result).to eq("swiftlint lint --strict")
         end
+
+        it "adds strict option for custom executable" do
+          CUSTOM_EXECUTABLE_NAME = "custom_executable"
+
+          # Override the already overridden swiftlint_version method to check
+          # that the correct exectuable is being passed in as a parameter.
+          allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version) { |params|
+            expect(params[:executable]).to eq(CUSTOM_EXECUTABLE_NAME)
+            swiftlint_gem_version
+          }
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              strict: true,
+              executable: '#{CUSTOM_EXECUTABLE_NAME}'
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("#{CUSTOM_EXECUTABLE_NAME} lint --strict")
+        end
       end
 
       context "when specify false for strict option" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This allows us to use the --strict parameter (and others) with a custom swiftlint executable (i.e. if it's installed as a cocoapod)

It fixes issue #9533

### Description

Duplicate the executable parameter when constructing the command so it doesn't get corrupted. This prevents further version checks from failing.
