### PR TITLE
Escape HipChat room name

### DIFF
--- a/fastlane/lib/fastlane/actions/hipchat.rb
+++ b/fastlane/lib/fastlane/actions/hipchat.rb
@@ -46,6 +46,9 @@ module Fastlane
           end
         else
           ########## running on V2 ##########
+          # Escape channel's name to guarantee it is a valid URL resource.
+          # First of all we verify that the value is not already escaped,
+          # escaping an escaped value will produce a wrong channel name.
           escaped_channel = URI.unescape(channel) == channel ? URI.escape(channel) : channel
           if user?(channel)
             params = { 'message' => message, 'message_format' => message_format }

--- a/fastlane/lib/fastlane/actions/hipchat.rb
+++ b/fastlane/lib/fastlane/actions/hipchat.rb
@@ -46,19 +46,19 @@ module Fastlane
           end
         else
           ########## running on V2 ##########
+          escaped_channel = URI.unescape(channel) == channel ? URI.escape(channel) : channel
           if user?(channel)
             params = { 'message' => message, 'message_format' => message_format }
             json_headers = { 'Content-Type' => 'application/json',
                              'Accept' => 'application/json', 'Authorization' => "Bearer #{api_token}" }
 
-            escaped_channel = URI.unescape(channel) == channel ? URI.escape(channel) : channel
             uri = URI.parse("https://#{api_host}/v2/user/#{escaped_channel}/message")
             http = Net::HTTP.new(uri.host, uri.port)
             http.use_ssl = true
 
             response = http.post(uri.path, params.to_json, json_headers)
           else
-            uri = URI.parse("https://#{api_host}/v2/room/#{channel}/notification")
+            uri = URI.parse("https://#{api_host}/v2/room/#{escaped_channel}/notification")
             response = Net::HTTP.post_form(uri, { 'from' => from,
                                                   'auth_token' => api_token,
                                                   'color' => color,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #10178 

### Description
The channel is being escaped before building the HipChat API URL for sending message to a specific user, but this was not true for messages sent to rooms.
