### PR TITLE
Add pem option active_days_limit

### DIFF
--- a/pem/lib/pem/manager.rb
+++ b/pem/lib/pem/manager.rb
@@ -16,11 +16,11 @@ module PEM
         if existing_certificate
           remaining_days = (existing_certificate.expires - Time.now) / 60 / 60 / 24
           UI.message "Existing push notification profile for '#{existing_certificate.owner_name}' is valid for #{remaining_days.round} more days."
-          if remaining_days > PEM.config[:current_active_days_limit].to_i
+          if remaining_days > PEM.config[:active_days_limit].to_i
             if PEM.config[:force]
               UI.success "You already have an existing push certificate, but a new one will be created since the --force option has been set."
             else
-              UI.success "You already have a push certificate, which is active for more than #{PEM.config[:current_active_days_limit]} more days. No need to create a new one"
+              UI.success "You already have a push certificate, which is active for more than #{PEM.config[:active_days_limit]} more days. No need to create a new one"
               UI.success "If you still want to create a new one, use the --force option when running PEM."
               return false
             end

--- a/pem/lib/pem/manager.rb
+++ b/pem/lib/pem/manager.rb
@@ -16,7 +16,7 @@ module PEM
         if existing_certificate
           remaining_days = (existing_certificate.expires - Time.now) / 60 / 60 / 24
           UI.message "Existing push notification profile for '#{existing_certificate.owner_name}' is valid for #{remaining_days.round} more days."
-          if remaining_days > PEM.config[:active_days_limit].to_i
+          if remaining_days > PEM.config[:active_days_limit]
             if PEM.config[:force]
               UI.success "You already have an existing push certificate, but a new one will be created since the --force option has been set."
             else

--- a/pem/lib/pem/manager.rb
+++ b/pem/lib/pem/manager.rb
@@ -16,11 +16,11 @@ module PEM
         if existing_certificate
           remaining_days = (existing_certificate.expires - Time.now) / 60 / 60 / 24
           UI.message "Existing push notification profile for '#{existing_certificate.owner_name}' is valid for #{remaining_days.round} more days."
-          if remaining_days > 30
+          if remaining_days > PEM.config[:current_active_days_limit].to_i
             if PEM.config[:force]
               UI.success "You already have an existing push certificate, but a new one will be created since the --force option has been set."
             else
-              UI.success "You already have a push certificate, which is active for more than 30 more days. No need to create a new one"
+              UI.success "You already have a push certificate, which is active for more than #{PEM.config[:current_active_days_limit]} more days. No need to create a new one"
               UI.success "If you still want to create a new one, use the --force option when running PEM."
               return false
             end

--- a/pem/lib/pem/options.rb
+++ b/pem/lib/pem/options.rb
@@ -23,7 +23,7 @@ module PEM
                                      description: "If the current certificate is active for less than this number of days, generate a new one. Default value is 30 days",
                                      default_value: 30,
                                      verify_block: proc do |value|
-                                       UI.user_error!("Value of active_days_limit must be a positive integer or left blank") if value.to_s !~ /\A\d*\z/
+                                       UI.user_error!("Value of active_days_limit must be a positive integer or left blank") if value.to_i <= 0
                                      end),
         FastlaneCore::ConfigItem.new(key: :force,
                                      env_name: "PEM_FORCE",

--- a/pem/lib/pem/options.rb
+++ b/pem/lib/pem/options.rb
@@ -18,9 +18,16 @@ module PEM
                                      description: "Generate a p12 file additionally to a PEM file",
                                      is_string: false,
                                      default_value: true),
+        FastlaneCore::ConfigItem.new(key: :current_active_days_limit,
+                                     env_name: "PEM_CURRENT_ACTIVE_DAYS_LIMIT",
+                                     description: "If current one is active for no more than this number of days, generate a new one. Default value is 30",
+                                     default_value: 30,
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Value of current_active_days_limit must be a positive integer or left blank") if value.to_s !~ /\A\d*\z/
+                                     end),
         FastlaneCore::ConfigItem.new(key: :force,
                                      env_name: "PEM_FORCE",
-                                     description: "Create a new push certificate, even if the current one is active for 30 more days",
+                                     description: "Create a new push certificate, even if the current one is active for 30 (or PEM_CURRENT_ACTIVE_DAYS_LIMIT) more days",
                                      is_string: false,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :save_private_key,

--- a/pem/lib/pem/options.rb
+++ b/pem/lib/pem/options.rb
@@ -23,7 +23,7 @@ module PEM
                                      description: "If the current certificate is active for less than this number of days, generate a new one. Default value is 30 days",
                                      default_value: 30,
                                      verify_block: proc do |value|
-                                       UI.user_error!("Value of active_days_limit must be a positive integer or left blank") if value.to_i <= 0
+                                       UI.user_error!("Value of active_days_limit must be a positive integer or left blank") unless value.kind_of?(Integer) && value > 0
                                      end),
         FastlaneCore::ConfigItem.new(key: :force,
                                      env_name: "PEM_FORCE",

--- a/pem/lib/pem/options.rb
+++ b/pem/lib/pem/options.rb
@@ -18,16 +18,16 @@ module PEM
                                      description: "Generate a p12 file additionally to a PEM file",
                                      is_string: false,
                                      default_value: true),
-        FastlaneCore::ConfigItem.new(key: :current_active_days_limit,
-                                     env_name: "PEM_CURRENT_ACTIVE_DAYS_LIMIT",
-                                     description: "If current one is active for no more than this number of days, generate a new one. Default value is 30",
+        FastlaneCore::ConfigItem.new(key: :active_days_limit,
+                                     env_name: "PEM_ACTIVE_DAYS_LIMIT",
+                                     description: "If the current certificate is active for less than this number of days, generate a new one. Default value is 30 days",
                                      default_value: 30,
                                      verify_block: proc do |value|
-                                       UI.user_error!("Value of current_active_days_limit must be a positive integer or left blank") if value.to_s !~ /\A\d*\z/
+                                       UI.user_error!("Value of active_days_limit must be a positive integer or left blank") if value.to_s !~ /\A\d*\z/
                                      end),
         FastlaneCore::ConfigItem.new(key: :force,
                                      env_name: "PEM_FORCE",
-                                     description: "Create a new push certificate, even if the current one is active for 30 (or PEM_CURRENT_ACTIVE_DAYS_LIMIT) more days",
+                                     description: "Create a new push certificate, even if the current one is active for 30 (or PEM_ACTIVE_DAYS_LIMIT) more days",
                                      is_string: false,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :save_private_key,


### PR DESCRIPTION
So user can specify how many days before current push certificate
expires should fastlane pem generate a new one.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I have many push certificates to renew.
And I need them renew before 32 days of expiry (just more than the longest month).

### Description
Added an option `current_active_days_limit` and the default value is same as previous hard-coded 30 days.