### PR TITLE
Set the original name for the uploaded ipa

### DIFF
--- a/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -34,8 +34,8 @@ module FastlaneCore
     private
 
     def copy_ipa(ipa_path)
-      ipa_file_name = Digest::MD5.hexdigest(ipa_path)
-      resulting_path = File.join(self.package_path, "#{ipa_file_name}.ipa")
+      ipa_file_name = File.basename(ipa_path) 
+      resulting_path = File.join(self.package_path, "#{ipa_file_name}")
       FileUtils.cp(ipa_path, resulting_path)
 
       return resulting_path

--- a/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -34,8 +34,8 @@ module FastlaneCore
     private
 
     def copy_ipa(ipa_path)
-      ipa_file_name = File.basename(ipa_path) 
-      resulting_path = File.join(self.package_path, "#{ipa_file_name}")
+      ipa_file_name = File.basename(ipa_path)
+      resulting_path = File.join(self.package_path, ipa_file_name)
       FileUtils.cp(ipa_path, resulting_path)
 
       return resulting_path

--- a/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -34,7 +34,7 @@ module FastlaneCore
     private
 
     def copy_ipa(ipa_path)
-      ipa_file_name = "#{File.basename(ipa_path, '.ipa')}_#{Digest::SHA256.file(ipa_path).hexdigest}.ipa"
+      ipa_file_name = "#{File.basename(ipa_path, '.ipa')}(#{Digest::SHA256.file(ipa_path).hexdigest}).ipa"
       resulting_path = File.join(self.package_path, ipa_file_name)
       FileUtils.cp(ipa_path, resulting_path)
 

--- a/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -34,7 +34,7 @@ module FastlaneCore
     private
 
     def copy_ipa(ipa_path)
-      ipa_file_name = File.basename(ipa_path)
+      ipa_file_name = "#{File.basename(ipa_path, '.ipa')}_#{Digest::SHA256.file(ipa_path).hexdigest}.ipa"
       resulting_path = File.join(self.package_path, ipa_file_name)
       FileUtils.cp(ipa_path, resulting_path)
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

With this change you get on iTunes connect the right ipa name, not a unusable hash

Issue related: 
https://github.com/fastlane/fastlane/issues/10247

