### PR TITLE
Update sigh docs

### DIFF
--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -95,7 +95,7 @@ module Sigh
         c.syntax = 'fastlane sigh resign'
         c.description = 'Resigns an existing ipa file with the given provisioning profile'
         c.option '-i', '--signing_identity STRING', String, 'The signing identity to use. Must match the one defined in the provisioning profile.'
-        c.option '-x', '--version_number STRING', String, 'Version number to force binary and all nested binaries to use. Changes both CFBundleShortVersionString and CFBundleIdentifier.'
+        c.option '-x', '--version_number STRING', String, 'Version number to force binary and all nested binaries to use. Changes both CFBundleShortVersionString and CFBundleVersion.'
         c.option '-p', '--provisioning_profile PATH', String, '(or BUNDLE_ID=PATH) The path to the provisioning profile which should be used. '\
                  'Can be provided multiple times if the application contains nested applications and app extensions, which need their own provisioning profile. '\
                  'The path may be prefixed with a identifier in order to determine which provisioning profile should be used on which app.',


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

```bash
$ fastlane sigh resign --help
```
didn't get right ouput.

### Description

The command 
```bash
$ fastlane sigh resign Demo.ipa --version_number=2 
```
didn't change `CFBundleIdentifier` to 2, and it should not change it. As a result, it changed `CFBundleShortVersionString` and `CFBundleVersion` to 2.

But the command
```bash
$ fastlane sigh resign --help
```
output that
```bash
-x, --version_number STRING Version number to force binary and all nested binaries to use. Changes both
CFBundleShortVersionString and CFBundleIdentifier.
```


