### PR TITLE
Fix disable_notify option on deploygate action

### DIFF
--- a/fastlane/lib/fastlane/actions/deploygate.rb
+++ b/fastlane/lib/fastlane/actions/deploygate.rb
@@ -30,6 +30,7 @@ module Fastlane
           file: Faraday::UploadIO.new(binary, 'application/octet-stream'),
           message: options[:message] || ''
         })
+        options[:disable_notify] = 'yes' if options[:disable_notify]
 
         connection.post("/api/users/#{user_name}/apps", options)
       rescue Faraday::Error::TimeoutError


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

`disable_notify` option on `deploygate` action seems not to work well. 🤔 

### Description

According to DeployGate API documentation (https://deploygate.com/docs/api?locale=en)
curiously, `disable_notify` must be `'yes'` as string not `true`.

On fastlane, `yes` is converted to `true` automatically.
https://github.com/fastlane/fastlane/blob/master/fastlane_core/lib/fastlane_core/configuration/config_item.rb#L166

So, this PR make converting boolean value to `'yes'` in API request.