### PR TITLE
Change invalid quotes in ToolsAndDebugging.md

### DIFF
--- a/ToolsAndDebugging.md
+++ b/ToolsAndDebugging.md
@@ -130,7 +130,7 @@ To make it easier to run the same script again, you can temporarily edit the `sp
 # leave existing code, and append the following
 
 task :debug do
-  require ‘spaceship’
+  require 'spaceship'
 
   # first login
   Spaceship::Tunes.login("apple@fastlane.tools") # use your own test account


### PR DESCRIPTION
- The current quotes in the `spaceship/Rakefile` example's `debug` rake task do not work when copy-pasted. 
- This PR changes the quotes to be valid.

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
When copying the example debug rake task it does not work because the quotes are not valid single quotes.

### Description
Changes quotes to be valid single quotes.
