### PR TITLE
Do not attempt to retrieve Xcode version on non-Mac platform

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -140,6 +140,7 @@ module FastlaneCore
 
     # @return The version of the currently used Xcode installation (e.g. "7.0")
     def self.xcode_version
+      return nil unless self.is_mac?
       return @xcode_version if @xcode_version
 
       begin


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary. (N/A)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Running any Fastlane command on a Linux host will print the following warning:

`No such file or directory - xcode-select`

This is confusing for end users. It doesn't fail the process.

<!--- If it fixes an open issue, please link to the issue here. -->
Related:
https://github.com/fastlane/fastlane/issues/9695
https://github.com/fastlane/fastlane/pull/9609

<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
To fix this, I added one line to immediately return `nil` in the method `xcode_version` when invoked on a non-Mac platform. This prevents Fastlane from attempting to run `xcode-select` to retrieve the Xcode path on a Linux host.
From what I understand,  [fastlane-runner](https://github.com/fastlane/fastlane/blob/master/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb#L51) will properly rescue the exception.
Alternatively this check could be removed entirely from the fastlane-runner itself on non-Mac platforms.
