### PR TITLE
Version bump to 2.55.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.54.4'.freeze
+  VERSION = '2.55.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.54.4':**

* make sure not to call map on nil array (#10219) via David Ohayon
* Update data structure for tester exporting (#10207) via David Ohayon
* Clarify question in app_store_build_number action (#10203) via Felix Krause
* Show nice error message for common Xcode 9 code signing issue (#10204) via Felix Krause
* Add support for provisioning profile templates for all fastlane tools (#9912) via Andrei Raifura
* Escape HipChat room name (#10179) via Takeichi Kanzaki Cabrera
