### PR TITLE
Update obbs feature

### DIFF
--- a/supply/README.md
+++ b/supply/README.md
@@ -138,6 +138,18 @@ Expansion files (obbs) found under the same directory as your APK will also be u
 - they are identified as type 'main' or 'patch' (by containing 'main' or 'patch' in their file name)
 - you have at most one of each type
 
+If you want only update expansion files from previous version on Google Play use
+
+```
+fastlane supply --apk path/app.apk --obb_main_references_version version --obb_main_file_size size
+```
+
+or
+
+```
+fastlane supply --apk path/app.apk --obb_patch_references_version version --obb_patch_file_size size
+```
+
 ## Images and Screenshots
 
 After running `fastlane supply init`, you will have a metadata directory. This directory contains one or more locale directories (e.g. en-US, en-GB, etc.), and inside this directory are text files such as `title.txt` and `short_description.txt`.

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -345,13 +345,14 @@ module Supply
 
       call_google_api do
         android_publisher.update_edit_expansionfile(
-            current_package_name,
-            current_edit.id,
-            apk_version_code,
-            expansion_file_type,
-            Google::Apis::AndroidpublisherV2::ExpansionFile.new(
-                references_version: references_version,
-                file_size: file_size)
+          current_package_name,
+          current_edit.id,
+          apk_version_code,
+          expansion_file_type,
+          Google::Apis::AndroidpublisherV2::ExpansionFile.new(
+            references_version: references_version,
+            file_size: file_size
+          )
         )
       end
     end

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -340,6 +340,22 @@ module Supply
       end
     end
 
+    def update_obb(apk_version_code, expansion_file_type, references_version, file_size)
+      ensure_active_edit!
+
+      call_google_api do
+        android_publisher.update_edit_expansionfile(
+            current_package_name,
+            current_edit.id,
+            apk_version_code,
+            expansion_file_type,
+            Google::Apis::AndroidpublisherV2::ExpansionFile.new(
+                references_version: references_version,
+                file_size: file_size)
+        )
+      end
+    end
+
     def upload_obb(obb_file_path: nil, apk_version_code: nil, expansion_file_type: nil)
       ensure_active_edit!
 

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -172,8 +172,28 @@ module Supply
                                      optional: true,
                                      verify_block: proc do |value|
                                        UI.user_error! "Could not parse URL '#{value}'" unless value =~ URI.regexp
-                                     end)
+                                     end),
 
+        FastlaneCore::ConfigItem.new(key: :obb_main_references_version,
+                                     env_name: "OBB_MAIN_REFERENCES_VERSION",
+                                     description: "References version of 'main' expansion file",
+                                     optional: true,
+                                     type: Numeric),
+        FastlaneCore::ConfigItem.new(key: :obb_main_file_size,
+                                     env_name: "OBB_MAIN_FILE SIZE",
+                                     description: "Size of 'main' expansion file in bytes",
+                                     optional: true,
+                                     type: Numeric),
+        FastlaneCore::ConfigItem.new(key: :obb_patch_references_version,
+                                     env_name: "OBB_PATCH_REFERENCES_VERSION",
+                                     description: "References version of 'patch' expansion file",
+                                     optional: true,
+                                     type: Numeric),
+        FastlaneCore::ConfigItem.new(key: :obb_patch_file_size,
+                                     env_name: "OBB_PATCH_FILE SIZE",
+                                     description: "Size of 'patch' expansion file in bytes",
+                                     optional: true,
+                                     type: Numeric)
       ]
     end
     # rubocop:enable Metrics/PerceivedComplexity

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -139,18 +139,18 @@ module Supply
         apk_version_code = client.upload_apk(apk_path)
         UI.user_error!("Could not upload #{apk_path}") unless apk_version_code
 
-        if Supply::config[:obb_main_references_version] && Supply::config[:obb_main_file_size]
+        if Supply.config[:obb_main_references_version] && Supply.config[:obb_main_file_size]
           update_obb(apk_version_code,
                      'main',
-                     Supply::config[:obb_main_references_version],
-                     Supply::config[:obb_main_file_size])
+                     Supply.config[:obb_main_references_version],
+                     Supply.config[:obb_main_file_size])
         end
 
-        if Supply::config[:obb_patch_references_version] && Supply::config[:obb_patch_file_size]
+        if Supply.config[:obb_patch_references_version] && Supply.config[:obb_patch_file_size]
           update_obb(apk_version_code,
                      'patch',
-                     Supply::config[:obb_patch_references_version],
-                     Supply::config[:obb_patch_file_size])
+                     Supply.config[:obb_patch_references_version],
+                     Supply.config[:obb_patch_file_size])
         end
 
         upload_obbs(apk_path, apk_version_code)

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -139,6 +139,20 @@ module Supply
         apk_version_code = client.upload_apk(apk_path)
         UI.user_error!("Could not upload #{apk_path}") unless apk_version_code
 
+        if Supply::config[:obb_main_references_version] && Supply::config[:obb_main_file_size]
+          update_obb(apk_version_code,
+                     'main',
+                     Supply::config[:obb_main_references_version],
+                     Supply::config[:obb_main_file_size])
+        end
+
+        if Supply::config[:obb_patch_references_version] && Supply::config[:obb_patch_file_size]
+          update_obb(apk_version_code,
+                     'patch',
+                     Supply::config[:obb_patch_references_version],
+                     Supply::config[:obb_patch_file_size])
+        end
+
         upload_obbs(apk_path, apk_version_code)
 
         if metadata_path
@@ -151,6 +165,14 @@ module Supply
         UI.message("No apk file found, you can pass the path to your apk using the `apk` option")
       end
       apk_version_code
+    end
+
+    def update_obb(apk_version_code, expansion_file_type, references_version, file_size)
+      UI.message("Updating '#{expansion_file_type}' expansion file from verison '#{references_version}'...")
+      client.update_obb(apk_version_code,
+                        expansion_file_type,
+                        references_version,
+                        file_size)
     end
 
     def update_track(apk_version_codes)


### PR DESCRIPTION
<!--- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run bundle exec rspec from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run bundle exec rubocop -a to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. -->
Unfortunatelly supply has no option to update expansion files from previous versions on Google play. It can be important when expansion files change rarely, but they are too large to upload them every version of your app. Even if you put the same expansion files with apk, 'upload_edit_expansionfile' method will make new versions of obb files, so user need to upload the same files.

Issues with this problem closed because of no activity (#7816, #8533)

Tested only by using supply to upload own app to Google Play.
### Description
<!--- Describe your changes in detail -->
Added new parametrs to supply action (obb_main_references_version, obb_main_file_size, obb_patch_references_version, obb_patch_file_size), which occure to use 'update_edit_expansionfile' method.
Added small changes in Readme.md