### PR TITLE
[spaceship] Fix reporting successful submission even it fails due to problems with Ad ID information

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -884,7 +884,13 @@ module Spaceship
 
       handle_itc_response(r.body)
 
-      if r.body.fetch('messages').fetch('info').last == "Successful POST"
+      # iTunes Connect still returns a success status code even the submission
+      # was failed because of Ad ID info.  This checks for any section error
+      # keys in returned adIdInfo and prints them out.
+      ad_id_error_keys = r.body.fetch('data').fetch('adIdInfo').fetch('sectionErrorKeys')
+      if ad_id_error_keys.any?
+        raise "Something wrong with your Ad ID information: #{ad_id_error_keys}."
+      elsif r.body.fetch('messages').fetch('info').last == "Successful POST"
         # success
       else
         raise "Something went wrong when submitting the app for review. Make sure to pass valid options to submit your app for review"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->

iTunes Connect still returns a success status code even the submission
was failed because of Ad ID info.  This checks for any section error
keys in returned adIdInfo.

This resolves #8260, where `deliver` says it successfully submitted
application for review when it really didn't. It should return an error
with appropriate info.