### PR TITLE
Fix dup crash on nil for gym

### DIFF
--- a/fastlane/lib/fastlane/actions/gym.rb
+++ b/fastlane/lib/fastlane/actions/gym.rb
@@ -22,8 +22,8 @@ module Fastlane
           # If that's the case, we won't set the provisioning profiles
           # see https://github.com/fastlane/fastlane/issues/9490
           if values[:export_options].kind_of?(Hash)
-            match_mapping = Actions.lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING].dup
-            existing_mapping = values[:export_options][:provisioningProfiles].dup
+            match_mapping = (Actions.lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING] || {}).dup
+            existing_mapping = (values[:export_options][:provisioningProfiles] || {}).dup
 
             # Be smart about how we merge those mappings in case there are conflicts
             mapping_object = Gym::CodeSigningMapping.new


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/10028

Works fine on my machine,  I assume the behavior changed with one the recent Ruby updates