### PR TITLE
Remove `--login` from xcbuild-safe.sh as per suggestion

### DIFF
--- a/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
+++ b/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --login
+#!/bin/bash
 # shellcheck disable=SC2155
 # shellcheck disable=SC1090
 


### PR DESCRIPTION
I don't know enough about it, but here we go: https://github.com/fastlane/fastlane/issues/9804

Seems like more and more people run into this, in particular with Xcode 9 it seems to take a lot longer. How can we avoid a problem once the Xcode 9 upgrade is happening?