### PR TITLE
ensure_xcode_version: clarify description

### DIFF
--- a/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
+++ b/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
@@ -30,7 +30,7 @@ module Fastlane
 
       def self.details
         "If building your app requires a specific version of Xcode, you can invoke this command before using gym.\n
-        For example, to ensure that a beta version is not accidentally selected to build, which would make uploading to TestFlight fail."
+        For example, to ensure that a beta version of Xcode is not accidentally selected to build, which would make uploading to TestFlight fail."
       end
 
       def self.available_options


### PR DESCRIPTION
### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When skimming the description you could get the impression it was talking about a beta version of the app for Testflight which gives a wrong picture what the action actually does.

### Description
Description now contains "of Xcode" to make sure it is clear about what version it is talking about.
