### PR TITLE
Adding tests to verify that Google API has expected methods

### DIFF
--- a/supply/spec/client_spec.rb
+++ b/supply/spec/client_spec.rb
@@ -1,6 +1,5 @@
 describe Supply do
   describe Supply::Client do
-
     describe "AndroidPublisher" do
       let(:subject) { Androidpublisher::AndroidPublisherService.new }
 

--- a/supply/spec/client_spec.rb
+++ b/supply/spec/client_spec.rb
@@ -1,0 +1,30 @@
+describe Supply do
+  describe Supply::Client do
+
+    describe "AndroidPublisher" do
+      let(:subject) { Androidpublisher::AndroidPublisherService.new }
+
+      # Verify that the Google API client has all the expected methods we use.
+      it "has all the expected Google API methods" do
+        expect(subject.class.method_defined?(:commit_edit)).to eq(true)
+        expect(subject.class.method_defined?(:delete_edit)).to eq(true)
+        expect(subject.class.method_defined?(:delete_all_images)).to eq(true)
+        expect(subject.class.method_defined?(:get_listing)).to eq(true)
+        expect(subject.class.method_defined?(:get_track)).to eq(true)
+        expect(subject.class.method_defined?(:insert_edit)).to eq(true)
+        expect(subject.class.method_defined?(:list_apk_listings)).to eq(true)
+        expect(subject.class.method_defined?(:list_apks)).to eq(true)
+        expect(subject.class.method_defined?(:list_images)).to eq(true)
+        expect(subject.class.method_defined?(:list_listings)).to eq(true)
+        expect(subject.class.method_defined?(:update_apk_listing)).to eq(true)
+        expect(subject.class.method_defined?(:update_listing)).to eq(true)
+        expect(subject.class.method_defined?(:update_track)).to eq(true)
+        expect(subject.class.method_defined?(:upload_apk)).to eq(true)
+        expect(subject.class.method_defined?(:upload_edit_deobfuscationfile)).to eq(true)
+        expect(subject.class.method_defined?(:upload_expansion_file)).to eq(true)
+        expect(subject.class.method_defined?(:upload_image)).to eq(true)
+        expect(subject.class.method_defined?(:validate_edit)).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Checklist
- [ X ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ X ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ X ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ X ] I've updated the documentation if necessary.

### Motivation and Context
This PR adds some tests that will hopefully prevent future trivial Supply breakages caused by updating the google-api-client gem without updating the callsites.

### Description

This PR adds a basic test to verify that the Google API for AndroidPublisher has the expected methods we require in Supply. This will (hopefully) help prevent trivial breakages during upgrades.

The Supply::Client class needs more extensive unit test coverage, but that can wait for a later date. This will at least address a primary cause of recent Supply breakages.
