### PR TITLE
App review submission fails

### DIFF
--- a/spaceship/lib/spaceship/base.rb
+++ b/spaceship/lib/spaceship/base.rb
@@ -59,6 +59,9 @@ module Spaceship
       def to_json(*a)
         h = @hash.dup
         h.delete(:application)
+        if h.key?(:version) && h[:version].is_a?(Spaceship::Tunes::AppVersion)
+          h.delete(:version)
+        end
         h.to_json(*a)
       end
 

--- a/spaceship/lib/spaceship/base.rb
+++ b/spaceship/lib/spaceship/base.rb
@@ -59,7 +59,7 @@ module Spaceship
       def to_json(*a)
         h = @hash.dup
         h.delete(:application)
-        if h.key?(:version) && h[:version].is_a?(Spaceship::Tunes::AppVersion)
+        if h.key?(:version) && h[:version].kind_of?(Spaceship::Tunes::AppVersion)
           h.delete(:version)
         end
         h.to_json(*a)

--- a/spaceship/lib/spaceship/base.rb
+++ b/spaceship/lib/spaceship/base.rb
@@ -43,6 +43,10 @@ module Spaceship
         ref[last] = value
       end
 
+      def delete(key)
+        @hash.delete(key)
+      end
+
       def lookup(keys)
         head, *tail = *keys
         if tail.empty?
@@ -59,9 +63,6 @@ module Spaceship
       def to_json(*a)
         h = @hash.dup
         h.delete(:application)
-        if h.key?(:version) && h[:version].kind_of?(Spaceship::Tunes::AppVersion)
-          h.delete(:version)
-        end
         h.to_json(*a)
       end
 

--- a/spaceship/lib/spaceship/tunes/app_submission.rb
+++ b/spaceship/lib/spaceship/tunes/app_submission.rb
@@ -124,7 +124,10 @@ module Spaceship
 
       # Save and complete the app submission
       def complete!
-        client.send_app_submission(application.apple_id, raw_data)
+        if self.content_rights_has_rights.nil? || self.content_rights_contains_third_party_content.nil?
+          raw_data.set(['contentRights'], nil)
+        end
+        client.send_app_submission(application.apple_id, application.edit_version.version_id, raw_data)
         @submitted_for_review = true
       end
 

--- a/spaceship/lib/spaceship/tunes/app_submission.rb
+++ b/spaceship/lib/spaceship/tunes/app_submission.rb
@@ -124,10 +124,13 @@ module Spaceship
 
       # Save and complete the app submission
       def complete!
+        raw_data_clone = raw_data.dup
         if self.content_rights_has_rights.nil? || self.content_rights_contains_third_party_content.nil?
-          raw_data.set(['contentRights'], nil)
+          raw_data_clone.set(["contentRights"], nil)
         end
-        client.send_app_submission(application.apple_id, application.edit_version.version_id, raw_data)
+        raw_data_clone.delete("version")
+
+        client.send_app_submission(application.apple_id, application.edit_version.version_id, raw_data_clone)
         @submitted_for_review = true
       end
 

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -855,12 +855,12 @@ module Spaceship
       parse_response(r, 'data')
     end
 
-    def send_app_submission(app_id, data)
+    def send_app_submission(app_id, version, data)
       raise "app_id is required" unless app_id
 
       # ra/apps/1039164429/version/submit/complete
       r = request(:post) do |req|
-        req.url "ra/apps/#{app_id}/version/submit/complete"
+        req.url "ra/apps/#{app_id}/versions/#{version}/submit/complete"
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
       end

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -140,7 +140,7 @@ class TunesStubbing
         to_return(status: 200, body: itc_read_fixture_file('app_submission/start_success.json'), headers: { 'Content-Type' => 'application/json' })
 
       # Complete app submission
-      stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/version/submit/complete").
+      stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/versions/812106519/submit/complete").
         to_return(status: 200, body: itc_read_fixture_file('app_submission/complete_success.json'), headers: { 'Content-Type' => 'application/json' })
     end
 
@@ -150,7 +150,7 @@ class TunesStubbing
         to_return(status: 200, body: itc_read_fixture_file('app_submission/start_success.json'), headers: { 'Content-Type' => 'application/json' })
 
       # Complete app submission
-      stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/version/submit/complete").
+      stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/versions/812106519/submit/complete").
         to_return(status: 200, body: itc_read_fixture_file('app_submission/complete_failed.json'), headers: { 'Content-Type' => 'application/json' })
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We were trying to automate the app submission for review for itunes.

This is the code we were using:

      itunes_app = get_itunes_app(options[:app])
      version = itunes_app.edit_version
      builds = version.candidate_builds
      version.select_build(builds.first)
      version.save!

      UI.success("Successfully selected build")

      submission = itunes_app.create_submission

      # Set app submission information
      submission.add_id_info_uses_idfa = true
      submission.add_id_info_serves_ads = true
      submission.add_id_info_tracks_install = true
      submission.add_id_info_tracks_action = true
      submission.add_id_info_limits_tracking = true

      # Finalize app submission
      submission.complete!

but the `submission.complete!` part failed with the following message: `Problem processing review submission.`
We found two issues here. 

The first one was that the url fastlane was using to send the app to review was incorrect.
Fastlane's version: `ra/apps/<app_id>/version/submit/complete`
The correct one: `ra/apps/<app_id>/versions/<version>/submit/complete`

The second, bigger issue came up when we weren't setting the `content_rights_has_rights` and the `content_rights_contains_third_party_content` variables to either true or false. In this case, iTunes connect was expecting the `contentRights` variable to be `null`, but fastlane sent the following instead:
`
"contentRights": {
   "containsThirdPartyContent": {
      "value": null
      },
      "hasRights": {
         "value": null
      }
}
`
and this caused the submission failure.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
We tested these changes on one of our applications. We were able to send it to review successfully with these changes.
### Description
<!--- Describe your changes in detail -->
app_submission.rb:
In the complete method I manually set the `contentRights` variable to nil in case either the `content_rights_has_rights` or the `content_rights_contains_third_party_content` is nil. (both of them has to have a value to work properly)
I also passed the version_id to the send_app_submission method as a parameter. (see below)

base.rb:
One other thing I found while debugging was that fastlane was sending an AppVersion object in the payload to iTunes Connect (as `version`). I am not sure if any other classes use DataHash, therefore I also made a type check there to not to delete anything from the payload accidentally. 

tunes_client.rb:
Here version_id was necessary in the url, because the original url was broken.