### PR TITLE
[snapshot] Change hardware-dependent test to check an additional mocked CPU count

### DIFF
--- a/snapshot/spec/runner_spec.rb
+++ b/snapshot/spec/runner_spec.rb
@@ -21,15 +21,6 @@ describe Snapshot do
     end
 
     describe 'Decides on the number of sims to launch when simultaneously snapshotting' do
-      it 'finds that the # of CPUs -1 is the number of sims to launch' do
-        snapshot_config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, {})
-        launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: snapshot_config)
-
-        sims = Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).default_number_of_simultaneous_simulators
-        expect(sims).to eq(Snapshot::CPUInspector.cpu_count - 1)
-        expect(sims >= 1).to be(true)
-      end
-
       it 'returns 1 if CPUs is 1' do
         snapshot_config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, {})
         launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: snapshot_config)
@@ -46,6 +37,15 @@ describe Snapshot do
 
         sims = Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).default_number_of_simultaneous_simulators
         expect(sims).to eq(2)
+      end
+
+      it 'returns 3 if CPUs is 4' do
+        snapshot_config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, {})
+        launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: snapshot_config)
+        allow(Snapshot::CPUInspector).to receive(:cpu_count).and_return(4)
+
+        sims = Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).default_number_of_simultaneous_simulators
+        expect(sims).to eq(3)
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The original test depended on the actual configuration of hardware, and failed if the machine only had 2 CPUs.

### Description
Remove original hardware-dependent test and add a test that checks a mocked 4-CPU machine.
