### PR TITLE
remove platform android from action `pilot`/`testflight`

### DIFF
--- a/fastlane/lib/fastlane/actions/pilot.rb
+++ b/fastlane/lib/fastlane/actions/pilot.rb
@@ -58,7 +58,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        true
+        [:ios, :mac].include?(platform)
       end
     end
   end


### PR DESCRIPTION
### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Action `pilot`/`testflight` doesn't actually support Android. But the actions docs on `testflight`/`pilot` are listed as supporting Android: https://docs.fastlane.tools/actions/#pilot


### Description
Source of docs here: https://github.com/fastlane/docs/blob/master/docs/actions.md#testflight
Looking at the history of that file it seems to be generated. 
Source seems to be the file I edited and changed the code so it doesn't report Android any more.
