### PR TITLE
Version bump to 2.46.1

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.46.0'.freeze
+  VERSION = '2.46.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.46.0':**

* [gym] Improve build error output to be more clear (#9727) via Felix Krause
* Fix grammer mistakes in docs (#9731) via Justin Swart
* Fix markdown formating in iTunesConnect (#9725) via Eugene Oskin
* add the word 'you' that was missing (#9713) via Tim Myers
