### PR TITLE
[snapshot] Add support for Xcode 9

### DIFF
--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -2,6 +2,10 @@ module Fastlane
   module Actions
     class ResetSimulatorContentsAction < Action
       def self.run(params)
+        if Helper.xcode_at_least?("9")
+          UI.user_error!("resetting simulators currently doesn't work with Xcode 9, stay tuned as we are working to add support for all new tools.")
+        end
+
         if params[:ios]
           params[:ios].each do |os_version|
             FastlaneCore::Simulator.reset_all_by_version(os_version: os_version)

--- a/snapshot/lib/snapshot/collector.rb
+++ b/snapshot/lib/snapshot/collector.rb
@@ -97,7 +97,7 @@ module Snapshot
         return find_screenshot(subactivity) if subactivity["Title"] == "Synthesize event"
       end
 
-      if Helper.xcode_at_least?("9") && activity["Attachments"]
+      if activity["Attachments"] && activity["Attachments"].last["Filename"]
         return activity["Attachments"].last["Filename"]
       elsif activity["Attachments"]
         return activity["Attachments"].last["FileName"]

--- a/snapshot/lib/snapshot/collector.rb
+++ b/snapshot/lib/snapshot/collector.rb
@@ -97,7 +97,7 @@ module Snapshot
         return find_screenshot(subactivity) if subactivity["Title"] == "Synthesize event"
       end
 
-      if activity["Attachments"] && activity["Attachments"].last["Filename"]
+      if activity["Attachments"] && activity["Attachments"].last && activity["Attachments"].last["Filename"]
         return activity["Attachments"].last["Filename"]
       elsif activity["Attachments"]
         return activity["Attachments"].last["FileName"]

--- a/snapshot/lib/snapshot/collector.rb
+++ b/snapshot/lib/snapshot/collector.rb
@@ -97,7 +97,9 @@ module Snapshot
         return find_screenshot(subactivity) if subactivity["Title"] == "Synthesize event"
       end
 
-      if activity["Attachments"]
+      if Helper.xcode_at_least?("9") && activity["Attachments"]
+        return activity["Attachments"].last["Filename"]
+      elsif activity["Attachments"]
         return activity["Attachments"].last["FileName"]
       else # Xcode 7.3 has stopped including 'Attachments', so we synthesize the filename manually
         return "Screenshot_#{activity['UUID']}.png"

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -18,10 +18,6 @@ module Snapshot
         sleep 3 # to be sure the user sees this, as compiling clears the screen
       end
 
-      if Helper.xcode_at_least?("9")
-        UI.user_error!("snapshot currently doesn't work with Xcode 9, we're working on implementing the new screenshots API to offer the best experience 🚀\nYou can change the Xcode version to use using `sudo xcode-select -s /Applications/Xcode...app`")
-      end
-
       Snapshot.config[:output_directory] = File.expand_path(Snapshot.config[:output_directory])
 
       verify_helper_is_current


### PR DESCRIPTION
In Xcode 9, Apple decided to use `Filename` rather than Xcode 8's `FileName` as a key in the plist generated by tests. This change just looks for that key if using Xcode 9.