### PR TITLE
Generate specific version url for a HockeyApp build

### DIFF
--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -171,10 +171,11 @@ module Fastlane
         case response.status
         when 200...300
           url = response.body['public_url']
-
+          version_url = url + "/app_versions/" + response.body['version']
           Actions.lane_context[SharedValues::HOCKEY_DOWNLOAD_LINK] = url
           Actions.lane_context[SharedValues::HOCKEY_BUILD_INFORMATION] = response.body
 
+          UI.message("Version Download URL: #{version_url}") if version_url
           UI.message("Public Download URL: #{url}") if url
           UI.success('Build successfully uploaded to HockeyApp!')
         else

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -172,7 +172,7 @@ module Fastlane
         when 200...300
           url = response.body['public_url']
           version_url = url + "/app_versions/" + response.body['version']
-          Actions.lane_context[SharedValues::HOCKEY_DOWNLOAD_LINK] = url
+          Actions.lane_context[SharedValues::HOCKEY_DOWNLOAD_LINK] = version_url
           Actions.lane_context[SharedValues::HOCKEY_BUILD_INFORMATION] = response.body
 
           UI.message("Version Download URL: #{version_url}") if version_url


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
The current HockeyApp configuration gives the public url. This means the last 25 versions.
The current approach we have many releases a day, and it's cumbersome to search.

This just adds a new line to the output so we can directly access the specific version url.

### Description
<!--- Describe your changes in detail -->
Using the existing information from the HockeyApp Build, we print a new url to access the current built version directly.