### PR TITLE
Fix xcode_version not changed after xcode_select

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -141,11 +141,12 @@ module FastlaneCore
     # @return The version of the currently used Xcode installation (e.g. "7.0")
     def self.xcode_version
       return nil unless self.is_mac?
-      return @xcode_version if @xcode_version
+      return @xcode_version if @xcode_version && @developer_dir == ENV['DEVELOPER_DIR']
 
       begin
         output = `DEVELOPER_DIR='' "#{xcode_path}/usr/bin/xcodebuild" -version`
         @xcode_version = output.split("\n").first.split(' ')[1]
+        @developer_dir = ENV['DEVELOPER_DIR']
       rescue => ex
         UI.error(ex)
         UI.user_error!("Error detecting currently used Xcode installation, please ensure that you have Xcode installed and set it using `sudo xcode-select -s [path]`")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

The result of `Helper.xcode_version` never changes even if the selected xcode version changed by the `xcode_select` action.

In my environment, Xcode 8.3.3 installed to `/Applications/Xcode.app` and Xcode 9 beta installed to `/Applications/Xcode-beta.app`.  Then
```
% cat fastlane/Fastfile
platform :ios do
  lane :test do
    UI.message Helper.xcode_path
    UI.message Helper.xcode_version
    UI.message `xcodebuild -version`

    xcode_select '/Applications/Xcode-beta.app'

    UI.message Helper.xcode_path
    UI.message Helper.xcode_version
    UI.message `xcodebuild -version`
  end
end

% fastlane ios test
[04:19:55]: Get started using a Gemfile for fastlane https://docs.fastlane.tools/getting-started/ios/setup/#use-a-gemfile
[04:19:57]: Driving the lane 'ios test' 🚀
[04:19:58]: /Applications/Xcode.app/Contents/Developer/
[04:19:58]: 8.3.3
[04:19:58]: Xcode 8.3.3
Build version 8E3004b

[04:19:58]: --------------------------
[04:19:58]: --- Step: xcode_select ---
[04:19:58]: --------------------------
[04:19:58]: Setting Xcode version to /Applications/Xcode-beta.app for all build steps
[04:19:58]: /Applications/Xcode-beta.app/Contents/Developer/
[04:19:58]: 8.3.3
[04:19:58]: Xcode 9.0
Build version 9M214v
```
The result of the second `Helper.xcode_version` should be `9.0` .

I found this problem when I used snapshot. It check the xcode version before test.
https://github.com/fastlane/fastlane/blob/f410f2a6d9d20ae8e6747db978cae7142a03d781/snapshot/lib/snapshot/runner.rb#L33

The `@xcode_version` is saved at the begening of the build.
https://github.com/fastlane/fastlane/blob/master/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb#L47

### Description
<!--- Describe your changes in detail -->

I added the `@developer_dir` variable to detect the change of the selected xcode path.