### PR TITLE
Updated supply rollout number verification: range is 0.0 - 1.0.

### DIFF
--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -26,9 +26,9 @@ module Supply
                                      description: "The percentage of the user fraction when uploading to the rollout track",
                                      default_value: '0.1',
                                      verify_block: proc do |value|
-                                       min = 0.01
-                                       max = 0.5
-                                       UI.user_error! "Invalid value '#{value}', must be between #{min} and #{max}" unless value.to_f.between?(min, max)
+                                       min = 0.0
+                                       max = 1.0
+                                       UI.user_error! "Invalid value '#{value}', must be greater than #{min} and less than #{max}" unless value.to_f > min && value.to_f < max
                                      end),
         FastlaneCore::ConfigItem.new(key: :metadata_path,
                                      env_name: "SUPPLY_METADATA_PATH",

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -41,7 +41,7 @@ module Supply
     def promote_track
       version_codes = client.track_version_codes(Supply.config[:track])
       # the actual value passed for the rollout argument does not matter because it will be ignored by the Google Play API
-      # but it has to be between 0.01 and 0.5 to pass the validity check. So we are passing the default value 0.1
+      # but it has to be between 0.0 and 1.0 to pass the validity check. So we are passing the default value 0.1
       client.update_track(Supply.config[:track], 0.1, nil)
       client.update_track(Supply.config[:track_promote_to], Supply.config[:rollout], version_codes)
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

Related issue: https://github.com/fastlane/fastlane/issues/9690

The range when this feature was added to fastlane was 0.05 - 0.5. I believe this was updated on the Google Play Developer Console in their recent update an I'm able to set the rollout percentage to anywhere from 0.0 - 1.0 on the console.

After testing, I was able to determine that the Google API considers numbers <= 0.0 invalid and numbers >= 1.0 invalid. Everything between that works. I tested this by updating a production app in the rollout track. This is the build step I'm using:

```
desc "bump production build to x% rollout in google play"
lane :updateRollout do |options|
# update rollout percentage on Google Play
supply(
  track: 'rollout',
  track_promote_to: 'rollout',
  rollout: options[:pct],
  metadata_path: 'fastlane/prod',
  skip_upload_apk: true,
  skip_upload_metadata: true,
  skip_upload_images: true,
  skip_upload_screenshots: true,
  check_superseded_tracks: true
)
end
```

I confirmed that numbers such as 0.75 and 0.90 work, while 1.0 does not work. 

### Description
<!--- Describe your changes in detail -->

I changed the min/max numbers to 0.0 and 1.0. The `between` check is inclusive, so I changed to to `value > min && value < max`.
