### PR TITLE
Fix slather action to provide correct flag to slather command

### DIFF
--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -8,7 +8,7 @@ module Fastlane
       # https://github.com/SlatherOrg/slather/blob/v2.4.2/lib/slather/command/coverage_command.rb
       ARGS_MAP = {
           travis: '--travis',
-          travis_pro: '--travis-pro',
+          travis_pro: '--travispro',
           circleci: '--circleci',
           jenkins: '--jenkins',
           buildkite: '--buildkite',

--- a/fastlane/spec/actions_specs/slather_spec.rb
+++ b/fastlane/spec/actions_specs/slather_spec.rb
@@ -38,7 +38,7 @@ describe Fastlane do
 
         expected = "slather coverage
                     --travis
-                    --travis-pro
+                    --travispro
                     --circleci
                     --jenkins
                     --buildkite
@@ -99,7 +99,7 @@ describe Fastlane do
 
         expected = 'bundle exec slather coverage
                     --travis
-                    --travis-pro
+                    --travispro
                     --circleci
                     --jenkins
                     --buildkite


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!--- Describe your changes in detail -->

When this option was added the flag it provided was incorrectly set to "-travis-pro" instead of "-travispro" this was a typo by myself that i found after the feature was merged, this PR fixes this option to provide the correct flag to slather.

