### PR TITLE
Make Carthage action support dependencies with build command

### DIFF
--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -11,7 +11,7 @@ module Fastlane
 
         if command_name == "archive" && params[:frameworks].count > 0
           cmd.concat params[:frameworks]
-        elsif command_name == "update" && params[:dependencies].count > 0
+        elsif (command_name == "update" || command_name == "build") && params[:dependencies].count > 0
           cmd.concat params[:dependencies]
         end
 
@@ -65,7 +65,7 @@ module Fastlane
                                          UI.user_error!("Please pass a valid command. Use one of the following: #{available_commands.join(', ')}") unless available_commands.include? value
                                        end),
           FastlaneCore::ConfigItem.new(key: :dependencies,
-                                       description: "Carthage dependencies to update",
+                                       description: "Carthage dependencies to update or build",
                                        default_value: [],
                                        is_string: false,
                                        type: Array),
@@ -174,7 +174,7 @@ module Fastlane
             frameworks: ["MyFramework1", "MyFramework2"],   # Specify which frameworks to archive (only for the archive command)
             output: "MyFrameworkBundle.framework.zip",      # Specify the output archive name (only for the archive command)
             command: "bootstrap",                           # One of: build, bootstrap, update, archive. (default: bootstrap)
-            dependencies: ["Alamofire", "Notice"],          # Specify which dependencies to update (only for the update command)
+            dependencies: ["Alamofire", "Notice"],          # Specify which dependencies to update or build (only for update and build commands)
             use_ssh: false,                                 # Use SSH for downloading GitHub repositories.
             use_submodules: false,                          # Add dependencies as Git submodules.
             use_binaries: true,                             # Check out dependency repositories even when prebuilt frameworks exist

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -422,6 +422,30 @@ describe Fastlane do
           eq("carthage update TestDependency1 TestDependency2")
       end
 
+      it "builds with a single dependency" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              command: 'build',
+              dependencies: ['TestDependency']
+            )
+          end").runner.execute(:test)
+
+        expect(result).to \
+          eq("carthage build TestDependency")
+      end
+
+      it "builds with multiple dependencies" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              command: 'build',
+              dependencies: ['TestDependency1', 'TestDependency2']
+            )
+          end").runner.execute(:test)
+
+        expect(result).to \
+          eq("carthage build TestDependency1 TestDependency2")
+      end
+
       it "works with no parameters" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With Carthage you can specify which dependencies should be built, e.g. you can run `carthage build Alamofire` and it will only build Alamofire and it's dependencies. The Carthage action ignores the `dependencies` parameter if the command is not `update`. This pr adds support for dependencies with the build command.
<!--- Please describe in detail how you tested your changes. --->
I used the same tests as for dependencies with the update command, only changed the command to `build` instead of `update`.