### PR TITLE
Add HockeyApp Action timeout option

### DIFF
--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -46,6 +46,7 @@ module Fastlane
         end
 
         connection.post do |req|
+          req.options.timeout = options.delete(:timeout)
           if options[:public_identifier].nil?
             req.url("/api/2/apps/upload")
           else
@@ -100,6 +101,7 @@ module Fastlane
         end
 
         connection.put do |req|
+          req.options.timeout = options.delete(:timeout)
           req.url("/api/2/apps/#{app_id}/app_versions/#{app_version_id}")
           req.headers['X-HockeyAppToken'] = api_token
           req.body = options
@@ -301,6 +303,11 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Invalid value '#{value}' for key 'strategy'. Allowed values are 'add', 'replace'.") unless ['add', 'replace'].include?(value)
                                        end),
+          FastlaneCore::ConfigItem.new(key: :timeout,
+                                      env_name: "FL_HOCKEY_TIMEOUT",
+                                      description: "Request timeout in seconds",
+                                      is_string: false,
+                                      optional: true),
           FastlaneCore::ConfigItem.new(key: :bypass_cdn,
                                       env_name: "FL_HOCKEY_BYPASS_CDN",
                                       description: "Flag to bypass Hockey CDN when it uploads successfully but reports error",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Some slower networks or larger IPA/DSYM files cause HockeyApp upload to timeout.  This change allows the user to set a different timeout than the default 60 seconds.

I have tested using a large binary with throttled network.  I was able to reproduce the Net::ReadTimeout reliably when not using the timeout; I was then able to resolve the issue using the new timeout option value.

### Description
Add an option to the HockeyApp action for timeout.  Inject that value into the uploads for DYSM and IPA files.
