### PR TITLE
Add missing devices in snapshot reports generator

### DIFF
--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -67,6 +67,9 @@ module Snapshot
       {
         # snapshot in Xcode 9 saves screenshots with the SIMULATOR_DEVICE_NAME
         # which includes spaces
+        'iPhone 8 Plus' => "iPhone 8 Plus",
+        'iPhone 8' => "iPhone 8",
+        'iPhone X' => "iPhone X",
         'iPhone 7 Plus' => "iPhone 7 Plus (5.5-Inch)",
         'iPhone 7' => "iPhone 7 (4.7-Inch)",
         'iPhone 6s Plus' => "iPhone 6s Plus (5.5-Inch)",
@@ -83,6 +86,8 @@ module Snapshot
         'iPad Pro (12.9-inch) (2nd generation)' => 'iPad Pro (12.9-inch) (2nd generation)',
         'iPad Pro (12.9-inch)' => 'iPad Pro (12.9-inch)',
         'Apple TV 1080p' => 'Apple TV',
+        'Apple TV 4K (at 1080p)' => 'Apple TV 4K (at 1080p)',
+        'Apple TV 4K' => 'Apple TV 4K',
         'Mac' => 'Mac'
       }
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR fixes #10343

### Description
It simply adds the new iOS devices to the `xcode_9_and_above_device_name_mappings` (iPhone 8, iPhone 8 Plus, iPhone X, Apple TV 4K and Apple TV 4K @1080p)
