### PR TITLE
Show prettier error message when user has insufficient permissions in iTunes Connect

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -608,6 +608,8 @@ module Spaceship
       # Check if the failure is due to missing permissions (iTunes Connect)
       if body["messages"] && body["messages"]["error"].include?("Forbidden")
         raise_insuffient_permission_error!
+      elsif body["messages"] && body["messages"]["error"].include?("insufficient privileges")
+        raise_insuffient_permission_error!(caller_location: 3)
       elsif body.to_s.include?("Internal Server Error - Read")
         raise InternalServerError, "Received an internal server error from iTunes Connect / Developer Portal, please try again later"
       elsif (body["resultString"] || "").include?("Program License Agreement")
@@ -616,12 +618,12 @@ module Spaceship
     end
 
     # This also gets called from subclasses
-    def raise_insuffient_permission_error!(additional_error_string: nil)
+    def raise_insuffient_permission_error!(additional_error_string: nil, caller_location: 2)
       # get the method name of the request that failed
       # `block in` is used very often for requests when surrounded for paging or retrying blocks
       # The ! is part of some methods when they modify or delete a resource, so we don't want to show it
       # Using `sub` instead of `delete` as we don't want to allow multiple matches
-      calling_method_name = caller_locations(2, 2).first.label.sub("block in", "").delete("!").strip
+      calling_method_name = caller_locations(caller_location, 2).first.label.sub("block in", "").delete("!").strip
       begin
         team_id = "(Team ID #{self.team_id}) "
       rescue

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -609,6 +609,8 @@ module Spaceship
       if body["messages"] && body["messages"]["error"].include?("Forbidden")
         raise_insuffient_permission_error!
       elsif body["messages"] && body["messages"]["error"].include?("insufficient privileges")
+        # Passing a specific `caller_location` here to make sure we return the correct method
+        # With the default location the error would say that `parse_response` is the caller
         raise_insuffient_permission_error!(caller_location: 3)
       elsif body.to_s.include?("Internal Server Error - Read")
         raise InternalServerError, "Received an internal server error from iTunes Connect / Developer Portal, please try again later"


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
A iTunes Connect user with 'Developer' role trying to update meta data for an app update will receive an error response like this:
```ruby
{"data"=>nil, "messages"=>{"warn"=>nil, "info"=>nil, "error"=>["insufficient privileges"]}, "statusCode"=>"ERROR"}`
```
This error is not handled and the user will get the above response printed in the log.

### Description
This change will print a prettier message when the above happens.

To ensure that the action/`calling_method_name` was correct in this case, I had to add a new option to `raise_insuffient_permission_error!`. Without this option the error would say that the user don't have permission to `parse_reponse`. I'm not sure this is the right way to do it.