### PR TITLE
Properly rescue around writing the report.xml to the fastlane directory

### DIFF
--- a/fastlane/lib/fastlane/junit_generator.rb
+++ b/fastlane/lib/fastlane/junit_generator.rb
@@ -14,7 +14,12 @@ module Fastlane
 
       xml = xml.gsub('system_', 'system-').delete("\e") # Jenkins can not parse 'ESC' symbol
 
-      File.write(path, xml)
+      begin
+        File.write(path, xml)
+      rescue => ex
+        UI.error(ex)
+        UI.error("Couldn't save report.xml at path '#{File.expand_path(output_path)}', make sure you have write access to the containing directory.")
+      end
 
       return path
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->

If the `.fastlane` directory is not writable (running on CI, for instance), writing the `report.xml` file will fail with an EACCESS exception and cause _fastlane_ to crash.

This wraps the file access to that directory in a `rescue` block that will log a non-terminating error if this problem occurs.