### PR TITLE
Fix shellcheck installing fails on Circle CI.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     version: "8.2"
 dependencies:
   pre:
-    - brew install shellcheck
+    - brew install ghc shellcheck
   override:
     - bundle check || bundle install --jobs=4 --retry=3 --path .bundle
 test:


### PR DESCRIPTION

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
The latest Homebrew core update introduces an issue which can't resolve
dependencies of shellcheck when there are two versions of ghc available.
This workaround install ghc first and then install shellcheck.
