### PR TITLE
[regression] [deliver] Fix deliver upload: Use underscore instead of parentheses when appending SHA256 hash to an IPA file name

### DIFF
--- a/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -34,7 +34,7 @@ module FastlaneCore
     private
 
     def copy_ipa(ipa_path)
-      ipa_file_name = "#{File.basename(ipa_path, '.ipa')}(#{Digest::SHA256.file(ipa_path).hexdigest}).ipa"
+      ipa_file_name = "#{File.basename(ipa_path, '.ipa')}_#{Digest::SHA256.file(ipa_path).hexdigest}.ipa"
       resulting_path = File.join(self.package_path, ipa_file_name)
       FileUtils.cp(ipa_path, resulting_path)
 


### PR DESCRIPTION
Fixes Deliver IPA upload. In the following example, the supplied IPA file is named 'da.ipa', and ITMS Transporter fails with the following error:
`The filename da(79a6c24a88310adf91490fa32eaa7e15dd91ee2d9d8139dfe86ac76320d04eac).ipa in the package contains an invalid character(s).  The valid characters are: A-Z, a-z, 0-9, dash, period, underscore, but the name cannot start with a dash, period, or underscore`

This fixes the following issues: 
https://github.com/fastlane/fastlane/issues/10327
https://github.com/fastlane/fastlane/issues/10356

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fix upload of IPA using deliver (Xcode 9 / fastlane 2.57.0)
https://github.com/fastlane/fastlane/issues/10327
https://github.com/fastlane/fastlane/issues/10356
I have run fastlane release to upload an IPA file and it succeeded.

### Description
Use underscore instead of parentheses when appending SHA256 hash to an IPA file name