### PR TITLE
make sure not to call map on nil array

### DIFF
--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
@@ -152,7 +152,7 @@ module Snapshot
           hash[name] = ["No tests were executed"]
         else
           tests = Array(summary.data.first[:tests])
-          hash[name] = tests.map { |test| test[:failures].map { |failure| failure[:failure_message] } }.flatten
+          hash[name] = tests.map { |test| Array(test[:failures]).map { |failure| failure[:failure_message] } }.flatten
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/10214 where the test's failure's array is nil.