### PR TITLE
passing release notes to deliver fails due to string/symbol mismatch

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -190,6 +190,7 @@ module Deliver
         current = options[key]
         next unless current && current.kind_of?(Hash)
         current.each do |language, value|
+          language = language.to_s
           enabled_languages << language unless enabled_languages.include?(language)
         end
       end

--- a/spaceship/lib/spaceship/tunes/language_item.rb
+++ b/spaceship/lib/spaceship/tunes/language_item.rb
@@ -26,6 +26,7 @@ module Spaceship
 
       def get_lang(lang)
         result = self.original_array.find do |current|
+          lang = lang.to_s
           current['language'] == lang or current['localeCode'] == lang # Apple being consistent
         end
         return result if result


### PR DESCRIPTION
fixes #9386

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
