### PR TITLE
Fix typos in the credentials_manager

### DIFF
--- a/credentials_manager/lib/credentials_manager/account_manager.rb
+++ b/credentials_manager/lib/credentials_manager/account_manager.rb
@@ -5,7 +5,7 @@ module CredentialsManager
   class AccountManager
     DEFAULT_PREFIX = "deliver"
     # @param prefix [String] Very optional, is used for the
-    #   iTunes Transporter which uses application specofic passwords
+    #   iTunes Transporter which uses application specific passwords
     # @param note [String] An optional note that will be shown next
     #   to the password and username prompt
     def initialize(user: nil, password: nil, prefix: nil, note: nil)
@@ -16,7 +16,7 @@ module CredentialsManager
       @note = note
     end
 
-    # Is the that default prefix "deliver"
+    # Is the default prefix "deliver"
     def default_prefix?
       @prefix == DEFAULT_PREFIX
     end
@@ -50,7 +50,7 @@ module CredentialsManager
     end
 
     # Call this method to ask the user to re-enter the credentials
-    # @param force: if false the user is asked before it gets deleted
+    # @param force: if false, the user is asked before it gets deleted
     # @return: Did the user decide to remove the old entry and enter a new password?
     def invalid_credentials(force: false)
       puts "The login credentials for '#{user}' seem to be wrong".red
@@ -117,7 +117,7 @@ module CredentialsManager
         prompt_text += " (#{@note})" if @note
         prompt_text += ": "
         @user = ask(prompt_text) while @user.to_s.length == 0
-        # we return here, as only the username was asked for now, we'll get called for the pw again anyway
+        # Returning here since only the username was asked for. This method will be called again when a password is needed.
         return
       end
 


### PR DESCRIPTION

Fixes some typos in comments in the credentials_manager code.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Documentation had some typos. It makes the code more beautiful to not have typos. There is no issue associated with this. I tested it by reading it out loud.

### Description

Fixed typos.