### PR TITLE
Fixed typos in the update_project_provisioning

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -70,7 +70,7 @@ module Fastlane
         project.save
 
         # complete
-        UI.success("Successfully updated project settings in'#{params[:xcodeproj]}'")
+        UI.success("Successfully updated project settings in '#{params[:xcodeproj]}'")
       end
 
       def self.description
@@ -79,7 +79,7 @@ module Fastlane
 
       def self.details
         [
-          "You should check out the code signing gide before using this action: https://docs.fastlane.tools/codesigning/getting-started/",
+          "You should check out the code signing guide before using this action: https://docs.fastlane.tools/codesigning/getting-started/",
           "This action retrieves a provisioning profile UUID from a provisioning profile (.mobileprovision) to set",
           "up the xcode projects' code signing settings in *.xcodeproj/project.pbxproj",
           "The `target_filter` value can be used to only update code signing for specified targets",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Because I found typos in the update_project_provisioning. There is no issue associated with this.

### Description
Fixed typos.