### PR TITLE
Revise SSL verification handling for debugging

### DIFF
--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -1,9 +1,3 @@
-if ENV["SPACESHIP_DEBUG"]
-  require 'openssl'
-  # this has to be on top of this file, since the value can't be changed later
-  OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
-end
-
 module Fastlane
   module Actions
     module SharedValues
@@ -26,15 +20,6 @@ module Fastlane
           builder.response :json, content_type: /\bjson$/
           builder.use FaradayMiddleware::FollowRedirects
           builder.adapter :net_http
-          if ENV['SPACESHIP_DEBUG']
-            # for debugging only
-            # This enables tracking of networking requests using Charles Web Proxy
-            builder.proxy "https://127.0.0.1:8888"
-          end
-
-          if ENV["DEBUG"]
-            puts "To run _spaceship_ through a local proxy, use SPACESHIP_DEBUG"
-          end
         end
       end
 

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -12,12 +12,6 @@ require 'cgi'
 
 Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder
 
-if ENV["SPACESHIP_DEBUG"]
-  require 'openssl'
-  # this has to be on top of this file, since the value can't be changed later
-  OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
-end
-
 module Spaceship
   # rubocop:disable Metrics/ClassLength
   class Client
@@ -264,6 +258,7 @@ module Spaceship
           # for debugging only
           # This enables tracking of networking requests using Charles Web Proxy
           c.proxy "https://127.0.0.1:8888"
+          c.ssl[:verify_mode] = OpenSSL::SSL::VERIFY_NONE
         end
 
         if ENV["DEBUG"]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
The execution of `OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE` should be revised.

### Description
<!--- Describe your changes in detail -->
Use Faraday option to use `OpenSSL::SSL::VERIFY_NONE` instead of using `OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE`.