### PR TITLE
Improve wording of Gemfile information

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -112,7 +112,7 @@ module Fastlane
           UI.message ""
           UI.important "After creating the Gemfile and Gemfile.lock, commit those files into version control"
         end
-        UI.important "For more information, check out https://docs.fastlane.tools/getting-started/ios/setup/#use-a-gemfile"
+        UI.important "Get started using a Gemfile for fastlane https://docs.fastlane.tools/getting-started/ios/setup/#use-a-gemfile"
 
         sleep 2 # napping is life, otherwise the user might not see this message
       end


### PR DESCRIPTION
Without this change, if there is no Gemfile, but startup is fast, the message misses the context of what this message is about