### PR TITLE
WIP / DISCUSSION Cocoapods action with the ability to run pod update

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -41,7 +41,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :update,
                                        env_name: "FL_COCOAPODS_UPDATE",
-                                       description: "Runs pod update instead of pod install, no-clean, no-integratio and repo-update command is not working in the update state",
+                                       description: "Runs pod update instead of pod install. Commands no-clean, no-integrate and repo-update are not working when update is used.",
                                        is_string: false,
                                        default_value: false)
           FastlaneCore::ConfigItem.new(key: :clean,

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -15,11 +15,17 @@ module Fastlane
         end
 
         cmd << ['bundle exec'] if params[:use_bundle_exec] && shell_out_should_use_bundle_exec?
-        cmd << ['pod install']
 
-        cmd << '--no-clean' unless params[:clean]
-        cmd << '--no-integrate' unless params[:integrate]
-        cmd << '--repo-update' if params[:repo_update]
+        if params[:update]
+          cmd << ['pod update']
+        else 
+          cmd << ['pod install']
+
+          cmd << '--no-clean' unless params[:clean]
+          cmd << '--no-integrate' unless params[:integrate]
+          cmd << '--repo-update' if params[:repo_update]
+        end
+
         cmd << '--silent' if params[:silent]
         cmd << '--verbose' if params[:verbose]
         cmd << '--no-ansi' unless params[:ansi]
@@ -33,6 +39,11 @@ module Fastlane
 
       def self.available_options
         [
+          FastlaneCore::ConfigItem.new(key: :update,
+                                       env_name: "FL_COCOAPODS_UPDATE",
+                                       description: "Runs pod update instead of pod install, no-clean, no-integratio and repo-update command is not working in the update state",
+                                       is_string: false,
+                                       default_value: false)
           FastlaneCore::ConfigItem.new(key: :clean,
                                        env_name: "FL_COCOAPODS_CLEAN",
                                        description: "Remove SCM directories",
@@ -92,7 +103,7 @@ module Fastlane
       end
 
       def self.authors
-        ["KrauseFx", "tadpol", "birmacher", "Liquidsoul"]
+        ["KrauseFx", "tadpol", "birmacher", "Liquidsoul", "mRs-"]
       end
 
       def self.details


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
Sometimes it's crucial in my setup to run cocoapods update instead of cocoapods install to get the newest dependencies in my project. I made it possible to run the cocoapods command with the parameter update to run `pod update` instead of `pod install`.

### Discussion
I was not really sure about if this should be a new action or I can implement this directly in the current cocoapods action. If you have any feedback for me where to place this, I would be very happy.