### PR TITLE
[Gym] fails to merge export_options.provisioningProfiles

### DIFF
--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -17,8 +17,8 @@ module Gym
       final_mapping = (primary_mapping || {}).dup # for verbose output at the end of the method
       secondary_mapping ||= self.detect_project_profile_mapping # default to Xcode project
 
-      final_mapping = Hash[final_mapping.map{|k,v| [k.to_sym, v] }]
-      secondary_mapping = Hash[secondary_mapping.map{|k,v| [k.to_sym, v] }]
+      final_mapping = Hash[final_mapping.map { |k, v| [k.to_sym, v] }]
+      secondary_mapping = Hash[secondary_mapping.map { |k, v| [k.to_sym, v] }]
 
       # Now it's time to merge the (potentially) existing mapping
       #   (e.g. coming from `provisioningProfiles` of the `export_options` or from previous match calls)

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -36,6 +36,7 @@ module Gym
       #     3.3) If none has the right export_method, we'll use whatever is defined in the Xcode project
       #
       # To get a better sense of this, check out code_signing_spec.rb for some test cases
+
       secondary_mapping.each do |bundle_identifier, provisioning_profile|
         if final_mapping[bundle_identifier].nil?
           final_mapping[bundle_identifier] = provisioning_profile

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -17,6 +17,9 @@ module Gym
       final_mapping = (primary_mapping || {}).dup # for verbose output at the end of the method
       secondary_mapping ||= self.detect_project_profile_mapping # default to Xcode project
 
+      final_mapping = Hash[final_mapping.map{|k,v| [k.to_sym, v] }]
+      secondary_mapping = Hash[secondary_mapping.map{|k,v| [k.to_sym, v] }]
+
       # Now it's time to merge the (potentially) existing mapping
       #   (e.g. coming from `provisioningProfiles` of the `export_options` or from previous match calls)
       # with the secondary hash we just created (or was provided as parameter).
@@ -33,7 +36,6 @@ module Gym
       #     3.3) If none has the right export_method, we'll use whatever is defined in the Xcode project
       #
       # To get a better sense of this, check out code_signing_spec.rb for some test cases
-
       secondary_mapping.each do |bundle_identifier, provisioning_profile|
         if final_mapping[bundle_identifier].nil?
           final_mapping[bundle_identifier] = provisioning_profile

--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -151,8 +151,8 @@ describe Gym::CodeSigningMapping do
         context "when primary's key is string and secondary's key is also string" do
           let(:primary_key) { "identifier.1" }
           let(:secondary_key) { "identifier.1" }
-            it "is merged correctly" do
-              expect(result).to eq({ :"identifier.1" => "AppStore" })
+          it "is merged correctly" do
+            expect(result).to eq({ :"identifier.1" => "AppStore" })
           end
         end
         context "when primary's key is string and secondary's key is also symbol" do

--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -62,7 +62,7 @@ describe Gym::CodeSigningMapping do
                                        secondary_mapping: { "identifier.1" => "value.1" },
                                            export_method: "app-store")
 
-      expect(result).to eq({ "identifier.1" => "value.1" })
+      expect(result).to eq({ :"identifier.1" => "value.1" })
     end
 
     it "only mapping from match (user) is available" do
@@ -70,7 +70,7 @@ describe Gym::CodeSigningMapping do
                                        secondary_mapping: {},
                                            export_method: "app-store")
 
-      expect(result).to eq({ "identifier.1" => "value.1" })
+      expect(result).to eq({ :"identifier.1" => "value.1" })
     end
 
     it "keeps both profiles if they don't conflict" do
@@ -78,7 +78,7 @@ describe Gym::CodeSigningMapping do
                                        secondary_mapping: { "identifier.2" => "value.2" },
                                            export_method: "app-store")
 
-      expect(result).to eq({ "identifier.1" => "value.1", "identifier.2" => "value.2" })
+      expect(result).to eq({ :"identifier.1" => "value.1", :"identifier.2" => "value.2" })
     end
 
     it "doesn't crash if nil is provided" do
@@ -92,7 +92,7 @@ describe Gym::CodeSigningMapping do
       expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.1" => "value.1" })
       result = csm.merge_profile_mapping(primary_mapping: {}, export_method: "app-store")
 
-      expect(result).to eq({ "identifier.1" => "value.1" })
+      expect(result).to eq({ :"identifier.1" => "value.1" })
     end
 
     describe "handle conflicts" do
@@ -101,23 +101,23 @@ describe Gym::CodeSigningMapping do
                                        secondary_mapping: { "identifier.1" => "Ap-pStoreValue1" },
                                            export_method: "app-store")
 
-        expect(result).to eq({ "identifier.1" => "Ap-pStoreValue2" })
+        expect(result).to eq({ :"identifier.1" => "Ap-pStoreValue2" })
       end
 
-      it "Both primary and secondary are available, and and the secondary is the only one that matches the export type" do
+      it "Both primary and secondary are available, and the secondary is the only one that matches the export type" do
         result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "Ap-p StoreValue1" },
                                        secondary_mapping: { "identifier.1" => "Ad-HocValue" },
                                            export_method: "app-store")
 
-        expect(result).to eq({ "identifier.1" => "Ap-p StoreValue1" })
+        expect(result).to eq({ :"identifier.1" => "Ap-p StoreValue1" })
       end
 
-      it "Both primary and secondary are available, and and the seocndary is the only one that matches the export type" do
+      it "Both primary and secondary are available, and the seocndary is the only one that matches the export type" do
         result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "Ap-p StoreValue1" },
                                        secondary_mapping: { "identifier.1" => "Ad-HocValue" },
                                            export_method: "ad-hoc")
 
-        expect(result).to eq({ "identifier.1" => "Ad-HocValue" })
+        expect(result).to eq({ :"identifier.1" => "Ad-HocValue" })
       end
 
       it "both primary and secondary are available, and neither of them match the export type, it should choose the secondary_mapping" do
@@ -125,9 +125,46 @@ describe Gym::CodeSigningMapping do
                                        secondary_mapping: { "identifier.1" => "Adhoc" },
                                            export_method: "development")
 
-        expect(result).to eq({ "identifier.1" => "Adhoc" })
+        expect(result).to eq({ :"identifier.1" => "Adhoc" })
+      end
+
+      context "when both primary and secondary are available and same value" do
+        let(:result) do
+          csm.merge_profile_mapping(primary_mapping: { primary_key => "AppStore" },
+                                    secondary_mapping: { secondary_key => "AppStore" },
+                                    export_method: "development")
+        end
+        context "when primary's key is symbol and secondary's key is also symbol" do
+          let(:primary_key) { :"identifier.1" }
+          let(:secondary_key) { :"identifier.1" }
+          it "is merged correctly" do
+            expect(result).to eq({ :"identifier.1" => "AppStore" })
+          end
+        end
+        context "when primary's key is symbol and secondary's key is string" do
+          let(:primary_key) { :"identifier.1" }
+          let(:secondary_key) { "identifier.1" }
+          it "is merged correctly" do
+            expect(result).to eq({ :"identifier.1" => "AppStore" })
+          end
+        end
+        context "when primary's key is string and secondary's key is also string" do
+          let(:primary_key) { "identifier.1" }
+          let(:secondary_key) { "identifier.1" }
+            it "is merged correctly" do
+              expect(result).to eq({ :"identifier.1" => "AppStore" })
+          end
+        end
+        context "when primary's key is string and secondary's key is also symbol" do
+          let(:primary_key) { "identifier.1" }
+          let(:secondary_key) { :"identifier.1" }
+          it "is merged correctly" do
+            expect(result).to eq({ :"identifier.1" => "AppStore" })
+          end
+        end
       end
     end
+
     describe "#test_target?" do
       let(:csm) { Gym::CodeSigningMapping.new(project: nil) }
       context "when build_setting include TEST_TARGET_NAME" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`Gym` collect Provisioning Profiles automatically and merge primary and secondary hash.
(https://github.com/fastlane/fastlane/blob/master/gym/lib/gym/code_signing_mapping.rb#L37-L50)

If the hash key type of `primary_mapping` and `secondary_mapping` hash different, `Gym` cannot merge it correctly. 
Currently, the hash key type of`secondary_mapping` is always string. 
On the other hand, the `primary_mapping`'s one depends on users definition like this
```
export_options: {
  provisioningProfiles: {
    'identifier1': 'Provioning1',    ## symbol
    'identifier2' => 'Provisioning1'  ## string      
  }
}
```

#### before
```
DEBUG [2017-08-19 16:08:01.68]: Primary provisioning profile mapping:
DEBUG [2017-08-19 16:08:01.68]: {:"jp.co.sample.enterprise.SampleApp"=>"Sample App InHouse AdHoc"}
DEBUG [2017-08-19 16:08:01.68]: Secondary provisioning profile mapping:
DEBUG [2017-08-19 16:08:01.68]: {"jp.co.sample.enterprise.SampleApp"=>"Sample App InHouse AdHoc"}
DEBUG [2017-08-19 16:08:01.68]: Resulting in the following mapping:
DEBUG [2017-08-19 16:08:01.68]: {:"jp.co.sample.enterprise.SampleApp"=>"Sample App InHouse AdHoc", "jp.co.sample.enterprise.SampleApp"=>"Sample App InHouse AdHoc"}
```

#### after
```
DEBUG [2017-08-19 16:10:07.24]: Primary provisioning profile mapping:
DEBUG [2017-08-19 16:10:07.24]: {:"jp.co.sample.enterprise.SampleApp"=>"Sample App InHouse AdHoc"}
DEBUG [2017-08-19 16:10:07.24]: Secondary provisioning profile mapping:
DEBUG [2017-08-19 16:10:07.24]: {:"jp.co.sample.enterprise.SampleApp"=>"Sample App InHouse AdHoc"}
DEBUG [2017-08-19 16:10:07.24]: Resulting in the following mapping:
DEBUG [2017-08-19 16:10:07.24]: {:"jp.co.sample.enterprise.SampleApp"=>"Sample App InHouse AdHoc"}
```

### Description
I changed the hash key type both of final_mapping and secondary_mapping to symbol.
