### PR TITLE
Version bump to 2.50.1

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.50.0'.freeze
+  VERSION = '2.50.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.50.0':**

* Fix incorrect GitHub url parameter validation (#9923) via Teddy Newell
* Do not run agvtool while under test (#9919) via David Ohayon
* Fix tests to avoid seeing rspec false-positive warnings (#9921) via David Ohayon
* Specify FastlaneError for git add conflicting options error (#9920) via David Ohayon
* Fix docs styles (#9918) via David Ohayon
