### PR TITLE
Fix markdown formating in iTunesConnect

### DIFF
--- a/spaceship/docs/iTunesConnect.md
+++ b/spaceship/docs/iTunesConnect.md
@@ -299,7 +299,7 @@ Spaceship::Tunes::Tester::External.create!(email: "github@krausefx.com",
                                       first_name: "Felix",
                                        last_name: "Krause",
                                           groups: ["spaceship"])
-
+```
 Right now, `spaceship` can't modify or create internal testers.
 
 ```ruby


### PR DESCRIPTION
### Motivation and Context

Code sample for `SandboxTester` usage in the iTunesConnect doc renders is broken.
