### PR TITLE
[Gemspec] Restrict public_suffix to version 2.0.x

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -41,6 +41,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multipart-post', '~> 2.0.0' # Needed for uploading builds to appetize
   spec.add_dependency 'word_wrap', '~> 1.0.0' # to add line breaks for tables with long strings
 
+  spec.add_dependency 'public_suffix', '~> 2.0.0' # https://github.com/fastlane/fastlane/issues/10162
+
   # TTY dependencies
   spec.add_dependency 'tty-screen', '~> 0.5.0' # detect the terminal width
 


### PR DESCRIPTION
closes https://github.com/fastlane/fastlane/issues/10162

public_suffix a gem which we require transitively through
google-api-client -> adressable -> public_suffix recently released
version 3.x, which removes support for ruby 2.0.0.

Because addressable requires <= 4.0.0, >= 2.0.2, it is safe to
pin this to the 2.x versions for now, to fix installation of fastlane on
macOS system ruby.

If preferred, we could also make this conditional based on the ruby
version, but I am not a fan of complicating dependency graphs.