### PR TITLE
Version bump to 2.50.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.49.0'.freeze
+  VERSION = '2.50.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.49.0':**

* Generic GitHub API action `github_api` - Update existing GitHub API actions to use shared action (#8971) via Tom Meier
* Adds a div around the actions so that CSS can be applied to it (#9894) via Orta
* Fix typo in docs (#9900) via Simon Brüchner
* Remove trailing command in gym docs (#9739) via Felix Krause
* Add link to available plugins in action docs (#9892) via Felix Krause
* Update maximum plugin score (#9883) via Felix Krause
* Disable blockchain rule in rubocop (#9891) via Felix Krause
* Add new `setup_travis` action (#9880) via Felix Krause
* Add ancestry_path parameter to changelog_from_git_commits (#9758) via DmitryArbuzov
* Fix upload of crashlytics symbols for tvOS apps (#9866) via Aman Gupta
* Allow using pathspec in `git_commit` action. (#9867) via thii
* Disable flaky Jenkins tests (#9868) via Felix Krause
