### PR TITLE
Add optional parameters to action appetize_viewing_url_generator

### DIFF
--- a/fastlane/lib/fastlane/actions/appetize_viewing_url_generator.rb
+++ b/fastlane/lib/fastlane/actions/appetize_viewing_url_generator.rb
@@ -5,7 +5,7 @@ module Fastlane
 
     class AppetizeViewingUrlGeneratorAction < Action
       def self.run(params)
-        link = "https://appetize.io/embed/#{params[:public_key]}"
+        link = "#{params[:base_url]}/#{params[:public_key]}"
 
         if params[:scale].nil? # sensible default values for scaling
           case params[:device].downcase.to_sym
@@ -27,6 +27,8 @@ module Fastlane
         url_params << "launchUrl=#{params[:launch_url]}" if params[:launch_url]
         url_params << "language=#{params[:language]}" if params[:language]
         url_params << "osVersion=#{params[:os_version]}" if params[:os_version]
+        url_params << "params=#{CGI.escape params[:params]}" if params[:params]
+        url_params << "proxy=#{CGI.escape params[:proxy]}" if params[:proxy]
 
         return link + "?" + url_params.join("&")
       end
@@ -57,6 +59,12 @@ module Fastlane
                                            UI.user_error!("You provided a private key to appetize, please provide the public key")
                                          end
                                        end),
+          FastlaneCore::ConfigItem.new(key: :base_url,
+                                       env_name: "APPETIZE_VIEWING_URL_GENERATOR_BASE",
+                                       description: "Base URL of Appetize service",
+                                       is_string: true,
+                                       default_value: "https://appetize.io/embed",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :device,
                                        env_name: "APPETIZE_VIEWING_URL_GENERATOR_DEVICE",
                                        description: "Device type: iphone4s, iphone5s, iphone6, iphone6plus, ipadair, iphone6s, iphone6splus, ipadair2, nexus5, nexus7 or nexus9",
@@ -102,6 +110,16 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :os_version,
                                        env_name: "APPETIZE_VIEWING_URL_GENERATOR_OS_VERSION",
                                        description: "The operating system version on which to run your app, e.g. 10.3, 8.0",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :params,
+                                       env_name: "APPETIZE_VIEWING_URL_GENERATOR_PARAMS",
+                                       description: "Specifiy params value to be passed to Appetize",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :proxy,
+                                       env_name: "APPETIZE_VIEWING_URL_GENERATOR_PROXY",
+                                       description: "Specify a HTTP proxy to be passed to Appetize",
                                        is_string: true,
                                        optional: true)
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When interacting with device_grid it may be convenient to include additional parameters and options to the url that is being generated via action `appetize_viewing_url_generator`.

### Description

The following parameters / environment variables have been added to action `appetize_viewing_url_generator`
* `base_url` / `APPETIZE_VIEWING_URL_GENERATOR_BASE`
    * optional: 
    * default https://appetize.io/embed, useful alternative https://appetize.io/app
* `params` / `APPETIZE_VIEWING_URL_GENERATOR_PARAMS`
    * optional: a serialized JSON object to pass to launched application
* `proxy` / `APPETIZE_VIEWING_URL_GENERATOR_PROXY`
    * optional: an HTTP proxy server passed to Appetize, or 'Intercept' to enable Chrome network debugging
