### PR TITLE
Readme: inform about limitations of `supply`

### DIFF
--- a/supply/README.md
+++ b/supply/README.md
@@ -188,6 +188,14 @@ This can be done using the `--track_promote_to` parameter.  The `--track_promote
 
 Before performing a new APK upload you may want to check existing track version codes, or you may simply want to provide an informational lane that displays the currently promoted version codes for the production track. You can use the `google_play_track_version_codes` action to retrieve existing version codes for a package and track. For more information, see `fastlane action google_play_track_version_codes` help output.
 
+## Limitations
+
+Please note these limitations of `supply` at the current time:
+
+* `supply` doesn't support the creation of new apps (as `produce` does for iOS). You have to do the initial creation of new apps manually.
+* It also doesn't support all metadata fields available for apps in the Google Play Console. For example "Content Rating", "Application Type" or "Category" are not down- or uploaded and have to be set manually.
+
+
 ## Tips
 
 ### [`fastlane`](https://fastlane.tools) Toolchain


### PR DESCRIPTION

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`supply` doesn't do some things that people might want it to do. by adding this information to the README they won't waste their time searching for a solution.

### Description
added a new headline and 2 short list items that explain that `supply` can't create new apps and doesn't support some metadata fields and both has to be taken care of manually for now by the developer.
