### PR TITLE
Fix string encoding in Readme

### DIFF
--- a/frameit/README.md
+++ b/frameit/README.md
@@ -188,7 +188,7 @@ To define the title and optionally the keyword, put two `.strings` files into th
 
 The `keyword.strings` and `title.strings` are standard `.strings` file you already use for your iOS apps, making it easy to use your existing translation service to get localized titles.
 
-**Note:** These `.strings` files **MUST** be utf-16 encoded (UTF-16 LE with BOM).  They also must begin with an empty line. If you are having trouble see [issue #1740](https://github.com/fastlane/fastlane/issues/1740)
+**Note:** These `.strings` files **MUST** be utf-16 encoded (UTF-16 BE with BOM).  They also must begin with an empty line. If you are having trouble see [issue #1740](https://github.com/fastlane/fastlane/issues/1740)
 
 **Note:** You **MUST** provide a background if you want titles. `frameit` will not add the tiles if a background is not specified.
 


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

This is just a documentation fix in the readme

### Motivation and Context

Following this Readme I've encoded the the .strings file with as `UTF-16 LE` but when running I got the error message

> Empty parsing result for .../fastlane/screenshots/en-US/keyword.strings. Please make sure the file is valid and UTF16 Big-endian encoded

This error message tells me to encode in Big Endian instead of Little Endian which contradicts the Readme. 

After converting the .strings files to `UTF-16 BE` frameit works so I beliefe the Readme was wrong.
