### PR TITLE
Fix creation of certificate when a keychain is specified.

### DIFF
--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -5,7 +5,7 @@ module Cert
     def launch
       run
 
-      installed = FastlaneCore::CertChecker.installed?(ENV["CER_FILE_PATH"])
+      installed = FastlaneCore::CertChecker.installed?(ENV["CER_FILE_PATH"], Cert.config[:keychain_path], Cert.config[:keychain_password])
       UI.message "Verifying the certificate is properly installed locally..."
       UI.user_error!("Could not find the newly generated certificate installed", show_github_issues: true) unless installed
       UI.success "Successfully installed certificate #{ENV['CER_CERTIFICATE_ID']}"

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -3,10 +3,10 @@ require 'tempfile'
 module FastlaneCore
   # This class checks if a specific certificate is installed on the current mac
   class CertChecker
-    def self.installed?(path)
+    def self.installed?(path, keychain = nil, password = nil)
       UI.user_error!("Could not find file '#{path}'") unless File.exist?(path)
 
-      ids = installed_identies
+      ids = installed_identies(keychain, password)
       finger_print = sha1_fingerprint(path)
 
       return ids.include? finger_print
@@ -17,10 +17,10 @@ module FastlaneCore
       installed?(path)
     end
 
-    def self.installed_identies
+    def self.installed_identies(keychain, password)
       install_wwdr_certificate unless wwdr_certificate_installed?
 
-      available = list_available_identities
+      available = list_available_identities(keychain, password)
       # Match for this text against word boundaries to avoid edge cases around multiples of 10 identities!
       if /\b0 valid identities found\b/ =~ available
         UI.error([
@@ -44,8 +44,13 @@ module FastlaneCore
       return ids
     end
 
-    def self.list_available_identities
-      `security find-identity -v -p codesigning`
+    def self.list_available_identities(keychain, password)
+      keychain = File.expand_path(keychain)
+      locked = keychain and !system("security show-keychain-info #{keychain} >/dev/null 2>/dev/null")
+      `security unlock -p #{password} #{keychain}` if locked
+      `security find-identity -v -p codesigning #{keychain}`
+    ensure
+      `security lock #{keychain}` if locked
     end
 
     def self.wwdr_certificate_installed?

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -1,20 +1,23 @@
 describe FastlaneCore do
   describe FastlaneCore::CertChecker do
     describe '#installed_identies' do
+      keychain = "something.keychain"
+      password = "12345678"
+
       it 'should print an error when no local code signing identities are found' do
         allow(FastlaneCore::CertChecker).to receive(:wwdr_certificate_installed?).and_return(true)
-        allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     0 valid identities found\n")
+        allow(FastlaneCore::CertChecker).to receive(:list_available_identities).with(keychain, password).and_return("     0 valid identities found\n")
         expect(FastlaneCore::UI).to receive(:error).with(/There are no local code signing identities found/)
 
-        FastlaneCore::CertChecker.installed_identies
+        FastlaneCore::CertChecker.installed_identies(keychain, password)
       end
 
       it 'should not be fooled by 10 local code signing identities available' do
         allow(FastlaneCore::CertChecker).to receive(:wwdr_certificate_installed?).and_return(true)
-        allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     10 valid identities found\n")
+        allow(FastlaneCore::CertChecker).to receive(:list_available_identities).with(keychain, password).and_return("     10 valid identities found\n")
         expect(FastlaneCore::UI).not_to receive(:error)
 
-        FastlaneCore::CertChecker.installed_identies
+        FastlaneCore::CertChecker.installed_identies(keychain, password)
       end
     end
 


### PR DESCRIPTION
In this case, the certificate is properly created in the specified
keychain, but the certificate validation used to fail since it kept
searching in the keychain search list.

This patch ensures the verification is performed using the specified
keychain file.
