### PR TITLE
Pilot: Refactor ipa path expansion

### DIFF
--- a/fastlane/lib/fastlane/actions/pilot.rb
+++ b/fastlane/lib/fastlane/actions/pilot.rb
@@ -9,6 +9,7 @@ module Fastlane
         values[:changelog] ||= changelog if changelog
 
         values[:ipa] ||= Actions.lane_context[SharedValues::IPA_OUTPUT_PATH]
+        values[:ipa] = File.expand_path(values[:ipa]) if values[:ipa]
 
         return values if Helper.test?
 

--- a/pilot/lib/pilot/commands_generator.rb
+++ b/pilot/lib/pilot/commands_generator.rb
@@ -20,7 +20,7 @@ module Pilot
 
     def handle_multiple(action, args, options)
       mgr = Pilot::TesterManager.new
-      config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
+      config = create_config(options)
       args.push(config[:email]) if config[:email] && args.empty?
       args.push(UI.input("Email address of the tester: ")) if args.empty?
       failures = []
@@ -56,7 +56,7 @@ module Pilot
         FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
 
         c.action do |args, options|
-          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
+          config = create_config(options)
           Pilot::BuildManager.new.upload(config)
         end
       end
@@ -68,7 +68,7 @@ module Pilot
         FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
 
         c.action do |args, options|
-          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
+          config = create_config(options)
           Pilot::BuildManager.new.distribute(config)
         end
       end
@@ -80,7 +80,7 @@ module Pilot
         FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
 
         c.action do |args, options|
-          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
+          config = create_config(options)
           Pilot::BuildManager.new.list(config)
         end
       end
@@ -103,7 +103,7 @@ module Pilot
         FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
 
         c.action do |args, options|
-          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
+          config = create_config(options)
           Pilot::TesterManager.new.list_testers(config)
         end
       end
@@ -137,7 +137,7 @@ module Pilot
         FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
 
         c.action do |args, options|
-          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
+          config = create_config(options)
           Pilot::TesterExporter.new.export_testers(config)
         end
       end
@@ -149,7 +149,7 @@ module Pilot
         FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
 
         c.action do |args, options|
-          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
+          config = create_config(options)
           Pilot::TesterImporter.new.import_testers(config)
         end
       end
@@ -157,6 +157,11 @@ module Pilot
       default_command :help
 
       run!
+    end
+
+    def create_config(options)
+      config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
+      return config
     end
   end
 end

--- a/pilot/lib/pilot/commands_generator.rb
+++ b/pilot/lib/pilot/commands_generator.rb
@@ -20,7 +20,7 @@ module Pilot
 
     def handle_multiple(action, args, options)
       mgr = Pilot::TesterManager.new
-      config = create_config(options)
+      config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
       args.push(config[:email]) if config[:email] && args.empty?
       args.push(UI.input("Email address of the tester: ")) if args.empty?
       failures = []
@@ -56,7 +56,7 @@ module Pilot
         FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
 
         c.action do |args, options|
-          config = create_config(options)
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
           Pilot::BuildManager.new.upload(config)
         end
       end
@@ -68,7 +68,7 @@ module Pilot
         FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
 
         c.action do |args, options|
-          config = create_config(options)
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
           Pilot::BuildManager.new.distribute(config)
         end
       end
@@ -80,7 +80,7 @@ module Pilot
         FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
 
         c.action do |args, options|
-          config = create_config(options)
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
           Pilot::BuildManager.new.list(config)
         end
       end
@@ -103,7 +103,7 @@ module Pilot
         FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
 
         c.action do |args, options|
-          config = create_config(options)
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
           Pilot::TesterManager.new.list_testers(config)
         end
       end
@@ -137,7 +137,7 @@ module Pilot
         FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
 
         c.action do |args, options|
-          config = create_config(options)
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
           Pilot::TesterExporter.new.export_testers(config)
         end
       end
@@ -149,7 +149,7 @@ module Pilot
         FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
 
         c.action do |args, options|
-          config = create_config(options)
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
           Pilot::TesterImporter.new.import_testers(config)
         end
       end
@@ -157,12 +157,6 @@ module Pilot
       default_command :help
 
       run!
-    end
-
-    def create_config(options)
-      config = FastlaneCore::Configuration.create(Pilot::Options.available_options, convert_options(options))
-      config[:ipa] = File.expand_path(config[:ipa]) if config[:ipa]
-      return config
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

During the last round of feedback/fixes on #9481, the main use case stopped working (sorry! I should have caught this :pensive:). This refactor moves the path expansion to seemingly the first place available in the Pilot action.

### Description
 * Reverts most of #9481, and re-implements a better way.
 * Fixes #9480 
