### PR TITLE
Add support for multiple threads when uploading dSYM files to crashlytics

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -1,3 +1,5 @@
+require 'thread'
+
 module Fastlane
   module Actions
     class UploadSymbolsToCrashlyticsAction < Action
@@ -20,8 +22,13 @@ module Fastlane
         dsym_paths = dsym_paths.collect { |a| File.expand_path(a) }
         dsym_paths.uniq!
 
+        max_worker_threads = Integer(params[:dsym_worker_threads]) || 1
+        if max_worker_threads > 1
+          UI.message("Using #{max_worker_threads} threads for Crashlytics dSYM upload 🏎")
+        end
+
         dsym_paths.each do |current_path|
-          handle_dsym(params, current_path)
+          handle_dsym(params, current_path, max_worker_threads)
         end
 
         UI.success("Successfully uploaded dSYM files to Crashlytics 💯")
@@ -29,7 +36,7 @@ module Fastlane
 
       # @param current_path this is a path to either a dSYM or a zipped dSYM
       #   this might also be either nested or not, we're flexible
-      def self.handle_dsym(params, current_path)
+      def self.handle_dsym(params, current_path, max_worker_threads)
         if current_path.end_with?(".dSYM")
           upload_dsym(params, current_path)
         elsif current_path.end_with?(".zip")
@@ -39,14 +46,33 @@ module Fastlane
           Dir.mktmpdir do |dir|
             Dir.chdir(dir) do
               Actions.sh("unzip -qo #{current_path.shellescape}")
+              work_q = Queue.new
               Dir["*.dSYM"].each do |sub|
-                handle_dsym(params, sub)
+                work_q.push sub
               end
+              execute_uploads(params, max_worker_threads, work_q)
             end
           end
         else
           UI.error "Don't know how to handle '#{current_path}'"
         end
+      end
+
+      def self.execute_uploads(params, max_worker_threads, work_q)
+        number_of_threads = [max_worker_threads, work_q.size].min
+        workers = (0...number_of_threads).map do
+          Thread.new do
+            begin
+              while work_q.size > 0
+                current_path = work_q.pop(true)
+                upload_dsym(params, current_path)
+              end
+            rescue => ex
+              UI.error ex.to_s
+            end
+          end
+        end
+        workers.map(&:join)
       end
 
       def self.upload_dsym(params, path)
@@ -133,6 +159,17 @@ module Fastlane
                                        verify_block: proc do |value|
                                          available = ['ios', 'appletvos', 'mac']
                                          UI.user_error!("Invalid platform '#{value}', must be #{available.join(', ')}") unless available.include?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :dsym_worker_threads,
+                                       env_name: "FL_UPLOAD_SYMBOLS_TO_CRASHLYTICS_DSYM_WORKER_THREADS",
+                                       default_value: '1',
+                                       optional: true,
+                                       description: "The number of threads to use for simultaneous dSYM upload",
+                                       verify_block: proc do |value|
+                                         min_threads = 1
+                                         max_threads = 15
+                                         UI.user_error!("Too few threads (#{value}) minimum number of threads: #{min_threads}") unless Integer(value) >= min_threads
+                                         UI.user_error!("Too many threads (#{value}) maximum number of threads: #{max_threads}") unless Integer(value) <= max_threads
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -22,7 +22,7 @@ module Fastlane
         dsym_paths = dsym_paths.collect { |a| File.expand_path(a) }
         dsym_paths.uniq!
 
-        max_worker_threads = Integer(params[:dsym_worker_threads]) || 1
+        max_worker_threads = params[:dsym_worker_threads]
         if max_worker_threads > 1
           UI.message("Using #{max_worker_threads} threads for Crashlytics dSYM upload 🏎")
         end
@@ -162,14 +162,15 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :dsym_worker_threads,
                                        env_name: "FL_UPLOAD_SYMBOLS_TO_CRASHLYTICS_DSYM_WORKER_THREADS",
-                                       default_value: '1',
+                                       type: Integer,
+                                       default_value: 1,
                                        optional: true,
                                        description: "The number of threads to use for simultaneous dSYM upload",
                                        verify_block: proc do |value|
                                          min_threads = 1
                                          max_threads = 15
-                                         UI.user_error!("Too few threads (#{value}) minimum number of threads: #{min_threads}") unless Integer(value) >= min_threads
-                                         UI.user_error!("Too many threads (#{value}) maximum number of threads: #{max_threads}") unless Integer(value) <= max_threads
+                                         UI.user_error!("Too few threads (#{value}) minimum number of threads: #{min_threads}") unless value >= min_threads
+                                         UI.user_error!("Too many threads (#{value}) maximum number of threads: #{max_threads}") unless value <= max_threads
                                        end)
         ]
       end


### PR DESCRIPTION
* Default number of threads is 1
* User can configure number of threads using :dsym_worker_threads
* Maximum number of threads is enforced by fastlane to avoid ridiculous number of threads causing all sorts of problems

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md) 🔑
- [X] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This patch reduced dSYM upload time from 1162 seconds to 118 seconds, when using 15 threads on a 100Mbit internet connection, for 711 dSYM files. That is a change from 1.63s/file to 0.166s/file.

<!--- If it fixes an open issue, please link to the issue here. -->
Issues: https://github.com/fastlane/fastlane/issues/10195

<!--- Please describe in detail how you tested your changes. --->
* I ran `bundle exec rspec` as required
* I created a lane for uploading dSYMs and ran it with the following variations:
    * Without setting dsym_worker_threads => Success, 1 thread used
    * With setting dsym_worker_threads to '15' => Success, 15 threads used
    * With setting dsym_worker_threads to '16' => Error
    * With setting dsym_worker_threads to '0' => Error
    * With setting dsym_worker_threads to 'potato' => Error 'potato' is not an integer

### Description
<!--- Describe your changes in detail -->
A new Queue is created. Instead of calling upload_dsym on every file in a directory each file path is added to the queue, and the configured number of worker threads pick files from the queue until it is empty. The code waits for all the threads to join before continuing execution.