### PR TITLE
Correctly format nested lists

### DIFF
--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -167,23 +167,23 @@ Overview of the used API endpoints
 
 - `https://idmsa.apple.com`: Used to authenticate to get a valid session
 - `https://developerservices2.apple.com`:
- - Get a list of all available provisioning profiles
- - Register new devices
+  - Get a list of all available provisioning profiles
+  - Register new devices
 - `https://developer.apple.com`:
- - List all devices, certificates, apps and app groups
- - Create new certificates, provisioning profiles and apps
- - Disable/enable services on apps and assign them to app groups
- - Delete certificates and apps
- - Repair provisioning profiles
- - Download provisioning profiles
- - Team selection
+  - List all devices, certificates, apps and app groups
+  - Create new certificates, provisioning profiles and apps
+  - Disable/enable services on apps and assign them to app groups
+  - Delete certificates and apps
+  - Repair provisioning profiles
+  - Download provisioning profiles
+  - Team selection
 - `https://itunesconnect.apple.com`:
- - Managing apps
- - Managing beta testers
- - Submitting updates to review
- - Managing app metadata
+  - Managing apps
+  - Managing beta testers
+  - Submitting updates to review
+  - Managing app metadata
 - `https://du-itc.itunesconnect.apple.com`:
- - Upload icons, screenshots, trailers ...
+  - Upload icons, screenshots, trailers ...
 
 `spaceship` uses all those API points to offer this seamless experience.
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR fixes the formatting of nested lists in the README under the "API Endpoints" section.

### Description
GitHub flavored markdown requires two spaces to nest list, not just one.
