### PR TITLE
Renaming a few additional missed methods to the 0.13.1 API

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -225,7 +225,7 @@ module Supply
       ensure_active_edit!
 
       call_google_api do
-        android_publisher.upload_deobfuscationfile(
+        android_publisher.upload_edit_deobfuscationfile(
           current_package_name,
           current_edit.id,
           apk_version_code,
@@ -346,7 +346,7 @@ module Supply
       ensure_active_edit!
 
       call_google_api do
-        android_publisher.upload_expansionfile(
+        android_publisher.upload_expansion_file(
           current_package_name,
           current_edit.id,
           apk_version_code,


### PR DESCRIPTION
### Checklist
- [ X ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ X ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ X ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ X ] I've updated the documentation if necessary.

### Motivation and Context

Supply was updated recently, but didn't have the correct names of the APIs from the 0.13.1 google-api-client gem.

### Description

There were a few more methods that were misnamed in https://github.com/fastlane/fastlane/pull/10120. This PR addresses them to fix Supply.