### PR TITLE
Allow using pathspec in `git_commit` action.

### DIFF
--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -29,16 +29,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :path,
                                        description: "The file you want to commit",
-                                       is_string: false,
-                                       verify_block: proc do |value|
-                                         if value.kind_of?(String)
-                                           UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
-                                         else
-                                           value.each do |x|
-                                             UI.user_error!("Couldn't find file at path '#{x}'") unless File.exist?(x)
-                                           end
-                                         end
-                                       end),
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :message,
                                        description: "The commit message that should be used")
         ]
@@ -62,7 +53,8 @@ module Fastlane
       def self.example_code
         [
           'git_commit(path: "./version.txt", message: "Version Bump")',
-          'git_commit(path: ["./version.txt", "./changelog.txt"], message: "Version Bump")'
+          'git_commit(path: ["./version.txt", "./changelog.txt"], message: "Version Bump")',
+          'git_commit(path: ["./*.txt", "./*.md"], message: "Update documentation")'
         ]
       end
 

--- a/fastlane/spec/actions_specs/git_commit_spec.rb
+++ b/fastlane/spec/actions_specs/git_commit_spec.rb
@@ -21,6 +21,14 @@ describe Fastlane do
         expect(result).to eq("git commit -m message ./fastlane/README.md ./LICENSE")
       end
 
+      it "generates the correct git command with an array of paths and/or pathspecs" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          git_commit(path: ['./fastlane/*.md', './LICENSE'], message: 'message')
+        end").runner.execute(:test)
+
+        expect(result).to eq("git commit -m message ./fastlane/*.md ./LICENSE")
+      end
+
       it "generates the correct git command with shell-escaped-paths" do
         result = Fastlane::FastFile.new.parse("lane :test do
           git_commit(path: ['./fastlane/README.md', './LICENSE', './fastlane/spec/fixtures/git_commit/A FILE WITH SPACE'], message: 'message')

--- a/fastlane/spec/actions_specs/git_commit_spec.rb
+++ b/fastlane/spec/actions_specs/git_commit_spec.rb
@@ -26,7 +26,7 @@ describe Fastlane do
           git_commit(path: ['./fastlane/*.md', './LICENSE'], message: 'message')
         end").runner.execute(:test)
 
-        expect(result).to eq("git commit -m message ./fastlane/*.md ./LICENSE")
+        expect(result).to eq("git commit -m message ./fastlane/\\*.md ./LICENSE")
       end
 
       it "generates the correct git command with shell-escaped-paths" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
This removes the verification for files exist so we can call
`git_commit` action with an array of pathspecs.
