### PR TITLE
Allow multiple paths with wildcards in git_add action.

### DIFF
--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -63,7 +63,9 @@ module Fastlane
           'git_add(path: "./version.txt")',
           'git_add(path: ["./version.txt", "./changelog.txt"])',
           'git_add(path: "./Frameworks/*")',
-          'git_add(path: ["*.h", "*.m"])'
+          'git_add(path: ["*.h", "*.m"])',
+          'git_add(pathspec: "./Frameworks/*")',
+          'git_add(pathspec: "*.txt")'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -2,14 +2,11 @@ module Fastlane
   module Actions
     class GitAddAction < Action
       def self.run(params)
-        if params[:pathspec]
-          paths = params[:pathspec]
-          UI.success("Successfully added from \"#{paths}\" 💾.")
-        elsif params[:path]
+        if params[:path]
           if params[:path].kind_of?(String)
-            paths = params[:path].shellescape
+            paths = params[:path]
           else
-            paths = params[:path].map(&:shellescape).join(' ')
+            paths = params[:path].join(' ')
           end
           UI.success("Successfully added \"#{paths}\" 💾.")
         else
@@ -32,23 +29,8 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :path,
-                                       description: "The file you want to add",
+                                       description: "The file(s) and path(s) you want to add",
                                        is_string: false,
-                                       conflicting_options: [:pathspec],
-                                       optional: true,
-                                       verify_block: proc do |value|
-                                         if value.kind_of?(String)
-                                           UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
-                                         else
-                                           value.each do |x|
-                                             UI.user_error!("Couldn't find file at path '#{x}'") unless File.exist?(x)
-                                           end
-                                         end
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :pathspec,
-                                       description: "The pathspec you want to add files from",
-                                       is_string: true,
-                                       conflicting_options: [:path],
                                        optional: true)
         ]
       end
@@ -70,8 +52,8 @@ module Fastlane
           'git_add',
           'git_add(path: "./version.txt")',
           'git_add(path: ["./version.txt", "./changelog.txt"])',
-          'git_add(pathspec: "./Frameworks/*")',
-          'git_add(pathspec: "*.txt")'
+          'git_add(path: "./Frameworks/*")',
+          'git_add(path: ["*.h", "*.m"])'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -34,10 +34,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :path,
                                        description: "The file(s) and path(s) you want to add",
                                        is_string: false,
+                                       conflicting_options: [:pathspec],
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :pathspec,
                                        description: "The pathspec you want to add files from",
                                        is_string: true,
+                                       conflicting_options: [:path],
                                        optional: true,
                                        deprecated: "Use --path instead")
         ]

--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -2,14 +2,18 @@ module Fastlane
   module Actions
     class GitAddAction < Action
       def self.run(params)
+        should_escape = params[:shell_escape]
+
         if params[:pathspec]
           paths = params[:pathspec]
           UI.success("Successfully added from \"#{paths}\" 💾.")
         elsif params[:path]
           if params[:path].kind_of?(String)
-            paths = params[:path]
+            paths = shell_escape(params[:path], should_escape)
           elsif params[:path].kind_of?(Array)
-            paths = params[:path].join(' ')
+            paths = params[:path].map do |p|
+              shell_escape(p, should_escape)
+            end.join(' ')
           end
           UI.success("Successfully added \"#{paths}\" 💾.")
         else
@@ -19,6 +23,11 @@ module Fastlane
 
         result = Actions.sh("git add #{paths}", log: FastlaneCore::Globals.verbose?).chomp
         return result
+      end
+
+      def self.shell_escape(path, should_escape)
+        path = path.shellescape if should_escape
+        path
       end
 
       #####################################################
@@ -36,6 +45,12 @@ module Fastlane
                                        is_string: false,
                                        conflicting_options: [:pathspec],
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :shell_escape,
+                                       description: "Shell escapes paths (set to false if using wildcards or manually escaping spaces in :path)",
+                                       is_string: false,
+                                       default_value: true,
+                                       optional: true),
+          # Deprecated
           FastlaneCore::ConfigItem.new(key: :pathspec,
                                        description: "The pathspec you want to add files from",
                                        is_string: true,
@@ -62,10 +77,10 @@ module Fastlane
           'git_add',
           'git_add(path: "./version.txt")',
           'git_add(path: ["./version.txt", "./changelog.txt"])',
-          'git_add(path: "./Frameworks/*")',
-          'git_add(path: ["*.h", "*.m"])',
-          'git_add(pathspec: "./Frameworks/*")',
-          'git_add(pathspec: "*.txt")'
+          'git_add(path: "./Frameworks/*", shell_escape: false',
+          'git_add(path: ["*.h", "*.m"], shell_escape: false)',
+          'git_add(path: "./Frameworks/*", shell_escape: false)',
+          'git_add(path: "*.txt", shell_escape: false)'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -2,7 +2,10 @@ module Fastlane
   module Actions
     class GitAddAction < Action
       def self.run(params)
-        if params[:path]
+        if params[:pathspec]
+          paths = params[:pathspec]
+          UI.success("Successfully added from \"#{paths}\" 💾.")
+        elsif params[:path]
           if params[:path].kind_of?(String)
             paths = params[:path]
           else
@@ -31,7 +34,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :path,
                                        description: "The file(s) and path(s) you want to add",
                                        is_string: false,
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :pathspec,
+                                       description: "The pathspec you want to add files from",
+                                       is_string: true,
+                                       optional: true,
+                                       deprecated: "Use --path instead")
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -8,7 +8,7 @@ module Fastlane
         elsif params[:path]
           if params[:path].kind_of?(String)
             paths = params[:path]
-          else
+          elsif params[:path].kind_of?(Array)
             paths = params[:path].join(' ')
           end
           UI.success("Successfully added \"#{paths}\" 💾.")

--- a/fastlane/spec/actions_specs/git_add_spec.rb
+++ b/fastlane/spec/actions_specs/git_add_spec.rb
@@ -27,11 +27,33 @@ describe Fastlane do
         end
       end
 
+      context "as string with spaces in name" do
+        let(:path) { "my file.txt" }
+
+        it "executes the correct git command" do
+          allow(Fastlane::Actions).to receive(:sh).with("git add my\\ file.txt", anything).and_return("")
+          result = Fastlane::FastFile.new.parse("lane :test do
+            git_add(path: '#{path}')
+          end").runner.execute(:test)
+        end
+      end
+
+      context "as array with spaces in name and directory" do
+        let(:path) { ["my file.txt", "some dir/your file.txt"] }
+
+        it "executes the correct git command" do
+          allow(Fastlane::Actions).to receive(:sh).with("git add my\\ file.txt some\\ dir/your\\ file.txt", anything).and_return("")
+          result = Fastlane::FastFile.new.parse("lane :test do
+            git_add(path: #{path})
+          end").runner.execute(:test)
+        end
+      end
+
       context "as string with wildcards" do
         it "executes the correct git command" do
           allow(Fastlane::Actions).to receive(:sh).with("git add *.txt", anything).and_return("")
           result = Fastlane::FastFile.new.parse("lane :test do
-            git_add(path: '*.txt')
+            git_add(path: '*.txt', shell_escape: false)
           end").runner.execute(:test)
         end
       end
@@ -42,7 +64,7 @@ describe Fastlane do
         it "executes the correct git command" do
           allow(Fastlane::Actions).to receive(:sh).with("git add *.h *.m", anything).and_return("")
           result = Fastlane::FastFile.new.parse("lane :test do
-            git_add(path: #{path})
+            git_add(path: #{path}, shell_escape: false)
           end").runner.execute(:test)
         end
       end

--- a/fastlane/spec/actions_specs/git_add_spec.rb
+++ b/fastlane/spec/actions_specs/git_add_spec.rb
@@ -5,52 +5,45 @@ describe Fastlane do
         allow(File).to receive(:exist?).with(anything).and_return(true)
       end
 
-      context "with path parameter" do
-        context "as string" do
-          let(:path) { "myfile.txt" }
+      context "as string" do
+        let(:path) { "myfile.txt" }
 
-          it "executes the correct git command" do
-            allow(Fastlane::Actions).to receive(:sh).with("git add #{path}", anything).and_return("")
-            result = Fastlane::FastFile.new.parse("lane :test do
-              git_add(path: '#{path}')
-            end").runner.execute(:test)
-          end
-        end
-
-        context "as array" do
-          let(:path) { ["myfile.txt", "yourfile.txt"] }
-
-          it "executes the correct git command" do
-            allow(Fastlane::Actions).to receive(:sh).with("git add #{path[0]} #{path[1]}", anything).and_return("")
-            result = Fastlane::FastFile.new.parse("lane :test do
-              git_add(path: #{path})
-            end").runner.execute(:test)
-          end
-        end
-
-        it "can not have pathspec parameter" do
-          expect do
-            Fastlane::FastFile.new.parse("lane :test do
-              git_add(path: 'myfile.txt', pathspec: 'Frameworks/*')
-            end").runner.execute(:test)
-          end.to raise_error(FastlaneCore::Interface::FastlaneError)
+        it "executes the correct git command" do
+          allow(Fastlane::Actions).to receive(:sh).with("git add #{path}", anything).and_return("")
+          result = Fastlane::FastFile.new.parse("lane :test do
+            git_add(path: '#{path}')
+          end").runner.execute(:test)
         end
       end
 
-      context "with pathspec parameter" do
+      context "as array" do
+        let(:path) { ["myfile.txt", "yourfile.txt"] }
+
+        it "executes the correct git command" do
+          allow(Fastlane::Actions).to receive(:sh).with("git add #{path[0]} #{path[1]}", anything).and_return("")
+          result = Fastlane::FastFile.new.parse("lane :test do
+            git_add(path: #{path})
+          end").runner.execute(:test)
+        end
+      end
+
+      context "as string with wildcards" do
         it "executes the correct git command" do
           allow(Fastlane::Actions).to receive(:sh).with("git add *.txt", anything).and_return("")
           result = Fastlane::FastFile.new.parse("lane :test do
-            git_add(pathspec: '*.txt')
+            git_add(path: '*.txt')
           end").runner.execute(:test)
         end
+      end
 
-        it "can not have path parameter" do
-          expect do
-            Fastlane::FastFile.new.parse("lane :test do
-              git_add(path: 'myfile.txt', pathspec: '*.txt')
-            end").runner.execute(:test)
-          end.to raise_error(FastlaneCore::Interface::FastlaneError)
+      context "as array with wildcards" do
+        let(:path) { ["*.h", "*.m"] }
+
+        it "executes the correct git command" do
+          allow(Fastlane::Actions).to receive(:sh).with("git add *.h *.m", anything).and_return("")
+          result = Fastlane::FastFile.new.parse("lane :test do
+            git_add(path: #{path})
+          end").runner.execute(:test)
         end
       end
 
@@ -70,6 +63,23 @@ describe Fastlane do
             git_add(path: 'foo.bar')
           end").runner.execute(:test)
         end
+      end
+
+      it "passes the deprecated pathspec parameter to path parameter" do
+        with_verbose(true) do
+          allow(Fastlane::Actions).to receive(:sh).with(anything, { log: true }).and_return("")
+          result = Fastlane::FastFile.new.parse("lane :test do
+            git_add(pathspec: 'myfile.txt')
+          end").runner.execute(:test)
+        end
+      end
+
+      it "cannot have both path and pathspec parameters" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            git_add(path: 'myfile.txt', pathspec: '*.txt')
+          end").runner.execute(:test)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError)
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Git doesn't have seperate concepts between path and pathspec when using
`git add` command, anything follows `git add` is accepted.

### Description
<!--- Describe your changes in detail -->
This combines `path` and `pathspec` parameters and allow multiple paths
with wildcards.
