### PR TITLE
Fixed typo near app thinning.

### DIFF
--- a/gym/README.md
+++ b/gym/README.md
@@ -157,7 +157,7 @@ output_name "MyApp"           # the name of the ipa file
 
 ## Export options
 
-Since Xcode 7, `gym` is using new Xcode API which allows us to specify export options using `plist` file. By default `gym` creates this file for you and you are able to modify some parameters by using `export_method`, `export_team_id`, `include_symbols` or `include_bitcode`. If you want to have more options, like creating manifest file or app thinning, you can provide your own `plist` file:
+Since Xcode 7, `gym` is using new Xcode API which allows us to specify export options using `plist` file. By default `gym` creates this file for you and you are able to modify some parameters by using `export_method`, `export_team_id`, `include_symbols` or `include_bitcode`. If you want to have more options, like creating manifest file for app thinning, you can provide your own `plist` file:
 
 ```ruby
 export_options "./ExportOptions.plist"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? --> Typo fix (minor)
<!--- If it fixes an open issue, please link to the issue here. --> N/A
<!--- Please describe in detail how you tested your changes. ---> N/A

### Description
Changed/Fixed typo near app thinning. Should say *for* instead of *or*. 
