### PR TITLE
[Fix slather.rb]  option source-files is Array not String

### DIFF
--- a/YourFirstPR.md
+++ b/YourFirstPR.md
@@ -2,6 +2,7 @@
 
 ## Prerequisites
 
+
 Before you start working on _fastlane_, you should have [Bundler][bundler] installed. Bundler is a ruby project that allows you to specify all ruby dependencies in a file called the `Gemfile`. If you want to learn more about how Bundler works, check out [their website][bundler help].
 
 ## Finding things to work on

--- a/YourFirstPR.md
+++ b/YourFirstPR.md
@@ -2,7 +2,6 @@
 
 ## Prerequisites
 
-
 Before you start working on _fastlane_, you should have [Bundler][bundler] installed. Bundler is a ruby project that allows you to specify all ruby dependencies in a file called the `Gemfile`. If you want to learn more about how Bundler works, check out [their website][bundler help].
 
 ## Finding things to work on

--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -240,6 +240,7 @@ Slather is available at https://github.com/SlatherOrg/slather
           FastlaneCore::ConfigItem.new(key: :source_files,
                                        env_name: "FL_SLATHER_SOURCE_FILES",
                                        description: "A Dir.glob compatible pattern used to limit the lookup to specific source files. Ignored in gcov mode",
+                                       is_string: false,
                                        default_value: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :decimals,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

You can check https://github.com/fastlane/fastlane/issues/10319
source-files type was wrong, I fix it with this PR

### Description
<!--- Describe your changes in detail -->
When initialize ```source_files``` add ```is_string: false``` to define type is not string
