### PR TITLE
Fix potential endless loop on CI systems for iTC team selection

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -86,6 +86,12 @@ module Spaceship
           puts "#{i + 1}) \"#{team['contentProvider']['name']}\" (#{team['contentProvider']['contentProviderId']})"
         end
 
+        unless Spaceship::Client::UserInterface.interactive?
+          puts "Multiple teams found on iTunes Connect, Your Terminal is running in non-interactive mode! Cannot continue from here."
+          puts "Please check that you set FASTLANE_ITC_TEAM_ID or FASTLANE_ITC_TEAM_NAME to the right value."
+          raise "Multiple iTunes Connect Teams found; unable to choose, terminal not ineractive!"
+        end
+
         selected = ($stdin.gets || '').strip.to_i - 1
         team_to_use = teams[selected] if selected >= 0
 

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -55,4 +55,13 @@ describe Spaceship::TunesClient do
       end
     end
   end
+
+  describe "CI" do
+    it "crashes when running in non-interactive shell" do
+      expect(FastlaneCore::Helper).to receive(:ci?).and_return(true)
+      provider = { 'contentProvider' => { 'name' => 'Tom', 'contentProviderId' => 1234 } }
+      allow(subject).to receive(:teams).and_return([provider, provider]) # pass it twice, to call the team selection
+      expect { subject.select_team }.to raise_error "Multiple iTunes Connect Teams found; unable to choose, terminal not ineractive!"
+    end
+  end
 end


### PR DESCRIPTION
Related https://github.com/fastlane/fastlane/pull/8827
Fixes https://github.com/fastlane/fastlane/issues/8824