### PR TITLE
fix "uninitialized constant Spaceship::Client::Tempfile" for client.rb

### DIFF
--- a/spaceship/lib/spaceship/two_step_client.rb
+++ b/spaceship/lib/spaceship/two_step_client.rb
@@ -1,3 +1,5 @@
+require 'tempfile'
+
 module Spaceship
   class Client
     def handle_two_step(response)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently, when using the FASTLANE_SESSION env var with spaceship
it will result in the following error being produced.

"fastlane/spaceship/lib/spaceship/two_step_client.rb:96:in `load_session_from_env': uninitialized constant Spaceship::Client::Tempfile (NameError)"

### Description
tempfile needs to be required.
