### PR TITLE
Update README to call out what operating systems can run fastlane

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ In addition to `fastlane`'s commands, you also have access to these `fastlane` t
 - [`scan`](https://github.com/fastlane/fastlane/tree/master/scan): The easiest way to run tests for your iOS and Mac apps
 - [`precheck`](https://github.com/fastlane/fastlane/tree/master/precheck): Check your app using a community driven set of App Store review rules to avoid being rejected
 
+## Where can fastlane run?
+Currently _fastlane_ is officially supported on macOS. Support for other operating systems is limited and untested at this point in time. _fastlane_ uses system apis that may not be implemented on other platforms (one example: we make use of `fork()` and it is not supported on Windows). 
+
+**Note:** If you'd like to add support for your favorite platform, feel free to [contribute a PR](https://github.com/fastlane/fastlane/tree/master/YourFirstPR.md)!
+
 ## Metrics
 
 _fastlane_ tracks a few key metrics to understand how developers are using the tool and to help us know what areas need improvement. No personal/sensitive information is ever collected. Metrics that are collected include: 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Get started distributing your first app with fastlane within minutes:
 Want to learn more? Explore guides for [iOS](https://docs.fastlane.tools/getting-started/ios/setup/)
  or [Android](https://docs.fastlane.tools/getting-started/android/setup/).
 
+## System Requirements
+Currently _fastlane_ is officially supported on macOS. Support for other operating systems is limited and untested at this point in time. _fastlane_ uses system APIs that may not be implemented on other platforms (one example: we make use of `fork()` and it is not supported on Windows). 
+
 ## Available Commands
 
 Typically you'll use `fastlane` by triggering individual lanes:
@@ -139,11 +142,6 @@ In addition to `fastlane`'s commands, you also have access to these `fastlane` t
 - [`match`](https://github.com/fastlane/fastlane/tree/master/match): Easily sync your certificates and profiles across your team using Git
 - [`scan`](https://github.com/fastlane/fastlane/tree/master/scan): The easiest way to run tests for your iOS and Mac apps
 - [`precheck`](https://github.com/fastlane/fastlane/tree/master/precheck): Check your app using a community driven set of App Store review rules to avoid being rejected
-
-## Where can fastlane run?
-Currently _fastlane_ is officially supported on macOS. Support for other operating systems is limited and untested at this point in time. _fastlane_ uses system apis that may not be implemented on other platforms (one example: we make use of `fork()` and it is not supported on Windows). 
-
-**Note:** If you'd like to add support for your favorite platform, feel free to [contribute a PR](https://github.com/fastlane/fastlane/tree/master/YourFirstPR.md)!
 
 ## Metrics
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Want to learn more? Explore guides for [iOS](https://docs.fastlane.tools/getting
  or [Android](https://docs.fastlane.tools/getting-started/android/setup/).
 
 ## System Requirements
-Currently _fastlane_ is officially supported on macOS. Support for other operating systems is limited and untested at this point in time. _fastlane_ uses system APIs that may not be implemented on other platforms (one example: we make use of `fork()` and it is not supported on Windows). 
+
+Currently, _fastlane_ is officially supported to run on macOS. Support for other operating systems is limited and untested at this point in time. _fastlane_ uses system APIs that may not be implemented on other platforms (one example: we make use of `fork()` and it is not supported on Windows).
 
 ## Available Commands
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Want to learn more? Explore guides for [iOS](https://docs.fastlane.tools/getting
 
 ## System Requirements
 
-Currently, _fastlane_ is officially supported to run on macOS. Support for other operating systems is limited and untested at this point in time. _fastlane_ uses system APIs that may not be implemented on other platforms (one example: we make use of `fork()` and it is not supported on Windows).
+Currently, _fastlane_ is officially supported to run on macOS. Support for other operating systems is limited and untested at this point in time. _fastlane_ uses system APIs that may not be implemented on other platforms, for example, we use the Ruby `fork` method for sub-process management, which isn't available on Windows.
 
 ## Available Commands
 


### PR DESCRIPTION
We want to make it more obvious what operating systems are currently supported so people don't spend a bunch of time trying to get it to work on unsupported platforms.