### PR TITLE
Disable precheck during deliver init

### DIFF
--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -102,7 +102,10 @@ module Deliver
           end
 
           require 'deliver/setup'
+
           options = FastlaneCore::Configuration.create(deliverfile_options, options.__hash__)
+          options[:run_precheck_before_submit] = false # precheck doesn't need to run during init
+
           Deliver::Runner.new(options) # to login...
           Deliver::Setup.new.run(options)
         end

--- a/deliver/spec/commands_generator_spec.rb
+++ b/deliver/spec/commands_generator_spec.rb
@@ -90,7 +90,8 @@ describe Deliver::CommandsGenerator do
 
       expected_options = FastlaneCore::Configuration.create(Deliver::Options.available_options, {
         description: 'My description',
-        username: 'me@it.com'
+        username: 'me@it.com',
+        run_precheck_before_submit: false
       })
 
       expect_runner_new_with(expected_options)
@@ -104,7 +105,9 @@ describe Deliver::CommandsGenerator do
 
       expected_options = FastlaneCore::Configuration.create(Deliver::Options.available_options, {
         description: 'My description',
-        app_identifier: 'abcd'
+        app_identifier: 'abcd',
+        run_precheck_before_submit: false
+
       })
 
       expect_runner_new_with(expected_options)

--- a/deliver/spec/commands_generator_spec.rb
+++ b/deliver/spec/commands_generator_spec.rb
@@ -107,7 +107,6 @@ describe Deliver::CommandsGenerator do
         description: 'My description',
         app_identifier: 'abcd',
         run_precheck_before_submit: false
-
       })
 
       expect_runner_new_with(expected_options)


### PR DESCRIPTION
`precheck` shouldn't run during `deliver init`. 