### PR TITLE
Detect selected provisioning profile UUIDs for Xcode 9

### DIFF
--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -98,9 +98,12 @@ module Gym
 
               bundle_identifier = current["PRODUCT_BUNDLE_IDENTIFIER"]
               provisioning_profile_specifier = current["PROVISIONING_PROFILE_SPECIFIER"]
-              next if provisioning_profile_specifier.to_s.length == 0
-
-              provisioning_profile_mapping[bundle_identifier] = provisioning_profile_specifier
+              provisioning_profile_uuid = current["PROVISIONING_PROFILE"]
+              if !provisioning_profile_specifier.nil? && !provisioning_profile_specifier.empty?
+                provisioning_profile_mapping[bundle_identifier] = provisioning_profile_specifier
+              elsif !provisioning_profile_uuid.nil? && !provisioning_profile_uuid.empty?
+                provisioning_profile_mapping[bundle_identifier] = provisioning_profile_uuid
+              end
             end
           end
         rescue => ex

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -99,9 +99,9 @@ module Gym
               bundle_identifier = current["PRODUCT_BUNDLE_IDENTIFIER"]
               provisioning_profile_specifier = current["PROVISIONING_PROFILE_SPECIFIER"]
               provisioning_profile_uuid = current["PROVISIONING_PROFILE"]
-              if !provisioning_profile_specifier.nil? && !provisioning_profile_specifier.empty?
+              if provisioning_profile_specifier.to_s.length > 0
                 provisioning_profile_mapping[bundle_identifier] = provisioning_profile_specifier
-              elsif !provisioning_profile_uuid.nil? && !provisioning_profile_uuid.empty?
+              elsif provisioning_profile_uuid.to_s.length > 0
                 provisioning_profile_mapping[bundle_identifier] = provisioning_profile_uuid
               end
             end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When using Xcode 9, if the project files has provisioning profile UUIDs but no provisioning profile specifiers, exporting an archive fails because the `provisioningProfiles` export option automatically generated by fastlane doesn't include the UUIDs.

### Description
The Xcode 9 `provisioningProfiles` export option allows to specify either provisioning profile names (specifiers) or UUIDs.
When automatically generating provisioningProfiles from the project file content, fastlane was only using specifiers.
If no specifier is present but a UUID is, this makes it use the UUID.
