### PR TITLE
Fix docs styles

### DIFF
--- a/fastlane/lib/assets/Actions.md.erb
+++ b/fastlane/lib/assets/Actions.md.erb
@@ -25,11 +25,7 @@ For _fastlane_ plugins, check out the [available plugins](https://docs.fastlane.
 <%- @categories.each do |category, actions| %>
 # <%= category %>
 
-<div class='category-actions'>
-
 <%- actions.sort.to_h.each do |_number_of_launches, action| -%>
-
-<div class='action'>
 
 ### <%= action.action_name %>
 
@@ -39,7 +35,7 @@ For _fastlane_ plugins, check out the [available plugins](https://docs.fastlane.
 
 <%= "> #{action.details.gsub("\n\n", "\n")}" unless action.details.to_s.empty? %>
 
-<%= action.action_name %> | 
+<%= action.action_name %> |
 -----|----
 Supported platforms | <%= [:ios, :android, :mac].find_all { |a| action.is_supported?(a) }.join(", ") %>
 Author | @<%= Array(action.author || action.authors).join(", @") %>
@@ -71,11 +67,9 @@ Key | Description
   `<%= config_item.key %>` | <%= config_item.description %>
 <%- end %>
 </details>
-</div>
 
 <% end %><%# End of action.available_options... %>
 
   <%- end %><%# End of actions.sort... %>
-</div>
 
 <%- end %><%# End of categories.each %>


### PR DESCRIPTION
This PR reverts https://github.com/fastlane/fastlane/pull/9894 which broke the formatting of our actions docs.