### PR TITLE
Fix upload_deobfuscationfile Error

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -225,7 +225,7 @@ module Supply
       ensure_active_edit!
 
       call_google_api do
-        android_publisher.upload_deobfuscationfile(
+        android_publisher.upload_edit_deobfuscationfile(
           current_package_name,
           current_edit.id,
           apk_version_code,


### PR DESCRIPTION
The method name appears to have changed recently and it is not possible
to upload mapping files without a fix. I have verified the fix by uploading an APK w/ a mapping file to the Google Play Store.

Closes #10154

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.