### PR TITLE
Added option to get reviews for all localisations

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_ratings.rb
+++ b/spaceship/lib/spaceship/tunes/app_ratings.rb
@@ -44,7 +44,7 @@ module Spaceship
       end
 
       # @return (Array) of Review Objects
-      def reviews(store_front, versionId = '')
+      def reviews(store_front = '', versionId = '')
         raw_reviews = client.get_reviews(application.apple_id, application.platform, store_front, versionId)
         raw_reviews.map do |review|
           review["value"]["application"] = self.application

--- a/spaceship/lib/spaceship/tunes/app_ratings.rb
+++ b/spaceship/lib/spaceship/tunes/app_ratings.rb
@@ -98,8 +98,8 @@ module Spaceship
         'lastModified' => :last_modified,
         'helpfulViews' => :helpful_views,
         'totalViews' => :total_views,
-        'developerResponse' => :raw_developer_response,
-        'edited' => :edited
+        'edited' => :edited,
+        'developerResponse' => :raw_developer_response
       })
       class << self
         # Create a new object based on a hash.

--- a/spaceship/lib/spaceship/tunes/app_ratings.rb
+++ b/spaceship/lib/spaceship/tunes/app_ratings.rb
@@ -44,8 +44,8 @@ module Spaceship
       end
 
       # @return (Array) of Review Objects
-      def reviews(store_front = '', versionId = '')
-        raw_reviews = client.get_reviews(application.apple_id, application.platform, store_front, versionId)
+      def reviews(store_front = '', version_id = '')
+        raw_reviews = client.get_reviews(application.apple_id, application.platform, store_front, version_id)
         raw_reviews.map do |review|
           review["value"]["application"] = self.application
           AppReview.factory(review["value"])

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -258,22 +258,28 @@ module Spaceship
       parse_response(r, 'data')
     end
 
-    def get_ratings(app_id, platform, versionId = '', storefront = '')
-      # if storefront or versionId is empty api fails
+    def get_ratings(app_id, platform, version_id = '', storefront = '')
+      # if storefront or version_id is empty api fails
       rating_url = "ra/apps/#{app_id}/platforms/#{platform}/reviews/summary?"
       rating_url << "storefront=#{storefront}" unless storefront.empty?
-      rating_url << "versionId=#{versionId}" unless versionId.empty?
+      rating_url << "version_id=#{version_id}" unless version_id.empty?
 
       r = request(:get, rating_url)
       parse_response(r, 'data')
     end
 
-    def get_reviews(app_id, platform, storefront, versionId = '')
+    def get_reviews(app_id, platform, storefront, version_id)
       index = 0
       per_page = 100 # apple default
       all_reviews = []
       loop do
-        r = request(:get, "ra/apps/#{app_id}/platforms/#{platform}/reviews?storefront=#{storefront}&versionId=#{versionId}&index=#{index}")
+        rating_url = "ra/apps/#{app_id}/platforms/#{platform}/reviews?"
+        rating_url << "sort=REVIEW_SORT_ORDER_MOST_RECENT"
+        rating_url << "&index=#{index}"
+        rating_url << "&storefront=#{storefront}" unless storefront.empty?
+        rating_url << "&version_id=#{version_id}" unless version_id.empty?
+
+        r = request(:get, rating_url)
         all_reviews.concat(parse_response(r, 'data')['reviews'])
         if all_reviews.count < parse_response(r, 'data')['reviewCount']
           index += per_page

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -84,7 +84,7 @@ class TunesStubbing
       stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/platforms/ios/reviews/summary?storefront=US").
         to_return(status: 200, body: itc_read_fixture_file('ratings_US.json'), headers: { 'Content-Type' => 'application/json' })
 
-      stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/platforms/ios/reviews?index=0&storefront=US&versionId=").
+      stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/platforms/ios/reviews?index=0&sort=REVIEW_SORT_ORDER_MOST_RECENT&storefront=US").
         to_return(status: 200, body: itc_read_fixture_file('review_by_storefront.json'), headers: { 'Content-Type' => 'application/json' })
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This allows the user to not specify the store_front (they don't have do do 155 requests per app)
fixes issue #9824 

In order to test this issue I added the following code to the fastfile:
```
desc "Using this option you can run a user created script called test.rb which should be located in the same folder as the fastlane directory"
lane :testScript do |options|
  require "../../test.rb"
end
```
I then created a script called test.rb in the same place as the fastlane folder

Through that script I authenticated and then used
`Spaceship::Tunes::Application.find({insert_app_code_here}).app.ratings.reviews()`
to get the reviews. Note that the store_front parameter is no longer required.

### Description
All changes are explained in the individual commit notes