### PR TITLE
Sort certificates to always verify the validity of the last

### DIFF
--- a/pem/lib/pem/manager.rb
+++ b/pem/lib/pem/manager.rb
@@ -9,7 +9,7 @@ module PEM
         FastlaneCore::PrintTable.print_values(config: PEM.config, hide_keys: [:new_profile], title: "Summary for PEM #{Fastlane::VERSION}")
         login
 
-        existing_certificate = certificate.all.detect do |c|
+        existing_certificate = certificate_sorted.detect do |c|
           c.owner_name == PEM.config[:app_identifier]
         end
 
@@ -87,6 +87,10 @@ module PEM
         else
           Spaceship.certificate.production_push
         end
+      end
+      
+      def certificate_sorted
+        certificate.all.sort {|x,y| y.expires <=> x.expires }
       end
     end
   end

--- a/pem/lib/pem/manager.rb
+++ b/pem/lib/pem/manager.rb
@@ -88,9 +88,9 @@ module PEM
           Spaceship.certificate.production_push
         end
       end
-      
+
       def certificate_sorted
-        certificate.all.sort {|x,y| y.expires <=> x.expires }
+        certificate.all.sort { |x, y| y.expires <=> x.expires }
       end
     end
   end


### PR DESCRIPTION
### Motivation and Context
In case I have a certificate expiring in less than 30 days and an expiring certificate in 300 days. Pem tries to create a certificate while the maximum number of certificates is reached and a certificate valid for more than 30 days.
It would be sufficient to verify that the certificate that expires last is still valid.

### Description
Sort certificates by descending expiration dates to check which expires last.