### PR TITLE
Adds a div around the actions so that CSS can be applied to it

### DIFF
--- a/fastlane/lib/assets/Actions.md.erb
+++ b/fastlane/lib/assets/Actions.md.erb
@@ -20,10 +20,14 @@ import './path/to/other/Fastfile'
 <%- end -%>
 - [Plugins](https://docs.fastlane.tools/plugins/available-plugins)
 
-
 <%- @categories.each do |category, actions| %>
 # <%= category %>
-  <%- actions.sort.to_h.each do |_number_of_launches, action| -%>
+
+<div class='category-actions'>
+
+<%- actions.sort.to_h.each do |_number_of_launches, action| -%>
+
+<div class='action'>
 
 ### <%= action.action_name %>
 
@@ -49,8 +53,8 @@ Returns | <%= action.return_value %>
 ```ruby
 <%= current_sample.gsub("          ", "") %>
 ```
-<% end %>
-<% end %>
+<% end %><%# End of action.example_code... %>
+<% end %><%# End of if %>
 </details>
 
 <% if action.available_options && action.available_options.first.kind_of?(FastlaneCore::ConfigItem) %>
@@ -65,9 +69,11 @@ Key | Description
   `<%= config_item.key %>` | <%= config_item.description %>
 <%- end %>
 </details>
-<% end %>
+</div>
 
+<% end %><%# End of action.available_options... %>
 
+  <%- end %><%# End of actions.sort... %>
+</div>
 
-  <%- end %>
-<%- end %>
+<%- end %><%# End of categories.each %>


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)  🔑
- [x] I've updated the documentation if necessary.

### Motivation and Context

I felt like the actions page could use a bit more hierarchy 

![screen shot 2017-07-28 at 12 30 30](https://user-images.githubusercontent.com/49038/28726795-9bcbcd1a-7390-11e7-8934-7490ddb62724.png)

### Description

So this PR adds two divs for styling `.category-actions` and `.action` - then the docs can use these to apply CSS to those elements

I also added comments to the `end`s, so I could keep track of which was which.