### PR TITLE
Add download Xcode managed provisioning profiles flag to sigh

### DIFF
--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -64,7 +64,7 @@ module Sigh
 
         c.action do |args, options|
           Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options.__hash__)
-          Sigh::Manager.download_all(options, args)
+          Sigh::Manager.download_all(options)
         end
       end
 

--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -64,7 +64,7 @@ module Sigh
 
         c.action do |args, options|
           Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options.__hash__)
-          Sigh::Manager.download_all
+          Sigh::Manager.download_all(options, args)
         end
       end
 

--- a/sigh/lib/sigh/download_all.rb
+++ b/sigh/lib/sigh/download_all.rb
@@ -1,7 +1,7 @@
 module Sigh
   class DownloadAll
     # Download all valid provisioning profiles
-    def download_all(commander_options, args)
+    def download_all(commander_options)
       download_xcode_profiles = commander_options.download_xcode_profiles
 
       UI.message "Starting login with user '#{Sigh.config[:username]}'"

--- a/sigh/lib/sigh/download_all.rb
+++ b/sigh/lib/sigh/download_all.rb
@@ -1,13 +1,15 @@
 module Sigh
   class DownloadAll
     # Download all valid provisioning profiles
-    def download_all
+    def download_all(options, args)
+      download_xcode_profiles = options.download_xcode_profiles
+
       UI.message "Starting login with user '#{Sigh.config[:username]}'"
       Spaceship.login(Sigh.config[:username], nil)
       Spaceship.select_team
       UI.message "Successfully logged in"
 
-      Spaceship.provisioning_profile.all.each do |profile|
+      Spaceship.provisioning_profile.all(xcode: download_xcode_profiles).each do |profile|
         if profile.valid?
           UI.message "Downloading profile '#{profile.name}'..."
           download_profile(profile)

--- a/sigh/lib/sigh/download_all.rb
+++ b/sigh/lib/sigh/download_all.rb
@@ -1,8 +1,8 @@
 module Sigh
   class DownloadAll
     # Download all valid provisioning profiles
-    def download_all(options, args)
-      download_xcode_profiles = options.download_xcode_profiles
+    def download_all(commander_options, args)
+      download_xcode_profiles = commander_options.download_xcode_profiles
 
       UI.message "Starting login with user '#{Sigh.config[:username]}'"
       Spaceship.login(Sigh.config[:username], nil)

--- a/sigh/lib/sigh/manager.rb
+++ b/sigh/lib/sigh/manager.rb
@@ -29,9 +29,9 @@ module Sigh
       return File.expand_path(output)
     end
 
-    def self.download_all(options, args)
+    def self.download_all(options)
       require 'sigh/download_all'
-      DownloadAll.new.download_all(options, args)
+      DownloadAll.new.download_all(options)
     end
 
     def self.install_profile(profile)

--- a/sigh/lib/sigh/manager.rb
+++ b/sigh/lib/sigh/manager.rb
@@ -29,9 +29,9 @@ module Sigh
       return File.expand_path(output)
     end
 
-    def self.download_all
+    def self.download_all(options, args)
       require 'sigh/download_all'
-      DownloadAll.new.download_all
+      DownloadAll.new.download_all(options, args)
     end
 
     def self.install_profile(profile)

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -121,7 +121,13 @@ module Sigh
                                        value = value.to_s
                                        pt = %w(macos tvos ios)
                                        UI.user_error!("Unsupported platform, must be: #{pt}") unless pt.include?(value)
-                                     end)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :download_xcode_profiles,
+                                     description: "Also download Xcode managed provisioning profiles",
+                                     is_string: false,
+                                     env_name: "SIGH_DOWNLOAD_XCODE_PROFILES",
+                                     short_option: "-x",
+                                     default_value: false)
       ]
     end
   end

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -123,7 +123,7 @@ module Sigh
                                        UI.user_error!("Unsupported platform, must be: #{pt}") unless pt.include?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :download_xcode_profiles,
-                                     description: "Also download Xcode managed provisioning profiles",
+                                     description: "Also download Xcode managed provisioning profiles. Should be used with download_all command",
                                      is_string: false,
                                      env_name: "SIGH_DOWNLOAD_XCODE_PROFILES",
                                      short_option: "-x",

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -123,7 +123,7 @@ module Sigh
                                        UI.user_error!("Unsupported platform, must be: #{pt}") unless pt.include?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :download_xcode_profiles,
-                                     description: "Also download Xcode managed provisioning profiles. Should be used with download_all command",
+                                     description: "[Only works with fastlane sigh download_all command]: Also download Xcode managed provisioning profiles",
                                      is_string: false,
                                      env_name: "SIGH_DOWNLOAD_XCODE_PROFILES",
                                      short_option: "-x",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
This PR adds `--download_xcode_profiles` flag to `sigh download_all` command to download Xcode managed provisioning profiles.

See #9679  

### Description
<!--- Describe your changes in detail -->
Solves issue #9679 
