### PR TITLE
Add chomp in the deliver metadata upload

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -277,7 +277,7 @@ module Deliver
       UI.user_error!("`app_review_information` must be a hash", show_github_issues: true) unless info.kind_of?(Hash)
 
       REVIEW_INFORMATION_VALUES.each do |key, option_name|
-        v.send("#{key}=", info[option_name]) if info[option_name]
+        v.send("#{key}=", info[option_name].to_s.chomp) if info[option_name]
       end
       v.review_user_needed = (v.review_demo_user.to_s.chomp + v.review_demo_password.to_s.chomp).length > 0
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

I found a problem that when `fastlane deliver download_metadata` and `fastlane deliver run` are repeated, a newline (`\n`) added many times to `review_information/*.txt`.

Why the problem occurred:
1. `deliver download_metadata` will save the downloaded each values with end of new line.
2. `deliver run` will upload to iTC values that read from the file and `strip` or `chomp`.
3. But, deliver does not contains `chomp` value for the review information process.

### Description
<!--- Describe your changes in detail -->
Added the `chomp` in the metadata upload process.