### PR TITLE
Version bump to 2.54.1

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.54.0'.freeze
+  VERSION = '2.54.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.54.0':**

* Update Xcode project syntax to work with older versions of Ruby (#10128) via Felix Krause
* Add a message about the badge plugin (#10127) via David Ohayon
* Deprecate badge action in favor of the plugin (#10026) via David Ohayon
* Use a method for oauth_app_name (#10126) via David Ohayon
* Use a method to generate the secondary target string (#10123) via David Ohayon
* Added option in deliver to ignore language directory validation from … (#10122) via Josh Holtz
* Correcting the AndroidPublisherService methods (#10120) via Minh Tran
* Values are represented as strings in FL_OCLINT_SELECT_REGEX (#10084) via Joshua Liebowitz
