### PR TITLE
Make curl command fail when wwdc certificate fails to download

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -61,7 +61,7 @@ module FastlaneCore
       filename = file.path
       keychain = wwdr_keychain
       keychain = "-k #{keychain.shellescape}" unless keychain.empty?
-      Helper.backticks("curl -o #{filename} #{url} && security import #{filename} #{keychain}", print: FastlaneCore::Globals.verbose?)
+      Helper.backticks("curl -f -o #{filename} #{url} && security import #{filename} #{keychain}", print: FastlaneCore::Globals.verbose?)
       UI.user_error!("Could not install WWDR certificate") unless $?.success?
     end
 

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -34,7 +34,7 @@ describe FastlaneCore do
         # We have to execute *something* using ` since otherwise we set expectations to `nil`, which is not healthy
         `ls`
 
-        cmd = %r{curl -o (/.+?) https://developer\.apple\.com/certificationauthority/AppleWWDRCA.cer && security import \1 -k keychain\\ with\\ spaces\.keychain}
+        cmd = %r{curl -f -o (/.+?) https://developer\.apple\.com/certificationauthority/AppleWWDRCA.cer && security import \1 -k keychain\\ with\\ spaces\.keychain}
 
         expect(FastlaneCore::Helper).to receive(:backticks).with(cmd, { print: nil }).and_return("")
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [N/A] I've updated the documentation if necessary.

### Motivation and Context

My builds are randomly failing because WWDR certificate is failing to install. It appears that its failing to download, but the `curl` command doesn't report this by default, and so `security` tries to import the file, that presumably has some html error message in it.

This is my current log output
```
[11:32:51]: Installing certificate...
security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   710  100   710    0     0    627      0  0:00:01  0:00:01 --:--:--   627
security: SecKeychainItemImport: Unknown format in import.
```

### Description

Adding `-f` makes `curl` exit code non-zero for non 200 http response codes. It also causes a message to be printed with the issue. (Something like `curl: (22) The requested URL returned error: 404 Not Found`). This should make debugging more clear and prevent `security` trying to import and invalid cert.
