### PR TITLE
Drastically improve Xcode 9 provisioning profile detection

### DIFF
--- a/fastlane/lib/fastlane/actions/gym.rb
+++ b/fastlane/lib/fastlane/actions/gym.rb
@@ -22,7 +22,7 @@ module Fastlane
           # If that's the case, we won't set the provisioning profiles
           # see https://github.com/fastlane/fastlane/issues/9490
           if values[:export_options].kind_of?(Hash)
-            match_mapping = (Actions.lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING] || {}).dup
+            match_mapping = Actions.lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING].dup
             existing_mapping = values[:export_options][:provisioningProfiles].dup
 
             # Be smart about how we merge those mappings in case there are conflicts

--- a/gym/lib/gym.rb
+++ b/gym/lib/gym.rb
@@ -7,6 +7,7 @@ require 'gym/error_handler'
 require 'gym/options'
 require 'gym/detect_values'
 require 'gym/xcode'
+require 'gym/code_signing_mapping'
 
 require 'fastlane_core'
 require 'terminal-table'

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -16,7 +16,7 @@ module Gym
 
       # Now it's time to merge the (potentially) existing `provisioningProfiles` of the `export_options`
       # with the hash we just created. Both might include information about what profile to use
-      # This is important, as :bell: (some users) didn't know to call match for each app target he wants profiles for
+      # This is important as it mght not be clear for the user that they have to call match for each app target
       # before adding this code, we'd only either use whatever we get from match, or what's defined in the Xcode project
       # With the code below, we'll make sure to take the best of it:
       #

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -59,8 +59,6 @@ module Gym
       return final_mapping
     end
 
-    # private # TODO
-
     # Helper method to remove "-" and " " and downcase app identifier
     # and compare if an app identifier includes a certain string
     # We do some `gsub`bing, because we can't really know the profile type, so we'll just look at the name and see if it includes

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -14,7 +14,7 @@ module Gym
     # @param secondary_mapping [Hash] (optional) The secondary mapping (e.g. whatever is detected from the Xcode project)
     # @param export_method [String] The method that should be preferred in case there is a conflict
     def merge_profile_mapping(primary_mapping: nil, secondary_mapping: nil, export_method: nil)
-      final_mapping = primary_mapping.dup # for verbose output at the end of the method
+      final_mapping = (primary_mapping || {}).dup # for verbose output at the end of the method
       secondary_mapping ||= self.detect_project_profile_mapping # default to Xcode project
 
       # Now it's time to merge the (potentially) existing mapping

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -1,0 +1,136 @@
+require 'xcodeproj'
+
+module Gym
+  class CodeSigningMapping
+    attr_accessor :project
+
+    attr_accessor :project_paths
+
+    def initialize(project: nil)
+      self.project = project
+    end
+
+    def merge_profile_mapping(existing_mapping: nil, export_method: nil)
+      final_mapping = existing_mapping.dup # for verbose output at the end of the method
+      project_mapping = self.detect_project_profile_mapping
+
+      # Now it's time to merge the (potentially) existing `provisioningProfiles` of the `export_options`
+      # with the hash we just created. Both might include information about what profile to use
+      # This is important, as :bell: (some users) didn't know to call match for each app target he wants profiles for
+      # before adding this code, we'd only either use whatever we get from match, or what's defined in the Xcode project
+      # With the code below, we'll make sure to take the best of it:
+      #
+      #   1) A provisioning profile is defined in the Xcode project only: we'll take that
+      #   2) A provisioning profile is defined manually from the user: we'll take that (same as 3)
+      #   3) A provisioning profile is defined after calling match: we'll take that (same as 2)
+      #   4) On a conflict (app identifier assigned both in xcode and match)
+      #     4.1) we'll choose whatever matches what's defined in the `export_method`
+      #     4.2) If both include the export_method, we'll prefer the one from match
+      #     4.3) If none has the right export_method, we'll use whatever is defined in the Xcode project
+
+      # 2) is already covered by assigning `final_mapping` above
+      # 3) see 2
+
+      project_mapping.each do |bundle_identifier, provisioning_profile|
+        if final_mapping[bundle_identifier].nil?
+          # 1)
+          final_mapping[bundle_identifier] = provisioning_profile
+        else
+          # 4) Conflict, we now have to choose if we prefer whatever match provides
+          #    or what's defined in the project
+          if self.app_identifier_contains?(final_mapping[bundle_identifier], export_method)
+          elsif self.app_identifier_contains?(provisioning_profile, export_method)
+            final_mapping[bundle_identifier] = provisioning_profile
+          end
+          # rubocop won't let us keep an empty else, imagine one being here
+          # else 4.3 let's keep it as is, prefer the Xcode project
+        end
+      end
+
+      UI.verbose("export_options coming from user or match:")
+      UI.verbose(existing_mapping)
+      UI.verbose("Detected profiles from Xcode project")
+      UI.verbose(project_mapping)
+      UI.verbose("Resulting in the following mapping")
+      UI.verbose(final_mapping)
+
+      return final_mapping
+    end
+
+    # private # TODO
+
+    # Helper method to remove "-" and " " and downcase app identifier
+    # and compare if an app identifier includes a certain string
+    # We do some `gsub`bing, because we can't really know the profile type, so we'll just look at the name and see if it includes
+    # the export method (which it usually does, but with different notations)
+    def app_identifier_contains?(str, contains)
+      return str.to_s.gsub("-", "").gsub(" ", "").downcase.include?(contains.to_s.downcase)
+    end
+
+    # Array of paths to all project files
+    # (might be multiple, because of workspaces)
+    def project_paths
+      return @_project_paths if @_project_paths
+      if self.project.workspace?
+        # Find the xcodeproj file, as the information isn't included in the workspace file
+        # We have a reference to the workspace, let's find the xcodeproj file
+        # For some reason the `plist` gem can't parse the content file
+        # so we'll use a regex to find all group references
+
+        workspace_data_path = File.join(self.project.path, "contents.xcworkspacedata")
+        workspace_data = File.read(workspace_data_path)
+        @_project_paths = workspace_data.scan(/\"group:(.*)\"/).collect do |current_match|
+          # It's a relative path from the workspace file
+          File.join(File.expand_path("..", self.project.path), current_match.first)
+        end.find_all do |current_match|
+          # We're not interested in a `Pods` project, as it doesn't contain any relevant
+          # information about code signing
+          !current_match.end_with?("Pods/Pods.xcodeproj")
+        end
+
+        return @_project_paths
+      else
+        # Return the path as an array
+        return @_project_paths = [self.project.path]
+      end
+    end
+
+    def detect_project_profile_mapping
+      provisioning_profile_mapping = {}
+
+      self.project_paths.each do |project_path|
+        UI.verbose("Parsing project file '#{project_path}' to find selected provisioning profiles")
+
+        begin
+          project = Xcodeproj::Project.open(project_path)
+          project.targets.each do |target|
+            target.build_configuration_list.build_configurations.each do |build_configuration|
+              current = build_configuration.build_settings
+
+              bundle_identifier = current["PRODUCT_BUNDLE_IDENTIFIER"]
+              provisioning_profile_specifier = current["PROVISIONING_PROFILE_SPECIFIER"]
+              provisioning_profile_uuid = current["PROVISIONING_PROFILE"]
+              if provisioning_profile_specifier.to_s.length > 0
+                provisioning_profile_mapping[bundle_identifier] = provisioning_profile_specifier
+              elsif provisioning_profile_uuid.to_s.length > 0
+                provisioning_profile_mapping[bundle_identifier] = provisioning_profile_uuid
+              end
+            end
+          end
+        rescue => ex
+          # We catch errors here, as we might run into an exception on one included project
+          # But maybe the next project actually contains the information we need
+          if Helper.xcode_at_least?("9.0")
+            UI.error("Couldn't automatically detect the provisioning profile mapping")
+            UI.error("Since Xcode 9 you need to provide an explicit mapping of what")
+            UI.error("provisioning profile to use for each target of your app")
+            UI.error(ex)
+            UI.verbose(ex.backtrace.join("\n"))
+          end
+        end
+      end
+
+      return provisioning_profile_mapping
+    end
+  end
+end

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -30,6 +30,8 @@ module Gym
 
       # 2) is already covered by assigning `final_mapping` above
       # 3) see 2
+      #
+      # To get a better sense of this, check out code_signing_spec.rb for some test cases
 
       project_mapping.each do |bundle_identifier, provisioning_profile|
         if final_mapping[bundle_identifier].nil?
@@ -64,7 +66,7 @@ module Gym
     # We do some `gsub`bing, because we can't really know the profile type, so we'll just look at the name and see if it includes
     # the export method (which it usually does, but with different notations)
     def app_identifier_contains?(str, contains)
-      return str.to_s.gsub("-", "").gsub(" ", "").downcase.include?(contains.to_s.downcase)
+      return str.to_s.gsub("-", "").gsub(" ", "").downcase.include?(contains.to_s.gsub("-", "").gsub(" ", "").downcase)
     end
 
     # Array of paths to all project files

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -117,7 +117,7 @@ module Gym
       return if provisioning_profile_mapping.count == 0
 
       Gym.config[:export_options] ||= {}
-      hash_to_use = Gym.config[:export_options][:provisioningProfiles].dup # dup so we can show the original values in `verbose` mode
+      hash_to_use = Gym.config[:export_options][:provisioningProfiles].dup || {} # dup so we can show the original values in `verbose` mode
 
       # Now it's time to merge the (potentially) existing `provisioningProfiles` of the `export_options`
       # with the hash we just created. Both might include information about what profile to use

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -63,9 +63,10 @@ module Gym
       hash_to_use = Gym.config[:export_options][:provisioningProfiles].dup || {} # dup so we can show the original values in `verbose` mode
 
       mapping_object = CodeSigningMapping.new(project: Gym.project)
-      hash_to_use = mapping_object.merge_profile_mapping(existing_mapping: hash_to_use, 
+      hash_to_use = mapping_object.merge_profile_mapping(existing_mapping: hash_to_use,
                                                             export_method: Gym.config[:export_method])
 
+      return if hash_to_use.count == 0 # We don't want to set a mapping if we don't have one
       Gym.config[:export_options][:provisioningProfiles] = hash_to_use
       UI.message("Detected provisioning profile mapping: #{hash_to_use}")
     rescue => ex

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -63,8 +63,8 @@ module Gym
       hash_to_use = (Gym.config[:export_options][:provisioningProfiles] || {}).dup || {} # dup so we can show the original values in `verbose` mode
 
       mapping_object = CodeSigningMapping.new(project: Gym.project)
-      hash_to_use = mapping_object.merge_profile_mapping(existing_mapping: hash_to_use,
-                                                            export_method: Gym.config[:export_method])
+      hash_to_use = mapping_object.merge_profile_mapping(primary_mapping: hash_to_use,
+                                                           export_method: Gym.config[:export_method])
 
       return if hash_to_use.count == 0 # We don't want to set a mapping if we don't have one
       Gym.config[:export_options][:provisioningProfiles] = hash_to_use

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -59,111 +59,15 @@ module Gym
     # Since Xcode 9 you need to provide the explicit mapping of what provisioning profile to use for
     # each target of your app
     def self.detect_selected_provisioning_profiles
-      require 'xcodeproj'
-
-      provisioning_profile_mapping = {}
-
-      # Find the xcodeproj file, as the information isn't included in the workspace file
-      if Gym.project.workspace?
-        # We have a reference to the workspace, let's find the xcodeproj file
-        # For some reason the `plist` gem can't parse the content file
-        # so we'll use a regex to find all group references
-
-        workspace_data_path = File.join(Gym.project.path, "contents.xcworkspacedata")
-        workspace_data = File.read(workspace_data_path)
-        project_paths = workspace_data.scan(/\"group:(.*)\"/).collect do |current_match|
-          # It's a relative path from the workspace file
-          File.join(File.expand_path("..", Gym.project.path), current_match.first)
-        end.find_all do |current_match|
-          !current_match.end_with?("Pods/Pods.xcodeproj")
-        end
-      else
-        project_paths = [Gym.project.path]
-      end
-
-      # Because there might be multiple projects inside a workspace
-      # we iterate over all of them (except for CocoaPods)
-      project_paths.each do |project_path|
-        UI.verbose("Parsing project file '#{project_path}' to find selected provisioning profiles")
-        begin
-          project = Xcodeproj::Project.open(project_path)
-          project.targets.each do |target|
-            target.build_configuration_list.build_configurations.each do |build_configuration|
-              current = build_configuration.build_settings
-
-              bundle_identifier = current["PRODUCT_BUNDLE_IDENTIFIER"]
-              provisioning_profile_specifier = current["PROVISIONING_PROFILE_SPECIFIER"]
-              provisioning_profile_uuid = current["PROVISIONING_PROFILE"]
-              if provisioning_profile_specifier.to_s.length > 0
-                provisioning_profile_mapping[bundle_identifier] = provisioning_profile_specifier
-              elsif provisioning_profile_uuid.to_s.length > 0
-                provisioning_profile_mapping[bundle_identifier] = provisioning_profile_uuid
-              end
-            end
-          end
-        rescue => ex
-          # We catch errors here, as we might run into an exception on one included project
-          # But maybe the next project actually contains the information we need
-          if Helper.xcode_at_least?("9.0")
-            UI.error("Couldn't automatically detect the provisioning profile mapping")
-            UI.error("Since Xcode 9 you need to provide an explicit mapping of what")
-            UI.error("provisioning profile to use for each target of your app")
-            UI.error(ex)
-            UI.verbose(ex.backtrace.join("\n"))
-          end
-        end
-      end
-
-      return if provisioning_profile_mapping.count == 0
-
       Gym.config[:export_options] ||= {}
       hash_to_use = Gym.config[:export_options][:provisioningProfiles].dup || {} # dup so we can show the original values in `verbose` mode
 
-      # Now it's time to merge the (potentially) existing `provisioningProfiles` of the `export_options`
-      # with the hash we just created. Both might include information about what profile to use
-      # This is important, as :bell: (some users) didn't know to call match for each app target he wants profiles for
-      # before adding this code, we'd only either use whatever we get from match, or what's defined in the Xcode project
-      # With the code below, we'll make sure to take the best of it:
-      #
-      #   1) A provisioning profile is defined in the Xcode project only: we'll take that
-      #   2) A provisioning profile is defined manually from the user: we'll take that (same as 3)
-      #   3) A provisioning profile is defined after calling match: we'll take that (same as 2)
-      #   4) On a conflict (app identifier assigned both in xcode and match)
-      #     4.1) we'll choose whatever matches the `export_method` defined
-      #     4.2) If both include the export_method, we'll prefer the one from match
-      #     4.3) If none has the right export_method, we'll use whatever is defined in the Xcode project
-
-      # 2) is already covered by assigning `hash_to_use` above
-      # 3) see 2
-
-      provisioning_profile_mapping.each do |bundle_identifier, provisioning_profile|
-        if hash_to_use[bundle_identifier].nil?
-          # 1)
-          hash_to_use[bundle_identifier] = provisioning_profile
-        else
-          # 4) Conflict, we now have to choose if we prefer whatever match provides
-          #    or what's defined in the project
-          if self.app_identifier_contains?(hash_to_use[bundle_identifier], Gym.config[:export_method])
-            # 4.1
-            # 4.2 is automatically covered by this, as we're checking for the one coming from the export plist first
-          elsif self.app_identifier_contains?(provisioning_profile, Gym.config[:export_method])
-            # 4.1
-            hash_to_use[bundle_identifier] = provisioning_profile
-          end
-          # rubocop won't let us keep an empty else, imagine one being here
-          # else 4.3 let's keep it as is, prefer the Xcode project
-        end
-      end
-
-      UI.verbose("export_options coming from user or match:")
-      UI.verbose(Gym.config[:export_options][:provisioningProfiles])
-      UI.verbose("Detected profiles from Xcode project")
-      UI.verbose(provisioning_profile_mapping)
-      UI.verbose("Resulting in the following mapping")
-      UI.verbose(hash_to_use)
+      mapping_object = CodeSigningMapping.new(project: Gym.project)
+      hash_to_use = mapping_object.merge_profile_mapping(existing_mapping: hash_to_use, 
+                                                            export_method: Gym.config[:export_method])
 
       Gym.config[:export_options][:provisioningProfiles] = hash_to_use
-      UI.message("Detected provisioning profile mapping: #{provisioning_profile_mapping}")
+      UI.message("Detected provisioning profile mapping: #{hash_to_use}")
     rescue => ex
       # We don't want to fail the build if the automatic detection doesn't work
       # especially since the mapping is optional for pre Xcode 9 setups
@@ -174,14 +78,6 @@ module Gym
         UI.error(ex)
         UI.verbose(ex.backtrace.join("\n"))
       end
-    end
-
-    # Helper method to remove "-" and " " and downcase app identifier
-    # and compare if an app identifier includes a certain string
-    # We do some `gsub`bing, because we can't really know the profile type, so we'll just look at the name and see if it includes
-    # the export method (which it usually does, but with different notations)
-    def self.app_identifier_contains?(str, contains)
-      return str.to_s.gsub("-", "").gsub(" ", "").downcase.include?(contains.to_s.downcase)
     end
 
     def self.detect_scheme

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -60,7 +60,7 @@ module Gym
     # each target of your app
     def self.detect_selected_provisioning_profiles
       Gym.config[:export_options] ||= {}
-      hash_to_use = Gym.config[:export_options][:provisioningProfiles].dup || {} # dup so we can show the original values in `verbose` mode
+      hash_to_use = (Gym.config[:export_options][:provisioningProfiles] || {}).dup || {} # dup so we can show the original values in `verbose` mode
 
       mapping_object = CodeSigningMapping.new(project: Gym.project)
       hash_to_use = mapping_object.merge_profile_mapping(existing_mapping: hash_to_use,

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -132,9 +132,6 @@ module Gym
       #     4.1) we'll choose whatever matches the `export_method` defined
       #     4.2) If both include the export_method, we'll prefer the one from match
       #     4.3) If none has the right export_method, we'll use whatever is defined in the Xcode project
-      #
-      # We do some `gsub`bing, because we can't really know the profile type, so we'll just look at the name and see if it includes
-      # the export method (which it usually does, but with different notations)
 
       # 2) is already covered by assigning `hash_to_use` above
       # 3) see 2
@@ -181,6 +178,8 @@ module Gym
 
     # Helper method to remove "-" and " " and downcase app identifier
     # and compare if an app identifier includes a certain string
+    # We do some `gsub`bing, because we can't really know the profile type, so we'll just look at the name and see if it includes
+    # the export method (which it usually does, but with different notations)
     def self.app_identifier_contains?(str, contains)
       return str.to_s.gsub("-", "").gsub(" ", "").downcase
     end

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -181,7 +181,7 @@ module Gym
     # We do some `gsub`bing, because we can't really know the profile type, so we'll just look at the name and see if it includes
     # the export method (which it usually does, but with different notations)
     def self.app_identifier_contains?(str, contains)
-      return str.to_s.gsub("-", "").gsub(" ", "").downcase
+      return str.to_s.gsub("-", "").gsub(" ", "").downcase.include?(contains.to_s.downcase)
     end
 
     def self.detect_scheme

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -250,7 +250,7 @@ module Gym
 
               next if matching_type.to_s == selected_export_method
               UI.message("")
-              UI.error("There is a mismatch between your provided `export_method` in gym")
+              UI.error("There seems to be a mismatch between your provided `export_method` in gym")
               UI.error("and the selected provisioning profiles. You passed the following options:")
               UI.important("  export_method:      #{selected_export_method}")
               UI.important("  Bundle identifier:  #{current_bundle_identifier}")

--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -59,46 +59,67 @@ describe Gym::CodeSigningMapping do
     let (:csm) { Gym::CodeSigningMapping.new }
 
     it "only mapping from Xcode Project is available" do
-      expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.1" => "value.1" })
-      result = csm.merge_profile_mapping(existing_mapping: {}, export_method: "app-store")
+      result = csm.merge_profile_mapping(primary_mapping: {},
+                                       secondary_mapping: { "identifier.1" => "value.1" },
+                                           export_method: "app-store")
 
       expect(result).to eq({ "identifier.1" => "value.1" })
     end
 
     it "only mapping from match (user) is available" do
-      expect(csm).to receive(:detect_project_profile_mapping).and_return({})
-      result = csm.merge_profile_mapping(existing_mapping: { "identifier.1" => "value.1" }, export_method: "app-store")
+      result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "value.1" },
+                                       secondary_mapping: {},
+                                           export_method: "app-store")
 
       expect(result).to eq({ "identifier.1" => "value.1" })
     end
 
     it "keeps both profiles if they don't conflict" do
-      expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.2" => "value.2" })
-      result = csm.merge_profile_mapping(existing_mapping: { "identifier.1" => "value.1" }, export_method: "app-store")
+      result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "value.1" },
+                                       secondary_mapping: { "identifier.2" => "value.2" },
+                                           export_method: "app-store")
 
       expect(result).to eq({ "identifier.1" => "value.1", "identifier.2" => "value.2" })
     end
 
+    it "accesses the Xcode profile mapping, if nothing else is given" do
+      expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.1" => "value.1" })
+      result = csm.merge_profile_mapping(primary_mapping: {}, export_method: "app-store")
+
+      expect(result).to eq({ "identifier.1" => "value.1" })
+    end
+
     describe "handle conflicts" do
-      it "Both Xcode project and match (user) are available, and both match the export method, it should prefer the user input (match)" do
-        expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.1" => "Ap-pStoreValue1" })
-        result = csm.merge_profile_mapping(existing_mapping: { "identifier.1" => "Ap-pStoreValue2" }, export_method: "app-store")
+      it "Both primary and secondary are available, and both match the export method, it should prefer the primary mapping" do
+        result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "Ap-pStoreValue2" },
+                                       secondary_mapping: { "identifier.1" => "Ap-pStoreValue1" },
+                                           export_method: "app-store")
 
         expect(result).to eq({ "identifier.1" => "Ap-pStoreValue2" })
       end
 
-      it "Both Xcode project and match (user) are available, and and the match (user) is the only one that matches the export type" do
-        expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.1" => "Ad-HocValue" })
-        result = csm.merge_profile_mapping(existing_mapping: { "identifier.1" => "Ap-p StoreValue1" }, export_method: "app-store")
+      it "Both primary and secondary are available, and and the secondary is the only one that matches the export type" do
+        result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "Ap-p StoreValue1" },
+                                       secondary_mapping: { "identifier.1" => "Ad-HocValue" },
+                                           export_method: "app-store")
 
         expect(result).to eq({ "identifier.1" => "Ap-p StoreValue1" })
       end
 
-      it "Both Xcode project and match (user) are available, and and the Xcode project is the only one that matches the export type" do
-        expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.1" => "Ad-HocValue" })
-        result = csm.merge_profile_mapping(existing_mapping: { "identifier.1" => "Ap-p StoreValue1" }, export_method: "ad-hoc")
+      it "Both primary and secondary are available, and and the seocndary is the only one that matches the export type" do
+        result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "Ap-p StoreValue1" },
+                                       secondary_mapping: { "identifier.1" => "Ad-HocValue" },
+                                           export_method: "ad-hoc")
 
         expect(result).to eq({ "identifier.1" => "Ad-HocValue" })
+      end
+
+      it "both primary and secondary are available, and neither of them match the export type, it should choose the secondary_mapping" do
+        result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "AppStore" },
+                                       secondary_mapping: { "identifier.1" => "Adhoc" },
+                                           export_method: "development")
+
+        expect(result).to eq({ "identifier.1" => "Adhoc" })
       end
     end
   end

--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -1,4 +1,4 @@
-describe Gym::CodeSigningMapping, now: true do
+describe Gym::CodeSigningMapping do
   describe "#project_paths" do
     it "works with basic projects" do
       project = FastlaneCore::Project.new({
@@ -18,8 +18,8 @@ describe Gym::CodeSigningMapping, now: true do
 
       csm = Gym::CodeSigningMapping.new(project: project)
       expect(csm.project_paths).to eq([
-        File.expand_path(workspace_path.gsub("xcworkspace", "xcodeproj")) # this should point to the included Xcode project
-      ])
+                                        File.expand_path(workspace_path.gsub("xcworkspace", "xcodeproj")) # this should point to the included Xcode project
+                                      ])
     end
   end
 
@@ -35,9 +35,15 @@ describe Gym::CodeSigningMapping, now: true do
       return_value = csm.app_identifier_contains?("FuLL-StRing Yo", "fullstringyo")
       expect(return_value).to eq(true)
     end
+
+    it "Strips out all the usual characters that are not needed" do
+      csm = Gym::CodeSigningMapping.new(project: nil)
+      return_value = csm.app_identifier_contains?("Ad-HocValue", "ad-hoc")
+      expect(return_value).to eq(true)
+    end
   end
 
-  describe "detect_project_profile_mapping" do
+  describe "#detect_project_profile_mapping" do
     it "returns the mapping of the selected provisioning profiles" do
       workspace_path = "gym/spec/fixtures/projects/cocoapods/Example.xcworkspace"
       project = FastlaneCore::Project.new({
@@ -45,7 +51,55 @@ describe Gym::CodeSigningMapping, now: true do
       })
 
       csm = Gym::CodeSigningMapping.new(project: project)
-      expect(csm.detect_project_profile_mapping).to eq({"family.wwdc.app"=>"match AppStore family.wwdc.app"})
+      expect(csm.detect_project_profile_mapping).to eq({ "family.wwdc.app" => "match AppStore family.wwdc.app" })
+    end
+  end
+
+  describe "#merge_profile_mapping" do
+    let (:csm) { Gym::CodeSigningMapping.new }
+
+    it "only mapping from Xcode Project is available" do
+      expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.1" => "value.1" })
+      result = csm.merge_profile_mapping(existing_mapping: {}, export_method: "app-store")
+
+      expect(result).to eq({ "identifier.1" => "value.1" })
+    end
+
+    it "only mapping from match (user) is available" do
+      expect(csm).to receive(:detect_project_profile_mapping).and_return({})
+      result = csm.merge_profile_mapping(existing_mapping: { "identifier.1" => "value.1" }, export_method: "app-store")
+
+      expect(result).to eq({ "identifier.1" => "value.1" })
+    end
+
+    it "keeps both profiles if they don't conflict" do
+      expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.2" => "value.2" })
+      result = csm.merge_profile_mapping(existing_mapping: { "identifier.1" => "value.1" }, export_method: "app-store")
+
+      expect(result).to eq({ "identifier.1" => "value.1", "identifier.2" => "value.2" })
+    end
+
+    describe "handle conflicts" do
+      it "Both Xcode project and match (user) are available, and both match the export method, it should prefer the user input (match)" do
+        expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.1" => "Ap-pStoreValue1" })
+        result = csm.merge_profile_mapping(existing_mapping: { "identifier.1" => "Ap-pStoreValue2" }, export_method: "app-store")
+
+        expect(result).to eq({ "identifier.1" => "Ap-pStoreValue2" })
+      end
+
+      it "Both Xcode project and match (user) are available, and and the match (user) is the only one that matches the export type" do
+        expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.1" => "Ad-HocValue" })
+        result = csm.merge_profile_mapping(existing_mapping: { "identifier.1" => "Ap-p StoreValue1" }, export_method: "app-store")
+
+        expect(result).to eq({ "identifier.1" => "Ap-p StoreValue1" })
+      end
+
+      it "Both Xcode project and match (user) are available, and and the Xcode project is the only one that matches the export type", nower: true do
+        expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.1" => "Ad-HocValue" })
+        result = csm.merge_profile_mapping(existing_mapping: { "identifier.1" => "Ap-p StoreValue1" }, export_method: "ad-hoc")
+
+        expect(result).to eq({ "identifier.1" => "Ad-HocValue" })
+      end
     end
   end
 end

--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -94,7 +94,7 @@ describe Gym::CodeSigningMapping do
         expect(result).to eq({ "identifier.1" => "Ap-p StoreValue1" })
       end
 
-      it "Both Xcode project and match (user) are available, and and the Xcode project is the only one that matches the export type", nower: true do
+      it "Both Xcode project and match (user) are available, and and the Xcode project is the only one that matches the export type" do
         expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.1" => "Ad-HocValue" })
         result = csm.merge_profile_mapping(existing_mapping: { "identifier.1" => "Ap-p StoreValue1" }, export_method: "ad-hoc")
 

--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -82,6 +82,13 @@ describe Gym::CodeSigningMapping do
       expect(result).to eq({ "identifier.1" => "value.1", "identifier.2" => "value.2" })
     end
 
+    it "doesn't crash if nil is provided" do
+      result = csm.merge_profile_mapping(primary_mapping: nil,
+                                       secondary_mapping: {},
+                                           export_method: "app-store")
+      expect(result).to eq({})
+    end
+
     it "accesses the Xcode profile mapping, if nothing else is given" do
       expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.1" => "value.1" })
       result = csm.merge_profile_mapping(primary_mapping: {}, export_method: "app-store")

--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -1,0 +1,51 @@
+describe Gym::CodeSigningMapping, now: true do
+  describe "#project_paths" do
+    it "works with basic projects" do
+      project = FastlaneCore::Project.new({
+        project: "gym/lib"
+      })
+
+      csm = Gym::CodeSigningMapping.new(project: project)
+      expect(csm.project_paths).to be_an(Array)
+      expect(csm.project_paths).to eq([File.expand_path("gym/lib")])
+    end
+
+    it "works with workspaces" do
+      workspace_path = "gym/spec/fixtures/projects/cocoapods/Example.xcworkspace"
+      project = FastlaneCore::Project.new({
+        workspace: workspace_path
+      })
+
+      csm = Gym::CodeSigningMapping.new(project: project)
+      expect(csm.project_paths).to eq([
+        File.expand_path(workspace_path.gsub("xcworkspace", "xcodeproj")) # this should point to the included Xcode project
+      ])
+    end
+  end
+
+  describe "#app_identifier_contains?" do
+    it "returns false if it doesn't contain it" do
+      csm = Gym::CodeSigningMapping.new(project: nil)
+      return_value = csm.app_identifier_contains?("dsfsdsdf", "somethingelse")
+      expect(return_value).to eq(false)
+    end
+
+    it "returns true if it doesn't contain it" do
+      csm = Gym::CodeSigningMapping.new(project: nil)
+      return_value = csm.app_identifier_contains?("FuLL-StRing Yo", "fullstringyo")
+      expect(return_value).to eq(true)
+    end
+  end
+
+  describe "detect_project_profile_mapping" do
+    it "returns the mapping of the selected provisioning profiles" do
+      workspace_path = "gym/spec/fixtures/projects/cocoapods/Example.xcworkspace"
+      project = FastlaneCore::Project.new({
+        workspace: workspace_path
+      })
+
+      csm = Gym::CodeSigningMapping.new(project: project)
+      expect(csm.detect_project_profile_mapping).to eq({"family.wwdc.app"=>"match AppStore family.wwdc.app"})
+    end
+  end
+end

--- a/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/project.pbxproj
+++ b/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/project.pbxproj
@@ -1,0 +1,593 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		521B376B1311B4AB3AA9800C /* libPods-Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BDC4BE00FA30F698E5A28354 /* libPods-Example.a */; };
+		CAC1E19D1B6A326100A8B23A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = CAC1E19C1B6A326100A8B23A /* main.m */; };
+		CAC1E1A01B6A326100A8B23A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = CAC1E19F1B6A326100A8B23A /* AppDelegate.m */; };
+		CAC1E1A31B6A326100A8B23A /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CAC1E1A21B6A326100A8B23A /* ViewController.m */; };
+		CAC1E1A61B6A326100A8B23A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CAC1E1A41B6A326100A8B23A /* Main.storyboard */; };
+		CAC1E1A81B6A326100A8B23A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CAC1E1A71B6A326100A8B23A /* Assets.xcassets */; };
+		CAC1E1AB1B6A326100A8B23A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CAC1E1A91B6A326100A8B23A /* LaunchScreen.storyboard */; };
+		CAC1E1B61B6A326200A8B23A /* ExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CAC1E1B51B6A326200A8B23A /* ExampleTests.m */; };
+		CAC1E1C11B6A326200A8B23A /* ExampleUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = CAC1E1C01B6A326200A8B23A /* ExampleUITests.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		CAC1E1B21B6A326100A8B23A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CAC1E1901B6A326100A8B23A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CAC1E1971B6A326100A8B23A;
+			remoteInfo = Example;
+		};
+		CAC1E1BD1B6A326200A8B23A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CAC1E1901B6A326100A8B23A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CAC1E1971B6A326100A8B23A;
+			remoteInfo = Example;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		7F17E2E4DB202336112485AA /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
+		ACCA4067A20AE82A13A55B4D /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
+		BDC4BE00FA30F698E5A28354 /* libPods-Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAC1E1981B6A326100A8B23A /* ExampleProductName.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleProductName.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAC1E19C1B6A326100A8B23A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		CAC1E19E1B6A326100A8B23A /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		CAC1E19F1B6A326100A8B23A /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		CAC1E1A11B6A326100A8B23A /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		CAC1E1A21B6A326100A8B23A /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		CAC1E1A51B6A326100A8B23A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		CAC1E1A71B6A326100A8B23A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		CAC1E1AA1B6A326100A8B23A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		CAC1E1AC1B6A326100A8B23A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CAC1E1B11B6A326100A8B23A /* ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAC1E1B51B6A326200A8B23A /* ExampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExampleTests.m; sourceTree = "<group>"; };
+		CAC1E1B71B6A326200A8B23A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CAC1E1BC1B6A326200A8B23A /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAC1E1C01B6A326200A8B23A /* ExampleUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExampleUITests.m; sourceTree = "<group>"; };
+		CAC1E1C21B6A326200A8B23A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CAC1E1951B6A326100A8B23A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				521B376B1311B4AB3AA9800C /* libPods-Example.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CAC1E1AE1B6A326100A8B23A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CAC1E1B91B6A326200A8B23A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9E1FB1D1D5F20339E5A8AFF2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				BDC4BE00FA30F698E5A28354 /* libPods-Example.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		BADC4719675AA7E88BB4142C /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				ACCA4067A20AE82A13A55B4D /* Pods-Example.debug.xcconfig */,
+				7F17E2E4DB202336112485AA /* Pods-Example.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		CAC1E18F1B6A326100A8B23A = {
+			isa = PBXGroup;
+			children = (
+				CAC1E19A1B6A326100A8B23A /* Example */,
+				CAC1E1B41B6A326100A8B23A /* ExampleTests */,
+				CAC1E1BF1B6A326200A8B23A /* ExampleUITests */,
+				CAC1E1991B6A326100A8B23A /* Products */,
+				BADC4719675AA7E88BB4142C /* Pods */,
+				9E1FB1D1D5F20339E5A8AFF2 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		CAC1E1991B6A326100A8B23A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CAC1E1981B6A326100A8B23A /* ExampleProductName.app */,
+				CAC1E1B11B6A326100A8B23A /* ExampleTests.xctest */,
+				CAC1E1BC1B6A326200A8B23A /* ExampleUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CAC1E19A1B6A326100A8B23A /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				CAC1E19E1B6A326100A8B23A /* AppDelegate.h */,
+				CAC1E19F1B6A326100A8B23A /* AppDelegate.m */,
+				CAC1E1A11B6A326100A8B23A /* ViewController.h */,
+				CAC1E1A21B6A326100A8B23A /* ViewController.m */,
+				CAC1E1A41B6A326100A8B23A /* Main.storyboard */,
+				CAC1E1A71B6A326100A8B23A /* Assets.xcassets */,
+				CAC1E1A91B6A326100A8B23A /* LaunchScreen.storyboard */,
+				CAC1E1AC1B6A326100A8B23A /* Info.plist */,
+				CAC1E19B1B6A326100A8B23A /* Supporting Files */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		CAC1E19B1B6A326100A8B23A /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				CAC1E19C1B6A326100A8B23A /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		CAC1E1B41B6A326100A8B23A /* ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				CAC1E1B51B6A326200A8B23A /* ExampleTests.m */,
+				CAC1E1B71B6A326200A8B23A /* Info.plist */,
+			);
+			path = ExampleTests;
+			sourceTree = "<group>";
+		};
+		CAC1E1BF1B6A326200A8B23A /* ExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				CAC1E1C01B6A326200A8B23A /* ExampleUITests.m */,
+				CAC1E1C21B6A326200A8B23A /* Info.plist */,
+			);
+			path = ExampleUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CAC1E1971B6A326100A8B23A /* Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CAC1E1C51B6A326200A8B23A /* Build configuration list for PBXNativeTarget "Example" */;
+			buildPhases = (
+				FD6E57C195D6DD9F5D5469C2 /* Check Pods Manifest.lock */,
+				CAC1E1941B6A326100A8B23A /* Sources */,
+				CAC1E1951B6A326100A8B23A /* Frameworks */,
+				CAC1E1961B6A326100A8B23A /* Resources */,
+				5F43814BE018E11BE30B947A /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Example;
+			productName = Example;
+			productReference = CAC1E1981B6A326100A8B23A /* ExampleProductName.app */;
+			productType = "com.apple.product-type.application";
+		};
+		CAC1E1B01B6A326100A8B23A /* ExampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CAC1E1C81B6A326200A8B23A /* Build configuration list for PBXNativeTarget "ExampleTests" */;
+			buildPhases = (
+				CAC1E1AD1B6A326100A8B23A /* Sources */,
+				CAC1E1AE1B6A326100A8B23A /* Frameworks */,
+				CAC1E1AF1B6A326100A8B23A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CAC1E1B31B6A326100A8B23A /* PBXTargetDependency */,
+			);
+			name = ExampleTests;
+			productName = ExampleTests;
+			productReference = CAC1E1B11B6A326100A8B23A /* ExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		CAC1E1BB1B6A326200A8B23A /* ExampleUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CAC1E1CB1B6A326200A8B23A /* Build configuration list for PBXNativeTarget "ExampleUITests" */;
+			buildPhases = (
+				CAC1E1B81B6A326200A8B23A /* Sources */,
+				CAC1E1B91B6A326200A8B23A /* Frameworks */,
+				CAC1E1BA1B6A326200A8B23A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CAC1E1BE1B6A326200A8B23A /* PBXTargetDependency */,
+			);
+			name = ExampleUITests;
+			productName = ExampleUITests;
+			productReference = CAC1E1BC1B6A326200A8B23A /* ExampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CAC1E1901B6A326100A8B23A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0700;
+				ORGANIZATIONNAME = "Felix Krause";
+				TargetAttributes = {
+					CAC1E1971B6A326100A8B23A = {
+						CreatedOnToolsVersion = 7.0;
+						DevelopmentTeam = 39WKQBKTL5;
+						ProvisioningStyle = Manual;
+					};
+					CAC1E1B01B6A326100A8B23A = {
+						CreatedOnToolsVersion = 7.0;
+						TestTargetID = CAC1E1971B6A326100A8B23A;
+					};
+					CAC1E1BB1B6A326200A8B23A = {
+						CreatedOnToolsVersion = 7.0;
+						TestTargetID = CAC1E1971B6A326100A8B23A;
+					};
+				};
+			};
+			buildConfigurationList = CAC1E1931B6A326100A8B23A /* Build configuration list for PBXProject "Example" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CAC1E18F1B6A326100A8B23A;
+			productRefGroup = CAC1E1991B6A326100A8B23A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CAC1E1971B6A326100A8B23A /* Example */,
+				CAC1E1B01B6A326100A8B23A /* ExampleTests */,
+				CAC1E1BB1B6A326200A8B23A /* ExampleUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CAC1E1961B6A326100A8B23A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CAC1E1AB1B6A326100A8B23A /* LaunchScreen.storyboard in Resources */,
+				CAC1E1A81B6A326100A8B23A /* Assets.xcassets in Resources */,
+				CAC1E1A61B6A326100A8B23A /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CAC1E1AF1B6A326100A8B23A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CAC1E1BA1B6A326200A8B23A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		5F43814BE018E11BE30B947A /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example/Pods-Example-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FD6E57C195D6DD9F5D5469C2 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CAC1E1941B6A326100A8B23A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CAC1E1A31B6A326100A8B23A /* ViewController.m in Sources */,
+				CAC1E1A01B6A326100A8B23A /* AppDelegate.m in Sources */,
+				CAC1E19D1B6A326100A8B23A /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CAC1E1AD1B6A326100A8B23A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CAC1E1B61B6A326200A8B23A /* ExampleTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CAC1E1B81B6A326200A8B23A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CAC1E1C11B6A326200A8B23A /* ExampleUITests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		CAC1E1B31B6A326100A8B23A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CAC1E1971B6A326100A8B23A /* Example */;
+			targetProxy = CAC1E1B21B6A326100A8B23A /* PBXContainerItemProxy */;
+		};
+		CAC1E1BE1B6A326200A8B23A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CAC1E1971B6A326100A8B23A /* Example */;
+			targetProxy = CAC1E1BD1B6A326200A8B23A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		CAC1E1A41B6A326100A8B23A /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				CAC1E1A51B6A326100A8B23A /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		CAC1E1A91B6A326100A8B23A /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				CAC1E1AA1B6A326100A8B23A /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		CAC1E1C31B6A326200A8B23A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		CAC1E1C41B6A326200A8B23A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		CAC1E1C61B6A326200A8B23A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ACCA4067A20AE82A13A55B4D /* Pods-Example.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = 39WKQBKTL5;
+				INFOPLIST_FILE = Example/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = family.wwdc.app;
+				PRODUCT_NAME = "$(TARGET_NAME)ProductName";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore family.wwdc.app";
+			};
+			name = Debug;
+		};
+		CAC1E1C71B6A326200A8B23A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7F17E2E4DB202336112485AA /* Pods-Example.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = Example/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = family.wwdc.app;
+				PRODUCT_NAME = "$(TARGET_NAME)ProductName";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore family.wwdc.app";
+			};
+			name = Release;
+		};
+		CAC1E1C91B6A326200A8B23A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = ExampleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.krausefx.ExampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
+			};
+			name = Debug;
+		};
+		CAC1E1CA1B6A326200A8B23A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = ExampleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.krausefx.ExampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
+			};
+			name = Release;
+		};
+		CAC1E1CC1B6A326200A8B23A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = ExampleUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.krausefx.ExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = Example;
+				USES_XCTRUNNER = YES;
+			};
+			name = Debug;
+		};
+		CAC1E1CD1B6A326200A8B23A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = ExampleUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.krausefx.ExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = Example;
+				USES_XCTRUNNER = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CAC1E1931B6A326100A8B23A /* Build configuration list for PBXProject "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CAC1E1C31B6A326200A8B23A /* Debug */,
+				CAC1E1C41B6A326200A8B23A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CAC1E1C51B6A326200A8B23A /* Build configuration list for PBXNativeTarget "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CAC1E1C61B6A326200A8B23A /* Debug */,
+				CAC1E1C71B6A326200A8B23A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CAC1E1C81B6A326200A8B23A /* Build configuration list for PBXNativeTarget "ExampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CAC1E1C91B6A326200A8B23A /* Debug */,
+				CAC1E1CA1B6A326200A8B23A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CAC1E1CB1B6A326200A8B23A /* Build configuration list for PBXNativeTarget "ExampleUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CAC1E1CC1B6A326200A8B23A /* Debug */,
+				CAC1E1CD1B6A326200A8B23A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CAC1E1901B6A326100A8B23A /* Project object */;
+}

--- a/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Example.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CAC1E1971B6A326100A8B23A"
+               BuildableName = "ExampleProductName.app"
+               BlueprintName = "Example"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CAC1E1B01B6A326100A8B23A"
+               BuildableName = "ExampleTests.xctest"
+               BlueprintName = "ExampleTests"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CAC1E1BB1B6A326200A8B23A"
+               BuildableName = "ExampleUITests.xctest"
+               BlueprintName = "ExampleUITests"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CAC1E1971B6A326100A8B23A"
+            BuildableName = "ExampleProductName.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CAC1E1971B6A326100A8B23A"
+            BuildableName = "ExampleProductName.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CAC1E1971B6A326100A8B23A"
+            BuildableName = "ExampleProductName.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/gym/spec/fixtures/projects/cocoapods/Example.xcworkspace/contents.xcworkspacedata
+++ b/gym/spec/fixtures/projects/cocoapods/Example.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Example.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/gym/spec/package_command_generator_xcode7_spec.rb
+++ b/gym/spec/package_command_generator_xcode7_spec.rb
@@ -82,9 +82,7 @@ describe Gym do
       config_path = Gym::PackageCommandGeneratorXcode7.config_path
 
       expect(Plist.parse_xml(config_path)).to eq({
-        'method' => "app-store",
-        'uploadBitcode' => false,
-        'uploadSymbols' => true
+        'method' => "app-store"
       })
     end
 


### PR DESCRIPTION
This PR adds support for merging of multiple profile mappings. Since Xcode 9, you as a user, have to provide the mapping from app identifier to provisioning profile. As we don't want people to have to manually update the config, we can do that automatically for them :) 

<img width="1159" alt="screen shot 2017-08-28 at 2 06 54 pm" src="https://user-images.githubusercontent.com/869950/29793799-2c915488-8bfa-11e7-821d-8d0191c5bbdd.png">
