### PR TITLE
Fix the generation of download url

### DIFF
--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -171,18 +171,8 @@ module Fastlane
         case response.status
         when 200...300
           url = response.body['public_url']
-          version_url = url
-
-          if response.body['version']
-            version_url = url + '/app_versions/' + response.body['version']
-          elsif response.body['config_url']
-            version_url = url + '/app_versions/' + response.body['config_url'].split('/').last
-          end
-
-          Actions.lane_context[SharedValues::HOCKEY_DOWNLOAD_LINK] = version_url
+          self.puts_download_url(response.body)
           Actions.lane_context[SharedValues::HOCKEY_BUILD_INFORMATION] = response.body
-
-          UI.message("Version Download URL: #{version_url}") if version_url
           UI.message("Public Download URL: #{url}") if url
           UI.success('Build successfully uploaded to HockeyApp!')
         else
@@ -192,6 +182,14 @@ module Fastlane
             UI.user_error!("Error when trying to upload file(s) to HockeyApp: #{response.status} - #{response.body}")
           end
         end
+      end
+
+      def self.puts_download_url(body)
+        version_url = body['public_url']
+        version_url = body['public_url'] + '/app_versions/' + body['config_url'].split('/').last if body['config_url']
+        version_url = body['public_url'] + '/app_versions/' + response.body['version'] if body['version']
+        Actions.lane_context[SharedValues::HOCKEY_DOWNLOAD_LINK] = version_url
+        UI.message("Version Download URL: #{version_url}") if version_url
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -186,7 +186,7 @@ module Fastlane
         end
       end
 
-      def self.puts_download_url(body)
+      def self.download_url(body)
         version_url = body['public_url']
         version_url = body['public_url'] + '/app_versions/' + body['config_url'].split('/').last if body['config_url']
         version_url = body['public_url'] + '/app_versions/' + response.body['version'] if body['version']

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -171,7 +171,14 @@ module Fastlane
         case response.status
         when 200...300
           url = response.body['public_url']
-          version_url = url + "/app_versions/" + response.body['version']
+          version_url = url
+
+          if response.body['version']
+            version_url = url + '/app_versions/' + response.body['version']
+          elsif response.body['config_url']
+            version_url = url + '/app_versions/' + response.body['config_url'].split('/').last
+          end
+
           Actions.lane_context[SharedValues::HOCKEY_DOWNLOAD_LINK] = version_url
           Actions.lane_context[SharedValues::HOCKEY_BUILD_INFORMATION] = response.body
 

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -171,9 +171,11 @@ module Fastlane
         case response.status
         when 200...300
           url = response.body['public_url']
-          self.puts_download_url(response.body)
+          app_url = self.puts_download_url(response.body)
           Actions.lane_context[SharedValues::HOCKEY_BUILD_INFORMATION] = response.body
+          Actions.lane_context[SharedValues::HOCKEY_DOWNLOAD_LINK] = app_url
           UI.message("Public Download URL: #{url}") if url
+          UI.message("New Version Download URL: #{app_url}") if app_url
           UI.success('Build successfully uploaded to HockeyApp!')
         else
           if response.body.to_s.include?("App could not be created")
@@ -188,8 +190,7 @@ module Fastlane
         version_url = body['public_url']
         version_url = body['public_url'] + '/app_versions/' + body['config_url'].split('/').last if body['config_url']
         version_url = body['public_url'] + '/app_versions/' + response.body['version'] if body['version']
-        Actions.lane_context[SharedValues::HOCKEY_DOWNLOAD_LINK] = version_url
-        UI.message("Version Download URL: #{version_url}") if version_url
+        version_url
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -171,7 +171,7 @@ module Fastlane
         case response.status
         when 200...300
           url = response.body['public_url']
-          app_url = self.puts_download_url(response.body)
+          app_url = self.download_url(response.body)
           Actions.lane_context[SharedValues::HOCKEY_BUILD_INFORMATION] = response.body
           Actions.lane_context[SharedValues::HOCKEY_DOWNLOAD_LINK] = app_url
           UI.message("Public Download URL: #{url}") if url


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
My apologies for failing many people's builds

### Description
This fixes the issue (generated by the previous merge) #9614
Generating crashes un upload https://github.com/fastlane/fastlane/issues/9616