### PR TITLE
Version bump to 2.49.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.48.0'.freeze
+  VERSION = '2.49.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.48.0':**

* Detect selected provisioning profile UUIDs for Xcode 9 (#9843) via Vincent Isambart
* Bumping version of screengrab for O support (#9861) via Joshua Liebowitz
* Add simplecov to plugin template (#9851) via Jimmy Dee
* Rollback https://github.com/fastlane/fastlane/pull/9760 (#9850) via Felix Krause
* Resolve PRODUCT_BUNDLE_IDENTIFIER and PROVISIONING_PROFILE_SPECIFIER for Xcode 9 export settings (#9760) via Renzo
* Update rest-client development dependency (#9842) via Felix Krause
