### PR TITLE
add Pod spec lint to resolve lint local podspec file inaccurate problem

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_spec_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_spec_lint.rb
@@ -1,0 +1,139 @@
+module Fastlane
+  module Actions
+    class PodSpecLintAction < Action
+      def self.run(params)
+        command = []
+
+        command << "bundle exec" if params[:use_bundle_exec] && shell_out_should_use_bundle_exec?
+
+        command << "pod spec lint"
+
+        if params[:sources]
+          sources = params[:sources].join(",")
+          command << "--sources='#{sources}'"
+        end
+
+        if params[:subspec]
+          subspec = params[:subspec]
+          command << "--subspec='#{subspec}'"
+        end
+        
+        if params[:swift_version]
+          swift_version = params[:swift_version]
+          command << "--swift-version=#{swift_version}"
+        end
+
+        command << "--allow-warnings" if params[:allow_warnings]
+        command << "--verbose" if params[:verbose]
+        command << "--quick" if params[:quick]
+        command << "--use-libraries" if params[:use_libraries]
+        command << "--fail-fast" if params[:fail_fast]
+        command << "--private" if params[:private]
+        
+        
+        result = Actions.sh(command.join(' '))
+        UI.success("Pod spec lint Successfully ⬆️ ")
+        return result
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Pod spec lint"
+      end
+
+      def self.details
+        "Validates `NAME.podspec`. If a `DIRECTORY` is provided, it validates the podspec
+        files found, including subfolders. In case the argument is omitted, it defaults
+        to the current working dir."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :use_bundle_exec,
+                                       description: "Use bundle exec when there is a Gemfile presented",
+                                       is_string: false,
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :quick,
+                                       description: "Lint skips checks that would require to download and build the spec",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :allow_warnings,
+                                       description: "Lint validates even if warnings are present",
+                                       optional: true,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :subspec,
+                                       description: "Lint validates only the given subspec",
+                                       optional: true,
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                          UI.user_error!("Subspec must be a string.") unless value.kind_of?(String)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :fail_fast,
+                                       description: "Lint stops on the first failing platform or subspec",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :use_libraries,
+                                       description: "Lint uses static libraries to install the spec",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :sources,
+                                       description: "he sources from which to pull dependent pods (defaults to https://github.com/CocoaPods/Specs.git). Multiple sources must be comma-delimited",
+                                       optional: true,
+                                       is_string: false,
+                                       verify_block: proc do |value|
+                                          UI.user_error!("Sources must be an array.") unless value.kind_of?(Array)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :private,
+                                       description: "Lint skips checks that apply only to public specs",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :swift_version,
+                                       description: "The SWIFT_VERSION that should be used to lint the spec. This takes precedence over a .swift-version file",
+                                       optional: true,
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                          UI.user_error!("Swift version must be a string.") unless value.kind_of?(String)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :verbose,
+                                       description: "Allow output detail in console",
+                                       optional: true,
+                                       is_string: false),
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.authors
+        ["GongCheng"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+
+      def self.example_code
+        [
+          'pod_spec_lint',
+          '# Show more debugging information during pod spec lint
+          pod_spec_lint(verbose: true)',
+          '# Allow warnings during pod spec lint
+          pod_spec_lint(allow_warnings: true)',
+          '# If the podspec has a dependency on another private pod, then you will have to supply the sources
+          pod_spec_lint(sources: ["https://github.com/MyGithubPage/Specs", "https://github.com/CocoaPods/Specs"])'
+        ]
+      end
+
+      def self.category
+        :misc
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/pod_spec_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_spec_lint.rb
@@ -17,7 +17,7 @@ module Fastlane
           subspec = params[:subspec]
           command << "--subspec='#{subspec}'"
         end
-        
+
         if params[:swift_version]
           swift_version = params[:swift_version]
           command << "--swift-version=#{swift_version}"
@@ -29,8 +29,7 @@ module Fastlane
         command << "--use-libraries" if params[:use_libraries]
         command << "--fail-fast" if params[:fail_fast]
         command << "--private" if params[:private]
-        
-        
+
         result = Actions.sh(command.join(' '))
         UI.success("Pod spec lint Successfully ⬆️ ")
         return result
@@ -69,7 +68,7 @@ module Fastlane
                                        optional: true,
                                        is_string: true,
                                        verify_block: proc do |value|
-                                          UI.user_error!("Subspec must be a string.") unless value.kind_of?(String)
+                                         UI.user_error!("Subspec must be a string.") unless value.kind_of?(String)
                                        end),
           FastlaneCore::ConfigItem.new(key: :fail_fast,
                                        description: "Lint stops on the first failing platform or subspec",
@@ -84,7 +83,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        verify_block: proc do |value|
-                                          UI.user_error!("Sources must be an array.") unless value.kind_of?(Array)
+                                         UI.user_error!("Sources must be an array.") unless value.kind_of?(Array)
                                        end),
           FastlaneCore::ConfigItem.new(key: :private,
                                        description: "Lint skips checks that apply only to public specs",
@@ -95,12 +94,12 @@ module Fastlane
                                        optional: true,
                                        is_string: true,
                                        verify_block: proc do |value|
-                                          UI.user_error!("Swift version must be a string.") unless value.kind_of?(String)
+                                         UI.user_error!("Swift version must be a string.") unless value.kind_of?(String)
                                        end),
           FastlaneCore::ConfigItem.new(key: :verbose,
                                        description: "Allow output detail in console",
                                        optional: true,
-                                       is_string: false),
+                                       is_string: false)
         ]
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ x ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ x ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ x ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ x ] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
when i add tag to my new repo, i run pod lib lint in local to check the validity of podspec,
and it show 'Validating podspec', so i run pod trunk push *.podspec to push it to Github, but it notices my sources_files cannot found, i was confused. when i see this
whats-the-difference-between-pod-spec-lint-and-pod-lib-lint , i know i should use pod spec lint better and more accurate. pod spec lint not only verify local but alse verify remote
so i write this to solve verify podspec file Inaccuratly in local problem

i set the wrong source_files path, pod lib lint still work, but pod spec lint will show an error,
and then i add some option args to test the changes

> [22:46:26]: Get started using a Gemfile for fastlane https://docs.fastlane.tools/getting-started/ios/setup/#use-a-gemfile
> ...
> [22:46:42]: --------------------------
> [22:46:42]: --- Step: pod_lib_lint ---
> [22:46:42]: --------------------------
> [22:46:42]: $ pod lib lint --allow-warnings
> [22:46:52]: ▸ -> FastlanePodspecDemo (0.1.1)
> [22:46:52]: ▸ - WARN | summary: The summary is not meaningful.
> [22:46:52]: ▸ - WARN | description: The description is equal to the summary.
> [22:46:52]: ▸ - WARN | [iOS] license: Unable to find a license file
> [22:46:52]: ▸ FastlanePodspecDemo passed validation.
> [22:46:52]: Pod lib lint Successfully ⬆️
> [22:46:52]: ----------------------------------
> ...
> [22:47:34]: --- Step: pod_push ---
> [22:47:34]: ----------------------
> [22:47:34]: $ pod trunk push 'FastlanePodspecDemo.podspec' --allow-warnings
> [22:47:34]: ▸ Updating spec repo master
> [22:49:36]: ▸ CocoaPods 1.3.1 is available.
> [22:49:36]: ▸ To update use: sudo gem install cocoapods
> [22:49:36]: ▸ For more information, see https://blog.cocoapods.org and the CHANGELOG for this version at https://github.com/CocoaPods/CocoaPods/releases/tag/1.3.1
> [22:49:36]: ▸ Validating podspec
> [22:49:51]: ▸ -> FastlanePodspecDemo (0.1.2)
> [22:49:51]: ▸ - WARN | summary: The summary is not meaningful.
> [22:49:51]: ▸ - WARN | description: The description is equal to the summary.
> [22:49:51]: ▸ - ERROR | [iOS] file patterns: The source_files pattern did not match any file.
> [22:49:51]: ▸ - ERROR | [iOS] file patterns: The resources pattern did not match any file.
> [22:49:51]: ▸ - WARN | [iOS] license: Unable to find a license file
> [22:49:51]: ▸ [!] The spec did not pass validation, due to 2 errors.
> [22:49:51]: ▸ [!] The validator for Swift projects uses Swift 3.0 by default, if you are using a different version of swift you can use a .swift-version file to set the version for your Pod. For example to use Swift 2.3, run:
> [22:49:51]: ▸ `echo "2.3
> " > .swift-version`.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->


### Description
<!--- Describe your changes in detail -->
i use pod spec lint to replace pod lib lint, it's right

> [22:58:00]: Get started using a Gemfile for fastlane https://docs.fastlane.tools/getting-started/ios/setup/#use-a-gemfile
> ...
> [22:58:06]: --- Step: pod_spec_lint ---
> [22:58:06]: ---------------------------
> [22:58:06]: $ pod spec lint --allow-warnings
> [22:58:19]: ▸ -> FastlanePodspecDemo (0.1.2)
> [22:58:19]: ▸ - WARN | summary: The summary is not meaningful.
> [22:58:19]: ▸ - WARN | description: The description is equal to the summary.
> [22:58:19]: ▸ - WARN | [iOS] license: Unable to find a license file
> [22:58:19]: ▸ Analyzed 1 podspec.
> [22:58:19]: ▸ FastlanePodspecDemo.podspec passed validation.
> [22:58:19]: Pod spec lint Successfully ⬆️
> [22:58:19]: ----------------------------------
> ...
> [22:58:40]: --- Step: pod_push ---
> [22:58:40]: ----------------------
> [22:58:40]: $ pod trunk push 'FastlanePodspecDemo.podspec' --allow-warnings
> [22:58:41]: ▸ Updating spec repo master
> [23:04:01]: ▸ CocoaPods 1.3.1 is available.
> [23:04:01]: ▸ To update use: sudo gem install cocoapods
> [23:04:01]: ▸ For more information, see https://blog.cocoapods.org and the CHANGELOG for this version at https://github.com/CocoaPods/CocoaPods/releases/tag/1.3.1
> [23:04:01]: ▸ Validating podspec
> [23:04:29]: ▸ -> FastlanePodspecDemo (0.1.3)
> [23:04:29]: ▸ - WARN | summary: The summary is not meaningful.
> [23:04:29]: ▸ - WARN | description: The description is equal to the summary.
> [23:04:29]: ▸ - WARN | [iOS] license: Unable to find a license file
> [23:04:29]: ▸ Updating spec repo master
> [23:05:45]: ▸ CocoaPods 1.3.1 is available.
> [23:05:45]: ▸ To update use: sudo gem install cocoapods
> [23:05:45]: ▸ For more information, see https://blog.cocoapods.org and the CHANGELOG for this version at https://github.com/CocoaPods/CocoaPods/releases/tag/1.3.1
> [23:05:46]: ▸ --------------------------------------------------------------------------------
> [23:05:46]: ▸ 🎉 Congrats
> [23:05:46]: ▸ 🚀 FastlanePodspecDemo (0.1.3) successfully published
> [23:05:46]: ▸ 📅 September 3rd, 09:04
> [23:05:46]: ▸ 🌎 https://cocoapods.org/pods/FastlanePodspecDemo
> [23:05:46]: ▸ 👍 Tell your friends!
> [23:05:46]: ▸ --------------------------------------------------------------------------------
> [23:05:46]: Successfully pushed Podspec ⬆️
> [23:05:46]: push success, current version is 0.1.3
> 
> +------+-------------------------------------+-------------+
> | fastlane summary |
> +------+-------------------------------------+-------------+
> | Step | Action | Time (in s) |
> +------+-------------------------------------+-------------+
> | 1 | Verifying required fastlane version | 0 |
> | 2 | default_platform | 0 |
> | 3 | git_pull | 3 |
> | 4 | ensure_git_branch | 0 |
> | 5 | pod_spec_lint | 13 |
> | 6 | version_bump_podspec | 0 |
> | 7 | git_add | 0 |
> | 8 | git_commit | 5 |
> | 9 | push_to_git_remote | 7 |
> | 10 | add_git_tag | 0 |
> | 11 | push_git_tags | 7 |
> | 12 | pod_push | 425 |
> +------+-------------------------------------+-------------+
> 
> [23:05:46]: fastlane.tools just saved you 8 minutes! 🎉