### PR TITLE
Specify FastlaneError for git add conflicting options error

### DIFF
--- a/fastlane/spec/actions_specs/git_add_spec.rb
+++ b/fastlane/spec/actions_specs/git_add_spec.rb
@@ -33,7 +33,7 @@ describe Fastlane do
             Fastlane::FastFile.new.parse("lane :test do
               git_add(path: 'myfile.txt', pathspec: 'Frameworks/*')
             end").runner.execute(:test)
-          end.to raise_error
+          end.to raise_error(FastlaneCore::Interface::FastlaneError)
         end
       end
 
@@ -50,7 +50,7 @@ describe Fastlane do
             Fastlane::FastFile.new.parse("lane :test do
               git_add(path: 'myfile.txt', pathspec: '*.txt')
             end").runner.execute(:test)
-          end.to raise_error
+          end.to raise_error(FastlaneCore::Interface::FastlaneError)
         end
       end
 


### PR DESCRIPTION
This PR fixes the rspec warnings where we are not specifying the expected error type.

```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<FastlaneCore::Interface::FastlaneError: Unresolved conflict between options: 'path' and 'pathspec'>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/ohayon/Google/git/fastlane/fastlane/spec/actions_specs/git_add_spec.rb:32:in `block (5 levels) in <top (required)>'.
```