### PR TITLE
More options for download_dsyms action

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -26,7 +26,6 @@ module Fastlane
         platform = params[:platform]
         output_directory = params[:output_directory]
 
-        latest_version = nil # If this is set, use this instead of looping through apps
         # Set version if it is latest
         if version == 'latest'
           # Try to grab the live version first, else fallback to edit version
@@ -43,18 +42,9 @@ module Fastlane
         # Write a nice message
         message = []
         message << "Looking for dSYM files for #{params[:app_identifier]}"
-        if version
-          message << "v#{version}"
-        end
-
-        if build_number
-          message << "(#{build_number})"
-        end
-
+        message << "v#{version}" if version
+        message << "(#{build_number})" if build_number
         UI.message(message.join(" "))
-
-        appsToLoop = [latest_version]
-        unless latest_version
 
         # Loop through all app versions and download their dSYM
         app.all_build_train_numbers(platform: platform).each do |train_number|

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -28,9 +28,11 @@ module Fastlane
 
         # Set version if it is latest
         if version == 'latest'
-          latest_build = latest_build(app.latest_version.candidate_builds)
-          version = latest_build.train_version
-          build_number = latest_build.build_version
+          # Try to grab the live version first, else fallback to edit version
+          latest_version = app.live_version(platform: platform) || app.edit_version(platform: platform)
+          UI.user_error!("Could not find a latest version of the app live or not.") unless latest_version
+          version = latest_version.version
+          build_number = latest_version.build_version
         end
 
         # Make sure save_directory has a slash on the end
@@ -95,21 +97,6 @@ module Fastlane
         http.use_ssl = (uri.scheme == "https")
         res = http.get(uri.request_uri)
         res.body
-      end
-
-      def self.latest_build(candidate_builds)
-        if (candidate_builds || []).count == 0
-          UI.user_error!("Could not find any available candidate builds on iTunes Connect to submit")
-        end
-
-        build = candidate_builds.first
-        candidate_builds.each do |b|
-          if b.upload_date > build.upload_date
-            build = b
-          end
-        end
-
-        return build
       end
 
       #####################################################

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -17,6 +17,12 @@ module Fastlane
         version = params[:version]
         build_number = params[:build_number]
         platform = params[:platform]
+        save_directory = params[:save_directory]
+
+        # Make sure save_directory has a slash on the end
+        if save_directory && !save_directory.end_with?('/')
+          save_directory += '/'
+        end
 
         message = []
         message << "Looking for dSYM files for #{params[:app_identifier]}"
@@ -52,6 +58,9 @@ module Fastlane
             if download_url
               result = self.download download_url
               file_name = "#{app.bundle_id}-#{train_number}-#{build.build_version}.dSYM.zip"
+              if save_directory
+                file_name = save_directory + file_name
+              end
               File.write(file_name, result)
               UI.success("🔑  Successfully downloaded dSYM file for #{train_number} - #{build.build_version} to '#{file_name}'")
 
@@ -147,6 +156,11 @@ module Fastlane
                                        short_option: "-b",
                                        env_name: "DOWNLOAD_DSYMS_BUILD_NUMBER",
                                        description: "The app build_number for dSYMs you wish to download",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :save_directory,
+                                       short_option: "-s",
+                                       env_name: "DOWNLOAD_DSYMS_SAVE_DIRECTORY",
+                                       description: "Where to save the download DSYMs, defaults to the current path",
                                        optional: true)
         ]
       end

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -24,8 +24,9 @@ module Fastlane
         version = params[:version]
         build_number = params[:build_number]
         platform = params[:platform]
-        save_directory = params[:save_directory]
+        output_directory = params[:output_directory]
 
+        latest_version = nil # If this is set, use this instead of looping through apps
         # Set version if it is latest
         if version == 'latest'
           # Try to grab the live version first, else fallback to edit version
@@ -34,9 +35,9 @@ module Fastlane
           build_number = latest_version.build_version
         end
 
-        # Make sure save_directory has a slash on the end
-        if save_directory && !save_directory.end_with?('/')
-          save_directory += '/'
+        # Make sure output_directory has a slash on the end
+        if output_directory && !output_directory.end_with?('/')
+          output_directory += '/'
         end
 
         # Write a nice message
@@ -51,6 +52,9 @@ module Fastlane
         end
 
         UI.message(message.join(" "))
+
+        appsToLoop = [latest_version]
+        unless latest_version
 
         # Loop through all app versions and download their dSYM
         app.all_build_train_numbers(platform: platform).each do |train_number|
@@ -71,8 +75,8 @@ module Fastlane
             if download_url
               result = self.download download_url
               file_name = "#{app.bundle_id}-#{train_number}-#{build.build_version}.dSYM.zip"
-              if save_directory
-                file_name = save_directory + file_name
+              if output_directory
+                file_name = output_directory + file_name
               end
               File.write(file_name, result)
               UI.success("🔑  Successfully downloaded dSYM file for #{train_number} - #{build.build_version} to '#{file_name}'")
@@ -170,9 +174,9 @@ module Fastlane
                                        env_name: "DOWNLOAD_DSYMS_BUILD_NUMBER",
                                        description: "The app build_number for dSYMs you wish to download",
                                        optional: true),
-          FastlaneCore::ConfigItem.new(key: :save_directory,
+          FastlaneCore::ConfigItem.new(key: :output_directory,
                                        short_option: "-s",
-                                       env_name: "DOWNLOAD_DSYMS_SAVE_DIRECTORY",
+                                       env_name: "DOWNLOAD_DSYMS_OUTPUT_DIRECTORY",
                                        description: "Where to save the download dSYMs, defaults to the current path",
                                        optional: true)
         ]

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -30,7 +30,6 @@ module Fastlane
         if version == 'latest'
           # Try to grab the live version first, else fallback to edit version
           latest_version = app.live_version(platform: platform) || app.edit_version(platform: platform)
-          UI.user_error!("Could not find a latest version of the app live or not.") unless latest_version
           version = latest_version.version
           build_number = latest_version.build_version
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The ability to specify where the dSYMs are saved when being downloaded from iTunes Connect.
Also the ability to only download the latest build's dSYM instead of having to look up the latest version before calling `download_dsyms`.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
I integrated this into my build system and have run it multiple times to check it grabs the latest, grabs a specific version, and all versions of build when downloading dSYMs.

### Description
<!--- Describe your changes in detail -->
- Add `save_directory` option to `download_dsyms` action. Allows specifying where the downloaded dSYMs are saved. Useful when you don't want dSYMs in the directory the command is run in.
- Adds keyword value `'latest'` to `version` option in `download_dsyms` action. Forces download of only the latest build's dSYM. Useful when you only need the dSYM for the latest version of the app. Having it be an option means the user doesn't have to figure out, or keep updating, the latest version.
