### PR TITLE
Update gym action to work if no ipa path is returned

### DIFF
--- a/fastlane/lib/fastlane/actions/gym.rb
+++ b/fastlane/lib/fastlane/actions/gym.rb
@@ -46,7 +46,14 @@ module Fastlane
             end
           end
         end
-        absolute_ipa_path = File.expand_path(Gym::Manager.new.work(values))
+
+        gym_output_path = Gym::Manager.new.work(values)
+        if gym_output_path.nil?
+          UI.important("No output path received from gym")
+          return nil
+        end
+
+        absolute_ipa_path = File.expand_path(gym_output_path)
         absolute_dsym_path = absolute_ipa_path.gsub(".ipa", ".app.dSYM.zip")
 
         # This might be the mac app path, so we don't want to set it here


### PR DESCRIPTION
Related to https://github.com/fastlane/fastlane/issues/9704 and https://github.com/fastlane/fastlane/issues/9260