### PR TITLE
Use new TestFlight API to find testers by full-text search

### DIFF
--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -67,7 +67,7 @@ module Pilot
         # If no groups are passed to options, remove the tester from the app-level,
         # otherwise remove the tester from the groups specified.
         if config[:groups].nil? && tester.kind_of?(Spaceship::Tunes::Tester::External)
-          test_flight_testers = Spaceship::TestFlight::Tester.search(app_id: app.apple_id, text: tester.email)
+          test_flight_testers = Spaceship::TestFlight::Tester.search(app_id: app.apple_id, text: tester.email, is_email_exact_match: true)
 
           if test_flight_testers.length > 1
             UI.user_error!("Could not remove #{tester.email} from app: #{app.name}, reason: too many matches: #{test_flight_testers}")

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -67,7 +67,14 @@ module Pilot
         # If no groups are passed to options, remove the tester from the app-level,
         # otherwise remove the tester from the groups specified.
         if config[:groups].nil? && tester.kind_of?(Spaceship::Tunes::Tester::External)
-          test_flight_tester = Spaceship::TestFlight::Tester.find(app_id: app.apple_id, email: tester.email)
+          test_flight_testers = Spaceship::TestFlight::Tester.search(app_id: app.apple_id, text: tester.email)
+
+          if test_flight_testers.length > 1
+            UI.user_error!("Could not remove #{tester.email} from app: #{app.name}, reason: too many matches: #{test_flight_testers}")
+          elsif test_flight_testers.length == 0
+            UI.user_error!("Could not remove #{tester.email} from app: #{app.name}, reason: unable to find tester on app")
+          end
+          test_flight_tester = test_flight_testers.first
           test_flight_tester.remove_from_app!(app_id: app.apple_id)
           UI.success("Successfully removed tester, #{test_flight_tester.email}, from app: #{app.name}")
         else

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -112,6 +112,14 @@ module Spaceship::TestFlight
       handle_response(response)
     end
 
+    def search_for_tester_in_app(app_id: nil, text: nil)
+      assert_required_params(__method__, binding)
+      text = CGI.escape(text)
+      url = "providers/#{team_id}/apps/#{app_id}/testers?order=asc&search=#{text}&sort=status"
+      response = request(:get, url)
+      handle_response(response)
+    end
+
     def resend_invite_to_external_tester(app_id: nil, tester_id: nil)
       assert_required_params(__method__, binding)
       url = "/testflight/v1/invites/#{app_id}/resend?testerId=#{tester_id}"

--- a/spaceship/lib/spaceship/test_flight/tester.rb
+++ b/spaceship/lib/spaceship/test_flight/tester.rb
@@ -20,11 +20,13 @@ module Spaceship::TestFlight
       client.testers_for_app(app_id: app_id).map { |data| self.new(data) }
     end
 
-    # @return (Spaceship::TestFlight::Tester) Returns the tester matching the parameter
-    #   as either the Tester id or email
-    # @param email (String) (required): Value used to filter the tester, case insensitive
-    def self.find(app_id: nil, email: nil)
-      self.all(app_id: app_id).find { |tester| tester.email == email }
+    # @return (Spaceship::TestFlight::Tester) Returns the testers matching the parameter.
+    # ITC searchs all fields, and is full text. The search results are the union of all words in the search text
+    # @param text (String) (required): Value used to filter the tester, case insensitive
+    def self.search(app_id: nil, text: nil)
+      testers_matching_email = client.search_for_tester_in_app(app_id: app_id, text: text).map { |data| self.new(data) }
+      testers_matching_email ||= []
+      return testers_matching_email
     end
 
     def self.create_app_level_tester(app_id: nil, first_name: nil, last_name: nil, email: nil)

--- a/spaceship/lib/spaceship/test_flight/tester.rb
+++ b/spaceship/lib/spaceship/test_flight/tester.rb
@@ -20,13 +20,27 @@ module Spaceship::TestFlight
       client.testers_for_app(app_id: app_id).map { |data| self.new(data) }
     end
 
+    # *DEPRECATED: Use `Spaceship::TestFlight::Tester.search` method instead*
+    def self.find(app_id: nil, email: nil)
+      testers = self.search(app_id: app_id, text: email, is_email_exact_match: true)
+      return testers.first
+    end
+
     # @return (Spaceship::TestFlight::Tester) Returns the testers matching the parameter.
     # ITC searchs all fields, and is full text. The search results are the union of all words in the search text
     # @param text (String) (required): Value used to filter the tester, case insensitive
-    def self.search(app_id: nil, text: nil)
-      testers_matching_email = client.search_for_tester_in_app(app_id: app_id, text: text).map { |data| self.new(data) }
-      testers_matching_email ||= []
-      return testers_matching_email
+    def self.search(app_id: nil, text: nil, is_email_exact_match: false)
+      text = text.strip
+      testers_matching_text = client.search_for_tester_in_app(app_id: app_id, text: text).map { |data| self.new(data) }
+      testers_matching_text ||= []
+      if is_email_exact_match
+        text = text.downcase
+        testers_matching_text = testers_matching_text.select do |tester|
+          tester.email.downcase == text
+        end
+      end
+
+      return testers_matching_text
     end
 
     def self.create_app_level_tester(app_id: nil, first_name: nil, last_name: nil, email: nil)

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -134,6 +134,14 @@ describe Spaceship::TestFlight::Client do
     end
   end
 
+  context '#search_for_tester_in_app' do
+    it 'executes the request' do
+      MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/testers?order=asc&search=fake%2Btester%2Btext&sort=status') {}
+      subject.search_for_tester_in_app(app_id: app_id, text: "fake+tester+text")
+      expect(WebMock).to have_requested(:get, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/testers?order=asc&search=fake%2Btester%2Btext&sort=status')
+    end
+  end
+
   context '#delete_tester_from_app' do
     it 'executes the request' do
       MockAPI::TestFlightServer.delete('/testflight/v2/providers/fake-team-id/apps/some-app-id/testers/fake-tester-id') {}

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -136,7 +136,7 @@ describe Spaceship::TestFlight::Client do
 
   context '#search_for_tester_in_app' do
     it 'executes the request' do
-      MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/testers?order=asc&search=fake%2Btester%2Btext&sort=status') {}
+      MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/testers') {}
       subject.search_for_tester_in_app(app_id: app_id, text: "fake+tester+text")
       expect(WebMock).to have_requested(:get, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/testers?order=asc&search=fake%2Btester%2Btext&sort=status')
     end

--- a/spaceship/spec/test_flight/tester_spec.rb
+++ b/spaceship/spec/test_flight/tester_spec.rb
@@ -45,6 +45,19 @@ describe Spaceship::TestFlight::Tester do
         ]
       end
 
+      mock_client_response(:search_for_tester_in_app, with: { app_id: 'app-id', text: 'EmAiL_3@domain.com' }) do
+        [
+          {
+            id: 3,
+            email: "EmAiL_3@domain.com"
+          },
+          {
+            id: 4,
+            email: "tacos_email_3@domain.com"
+          }
+        ]
+      end
+
       mock_client_response(:search_for_tester_in_app, with: { app_id: 'app-id', text: 'taquito' }) do
         [
           {
@@ -74,10 +87,31 @@ describe Spaceship::TestFlight::Tester do
 
     context '.find' do
       it 'returns a Tester by email address' do
+        tester = Spaceship::TestFlight::Tester.find(app_id: 'app-id', email: 'email_1@domain.com')
+        expect(tester).to be_instance_of(Spaceship::TestFlight::Tester)
+        expect(tester.tester_id).to be(1)
+      end
+
+      it 'returns nil if no Tester matches' do
+        tester = Spaceship::TestFlight::Tester.find(app_id: 'app-id', email: 'NaN@domain.com')
+        expect(tester).to be_nil
+      end
+    end
+
+    context '.search' do
+      it 'returns a Tester by email address' do
         testers = Spaceship::TestFlight::Tester.search(app_id: 'app-id', text: 'email_1@domain.com')
         expect(testers.length).to be(1)
         expect(testers.first).to be_instance_of(Spaceship::TestFlight::Tester)
         expect(testers.first.tester_id).to be(1)
+      end
+
+      it 'returns a Tester by email address if exact match case-insensitive' do
+        testers = Spaceship::TestFlight::Tester.search(app_id: 'app-id', text: 'EmAiL_3@domain.com', is_email_exact_match: true)
+        expect(testers.length).to be(1)
+        expect(testers.first).to be_instance_of(Spaceship::TestFlight::Tester)
+        expect(testers.first.tester_id).to be(3)
+        expect(testers.first.email).to eq("EmAiL_3@domain.com")
       end
 
       it 'returns empty array if no Tester matches' do

--- a/spaceship/spec/test_flight/tester_spec.rb
+++ b/spaceship/spec/test_flight/tester_spec.rb
@@ -35,26 +35,60 @@ describe Spaceship::TestFlight::Tester do
           }
         ]
       end
+
+      mock_client_response(:search_for_tester_in_app, with: { app_id: 'app-id', text: 'email_1@domain.com' }) do
+        [
+          {
+            id: 1,
+            email: "email_1@domain.com"
+          }
+        ]
+      end
+
+      mock_client_response(:search_for_tester_in_app, with: { app_id: 'app-id', text: 'taquito' }) do
+        [
+          {
+            id: 1,
+            email: "taquito@domain.com"
+          },
+          {
+            id: 2,
+            email: "taquitos@domain.com"
+          }
+
+        ]
+      end
+
+      mock_client_response(:search_for_tester_in_app, with: { app_id: 'app-id', text: 'NaN@domain.com' }) do
+        []
+      end
     end
 
     context '.all' do
       it 'returns all of the testers' do
         groups = Spaceship::TestFlight::Tester.all(app_id: 'app-id')
         expect(groups.size).to eq(2)
-        expect(groups.first).to be_instance_of(Spaceship::TestFlight::Tester)
+        expect(groups).to all(be_instance_of(Spaceship::TestFlight::Tester))
       end
     end
 
     context '.find' do
       it 'returns a Tester by email address' do
-        tester = Spaceship::TestFlight::Tester.find(app_id: 'app-id', email: 'email_1@domain.com')
-        expect(tester).to be_instance_of(Spaceship::TestFlight::Tester)
-        expect(tester.tester_id).to be(1)
+        testers = Spaceship::TestFlight::Tester.search(app_id: 'app-id', text: 'email_1@domain.com')
+        expect(testers.length).to be(1)
+        expect(testers.first).to be_instance_of(Spaceship::TestFlight::Tester)
+        expect(testers.first.tester_id).to be(1)
       end
 
-      it 'returns nil if no Tester matches' do
-        tester = Spaceship::TestFlight::Tester.find(app_id: 'app-id', email: 'NaN@domain.com')
-        expect(tester).to be_nil
+      it 'returns empty array if no Tester matches' do
+        testers = Spaceship::TestFlight::Tester.search(app_id: 'app-id', text: 'NaN@domain.com')
+        expect(testers.length).to be(0)
+      end
+
+      it 'returns two testers if two testers match full-text search' do
+        testers = Spaceship::TestFlight::Tester.search(app_id: 'app-id', text: 'taquito')
+        expect(testers.length).to be(2)
+        expect(testers).to all(be_instance_of(Spaceship::TestFlight::Tester))
       end
     end
   end


### PR DESCRIPTION
The original way we were finding testers was by trying to grab all testers and then filter them. Turns out, the API doesn't return all testers anymore, just a max of 40. 

BUT

We have a new full-text search API to play with, and we can pass in email addresses 🎉 
This PR changes TestFlight::Tester.find to .search and uses the new api.
Should fix #9973