### PR TITLE
Version bump to 2.47.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.46.1'.freeze
+  VERSION = '2.47.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.46.1':**

* Add cert, sigh and match section to FAQs (#9738) via Felix Krause
* Check superseded tracks for rollout in supply (already works for production, beta and alpha). (#9736) via JacobMuchow
* Updated rollout number verification: rollout range on Google Play Developer API is 0.0 - 1.0 (#9737) via JacobMuchow
* Update README to call out what operating systems can run fastlane (#9721) via Joshua Liebowitz
* Manage JWT with Spaceship (#9560) via Stefan Natchev
