### PR TITLE
[reset_simulator_contents] Soften xcode 9 action failure to a warning

### DIFF
--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -3,7 +3,8 @@ module Fastlane
     class ResetSimulatorContentsAction < Action
       def self.run(params)
         if Helper.xcode_at_least?("9")
-          UI.user_error!("resetting simulators currently doesn't work with Xcode 9, stay tuned as we are working to add support for all new tools.")
+          UI.important("Resetting simulators currently doesn't work with Xcode 9, stay tuned as we are working to add support for all new tools.")
+          return
         end
 
         if params[:ios]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When upgrading xcode or switching between Xcode 8.X and xcode 9 it is very difficult to continually remove this action from the Fastfile to avoid a hard failure.  For backward compatibility and easier forward compatibility, a warning and continue seems a more favorable behavior.

Executed the task with several versions of xcode to ensure that it would message and act properly.

### Description
Change the message from user_error! to important.  Return from the run action immediately so as to not attempt the non-functional operations.
