### PR TITLE
Require 0.13.1+ of the google-api-client

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -51,7 +51,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
   spec.add_dependency 'fastimage', '>= 2.1.0', '< 3.0.0' # fetch the image sizes from the screenshots
   spec.add_dependency 'gh_inspector', '>= 1.0.1', '< 2.0.0' # search for issues on GitHub when something goes wrong
-  spec.add_dependency 'google-api-client', '>= 0.12.0', '< 1.0.0' # Google API Client to access Play Publishing API
   spec.add_dependency 'highline', '>= 1.7.2', '< 2.0.0' # user inputs (e.g. passwords)
   spec.add_dependency 'json', '< 3.0.0' # Because sometimes it's just not installed
   spec.add_dependency 'mini_magick', '~> 4.5.1' # To open, edit and export PSD files
@@ -64,6 +63,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bundler', '>= 1.12.0', '< 2.0.0' # Used for fastlane plugins
   spec.add_dependency 'faraday', '~> 0.9' # Used for deploygate, hockey and testfairy actions
   spec.add_dependency 'faraday_middleware', '~> 0.9' # same as faraday
+
+  # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.
+  # If you upgrade this gem, make sure to upgrade the users of it as well.
+  spec.add_dependency 'google-api-client', '>= 0.13.1', '< 0.14.0' # Google API Client to access Play Publishing API
 
   # Development only
   spec.add_development_dependency 'rake', '< 12'

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -333,7 +333,7 @@ module Supply
       ensure_active_edit!
 
       call_google_api do
-        android_publisher.deleteall_image(
+        android_publisher.delete_all_images(
           current_package_name,
           current_edit.id,
           language,


### PR DESCRIPTION

### Checklist
- [ X ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ X ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ X ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ X ] I've updated the documentation if necessary.

### Motivation and Context

Supply was recently updated to require the 0.13.0 branch of the google-api-client gem, but the gemspec didn't update to enforce this. See https://github.com/fastlane/fastlane/issues/10136 for more.

### Description

This PR pins the google-api-client version to the 0.13.x version of the gem to prevent drift, along with adding comments which should help to reduce inadvertent churn here. It also corrects what appears to be a missed name in one of the supply APIs (deleteall_image doesn't appear to exist, and should be delete_all_images instead)
