### PR TITLE
[gym] Improve build error output to be more clear

### DIFF
--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -51,9 +51,10 @@ module Gym
           print "For more information visit this stackoverflow answer:"
           print "https://stackoverflow.com/a/17031697/445598"
         end
-        print_full_log_path
         print_xcode_path_instructions
         print_xcode_version
+        print_full_log_path
+        print_build_error_instructions
         UI.build_failure!("Error building the application - see the log above", error_info: output)
       end
 
@@ -89,6 +90,7 @@ module Gym
           print "provisioning profile and code signing identity."
         end
         print_full_log_path
+        print_build_error_instructions
         UI.build_failure!("Error packaging up the application", error_info: output)
       end
 
@@ -102,17 +104,7 @@ module Gym
         UI.build_failure!("Archive invalid")
       end
 
-      def find_standard_output_path(output)
-        m = /Created bundle at path '(.*)'/.match(output)
-        return File.join(m[1], 'IDEDistribution.standard.log') unless m.nil?
-      end
-
       private
-
-      def read_standard_output(output)
-        path = find_standard_output_path output
-        return File.read(path) if File.exist?(path)
-      end
 
       # Just to make things easier
       def print(text)
@@ -121,8 +113,19 @@ module Gym
 
       def print_full_log_path
         return if Gym.config[:disable_xcpretty]
+
         log_path = Gym::BuildCommandGenerator.xcodebuild_log_path
-        UI.important("📋  For a more detailed error log, check the full log at:")
+        # `xcodebuild` doesn't properly mark lines as failure reason or important information
+        # so we assume that the last few lines show the error message that's relevant
+        # (at least that's what was correct during testing)
+        log_content = File.read(log_path).split("\n")[-5..-1]
+        log_content.each do |row|
+          UI.command_output(row)
+        end
+
+        UI.message("")
+        UI.error("⬆️  Check out the few lines of raw `xcodebuild` output above for potential hints on how to solve this error")
+        UI.important("📋  For the complete and more detailed error log, check the full log at:")
         UI.important("📋  #{log_path}")
       end
 
@@ -148,25 +151,41 @@ module Gym
         default_xcode_path = "/Applications/"
 
         xcode_installations_in_default_path = Dir[File.join(default_xcode_path, "Xcode*.app")]
-        if xcode_installations_in_default_path.count > 1
-          UI.error "Found multiple versions of Xcode in '#{default_xcode_path}'"
-          UI.error "Make sure you selected the right version for your project"
-          UI.error "This build process was executed using '#{xcode_path}'"
-          UI.important "If you want to update your Xcode path, either"
-          UI.message ""
+        return unless xcode_installations_in_default_path.count > 1
+        UI.message ""
+        UI.important "Maybe the error shown is caused by using the wrong version of Xcode"
+        UI.important "Found multiple versions of Xcode in '#{default_xcode_path}'"
+        UI.important "Make sure you selected the right version for your project"
+        UI.important "This build process was executed using '#{xcode_path}'"
+        UI.important "If you want to update your Xcode path, either"
+        UI.message ""
 
-          UI.message "- Specify the Xcode version in your Fastfile"
-          UI.command_output "xcversion(version: \"8.1\") # Selects Xcode 8.1.0"
-          UI.message ""
+        UI.message "- Specify the Xcode version in your Fastfile"
+        UI.command_output "xcversion(version: \"8.1\") # Selects Xcode 8.1.0"
+        UI.message ""
 
-          UI.message "- Specify an absolute path to your Xcode installation in your Fastfile"
-          UI.command_output "xcode_select \"/Applications/Xcode8.app\""
-          UI.message ""
+        UI.message "- Specify an absolute path to your Xcode installation in your Fastfile"
+        UI.command_output "xcode_select \"/Applications/Xcode8.app\""
+        UI.message ""
 
-          UI.message "- Manually update the path using"
-          UI.command_output "sudo xcode-select -s /Applications/Xcode.app"
-          UI.message ""
-        end
+        UI.message "- Manually update the path using"
+        UI.command_output "sudo xcode-select -s /Applications/Xcode.app"
+        UI.message ""
+      end
+
+      # Indicate that code signing errors are not caused by fastlane
+      # and that fastlane only runs `xcodebuild` commands
+      def print_build_error_instructions
+        UI.message("")
+        UI.error("Looks like fastlane ran into a build/archive error with your project")
+        UI.error("It's hard to tell what's causing the error, so we wrote some guides on how")
+        UI.error("to troubleshoot build and signing issues: https://docs.fastlane.tools/codesigning/getting-started/")
+        UI.error("Before submitting an issue on GitHub, please follow the guide above and make")
+        UI.error("sure your project is set up correctly.")
+        UI.error("fastlane uses `xcodebuild` commands to generate your binary, you can see the")
+        UI.error("the full commands printed out in yellow in the above log.")
+        UI.error("Make sure to inspect the output above, as usually you'll find more error information there")
+        UI.message("")
       end
     end
   end

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -115,6 +115,8 @@ module Gym
         return if Gym.config[:disable_xcpretty]
 
         log_path = Gym::BuildCommandGenerator.xcodebuild_log_path
+        return unless File.exist?(log_content)
+
         # `xcodebuild` doesn't properly mark lines as failure reason or important information
         # so we assume that the last few lines show the error message that's relevant
         # (at least that's what was correct during testing)

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -115,7 +115,7 @@ module Gym
         return if Gym.config[:disable_xcpretty]
 
         log_path = Gym::BuildCommandGenerator.xcodebuild_log_path
-        return unless File.exist?(log_content)
+        return unless File.exist?(log_path)
 
         # `xcodebuild` doesn't properly mark lines as failure reason or important information
         # so we assume that the last few lines show the error message that's relevant

--- a/gym/spec/error_handler_spec.rb
+++ b/gym/spec/error_handler_spec.rb
@@ -14,12 +14,21 @@ describe Gym do
   describe Gym::ErrorHandler do
     before(:each) { Gym.config = @config }
 
+    def mock_gym_path(content)
+      log_path = "log_path"
+      expect(File).to receive(:exist?).with(log_path).and_return(true)
+      expect(Gym::BuildCommandGenerator).to receive(:xcodebuild_log_path).and_return(log_path)
+      expect(File).to receive(:read).with(log_path).and_return(content)
+    end
+
     it "raises build error with error_info" do
+      mock_gym_path(@output)
       expect(UI).to receive(:build_failure!).with("Error building the application - see the log above", error_info: @output)
       Gym::ErrorHandler.handle_build_error(@output)
     end
 
     it "raises package error with error_info" do
+      mock_gym_path(@output)
       expect(UI).to receive(:build_failure!).with("Error packaging up the application", error_info: @output)
       Gym::ErrorHandler.handle_package_error(@output)
     end
@@ -36,10 +45,7 @@ Check dependencies
 No profile for team 'N8X438SEU2' matching 'match AppStore me.themoji.app.beta' found:  Xcode couldn't find any provisioning profiles matching 'N8X438SEU2/match AppStore me.themoji.app.beta'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the General tab of the target editor.
 Code signing is required for product type 'Application' in SDK 'iOS 11.0'
 )
-
-      log_path = "log_path"
-      expect(Gym::BuildCommandGenerator).to receive(:xcodebuild_log_path).and_return(log_path)
-      expect(File).to receive(:read).with(log_path).and_return(code_signing_output)
+      mock_gym_path(code_signing_output)
       expect(UI).to receive(:build_failure!).with("Error building the application - see the log above", error_info: code_signing_output)
       expect(UI).to receive(:command_output).with("No profile for team 'N8X438SEU2' matching 'match AppStore me.themoji.app.beta' found:  Xcode couldn't find any provisioning profiles matching 'N8X438SEU2/match AppStore me.themoji.app.beta'. " \
         "Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the General tab of the target editor.")

--- a/gym/spec/error_handler_spec.rb
+++ b/gym/spec/error_handler_spec.rb
@@ -20,12 +20,12 @@ describe Gym do
     end
 
     it "raises build error with error_info" do
-      expect(UI).to receive(:user_error!).with("Error building the application - see the log above", error_info: @output)
+      expect(UI).to receive(:build_failure!).with("Error building the application - see the log above", error_info: @output)
       Gym::ErrorHandler.handle_build_error(@output)
     end
 
     it "raises package error with error_info" do
-      expect(UI).to receive(:user_error!).with("Error packaging up the application", error_info: @output)
+      expect(UI).to receive(:build_failure!).with("Error packaging up the application", error_info: @output)
       Gym::ErrorHandler.handle_package_error(@output)
     end
   end

--- a/gym/spec/error_handler_spec.rb
+++ b/gym/spec/error_handler_spec.rb
@@ -14,11 +14,6 @@ describe Gym do
   describe Gym::ErrorHandler do
     before(:each) { Gym.config = @config }
 
-    it "finds the standard output path" do
-      expected = '/var/folders/88/l77k840955j0x55fkb3m6cdr0000gn/T/EventLink_2015-12-15_13-00-57.177.xcdistributionlogs/IDEDistribution.standard.log'
-      expect(Gym::ErrorHandler.find_standard_output_path(@output)).to eq(expected)
-    end
-
     it "raises build error with error_info" do
       expect(UI).to receive(:build_failure!).with("Error building the application - see the log above", error_info: @output)
       Gym::ErrorHandler.handle_build_error(@output)
@@ -27,6 +22,31 @@ describe Gym do
     it "raises package error with error_info" do
       expect(UI).to receive(:build_failure!).with("Error packaging up the application", error_info: @output)
       Gym::ErrorHandler.handle_package_error(@output)
+    end
+
+    it "prints the last few lines of the raw output, as `xcpretty` doesn't render all error messages correctly" do
+      code_signing_output = @output + %(
+SetMode u+w,go-w,a+rX /Users/fkrause/Library/Developer/Xcode/DerivedData/Themoji-aanbocksacwzrydzjzjvnfrcqibb/Build/Intermediates.noindex/ArchiveIntermediates/Themoji/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/Pods_Themoji.framework
+    cd /Users/fkrause/Developer/hacking/themoji/Pods
+    export PATH="/Applications/Xcode-9.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin:/Applications/Xcode-9.app/Contents/Developer/usr/bin:/Users/fkrause/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bin:/Users/fkrause/.rbenv/versions/2.4.0/bin:/Users/fkrause/homebrew/Cellar/rbenv/1.1.0/libexec:/Users/fkrause/.rbenv/shims:/Users/fkrause/homebrew/bin:/Users/fkrause/bin:/usr/local/heroku/bin:/usr/local/git/current/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Applications/Postgres.app/Contents/Versions/latest/bin"
+    /bin/chmod -RH u+w,go-w,a+rX /Users/fkrause/Library/Developer/Xcode/DerivedData/Themoji-aanbocksacwzrydzjzjvnfrcqibb/Build/Intermediates.noindex/ArchiveIntermediates/Themoji/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/Pods_Themoji.framework
+
+=== BUILD TARGET Themoji OF PROJECT Themoji WITH CONFIGURATION Release ===
+
+Check dependencies
+No profile for team 'N8X438SEU2' matching 'match AppStore me.themoji.app.beta' found:  Xcode couldn't find any provisioning profiles matching 'N8X438SEU2/match AppStore me.themoji.app.beta'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the General tab of the target editor.
+Code signing is required for product type 'Application' in SDK 'iOS 11.0'
+)
+
+      log_path = "log_path"
+      expect(Gym::BuildCommandGenerator).to receive(:xcodebuild_log_path).and_return(log_path)
+      expect(File).to receive(:read).with(log_path).and_return(code_signing_output)
+      expect(UI).to receive(:build_failure!).with("Error building the application - see the log above", error_info: code_signing_output)
+      expect(UI).to receive(:command_output).with("No profile for team 'N8X438SEU2' matching 'match AppStore me.themoji.app.beta' found:  Xcode couldn't find any provisioning profiles matching 'N8X438SEU2/match AppStore me.themoji.app.beta'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the General tab of the target editor.")
+      expect(UI).to receive(:command_output).with("Code signing is required for product type 'Application' in SDK 'iOS 11.0'")
+      expect(UI).to receive(:command_output).at_least(:once) # as this is called multiple times before
+
+      Gym::ErrorHandler.handle_build_error(code_signing_output)
     end
   end
 end

--- a/gym/spec/error_handler_spec.rb
+++ b/gym/spec/error_handler_spec.rb
@@ -28,7 +28,6 @@ describe Gym do
       code_signing_output = @output + %(
 SetMode u+w,go-w,a+rX /Users/fkrause/Library/Developer/Xcode/DerivedData/Themoji-aanbocksacwzrydzjzjvnfrcqibb/Build/Intermediates.noindex/ArchiveIntermediates/Themoji/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/Pods_Themoji.framework
     cd /Users/fkrause/Developer/hacking/themoji/Pods
-    export PATH="/Applications/Xcode-9.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin:/Applications/Xcode-9.app/Contents/Developer/usr/bin:/Users/fkrause/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/bin:/Users/fkrause/.rbenv/versions/2.4.0/bin:/Users/fkrause/homebrew/Cellar/rbenv/1.1.0/libexec:/Users/fkrause/.rbenv/shims:/Users/fkrause/homebrew/bin:/Users/fkrause/bin:/usr/local/heroku/bin:/usr/local/git/current/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Applications/Postgres.app/Contents/Versions/latest/bin"
     /bin/chmod -RH u+w,go-w,a+rX /Users/fkrause/Library/Developer/Xcode/DerivedData/Themoji-aanbocksacwzrydzjzjvnfrcqibb/Build/Intermediates.noindex/ArchiveIntermediates/Themoji/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/Pods_Themoji.framework
 
 === BUILD TARGET Themoji OF PROJECT Themoji WITH CONFIGURATION Release ===
@@ -42,7 +41,8 @@ Code signing is required for product type 'Application' in SDK 'iOS 11.0'
       expect(Gym::BuildCommandGenerator).to receive(:xcodebuild_log_path).and_return(log_path)
       expect(File).to receive(:read).with(log_path).and_return(code_signing_output)
       expect(UI).to receive(:build_failure!).with("Error building the application - see the log above", error_info: code_signing_output)
-      expect(UI).to receive(:command_output).with("No profile for team 'N8X438SEU2' matching 'match AppStore me.themoji.app.beta' found:  Xcode couldn't find any provisioning profiles matching 'N8X438SEU2/match AppStore me.themoji.app.beta'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the General tab of the target editor.")
+      expect(UI).to receive(:command_output).with("No profile for team 'N8X438SEU2' matching 'match AppStore me.themoji.app.beta' found:  Xcode couldn't find any provisioning profiles matching 'N8X438SEU2/match AppStore me.themoji.app.beta'. " \
+        "Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the General tab of the target editor.")
       expect(UI).to receive(:command_output).with("Code signing is required for product type 'Application' in SDK 'iOS 11.0'")
       expect(UI).to receive(:command_output).at_least(:once) # as this is called multiple times before
 


### PR DESCRIPTION
This PR will make it more clear on *why* the build failed. The goal is to get less issues submitted on GH that are related to build failures, which are mostly out of our control anyway

This PR will also add printing out the last few lines of the raw xcodebuild output, as `xcpretty` doesn't render all the errors

This PR also removes some unused methods in the `error_handler` class

Also, of course, there is tests

Also, improved wording and order of error message (see screenshots)

**Old**
<img width="810" alt="screen shot 2017-07-12 at 12 32 49 pm" src="https://user-images.githubusercontent.com/869950/28114922-226a866c-6703-11e7-8677-c112521ae656.png">

**New**
<img width="948" alt="screen shot 2017-07-12 at 1 00 42 pm" src="https://user-images.githubusercontent.com/869950/28114943-348dab62-6703-11e7-9505-2c3718baeba1.png">
