### PR TITLE
fix: Encoded the url before passing to faraday

### DIFF
--- a/precheck/lib/precheck/rules/unreachable_urls_rule.rb
+++ b/precheck/lib/precheck/rules/unreachable_urls_rule.rb
@@ -24,7 +24,7 @@ module Precheck
         return RuleReturn.new(validation_state: Precheck::VALIDATION_STATES[:failed], failure_data: "empty url") if url.empty?
 
         begin
-          request = Faraday.new(url) do |connection|
+          request = Faraday.new(URI.encode(url)) do |connection|
             connection.use FaradayMiddleware::FollowRedirects
             connection.adapter :net_http
           end

--- a/precheck/spec/rules/unreachable_urls_rule_spec.rb
+++ b/precheck/spec/rules/unreachable_urls_rule_spec.rb
@@ -5,7 +5,7 @@ module Precheck
     describe Precheck::UnreachableURLRule do
       let(:rule) { UnreachableURLRule.new }
 
-      def setup_url_rule_mock(return_status: 200)
+      def setup_url_rule_mock(url: "http://fastlane.tools", return_status: 200)
         request = "fake request"
         head_object = "fake head object"
 
@@ -15,12 +15,21 @@ module Precheck
         allow(request).to receive(:adapter).and_return(nil)
         allow(request).to receive(:head).and_return(head_object)
 
-        allow(Faraday).to receive(:new).and_return(request)
+        allow(Faraday).to receive(:new).with(url).and_return(request)
       end
 
       it "passes for 200 status URL" do
         setup_url_rule_mock
         item = URLItemToCheck.new("http://fastlane.tools", "some_url", "test URL")
+        result = rule.check_item(item)
+
+        expect(result.status).to eq(VALIDATION_STATES[:passed])
+      end
+
+      it "passes for valid non encoded URL" do
+        setup_url_rule_mock(url: "http://fastlane.tools/%E3%83%86%E3%82%B9%E3%83%88")
+
+        item = URLItemToCheck.new("http://fastlane.tools/テスト", "some_url", "test URL")
         result = rule.check_item(item)
 
         expect(result.status).to eq(VALIDATION_STATES[:passed])


### PR DESCRIPTION
This is to avoid failure when the url is valid but not encoded

### Checklist
🔑
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The url metada in iTunes Connect can contain a non encoded url, like in our case, [https://moneytree.jp/個人情報保護方針/](https://moneytree.jp/個人情報保護方針/) that is a valid url. But running `bundle exec fastlane precheck` returns a failure.

### Description

In `unreachable_url_rule.rb`, passing a non encoded url when initializing Faraday throws an exception. This exception is caught and a failure with unreachable url is returned.

```
irb(main):013:0> url = 'https://moneytree.jp/個人情報保護方針/'.to_s.strip
=> "https://moneytree.jp/個人情報保護方針/"
irb(main):014:0> request = Faraday.new(url)
URI::InvalidURIError: bad URI(is not URI?): https://moneytree.jp/個人情報保護方針/
	from /Users/RenD/.rbenv/versions/2.0.0-p576/lib/ruby/2.0.0/uri/common.rb:176:in `split'
	from /Users/RenD/.rbenv/versions/2.0.0-p576/lib/ruby/2.0.0/uri/common.rb:211:in `parse'
	from /Users/RenD/.rbenv/versions/2.0.0-p576/lib/ruby/2.0.0/uri/common.rb:747:in `parse'
	from /Users/RenD/.rbenv/versions/2.0.0-p576/lib/ruby/2.0.0/uri/common.rb:996:in `URI'
	from /Users/RenD/.rbenv/versions/2.0.0-p576/lib/ruby/gems/2.0.0/gems/faraday-0.12.1/lib/faraday/utils.rb:266:in `call'
	from /Users/RenD/.rbenv/versions/2.0.0-p576/lib/ruby/gems/2.0.0/gems/faraday-0.12.1/lib/faraday/utils.rb:266:in `URI'
	from /Users/RenD/.rbenv/versions/2.0.0-p576/lib/ruby/gems/2.0.0/gems/faraday-0.12.1/lib/faraday/connection.rb:318:in `url_prefix='
	from /Users/RenD/.rbenv/versions/2.0.0-p576/lib/ruby/gems/2.0.0/gems/faraday-0.12.1/lib/faraday/connection.rb:77:in `initialize'
	from /Users/RenD/.rbenv/versions/2.0.0-p576/lib/ruby/gems/2.0.0/gems/faraday-0.12.1/lib/faraday.rb:67:in `new'
	from /Users/RenD/.rbenv/versions/2.0.0-p576/lib/ruby/gems/2.0.0/gems/faraday-0.12.1/lib/faraday.rb:67:in `new'
	from (irb):14
	from /Users/RenD/.rbenv/versions/2.0.0-p576/bin/irb:12:in `<main>'
```
