### PR TITLE
Fix download_dsyms.rb ‘latest’

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -64,16 +64,12 @@ module Fastlane
 
             if download_url
               result = self.download download_url
-              file_name = "#{app.bundle_id}-#{train_number}-#{build.build_version}.dSYM.zip"
-              if output_directory
-                file_name = output_directory + file_name
-              end
-              File.write(file_name, result)
-              UI.success("🔑  Successfully downloaded dSYM file for #{train_number} - #{build.build_version} to '#{file_name}'")
+              path   = write_dsym(result, app.bundle_id, train_number, build_number, output_directory)
+              UI.success("🔑  Successfully downloaded dSYM file for #{train_number} - #{build_number} to '#{path}'")
 
               Actions.lane_context[SharedValues::DSYM_PATHS] ||= []
-              Actions.lane_context[SharedValues::DSYM_PATHS] << File.expand_path(file_name)
-              return if build_number 
+              Actions.lane_context[SharedValues::DSYM_PATHS] << File.expand_path(path)
+              break if build_number
             else
               UI.message("No dSYM URL for #{build.build_version} (#{build.train_version})")
             end
@@ -83,6 +79,15 @@ module Fastlane
         if (Actions.lane_context[SharedValues::DSYM_PATHS] || []).count == 0
           UI.error("No dSYM files found on iTunes Connect - this usually happens when no recompling happened yet")
         end
+      end
+
+      def self.write_dsym(data, bundle_id, train_number, build_number, output_directory)
+        file_name = "#{bundle_id}-#{train_number}-#{build_number}.dSYM.zip"
+        if output_directory
+          file_name = output_directory + file_name
+        end
+        File.write(file_name, data)
+        file_name
       end
 
       def self.download(url)

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -28,9 +28,9 @@ module Fastlane
 
         # Set version if it is latest
         if version == 'latest'
-          # Try to grab the live version first, else fallback to edit version
-          latest_version = app.live_version(platform: platform) || app.edit_version(platform: platform)
-          version = latest_version.version
+          # Try to grab the edit version first, else fallback to live version
+          latest_version = app.edit_version(platform: platform) || app.live_version(platform: platform)
+          version = nil
           build_number = latest_version.build_version
         end
 
@@ -73,6 +73,7 @@ module Fastlane
 
               Actions.lane_context[SharedValues::DSYM_PATHS] ||= []
               Actions.lane_context[SharedValues::DSYM_PATHS] << File.expand_path(file_name)
+              return if build_number 
             else
               UI.message("No dSYM URL for #{build.build_version} (#{build.train_version})")
             end


### PR DESCRIPTION
When `version` is set to `latest`, the following changes apply
• choose the edit version before the live version, since the edit version will be newer
• nil out `version` since `AppVersion.version` will not necessarily match any version in a `BuildTrain`
• return immediately if a `build_number` is found, since there will only be one dSYM for a given build number

Closes #10255

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
