### PR TITLE
remove factory/unfolding usage

### DIFF
--- a/spaceship/lib/spaceship/portal/app.rb
+++ b/spaceship/lib/spaceship/portal/app.rb
@@ -71,18 +71,10 @@ module Spaceship
       )
 
       class << self
-        # Create a new object based on a hash.
-        # This is used to create a new object based on the server response.
-        def factory(attrs)
-          obj = self.new(attrs)
-          obj.unfold_associated_groups(attrs['associatedApplicationGroups'])
-          return obj
-        end
-
         # @param mac [Bool] Fetches Mac apps if true
         # @return (Array) Returns all apps available for this account
         def all(mac: false)
-          client.apps(mac: mac).map { |app| self.factory(app) }
+          client.apps(mac: mac).map { |app| self.new(app) }
         end
 
         # Creates a new App ID on the Apple Dev Portal
@@ -114,10 +106,12 @@ module Spaceship
         end
       end
 
-      def unfold_associated_groups(attrs)
-        return unless attrs
-        unfolded_associated_groups = attrs.map { |info| Spaceship::Portal::AppGroup.new(info) }
-        instance_variable_set(:@associated_groups, unfolded_associated_groups)
+      def associated_groups
+        return unless raw_data.key?('associatedApplicationGroups')
+
+        @associated_groups ||= raw_data['associatedApplicationGroups'].map do |info|
+          Spaceship::Portal::AppGroup.new(info)
+        end
       end
 
       # Delete this App ID. This action will most likely fail if the App ID is already in the store

--- a/spaceship/lib/spaceship/tunes/availability.rb
+++ b/spaceship/lib/spaceship/tunes/availability.rb
@@ -11,35 +11,24 @@ module Spaceship
         'theWorld' => :include_future_territories
       )
 
-      class << self
-        # Create a new object based on a hash.
-        # This is used to create a new object based on the server response.
-        def factory(attrs)
-          obj = self.new(attrs)
-          obj.unfold_territories(attrs['countries'])
-          return obj
-        end
-
-        # Create a new object based on a set of territories.
-        # @param territories (Array of String or Spaceship::Tunes::Territory objects): A list of the territories
-        # @param params (Hash): Optional parameters (include_future_territories (Bool, default: true) Are future territories included?)
-        def from_territories(territories = [], params = {})
-          obj = self.new
-          # Detect if the territories attribute is an array of Strings and convert to Territories
-          obj.territories =
-            if territories[0].kind_of?(String)
-              territories.map { |territory| Spaceship::Tunes::Territory.from_code(territory) }
-            else
-              territories
-            end
-          obj.include_future_territories = params.fetch(:include_future_territories, true)
-          return obj
-        end
+      # Create a new object based on a set of territories.
+      # @param territories (Array of String or Spaceship::Tunes::Territory objects): A list of the territories
+      # @param params (Hash): Optional parameters (include_future_territories (Bool, default: true) Are future territories included?)
+      def self.from_territories(territories = [], params = {})
+        obj = self.new
+        # Detect if the territories attribute is an array of Strings and convert to Territories
+        obj.territories =
+          if territories[0].kind_of?(String)
+            territories.map { |territory| Spaceship::Tunes::Territory.from_code(territory) }
+          else
+            territories
+          end
+        obj.include_future_territories = params.fetch(:include_future_territories, true)
+        return obj
       end
 
-      def unfold_territories(attrs)
-        unfolded_territories = attrs.map { |info| Territory.new(info) }
-        instance_variable_set(:@territories, unfolded_territories)
+      def territories
+        @territories ||= raw_data['countries'].map { |info| Territory.new(info) }
       end
     end
   end

--- a/spaceship/lib/spaceship/tunes/iap_subscription_pricing_tier.rb
+++ b/spaceship/lib/spaceship/tunes/iap_subscription_pricing_tier.rb
@@ -15,20 +15,8 @@ module Spaceship
         "tierName" => :tier_name
       )
 
-      class << self
-        # Create a new object based on a hash.
-        # This is used to create a new object based on the server response.
-        def factory(attrs)
-          obj = self.new(attrs)
-          obj.unfold_pricing_info(attrs["pricingInfo"])
-
-          return obj
-        end
-      end
-
-      def unfold_pricing_info(attrs)
-        unfolded_pricing_info = attrs.map { |info| IAPSubscriptionPricingInfo.new(info) }
-        instance_variable_set(:@pricing_info, unfolded_pricing_info)
+      def pricing_info
+        @pricing_info ||= raw_data['pricingInfo'].map { |info| IAPSubscriptionPricingInfo.new(info) }
       end
     end
 

--- a/spaceship/lib/spaceship/tunes/pricing_tier.rb
+++ b/spaceship/lib/spaceship/tunes/pricing_tier.rb
@@ -15,20 +15,8 @@ module Spaceship
         'tierName' => :tier_name
       )
 
-      class << self
-        # Create a new object based on a hash.
-        # This is used to create a new object based on the server response.
-        def factory(attrs)
-          obj = self.new(attrs)
-          obj.unfold_pricing_info(attrs['pricingInfo'])
-
-          return obj
-        end
-      end
-
-      def unfold_pricing_info(attrs)
-        unfolded_pricing_info = attrs.map { |info| PricingInfo.new(info) }
-        instance_variable_set(:@pricing_info, unfolded_pricing_info)
+      def pricing_info
+        @pricing_info ||= raw_data['pricingInfo'].map { |info| PricingInfo.new(info) }
       end
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Continuing off of the PRs #9971 and #8146 to remove the `factory` usage patterns. This PR removes usage that was non-trivial and required some code changes.

### Description
The `factory` method is a less than ideal place to put data manipulation logic. We can overload the getter for the attributes to return complex objects. This also allows us to remove calls to `instance_variable_set`. The refactored code uses the `||=` operator to have effectively the same behavior as setting an instance after initialization.


