### PR TITLE
Update Google API Client version requirement

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
   spec.add_dependency 'fastimage', '>= 2.1.0', '< 3.0.0' # fetch the image sizes from the screenshots
   spec.add_dependency 'gh_inspector', '>= 1.0.1', '< 2.0.0' # search for issues on GitHub when something goes wrong
-  spec.add_dependency 'google-api-client', '>= 0.12.0', '< 0.13.0' # Google API Client to access Play Publishing API
+  spec.add_dependency 'google-api-client', '>= 0.12.0', '< 1.0.0' # Google API Client to access Play Publishing API
   spec.add_dependency 'highline', '>= 1.7.2', '< 2.0.0' # user inputs (e.g. passwords)
   spec.add_dependency 'json', '< 3.0.0' # Because sometimes it's just not installed
   spec.add_dependency 'mini_magick', '~> 4.5.1' # To open, edit and export PSD files


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

Since release [2.39.0](https://github.com/fastlane/fastlane/releases/tag/2.39.0) fastlane is requiring [`google-api-client`](https://rubygems.org/gems/google-api-client) version to be `0.12.x` (https://github.com/fastlane/fastlane/pull/9445). Locking it to version `0.12.x` may block other gems from being used, e.g.: [`google-cloud-storage`](https://rubygems.org/gems/google-cloud-storage) requires version `0.13.x`.

### Description
<!--- Describe your changes in detail -->

I kept the requirement for `google-api-client` version 0.12.0 or higher, updating only the maximum version to be lower than `1.0.0`, following the same standard as other dependencies.