### PR TITLE
[snapshot] excludes helpers in assets when finding helpers

### DIFF
--- a/snapshot/lib/snapshot/update.rb
+++ b/snapshot/lib/snapshot/update.rb
@@ -3,7 +3,9 @@ module Snapshot
   class Update
     # @return [Array] A list of helper files (usually just one)
     def self.find_helper
-      Dir["./**/SnapshotHelper.swift"] + Dir["./**/SnapshotHelperXcode8.swift"]
+      paths = Dir["./**/SnapshotHelper.swift"] + Dir["./**/SnapshotHelperXcode8.swift"]
+      # exclude assets in gym
+      paths.reject { |p| p.include?("snapshot/lib/assets/") }
     end
 
     def update


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When install fastlane with `bundle install --path xxx` (e.g. `bundle install --path vendor/bundle`), snapshot helpers is created under the current directory. In current `fastlane snapshot update` is check the all sources under the current directory.

```
$ bundle install --path vendor/bundle
$ bundle exec fastlane snapshot update
[18:29:12]: Found the following SnapshotHelper:
[18:29:12]:     ./sample-ios-swift-snapshot/Helpers/SnapshotHelper.swift
[18:29:12]:     ./vendor/bundle/ruby/2.4.0/gems/fastlane-2.54.3/snapshot/lib/assets/SnapshotHelper.swift
[18:29:12]:     ./vendor/bundle/ruby/2.4.0/gems/fastlane-2.54.3/snapshot/lib/assets/SnapshotHelperXcode8.swift
[18:29:12]: Are you sure you want to automatically update the helpers listed above?
[18:29:12]: This will overwrite all its content with the latest code.
[18:29:12]: The underlying API will not change. You can always migrate manually by looking at
[18:29:12]: https://github.com/fastlane/fastlane/blob/master/snapshot/lib/assets/SnapshotHelper.swift
[18:29:12]: Overwrite configuration files? (y/n)
```

Helpers under `lib/assets` is original sources, therefore it should not be included in lists. Expected behaviors are as follows.

```
$ bundle exec fastlane snapshot update
[18:30:33]: Found the following SnapshotHelper:
[18:30:33]:     ./sample-ios-swift-snapshot/Helpers/SnapshotHelper.swift
[18:30:33]: Are you sure you want to automatically update the helpers listed above?
[18:30:33]: This will overwrite all its content with the latest code.
[18:30:33]: The underlying API will not change. You can always migrate manually by looking at
[18:30:33]: https://github.com/fastlane/fastlane/blob/master/snapshot/lib/assets/SnapshotHelper.swift
[18:30:33]: Overwrite configuration files? (y/n)
```

### Description
Excludes helper paths in assets when finding helpers.