### PR TITLE
Add google_play_track_version_codes Action

### DIFF
--- a/fastlane/lib/fastlane/actions/google_play_track_version_codes.rb
+++ b/fastlane/lib/fastlane/actions/google_play_track_version_codes.rb
@@ -1,0 +1,70 @@
+module Fastlane
+  module Actions
+    class GooglePlayTrackVersionCodesAction < Action
+      # Supply::Options.available_options keys that apply to this action.
+      OPTIONS = [
+        :package_name,
+        :track,
+        :json_key,
+        :json_key_data,
+        :root_url
+      ]
+
+      def self.run(params)
+        require 'supply'
+        require 'supply/options'
+        require 'supply/reader'
+
+        Supply.config = params
+
+        Supply::Reader.new.track_version_codes
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Retrieves version codes for a Google Play track"
+      end
+
+      def self.details
+        "More information: https://github.com/fastlane/fastlane/tree/master/supply"
+      end
+
+      def self.available_options
+        require 'supply'
+        require 'supply/options'
+
+        Supply::Options.available_options.select do |option|
+          OPTIONS.include?(option.key)
+        end
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+        "Array of integers representing the version codes for the given Google Play track"
+      end
+
+      def self.authors
+        ["panthomakos"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+
+      def self.example_code
+        [
+          'google_play_track_version_codes'
+        ]
+      end
+
+      def self.category
+        :misc
+      end
+    end
+  end
+end

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -1,7 +1,7 @@
 describe Fastlane do
   describe Fastlane::Action do
     describe "No unused options" do
-      let (:all_exceptions) { %w(pilot appstore cert deliver gym match pem produce scan sigh snapshot precheck supply testflight mailgun testfairy ipa import_from_git hockey deploygate crashlytics artifactory appledoc slather screengrab download_dsyms notification frameit set_changelog register_device register_devices latest_testflight_build_number app_store_build_number sh swiftlint plugin_scores) } # rubocop:disable Metrics/LineLength
+      let (:all_exceptions) { %w(pilot appstore cert deliver gym match pem produce scan sigh snapshot precheck supply testflight mailgun testfairy ipa import_from_git hockey deploygate crashlytics artifactory appledoc slather screengrab download_dsyms notification frameit set_changelog register_device register_devices latest_testflight_build_number app_store_build_number sh swiftlint plugin_scores google_play_track_version_codes) } # rubocop:disable Metrics/LineLength
 
       Fastlane::ActionsList.all_actions do |action, name|
         next unless action.available_options.kind_of?(Array)

--- a/supply/README.md
+++ b/supply/README.md
@@ -63,6 +63,7 @@ Get in contact with the developer on Twitter: [@FastlaneTools](https://twitter.c
 - Retrieve and edit metadata, such as title and description, for multiple languages
 - Upload the app icon, promo graphics and screenshots for multiple languages
 - Have a local copy of the metadata in your git repository
+- Retrieve version code numbers from existing Google Play tracks
 
 ##### [Do you like fastlane? Be the first to know about updates and new fastlane tools](https://tinyletter.com/fastlane-tools)
 
@@ -182,6 +183,10 @@ You can add changelog files under the `changelogs/` directory for each locale. T
 A common Play publishing scenario might involve uploading an APK version to a test track, testing it, and finally promoting that version to production.
 
 This can be done using the `--track_promote_to` parameter.  The `--track_promote_to` parameter works with the `--track` parameter to command the Play API to promote existing Play track APK version(s) (those active on the track identified by the `--track` param value) to a new track (`--track_promote_to` value).
+
+## Retrieve Track Version Codes
+
+Before performing a new APK upload you may want to check existing track version codes, or you may simply want to provide an informational lane that displays the currently promoted version codes for the production track. You can use the `google_play_track_version_codes` action to retrieve existing version codes for a package and track. For more information, see `fastlane action google_play_track_version_codes` help output.
 
 ## Tips
 

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -10,12 +10,12 @@ module Supply
         FastlaneCore::ConfigItem.new(key: :package_name,
                                      env_name: "SUPPLY_PACKAGE_NAME",
                                      short_option: "-p",
-                                     description: "The package name of the Application to modify",
+                                     description: "The package name of the Application to use",
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:package_name)),
         FastlaneCore::ConfigItem.new(key: :track,
                                      short_option: "-a",
                                      env_name: "SUPPLY_TRACK",
-                                     description: "The Track to upload the Application to: #{valid_tracks.join(', ')}",
+                                     description: "The Track of the Application to use: #{valid_tracks.join(', ')}",
                                      default_value: 'production',
                                      verify_block: proc do |value|
                                        available = valid_tracks

--- a/supply/lib/supply/reader.rb
+++ b/supply/lib/supply/reader.rb
@@ -1,0 +1,25 @@
+module Supply
+  class Reader
+    def track_version_codes
+      track = Supply.config[:track]
+
+      client.begin_edit(package_name: Supply.config[:package_name])
+      version_codes = client.track_version_codes(track)
+      client.abort_current_edit
+
+      if version_codes.empty?
+        UI.important("No version codes found in track '#{track}'")
+      else
+        UI.success("Found '#{version_codes.join(', ')}' version codes in track '#{track}'")
+      end
+
+      version_codes
+    end
+
+    private
+
+    def client
+      @client ||= Client.make_from_config
+    end
+  end
+end


### PR DESCRIPTION
It is often useful to be able to retrieve the version codes for a
Google Play track to determine if it is appropriate to continue with
a particular supply action. For instance, we may want to create an
idempotent lane that uploads a version code APK to a track by first
checking the existing version codes on the given track to ensure the
action has not already completed.

In this change I have added a new action that is similar to the
`latest_testflight_build_number` action for iPhone. This new action
retrieves the version codes for a given Google Play track.

To accomodate this change I made the Supply option descriptions slightly
more generic.

Examples:

    lane :foo do
      puts google_play_track_version_codes(
        package_name: application_id,
        json_key: key_file,
        track: track
      ).inspect
    end

    $ fastlane boo

    [15:12:04]: Driving the lane 'android foo'
    [15:12:04]: ---------------------------------------------
    [15:12:04]: --- Step: google_play_track_version_codes ---
    [15:12:04]: ---------------------------------------------
    [15:12:05]: No version codes found in track 'beta'
    [15:12:05]: []

    $ fastlane boo

    [15:11:26]: Driving the lane 'android foo'
    [15:11:26]: ---------------------------------------------
    [15:11:26]: --- Step: google_play_track_version_codes ---
    [15:11:26]: ---------------------------------------------
    [15:11:27]: Found '12100' version codes in track 'production'
    [15:11:27]: [12100]

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.