### PR TITLE
Fix 'update_project_provisioning' to set PROVISIONING_PROFILE_SPECIFIER

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -64,6 +64,7 @@ module Fastlane
             end
 
             build_configuration.build_settings["PROVISIONING_PROFILE"] = data["UUID"]
+            build_configuration.build_settings["PROVISIONING_PROFILE_SPECIFIER"] = data["Name"]
           end
         end
 


### PR DESCRIPTION
Update the 'update_project_provisioning' action to set PROVISIONING_PROFILE_SPECIFIER (Name) rather than just the PROVISIONING_PROFILE (UUID)

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Xcode 8 uses PROVISIONING_PROFILE_SPECIFIER in preference over PROVISIONING_PROFILE but this action is only setting PROVISIONING_PROFILE. This change adds better support for the Xcode 8+

<!--- If it fixes an open issue, please link to the issue here. -->
[https://github.com/fastlane/fastlane/issues/8973](https://github.com/fastlane/fastlane/issues/8973)

<!--- Please describe in detail how you tested your changes. --->
Manually tested using both a small test app and a full scale production app. 
I looked into writing a unit test for this change but the existing behavior (setting the PROVISIONING_PROFILE) is not unit tested and it was difficult to add a specific unit test for this change.

### Description
<!--- Describe your changes in detail -->

Set PROVISIONING_PROFILE_SPECIFIER so that the correct provisioning profile is used when building with Xcode 8+. 