### PR TITLE
Version bump to 2.57.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.56.0'.freeze
+  VERSION = '2.57.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.56.0':**

* Fix download_dsyms.rb ‘latest’ (#10337) via David Whetstone
* Add missing new iOS / TvOS devices in the available devices matrix of snapshot reports generator (closes #10343) (#10346) via Julien Quéré
* [fix] slather.rb option source_files type is Array not String (#10333) via Demo
* [snapshot] Delete simulators based on versions (#10215) via Joseph Petersen
* [supply] Fix crash in apks_version_codes (#10330) via David Ohayon
* Make xcode_9 hard failure a warning (#10326) via Jacob Aleksynas
* Set the original name for the uploaded ipa (#10248) via Christian
* Fix creation of certificate when a keychain is specified. (#10321) via Typz
* [deliver] Add supply's `android` folder to list of excluded directories for language check (#10267) via Jan Piotrowski
* Fixed wrong working directory in cocoapods.error_callback call (#10309) via Siarhei Fiedartsou
* [snapshot] excludes helpers in assets when finding helpers (#10212) via Yusuke Hosonuma
