### PR TITLE
Deliver: Add supply's `android` folder to list of excluded directories for language check

### DIFF
--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -13,7 +13,7 @@ module Deliver
     # If the user also uses `supply` in the same project, an 'android' folder might exist
     SUPPLY_DIR_NAME = "android".freeze
 
-    EXCEPTION_DIRECTORIES = (UploadMetadata::ALL_META_SUB_DIRS.map(&:downcase) + SUPPLY_DIR_NAME).freeze
+    EXCEPTION_DIRECTORIES = (UploadMetadata::ALL_META_SUB_DIRS.map(&:downcase) << SUPPLY_DIR_NAME).freeze
 
     def self.language_folders(root, ignore_validation)
       folders = Dir.glob(File.join(root, '*'))

--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -10,7 +10,11 @@ module Deliver
 
     SPECIAL_DIR_NAMES = [APPLE_TV_DIR_NAME, IMESSAGE_DIR_NAME, DEFAULT_DIR_NAME].freeze
 
-    EXCEPTION_DIRECTORIES = UploadMetadata::ALL_META_SUB_DIRS.map(&:downcase).freeze
+    # If the user also uses `supply` in the same project, an 'android' folder might exist
+    SUPPLY_DIR_NAME = "android".freeze
+
+    EXCEPTION_DIRECTORIES = (UploadMetadata::ALL_META_SUB_DIRS.map(&:downcase) + SUPPLY_DIR_NAME).freeze
+
 
     def self.language_folders(root, ignore_validation)
       folders = Dir.glob(File.join(root, '*'))

--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -15,7 +15,6 @@ module Deliver
 
     EXCEPTION_DIRECTORIES = (UploadMetadata::ALL_META_SUB_DIRS.map(&:downcase) + SUPPLY_DIR_NAME).freeze
 
-
     def self.language_folders(root, ignore_validation)
       folders = Dir.glob(File.join(root, '*'))
 


### PR DESCRIPTION
Currently the check for invalid languages also triggers when using `supply` as it creates an "android" folder that this check doesn't like. This adds this folder to the EXCEPTION_DIRECTORIES list so this doesn't happen any more

fixes #10265

(Please note that I have no ruby experience at all - bear with me if my suggested changes are not perfect. Feel free to fix everything I messed up, or let me know so I can)
