### PR TITLE
[match] add template parameter

### DIFF
--- a/match/lib/match/generator.rb
+++ b/match/lib/match/generator.rb
@@ -61,6 +61,7 @@ module Match
       values[:platform] = params[:platform]
       values[:adhoc] = true if prov_type == :adhoc
       values[:development] = true if prov_type == :development
+      values[:template] = params[:template] if params[:template]
 
       arguments = FastlaneCore::Configuration.create(Sigh::Options.available_options, values)
 

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -143,7 +143,12 @@ module Match
                                        value = value.to_s
                                        pt = %w(tvos ios)
                                        UI.user_error!("Unsupported platform, must be: #{pt}") unless pt.include?(value)
-                                     end)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :template,
+                                     env_name: "MATCH_TEMPLATE",
+                                     description: "The value of the entitlement that is used on the Apple Developer Portal",
+                                     optional: true,
+                                     default_value: nil)
       ]
     end
   end

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -121,7 +121,11 @@ module Sigh
                                        value = value.to_s
                                        pt = %w(macos tvos ios)
                                        UI.user_error!("Unsupported platform, must be: #{pt}") unless pt.include?(value)
-                                     end)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :template,
+                                     env_name: "SIGH_PROVISIONING_TEMPLATE",
+                                     description: "The value of the entitlement that is used on the Apple Developer Portal",
+                                     optional: true)
       ]
     end
   end

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -137,6 +137,7 @@ module Sigh
       cert = certificate_to_use
       bundle_id = Sigh.config[:app_identifier]
       name = Sigh.config[:provisioning_name] || [bundle_id, profile_type.pretty_type].join(' ')
+      template = Sigh.config[:template]
 
       unless Sigh.config[:skip_fetch_profiles]
         if Spaceship.provisioning_profile.all.find { |p| p.name == name }
@@ -150,7 +151,8 @@ module Sigh
                                 bundle_id: bundle_id,
                               certificate: cert,
                                       mac: Sigh.config[:platform].to_s == 'macos',
-                             sub_platform: Sigh.config[:platform].to_s == 'tvos' ? 'tvOS' : nil)
+                             sub_platform: Sigh.config[:platform].to_s == 'tvos' ? 'tvOS' : nil,
+                                 template: template)
       profile
     end
 

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -491,7 +491,7 @@ module Spaceship
       parse_response(r, 'provisioningProfile')
     end
 
-    def create_provisioning_profile!(name, distribution_method, app_id, certificate_ids, device_ids, mac: false, sub_platform: nil)
+    def create_provisioning_profile!(name, distribution_method, app_id, certificate_ids, device_ids, mac: false, sub_platform: nil, template: nil)
       ensure_csrf(Spaceship::ProvisioningProfile) do
         fetch_csrf_token_for_provisioning
       end
@@ -505,6 +505,7 @@ module Spaceship
         deviceIds: device_ids
       }
       params[:subPlatform] = sub_platform if sub_platform
+      params[:template] = template if template
 
       r = request(:post, "account/#{platform_slug(mac)}/profile/createProvisioningProfile.action", params)
       parse_response(r, 'provisioningProfile')

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -540,7 +540,7 @@ module Spaceship
       parse_response(r)
     end
 
-    def repair_provisioning_profile!(profile_id, name, distribution_method, app_id, certificate_ids, device_ids, mac: false, sub_platform: nil)
+    def repair_provisioning_profile!(profile_id, name, distribution_method, app_id, certificate_ids, device_ids, mac: false, sub_platform: nil, template: nil)
       ensure_csrf(Spaceship::ProvisioningProfile) do
         fetch_csrf_token_for_provisioning
       end
@@ -555,6 +555,7 @@ module Spaceship
           deviceIds: device_ids
       }
       params[:subPlatform] = sub_platform if sub_platform
+      params[:template] = template if template
 
       r = request(:post, "account/#{platform_slug(mac)}/profile/regenProvisioningProfile.action", params)
 

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -73,6 +73,11 @@ module Spaceship
       #   "tvOS"
       attr_accessor :sub_platform
 
+      # @return (String) The value of the entitlement that is used on the Apple Developer Portal
+      # @example
+      #   "Standard"
+      attr_accessor :template
+
       # No information about this attribute
       attr_accessor :managing_app
 
@@ -146,7 +151,8 @@ module Spaceship
         'proProPlatform' => :platform,
         'proProSubPlatform' => :sub_platform,
         'managingApp' => :managing_app,
-        'appId' => :app
+        'appId' => :app,
+        'template' => :template
       })
 
       class << self
@@ -422,7 +428,8 @@ module Spaceship
             certificates.map(&:id),
             devices.map(&:id),
             mac: mac?,
-            sub_platform: tvos? ? 'tvOS' : nil
+            sub_platform: tvos? ? 'tvOS' : nil,
+            template: template
           )
         end
 

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -209,8 +209,9 @@ module Spaceship
         #  and Development profiles and add none for AppStore and Enterprise Profiles
         # @param mac (Bool) (optional): Pass true if you're making a Mac provisioning profile
         # @param sub_platform (String) Used to create tvOS profiles at the moment. Value should equal 'tvOS' or nil.
+        # @param template (String) Used to select custom Entitlements found on the Developer Portal
         # @return (ProvisioningProfile): The profile that was just created
-        def create!(name: nil, bundle_id: nil, certificate: nil, devices: [], mac: false, sub_platform: nil)
+        def create!(name: nil, bundle_id: nil, certificate: nil, devices: [], mac: false, sub_platform: nil, template: nil)
           raise "Missing required parameter 'bundle_id'" if bundle_id.to_s.empty?
           raise "Missing required parameter 'certificate'. e.g. use `Spaceship::Certificate::Production.all.first`" if certificate.to_s.empty?
 
@@ -253,7 +254,8 @@ module Spaceship
                                                 certificate_parameter,
                                                 devices.map(&:id),
                                                 mac: mac,
-                                                sub_platform: sub_platform)
+                                                sub_platform: sub_platform,
+                                                template: template)
           end
 
           self.new(profile)

--- a/spaceship/spec/provisioning_profile_spec.rb
+++ b/spaceship/spec/provisioning_profile_spec.rb
@@ -167,9 +167,20 @@ describe Spaceship::ProvisioningProfile do
       Spaceship::ProvisioningProfile::Development.create!(name: 'Delete Me', bundle_id: 'net.sunapps.1', certificate: certificate)
     end
 
+    it 'creates a new development provisioning profile' do
+      expect(Spaceship::Device).to receive(:all).and_return([])
+      expect(client).to receive(:create_provisioning_profile!).with('Delete Me', 'limited', '2UMR2S6PAA', "XC5PH8DAAA", [], mac: false, sub_platform: nil, template: "Standard").and_return({})
+      Spaceship::ProvisioningProfile::Development.create!(name: 'Delete Me', bundle_id: 'net.sunapps.1', certificate: certificate, template: "Standard")
+    end
+
     it 'creates a new appstore provisioning profile' do
       expect(client).to receive(:create_provisioning_profile!).with('Delete Me', 'store', '2UMR2S6PAA', "XC5PH8DAAA", [], mac: false, sub_platform: nil, template: nil).and_return({})
       Spaceship::ProvisioningProfile::AppStore.create!(name: 'Delete Me', bundle_id: 'net.sunapps.1', certificate: certificate)
+    end
+
+    it 'creates a new appstore provisioning profile with a template' do
+      expect(client).to receive(:create_provisioning_profile!).with('Delete Me', 'store', '2UMR2S6PAA', "XC5PH8DAAA", [], mac: false, sub_platform: nil, template: "Standard").and_return({})
+      Spaceship::ProvisioningProfile::AppStore.create!(name: 'Delete Me', bundle_id: 'net.sunapps.1', certificate: certificate, template: "Standard")
     end
 
     it 'creates a provisioning profile with only the required parameters and auto fills all available devices' do

--- a/spaceship/spec/provisioning_profile_spec.rb
+++ b/spaceship/spec/provisioning_profile_spec.rb
@@ -163,12 +163,12 @@ describe Spaceship::ProvisioningProfile do
 
     it 'creates a new development provisioning profile' do
       expect(Spaceship::Device).to receive(:all).and_return([])
-      expect(client).to receive(:create_provisioning_profile!).with('Delete Me', 'limited', '2UMR2S6PAA', "XC5PH8DAAA", [], mac: false, sub_platform: nil).and_return({})
+      expect(client).to receive(:create_provisioning_profile!).with('Delete Me', 'limited', '2UMR2S6PAA', "XC5PH8DAAA", [], mac: false, sub_platform: nil, template: nil).and_return({})
       Spaceship::ProvisioningProfile::Development.create!(name: 'Delete Me', bundle_id: 'net.sunapps.1', certificate: certificate)
     end
 
     it 'creates a new appstore provisioning profile' do
-      expect(client).to receive(:create_provisioning_profile!).with('Delete Me', 'store', '2UMR2S6PAA', "XC5PH8DAAA", [], mac: false, sub_platform: nil).and_return({})
+      expect(client).to receive(:create_provisioning_profile!).with('Delete Me', 'store', '2UMR2S6PAA', "XC5PH8DAAA", [], mac: false, sub_platform: nil, template: nil).and_return({})
       Spaceship::ProvisioningProfile::AppStore.create!(name: 'Delete Me', bundle_id: 'net.sunapps.1', certificate: certificate)
     end
 
@@ -179,7 +179,8 @@ describe Spaceship::ProvisioningProfile do
                                                                     "XC5PH8DAAA",
                                                                     [],
                                                                     mac: false,
-                                                                    sub_platform: nil).
+                                                                    sub_platform: nil,
+                                                                    template: nil).
         and_return({})
       Spaceship::ProvisioningProfile::AppStore.create!(bundle_id: 'net.sunapps.1', certificate: certificate)
     end
@@ -194,28 +195,28 @@ describe Spaceship::ProvisioningProfile do
       it 'Direct (Mac) profile types have no devices' do
         fake_devices = Spaceship::Device.all
         expected_devices = []
-        expect(Spaceship::ProvisioningProfile::Direct.client).to receive(:create_provisioning_profile!).with('Delete Me', 'direct', '2UMR2S6PAA', "XC5PH8DAAA", expected_devices, mac: true, sub_platform: nil).and_return({})
+        expect(Spaceship::ProvisioningProfile::Direct.client).to receive(:create_provisioning_profile!).with('Delete Me', 'direct', '2UMR2S6PAA', "XC5PH8DAAA", expected_devices, mac: true, sub_platform: nil, template: nil).and_return({})
         Spaceship::ProvisioningProfile::Direct.create!(name: 'Delete Me', bundle_id: 'net.sunapps.1', certificate: certificate, mac: true, devices: fake_devices)
       end
 
       it 'Development profile types have devices' do
         fake_devices = Spaceship::Device.all
         expected_devices = fake_devices.collect(&:id)
-        expect(Spaceship::ProvisioningProfile::Development.client).to receive(:create_provisioning_profile!).with('Delete Me', 'limited', '2UMR2S6PAA', "XC5PH8DAAA", expected_devices, mac: false, sub_platform: nil).and_return({})
+        expect(Spaceship::ProvisioningProfile::Development.client).to receive(:create_provisioning_profile!).with('Delete Me', 'limited', '2UMR2S6PAA', "XC5PH8DAAA", expected_devices, mac: false, sub_platform: nil, template: nil).and_return({})
         Spaceship::ProvisioningProfile::Development.create!(name: 'Delete Me', bundle_id: 'net.sunapps.1', certificate: certificate, devices: fake_devices)
       end
 
       it 'AdHoc profile types have no devices' do
         fake_devices = Spaceship::Device.all
         expected_devices = fake_devices.collect(&:id)
-        expect(Spaceship::ProvisioningProfile::AdHoc.client).to receive(:create_provisioning_profile!).with('Delete Me', 'adhoc', '2UMR2S6PAA', "XC5PH8DAAA", expected_devices, mac: false, sub_platform: nil).and_return({})
+        expect(Spaceship::ProvisioningProfile::AdHoc.client).to receive(:create_provisioning_profile!).with('Delete Me', 'adhoc', '2UMR2S6PAA', "XC5PH8DAAA", expected_devices, mac: false, sub_platform: nil, template: nil).and_return({})
         Spaceship::ProvisioningProfile::AdHoc.create!(name: 'Delete Me', bundle_id: 'net.sunapps.1', certificate: certificate, devices: fake_devices)
       end
 
       it 'AppStore profile types have no devices' do
         fake_devices = Spaceship::Device.all
         expected_devices = []
-        expect(Spaceship::ProvisioningProfile::AppStore.client).to receive(:create_provisioning_profile!).with('Delete Me', 'store', '2UMR2S6PAA', "XC5PH8DAAA", expected_devices, mac: false, sub_platform: nil).and_return({})
+        expect(Spaceship::ProvisioningProfile::AppStore.client).to receive(:create_provisioning_profile!).with('Delete Me', 'store', '2UMR2S6PAA', "XC5PH8DAAA", expected_devices, mac: false, sub_platform: nil, template: nil).and_return({})
         Spaceship::ProvisioningProfile::AppStore.create!(name: 'Delete Me', bundle_id: 'net.sunapps.1', certificate: certificate, devices: fake_devices)
       end
     end
@@ -234,26 +235,26 @@ describe Spaceship::ProvisioningProfile do
 
     it "repairs an existing profile with added devices" do
       profile.devices = Spaceship::Device.all_for_profile_type(profile.type)
-      expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [cert_id], ["AAAAAAAAAA", "BBBBBBBBBB", "CCCCCCCCCC", "DDDDDDDDDD"], mac: false, sub_platform: nil).and_return({})
+      expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [cert_id], ["AAAAAAAAAA", "BBBBBBBBBB", "CCCCCCCCCC", "DDDDDDDDDD"], mac: false, sub_platform: nil, template: nil).and_return({})
       profile.repair!
     end
 
     it "update the certificate if the current one doesn't exist" do
       profile.certificates = []
-      expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: nil).and_return({})
+      expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: nil, template: nil).and_return({})
 
-      # expect(client).to receive(:repair_provisioning_profile!).with('PP00000002', '1 Gut Altentann Ad Hoc', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: nil).and_return({})
+      # expect(client).to receive(:repair_provisioning_profile!).with('PP00000002', '1 Gut Altentann Ad Hoc', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: nil, template: nil).and_return({})
       profile.repair!
     end
 
     it "update the certificate if the current one is invalid" do
       expect(profile.certificates.first.id).to eq("3BH4JJSWM4")
-      expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: nil).and_return({})
+      expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: nil, template: nil).and_return({})
       profile.repair! # repair will replace the old certificate with the new one
     end
 
     it "repairs an existing profile with no devices" do
-      expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: nil).and_return({})
+      expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: nil, template: nil).and_return({})
       profile.repair!
     end
 
@@ -261,7 +262,7 @@ describe Spaceship::ProvisioningProfile do
       it "Development" do
         profile = Spaceship::ProvisioningProfile::Development.all.first
         devices = ["FVRY7XH22J", "4ZE252U553"]
-        expect(client).to receive(:repair_provisioning_profile!).with('PP00000005', '112 Wombats RC Development', 'limited', '2UMR2S6P4L', [cert_id], devices, mac: false, sub_platform: nil).and_return({})
+        expect(client).to receive(:repair_provisioning_profile!).with('PP00000005', '112 Wombats RC Development', 'limited', '2UMR2S6P4L', [cert_id], devices, mac: false, sub_platform: nil, template: nil).and_return({})
         profile.repair!
       end
     end
@@ -272,12 +273,12 @@ describe Spaceship::ProvisioningProfile do
     let(:tvOSProfile) { Spaceship::ProvisioningProfile.all_tvos.first }
 
     it "updates an existing iOS profile" do
-      expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: nil).and_return({})
+      expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: nil, template: nil).and_return({})
       profile.update!
     end
 
     it "updates an existing tvOS profile" do
-      expect(client).to receive(:repair_provisioning_profile!).with('PP00000004', '107 GC Lorenzen AppStore tvOS', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: 'tvOS').and_return({})
+      expect(client).to receive(:repair_provisioning_profile!).with('PP00000004', '107 GC Lorenzen AppStore tvOS', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: 'tvOS', template: nil).and_return({})
       tvOSProfile.update!
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
For some users of Match, the lack of support for the `template` (entitlements) parameter when creating provisioning profiles is a deal breaker. For the apps my team is working on, we rely on specific entitlements configured in the dev portal when creating/updating a provisioning profile.

This has been discussed in a few issues before, but we cannot find a pull request with this change. The issue we used as guidance is #4548. We know this was kind of dismissed back then, but hopefully this PR will make sense, since it breaks nothing for regular usage, and it will be of great benefit to the ones actually using this `template` parameter.

The changes made in this pull request have been tested with our own provisioning profiles both for development and distribution.

### Description
We have made changes to Match, Sigh and Spaceship.

#### Match
* Added a template parameter and option

#### Sigh
* Added template parameter and option

#### Spaceship
* Use the template parameter in the dev portal calls

#### Tests
* Updated tests to handle the new template parameter

I'm not an every day ruby developer, but I have tried to follow all guidances for making changes to fastlane and a pull request.