### PR TITLE
Enable -allowProvisioningUpdates for gym builds in Xcode 9 by default

### DIFF
--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -32,6 +32,13 @@ module Gym
         options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]
         options << config[:export_xcargs] if config[:export_xcargs]
 
+        if Helper.xcode_at_least?("9.0") && !config[:export_xcargs].include?("-allowProvisioningUpdates")
+          # via https://github.com/fastlane/fastlane/issues/9589
+          # With Xcode 9, we should allow ProvisioningUpdates, since this enables Xcode
+          # to use the team provisioning profiles, according to users, this fixes lots of problems
+          options << "-allowProvisioningUpdates"
+        end
+
         options
       end
 


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/9589