### PR TITLE
Correct grammar and spelling for ‘anymore’ and ‘altogether’

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -35,13 +35,13 @@ module FastlaneCore
       end
 
       def report_status(build: nil)
-        # Due to iTunes Connect, builds disappear from the build list alltogether
+        # Due to iTunes Connect, builds disappear from the build list altogether
         # after they finished processing. Before returning this build, we have to
         # wait for the build to appear in the build list again
         # As this method is very often used to wait for a build, and then do something
         # with it, we have to be sure that the build actually is ready
         if build.nil?
-          UI.message("Build doesn't show up in the build list any more, waiting for it to appear again")
+          UI.message("Build doesn't show up in the build list anymore, waiting for it to appear again")
         elsif build.active?
           UI.success("Build #{build.train_version} - #{build.build_version} is already being tested")
         elsif build.ready_to_submit? || build.export_compliance_missing?

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -113,7 +113,7 @@ describe FastlaneCore::BuildWatcher do
       expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([], [ready_build])
       expect(FastlaneCore::BuildWatcher).to receive(:sleep)
 
-      expect(UI).to receive(:message).with("Build doesn't show up in the build list any more, waiting for it to appear again")
+      expect(UI).to receive(:message).with("Build doesn't show up in the build list anymore, waiting for it to appear again")
       expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.train_version} - #{ready_build.build_version}")
       found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
 


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context

These are just two small grammar and spelling corrections:

- Anymore (one word) means "any longer" which is the context of this error message.
- Altogether (one L) is the correct spelling of that word.

I've just noticed the incorrect _any more_ occasionally when seeing this error message and thought I should submit a correction. While changing that I noticed the incorrect spelling of _altogether_ just above it in the comment.

### Description

I've corrected the error message and its corresponding test.
