### PR TITLE
Version bump to 2.46.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.45.0'.freeze
+  VERSION = '2.46.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.45.0':**

* Allow the slather action to accept multiple binary_basename and binary_file arguments (#9696) via Renaud Lienhart
* Fix google_play_track_version_codes options (#9693) via Pan Thomakos
* Improve some more docs (#9675) via Felix Krause
* Plugin scores: follow redirects (#9659) via Felix Krause
