### PR TITLE
Ignore Apple Watch screenshots (improved)

### DIFF
--- a/frameit/lib/frameit/runner.rb
+++ b/frameit/lib/frameit/runner.rb
@@ -25,7 +25,11 @@ module Frameit
           next if full_path.include? "_framed.png"
           next if full_path.include? ".itmsp/" # a package file, we don't want to modify that
           next if full_path.include? "device_frames/" # these are the device frames the user is using
-          next if full_path.downcase.include? "watch" # we don't care about watches right now
+          device = full_path.rpartition('/').last.partition('-').first # extract device name
+          if device.downcase.include? "watch"
+            UI.error("Apple Watch screenshots are not framed: '#{full_path}'")
+            next # we don't care about watches right now
+          end
 
           UI.message("Framing screenshot '#{full_path}'")
 


### PR DESCRIPTION
🔑

### Checklist
- [x ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x ] I've updated the documentation if necessary.

### Motivation and Context

`frameit` currently ignores any screenshot with the word 'watch' in the filename. It does so by looking for the word 'watch' in the full path of the filename. This caused me problems since I created a screenshot called 'PriceWatch' and it wouldn't be processed by `frameit`.

I successfully tested the code on my project and by running `bundle exec rspec frameit`

### Description

I solved this by extracting the device name from the full path of the screenshot. I then check if the device name contains the word 'watch'.