### PR TITLE
Added command to create external beta tester groups

### DIFF
--- a/pilot/lib/pilot.rb
+++ b/pilot/lib/pilot.rb
@@ -9,6 +9,7 @@ require "pilot/build_manager"
 require "pilot/tester_manager"
 require "pilot/tester_importer"
 require "pilot/tester_exporter"
+require "pilot/group_manager"
 
 require "spaceship"
 require "terminal-table"

--- a/pilot/lib/pilot/commands_generator.rb
+++ b/pilot/lib/pilot/commands_generator.rb
@@ -154,6 +154,18 @@ module Pilot
         end
       end
 
+      command :group do |c|
+        c.syntax = "fastlane pilot group"
+        c.description = "Create external testers groups"
+
+        FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
+
+        c.action do |args, options|
+          config = create_config(options)
+          Pilot::GroupManager.new.create_group(config)
+        end
+      end
+
       default_command :help
 
       run!

--- a/pilot/lib/pilot/group_manager.rb
+++ b/pilot/lib/pilot/group_manager.rb
@@ -4,19 +4,19 @@ require 'terminal-table'
 module Pilot
   class GroupManager < Manager
     def create_group(options)
-        start(options)
-        if config[:apple_id].to_s.length == 0 and config[:app_identifier].to_s.length == 0
-            config[:app_identifier] = UI.input("App Identifier: ")
-            config[:apple_id] = Spaceship::Tunes::Application.find(config[:app_identifier]).apple_id
-        end
-        if config[:apple_id].to_s.length == 0 and config[:app_identifier].to_s.length != 0
-            config[:apple_id] = Spaceship::Tunes::Application.find(config[:app_identifier]).apple_id
-        end
-        if config[:group_name].to_s.length == 0
-            config[:group_name] = UI.input("Group Name: ")
-        end
-        Spaceship::TestFlight::Group.create_group!(app_id: config[:apple_id], group_name: config[:group_name])
-        UI.success "Successfully added #{config[:group_name]} to app"
+      start(options)
+      if config[:apple_id].to_s.length == 0 and config[:app_identifier].to_s.length == 0
+        config[:app_identifier] = UI.input("App Identifier: ")
+        config[:apple_id] = Spaceship::Tunes::Application.find(config[:app_identifier]).apple_id
+      end
+      if config[:apple_id].to_s.length == 0 and config[:app_identifier].to_s.length != 0
+        config[:apple_id] = Spaceship::Tunes::Application.find(config[:app_identifier]).apple_id
+      end
+      if config[:group_name].to_s.length == 0
+        config[:group_name] = UI.input("Group Name: ")
+      end
+      Spaceship::TestFlight::Group.create_group!(app_id: config[:apple_id], group_name: config[:group_name])
+      UI.success "Successfully added #{config[:group_name]} to app"
     end
   end
 end

--- a/pilot/lib/pilot/group_manager.rb
+++ b/pilot/lib/pilot/group_manager.rb
@@ -1,0 +1,22 @@
+require "fastlane_core"
+require 'terminal-table'
+
+module Pilot
+  class GroupManager < Manager
+    def create_group(options)
+        start(options)
+        if config[:apple_id].to_s.length == 0 and config[:app_identifier].to_s.length == 0
+            config[:app_identifier] = UI.input("App Identifier: ")
+            config[:apple_id] = Spaceship::Tunes::Application.find(config[:app_identifier]).apple_id
+        end
+        if config[:apple_id].to_s.length == 0 and config[:app_identifier].to_s.length != 0
+            config[:apple_id] = Spaceship::Tunes::Application.find(config[:app_identifier]).apple_id
+        end
+        if config[:group_name].to_s.length == 0
+            config[:group_name] = UI.input("Group Name: ")
+        end
+        Spaceship::TestFlight::Group.create_group!(app_id: config[:apple_id], group_name: config[:group_name])
+        UI.success "Successfully added #{config[:group_name]} to app"
+    end
+  end
+end

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -160,7 +160,7 @@ module Pilot
         FastlaneCore::ConfigItem.new(key: :group_name,
                                      env_name: "PILOT_GROUP_NAME",
                                      description: "The name of the group being made for external testers",
-                                     optional: true),
+                                     optional: true)
       ]
     end
   end

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -156,7 +156,11 @@ module Pilot
                                      type: Array,
                                      verify_block: proc do |value|
                                        UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
-                                     end)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :group_name,
+                                     env_name: "PILOT_GROUP_NAME",
+                                     description: "The name of the group being made for external testers",
+                                     optional: true),
       ]
     end
   end

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -79,6 +79,20 @@ module Spaceship::TestFlight
       handle_response(response)
     end
 
+    def add_group_to_app(app_id: nil, group_name: nil)
+      assert_required_params(__method__, binding)
+
+      body = {
+        'name' => group_name
+      }
+      response = request(:post) do |req|
+        req.url "providers/#{team_id}/apps/#{app_id}/groups"
+        req.body = body.to_json
+        req.headers['Content-Type'] = 'application/json'
+      end
+      handle_response(response)
+    end
+
     def add_group_to_build(app_id: nil, group_id: nil, build_id: nil)
       assert_required_params(__method__, binding)
 

--- a/spaceship/lib/spaceship/test_flight/group.rb
+++ b/spaceship/lib/spaceship/test_flight/group.rb
@@ -101,9 +101,9 @@ module Spaceship::TestFlight
 
       test_flight_groups.each(&block)
     end
-    
+
     def self.create_group!(app_id: nil, group_name: nil)
-        client.add_group_to_app(app_id: app_id, group_name: group_name)
+      client.add_group_to_app(app_id: app_id, group_name: group_name)
     end
   end
 end

--- a/spaceship/lib/spaceship/test_flight/group.rb
+++ b/spaceship/lib/spaceship/test_flight/group.rb
@@ -101,5 +101,9 @@ module Spaceship::TestFlight
 
       test_flight_groups.each(&block)
     end
+    
+    def self.create_group!(app_id: nil, group_name: nil)
+        client.add_group_to_app(app_id: app_id, group_name: group_name)
+    end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change allows Pilot to ability to add external beta tester groups. Since iTunes no longer comes with default external tester groups, it's important to maintain an ability to add these groups manually to allow developers to setup their apps and those apps tests without accessing ITC's UI. This also opens up the possibility to have dynamic groups of external testers for specific builds and specific users.
I typed out the edge cases that would cause a problem (no input, missing input, invalid input, incorrect input) and test for all cases I suspected could happen.

### Description
I created a new manager class in Pilot called GroupManager with the single responsibility of handling groups, as TesterManager and BuildManager didn't feel apt for such a role. I added a command to the commands_generator in Pilot called "group". I also updated Spaceship's client to have the ability to access TestFlight's Groups API endpoint to POST a group name to a specific application. I accessed this new client function by adding static functionality to the Spaceship::TestFlight::Group class to handle a new group.
