### PR TITLE
Ignore empty password for FASTLANE_PASSWORD

### DIFF
--- a/credentials_manager/lib/credentials_manager/account_manager.rb
+++ b/credentials_manager/lib/credentials_manager/account_manager.rb
@@ -34,7 +34,7 @@ module CredentialsManager
 
     def fetch_password_from_env
       password = ENV["FASTLANE_PASSWORD"] || ENV["DELIVER_PASSWORD"]
-      password unless password.to_s.length == 0
+      return password unless password.to_s.length == 0
     end
 
     def password(ask_if_missing: true)

--- a/credentials_manager/lib/credentials_manager/account_manager.rb
+++ b/credentials_manager/lib/credentials_manager/account_manager.rb
@@ -33,7 +33,8 @@ module CredentialsManager
     end
 
     def fetch_password_from_env
-      ENV["FASTLANE_PASSWORD"] || ENV["DELIVER_PASSWORD"]
+      password = ENV["FASTLANE_PASSWORD"] || ENV["DELIVER_PASSWORD"]
+      password unless password.to_s.length == 0
     end
 
     def password(ask_if_missing: true)

--- a/credentials_manager/spec/account_manager_spec.rb
+++ b/credentials_manager/spec/account_manager_spec.rb
@@ -52,6 +52,20 @@ describe CredentialsManager do
       ENV.delete('FASTLANE_USER')
     end
 
+    it "loads the password from the keychain if empty password is stored by env" do
+      ENV['FASTLANE_USER'] = user
+      ENV['FASTLANE_PASSWORD'] = ''
+      c = CredentialsManager::AccountManager.new
+
+      dummy = Object.new
+      expect(dummy).to receive(:password).and_return("Yeah! Pass!")
+
+      expect(Security::InternetPassword).to receive(:find).with(server: "deliver.felix@krausefx.com").and_return(dummy)
+      expect(c.password).to eq("Yeah! Pass!")
+      ENV.delete('FASTLANE_USER')
+      ENV.delete('FASTLANE_PASSWORD')
+    end
+
     it "removes the Keychain item if the user agrees when the credentials are invalid" do
       expect(Security::InternetPassword).to receive(:delete).with(server: "deliver.felix@krausefx.com").and_return(nil)
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
I found this input field when I use match in spite of storing password in Keychain.
```
-------------------------------------------------------------------------------------
Please provide your Apple Developer Program account credentials
The login information you enter will be stored in your macOS Keychain
You can also pass the password using the `FASTLANE_PASSWORD` environment variable
More information about it on GitHub: https://github.com/fastlane/fastlane/tree/master/credentials_manager
-------------------------------------------------------------------------------------
Password (for yourmail@yourdomain): 
```
I noticed that my env file includes this line `FASTLANE_PASSWORD = ''` 
If empty password exists in env file, the user cannot use password from keychain and cannot store password to keychain. I think the user wants to get the password from keychain in this case.

### Description
<!--- Describe your changes in detail -->
If FASTLANE_PASSWORD is empty in env, ignore it.
