### PR TITLE
Fix missing email method when working with Spaceship::Tunes::Member

### DIFF
--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -113,7 +113,7 @@ module Pilot
         tester = Spaceship::Tunes::Tester::Internal.find_by_app(app.apple_id, email)
         tester ||= Spaceship::Tunes::Tester::External.find_by_app(app.apple_id, email)
       else
-        UI.user_error!("Account #{current_user.email} doesn't have a role that is allowed to administer app testers, current roles: #{current_user.roles}")
+        UI.user_error!("Account #{current_user.email_address} doesn't have a role that is allowed to administer app testers, current roles: #{current_user.roles}")
         tester = nil
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
Simple fix for a missing method `email` error when printing an error message.