### PR TITLE
Add detection of developerRemovedFromSale to iap_status (#10206)

### DIFF
--- a/spaceship/lib/spaceship/tunes/iap_status.rb
+++ b/spaceship/lib/spaceship/tunes/iap_status.rb
@@ -25,6 +25,9 @@ module Spaceship
       # In-app purchase rejected for whatever reason
       REJECTED = "Rejected"
 
+      # The developer took the app from the App Store
+      DEVELOPER_REMOVED_FROM_SALE = "Developer Removed From Sale"
+
       # Get the iap status matching based on a string (given by iTunes Connect)
       def self.get_from_string(text)
         mapping = {
@@ -34,7 +37,8 @@ module Spaceship
           'inReview' => IN_REVIEW,
           'readyForSale' => APPROVED,
           'deleted' => DELETED,
-          'rejected' => REJECTED
+          'rejected' => REJECTED,
+          'developerRemovedFromSale' => DEVELOPER_REMOVED_FROM_SALE
         }
 
         mapping.each do |itc_status, readable_status|


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
IAPList's `status` returns `nil` when in "Developer removed from sale" status.
Please refer to #10206 for more details.


### Description
<!--- Describe your changes in detail -->
I added a `DEVELOPER_REMOVED_FROM_SALE` status and its matching string to `IAPStatus` class.