### PR TITLE
Find getConfigurationMethod on IActivityManager Interface

### DIFF
--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
@@ -27,7 +27,7 @@ public class LocaleUtil {
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 // getConfiguration moved from ActivityManagerNative to ActivityManagerProxy
-                amnClass = Class.forName(activityManagerNative.getClass().toString());
+                amnClass = Class.forName(activityManagerNative.getClass().getName());
             }
 
             Method methodGetConfiguration = amnClass.getMethod("getConfiguration");

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
@@ -25,8 +25,12 @@ public class LocaleUtil {
             methodGetDefault.setAccessible(true);
             Object activityManagerNative = methodGetDefault.invoke(amnClass);
 
-            Class iam = Class.forName(activityManagerNative.getClass().toString());
-            Method methodGetConfiguration = iam.getMethod("getConfiguration");
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                // getConfiguration moved from ActivityManagerNative to ActivityManagerProxy
+                amnClass = Class.forName(activityManagerNative.getClass().toString());
+            }
+
+            Method methodGetConfiguration = amnClass.getMethod("getConfiguration");
             methodGetConfiguration.setAccessible(true);
             Configuration config  = (Configuration) methodGetConfiguration.invoke(activityManagerNative);
 
@@ -37,7 +41,7 @@ public class LocaleUtil {
                 config.setLayoutDirection(locale);
             }
 
-            Method updateConfigurationMethod = iam.getMethod("updateConfiguration", Configuration.class);
+            Method updateConfigurationMethod = amnClass.getMethod("updateConfiguration", Configuration.class);
             updateConfigurationMethod.setAccessible(true);
             updateConfigurationMethod.invoke(activityManagerNative, config);
 

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
@@ -37,7 +37,7 @@ public class LocaleUtil {
                 config.setLayoutDirection(locale);
             }
 
-            Method updateConfigurationMethod = iactivityman.getMethod("updateConfiguration", Configuration.class);
+            Method updateConfigurationMethod = iam.getMethod("updateConfiguration", Configuration.class);
             updateConfigurationMethod.setAccessible(true);
             updateConfigurationMethod.invoke(activityManagerNative, config);
 

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
@@ -25,7 +25,8 @@ public class LocaleUtil {
             methodGetDefault.setAccessible(true);
             Object activityManagerNative = methodGetDefault.invoke(amnClass);
 
-            Method methodGetConfiguration = amnClass.getMethod("getConfiguration");
+            Class iam = Class.forName(activityManagerNative.getClass().toString());
+            Method methodGetConfiguration = iam.getMethod("getConfiguration");
             methodGetConfiguration.setAccessible(true);
             Configuration config  = (Configuration) methodGetConfiguration.invoke(activityManagerNative);
 

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
@@ -37,7 +37,7 @@ public class LocaleUtil {
                 config.setLayoutDirection(locale);
             }
 
-            Method updateConfigurationMethod = amnClass.getMethod("updateConfiguration", Configuration.class);
+            Method updateConfigurationMethod = iactivityman.getMethod("updateConfiguration", Configuration.class);
             updateConfigurationMethod.setAccessible(true);
             updateConfigurationMethod.invoke(activityManagerNative, config);
 

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
@@ -25,7 +25,7 @@ public class LocaleUtil {
             methodGetDefault.setAccessible(true);
             Object activityManagerNative = methodGetDefault.invoke(amnClass);
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 // getConfiguration moved from ActivityManagerNative to ActivityManagerProxy
                 amnClass = Class.forName(activityManagerNative.getClass().getName());
             }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
Fixes #9521

Find `getConfigurationMethod` on IActivityManager Interface instead of `ActivityManagerNative`. As of API 25 this method moved to an inner class.