### PR TITLE
Added option in deliver to ignore language directory validation from …

### DIFF
--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -38,7 +38,7 @@ module Deliver
         rejected_folders = rejected_folders.map { |path| File.basename(path) }
         UI.user_error! "Unsupported directory name(s) for screenshots/metadata in '#{root}': #{rejected_folders.join(', ')}" \
                        "\nValid directory names are: #{allowed_directory_names_with_case}" \
-                       "\n\nEnabled 'ignore_language_directory_validation' to prevent this validation from happening"
+                       "\n\nEnable 'ignore_language_directory_validation' to prevent this validation from happening"
       end
 
       selected_folders

--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -12,7 +12,7 @@ module Deliver
 
     EXCEPTION_DIRECTORIES = UploadMetadata::ALL_META_SUB_DIRS.map(&:downcase).freeze
 
-    def self.language_folders(root)
+    def self.language_folders(root, ignore_validation)
       folders = Dir.glob(File.join(root, '*'))
 
       if Helper.is_test?
@@ -21,7 +21,8 @@ module Deliver
         available_languages = Spaceship::Tunes.client.available_languages.sort
       end
 
-      allowed_directory_names = (available_languages + SPECIAL_DIR_NAMES).map(&:downcase).freeze
+      allowed_directory_names_with_case = (available_languages + SPECIAL_DIR_NAMES)
+      allowed_directory_names = allowed_directory_names_with_case.map(&:downcase).freeze
 
       selected_folders = folders.select do |path|
         File.directory?(path) && allowed_directory_names.include?(File.basename(path).downcase)
@@ -33,9 +34,11 @@ module Deliver
         File.directory?(path) && !allowed_directory_names.include?(normalized_path) && !EXCEPTION_DIRECTORIES.include?(normalized_path)
       end.sort
 
-      unless rejected_folders.empty?
+      if !ignore_validation && !rejected_folders.empty?
         rejected_folders = rejected_folders.map { |path| File.basename(path) }
-        UI.user_error! "Unsupport directory name(s) for screenshots/metadata: #{rejected_folders.join(', ')}\n\nValid directory names are: #{allowed_directory_names}"
+        UI.user_error! "Unsupported directory name(s) for screenshots/metadata in '#{root}': #{rejected_folders.join(', ')}" \
+                       "\nValid directory names are: #{allowed_directory_names_with_case}" \
+                       "\n\nEnabled 'ignore_language_directory_validation' to prevent this validation from happening"
       end
 
       selected_folders

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -315,7 +315,12 @@ module Deliver
         FastlaneCore::ConfigItem.new(key: :languages,
                                      description: "Metadata: List of languages to activate",
                                      type: Array,
-                                     optional: true)
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :ignore_language_directory_validation,
+                                     env_name: "DELIVER_IGNORE_LANGUAGE_DIRECTORY_VALIDATION",
+                                     description: "Ignore errors when invalid languages are found in metadata and screeenshot directories",
+                                     default_value: false,
+                                     is_string: false)
       ]
     end
   end

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -158,7 +158,8 @@ module Deliver
       end
 
       # Check folder list (an empty folder signifies a language is required)
-      Loader.language_folders(options[:metadata_path]).each do |lang_folder|
+      ignore_validation = options[:ignore_language_directory_validation]
+      Loader.language_folders(options[:metadata_path], ignore_validation).each do |lang_folder|
         next unless File.directory?(lang_folder) # We don't want to read txt as they are non localised
         language = File.basename(lang_folder)
         enabled_languages << language unless enabled_languages.include?(language)
@@ -198,7 +199,8 @@ module Deliver
       end
 
       # Check folder list (an empty folder signifies a language is required)
-      Loader.language_folders(options[:metadata_path]).each do |lang_folder|
+      ignore_validation = options[:ignore_language_directory_validation]
+      Loader.language_folders(options[:metadata_path], ignore_validation).each do |lang_folder|
         next unless File.directory?(lang_folder) # We don't want to read txt as they are non localised
 
         language = File.basename(lang_folder)
@@ -252,7 +254,8 @@ module Deliver
       return if options[:skip_metadata]
 
       # Load localised data
-      Loader.language_folders(options[:metadata_path]).each do |lang_folder|
+      ignore_validation = options[:ignore_language_directory_validation]
+      Loader.language_folders(options[:metadata_path], ignore_validation).each do |lang_folder|
         language = File.basename(lang_folder)
         (LOCALISED_VERSION_VALUES + LOCALISED_APP_VALUES).each do |key|
           path = File.join(lang_folder, "#{key}.txt")

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -68,10 +68,12 @@ module Deliver
 
     def collect_screenshots(options)
       return [] if options[:skip_screenshots]
-      return collect_screenshots_for_languages(options[:screenshots_path])
+      return collect_screenshots_for_languages(options)
     end
 
-    def collect_screenshots_for_languages(path)
+    def collect_screenshots_for_languages(options)
+      path = options[:screenshots_path]
+
       screenshots = []
       extensions = '{png,jpg,jpeg}'
 
@@ -79,7 +81,8 @@ module Deliver
         lang_hash[lang.downcase] = lang
       end
 
-      Loader.language_folders(path).each do |lng_folder|
+      ignore_validation = options[:ignore_language_directory_validation]
+      Loader.language_folders(path, ignore_validation).each do |lng_folder|
         language = File.basename(lng_folder)
 
         # Check to see if we need to traverse multiple platforms or just a single platform

--- a/deliver/spec/loader_spec.rb
+++ b/deliver/spec/loader_spec.rb
@@ -19,14 +19,15 @@ describe Deliver::Loader do
   end
 
   it 'only returns directories in the specified directory' do
-    @folders = Deliver::Loader.language_folders(@root)
+    @folders = Deliver::Loader.language_folders(@root, false)
 
     expect(@folders.size).not_to eq(0)
     expect(@folders.all? { |f| File.directory?(f) }).to eq(true)
   end
 
   it 'only returns directories regardless of case' do
-    @folders = Deliver::Loader.language_folders(@root)
+    FileUtils.mkdir(File.join(@root, 'unrelated-dir'))
+    @folders = Deliver::Loader.language_folders(@root, true)
 
     expect(@folders.size).not_to eq(0)
     expected_languages = @languages[1..-1].map(&:downcase).sort
@@ -35,11 +36,13 @@ describe Deliver::Loader do
   end
 
   it 'raises error when a directory name contains an unsupported directory name' do
-    allowed_directory_names = (@languages + Deliver::Loader::SPECIAL_DIR_NAMES).map(&:downcase).freeze
+    allowed_directory_names = (@languages + Deliver::Loader::SPECIAL_DIR_NAMES)
 
     FileUtils.mkdir(File.join(@root, 'unrelated-dir'))
     expect do
-      @folders = Deliver::Loader.language_folders(@root)
-    end.to raise_error FastlaneCore::Interface::FastlaneError, "Unsupport directory name(s) for screenshots/metadata: unrelated-dir\n\nValid directory names are: #{allowed_directory_names}"
+      @folders = Deliver::Loader.language_folders(@root, false)
+    end.to raise_error FastlaneCore::Interface::FastlaneError, "Unsupported directory name(s) for screenshots/metadata in '#{@root}': unrelated-dir" \
+                                                               "\nValid directory names are: #{allowed_directory_names}" \
+                                                               "\n\nEnabled 'ignore_language_directory_validation' to prevent this validation from happening"
   end
 end

--- a/deliver/spec/loader_spec.rb
+++ b/deliver/spec/loader_spec.rb
@@ -43,6 +43,6 @@ describe Deliver::Loader do
       @folders = Deliver::Loader.language_folders(@root, false)
     end.to raise_error FastlaneCore::Interface::FastlaneError, "Unsupported directory name(s) for screenshots/metadata in '#{@root}': unrelated-dir" \
                                                                "\nValid directory names are: #{allowed_directory_names}" \
-                                                               "\n\nEnabled 'ignore_language_directory_validation' to prevent this validation from happening"
+                                                               "\n\nEnable 'ignore_language_directory_validation' to prevent this validation from happening"
   end
 end


### PR DESCRIPTION
…raising error

Fixes #9351
... again 😇 

### Problem
- Need to allow option to ignore language directory structure for invalid languages as not everyone will have same file structure
- Error message was also showing languages in all lowercase which wasn't correct

### Solution
- Added new option to ignore validation on metadata and screenshot directories
  - `ignore_language_directory_validation`
- Error message that gets raised will tell user about this new option
- Error message isn't all lowercase anymore

```sh
[!] Unsupported directory name(s) for screenshots/metadata in './fastlane/metadata': da-AAAAA
Valid directory names are: ["da", "de-DE", "el", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "fi", "fr-CA", "fr-FR", "id", "it", "ja", "ko", "ms", "nl-NL", "no", "pt-BR", "pt-PT", "ru", "sv", "th", "tr", "vi", "zh-Hans", "zh-Hant", "appleTV", "iMessage", "default"]

Enabled 'ignore_language_directory_validation' to prevent this validation from happening
```
