### PR TITLE
[gym] Refactor and improve build failure output when using an incorrect export_method in gym

### DIFF
--- a/fastlane/lib/fastlane/actions/gym.rb
+++ b/fastlane/lib/fastlane/actions/gym.rb
@@ -9,7 +9,7 @@ module Fastlane
       def self.run(values)
         require 'gym'
 
-        unless Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE].to_sym == :development
+        unless Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE].to_s == "development"
           values[:export_method] ||= Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE]
         end
 

--- a/fastlane/lib/fastlane/actions/gym.rb
+++ b/fastlane/lib/fastlane/actions/gym.rb
@@ -9,7 +9,9 @@ module Fastlane
       def self.run(values)
         require 'gym'
 
-        values[:export_method] ||= Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE]
+        unless Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE].to_sym == :development
+          values[:export_method] ||= Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE]
+        end
 
         if Actions.lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING]
           # Since Xcode 9 you need to explicitly provide the provisioning profile per app target

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -184,7 +184,7 @@ module Gym
           UI.message("")
           UI.error("Your `export_method` in gym is defined as `:development`")
           UI.error("which can't be used for `ipa` files for beta or App Store distribution")
-          UI.error("Please make sure to define a correct `export_method` when calling")
+          UI.error("Please make sure to define the correct export methods when calling")
           UI.error("gym in your Fastfile or from the command line")
           UI.message("")
         elsif Gym.config[:export_options]

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -54,6 +54,7 @@ module Gym
         print_xcode_path_instructions
         print_xcode_version
         print_full_log_path
+        print_environment_information
         print_build_error_instructions
         UI.build_failure!("Error building the application - see the log above", error_info: output)
       end
@@ -89,7 +90,9 @@ module Gym
           print "A general code signing error occurred. Make sure you passed a valid"
           print "provisioning profile and code signing identity."
         end
+        print_xcode_version
         print_full_log_path
+        print_environment_information
         print_build_error_instructions
         UI.build_failure!("Error packaging up the application", error_info: output)
       end
@@ -137,7 +140,8 @@ module Gym
         # sure they are aware of the Xcode version and SDK they're using
         values = {
           xcode_path: File.expand_path("../..", FastlaneCore::Helper.xcode_path),
-          gym_version: Fastlane::VERSION
+          gym_version: Fastlane::VERSION,
+          export_method: Gym.config[:export_method]
         }
 
         sdk_path = Gym.project.build_settings(key: "SDKROOT")
@@ -173,6 +177,17 @@ module Gym
         UI.message "- Manually update the path using"
         UI.command_output "sudo xcode-select -s /Applications/Xcode.app"
         UI.message ""
+      end
+
+      def print_environment_information
+        if Gym.config[:export_method].to_sym == :development
+          UI.message("")
+          UI.error("Your `export_method` in gym is defined as `:development`")
+          UI.error("which can't be used for `ipa` files for beta or App Store distribution")
+          UI.error("Please make sure to define a correct `export_method` when calling")
+          UI.error("gym in your Fastfile or from the command line")
+          UI.message("")
+        end
       end
 
       # Indicate that code signing errors are not caused by fastlane

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -180,7 +180,7 @@ module Gym
       end
 
       def print_environment_information
-        if Gym.config[:export_method].to_sym == :development
+        if Gym.config[:export_method].to_s == "development"
           UI.message("")
           UI.error("Your `export_method` in gym is defined as `:development`")
           UI.error("which can't be used for `ipa` files for beta or App Store distribution")
@@ -208,8 +208,8 @@ module Gym
             "ad-hoc" => :adhoc,
             "adhoc" => :adhoc,
             "ad hoc" => :adhoc,
-            "enterprise" => :enterprise, 
-            "development" => :development,
+            "enterprise" => :enterprise,
+            "development" => :development
           }
 
           selected_provisioning_profiles.each do |current_bundle_identifier, current_profile_name|
@@ -218,12 +218,12 @@ module Gym
 
               # Check if there is a mismatch between the name and the selected export method
               # Example
-              # 
+              #
               #   current_profile_name = "me.themoji.app.beta App Store""
               #   current_to_try = "app store"
               #   matching_type = :appstore
               #   selected_export_method = "enterprise"
-              # 
+              #
               # As seen above, there is obviously a mismatch, the user selected an App Store
               # profile, but the export method that's being passed to Xcode is "enterprise"
 


### PR DESCRIPTION
- Automatically detect mismatches between the provided `export_method` and the selected provisioning profiles
- On build failure, show `export_method` and warn about using :development
- Don't use `:development` export type when running match before _gym_

----

**Screenshot 1:**
- Shows the `export_method` in the summary
- Show that `development` was defined as `export_method` which almost never makes sense
<img width="948" alt="screen shot 2017-07-13 at 4 55 27 pm" src="https://user-images.githubusercontent.com/869950/28174213-258de912-67f1-11e7-9912-b281e15b239c.png">

**Screenshot 2**
- Show information about a mismatch of `export_method` and provisioning profiles for each app target
<img width="948" alt="screen shot 2017-07-13 at 5 31 32 pm" src="https://user-images.githubusercontent.com/869950/28174263-55c3750c-67f1-11e7-9ac9-cf577e423d41.png">

