### PR TITLE
Allow snapshot to handle multiple tvOS devices

### DIFF
--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -55,9 +55,17 @@ module Snapshot
         end
         # Return true if all devices are iOS devices
         return true unless all_ios.include?(false)
+
+        all_tvos = devices.map do |device|
+          device = device.downcase
+          device.start_with?('apple tv')
+        end
+        # Return true if all devices are iOS devices
+        return true unless all_tvos.include?(false)
+
         # There should only be more than 1 device type if
-        # it is iOS, therefore, if there is more than 1
-        # device in the array, and they are not all iOS
+        # it is iOS or tvOS, therefore, if there is more than 1
+        # device in the array, and they are not all iOS or tvOS
         # as checked above, that would imply that this is a mixed bag
         return devices.count == 1
       end

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -16,6 +16,29 @@ describe Snapshot do
       fake_out_xcode_project_loading
     end
 
+    describe '#verify_devices_share_os' do
+      before(:each) do
+        @test_command_generator = Snapshot::TestCommandGenerator.new
+      end
+      it "returns true with only iOS devices" do
+        devices = ["iPhone 8", "iPad Air 2", "iPhone X", "iPhone 8 plus"]
+        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+        expect(result).to be(true)
+      end
+
+      it "returns true with only Apple TV devices" do
+        devices = ["Apple TV 1080p", "Apple TV 4K", "Apple TV 4K (at 1080p)"]
+        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+        expect(result).to be(true)
+      end
+
+      it "returns false with mixed device OS" do
+        devices = ["Apple TV 1080p", "iPad Air 2", "iPhone 8"]
+        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+        expect(result).to be(false)
+      end
+    end
+
     describe '#find_device' do
       it 'finds a device that has a matching name and OS version' do
         found = Snapshot::TestCommandGenerator.find_device('iPhone 6', '9.0')


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR is relative to #10347.  Now, we can use `snapshots` with multiple Apple TV devices. Like: 
```ruby
devices([
	"Apple TV 1080p", 
	"Apple TV 4K", 
	"Apple TV 4K (at 1080p)"
])
```

### Description
I edited `verify_devices_share_os()` method to do so. I also added some tests that checks if `verify_devices_share_os`:
- Still return true if there is only iOS devices. 
- Still return false if there is iOS and tvOS devices.
- Return true if there is only tvOS devices (and more than 1).

I also checked that the error mentioned in #10347 is not trigged anymore. 