### PR TITLE
[match] Ignore `force_for_new_devices` for App Store profiles

### DIFF
--- a/match/README.md
+++ b/match/README.md
@@ -274,6 +274,8 @@ end
 
 By using the `force_for_new_devices` parameter, `match` will check if the device count has changed since the last time you ran `match`, and automatically re-generate the provisioning profile if necessary. You can also use `force: true` to re-generate the provisioning profile on each run.
 
+_**Important:** The `force_for_new_devices` parameter is ignored for App Store provisioning profiles since they don't contain any device information._
+
 If you're not using `fastlane`, you can also use the `force_for_new_devices` option from the command line:
 
 ```

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -125,7 +125,7 @@ module Match
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :force_for_new_devices,
                                      env_name: "MATCH_FORCE_FOR_NEW_DEVICES",
-                                     description: "Renew the provisioning profiles if the device count on the developer portal has changed",
+                                     description: "Renew the provisioning profiles if the device count on the developer portal has changed. Ignored for profile type 'appstore'",
                                      is_string: false,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :skip_docs,

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -120,7 +120,14 @@ module Match
       profile = profiles.last
 
       if params[:force_for_new_devices] && !params[:readonly]
-        params[:force] = device_count_different?(profile: profile) unless params[:force]
+        if prov_type != :appstore
+          params[:force] = device_count_different?(profile: profile) unless params[:force]
+        else
+          # App Store provisioning profiles don't contain device identifiers and
+          # thus shouldn't be renewed if the device count has changed.
+          UI.important "Warning: `force_for_new_devices` is set but is ignored for App Store provisioning profiles."
+          UI.important "You can safely stop specifying `force_for_new_devices` when running Match for type 'appstore'."
+        end
       end
 
       if profile.nil? or params[:force]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This pull request implements the change detailed in issue #10103.

I've tested my changes by running `fastlane match appstore --force_for_new_devices true --app_identifier "com.coolcompany.foo"` and verified both that the App Store provisioning profile is not renewed and that the new warning message is displayed.

If the _fastlane_ maintainers feel that this should be covered by an `rspec` test, I would appreciate some help in writing one (having no prior experience with `rspec`) 🙂

### Description
This pull request changes the behaviour of Match to ignore `force_for_new_devices` when running Match for App Store profiles. Before this change, invoking Match for `appstore` profiles with `force_for_new_devices` set would _always_ renew the App Store provisioning profiles, even if there were no new devices on the developer portal.

Even if there would have been new devices on the developer portal, renewing the App Store provisioning profile would be unnecessary since they don't contain any device information.

 Since the App Store profiles don’t contain any devices, the `device_count_different?` method would always return `true` (if there were at least 1 device on the developer portal), resulting in the observed behaviour. This method is no longer invoked for App Store profiles.