### PR TITLE
Check for null keychain path before attempting to use it

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -45,7 +45,7 @@ module FastlaneCore
     end
 
     def self.list_available_identities(keychain, password)
-      keychain = File.expand_path(keychain)
+      keychain = File.expand_path(keychain) if keychain
       locked = keychain and !system("security show-keychain-info #{keychain} >/dev/null 2>/dev/null")
       `security unlock -p #{password} #{keychain}` if locked
       `security find-identity -v -p codesigning #{keychain}`


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass. Can not run in any directory because of https://github.com/fastlane/fastlane/issues/9177. Happy to run if I can get it working.
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Upgrading to 2.57 broke the match command for my workflow as referenced in this issue: https://github.com/fastlane/fastlane/issues/10358. 
At @snelson21 's suggestion I have submitted this fix based on his comments.
As I am not currently able to run tests via rspec, I ran my updated fork in my app's repo (by pointing my Gemfile at my local fork) and have confirmed that the `self.list_available_identities(keychain, password)` no longer fails on a null `keychain` parameter.

### Description
I have added an `if keychain` check to the `self.list_available_identities(keychain, password)` method. Previously it called `keychain = File.expand_path(keychain)`, but the `keychain` value may be null, which would cause the `match` fastlane command to fail in my workflow. I'm happy to make any changes or add tests as seen fit.
