### PR TITLE
[snapshot] Delete simulators based on versions

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -180,6 +180,13 @@ module FastlaneCore
         `xcrun simctl erase #{self.udid}`
         return
       end
+
+      def delete
+        UI.message("Deleting #{self}")
+        `xcrun simctl shutdown #{self.udid}` if self.state == "Booted"
+        `xcrun simctl delete #{self.udid}`
+        return
+      end
     end
   end
 
@@ -204,6 +211,16 @@ module FastlaneCore
       def reset(udid: nil, name: nil, os_version: nil)
         match = all.detect { |device| device.udid == udid || device.name == name && device.os_version == os_version }
         match.reset if match
+      end
+
+      # Delete all simulators of this type
+      def delete_all
+        all.each(&:delete)
+      end
+
+      def delete_all_by_version(os_version: nil)
+        return false unless os_version
+        all.select { |device| device.os_version == os_version }.each(&:delete)
       end
 
       def clear_cache

--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -183,7 +183,7 @@ module FastlaneCore
 
       def delete
         UI.message("Deleting #{self}")
-        `xcrun simctl shutdown #{self.udid}` if self.state == "Booted"
+        `xcrun simctl shutdown #{self.udid}` unless self.state == "Shutdown"
         `xcrun simctl delete #{self.udid}`
         return
       end

--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -18,18 +18,13 @@ module Snapshot
       if ios_versions
         ios_versions.each do |version|
           FastlaneCore::Simulator.delete_all_by_version(os_version: version)
-          FastlaneCore::SimulatorTV.delete_all_by_version(os_version: version)
-        end
-        if version.include?('11')
-          FastlaneCore::SimulatorWatch.delete_all_by_version(os_version: '4.0')
-        else
-          FastlaneCore::SimulatorWatch.delete_all_by_version(os_version: '3.2')
         end
       else
         FastlaneCore::Simulator.delete_all
-        FastlaneCore::SimulatorTV.delete_all
-        FastlaneCore::SimulatorWatch.delete_all
       end
+
+      FastlaneCore::SimulatorTV.delete_all
+      FastlaneCore::SimulatorWatch.delete_all
 
       all_runtime_type = `xcrun simctl list runtimes`.scan(/(.*)\s\(\d.*(com\.apple[^)\s]*)/)
       # == Runtimes ==

--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -21,7 +21,7 @@ module Snapshot
         FastlaneCore::Simulator.delete_all
       end
 
-      all_runtime_type = `xcrun simctl list runtimes`.scan(/(.*)\s\(.*\((.*)\)/)
+      all_runtime_type = `xcrun simctl list runtimes`.scan(/(.*)\s\(\d.*(com\.apple[^)\s]*)/)
       # == Runtimes ==
       # iOS 9.3 (9.3 - 13E233) (com.apple.CoreSimulator.SimRuntime.iOS-9-3)
       # iOS 10.0 (10.0 - 14A345) (com.apple.CoreSimulator.SimRuntime.iOS-10-0)

--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -26,7 +26,7 @@ module Snapshot
       FastlaneCore::SimulatorTV.delete_all
       FastlaneCore::SimulatorWatch.delete_all
 
-      all_runtime_type = `xcrun simctl list runtimes`.scan(/(.*)\s\(\d.*(com\.apple[^)\s]*)/)
+      all_runtime_type = runtimes()
       # == Runtimes ==
       # iOS 9.3 (9.3 - 13E233) (com.apple.CoreSimulator.SimRuntime.iOS-9-3)
       # iOS 10.0 (10.0 - 14A345) (com.apple.CoreSimulator.SimRuntime.iOS-10-0)
@@ -89,6 +89,10 @@ module Snapshot
       end
 
       result.select { |parsed| parsed.length == 3 } # we don't care about those headers
+    end
+
+    def self.runtimes
+      all_runtime_type = Helper.backticks('xcrun simctl list runtimes', print: FastlaneCore::Globals.verbose?).scan(/(.*)\s\(\d.*(com\.apple[^)\s]*)/)
     end
 
     def self.make_phone_watch_pair

--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -26,7 +26,7 @@ module Snapshot
       FastlaneCore::SimulatorTV.delete_all
       FastlaneCore::SimulatorWatch.delete_all
 
-      all_runtime_type = runtimes()
+      all_runtime_type = runtimes
       # == Runtimes ==
       # iOS 9.3 (9.3 - 13E233) (com.apple.CoreSimulator.SimRuntime.iOS-9-3)
       # iOS 10.0 (10.0 - 14A345) (com.apple.CoreSimulator.SimRuntime.iOS-10-0)
@@ -92,7 +92,7 @@ module Snapshot
     end
 
     def self.runtimes
-      all_runtime_type = Helper.backticks('xcrun simctl list runtimes', print: FastlaneCore::Globals.verbose?).scan(/(.*)\s\(\d.*(com\.apple[^)\s]*)/)
+      Helper.backticks('xcrun simctl list runtimes', print: FastlaneCore::Globals.verbose?).scan(/(.*)\s\(\d.*(com\.apple[^)\s]*)/)
     end
 
     def self.make_phone_watch_pair

--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -29,6 +29,12 @@ module Snapshot
       # iOS 10.2 (10.2 - 14C89) (com.apple.CoreSimulator.SimRuntime.iOS-10-2)
       # tvOS 10.1 (10.1 - 14U591) (com.apple.CoreSimulator.SimRuntime.tvOS-10-1)
       # watchOS 3.1 (3.1 - 14S471a) (com.apple.CoreSimulator.SimRuntime.watchOS-3-1)
+      #
+      # Xcode 9 changed the format
+      # == Runtimes ==
+      # iOS 11.0 (11.0 - 15A5361a) - com.apple.CoreSimulator.SimRuntime.iOS-11-0
+      # tvOS 11.0 (11.0 - 15J5368a) - com.apple.CoreSimulator.SimRuntime.tvOS-11-0
+      # watchOS 4.0 (4.0 - 15R5363a) - com.apple.CoreSimulator.SimRuntime.watchOS-4-0
       ios_versions_ids = filter_runtimes(all_runtime_type, 'iOS', ios_versions)
       tv_version_ids = filter_runtimes(all_runtime_type, 'tvOS')
       watch_versions_ids = filter_runtimes(all_runtime_type, 'watchOS')

--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -15,10 +15,10 @@ module Snapshot
 
       UI.abort_with_message!("User cancelled action") unless sure
 
-      devices.each do |device|
-        _, name, id = device
-        puts "Removing device #{name} (#{id})"
-        `xcrun simctl delete #{id}`
+      if ios_versions
+        FastlaneCore::Simulator.delete_all_by_version(ios_versions)
+      else
+        FastlaneCore::Simulator.delete_all
       end
 
       all_runtime_type = `xcrun simctl list runtimes`.scan(/(.*)\s\(.*\((.*)\)/)

--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -18,9 +18,17 @@ module Snapshot
       if ios_versions
         ios_versions.each do |version|
           FastlaneCore::Simulator.delete_all_by_version(os_version: version)
+          FastlaneCore::SimulatorTV.delete_all_by_version(os_version: version)
+        end
+        if version.include?('11')
+          FastlaneCore::SimulatorWatch.delete_all_by_version(os_version: '4.0')
+        else
+          FastlaneCore::SimulatorWatch.delete_all_by_version(os_version: '3.2')
         end
       else
         FastlaneCore::Simulator.delete_all
+        FastlaneCore::SimulatorTV.delete_all
+        FastlaneCore::SimulatorWatch.delete_all
       end
 
       all_runtime_type = `xcrun simctl list runtimes`.scan(/(.*)\s\(\d.*(com\.apple[^)\s]*)/)

--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -16,7 +16,9 @@ module Snapshot
       UI.abort_with_message!("User cancelled action") unless sure
 
       if ios_versions
-        FastlaneCore::Simulator.delete_all_by_version(os_version: ios_versions)
+        ios_versions.each do |version|
+          FastlaneCore::Simulator.delete_all_by_version(os_version: version)
+        end
       else
         FastlaneCore::Simulator.delete_all
       end

--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -16,7 +16,7 @@ module Snapshot
       UI.abort_with_message!("User cancelled action") unless sure
 
       if ios_versions
-        FastlaneCore::Simulator.delete_all_by_version(ios_versions)
+        FastlaneCore::Simulator.delete_all_by_version(os_version: ios_versions)
       else
         FastlaneCore::Simulator.delete_all
       end

--- a/snapshot/spec/fixtures/xcrun-simctl-list-runtimes-Xcode8.txt
+++ b/snapshot/spec/fixtures/xcrun-simctl-list-runtimes-Xcode8.txt
@@ -1,0 +1,4 @@
+== Runtimes ==
+iOS 10.3 (10.3.1 - 14E8301) (com.apple.CoreSimulator.SimRuntime.iOS-10-3)
+tvOS 10.2 (10.2 - 14W260) (com.apple.CoreSimulator.SimRuntime.tvOS-10-2)
+watchOS 3.2 (3.2 - 14V243) (com.apple.CoreSimulator.SimRuntime.watchOS-3-2)

--- a/snapshot/spec/fixtures/xcrun-simctl-list-runtimes-Xcode9.txt
+++ b/snapshot/spec/fixtures/xcrun-simctl-list-runtimes-Xcode9.txt
@@ -1,0 +1,4 @@
+== Runtimes ==
+iOS 10.3 (10.3.1 - 14E8301) - com.apple.CoreSimulator.SimRuntime.iOS-10-3
+tvOS 10.2 (10.2 - 14W260) - com.apple.CoreSimulator.SimRuntime.tvOS-10-2
+watchOS 3.2 (3.2 - 14V243) - com.apple.CoreSimulator.SimRuntime.watchOS-3-2

--- a/snapshot/spec/reset_simulators_spec.rb
+++ b/snapshot/spec/reset_simulators_spec.rb
@@ -20,17 +20,43 @@ describe Snapshot::ResetSimulators do
     ]
   end
 
+  let(:runtimes) do
+    [
+      ["iOS 10.3", "com.apple.CoreSimulator.SimRuntime.iOS-10-3"],
+      ["tvOS 10.2", "com.apple.CoreSimulator.SimRuntime.tvOS-10-2"],
+      ["watchOS 3.2", "com.apple.CoreSimulator.SimRuntime.watchOS-3-2"]
+    ]
+  end
+
   let(:all_devices) do
     usable_devices + unusable_devices
   end
 
   let(:fixture_data) { File.read('snapshot/spec/fixtures/xcrun-simctl-list-devices.txt') }
 
+  let(:fixture_runtimes_xcode8) { File.read('snapshot/spec/fixtures/xcrun-simctl-list-runtimes-Xcode8.txt') }
+
+  let(:fixture_runtimes_xcode9) { File.read('snapshot/spec/fixtures/xcrun-simctl-list-runtimes-Xcode9.txt') }
+
   describe '#devices' do
     it 'should read simctl output into arrays of device info' do
       expect(FastlaneCore::Helper).to receive(:backticks).with(/xcrun simctl list devices/, print: FastlaneCore::Globals.verbose?).and_return(fixture_data)
 
       expect(Snapshot::ResetSimulators.devices).to eq(all_devices)
+    end
+  end
+
+  describe '#clear_everything' do
+    describe 'runtimes' do
+      it "should find runtimes that are available for Xcode 8" do
+        expect(FastlaneCore::Helper).to receive(:backticks).with(/xcrun simctl list runtimes/, print: FastlaneCore::Globals.verbose?).and_return(fixture_runtimes_xcode8)
+        expect(Snapshot::ResetSimulators.runtimes).to eq(runtimes)
+      end
+
+      it "should find runtimes that are available for Xcode 9" do
+        expect(FastlaneCore::Helper).to receive(:backticks).with(/xcrun simctl list runtimes/, print: FastlaneCore::Globals.verbose?).and_return(fixture_runtimes_xcode9)
+        expect(Snapshot::ResetSimulators.runtimes).to eq(runtimes)
+      end
     end
   end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Would be better to have the option to delete on specific version.
Also fixes #10174 