### PR TITLE
Fix upload_screenshots.rb requiring the options hash (#10173)

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -70,10 +70,10 @@ module Deliver
 
     def collect_screenshots(options)
       return [] if options[:skip_screenshots]
-      return collect_screenshots_for_languages(options[:screenshots_path])
+      return collect_screenshots_for_languages(options[:screenshots_path], options[:ignore_language_directory_validation])
     end
 
-    def collect_screenshots_for_languages(path)
+    def collect_screenshots_for_languages(path, ignore_validation)
       screenshots = []
       extensions = '{png,jpg,jpeg}'
 
@@ -81,7 +81,6 @@ module Deliver
         lang_hash[lang.downcase] = lang
       end
 
-      ignore_validation = options[:ignore_language_directory_validation]
       Loader.language_folders(path, ignore_validation).each do |lng_folder|
         language = File.basename(lng_folder)
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

#10173 describes the issue. 
I've tested it using the local version fastlane to actually deliver an app I'm working on.

### Description

A previous commit edited deliver's `upload_screenshots.rb` in a way that broke the function. This change fixes it while keeping the reasoning behind the previous change (I hope!).
