### PR TITLE
Add retry logic for new exception: ITunesConnectPotentialServerError

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -10,6 +10,10 @@ module Spaceship
     class ITunesConnectTemporaryError < ITunesConnectError
     end
 
+    # raised if the server failed to save, and it might be caused by an invisible server error
+    class ITunesConnectPotentialServerError < ITunesConnectError
+    end
+
     attr_reader :du_client
 
     def initialize
@@ -108,7 +112,9 @@ module Spaceship
     end
 
     # rubocop:disable Metrics/PerceivedComplexity
-    def handle_itc_response(raw)
+    # If the response is coming from a flaky api, set flaky_api_call to true so we retry a little.
+    # Patience is a virtue.
+    def handle_itc_response(raw, flaky_api_call: false)
       return unless raw
       return unless raw.kind_of? Hash
 
@@ -164,6 +170,8 @@ module Spaceship
           raise ITunesConnectTemporaryError.new, errors.first
         elsif errors.count == 1 and errors.first.include?("Forbidden")
           raise_insuffient_permission_error!
+        elsif flaky_api_call
+          raise ITunesConnectPotentialServerError.new, errors.join(' ')
         else
           raise ITunesConnectError.new, errors.join(' ')
         end
@@ -343,7 +351,7 @@ module Spaceship
           req.headers['Content-Type'] = 'application/json'
         end
 
-        handle_itc_response(r.body)
+        handle_itc_response(r.body, flaky_api_call: true)
       end
     end
 
@@ -1315,7 +1323,7 @@ module Spaceship
 
     private
 
-    def with_tunes_retry(tries = 5, &_block)
+    def with_tunes_retry(tries = 5, potential_server_error_tries = 3, &_block)
       return yield
     rescue Spaceship::TunesClient::ITunesConnectTemporaryError => ex
       unless (tries -= 1).zero?
@@ -1326,6 +1334,15 @@ module Spaceship
         retry
       end
       raise ex # re-raise the exception
+    rescue Spaceship::TunesClient::ITunesConnectPotentialServerError => ex
+      unless (potential_server_error_tries -= 1).zero?
+        msg = "Potential server error received: '#{ex.message}'. Retrying after 10 seconds (remaining: #{tries})..."
+        puts msg
+        logger.warn msg
+        sleep 10 unless defined? SpecHelper # unless FastlaneCore::Helper.is_test?
+        retry
+      end
+      raise ex
     end
 
     def clear_user_cached_data


### PR DESCRIPTION
Sometimes you get a bad response from whatever API you're calling and it's not your fault. If you use `handle_itc_response` from `TunesClient` you can now pass `flaky_api_call: true` and it will auto-retry 3 times, with 10 second waits in-between. 

This motivation came after reading #9859, I thought "gee whiz, this sure looks like flaky API if all you have to do is retry your upload script" So, let's do it 😜

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
(https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
