### PR TITLE
Improve mismatch message between export_method and selected profiles

### DIFF
--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -237,10 +237,13 @@ module Gym
             "app-store" => "app-store",
             "app store" => "app-store",
             "appstore" => "app-store",
+            "enterprise" => "enterprise",
+            "in-house" => "enterprise",
+            "in house" => "enterprise",
+            "inhouse" => "enterprise",
             "ad-hoc" => "ad-hoc",
             "adhoc" => "ad-hoc",
             "ad hoc" => "ad-hoc",
-            "enterprise" => "enterprise",
             "development" => "development"
           }
 
@@ -259,7 +262,7 @@ module Gym
               # As seen above, there is obviously a mismatch, the user selected an App Store
               # profile, but the export method that's being passed to Xcode is "enterprise"
 
-              next if matching_type.to_s == selected_export_method
+              break if matching_type.to_s == selected_export_method
               UI.message("")
               UI.error("There seems to be a mismatch between your provided `export_method` in gym")
               UI.error("and the selected provisioning profiles. You passed the following options:")
@@ -271,6 +274,7 @@ module Gym
               UI.error("or select the correct provisioning profiles by updating your Xcode project")
               UI.error("or passing the profiles to use by using match or manually via the `export_options` hash")
               UI.message("")
+              break
             end
           end
         end

--- a/gym/spec/error_handler_spec.rb
+++ b/gym/spec/error_handler_spec.rb
@@ -54,5 +54,35 @@ Code signing is required for product type 'Application' in SDK 'iOS 11.0'
 
       Gym::ErrorHandler.handle_build_error(code_signing_output)
     end
+
+    it "prints mismatch between the export_method and the selected profiles only once" do
+      mock_gym_path(@output)
+      expect(UI).to receive(:build_failure!).with("Error building the application - see the log above", error_info: @output)
+
+      Gym.config[:export_method] = 'app-store'
+      Gym.config[:export_options][:provisioningProfiles] = {
+        'com.sample.app' => 'In House Ad Hoc'
+      }
+
+      expect(UI).to receive(:error).with(/There seems to be a mismatch between/).once
+      allow(UI).to receive(:error)
+
+      Gym::ErrorHandler.handle_build_error(@output)
+    end
+
+    it "does not print mismatch if the export_method and the selected profiles matched" do
+      mock_gym_path(@output)
+      expect(UI).to receive(:build_failure!).with("Error building the application - see the log above", error_info: @output)
+
+      Gym.config[:export_method] = 'enterprise'
+      Gym.config[:export_options][:provisioningProfiles] = {
+        'com.sample.0' => 'In House Ad Hoc' # `enterprise` take precedence over `ad-hoc`
+      }
+
+      expect(UI).to receive(:error).with(/There seems to be a mismatch between/).never
+      allow(UI).to receive(:error)
+
+      Gym::ErrorHandler.handle_build_error(@output)
+    end
   end
 end

--- a/gym/spec/error_handler_spec.rb
+++ b/gym/spec/error_handler_spec.rb
@@ -76,7 +76,7 @@ Code signing is required for product type 'Application' in SDK 'iOS 11.0'
 
       Gym.config[:export_method] = 'enterprise'
       Gym.config[:export_options][:provisioningProfiles] = {
-        'com.sample.0' => 'In House Ad Hoc' # `enterprise` take precedence over `ad-hoc`
+        'com.sample.app' => 'In House Ad Hoc' # `enterprise` take precedence over `ad-hoc`
       }
 
       expect(UI).to receive(:error).with(/There seems to be a mismatch between/).never


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

Unfortunately our organization uses a **enterprise** profile named `MyOrg InHouse AdHoc`, then the following message is displayed every time after a build error. 

```
ERROR [2017-09-06 20:51:16.17]: There seems to be a mismatch between your provided `export_method` in gym
ERROR [2017-09-06 20:51:16.17]: and the selected provisioning profiles. You passed the following options:
WARN [2017-09-06 20:51:16.18]:   export_method:      enterprise
WARN [2017-09-06 20:51:16.18]:   Bundle identifier:  my.org.app
WARN [2017-09-06 20:51:16.18]:   Profile name:       MyOrg InHouse AdHoc
WARN [2017-09-06 20:51:16.18]:   Profile type:       ad-hoc
ERROR [2017-09-06 20:51:16.18]: Make sure to either change the `export_method` passed from your Fastfile or CLI
ERROR [2017-09-06 20:51:16.18]: or select the correct provisioning profiles by updating your Xcode project
ERROR [2017-09-06 20:51:16.18]: or passing the profiles to use by using match or manually via the `export_options` hash
```

The printed profile type is wrong, and printed regardless of the cause of the error. 😞


### Description
<!--- Describe your changes in detail -->

1. Add `inhouse` key to available_export_types
  - Probably, the enterprise profiles are often named `inhouse`.
2. The enterprise export type take precedence over `ad-hoc`
3. Print message only once
4. Once it matches, don't check subsequent items

I think that this change has little negative impact on other people.