### PR TITLE
MOSTLY fixes gym auto selects provisioning profile mapping wrong in an Xcode project with multiple configs

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = Dir["*/lib"]
 
   spec.add_dependency 'slack-notifier', '>= 1.3', '< 2.0.0' # Slack notifications
-  spec.add_dependency 'xcodeproj', '>= 1.4.4', '< 2.0.0' # Needed for commit_version_bump action
+  spec.add_dependency 'xcodeproj', '>= 1.5.0', '< 2.0.0' # Needed for commit_version_bump action
   spec.add_dependency 'xcpretty', '>= 0.2.4', '< 1.0.0' # prettify xcodebuild output
   spec.add_dependency 'terminal-notifier', '>= 1.6.2', '< 2.0.0' # macOS notifications
   spec.add_dependency 'terminal-table', '>= 1.4.5', '< 2.0.0' # Actions documentation

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -107,11 +107,11 @@ module Gym
       self.project_paths.each do |project_path|
         UI.verbose("Parsing project file '#{project_path}' to find selected provisioning profiles")
 
-        # Storing bundle identifiers with duplicate profiles
-        # for informing user later on
-        bundle_identifiers_with_duplicates = []
-
         begin
+          # Storing bundle identifiers with duplicate profiles
+          # for informing user later on
+          bundle_identifiers_with_duplicates = []
+
           project = Xcodeproj::Project.open(project_path)
           project.targets.each do |target|
             target.build_configuration_list.build_configurations.each do |build_configuration|
@@ -121,15 +121,15 @@ module Gym
               bundle_identifier = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER")
               provisioning_profile_specifier = build_configuration.resolve_build_setting("PROVISIONING_PROFILE_SPECIFIER")
               provisioning_profile_uuid = build_configuration.resolve_build_setting("PROVISIONING_PROFILE")
-              
+
               has_profile_specifier = provisioning_profile_specifier.to_s.length > 0
               has_profile_uuid = provisioning_profile_uuid.to_s.length > 0
-              
+
               # Stores bundle identifiers that have already been mapped to inform user
               if provisioning_profile_mapping[bundle_identifier] && (has_profile_specifier || has_profile_uuid)
                 bundle_identifiers_with_duplicates << bundle_identifier
               end
-              
+
               # Creates the mapping for a bundle identifier and profile specifier/uuid
               if has_profile_specifier
                 provisioning_profile_mapping[bundle_identifier] = provisioning_profile_specifier
@@ -137,10 +137,9 @@ module Gym
                 provisioning_profile_mapping[bundle_identifier] = provisioning_profile_uuid
               end
             end
-          end
-          
-          # Alerting user to explicitly specify a mapping it cannot be determined
-          unless bundle_identifiers_with_duplicates.empty?
+
+            # Alerting user to explicitly specify a mapping it cannot be determined
+            next if bundle_identifiers_with_duplicates.empty?
             UI.error("Couldn't automatically detect the provisioning profile mapping")
             UI.error("There were multiple profiles for bundle identifier(s): #{bundle_identifiers_with_duplicates.uniq.join(', ')}")
             UI.error("You need to provide an explicit mapping of what provisioning")

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -107,6 +107,10 @@ module Gym
       self.project_paths.each do |project_path|
         UI.verbose("Parsing project file '#{project_path}' to find selected provisioning profiles")
 
+        # Storing bundle identifiers with duplicate profiles
+        # for informing user later on
+        bundle_identifiers_with_duplicates = []
+
         begin
           project = Xcodeproj::Project.open(project_path)
           project.targets.each do |target|
@@ -117,12 +121,30 @@ module Gym
               bundle_identifier = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER")
               provisioning_profile_specifier = build_configuration.resolve_build_setting("PROVISIONING_PROFILE_SPECIFIER")
               provisioning_profile_uuid = build_configuration.resolve_build_setting("PROVISIONING_PROFILE")
-              if provisioning_profile_specifier.to_s.length > 0
+              
+              has_profile_specifier = provisioning_profile_specifier.to_s.length > 0
+              has_profile_uuid = provisioning_profile_uuid.to_s.length > 0
+              
+              # Stores bundle identifiers that have already been mapped to inform user
+              if provisioning_profile_mapping[bundle_identifier] && (has_profile_specifier || has_profile_uuid)
+                bundle_identifiers_with_duplicates << bundle_identifier
+              end
+              
+              # Creates the mapping for a bundle identifier and profile specifier/uuid
+              if has_profile_specifier
                 provisioning_profile_mapping[bundle_identifier] = provisioning_profile_specifier
-              elsif provisioning_profile_uuid.to_s.length > 0
+              elsif has_profile_uuid
                 provisioning_profile_mapping[bundle_identifier] = provisioning_profile_uuid
               end
             end
+          end
+          
+          # Alerting user to explicitly specify a mapping it cannot be determined
+          unless bundle_identifiers_with_duplicates.empty?
+            UI.error("Couldn't automatically detect the provisioning profile mapping")
+            UI.error("There were multiple profiles for bundle identifier(s): #{bundle_identifiers_with_duplicates.uniq.join(', ')}")
+            UI.error("You need to provide an explicit mapping of what provisioning")
+            UI.error("profile to use for each bundle identifier of your app")
           end
         rescue => ex
           # We catch errors here, as we might run into an exception on one included project

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -102,10 +102,12 @@ module Gym
     end
 
     def detect_project_profile_mapping
-      provisioning_profile_mapping = {}
+      provisioning_profile_mapping = {}  
+      specified_configuration = Gym.config[:configuration] || Gym.project.default_build_settings(key: "CONFIGURATION")
 
       self.project_paths.each do |project_path|
         UI.verbose("Parsing project file '#{project_path}' to find selected provisioning profiles")
+        UI.verbose("Finding provision profiles for '#{specified_configuration}'") if specified_configuration
 
         begin
           # Storing bundle identifiers with duplicate profiles
@@ -117,6 +119,7 @@ module Gym
             target.build_configuration_list.build_configurations.each do |build_configuration|
               current = build_configuration.build_settings
               next if test_target?(current)
+              next unless specified_configuration == build_configuration.name
 
               bundle_identifier = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER")
               provisioning_profile_specifier = build_configuration.resolve_build_setting("PROVISIONING_PROFILE_SPECIFIER")

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -102,7 +102,7 @@ module Gym
     end
 
     def detect_project_profile_mapping
-      provisioning_profile_mapping = {}  
+      provisioning_profile_mapping = {}
       specified_configuration = Gym.config[:configuration] || Gym.project.default_build_settings(key: "CONFIGURATION")
 
       self.project_paths.each do |project_path|

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -114,9 +114,9 @@ module Gym
               current = build_configuration.build_settings
               next if test_target?(current)
 
-              bundle_identifier = current["PRODUCT_BUNDLE_IDENTIFIER"]
-              provisioning_profile_specifier = current["PROVISIONING_PROFILE_SPECIFIER"]
-              provisioning_profile_uuid = current["PROVISIONING_PROFILE"]
+              bundle_identifier = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER")
+              provisioning_profile_specifier = build_configuration.resolve_build_setting("PROVISIONING_PROFILE_SPECIFIER")
+              provisioning_profile_uuid = build_configuration.resolve_build_setting("PROVISIONING_PROFILE")
               if provisioning_profile_specifier.to_s.length > 0
                 provisioning_profile_mapping[bundle_identifier] = provisioning_profile_specifier
               elsif provisioning_profile_uuid.to_s.length > 0

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -141,7 +141,7 @@ module Gym
               end
             end
 
-            # Alerting user to explicitly specify a mapping it cannot be determined
+            # Alerting user to explicitly specify a mapping if cannot be determined
             next if bundle_identifiers_with_duplicates.empty?
             UI.error("Couldn't automatically detect the provisioning profile mapping")
             UI.error("There were multiple profiles for bundle identifier(s): #{bundle_identifiers_with_duplicates.uniq.join(', ')}")

--- a/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/project.pbxproj
+++ b/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/project.pbxproj
@@ -36,8 +36,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		7F17E2E4DB202336112485AA /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
-		ACCA4067A20AE82A13A55B4D /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
 		BDC4BE00FA30F698E5A28354 /* libPods-Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAC1E1981B6A326100A8B23A /* ExampleProductName.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleProductName.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAC1E19C1B6A326100A8B23A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -94,8 +92,6 @@
 		BADC4719675AA7E88BB4142C /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				ACCA4067A20AE82A13A55B4D /* Pods-Example.debug.xcconfig */,
-				7F17E2E4DB202336112485AA /* Pods-Example.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -175,7 +171,6 @@
 				CAC1E1941B6A326100A8B23A /* Sources */,
 				CAC1E1951B6A326100A8B23A /* Frameworks */,
 				CAC1E1961B6A326100A8B23A /* Resources */,
-				5F43814BE018E11BE30B947A /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -296,21 +291,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		5F43814BE018E11BE30B947A /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example/Pods-Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		FD6E57C195D6DD9F5D5469C2 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -472,7 +452,6 @@
 		};
 		CAC1E1C61B6A326200A8B23A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = ACCA4067A20AE82A13A55B4D /* Pods-Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
@@ -488,7 +467,6 @@
 		};
 		CAC1E1C71B6A326200A8B23A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7F17E2E4DB202336112485AA /* Pods-Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";

--- a/gym/spec/fixtures/projects/cocoapods/Example.xcworkspace/contents.xcworkspacedata
+++ b/gym/spec/fixtures/projects/cocoapods/Example.xcworkspace/contents.xcworkspacedata
@@ -4,7 +4,4 @@
    <FileRef
       location = "group:Example.xcodeproj">
    </FileRef>
-   <FileRef
-      location = "group:Pods/Pods.xcodeproj">
-   </FileRef>
 </Workspace>


### PR DESCRIPTION
Fixes #9890

^^ Or at least helps to fix this 😇 

### Problem
`gym` will create the `export_options.provisionalProfiles` mapping wrong when:
1) There were multiple configurations with the same bundle identifier 
2) `xcconfig` files are being used to specific the `PRODUCT_BUNDLE_IDENTIFIER`, `PROVISIONING_PROFILE_SPECIFIER`, and/or `PROVISIONING_PROFILE`

This was resulting in a mapping with keys of `nil` (due to `PRODUCT_BUNDLE_IDENTIFIER`) not being resolved from the `xcconfig` file and/or the wrong provisioning profile selected due to duplicate bundle identifiers that are overwriting previously mapped provisioning profiles

### Solution

#### xcconfig file
To solve the `xcconfig` files from not being resolved, I upgraded the `xcodeproj` gem from at least `1.4.4` to at least `1.5.0`. `1.5.0` [added a method](https://github.com/CocoaPods/Xcodeproj/releases/tag/1.5.0) called `resolve_build_setting` which takes into account any referenced `xcconfig` files. This will now solve the `nil` key that appears when a bundle identifier is specified via a `xcconfig` file`

#### duplicate bundle identifier
This issue is not 100% solved yet. This **probably needs a more in depth discussion**. The current solution warns the user when duplicate bundle identifiers are found and tells them to explicitly create a map. This _could_ be improved in this pull request by showing an example mapping to put in the `Fastfile` - **thoughts??**

Below is an example of how things can get messed up...
```sh
Debug
	com.myapp.PizzaApp: Development Team
Debug-CookieApp
	com.myapp.CookieApp: Development Team
Release
	com.myapp.PizzaApp: match AppStore com.myapp.PizzaApp
Enterprise
	com.myapp.PizzaApp: In House
Release-CookieApp
	com.myapp.CookieApp: CookieApp AppStore
Enterprise-CookieApp
	com.myapp.CookieApp: In House
[22:56:42]: Detected provisioning profile mapping: {"com.myapp.PizzaApp"=>"In House", "com.myapp.CookieApp"=>"In House"}
```

You can see above that a map was created that resulted in "In House" which is _okay_ if I am doing an enterprise build but if I'm trying to do a release/appstore build, this same profile will get created and make the signing go 💥 

A **better** solution would be to pass which configuration is being used into the `CodeSigningMap` so that it can choose the correct bundle identifier and provisioning profile from above ^^ **Thoughts??**