### PR TITLE
Fix, action calld by other_action not run in the root of the project

### DIFF
--- a/fastlane/lib/fastlane/other_action.rb
+++ b/fastlane/lib/fastlane/other_action.rb
@@ -11,17 +11,8 @@ module Fastlane
 
     # Allows the user to call an action from an action
     def method_missing(method_sym, *arguments, &_block)
-      # We have to go inside the fastlane directory
-      # since in the fastlane runner.rb we do the following
-      #   custom_dir = ".."
-      #   Dir.chdir(custom_dir) do
-      # this goes one folder up, since we're inside the "fastlane"
-      # folder at that point
-      # Since we call an action from an action we need to go inside
-      # the fastlane folder too
-
       self.runner.trigger_action_by_name(method_sym,
-                                         FastlaneCore::FastlaneFolder.path,
+                                         File.expand_path('..', FastlaneCore::FastlaneFolder.path),
                                          true,
                                          *arguments)
     end

--- a/fastlane/spec/action_spec.rb
+++ b/fastlane/spec/action_spec.rb
@@ -64,14 +64,14 @@ describe Fastlane do
 
     describe "Call another action from an action" do
       it "allows the user to call it using `other_action.rocket`" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(Dir.pwd)
         Fastlane::Actions.load_external_actions("./fastlane/spec/fixtures/actions")
         ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileActionFromAction')
         Fastlane::Actions.executed_actions.clear
 
         response = {
           rocket: "🚀",
-          pwd: Dir.pwd
+          pwd: File.expand_path('..', Dir.pwd)
         }
         expect(ff.runner.execute(:something, :ios)).to eq(response)
         expect(Fastlane::Actions.executed_actions.map { |a| a[:name] }).to eq(['from'])


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

The current directory for the action called from `other_action` is incorrect.

For example.

`print_pwd_wrapper` action
```
    def self.run(params)
      other_action.print_pwd()
    end
```

`print_pwd` action
```
    def self.run(params)
      UI.message "pwd: #{Dir.pwd}"
    end
```

Then call them.
```
% cat fastlane/Fastfile
lane :test do
  print_pwd()
  print_pwd_wrapper()
end

% fastlane test
[23:39:19]: -----------------------
[23:39:19]: --- Step: print_pwd ---
[23:39:19]: -----------------------
[23:39:19]: pwd: /Users/tahori/workspace/fast_test
[23:39:19]: -------------------------------
[23:39:19]: --- Step: print_pwd_wrapper ---
[23:39:19]: -------------------------------
[23:39:19]: pwd: /Users/tahori/workspace/fast_test/fastlane
```

The current directory in action should not be the Fastfile's directory...

### Description
<!--- Describe your changes in detail -->

The comment in `OtherAction#method_missing` seems to be outdated. I jus passed the corrent directory.