### PR TITLE
Frameit/title below image

### DIFF
--- a/frameit/README.md
+++ b/frameit/README.md
@@ -141,7 +141,8 @@ Use it to define the general information:
     "background": "./background.jpg",
     "padding": 50,
     "show_complete_frame": false,
-    "stack_title" : false
+    "stack_title" : false,
+    "title_below_image": true
   },
 
   "data": [
@@ -175,6 +176,8 @@ Use it to define the general information:
 The `stack_title` value specifies whether `frameit` should display the keyword above the title when both keyword and title are defined.
 
 The `show_complete_frame` value specifies whether `frameit` should shrink the device and frame so that they show in full in the framed screenshot. If it is false, then they can hang over the bottom of the screenshot.
+
+The `title_below_image` value specifies whether `frameit` should place the title below the screenshot. If it is false, it will be placed above the screenshot.
 
 The `filter` value is a part of the screenshot named for which the given option should be used. If a screenshot is named `iPhone5_Brainstorming.png` the first entry in the `data` array will be used.
 

--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -83,10 +83,8 @@ module Frameit
             unless value.kind_of?(Integer) || value.split('x').length == 2 || (value.end_with?('%') && value.to_f > 0)
               UI.user_error!("padding must be type integer or pair of integers of format 'AxB' or a percentage of screen size")
             end
-          when 'show_complete_frame'
-            UI.user_error! "show_complete_frame must be a Boolean" unless [true, false].include?(value)
-          when 'title_below_image'
-            UI.user_error! "title_below_image must be a Boolean" unless [true, false].include?(value)
+          when 'show_complete_frame', 'title_below_image'
+            UI.user_error! "'#{key}' must be a Boolean" unless [true, false].include?(value)
           when 'font_scale_factor'
             UI.user_error!("font_scale_factor must be numeric") unless value.kind_of?(Numeric)
           end

--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -85,6 +85,8 @@ module Frameit
             end
           when 'show_complete_frame'
             UI.user_error! "show_complete_frame must be a Boolean" unless [true, false].include?(value)
+          when 'title_below_image'
+            UI.user_error! "title_below_image must be a Boolean" unless [true, false].include?(value)
           when 'font_scale_factor'
             UI.user_error!("font_scale_factor must be numeric") unless value.kind_of?(Numeric)
           end

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -3,7 +3,7 @@ module Frameit
     attr_accessor :screenshot # reference to the screenshot object to fetch the path, title, etc.
     attr_accessor :frame # the frame of the device
     attr_accessor :image # the current image used for editing
-    attr_accessor :top_space_above_device
+    attr_accessor :space_to_device
 
     def frame!(screenshot)
       self.screenshot = screenshot
@@ -104,7 +104,7 @@ module Frameit
     def complex_framing
       background = generate_background
 
-      self.top_space_above_device = vertical_frame_padding
+      self.space_to_device = vertical_frame_padding
 
       if fetch_config['title']
         background = put_title_into_background(background, fetch_config['stack_title'])
@@ -116,7 +116,7 @@ module Frameit
 
         # Decrease the size of the framed screenshot to fit into the defined padding + background
         frame_width = background.width - horizontal_frame_padding * 2
-        frame_height = background.height - top_space_above_device - vertical_frame_padding
+        frame_height = background.height - space_to_device - vertical_frame_padding
 
         if fetch_config['show_complete_frame']
           # calculate the final size of the screenshot to resize in one go
@@ -177,10 +177,17 @@ module Frameit
 
     def put_device_into_background(background)
       left_space = (background.width / 2.0 - image.width / 2.0).round
+      title_below_image = fetch_config['title_below_image']
 
       @image = background.composite(image, "png") do |c|
         c.compose "Over"
-        c.geometry "+#{left_space}+#{top_space_above_device}"
+        if title_below_image
+          show_complete_frame = fetch_config['show_complete_frame']
+          c.geometry "+#{left_space}+#{background.height - image.height - space_to_device}" unless show_complete_frame
+          c.geometry "+#{left_space}" if show_complete_frame
+        else
+          c.geometry "+#{left_space}+#{space_to_device}"
+        end
       end
 
       return image
@@ -205,8 +212,8 @@ module Frameit
         text.resize "#{(smaller * text.width).round}x"
       end
     end
-    # Add the title above the device
 
+    # Add the title above or below the device
     def put_title_into_background_stacked(background, title, keyword)
       resize_text(title)
       resize_text(keyword)
@@ -222,16 +229,20 @@ module Frameit
       title_left_space = (background.width / 2.0 - title_width / 2.0).round
       keyword_left_space = (background.width / 2.0 - keyword_width / 2.0).round
 
-      self.top_space_above_device += title.height + keyword.height + spacing_between_title_and_keyword + vertical_padding
+      self.space_to_device += title.height + keyword.height + spacing_between_title_and_keyword + vertical_padding
+      title_below_image = fetch_config['title_below_image']
       # keyword
       background = background.composite(keyword, "png") do |c|
         c.compose "Over"
-        c.geometry "+#{keyword_left_space}+#{keyword_top_space}"
+        c.geometry "+#{keyword_left_space}+#{keyword_top_space}" unless title_below_image
+        c.geometry "+#{keyword_left_space}+#{background.height - space_to_device + keyword_top_space}" if title_below_image
       end
       # Then, put the title on top of the screenshot next to the keyword
+      # Then, put the title above/below of the screenshot next to the keyword
       background = background.composite(title, "png") do |c|
         c.compose "Over"
-        c.geometry "+#{title_left_space}+#{title_top_space}"
+        c.geometry "+#{title_left_space}+#{title_top_space}" unless title_below_image
+        c.geometry "+#{title_left_space}+#{background.height - space_to_device + title_top_space}" if title_below_image
       end
       background
     end
@@ -268,14 +279,16 @@ module Frameit
       vertical_padding = vertical_frame_padding
       top_space = vertical_padding + (actual_font_size - title.height) / 2
       left_space = (background.width / 2.0 - sum_width / 2.0).round
+      title_below_image = fetch_config['title_below_image']
 
-      self.top_space_above_device += actual_font_size + vertical_padding
+      self.space_to_device += actual_font_size + vertical_padding
 
       # First, put the keyword on top of the screenshot, if we have one
       if keyword
         background = background.composite(keyword, "png") do |c|
           c.compose "Over"
-          c.geometry "+#{left_space}+#{top_space}"
+          c.geometry "+#{left_space}+#{top_space}" unless title_below_image
+          c.geometry "+#{left_space}+#{background.height - space_to_device + top_space}" if title_below_image
         end
 
         left_space += keyword.width + (keyword_padding * smaller)
@@ -284,7 +297,8 @@ module Frameit
       # Then, put the title on top of the screenshot next to the keyword
       background = background.composite(title, "png") do |c|
         c.compose "Over"
-        c.geometry "+#{left_space}+#{top_space}"
+        c.geometry "+#{left_space}+#{top_space}" unless title_below_image
+        c.geometry "+#{left_space}+#{background.height - space_to_device + top_space}" if title_below_image
       end
       background
     end

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -184,7 +184,7 @@ module Frameit
         if title_below_image
           show_complete_frame = fetch_config['show_complete_frame']
           c.geometry "+#{left_space}+#{background.height - image.height - space_to_device}" unless show_complete_frame
-          c.geometry "+#{left_space}" if show_complete_frame
+          c.geometry "+#{left_space}+#{vertical_frame_padding}" if show_complete_frame
         else
           c.geometry "+#{left_space}+#{space_to_device}"
         end


### PR DESCRIPTION
🔑

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

`frameit` places the title above the screenshot. I thought it might be useful to be able to place it below the screenshot when desired.

I successfully tested the code on my project and by running `bundle exec rspec`.

### Description

Support for the new parameter `title_below_image` has been added. It can be used in `Framefile.json`.