### PR TITLE
Looking for a member by email doesn't work if we only have AppleId

### DIFF
--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -104,7 +104,8 @@ module Pilot
     end
 
     def find_app_tester(email: nil, app: nil)
-      current_user = Spaceship::Members.find(Spaceship::Tunes.client.user)
+      current_user = find_current_user
+
       if current_user.admin?
         tester = Spaceship::Tunes::Tester::Internal.find(email)
         tester ||= Spaceship::Tunes::Tester::External.find(email)
@@ -126,8 +127,20 @@ module Pilot
       return tester
     end
 
+    def find_current_user
+      current_user_email = Spaceship::Tunes.client.user_email
+      current_user_apple_id = Spaceship::Tunes.client.user
+
+      current_user = Spaceship::Members.find(current_user_email)
+      unless current_user
+        UI.user_error!("Unable to find a member for AppleID: #{current_user_apple_id}, email: #{current_user_email}")
+        return nil
+      end
+      return current_user
+    end
+
     def create_tester(email: nil, first_name: nil, last_name: nil, app: nil)
-      current_user = Spaceship::Members.find(Spaceship::Tunes.client.user)
+      current_user = find_current_user
       if current_user.admin?
         tester = Spaceship::Tunes::Tester::External.create!(email: email,
                                                        first_name: first_name,

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -134,7 +134,6 @@ module Pilot
       current_user = Spaceship::Members.find(current_user_email)
       unless current_user
         UI.user_error!("Unable to find a member for AppleID: #{current_user_apple_id}, email: #{current_user_email}")
-        return nil
       end
       return current_user
     end

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -112,6 +112,7 @@ describe Pilot::TesterManager do
       allow(tester_manager).to receive(:login) # prevent attempting to log in with iTC
       allow(fake_client).to receive(:user).and_return(current_user)
       allow(fake_client).to receive(:testers).and_return(global_testers)
+      allow(fake_client).to receive(:user_email).and_return("taquitos@fastlane.tools")
     end
 
     describe "when invoked from a global context" do

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -23,6 +23,9 @@ module Spaceship
     # The user that is currently logged in
     attr_accessor :user
 
+    # The email of the user that is currently logged in
+    attr_accessor :user_email
+
     # The logger in which all requests are logged
     # /tmp/spaceship[time]_[pid].log by default
     attr_accessor :logger
@@ -479,7 +482,13 @@ module Spaceship
 
     # Get the `itctx` from the new (22nd May 2017) API endpoint "olympus"
     def fetch_olympus_session
-      request(:get, "https://olympus.itunes.apple.com/v1/session")
+      response = request(:get, "https://olympus.itunes.apple.com/v1/session")
+      if response.body
+        user_map = response.body["user"]
+        if user_map
+          self.user_email = user_map["emailAddress"]
+        end
+      end
     end
 
     def itc_service_key


### PR DESCRIPTION
There is a very good chance this fixes #9973 
We've been mostly using client.user string, which is a "username" (AppleID), but... usernames could be email or non-email. You can no longer create a username that isn't an email, but for a number of years, you could. 
This means, if you search for a member using the currently logged-in user, you'd be searching using an AppleID, so if you compare AppleID to email, it can fail. 
Now, we hold both the AppleID and the email address associated with it.
