### PR TITLE
Add information in docs plugin page when plugin has no GitHub URL

### DIFF
--- a/fastlane/assets/render_plugin.md.erb
+++ b/fastlane/assets/render_plugin.md.erb
@@ -19,4 +19,11 @@
  
 </details>
 
-<a href="<%= @plugin.homepage %>" target="_blank">Open on GitHub</a>
+<p>
+<% if @plugin.data[:has_github_page] %>
+  <a href="<%= @plugin.homepage %>" target="_blank">Open on GitHub</a>
+<% else %>
+  <a href="<%= @plugin.homepage %>" target="_blank">Open website</a>
+  <span style="color: #a03030">(no GitHub link provided in gemspec)</span>
+<% end %>
+</p>


### PR DESCRIPTION
- This way we show that the code might not be hosted somewhere
- This way we kind of explain why this score is lower (e.g. we couldn't verify the README or the # of tests)

<img width="709" alt="screen shot 2017-06-29 at 2 15 44 pm" src="https://user-images.githubusercontent.com/869950/27710697-77056396-5cd5-11e7-9922-d415530fcd1d.png">
