### PR TITLE
Fix tests to avoid seeing rspec false-positive warnings

### DIFF
--- a/fastlane/spec/actions_specs/update_project_provisioning_spec.rb
+++ b/fastlane/spec/actions_specs/update_project_provisioning_spec.rb
@@ -19,7 +19,7 @@ describe Fastlane do
                     target_filter: 'Name'
                 })
               end").runner.execute(:test)
-            end.not_to raise_error(FastlaneCore::Interface::FastlaneError)
+            end.not_to raise_error
           end
         end
 
@@ -33,7 +33,7 @@ describe Fastlane do
                     target_filter: /Name/
                 })
               end").runner.execute(:test)
-            end.not_to raise_error(FastlaneCore::Interface::FastlaneError)
+            end.not_to raise_error
           end
         end
 
@@ -67,7 +67,7 @@ describe Fastlane do
                     build_configuration: 'Debug'
                 })
               end").runner.execute(:test)
-            end.not_to raise_error(FastlaneCore::Interface::FastlaneError)
+            end.not_to raise_error
           end
         end
 
@@ -81,7 +81,7 @@ describe Fastlane do
                     build_configuration: /Debug/
                 })
               end").runner.execute(:test)
-            end.not_to raise_error(FastlaneCore::Interface::FastlaneError)
+            end.not_to raise_error
           end
         end
 


### PR DESCRIPTION
This fixes the following warnings:

```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. NoMethodError, NameError and ArgumentError), meaning the code you are intending to test may not even get reached. Instead consider using `expect {}.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/ohayon/Google/git/fastlane/fastlane/spec/actions_specs/update_project_provisioning_spec.rb:76:in `block (6 levels) in <top (required)>'.
```