### PR TITLE
Remove tizen from platforms rule, it's not needed and causes issues

### DIFF
--- a/precheck/lib/precheck/rules/other_platforms_rule.rb
+++ b/precheck/lib/precheck/rules/other_platforms_rule.rb
@@ -29,7 +29,6 @@ module Precheck
         "google",
         "compuserve",
         "windows phone",
-        "tizen",
         "windows 10 mobile",
         "sailfish os",
         "windows universal app",


### PR DESCRIPTION
Fix for #9761 
Longer-term, we could consider splitting words instead of just checking if each word is contained in the text.