### PR TITLE
Git add new options

### DIFF
--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -2,14 +2,22 @@ module Fastlane
   module Actions
     class GitAddAction < Action
       def self.run(params)
-        if params[:path].kind_of?(String)
-          paths = params[:path].shellescape
+        if params[:pathspec]
+          paths = params[:pathspec]
+          UI.success("Successfully added from \"#{paths}\" 💾.")
+        elsif params[:path]
+          if params[:path].kind_of?(String)
+            paths = params[:path].shellescape
+          else
+            paths = params[:path].map(&:shellescape).join(' ')
+          end
+          UI.success("Successfully added \"#{paths}\" 💾.")
         else
-          paths = params[:path].map(&:shellescape).join(' ')
+          paths = "."
+          UI.success("Successfully added all files 💾.")
         end
 
         result = Actions.sh("git add #{paths}", log: FastlaneCore::Globals.verbose?).chomp
-        UI.success("Successfully added \"#{params[:path]}\" 💾.")
         return result
       end
 
@@ -18,14 +26,16 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Directly add the given file"
+        "Directly add the given file or all files"
       end
 
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :path,
-                                       description: "The file[s] you want to add",
+                                       description: "The file you want to add",
                                        is_string: false,
+                                       conflicting_options: [:pathspec],
+                                       optional: true,
                                        verify_block: proc do |value|
                                          if value.kind_of?(String)
                                            UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
@@ -34,7 +44,12 @@ module Fastlane
                                              UI.user_error!("Couldn't find file at path '#{x}'") unless File.exist?(x)
                                            end
                                          end
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :pathspec,
+                                       description: "The pathspec you want to add files from",
+                                       is_string: true,
+                                       conflicting_options: [:path],
+                                       optional: true),
         ]
       end
 
@@ -43,7 +58,7 @@ module Fastlane
       end
 
       def self.authors
-        ["4brunu"]
+        ["4brunu", "antondomashnev"]
       end
 
       def self.is_supported?(platform)
@@ -52,8 +67,11 @@ module Fastlane
 
       def self.example_code
         [
+          'git_add',
           'git_add(path: "./version.txt")',
-          'git_add(path: ["./version.txt", "./changelog.txt"])'
+          'git_add(path: ["./version.txt", "./changelog.txt"])',
+          'git_add(pathspec: "./Frameworks/*")',
+          'git_add(pathspec: "*.txt")'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -49,7 +49,7 @@ module Fastlane
                                        description: "The pathspec you want to add files from",
                                        is_string: true,
                                        conflicting_options: [:path],
-                                       optional: true),
+                                       optional: true)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -8,7 +8,7 @@ module Fastlane
           paths = params[:path].map(&:shellescape).join(' ')
         end
 
-        result = Actions.sh("git add #{paths}")
+        result = Actions.sh("git add #{paths}", log: FastlaneCore::Globals.verbose?).chomp
         UI.success("Successfully added \"#{params[:path]}\" 💾.")
         return result
       end
@@ -24,7 +24,7 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :path,
-                                       description: "The file you want to add",
+                                       description: "The file[s] you want to add",
                                        is_string: false,
                                        verify_block: proc do |value|
                                          if value.kind_of?(String)

--- a/fastlane/spec/actions_specs/git_add_spec.rb
+++ b/fastlane/spec/actions_specs/git_add_spec.rb
@@ -1,0 +1,42 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "git_add" do
+      before do
+        allow(File).to receive(:exist?).with(anything).and_return(true)
+      end
+
+      context "with path parameter" do
+        context "as string" do
+          let(:path) { "myfile.txt" }
+
+          it "executes the correct git command" do
+            allow(Fastlane::Actions).to receive(:sh).with("git add #{path}", anything).and_return("")
+            result = Fastlane::FastFile.new.parse("lane :test do
+              git_add(path: '#{path}')
+            end").runner.execute(:test)
+          end
+        end
+
+        context "as array" do
+          let(:path) { ["myfile.txt", "yourfile.txt"] }
+
+          it "executes the correct git command" do
+            allow(Fastlane::Actions).to receive(:sh).with("git add #{path[0]} #{path[1]}", anything).and_return("")
+            result = Fastlane::FastFile.new.parse("lane :test do
+              git_add(path: #{path})
+            end").runner.execute(:test)
+          end
+        end
+      end
+
+      it "logs the command if verbose" do
+        with_verbose(true) do
+          allow(Fastlane::Actions).to receive(:sh).with(anything, { log: true }).and_return("")
+          result = Fastlane::FastFile.new.parse("lane :test do
+            git_add(path: 'foo.bar')
+          end").runner.execute(:test)
+        end
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/git_add_spec.rb
+++ b/fastlane/spec/actions_specs/git_add_spec.rb
@@ -29,11 +29,11 @@ describe Fastlane do
         end
 
         it "can not have pathspec parameter" do
-          expect {
+          expect do
             Fastlane::FastFile.new.parse("lane :test do
               git_add(path: 'myfile.txt', pathspec: 'Frameworks/*')
             end").runner.execute(:test)
-          }.to raise_error
+          end.to raise_error
         end
       end
 
@@ -46,11 +46,11 @@ describe Fastlane do
         end
 
         it "can not have path parameter" do
-          expect {
+          expect do
             Fastlane::FastFile.new.parse("lane :test do
               git_add(path: 'myfile.txt', pathspec: '*.txt')
             end").runner.execute(:test)
-          }.to raise_error
+          end.to raise_error
         end
       end
 

--- a/fastlane/spec/actions_specs/git_add_spec.rb
+++ b/fastlane/spec/actions_specs/git_add_spec.rb
@@ -27,6 +27,40 @@ describe Fastlane do
             end").runner.execute(:test)
           end
         end
+
+        it "can not have pathspec parameter" do
+          expect {
+            Fastlane::FastFile.new.parse("lane :test do
+              git_add(path: 'myfile.txt', pathspec: 'Frameworks/*')
+            end").runner.execute(:test)
+          }.to raise_error
+        end
+      end
+
+      context "with pathspec parameter" do
+        it "executes the correct git command" do
+          allow(Fastlane::Actions).to receive(:sh).with("git add *.txt", anything).and_return("")
+          result = Fastlane::FastFile.new.parse("lane :test do
+            git_add(pathspec: '*.txt')
+          end").runner.execute(:test)
+        end
+
+        it "can not have path parameter" do
+          expect {
+            Fastlane::FastFile.new.parse("lane :test do
+              git_add(path: 'myfile.txt', pathspec: '*.txt')
+            end").runner.execute(:test)
+          }.to raise_error
+        end
+      end
+
+      context "without parameters" do
+        it "executes the correct git command" do
+          allow(Fastlane::Actions).to receive(:sh).with("git add .", anything).and_return("")
+          result = Fastlane::FastFile.new.parse("lane :test do
+            git_add
+          end").runner.execute(:test)
+        end
       end
 
       it "logs the command if verbose" do


### PR DESCRIPTION
🔑

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change is a result of a need to add all file to the git - analog of the `git add .` command. There was an [issue](https://github.com/fastlane/fastlane/issues/9547) created to discuss the sense of the addition.

### Description
The PR brings two new features for `git_add` action:
1. Ability to add all files with just `git_add` call without parameters
2. Ability to add files with path conforming to the given template - like `*.txt` or `./Frameworks/*` 
