### PR TITLE
Rename min xcode release variable

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   VERSION = '2.44.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
-  MINIMUM_XCODE_VERSION = "7.0".freeze
+  MINIMUM_XCODE_RELEASE = "7.0".freeze
 end

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -36,7 +36,7 @@ module Commander
 
       xcode_outdated = false
       begin
-        unless FastlaneCore::Helper.xcode_at_least?(Fastlane::MINIMUM_XCODE_VERSION)
+        unless FastlaneCore::Helper.xcode_at_least?(Fastlane::MINIMUM_XCODE_RELEASE)
           xcode_outdated = true
         end
       rescue
@@ -49,7 +49,7 @@ module Commander
       begin
         if xcode_outdated
           # We have to raise that error within this `begin` block to show a nice user error without a stack trace
-          FastlaneCore::UI.user_error!("fastlane requires a minimum version of Xcode #{Fastlane::MINIMUM_XCODE_VERSION}, please upgrade and make sure to use `sudo xcode-select -s /Applications/Xcode.app`")
+          FastlaneCore::UI.user_error!("fastlane requires a minimum version of Xcode #{Fastlane::MINIMUM_XCODE_RELEASE}, please upgrade and make sure to use `sudo xcode-select -s /Applications/Xcode.app`")
         end
 
         collector.did_launch_action(@program[:name])


### PR DESCRIPTION
This was causing problems in our release script as we use a regex to detect the version number