### PR TITLE
Handle TestFairy timeout better

### DIFF
--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -25,9 +25,13 @@ module Fastlane
           options[:symbols_file] = Faraday::UploadIO.new(symbols_file, 'application/octet-stream')
         end
 
-        connection.post do |req|
-          req.url("/api/upload/")
-          req.body = options
+        begin
+          connection.post do |req|
+            req.url("/api/upload/")
+            req.body = options
+          end
+        rescue Faraday::Error::TimeoutError
+          UI.crash!("Uploading build to TestFairy timed out ⏳")
         end
       end
 

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -9,7 +9,7 @@ module Fastlane
         require 'faraday'
         require 'faraday_middleware'
 
-        connection = Faraday.new(url: "https://app.testfairy.com") do |builder|
+        connection = Faraday.new(url: "https://upload.testfairy.com") do |builder|
           builder.request :multipart
           builder.request :url_encoded
           builder.response :json, content_type: /\bjson$/

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -12,6 +12,7 @@ module Fastlane
         connection = Faraday.new(url: "https://upload.testfairy.com") do |builder|
           builder.request :multipart
           builder.request :url_encoded
+          builder.request :retry, max: 3, interval: 5
           builder.response :json, content_type: /\bjson$/
           builder.use FaradayMiddleware::FollowRedirects
           builder.adapter :net_http


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
TestFairy has updated their upload URL according to [docs](https://docs.testfairy.com/) and https://github.com/testfairy/testfairy-gradle-plugin/commit/834ea76530b7aa13a656b8a89691962ccad97fee

Occasionally uploads would fail and it would give us a red build, so lets retry. 🤖
TestFairy always overwrites builds with same build number, so operation should be safe.

The thrown exception does not provide any help, so lets rescue it.
Would you look at the size of it!? 😞 
```
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/net/protocol.rb:176:in `rbuf_fill': [!] Net::ReadTimeout (Faraday::TimeoutError)
	from /usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/net/protocol.rb:154:in `readuntil'
	from /usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/net/protocol.rb:164:in `readline'
	from /usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/net/http/response.rb:40:in `read_status_line'
	from /usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/net/http/response.rb:29:in `read_new'
	from /usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/net/http.rb:1446:in `block in transport_request'
	from /usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/net/http.rb:1443:in `catch'
	from /usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/net/http.rb:1443:in `transport_request'
	from /usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/net/http.rb:1416:in `request'
	from /usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/net/http.rb:1409:in `block in request'
	from /usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/net/http.rb:877:in `start'
	from /usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/net/http.rb:1407:in `request'
	from /usr/local/lib/ruby/gems/2.4.0/gems/faraday-0.13.0/lib/faraday/adapter/net_http.rb:80:in `perform_request'
	from /usr/local/lib/ruby/gems/2.4.0/gems/faraday-0.13.0/lib/faraday/adapter/net_http.rb:38:in `block in call'
	from /usr/local/lib/ruby/gems/2.4.0/gems/faraday-0.13.0/lib/faraday/adapter/net_http.rb:85:in `with_net_http_connection'
	from /usr/local/lib/ruby/gems/2.4.0/gems/faraday-0.13.0/lib/faraday/adapter/net_http.rb:33:in `call'
	from /usr/local/lib/ruby/gems/2.4.0/gems/faraday_middleware-0.12.2/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
	from /usr/local/lib/ruby/gems/2.4.0/gems/faraday_middleware-0.12.2/lib/faraday_middleware/response/follow_redirects.rb:66:in `call'
	from /usr/local/lib/ruby/gems/2.4.0/gems/faraday_middleware-0.12.2/lib/faraday_middleware/response_middleware.rb:31:in `call'
	from /usr/local/lib/ruby/gems/2.4.0/gems/faraday-0.13.0/lib/faraday/request/url_encoded.rb:15:in `call'
	from /usr/local/lib/ruby/gems/2.4.0/gems/faraday-0.13.0/lib/faraday/request/multipart.rb:15:in `call'
	from /usr/local/lib/ruby/gems/2.4.0/gems/faraday-0.13.0/lib/faraday/rack_builder.rb:141:in `build_response'
	from /usr/local/lib/ruby/gems/2.4.0/gems/faraday-0.13.0/lib/faraday/connection.rb:387:in `run_request'
	from /usr/local/lib/ruby/gems/2.4.0/gems/faraday-0.13.0/lib/faraday/connection.rb:174:in `post'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/actions/testfairy.rb:27:in `upload_build'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/actions/testfairy.rb:91:in `run'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/runner.rb:252:in `block (2 levels) in execute_action'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/actions/actions_helper.rb:50:in `execute_action'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/runner.rb:230:in `block in execute_action'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/runner.rb:226:in `chdir'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/runner.rb:226:in `execute_action'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/runner.rb:148:in `trigger_action_by_name'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/fast_file.rb:146:in `method_missing'
	from Fastfile:208:in `block (2 levels) in parsing_binding'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/lane.rb:33:in `call'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/runner.rb:49:in `block in execute'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/runner.rb:45:in `chdir'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/runner.rb:45:in `execute'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/lane_manager.rb:52:in `cruise_lane'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/command_line_handler.rb:30:in `handle'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/commands_generator.rb:104:in `block (2 levels) in run'
	from /usr/local/lib/ruby/gems/2.4.0/gems/commander-fastlane-4.4.5/lib/commander/command.rb:178:in `call'
	from /usr/local/lib/ruby/gems/2.4.0/gems/commander-fastlane-4.4.5/lib/commander/command.rb:153:in `run'
	from /usr/local/lib/ruby/gems/2.4.0/gems/commander-fastlane-4.4.5/lib/commander/runner.rb:476:in `run_active_command'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:64:in `run!'
	from /usr/local/lib/ruby/gems/2.4.0/gems/commander-fastlane-4.4.5/lib/commander/delegates.rb:15:in `run!'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/commands_generator.rb:303:in `run'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/commands_generator.rb:42:in `start'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/fastlane/lib/fastlane/cli_tools_distributor.rb:66:in `take_off'
	from /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.54.0/bin/fastlane:20:in `<top (required)>'
	from /usr/local/bin/fastlane:22:in `load'
	from /usr/local/bin/fastlane:22:in `<main>'
```