### PR TITLE
Updating obb files from earlier versions added

### DIFF
--- a/supply/README.md
+++ b/supply/README.md
@@ -138,6 +138,18 @@ Expansion files (obbs) found under the same directory as your APK will also be u
 - they are identified as type 'main' or 'patch' (by containing 'main' or 'patch' in their file name)
 - you have at most one of each type
 
+If you want only update expansion files from previous version on Google Play use
+
+```
+fastlane supply --apk path/app.apk --obb_main_references_version version --obb_main_file_size size
+```
+
+or
+ 
+```
+fastlane supply --apk path/app.apk --obb_patch_references_version version --obb_patch_file_size size
+```
+
 ## Images and Screenshots
 
 After running `fastlane supply init`, you will have a metadata directory. This directory contains one or more locale directories (e.g. en-US, en-GB, etc.), and inside this directory are text files such as `title.txt` and `short_description.txt`.

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -50,8 +50,8 @@ module Supply
         require 'google/api_client/auth/key_utils'
         key = Google::APIClient::KeyUtils.load_from_pkcs12(File.expand_path(path_to_key), 'notasecret')
         cred_json = {
-          private_key: key.to_s,
-          client_email: issuer
+            private_key: key.to_s,
+            client_email: issuer
         }
         key_io = StringIO.new(MultiJson.dump(cred_json))
       end
@@ -143,9 +143,9 @@ module Supply
 
       begin
         result = android_publisher.get_edit_listing(
-          current_package_name,
-          current_edit.id,
-          language
+            current_package_name,
+            current_edit.id,
+            language
         )
 
         return Listing.new(self, language, result)
@@ -170,9 +170,9 @@ module Supply
 
       result = call_google_api do
         android_publisher.list_edit_apklistings(
-          current_package_name,
-          current_edit.id,
-          apk_version_code
+            current_package_name,
+            current_edit.id,
+            apk_version_code
         )
       end
 
@@ -190,19 +190,19 @@ module Supply
       ensure_active_edit!
 
       listing = Androidpublisher::Listing.new({
-        language: language,
-        title: title,
-        full_description: full_description,
-        short_description: short_description,
-        video: video
-      })
+                                                  language: language,
+                                                  title: title,
+                                                  full_description: full_description,
+                                                  short_description: short_description,
+                                                  video: video
+                                              })
 
       call_google_api do
         android_publisher.update_edit_listing(
-          current_package_name,
-          current_edit.id,
-          language,
-          listing
+            current_package_name,
+            current_edit.id,
+            language,
+            listing
         )
       end
     end
@@ -212,9 +212,9 @@ module Supply
 
       result_upload = call_google_api do
         android_publisher.upload_edit_apk(
-          current_package_name,
-          current_edit.id,
-          upload_source: path_to_apk
+            current_package_name,
+            current_edit.id,
+            upload_source: path_to_apk
         )
       end
 
@@ -226,12 +226,12 @@ module Supply
 
       call_google_api do
         android_publisher.upload_edit_deobfuscationfile(
-          current_package_name,
-          current_edit.id,
-          apk_version_code,
-          "proguard",
-          upload_source: path_to_mapping,
-          content_type: "application/octet-stream"
+            current_package_name,
+            current_edit.id,
+            apk_version_code,
+            "proguard",
+            upload_source: path_to_mapping,
+            content_type: "application/octet-stream"
         )
       end
     end
@@ -243,17 +243,17 @@ module Supply
       track_version_codes = apk_version_code.kind_of?(Array) ? apk_version_code : [apk_version_code]
 
       track_body = Androidpublisher::Track.new({
-        track: track,
-        user_fraction: rollout,
-        version_codes: track_version_codes
-      })
+                                                   track: track,
+                                                   user_fraction: rollout,
+                                                   version_codes: track_version_codes
+                                               })
 
       call_google_api do
         android_publisher.update_edit_track(
-          current_package_name,
-          current_edit.id,
-          track,
-          track_body
+            current_package_name,
+            current_edit.id,
+            track,
+            track_body
         )
       end
     end
@@ -264,9 +264,9 @@ module Supply
 
       begin
         result = android_publisher.get_edit_track(
-          current_package_name,
-          current_edit.id,
-          track
+            current_package_name,
+            current_edit.id,
+            track
         )
       end
 
@@ -277,17 +277,17 @@ module Supply
       ensure_active_edit!
 
       apk_listing_object = Androidpublisher::ApkListing.new({
-        language: apk_listing.language,
-        recent_changes: apk_listing.recent_changes
-      })
+                                                                language: apk_listing.language,
+                                                                recent_changes: apk_listing.recent_changes
+                                                            })
 
       call_google_api do
         android_publisher.update_edit_apklisting(
-          current_package_name,
-          current_edit.id,
-          apk_listing.apk_version_code,
-          apk_listing.language,
-          apk_listing_object
+            current_package_name,
+            current_edit.id,
+            apk_listing.apk_version_code,
+            apk_listing.language,
+            apk_listing_object
         )
       end
     end
@@ -301,10 +301,10 @@ module Supply
 
       result = call_google_api do
         android_publisher.list_edit_images(
-          current_package_name,
-          current_edit.id,
-          language,
-          image_type
+            current_package_name,
+            current_edit.id,
+            language,
+            image_type
         )
       end
 
@@ -317,12 +317,12 @@ module Supply
 
       call_google_api do
         android_publisher.upload_edit_image(
-          current_package_name,
-          current_edit.id,
-          language,
-          image_type,
-          upload_source: image_path,
-          content_type: 'image/*'
+            current_package_name,
+            current_edit.id,
+            language,
+            image_type,
+            upload_source: image_path,
+            content_type: 'image/*'
         )
       end
     end
@@ -332,10 +332,27 @@ module Supply
 
       call_google_api do
         android_publisher.deleteall_edit_image(
-          current_package_name,
-          current_edit.id,
-          language,
-          image_type
+            current_package_name,
+            current_edit.id,
+            language,
+            image_type
+        )
+      end
+    end
+
+    def update_obb(apk_version_code, expansion_file_type, references_version, file_size)
+      ensure_active_edit!
+
+      call_google_api do
+        android_publisher.update_edit_expansionfile(
+            current_package_name,
+            current_edit.id,
+            apk_version_code,
+            expansion_file_type,
+            Google::Apis::AndroidpublisherV2::ExpansionFile.new(
+                references_version: references_version,
+                file_size: file_size
+            )
         )
       end
     end
@@ -345,12 +362,12 @@ module Supply
 
       call_google_api do
         android_publisher.upload_edit_expansionfile(
-          current_package_name,
-          current_edit.id,
-          apk_version_code,
-          expansion_file_type,
-          upload_source: obb_file_path,
-          content_type: 'application/octet-stream'
+            current_package_name,
+            current_edit.id,
+            apk_version_code,
+            expansion_file_type,
+            upload_source: obb_file_path,
+            content_type: 'application/octet-stream'
         )
       end
     end

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -7,173 +7,192 @@ module Supply
     def self.available_options
       valid_tracks = %w(production beta alpha rollout)
       @options ||= [
-        FastlaneCore::ConfigItem.new(key: :package_name,
-                                     env_name: "SUPPLY_PACKAGE_NAME",
-                                     short_option: "-p",
-                                     description: "The package name of the Application to modify",
-                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:package_name)),
-        FastlaneCore::ConfigItem.new(key: :track,
-                                     short_option: "-a",
-                                     env_name: "SUPPLY_TRACK",
-                                     description: "The Track to upload the Application to: #{valid_tracks.join(', ')}",
-                                     default_value: 'production',
-                                     verify_block: proc do |value|
-                                       available = valid_tracks
-                                       UI.user_error! "Invalid value '#{value}', must be #{available.join(', ')}" unless available.include? value
-                                     end),
-        FastlaneCore::ConfigItem.new(key: :rollout,
-                                     short_option: "-r",
-                                     description: "The percentage of the user fraction when uploading to the rollout track",
-                                     default_value: '0.1',
-                                     verify_block: proc do |value|
-                                       min = 0.01
-                                       max = 0.5
-                                       UI.user_error! "Invalid value '#{value}', must be between #{min} and #{max}" unless value.to_f.between?(min, max)
-                                     end),
-        FastlaneCore::ConfigItem.new(key: :metadata_path,
-                                     env_name: "SUPPLY_METADATA_PATH",
-                                     short_option: "-m",
-                                     optional: true,
-                                     description: "Path to the directory containing the metadata files",
-                                     default_value: (Dir["./fastlane/metadata/android"] + Dir["./metadata"]).first),
-        FastlaneCore::ConfigItem.new(key: :key,
-                                     env_name: "SUPPLY_KEY",
-                                     short_option: "-k",
-                                     conflicting_options: [:json_key],
-                                     deprecated: 'Use --json_key instead',
-                                     description: "The p12 File used to authenticate with Google",
-                                     default_value: Dir["*.p12"].first || CredentialsManager::AppfileConfig.try_fetch_value(:keyfile),
-                                     verify_block: proc do |value|
-                                       UI.user_error! "Could not find p12 file at path '#{File.expand_path(value)}'" unless File.exist?(File.expand_path(value))
-                                     end),
-        FastlaneCore::ConfigItem.new(key: :issuer,
-                                     env_name: "SUPPLY_ISSUER",
-                                     short_option: "-i",
-                                     conflicting_options: [:json_key],
-                                     deprecated: 'Use --json_key instead',
-                                     description: "The issuer of the p12 file (email address of the service account)",
-                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:issuer),
-                                     verify_block: proc do |value|
-                                       UI.important("DEPRECATED --issuer OPTION. Use --json_key instead")
-                                     end),
-        FastlaneCore::ConfigItem.new(key: :json_key,
-                                     env_name: "SUPPLY_JSON_KEY",
-                                     short_option: "-j",
-                                     conflicting_options: [:issuer, :key, :json_key_data],
-                                     optional: true, # this is shouldn't be optional but is until --key and --issuer are completely removed
-                                     description: "The service account json file used to authenticate with Google",
-                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
-                                     verify_block: proc do |value|
-                                       UI.user_error! "'#{value}' doesn't seem to be a JSON file" unless FastlaneCore::Helper.json_file?(File.expand_path(value))
-                                       UI.user_error! "Could not find service account json file at path '#{File.expand_path(value)}'" unless File.exist?(File.expand_path(value))
-                                     end),
-        FastlaneCore::ConfigItem.new(key: :json_key_data,
-                                     env_name: "SUPPLY_JSON_KEY_DATA",
-                                     short_option: "-c",
-                                     conflicting_options: [:issuer, :key, :json_key],
-                                     optional: true,
-                                     description: "The service account json used to authenticate with Google",
-                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
-                                     verify_block: proc do |value|
-                                       begin
-                                         JSON.parse(value)
-                                       rescue JSON::ParserError
-                                         UI.user_error! "Could not parse service account json  JSON::ParseError"
-                                       end
-                                     end),
-        FastlaneCore::ConfigItem.new(key: :apk,
-                                     env_name: "SUPPLY_APK",
-                                     description: "Path to the APK file to upload",
-                                     short_option: "-b",
-                                     conflicting_options: [:apk_paths],
-                                     default_value: Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-Release.apk")].last,
-                                     optional: true,
-                                     verify_block: proc do |value|
-                                       UI.user_error! "Could not find apk file at path '#{value}'" unless File.exist?(value)
-                                       UI.user_error! "apk file is not an apk" unless value.end_with?('.apk')
-                                     end),
-        FastlaneCore::ConfigItem.new(key: :apk_paths,
-                                     env_name: "SUPPLY_APK_PATHS",
-                                     conflicting_options: [:apk],
-                                     optional: true,
-                                     type: Array,
-                                     description: "An array of paths to APK files to upload",
-                                     short_option: "-u",
-                                     verify_block: proc do |value|
-                                       UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
-                                       value.each do |path|
-                                         UI.user_error! "Could not find apk file at path '#{path}'" unless File.exist?(path)
-                                         UI.user_error! "file at path '#{path}' is not an apk" unless path.end_with?('.apk')
-                                       end
-                                     end),
-        FastlaneCore::ConfigItem.new(key: :skip_upload_apk,
-                                     env_name: "SUPPLY_SKIP_UPLOAD_APK",
-                                     optional: true,
-                                     description: "Whether to skip uploading APK",
-                                     is_string: false,
-                                     default_value: false),
-        FastlaneCore::ConfigItem.new(key: :skip_upload_metadata,
-                                     env_name: "SUPPLY_SKIP_UPLOAD_METADATA",
-                                     optional: true,
-                                     description: "Whether to skip uploading metadata",
-                                     is_string: false,
-                                     default_value: false),
-        FastlaneCore::ConfigItem.new(key: :skip_upload_images,
-                                     env_name: "SUPPLY_SKIP_UPLOAD_IMAGES",
-                                     optional: true,
-                                     description: "Whether to skip uploading images, screenshots not included",
-                                     is_string: false,
-                                     default_value: false),
-        FastlaneCore::ConfigItem.new(key: :skip_upload_screenshots,
-                                     env_name: "SUPPLY_SKIP_UPLOAD_SCREENSHOTS",
-                                     optional: true,
-                                     description: "Whether to skip uploading SCREENSHOTS",
-                                     is_string: false,
-                                     default_value: false),
-        FastlaneCore::ConfigItem.new(key: :track_promote_to,
-                                     env_name: "SUPPLY_TRACK_PROMOTE_TO",
-                                     optional: true,
-                                     description: "The Track to promote to: #{valid_tracks.join(', ')}",
-                                     verify_block: proc do |value|
-                                       available = valid_tracks
-                                       UI.user_error! "Invalid value '#{value}', must be #{available.join(', ')}" unless available.include? value
-                                     end),
-        FastlaneCore::ConfigItem.new(key: :validate_only,
-                                     env_name: "SUPPLY_VALIDATE_ONLY",
-                                     optional: true,
-                                     description: "Indicate that changes will only be validated with Google Play rather than actually published",
-                                     is_string: false,
-                                     default_value: false),
-        FastlaneCore::ConfigItem.new(key: :mapping,
-                                     env_name: "SUPPLY_MAPPING",
-                                     description: "Path to the mapping file to upload",
-                                     short_option: "-d",
-                                     conflicting_options: [:mapping_paths],
-                                     optional: true,
-                                     verify_block: proc do |value|
-                                       UI.user_error! "Could not find mapping file at path '#{value}'" unless File.exist?(value)
-                                     end),
-        FastlaneCore::ConfigItem.new(key: :mapping_paths,
-                                     env_name: "SUPPLY_MAPPING_PATHS",
-                                     conflicting_options: [:mapping],
-                                     optional: true,
-                                     type: Array,
-                                     description: "An array of paths to mapping files to upload",
-                                     short_option: "-s",
-                                     verify_block: proc do |value|
-                                       UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
-                                       value.each do |path|
-                                         UI.user_error! "Could not find mapping file at path '#{path}'" unless File.exist?(path)
-                                       end
-                                     end),
-        FastlaneCore::ConfigItem.new(key: :root_url,
-                                     env_name: "SUPPLY_ROOT_URL",
-                                     description: "Root URL for the Google Play API. The provided URL will be used for API calls in place of https://www.googleapis.com/",
-                                     optional: true,
-                                     verify_block: proc do |value|
-                                       UI.user_error! "Could not parse URL '#{value}'" unless value =~ URI.regexp
-                                     end)
-
+          FastlaneCore::ConfigItem.new(key: :package_name,
+                                       env_name: "SUPPLY_PACKAGE_NAME",
+                                       short_option: "-p",
+                                       description: "The package name of the Application to modify",
+                                       default_value: CredentialsManager::AppfileConfig.try_fetch_value(:package_name)),
+          FastlaneCore::ConfigItem.new(key: :track,
+                                       short_option: "-a",
+                                       env_name: "SUPPLY_TRACK",
+                                       description: "The Track to upload the Application to: #{valid_tracks.join(', ')}",
+                                       default_value: 'production',
+                                       verify_block: proc do |value|
+                                         available = valid_tracks
+                                         UI.user_error! "Invalid value '#{value}', must be #{available.join(', ')}" unless available.include? value
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :rollout,
+                                       short_option: "-r",
+                                       description: "The percentage of the user fraction when uploading to the rollout track",
+                                       default_value: '0.1',
+                                       verify_block: proc do |value|
+                                         min = 0.01
+                                         max = 0.5
+                                         UI.user_error! "Invalid value '#{value}', must be between #{min} and #{max}" unless value.to_f.between?(min, max)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :metadata_path,
+                                       env_name: "SUPPLY_METADATA_PATH",
+                                       short_option: "-m",
+                                       optional: true,
+                                       description: "Path to the directory containing the metadata files",
+                                       default_value: (Dir["./fastlane/metadata/android"] + Dir["./metadata"]).first),
+          FastlaneCore::ConfigItem.new(key: :key,
+                                       env_name: "SUPPLY_KEY",
+                                       short_option: "-k",
+                                       conflicting_options: [:json_key],
+                                       deprecated: 'Use --json_key instead',
+                                       description: "The p12 File used to authenticate with Google",
+                                       default_value: Dir["*.p12"].first || CredentialsManager::AppfileConfig.try_fetch_value(:keyfile),
+                                       verify_block: proc do |value|
+                                         UI.user_error! "Could not find p12 file at path '#{File.expand_path(value)}'" unless File.exist?(File.expand_path(value))
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :issuer,
+                                       env_name: "SUPPLY_ISSUER",
+                                       short_option: "-i",
+                                       conflicting_options: [:json_key],
+                                       deprecated: 'Use --json_key instead',
+                                       description: "The issuer of the p12 file (email address of the service account)",
+                                       default_value: CredentialsManager::AppfileConfig.try_fetch_value(:issuer),
+                                       verify_block: proc do |value|
+                                         UI.important("DEPRECATED --issuer OPTION. Use --json_key instead")
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :json_key,
+                                       env_name: "SUPPLY_JSON_KEY",
+                                       short_option: "-j",
+                                       conflicting_options: [:issuer, :key, :json_key_data],
+                                       optional: true, # this is shouldn't be optional but is until --key and --issuer are completely removed
+                                       description: "The service account json file used to authenticate with Google",
+                                       default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
+                                       verify_block: proc do |value|
+                                         UI.user_error! "'#{value}' doesn't seem to be a JSON file" unless FastlaneCore::Helper.json_file?(File.expand_path(value))
+                                         UI.user_error! "Could not find service account json file at path '#{File.expand_path(value)}'" unless File.exist?(File.expand_path(value))
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :json_key_data,
+                                       env_name: "SUPPLY_JSON_KEY_DATA",
+                                       short_option: "-c",
+                                       conflicting_options: [:issuer, :key, :json_key],
+                                       optional: true,
+                                       description: "The service account json used to authenticate with Google",
+                                       default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
+                                       verify_block: proc do |value|
+                                         begin
+                                           JSON.parse(value)
+                                         rescue JSON::ParserError
+                                           UI.user_error! "Could not parse service account json  JSON::ParseError"
+                                         end
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :apk,
+                                       env_name: "SUPPLY_APK",
+                                       description: "Path to the APK file to upload",
+                                       short_option: "-b",
+                                       conflicting_options: [:apk_paths],
+                                       default_value: Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-Release.apk")].last,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error! "Could not find apk file at path '#{value}'" unless File.exist?(value)
+                                         UI.user_error! "apk file is not an apk" unless value.end_with?('.apk')
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :apk_paths,
+                                       env_name: "SUPPLY_APK_PATHS",
+                                       conflicting_options: [:apk],
+                                       optional: true,
+                                       type: Array,
+                                       description: "An array of paths to APK files to upload",
+                                       short_option: "-u",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
+                                         value.each do |path|
+                                           UI.user_error! "Could not find apk file at path '#{path}'" unless File.exist?(path)
+                                           UI.user_error! "file at path '#{path}' is not an apk" unless path.end_with?('.apk')
+                                         end
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :skip_upload_apk,
+                                       env_name: "SUPPLY_SKIP_UPLOAD_APK",
+                                       optional: true,
+                                       description: "Whether to skip uploading APK",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :skip_upload_metadata,
+                                       env_name: "SUPPLY_SKIP_UPLOAD_METADATA",
+                                       optional: true,
+                                       description: "Whether to skip uploading metadata",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :skip_upload_images,
+                                       env_name: "SUPPLY_SKIP_UPLOAD_IMAGES",
+                                       optional: true,
+                                       description: "Whether to skip uploading images, screenshots not included",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :skip_upload_screenshots,
+                                       env_name: "SUPPLY_SKIP_UPLOAD_SCREENSHOTS",
+                                       optional: true,
+                                       description: "Whether to skip uploading SCREENSHOTS",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :track_promote_to,
+                                       env_name: "SUPPLY_TRACK_PROMOTE_TO",
+                                       optional: true,
+                                       description: "The Track to promote to: #{valid_tracks.join(', ')}",
+                                       verify_block: proc do |value|
+                                         available = valid_tracks
+                                         UI.user_error! "Invalid value '#{value}', must be #{available.join(', ')}" unless available.include? value
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :validate_only,
+                                       env_name: "SUPPLY_VALIDATE_ONLY",
+                                       optional: true,
+                                       description: "Indicate that changes will only be validated with Google Play rather than actually published",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :mapping,
+                                       env_name: "SUPPLY_MAPPING",
+                                       description: "Path to the mapping file to upload",
+                                       short_option: "-d",
+                                       conflicting_options: [:mapping_paths],
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error! "Could not find mapping file at path '#{value}'" unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :mapping_paths,
+                                       env_name: "SUPPLY_MAPPING_PATHS",
+                                       conflicting_options: [:mapping],
+                                       optional: true,
+                                       type: Array,
+                                       description: "An array of paths to mapping files to upload",
+                                       short_option: "-s",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
+                                         value.each do |path|
+                                           UI.user_error! "Could not find mapping file at path '#{path}'" unless File.exist?(path)
+                                         end
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :root_url,
+                                       env_name: "SUPPLY_ROOT_URL",
+                                       description: "Root URL for the Google Play API. The provided URL will be used for API calls in place of https://www.googleapis.com/",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error! "Could not parse URL '#{value}'" unless value =~ URI.regexp
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :obb_main_references_version,
+                                       env_name: "OBB_MAIN_REFERENCES_VERSION",
+                                       description: "References version of 'main' expansion file",
+                                       optional: true,
+                                       type: Numeric),
+          FastlaneCore::ConfigItem.new(key: :obb_main_file_size,
+                                       env_name: "OBB_MAIN_FILE SIZE",
+                                       description: "Size of 'main' expansion file in bytes",
+                                       optional: true,
+                                       type: Numeric),
+          FastlaneCore::ConfigItem.new(key: :obb_patch_references_version,
+                                       env_name: "OBB_PATCH_REFERENCES_VERSION",
+                                       description: "References version of 'patch' expansion file",
+                                       optional: true,
+                                       type: Numeric),
+          FastlaneCore::ConfigItem.new(key: :obb_patch_file_size,
+                                       env_name: "OBB_PATCH_FILE SIZE",
+                                       description: "Size of 'patch' expansion file in bytes",
+                                       optional: true,
+                                       type: Numeric)
       ]
     end
     # rubocop:enable Metrics/PerceivedComplexity

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -83,7 +83,7 @@ module Supply
         UI.message("Uploading image file #{path}...")
         client.upload_image(image_path: File.expand_path(path),
                             image_type: image_type,
-                              language: language)
+                            language: language)
       end
     end
 
@@ -99,7 +99,7 @@ module Supply
           UI.message("Uploading screenshot #{path}...")
           client.upload_image(image_path: File.expand_path(path),
                               image_type: screenshot_type,
-                                language: language)
+                              language: language)
         end
       end
     end
@@ -139,6 +139,20 @@ module Supply
         apk_version_code = client.upload_apk(apk_path)
         UI.user_error!("Could not upload #{apk_path}") unless apk_version_code
 
+        if Supply.config[:obb_main_references_version] && Supply.config[:obb_main_file_size]
+          update_obb(apk_version_code,
+                     'main',
+                     Supply.config[:obb_main_references_version],
+                     Supply.config[:obb_main_file_size])
+        end
+
+        if Supply.config[:obb_patch_references_version] && Supply.config[:obb_patch_file_size]
+          update_obb(apk_version_code,
+                     'patch',
+                     Supply.config[:obb_patch_references_version],
+                     Supply.config[:obb_patch_file_size])
+        end
+
         upload_obbs(apk_path, apk_version_code)
 
         if metadata_path
@@ -153,6 +167,14 @@ module Supply
       apk_version_code
     end
 
+    def update_obb(apk_version_code, expansion_file_type, references_version, file_size)
+      UI.message("Updating '#{expansion_file_type}' expansion file from verison '#{references_version}'...")
+      client.update_obb(apk_version_code,
+                        expansion_file_type,
+                        references_version,
+                        file_size)
+    end
+
     def update_track(apk_version_codes)
       UI.message("Updating track '#{Supply.config[:track]}'...")
       if Supply.config[:track].eql? "rollout"
@@ -165,9 +187,9 @@ module Supply
     # returns only language directories from metadata_path
     def all_languages
       Dir.entries(metadata_path)
-         .select { |f| File.directory? File.join(metadata_path, f) }
-         .reject { |f| f.start_with?('.') }
-         .sort { |x, y| x <=> y }
+          .select { |f| File.directory? File.join(metadata_path, f) }
+          .reject { |f| f.start_with?('.') }
+          .sort { |x, y| x <=> y }
     end
 
     def client


### PR DESCRIPTION
<!--- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] --->

### Checklist
- [x] I've run bundle exec rspec from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run bundle exec rubocop -a to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? --->
<!--- If it fixes an open issue, please link to the issue here. --->
<!--- Please describe in detail how you tested your changes. --->
Unfortunatelly supply has no option to update expansion files from previous versions on Google play. It can be important when expansion files change rarely, but they are too large to upload them every version of your app. Even if you put the same expansion files with apk, 'upload_edit_expansionfile' method will make new versions of obb files, so user need to upload the same files.

Issues with this problem closed because of no activity (#7816, #8533)

Tested only by using supply to upload own app to Google Play.
### Description
<!--- Describe your changes in detail --->
Added new parametrs to supply action (obb_main_references_version, obb_main_file_size, obb_patch_references_version, obb_patch_file_size), which occure to use 'update_edit_expansionfile' method.
Added small changes in Readme.md