### PR TITLE
Fix broken unit tests for plugin generation

### DIFF
--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -273,36 +273,37 @@ describe Fastlane::PluginGenerator do
     end
 
     describe "All tests and style validation of the new plugin are passing" do
+      before (:all) do
+        # let(:gem_name) is not available in before(:all), so pass the directory
+        # in explicitly once instead of making this a before(:each)
+        plugin_sh 'bundle install', 'fastlane-plugin-tester_thing'
+      end
+
       it "rspec tests are passing" do
         # Actually run our generated spec as part of this spec #yodawg
-        Dir.chdir(gem_name) do
-          Bundler.setup do
-            `rspec &> /dev/null`
-            expect($?.exitstatus).to be(0)
-          end
-        end
+        plugin_sh 'bundle exec rspec'
+        expect($?.exitstatus).to eq(0)
       end
 
       it "rubocop validations are passing" do
         # Actually run our generated spec as part of this spec #yodawg
-        Dir.chdir(gem_name) do
-          Bundler.setup do
-            `rubocop &> /dev/null`
-            expect($?.exitstatus).to be(0)
-          end
-        end
+        plugin_sh 'bundle exec rubocop'
+        expect($?.exitstatus).to eq(0)
       end
 
       it "`rake` runs both rspec and rubocop" do
-        Dir.chdir(gem_name) do
-          Bundler.setup do
-            result = `rake`
-            expect($?.exitstatus).to be(0)
-            expect(result).to include("no offenses detected") # rubocop
-            expect(result).to include("example, 0 failures") # rspec
-          end
-        end
+        # Actually run our generated spec as part of this spec #yodawg
+        result = plugin_sh 'bundle exec rake'
+        expect($?.exitstatus).to eq(0)
+        expect(result).to include("no offenses detected") # rubocop
+        expect(result).to include("example, 0 failures") # rspec
       end
     end
+  end
+
+  private
+
+  def plugin_sh(command, plugin_path = gem_name)
+    Dir.chdir(plugin_path) { |path| `#{command}` }
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

See the discussion from #9564.

Unit tests for rake, rspec  and rubocop in new plugins are all executed by passing a block to `Bundler.setup`, but they don't appear to be executed at all, and actual failures are not reported. I wasn't familiar with `Bundler.setup`, and I can't find docs for that method, but judging from the source code:

https://github.com/bundler/bundler/blob/master/lib/bundler.rb#L92
https://github.com/bundler/bundler/blob/master/lib/bundler/runtime.rb#L13

It doesn't look like the method takes a block. I think it wants an array of symbols for groups from the Gemfile, e.g. `Bundler.setup [:dev, :test]`. I suspect that it is called long before execution of these examples, and these calls just short circuit and return `@setup` without doing anything else.

### Description

It wasn't hard to use `RuboCop::CLI` to run RuboCop programmatically from the example. Rake was hard enough that I took another crack at shelling out to `bundle exec`, which turns out to work well.

These tests will now report failures when appropriate. For example, remove the blank line after `# coding: utf-8` in fastlane/lib/fastlane/plugins/template/%gem_name%.gemspec.erb and run

```bash
bundle exec rspec fastlane/spec/plugins_specs/plugin_generator_spec.rb
```

This will show a RuboCop failure.