### PR TITLE
Fix google_play_track_version_codes Options

### DIFF
--- a/fastlane/lib/fastlane/actions/google_play_track_version_codes.rb
+++ b/fastlane/lib/fastlane/actions/google_play_track_version_codes.rb
@@ -5,6 +5,8 @@ module Fastlane
       OPTIONS = [
         :package_name,
         :track,
+        :key,
+        :issuer,
         :json_key,
         :json_key_data,
         :root_url


### PR DESCRIPTION
Not sure what changed between my testing and the release. The `:issuer`
and `:key` options (although they are deprecated) need to be added to
`GooglePlayTrackVersionCodes` otherwise using this action results in an
error:

    [14:38:44]: Could not find option for key :issuer. Available keys: package_name, track, key, json_key, json_key_data, root_url

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
