### PR TITLE
enable app_manager to delete and list app testers

### DIFF
--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -38,9 +38,10 @@ module Pilot
     def find_tester(options)
       start(options)
 
-      tester = Spaceship::Tunes::Tester::Internal.find(config[:email])
-      tester ||= Spaceship::Tunes::Tester::External.find(config[:email])
+      app_filter = (config[:apple_id] || config[:app_identifier])
+      app = find_app(app_filter: app_filter)
 
+      tester = find_app_tester(email: config[:email], app: app)
       UI.user_error!("Tester #{config[:email]} not found") unless tester
 
       describe_tester(tester)
@@ -50,11 +51,12 @@ module Pilot
     def remove_tester(options)
       start(options)
 
-      tester = Spaceship::Tunes::Tester::External.find(config[:email])
-      tester ||= Spaceship::Tunes::Tester::Internal.find(config[:email])
-      UI.user_error!("Tester not found: #{config[:email]}") if tester.nil?
+      app_filter = (config[:apple_id] || config[:app_identifier])
+      app = find_app(app_filter: app_filter)
 
-      app = find_app(app_filter: config[:apple_id] || config[:app_identifier])
+      tester = find_app_tester(email: config[:email], app: app)
+      UI.user_error!("Tester #{config[:email]} not found") unless tester
+
       unless app
         tester.delete!
         UI.success("Successfully removed tester #{tester.email} from Users and Roles")
@@ -223,7 +225,7 @@ module Pilot
       rows << ["Last name", tester.last_name]
       rows << ["Email", tester.email]
 
-      if tester.groups.length > 0
+      if tester.groups.to_s.length > 0
         rows << ["Groups", tester.groups_list]
       end
 
@@ -232,7 +234,7 @@ module Pilot
         rows << ["Latest Install Date", tester.pretty_install_date]
       end
 
-      if tester.devices.length == 0
+      if tester.devices.to_so.length == 0
         rows << ["Devices", "No devices"]
       else
         rows << ["#{tester.devices.count} Devices", ""]

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -234,7 +234,7 @@ module Pilot
         rows << ["Latest Install Date", tester.pretty_install_date]
       end
 
-      if tester.devices.to_so.length == 0
+      if tester.devices.to_s.length == 0
         rows << ["Devices", "No devices"]
       else
         rows << ["#{tester.devices.count} Devices", ""]

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -111,6 +111,7 @@ describe Pilot::TesterManager do
 
       allow(tester_manager).to receive(:login) # prevent attempting to log in with iTC
       allow(fake_client).to receive(:user).and_return(current_user)
+      allow(fake_client).to receive(:testers).and_return(global_testers)
     end
 
     describe "when invoked from a global context" do
@@ -265,6 +266,7 @@ describe Pilot::TesterManager do
 
         expect(Spaceship::Tunes::Tester::External).to receive(:find).and_return(fake_tester)
         expect(Spaceship::TestFlight::Group).to_not receive(:remove_tester_from_groups!)
+        expect(FastlaneCore::UI).to receive(:success).with('Found existing tester fabric-devtools@gmail.com+fake@gmail.com')
         expect(FastlaneCore::UI).to receive(:success).with('Successfully removed tester fabric-devtools@gmail.com+fake@gmail.com from Users and Roles')
 
         tester_manager.remove_tester(remove_tester_options)


### PR DESCRIPTION
app_managers should be able to list testers and also delete them.
fix for #9910