### PR TITLE
Use the #defined? method to see if DidYouMean::SpellChecker is available

### DIFF
--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -88,7 +88,7 @@ module Fastlane
 
         corrections = []
 
-        if !Gem.loaded_specs["did_you_mean"].nil? && Gem.loaded_specs["did_you_mean"].version >= Gem::Version.new('1.1.0')
+        if defined?(DidYouMean::SpellChecker)
           spell_checker = DidYouMean::SpellChecker.new(dictionary: action_names)
           corrections << spell_checker.correct(filter).compact
         end


### PR DESCRIPTION
Thanks for speaking at Artsy today! Here's my first PR to fastlane...

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

The `DidYouMean::SpellChecker` class is available in did_you_mean [1.0.2][1] as well as [1.1.0](https://github.com/yuki24/did_you_mean/releases/tag/v1.1.0) and later. Ruby 2.4.x ships with 1.1.x, and 2.3.x ships with 1.0.x, so using the `#defined?` method will allow fastlane to suggest action names also on Ruby 2.3.

[1]: https://github.com/yuki24/did_you_mean/releases/tag/v1.0.2

### Description

 *  Use the `#defined?` method to see if the `DidYouMean::SpellChecker` class is available