### PR TITLE
Version bump to 2.40.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,4 +1,4 @@
 module Fastlane
-  VERSION = '2.39.2'.freeze
+  VERSION = '2.40.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.39.2':**

* Added ability to explicity flag "is_optional" for fields that we check via Joshua Liebowitz
* Allow to skip updating of an app version under 'Prepare for submission' (#9469) via Victor Ronin
* Wrap call to precheck to prevent it from crashing deliver if it throws an exception via Joshua Liebowitz
* deliver now depends on precheck - only submit to review if precheck is successful - precheck warns by default when run from deliver via Joshua Liebowitz
* added copyright date check rule via Joshua Liebowitz
* Added rule that allows you to pass in an array of words to check for Made many rule methods instance methods instead of class Updated PrecheckfileTemplate to include example of custom text via Joshua Liebowitz
* fastlane precheck init creates Precheckfile Precheckfile template updated with examples Add precheck action via Joshua Liebowitz
* Added app subtitle checking Can specify rule levels now :warn :error :skip Updated rule descriptions and text Output is more friendly and less verbose update README for Precheckfile example changes Print out missing metadata fields only if there are missing fields Enable URLRules via Joshua Liebowitz
* Added apple tv privacy policy checking via Joshua Liebowitz
* Check app name and app privacy policy url via Joshua Liebowitz
* Added curse word rule and common english curse hashes via Joshua Liebowitz
* Added rule for test data via Joshua Liebowitz
* Unreachable URL, and Apple name rules implemented via Joshua Liebowitz
* Added friendly error message if app can't be found via Joshua Liebowitz
* commands_generator added inspect AppVersion for fields that contain metadata we should check for violations via Joshua Liebowitz
* Initial layout of review tool via Joshua Liebowitz
* Apk check superseded tracks (#9459) via Marcelo Oliveira
* Fixed issue where deliver would not print appropriate error messages after failing to upload metadata (#9515) via Colin McDonnell
