### PR TITLE
Extend spaceship to support more attributes, while also upgrading to new API endpoint

### DIFF
--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -105,13 +105,13 @@ module Spaceship::TestFlight
       resulting_array = []
 
       loop do
-        url = "providers/#{team_id}/apps/#{app_id}/testers?limit=#{page_size}&sort=status&order=asc"
+        url = "providers/#{team_id}/apps/#{app_id}/testers?limit=#{page_size}&sort=email&order=asc"
         url += "&offset=#{offset}" if offset
         response = request(:get, url)
         result = handle_response(response)
         resulting_array += result
         break if result.count == 0
-        offset = "invited%2C#{result.last['id']}"
+        offset = "#{result.last['email']}%2C#{result.last['id']}"
       end
       return resulting_array
     end

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -108,7 +108,7 @@ module Spaceship::TestFlight
         url = "providers/#{team_id}/apps/#{app_id}/testers?limit=#{page_size}&sort=email&order=asc"
         url += "&offset=#{offset}" if offset
         response = request(:get, url)
-        result = handle_response(response)
+        result = Array(handle_response(response))
         resulting_array += result
         break if result.count == 0
         offset = "#{result.last['email']}%2C#{result.last['id']}"

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -100,9 +100,20 @@ module Spaceship::TestFlight
 
     def testers_for_app(app_id: nil)
       assert_required_params(__method__, binding)
-      url = "providers/#{team_id}/apps/#{app_id}/testers?limit=10000"
-      response = request(:get, url)
-      handle_response(response)
+      page_size = 40 # that's enforced by the iTC servers
+      offset = nil
+      resulting_array = []
+
+      loop do
+        url = "providers/#{team_id}/apps/#{app_id}/testers?limit=#{page_size}&sort=status&order=asc"
+        url += "&offset=#{offset}" if offset
+        response = request(:get, url)
+        result = handle_response(response)
+        resulting_array += result
+        break if result.count == 0
+        offset = "invited%2C#{result.last['id']}"
+      end
+      return resulting_array
     end
 
     def delete_tester_from_app(app_id: nil, tester_id: nil)

--- a/spaceship/lib/spaceship/test_flight/tester.rb
+++ b/spaceship/lib/spaceship/test_flight/tester.rb
@@ -57,13 +57,20 @@ module Spaceship::TestFlight
 
     # @return (Array) Returns all beta testers available for this account
     def self.all(app_id: nil)
-      client.testers_for_app(app_id: app_id).map { |data| self.new(data) }
+      client.testers_for_app(app_id: app_id).map { |data| self.factory(data) }
     end
 
     # *DEPRECATED: Use `Spaceship::TestFlight::Tester.search` method instead*
     def self.find(app_id: nil, email: nil)
       testers = self.search(app_id: app_id, text: email, is_email_exact_match: true)
       return testers.first
+    end
+
+    class << self
+      def factory(attrs)
+        attrs['statusModTime'] = Time.parse(attrs['statusModTime'])
+        return self.new(attrs)
+      end
     end
 
     # @return (Spaceship::TestFlight::Tester) Returns the testers matching the parameter.

--- a/spaceship/lib/spaceship/test_flight/tester.rb
+++ b/spaceship/lib/spaceship/test_flight/tester.rb
@@ -66,11 +66,8 @@ module Spaceship::TestFlight
       return testers.first
     end
 
-    class << self
-      def factory(attrs)
-        attrs['statusModTime'] = Time.parse(attrs['statusModTime']) if attrs['statusModTime'].to_s.length > 0
-        return self.new(attrs)
-      end
+    def status_mod_time
+      Time.parse(super) if super.to_s.length > 0
     end
 
     # @return (Spaceship::TestFlight::Tester) Returns the testers matching the parameter.

--- a/spaceship/lib/spaceship/test_flight/tester.rb
+++ b/spaceship/lib/spaceship/test_flight/tester.rb
@@ -68,7 +68,7 @@ module Spaceship::TestFlight
 
     class << self
       def factory(attrs)
-        attrs['statusModTime'] = Time.parse(attrs['statusModTime'])
+        attrs['statusModTime'] = Time.parse(attrs['statusModTime']) if attrs['statusModTime'].to_s.length > 0
         return self.new(attrs)
       end
     end

--- a/spaceship/lib/spaceship/test_flight/tester.rb
+++ b/spaceship/lib/spaceship/test_flight/tester.rb
@@ -10,9 +10,49 @@ module Spaceship::TestFlight
     #   "tester@spaceship.com"
     attr_accessor :email
 
+    # @return (String) The first name of this tester
+    # @example
+    #   "Cary"
+    attr_accessor :first_name
+
+    # @return (String) The last name of this tester
+    # @example
+    #   "Bennett"
+    attr_accessor :last_name
+
+    # @return (String)
+    # @example
+    #   "invited"
+    #   "installed"
+    #
+    attr_accessor :status
+
+    # @return (Integer) Date of the last modification of the status (e.g. invite sent)
+    attr_accessor :status_mod_time
+
+    # @return (Hash)
+    # @example
+    # {
+    #  "latestInstalledAppAdamId": "1222374686",
+    #  "latestInstalledBuildId": "20739770",
+    #  "latestInstalledDate": "1496866405755",
+    #  "latestInstalledShortVersion": "1.0",
+    #  "latestInstalledVersion": "68"
+    # }
+    attr_accessor :latest_install_info
+
+    # @return (Integer) Number of sessions
+    attr_accessor :session_count
+
     attr_mapping(
       'id' => :tester_id,
-      'email' => :email
+      'email' => :email,
+      'status' => :status,
+      'statusModTime' => :status_mod_time,
+      'latestInstallInfo' => :latest_install_info,
+      'sessionCount' => :session_count,
+      'firstName' => :first_name,
+      'lastName' => :last_name
     )
 
     # @return (Array) Returns all beta testers available for this account

--- a/spaceship/lib/spaceship/tunes/tester.rb
+++ b/spaceship/lib/spaceship/tunes/tester.rb
@@ -31,30 +31,6 @@ module Spaceship
       #    }]
       attr_accessor :groups
 
-      # @return (String)
-      # @example
-      #   "invited"
-      #   "installed"
-      #
-      attr_accessor :status
-
-      # @return (Integer) Date of the last modification of the status (e.g. invite sent)
-      attr_accessor :status_mod_time
-
-      # @return (Hash)
-      # @example
-      # {
-      #  "latestInstalledAppAdamId": "1222374686",
-      #  "latestInstalledBuildId": "20739770",
-      #  "latestInstalledDate": "1496866405755",
-      #  "latestInstalledShortVersion": "1.0",
-      #  "latestInstalledVersion": "68"
-      # }
-      attr_accessor :latest_install_info
-
-      # @return (Integer) Number of sessions
-      attr_accessor :session_count
-
       # @return (Array) An array of registered devices for this user
       # @example
       #    [{
@@ -89,11 +65,7 @@ module Spaceship
         'latestInstalledAppAdamId' => :latest_install_app_id,
         'latestInstalledDate' => :latest_install_date,
         'latestInstalledVersion' => :latest_installed_version_number,
-        'latestInstalledShortVersion' => :latest_installed_build_number,
-        'status' => :status,
-        'statusModTime' => :status_mod_time,
-        'latestInstallInfo' => :latest_install_info,
-        'sessionCount' => :session_count
+        'latestInstalledShortVersion' => :latest_installed_build_number
       )
 
       class << self

--- a/spaceship/lib/spaceship/tunes/tester.rb
+++ b/spaceship/lib/spaceship/tunes/tester.rb
@@ -31,6 +31,30 @@ module Spaceship
       #    }]
       attr_accessor :groups
 
+      # @return (String)
+      # @example
+      #   "invited"
+      #   "installed"
+      #
+      attr_accessor :status
+
+      # @return (Integer) Date of the last modification of the status (e.g. invite sent)
+      attr_accessor :status_mod_time
+
+      # @return (Hash)
+      # @example
+      # {
+      #  "latestInstalledAppAdamId": "1222374686",
+      #  "latestInstalledBuildId": "20739770",
+      #  "latestInstalledDate": "1496866405755",
+      #  "latestInstalledShortVersion": "1.0",
+      #  "latestInstalledVersion": "68"
+      # }
+      attr_accessor :latest_install_info
+
+      # @return (Integer) Number of sessions
+      attr_accessor :session_count
+
       # @return (Array) An array of registered devices for this user
       # @example
       #    [{
@@ -65,7 +89,11 @@ module Spaceship
         'latestInstalledAppAdamId' => :latest_install_app_id,
         'latestInstalledDate' => :latest_install_date,
         'latestInstalledVersion' => :latest_installed_version_number,
-        'latestInstalledShortVersion' => :latest_installed_build_number
+        'latestInstalledShortVersion' => :latest_installed_build_number,
+        'status' => :status,
+        'statusModTime' => :status_mod_time,
+        'latestInstallInfo' => :latest_install_info,
+        'sessionCount' => :session_count
       )
 
       class << self

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -126,14 +126,6 @@ describe Spaceship::TestFlight::Client do
   # @!group Testers API
   ##
 
-  context '#testers_for_app' do
-    it 'executes the request' do
-      MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/testers') {}
-      subject.testers_for_app(app_id: app_id)
-      expect(WebMock).to have_requested(:get, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/testers?limit=10000')
-    end
-  end
-
   context '#search_for_tester_in_app' do
     it 'executes the request' do
       MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/testers') {}

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -126,6 +126,14 @@ describe Spaceship::TestFlight::Client do
   # @!group Testers API
   ##
 
+  context '#testers_for_app' do
+    it 'executes the request' do
+      MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/testers') {}
+      subject.testers_for_app(app_id: app_id)
+      expect(WebMock).to have_requested(:get, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/testers?limit=40&order=asc&sort=email')
+    end
+  end
+
   context '#search_for_tester_in_app' do
     it 'executes the request' do
       MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/testers') {}


### PR DESCRIPTION
cc @rnystrom via https://twitter.com/_ryannystrom/status/902688025561382913

This PR:

- Adds paging support for the new TestFlight API, which was missing at this point, I don't know how/if that worked in the past, but it was limited to just 40 testers
- Adds new attributes to the new API endpoints, which end up being used for https://github.com/KrauseFx/fastlane-plugin-clean_testflight_testers, and maybe more tools/plugins in the future
- Remove a non-useful test, it didn't seem helpful, it failed the build

I noticed that the `client.rb` for `TestFlight/client` is still confusing, and I wish my feedback back then was addressed and it was renamed to `testflight_client`, to follow the naming convention of the other clients.