### PR TITLE
Add ancestry_path parameter to changelog_from_git_commits

### DIFF
--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -30,9 +30,9 @@ module Fastlane
         end
 
         if params[:commits_count]
-          changelog = Actions.git_log_last_commits(params[:pretty], params[:commits_count], merge_commit_filtering, params[:date_format])
+          changelog = Actions.git_log_last_commits(params[:pretty], params[:commits_count], merge_commit_filtering, params[:date_format], params[:ancestry_path])
         else
-          changelog = Actions.git_log_between(params[:pretty], from, to, merge_commit_filtering, params[:date_format])
+          changelog = Actions.git_log_between(params[:pretty], from, to, merge_commit_filtering, params[:date_format], params[:ancestry_path])
         end
         changelog = changelog.gsub("\n\n", "\n") if changelog # as there are duplicate newlines
         Actions.lane_context[SharedValues::FL_CHANGELOG] = changelog
@@ -94,6 +94,12 @@ module Fastlane
                                        description: 'The date format applied to each commit while generating the collected value',
                                        optional: true,
                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :ancestry_path,
+                                       env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_ANCESTRY_PATH',
+                                       description: 'Whether or not to use ancestry-path param',
+                                       optional: true,
+                                       default_value: false,
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :tag_match_pattern,
                                        env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_TAG_MATCH_PATTERN',
                                        description: 'A glob(7) pattern to match against when finding the last git tag',

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -2,10 +2,11 @@ module Fastlane
   module Actions
     GIT_MERGE_COMMIT_FILTERING_OPTIONS = [:include_merges, :exclude_merges, :only_include_merges].freeze
 
-    def self.git_log_between(pretty_format, from, to, merge_commit_filtering, date_format = nil)
+    def self.git_log_between(pretty_format, from, to, merge_commit_filtering, date_format = nil, ancestry_path)
       command = ['git log']
       command << "--pretty=\"#{pretty_format}\""
       command << "--date=\"#{date_format}\"" if date_format
+      command << '--ancestry-path' if ancestry_path
       command << "#{from.shellescape}...#{to.shellescape}"
       command << git_log_merge_commit_filtering_option(merge_commit_filtering)
       Actions.sh(command.compact.join(' '), log: false).chomp
@@ -13,10 +14,11 @@ module Fastlane
       nil
     end
 
-    def self.git_log_last_commits(pretty_format, commit_count, merge_commit_filtering, date_format = nil)
+    def self.git_log_last_commits(pretty_format, commit_count, merge_commit_filtering, date_format = nil, ancestry_path)
       command = ['git log']
       command << "--pretty=\"#{pretty_format}\""
       command << "--date=\"#{date_format}\"" if date_format
+      command << '--ancestry-path' if ancestry_path
       command << "-n #{commit_count}"
       command << git_log_merge_commit_filtering_option(merge_commit_filtering)
       Actions.sh(command.compact.join(' '), log: false).chomp


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
In projects I work on, developers merge branches without squashing. So, when we use git log without --ancestry_path param, we get incorrect changelog.

### Description
<!--- Describe your changes in detail -->
I added optional parameter ancestry_path to changelog_from_git_commits to support this scenario in fastlane.

I am sure it'll help to others.

Some details
https://stackoverflow.com/questions/36433572/how-does-ancestry-path-work-with-git-log