### PR TITLE
Fix #10027. Filter match/sigh returned profiles based on the platform ios/tvos

### DIFF
--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -61,7 +61,9 @@ module Sigh
     # Fetches a profile matching the user's search requirements
     def fetch_profiles
       UI.message "Fetching profiles..."
-      results = profile_type.find_by_bundle_id(Sigh.config[:app_identifier], mac: Sigh.config[:platform].to_s == 'macos')
+      results = profile_type.find_by_bundle_id(bundle_id: Sigh.config[:app_identifier],
+                                                     mac: Sigh.config[:platform].to_s == 'macos',
+                                            sub_platform: Sigh.config[:platform].to_s == 'tvos' ? 'tvOS' : nil)
       results = results.find_all do |current_profile|
         if current_profile.valid? || Sigh.config[:force]
           true

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -319,8 +319,9 @@ module Spaceship
         def find_by_bundle_id(bundle_id: nil, mac: false, sub_platform: nil)
           raise "Missing required parameter 'bundle_id'" if bundle_id.to_s.empty?
           raise "Invalid sub_platform #{sub_platform}, valid values are tvOS" if !sub_platform.nil? and sub_platform != 'tvOS'
+          find_tvos_profiles = sub_platform == 'tvOS'
           all(mac: mac).find_all do |profile|
-            profile.app.bundle_id == bundle_id && profile.tvos? == !sub_platform.nil?
+            profile.app.bundle_id == bundle_id && profile.tvos? == find_tvos_profiles
           end
         end
       end

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -316,9 +316,12 @@ module Spaceship
         #   profiles matching the bundle identifier
         #   Returns [] if no profiles were found
         #   This may also contain invalid or expired profiles
-        def find_by_bundle_id(bundle_id, mac: false)
-          all(mac: mac).find_all do |profile|
-            profile.app.bundle_id == bundle_id
+        def find_by_bundle_id(bundle_id: nil, mac: false, sub_platform: nil)
+          raise "Missing required parameter 'bundle_id'" if bundle_id.to_s.empty?
+          raise "Invalid sub_platform #{sub_platform}, valid values are tvOS" if !sub_platform.nil? and sub_platform != 'tvOS'
+          profiles = all(mac: mac)
+          profiles.find_all do |profile|
+            profile.app.bundle_id == bundle_id && profile.tvos? == !sub_platform.nil?
           end
         end
       end

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -319,8 +319,7 @@ module Spaceship
         def find_by_bundle_id(bundle_id: nil, mac: false, sub_platform: nil)
           raise "Missing required parameter 'bundle_id'" if bundle_id.to_s.empty?
           raise "Invalid sub_platform #{sub_platform}, valid values are tvOS" if !sub_platform.nil? and sub_platform != 'tvOS'
-          profiles = all(mac: mac)
-          profiles.find_all do |profile|
+          all(mac: mac).find_all do |profile|
             profile.app.bundle_id == bundle_id && profile.tvos? == !sub_platform.nil?
           end
         end

--- a/spaceship/spec/provisioning_profile_spec.rb
+++ b/spaceship/spec/provisioning_profile_spec.rb
@@ -66,7 +66,7 @@ describe Spaceship::ProvisioningProfile do
       expect(client).to receive(:provisioning_profiles_via_xcode_api).and_call_original
       expect(client).not_to receive(:provisioning_profiles)
       expect(client).not_to receive(:provisioning_profile_details)
-      Spaceship::ProvisioningProfile.find_by_bundle_id('some-fake-id')
+      Spaceship::ProvisioningProfile.find_by_bundle_id(bundle_id: 'some-fake-id')
     end
 
     it 'should use the developer portal api to get provisioning profiles and their appIds' do
@@ -74,19 +74,27 @@ describe Spaceship::ProvisioningProfile do
       expect(client).not_to receive(:provisioning_profiles_via_xcode_api)
       expect(client).to receive(:provisioning_profiles).and_call_original
       expect(client).to receive(:provisioning_profile_details).and_call_original.exactly(6).times
-      Spaceship::ProvisioningProfile.find_by_bundle_id('some-fake-id')
+      Spaceship::ProvisioningProfile.find_by_bundle_id(bundle_id: 'some-fake-id')
     end
   end
 
   describe '#find_by_bundle_id' do
     it "returns [] if there are no profiles" do
-      profiles = Spaceship::ProvisioningProfile.find_by_bundle_id("notExistent")
+      profiles = Spaceship::ProvisioningProfile.find_by_bundle_id(bundle_id: "notExistent")
       expect(profiles).to eq([])
     end
 
-    it "returns the profile in an array if matching" do
-      profiles = Spaceship::ProvisioningProfile.find_by_bundle_id("net.sunapps.1")
-      expect(profiles.count).to eq(6)
+    it "returns the profile in an array if matching for ios" do
+      profiles = Spaceship::ProvisioningProfile.find_by_bundle_id(bundle_id: "net.sunapps.1")
+      expect(profiles.count).to eq(5)
+
+      expect(profiles.first.app.bundle_id).to eq('net.sunapps.1')
+      expect(profiles.first.distribution_method).to eq('store')
+    end
+
+    it "returns the profile in an array if matching for tvos" do
+      profiles = Spaceship::ProvisioningProfile.find_by_bundle_id(bundle_id: "net.sunapps.1", sub_platform: 'tvOS')
+      expect(profiles.count).to eq(1)
 
       expect(profiles.first.app.bundle_id).to eq('net.sunapps.1')
       expect(profiles.first.distribution_method).to eq('store')


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.


### Motivation and Context
See https://github.com/fastlane/fastlane/issues/10027

### Description
• Pass the `sub_platform` param to find_by_bundle_id in `spaceship`
• Based on this filter the result (remove iOS for tvos but also remove tvOS if no subplatform passed)
• Call this updated method from `sigh`

Try to be consistent with https://github.com/nicolasbraun/fastlane/blob/a5b8edb8f9ecff854ac1258a1a3fee8c36917f3a/spaceship/lib/spaceship/portal/provisioning_profile.rb#L213