### PR TITLE
Precheck text rules refining

### DIFF
--- a/precheck/lib/precheck/rule_processor.rb
+++ b/precheck/lib/precheck/rule_processor.rb
@@ -140,12 +140,6 @@ module Precheck
     def self.generate_text_items_to_check(app: nil, app_version: nil)
       items = []
       items << TextItemToCheck.new(app_version.copyright, :copyright, "copyright")
-      items << TextItemToCheck.new(app_version.review_first_name, :review_first_name, "review first name")
-      items << TextItemToCheck.new(app_version.review_last_name, :review_last_name, "review last name")
-      items << TextItemToCheck.new(app_version.review_phone_number, :review_phone_number, "review phone number")
-      items << TextItemToCheck.new(app_version.review_email, :review_email, "review email")
-      items << TextItemToCheck.new(app_version.review_demo_user, :review_demo_user, "review demo user")
-      items << TextItemToCheck.new(app_version.review_notes, :review_notes, "review notes")
 
       items += collect_text_items_from_language_item(hash: app_version.keywords,
                                                 item_name: :keywords,

--- a/precheck/lib/precheck/rules/abstract_text_match_rule.rb
+++ b/precheck/lib/precheck/rules/abstract_text_match_rule.rb
@@ -14,12 +14,26 @@ module Precheck
       not_implemented(__method__)
     end
 
+    # list of words or phrases that should be excluded from this rule
+    # they will be removed from the text string before the rule is executed
+    def allowed_lowercased_words
+      []
+    end
+
     def pass_if_empty?
       return true
     end
 
     def word_search_type
       WORD_SEARCH_TYPES[:fail_on_inclusion]
+    end
+
+    def remove_safe_words(text: nil)
+      text_without_safe_words = text
+      allowed_lowercased_words.each do |safe_word|
+        text_without_safe_words.gsub!(safe_word, '')
+      end
+      return text_without_safe_words
     end
 
     # rule block that checks text for any instance of each string in lowercased_words_to_look_for
@@ -33,6 +47,8 @@ module Precheck
             return RuleReturn.new(validation_state: VALIDATION_STATES[:failed], failure_data: "missing text")
           end
         end
+
+        text = remove_safe_words(text: text)
 
         matches = lowercased_words_to_look_for.each_with_object([]) do |word, found_words|
           if text.include?(word)

--- a/precheck/lib/precheck/rules/other_platforms_rule.rb
+++ b/precheck/lib/precheck/rules/other_platforms_rule.rb
@@ -19,6 +19,10 @@ module Precheck
       "mentioning other platforms, like Android or Blackberry"
     end
 
+    def allowed_lowercased_words
+      ["google analytics"]
+    end
+
     def lowercased_words_to_look_for
       [
         "android",

--- a/precheck/lib/precheck/rules/placeholder_words_rule.rb
+++ b/precheck/lib/precheck/rules/placeholder_words_rule.rb
@@ -25,8 +25,7 @@ module Precheck
         "bacon ipsum",
         "lorem ipsum",
         "placeholder",
-        "text here",
-        "todo"
+        "text here"
       ].map(&:downcase)
     end
   end


### PR DESCRIPTION
A few rules were flagging things that shouldn't have been. This fixes: https://github.com/fastlane/fastlane/issues/9568
https://github.com/fastlane/fastlane/issues/9567

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.


