### PR TITLE
[Gym] Overwrite Provisioing Profile if PROVISIONING_PROFILE_SPECIFIER is set

### DIFF
--- a/gym/examples/cocoapods/Example.xcodeproj/project.pbxproj
+++ b/gym/examples/cocoapods/Example.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 				TargetAttributes = {
 					CAC1E1971B6A326100A8B23A = {
 						CreatedOnToolsVersion = 7.0;
+						ProvisioningStyle = Manual;
 					};
 					CAC1E1B01B6A326100A8B23A = {
 						CreatedOnToolsVersion = 7.0;
@@ -472,11 +473,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = tools.fastlane.app;
+				PRODUCT_BUNDLE_IDENTIFIER = tools.fastlane.debug.app;
 				PRODUCT_NAME = "$(TARGET_NAME)ProductName";
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Test Provisioning Profile for Debug";
 			};
 			name = Debug;
 		};
@@ -486,11 +489,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = tools.fastlane.app;
 				PRODUCT_NAME = "$(TARGET_NAME)ProductName";
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Test Provisioning Profile for Release";
 			};
 			name = Release;
 		};

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -59,9 +59,14 @@ module Gym
     def self.provisioning_profile_specifier_from_xcargs
       return unless Gym.config[:xcargs]
 
-      provisioning_profile_specifier = ''
-      Gym.config[:xcargs].match(/PROVISIONING_PROFILE_SPECIFIER[ ]*=[ ]*['"](.+?)["']/) do |match|
-        provisioning_profile_specifier = match[1]
+      provisioning_profile_specifier = nil
+      require 'shellwords'
+      xcargs = Shellwords.shellwords(Gym.config[:xcargs])
+      xcargs.each do |arg|
+        arg.match(/^PROVISIONING_PROFILE_SPECIFIER=(.+)$/) do |match|
+          provisioning_profile_specifier = match[1]
+          break
+        end
       end
       provisioning_profile_specifier
     end

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -56,6 +56,16 @@ module Gym
       CFPropertyList.native_types(CFPropertyList::List.new(file: path).value)
     end
 
+    def self.provisioning_profile_specifier_from_xcargs
+      return unless Gym.config[:xcargs]
+
+      provisioning_profile_specifier = ''
+      Gym.config[:xcargs].match(/PROVISIONING_PROFILE_SPECIFIER[ ]*=[ ]*['"](.+?)["']/) do |match|
+        provisioning_profile_specifier = match[1]
+      end
+      provisioning_profile_specifier
+    end
+
     # Since Xcode 9 you need to provide the explicit mapping of what provisioning profile to use for
     # each target of your app
     # rubocop:disable Style/MultilineBlockChain
@@ -96,8 +106,9 @@ module Gym
             target.build_configuration_list.build_configurations.each do |build_configuration|
               current = build_configuration.build_settings
 
+              provisioning_profile_specifier = provisioning_profile_specifier_from_xcargs
               bundle_identifier = current["PRODUCT_BUNDLE_IDENTIFIER"]
-              provisioning_profile_specifier = current["PROVISIONING_PROFILE_SPECIFIER"]
+              provisioning_profile_specifier ||= current["PROVISIONING_PROFILE_SPECIFIER"]
               provisioning_profile_uuid = current["PROVISIONING_PROFILE"]
               if provisioning_profile_specifier.to_s.length > 0
                 provisioning_profile_mapping[bundle_identifier] = provisioning_profile_specifier

--- a/gym/spec/detect_values_spec.rb
+++ b/gym/spec/detect_values_spec.rb
@@ -35,6 +35,50 @@ describe Gym do
         expect(path).to eq(archive_path)
       end
 
+      describe "self.provisioning_profile_specifier_from_xcargs" do
+        let(:options) { { project: "./gym/examples/multipleSchemes/Example.xcodeproj" } }
+        context "when xcargs is nil" do
+          it "return nil" do
+            Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+            expect(Gym::DetectValues.provisioning_profile_specifier_from_xcargs).to be nil
+          end
+        end
+        context "when PROVISIONING_PROFILE_SPECIFIER does not exist" do
+          it "return nil" do
+            options[:xcargs] = 'FOO="BAR"'
+            Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+            expect(Gym::DetectValues.provisioning_profile_specifier_from_xcargs).to be nil
+          end
+        end
+        context "when single quote is used" do
+          it "return the value of PROVISIONING_PROFILE_SPECIFIER" do
+            options[:xcargs] = "PROVISIONING_PROFILE_SPECIFIER='Overwrited Provisioning Name'"
+            Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+            expect(Gym::DetectValues.provisioning_profile_specifier_from_xcargs).to eq('Overwrited Provisioning Name')
+          end
+        end
+        context "when double quote is used" do
+          it "return the value of PROVISIONING_PROFILE_SPECIFIER" do
+            options[:xcargs] = 'PROVISIONING_PROFILE_SPECIFIER="Overwrited Provisioning Name"'
+            Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+            expect(Gym::DetectValues.provisioning_profile_specifier_from_xcargs).to eq('Overwrited Provisioning Name')
+          end
+        end
+        context "when double quote is used" do
+          it "return the value of PROVISIONING_PROFILE_SPECIFIER" do
+            xcargs = { PROVISIONING_PROFILE_SPECIFIER: "Overwrited Provisioning Name"}
+            options[:xcargs] = xcargs
+            Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+            expect(Gym::DetectValues.provisioning_profile_specifier_from_xcargs).to eq('Overwrited Provisioning Name')
+          end
+        end
+      end
+
       describe "provisioning profile" do
         let(:configuration) { "Debug" }
         let(:options) do
@@ -47,33 +91,17 @@ describe Gym do
         end
 
         describe "overwrite PROVISIONING_PROFILE_SPECIFIER set in xcargs option" do
-          context "when single quote is used" do
-            it "overwrite the value correctly" do
-              options[:xcargs] = "PROVISIONING_PROFILE_SPECIFIER='Overwrited Provisioning'"
-              Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+          it "overwrite the value correctly" do
+            options[:xcargs] = "PROVISIONING_PROFILE_SPECIFIER='Overwrited Provisioning'"
+            Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 
-              Gym::DetectValues.detect_selected_provisioning_profiles
-              expect(Gym.config[:export_options][:provisioningProfiles]).to eq({
-                "tools.fastlane.debug.app" => "Overwrited Provisioning",
-                "tools.fastlane.app" => "Overwrited Provisioning",
-                "com.krausefx.ExampleTests" => "Overwrited Provisioning",
-                "com.krausefx.ExampleUITests" => "Overwrited Provisioning"
-              })
-            end
-          end
-          context "when double quote is used" do
-            it "overwrite the value correctly" do
-              options[:xcargs] = 'PROVISIONING_PROFILE_SPECIFIER="Overwrited Provisioning"'
-              Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
-
-              Gym::DetectValues.detect_selected_provisioning_profiles
-              expect(Gym.config[:export_options][:provisioningProfiles]).to eq({
-                "tools.fastlane.debug.app" => "Overwrited Provisioning",
-                "tools.fastlane.app" => "Overwrited Provisioning",
-                "com.krausefx.ExampleTests" => "Overwrited Provisioning",
-                "com.krausefx.ExampleUITests" => "Overwrited Provisioning"
-              })
-            end
+            Gym::DetectValues.detect_selected_provisioning_profiles
+            expect(Gym.config[:export_options][:provisioningProfiles]).to eq({
+              "tools.fastlane.debug.app" => "Overwrited Provisioning",
+              "tools.fastlane.app" => "Overwrited Provisioning",
+              "com.krausefx.ExampleTests" => "Overwrited Provisioning",
+              "com.krausefx.ExampleUITests" => "Overwrited Provisioning"
+            })
           end
         end
       end

--- a/gym/spec/detect_values_spec.rb
+++ b/gym/spec/detect_values_spec.rb
@@ -34,6 +34,49 @@ describe Gym do
         path = Gym.config[:build_path]
         expect(path).to eq(archive_path)
       end
+
+      describe "provisioning profile" do
+        let(:configuration) { "Debug" }
+        let(:options) do
+          {
+              workspace: "./gym/examples/cocoapods/Example.xcworkspace",
+              export_method: "enterprise",
+              scheme: "Example",
+              configuration: configuration
+          }
+        end
+
+        describe "overwrite PROVISIONING_PROFILE_SPECIFIER set in xcargs option" do
+          context "when single quote is used" do
+            it "overwrite the value correctly" do
+              options[:xcargs] = "PROVISIONING_PROFILE_SPECIFIER='Overwrited Provisioning'"
+              Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+              Gym::DetectValues.detect_selected_provisioning_profiles
+              expect(Gym.config[:export_options][:provisioningProfiles]).to eq({
+                "tools.fastlane.debug.app" => "Overwrited Provisioning",
+                "tools.fastlane.app" => "Overwrited Provisioning",
+                "com.krausefx.ExampleTests" => "Overwrited Provisioning",
+                "com.krausefx.ExampleUITests" => "Overwrited Provisioning"
+              })
+            end
+          end
+          context "when double quote is used" do
+            it "overwrite the value correctly" do
+              options[:xcargs] = 'PROVISIONING_PROFILE_SPECIFIER="Overwrited Provisioning"'
+              Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+              Gym::DetectValues.detect_selected_provisioning_profiles
+              expect(Gym.config[:export_options][:provisioningProfiles]).to eq({
+                "tools.fastlane.debug.app" => "Overwrited Provisioning",
+                "tools.fastlane.app" => "Overwrited Provisioning",
+                "com.krausefx.ExampleTests" => "Overwrited Provisioning",
+                "com.krausefx.ExampleUITests" => "Overwrited Provisioning"
+              })
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/gym/spec/detect_values_spec.rb
+++ b/gym/spec/detect_values_spec.rb
@@ -70,7 +70,7 @@ describe Gym do
         end
         context "when double quote is used" do
           it "return the value of PROVISIONING_PROFILE_SPECIFIER" do
-            xcargs = { PROVISIONING_PROFILE_SPECIFIER: "Overwrited Provisioning Name"}
+            xcargs = { PROVISIONING_PROFILE_SPECIFIER: "Overwrited Provisioning Name" }
             options[:xcargs] = xcargs
             Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Gym set `provisioningProfile` parameter to archive package.
Although I set PROVISIONING_PROFILE_IDENTIFIER into xcargs paramter, `provisioningProfile` is set the value in Xcode config.
 
### Description
This PR allow Gym to overwrite provisioning profile settings.
If the `PROVISIONING_PROFILE_IDENTIFIER` variable is set in xcargs options, this value is used to archive package. 

If https://github.com/fastlane/fastlane/pull/9885 is merged, this PR have to fix and merge.