### PR TITLE
Fixed wrong working directory in cocoapods.error_callback call

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -24,7 +24,15 @@ module Fastlane
         cmd << '--verbose' if params[:verbose]
         cmd << '--no-ansi' unless params[:ansi]
 
-        Actions.sh(cmd.join(' '), error_callback: params[:error_callback])
+        if params[:error_callback]
+          Actions.sh(cmd.join(' '), error_callback: lambda { |result|
+            Dir.chdir(FastlaneCore::FastlaneFolder.path) do
+              params[:error_callback].call(result)
+            end
+          })
+        else
+          Actions.sh(cmd.join(' '))
+        end
       end
 
       def self.description


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
See the issue: https://github.com/fastlane/fastlane/issues/10308

### Description
I'm just changing directory to default fastlane folder before calling `error_callback`. Also I'm not sure: maybe it should be fixed at global level in `sh_helper.rb:sh_control_output` method?
