### PR TITLE
Check superseded tracks for rollout in supply

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -155,10 +155,11 @@ module Supply
 
     def update_track(apk_version_codes)
       UI.message("Updating track '#{Supply.config[:track]}'...")
+      check_superseded_tracks(apk_version_codes) if Supply.config[:check_superseded_tracks]
+
       if Supply.config[:track].eql? "rollout"
         client.update_track(Supply.config[:track], Supply.config[:rollout], apk_version_codes)
       else
-        check_superseded_tracks(apk_version_codes) if Supply.config[:check_superseded_tracks]
         client.update_track(Supply.config[:track], 1.0, apk_version_codes)
       end
     end
@@ -171,7 +172,7 @@ module Supply
       max_apk_version_code = apk_version_codes.max
       max_tracks_version_code = nil
 
-      tracks = ["production", "beta", "alpha"]
+      tracks = ["production", "rollout", "beta", "alpha"]
       config_track_index = tracks.index(Supply.config[:track])
 
       tracks.each_index do |track_index|


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

In the current version of fastlane, it isn't possible to supersede tracks on Google Play when deploying to the rollout track. I don't know if this was intentional, but it doesn't appear to be as it worked for me in testing. For my test, I had multiple APKs in the Alpha channel on Google play and did a Rollout to 25% using fastlane with new APKs. Before this change, I would get the multishadow APK error from the Google Developer API. With this change, it worked successfully like it does for the other tracks.

### Description
<!--- Describe your changes in detail -->

* Moved the check for superseded tracks to before if/else chain for update_track. Previously it would only check for production, beta and alpha.

* Added "rollout" to the tracks list for checking supersession. 