### PR TITLE
Make sure crashlytics action fails when submit binary returns failure

### DIFF
--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -39,7 +39,7 @@ module Fastlane
 
         error_callback = proc do |error|
           clean_error = sanitizer.call(error)
-          UI.error(clean_error)
+          UI.user_error!(clean_error)
         end
 
         result = Actions.sh_control_output(


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
A recent change to how `sh` and its `error_callback` worked means that a fatal error (i.e., `shell_error!`) is not thrown if an `error_callback` was provided.  Since the `crashlytics` action makes no attempts to rescue in the event of an error and only uses the callback to print out a sanitized version of the error message, we need to be sure the callback reports fatal error in the event of failure.