### PR TITLE
Version bump to 2.56.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.55.0'.freeze
+  VERSION = '2.56.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.55.0':**

* Update the 'update_project_provisioning' action to set PROVISIONING_PROFILE_SPECIFIER (#10298) via Col
* fixed typos (#10305) via kaso1024
* Revert `#factory` with `#new` for instantiation (#10296) via Stefan Natchev
* Extend spaceship to support more attributes, while also upgrading to new API endpoint (#10186) via Felix Krause
* [deliver] Fix crash when uploading Apple TV screenshots (#10287) via Felix Krause
* Improve gym error message (#10285) via Felix Krause
* Code style improvements (#10286) via Felix Krause
* [match] Ignore `force_for_new_devices` for App Store profiles (#10141) via Tim Andersson
* Ignore empty password for FASTLANE_PASSWORD (#10194) via Kouki Saito
* Add detection of developerRemovedFromSale to iap_status (#10206) (#10224) via gylee2011
* Fixed markdown formatting issue (#10284) via Rishabh Tayal
* Add details to error when Apple services are down (#10275) via Ray Lillywhite
* Add support for multiple threads when uploading dSYM files to crashlytics (#10264) via Erik Zivkovic
* Make curl command fail when wwdc certificate fails to download (#10278) via Fred Cox
* Better failure/success messaging from precheck (#10283) via Joshua Liebowitz
* Disable precheck during deliver init (#10281) via Joshua Liebowitz
* Fix slather action to provide correct flag to slather command (#10263) via Matthew Ellis
* Fix not commiting all .md files for `update_docs` (#10222) via Felix Krause
* Fix spelling in deliver docs (#10250) via Felix Krause
* Change order of action categories for docs (#10223) via Felix Krause
* Add HockeyApp action timeout option (#10258) via Jacob Aleksynas
* Support for updating roles on iTunes Connect members (#10257) via Morten Gregersen
* Fix supported platform of pilot, and testflight action (#10253) via Taisuke Hori
* Fix xcode_version not changed after xcode_select (#10235) via Taisuke Hori
