### PR TITLE
Fix regression with iMessage and AppleTV screenshots.

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -70,12 +70,10 @@ module Deliver
 
     def collect_screenshots(options)
       return [] if options[:skip_screenshots]
-      return collect_screenshots_for_languages(options)
+      return collect_screenshots_for_languages(options[:screenshots_path])
     end
 
-    def collect_screenshots_for_languages(options)
-      path = options[:screenshots_path]
-
+    def collect_screenshots_for_languages(path)
       screenshots = []
       extensions = '{png,jpg,jpeg}'
 


### PR DESCRIPTION
Revert to using a `path` argument to
`collect_screenshots_for_languages` to simpify recursive calling.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This fixes the regression described in #10157: having screenshots to upload in a "iMessage" or "appleTV" subdirectory causes a crash.

### Description
Revert back to having `collect_screenshots_for_languages` take a `path`, not an options hash to make it a bit simpler to recursively call the method.