### PR TITLE
Fix incorrect GitHub url parameter validation

### DIFF
--- a/fastlane/lib/fastlane/actions/github_api.rb
+++ b/fastlane/lib/fastlane/actions/github_api.rb
@@ -206,11 +206,9 @@ module Fastlane
         end
 
         def construct_url(server_url, path, url)
-          UI.user_error!("Please provide server URL, eg: https://api.github.com") unless server_url
+          return_url = (server_url && path) ? File.join(server_url, path) : url
 
-          return_url = path ? File.join(server_url, path) : url
-
-          UI.user_error!("Please provide either 'path' or full 'url' for GitHub API endpoint") unless return_url
+          UI.user_error!("Please provide either `server_url` (e.g. https://api.github.com) and 'path' or full 'url' for GitHub API endpoint") unless return_url
 
           return_url
         end


### PR DESCRIPTION
Properly validates that either a `server_url` and `path` are provided, or a full `url`.
This resolves #9922.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #9922 by allowing GitHub urls to be constructed from only the full url.

Tested with additional test cases in `fastlane/spec/actions_specs/github_api_spec.rb`
