### PR TITLE
Refresh app.edit_version after every locale during screenshot upload …

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -57,6 +57,8 @@ module Deliver
                                screenshot.language,
                                screenshot.device_type,
                                screenshot.is_messages?)
+          # Refresh app version to start clean again. See issue #9859
+          v = app.edit_version
         end
         # ideally we should only save once, but itunes server can't cope it seems
         # so we save per language. See issue #349

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -57,13 +57,13 @@ module Deliver
                                screenshot.language,
                                screenshot.device_type,
                                screenshot.is_messages?)
-          # Refresh app version to start clean again. See issue #9859
-          v = app.edit_version
         end
         # ideally we should only save once, but itunes server can't cope it seems
         # so we save per language. See issue #349
         UI.message("Saving changes")
         v.save!
+        # Refresh app version to start clean again. See issue #9859
+        v = app.edit_version
       end
       UI.success("Successfully uploaded screenshots to iTunes Connect")
     end


### PR DESCRIPTION
…(#9859)

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

iTunesConnect: Uploading screenshots to multiple locales fails. See issue #9859

### Description
<!--- Describe your changes in detail -->

Refresh the edited app after every locale, similar strategy is done in the loop that activates locales.
