### PR TITLE
change action `tryouts` to "beta" category

### DIFF
--- a/fastlane/lib/fastlane/actions/tryouts.rb
+++ b/fastlane/lib/fastlane/actions/tryouts.rb
@@ -127,7 +127,7 @@ module Fastlane
       end
 
       def self.category
-        :misc
+        :beta
       end
 
       def self.output


### PR DESCRIPTION
### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
While reading through the available default actions I noticed this `tryouts` action in the "misc" category. As Tryouts.io is a (beta) distribution service, this is not really correct.

### Description
I changed the category from "misc" to "beta".
