### PR TITLE
Fix supported platform of pilot, and testflight action

### DIFF
--- a/fastlane/lib/fastlane/actions/pilot.rb
+++ b/fastlane/lib/fastlane/actions/pilot.rb
@@ -59,7 +59,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        true
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/pilot.rb
+++ b/fastlane/lib/fastlane/actions/pilot.rb
@@ -59,7 +59,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include?(platform)
+        [:ios].include?(platform)
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

The `pilot` action doesn't support android platform. I think it would be misleading.

![image](https://user-images.githubusercontent.com/282077/30071252-025b3794-92a1-11e7-8ff8-ff4ce5f5c452.png)


### Description
<!--- Describe your changes in detail -->

This change alos affects the `testflight` action.
https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/testflight.rb#L39
