### PR TITLE
Add support for OS version in Appetize options

### DIFF
--- a/fastlane/lib/fastlane/actions/appetize_viewing_url_generator.rb
+++ b/fastlane/lib/fastlane/actions/appetize_viewing_url_generator.rb
@@ -26,6 +26,7 @@ module Fastlane
         url_params << "scale=#{params[:scale]}"
         url_params << "launchUrl=#{params[:launch_url]}" if params[:launch_url]
         url_params << "language=#{params[:language]}" if params[:language]
+        url_params << "osVersion=#{params[:os_version]}" if params[:os_version]
 
         return link + "?" + url_params.join("&")
       end
@@ -96,6 +97,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :launch_url,
                                        env_name: "APPETIZE_VIEWING_URL_GENERATOR_LAUNCH_URL",
                                        description: "Specify a deep link to open when your app is launched",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :os_version,
+                                       env_name: "APPETIZE_VIEWING_URL_GENERATOR_OS_VERSION",
+                                       description: "The operating system version on which to run your app, e.g. 10.3, 8.0",
                                        is_string: true,
                                        optional: true)
         ]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
By default, Appetize launches with the iOS version set to iOS 8.0. Creating an Appetize URL via Fastlane for an app that targets a more recent iOS version requires the user to manually select the iOS version in the Appetize webpage for the app to work. 

For apps that target more recent iOS versions, the `osVersion` parameter allows an Appetize URL to be created with the correct iOS version. This PR allows this parameter to be specified from Fastlane.

### Description
Adds an `os_version` parameter to `appetize_viewing_url_generator.rb`.