### PR TITLE
Resolve PRODUCT_BUNDLE_IDENTIFIER and PROVISIONING_PROFILE_SPECIFIER for Xcode 9 export settings

### DIFF
--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -94,10 +94,8 @@ module Gym
           project = Xcodeproj::Project.open(project_path)
           project.targets.each do |target|
             target.build_configuration_list.build_configurations.each do |build_configuration|
-              current = build_configuration.build_settings
-
-              bundle_identifier = current["PRODUCT_BUNDLE_IDENTIFIER"]
-              provisioning_profile_specifier = current["PROVISIONING_PROFILE_SPECIFIER"]
+              bundle_identifier = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER")
+              provisioning_profile_specifier = build_configuration.resolve_build_setting("PROVISIONING_PROFILE_SPECIFIER")
               next if provisioning_profile_specifier.to_s.length == 0
 
               provisioning_profile_mapping[bundle_identifier] = provisioning_profile_specifier

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -94,8 +94,8 @@ module Gym
           project = Xcodeproj::Project.open(project_path)
           project.targets.each do |target|
             target.build_configuration_list.build_configurations.each do |build_configuration|
-              bundle_identifier = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER")
-              provisioning_profile_specifier = build_configuration.resolve_build_setting("PROVISIONING_PROFILE_SPECIFIER")
+              bundle_identifier = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER", target)
+              provisioning_profile_specifier = build_configuration.resolve_build_setting("PROVISIONING_PROFILE_SPECIFIER", target)
               next if provisioning_profile_specifier.to_s.length == 0
 
               provisioning_profile_mapping[bundle_identifier] = provisioning_profile_specifier


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I ran into the issue some users are reporting in https://github.com/fastlane/fastlane/pull/9460#issuecomment-312931119. I think while implementing #9380 in #9460, projects that use xcconfig files to override `PRODUCT_BUNDLE_IDENTIFIER` and `PROVISIONING_PROFILE_SPECIFIER` build settings were not considered.

### Description

If a user project uses xcconfig files to set up these build settings, `XCBuildConfiguration#resolve_build_setting` from `xcodeproj` properly resolves the value in case of variable substitution.

This PR depends on https://github.com/CocoaPods/Xcodeproj/pull/501

### Sample project

Get it from: https://github.com/Ruenzuo/fastlane_xcconfig_xcode_9

xcconfig file using variable substitution looks like:

```
PRODUCT_BUNDLE_IDENTIFIER_Release = com.cocoapods.app
PRODUCT_BUNDLE_IDENTIFIER_Debug = com.cocoapods.app.dev
PRODUCT_BUNDLE_IDENTIFIER = $(PRODUCT_BUNDLE_IDENTIFIER_$(CONFIGURATION))

PROVISIONING_PROFILE_SPECIFIER_Release = Some Provisioning Profile
PROVISIONING_PROFILE_SPECIFIER_Debug = Some Other Provisioning Profile
PROVISIONING_PROFILE_SPECIFIER = $(PROVISIONING_PROFILE_SPECIFIER_$(CONFIGURATION))
```

Run on master (using latest fastlane), logs show:

```
Detected provisioning profile mapping: {"$(PRODUCT_BUNDLE_IDENTIFIER_$(CONFIGURATION))"=>"$(PROVISIONING_PROFILE_SPECIFIER_$(CONFIGURATION))"}
```

Run on fix_xcconfig_files (using this and https://github.com/CocoaPods/Xcodeproj/pull/501), logs show:

```
Detected provisioning profile mapping: {"com.cocoapods.app.dev"=>"Some Other Provisioning Profile", "com.cocoapods.app"=>"Some Provisioning Profile"}
```