### PR TITLE
Add simplecov to plugin template

### DIFF
--- a/fastlane/lib/fastlane/plugins/template/%gem_name%.gemspec.erb
+++ b/fastlane/lib/fastlane/plugins/template/%gem_name%.gemspec.erb
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'fastlane', '>= <%= Fastlane::VERSION %>'
 end

--- a/fastlane/lib/fastlane/plugins/template/.gitignore
+++ b/fastlane/lib/fastlane/plugins/template/.gitignore
@@ -8,3 +8,4 @@ Gemfile.lock
 /rdoc/
 fastlane/README.md
 fastlane/report.xml
+coverage

--- a/fastlane/lib/fastlane/plugins/template/spec/spec_helper.rb.erb
+++ b/fastlane/lib/fastlane/plugins/template/spec/spec_helper.rb.erb
@@ -1,5 +1,10 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
+require 'simplecov'
+
+# SimpleCov.minimum_coverage 95
+SimpleCov.start
+
 # This module is only used to check the environment is currently a testing env
 module SpecHelper
 end

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -225,6 +225,7 @@ describe Fastlane::PluginGenerator do
           Gem::Dependency.new("rspec", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("rake", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("rubocop", Gem::Requirement.new([">= 0"]), :development),
+          Gem::Dependency.new("simplecov", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("fastlane", Gem::Requirement.new([">= #{Fastlane::VERSION}"]), :development)
         )
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Code coverage is a valuable tool, and `simplecov` is a common solution for Ruby (used in this repo).

### Description

This adds `simplecov` as a development dependency in new plugins. It also adds the appropriate initialization to the `spec_helper` and adds the `coverage` directory to the .gitignore.

I also tend to use `rspec-simplecov`, but I'm not sure how much it adds. I added it at first, but a test failed because it's not a dependency of Fastlane itself. It's easy to add if desired. This plugin, among others, uses it: https://github.com/jdee/settings-bundle.
