### PR TITLE
Add missing parameter for travis-pro to slather action (#9531)

### DIFF
--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -5,9 +5,10 @@ module Fastlane
     end
 
     class SlatherAction < Action
-      # https://github.com/SlatherOrg/slather/blob/cbc5099cd25beb43fd978b7a3e5428f02230122d/lib/slather/command/coverage_command.rb#L24
+      # https://github.com/SlatherOrg/slather/blob/v2.4.2/lib/slather/command/coverage_command.rb
       ARGS_MAP = {
           travis: '--travis',
+          travis_pro: '--travis-pro',
           circleci: '--circleci',
           jenkins: '--jenkins',
           buildkite: '--buildkite',
@@ -161,6 +162,11 @@ Slather is available at https://github.com/SlatherOrg/slather
           FastlaneCore::ConfigItem.new(key: :travis,
                                        env_name: "FL_SLATHER_TRAVIS_ENABLED", # The name of the environment variable
                                        description: "Tell slather that it is running on TravisCI",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :travis_pro,
+                                       env_name: "FL_SLATHER_TRAVIS_PRO_ENABLED", # The name of the environment variable
+                                       description: "Tell slather that it is running on TravisCI Pro",
                                        is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :circleci,

--- a/fastlane/spec/actions_specs/slather_spec.rb
+++ b/fastlane/spec/actions_specs/slather_spec.rb
@@ -14,6 +14,7 @@ describe Fastlane do
             buildkite: true,
             jenkins: true,
             travis: true,
+            travis_pro: true,
             circleci: true,
             coveralls: true,
             teamcity: true,
@@ -37,6 +38,7 @@ describe Fastlane do
 
         expected = "slather coverage
                     --travis
+                    --travis-pro
                     --circleci
                     --jenkins
                     --buildkite
@@ -77,6 +79,7 @@ describe Fastlane do
             buildkite: true,
             jenkins: true,
             travis: true,
+            travis_pro: true,
             circleci: true,
             coveralls: true,
             simple_output: true,
@@ -96,6 +99,7 @@ describe Fastlane do
 
         expected = 'bundle exec slather coverage
                     --travis
+                    --travis-pro
                     --circleci
                     --jenkins
                     --buildkite


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
While trying to setup slather i discovered this parameter was missing from the action but was present in the slather.

### Description
This simply adds the additional option for travis pro the the slather action as described in #9531
