### PR TITLE
Fix missing keychain params passed to installed?

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -86,7 +86,7 @@ module Match
         cert_path = certs.last
         UI.message "Installing certificate..."
 
-        if FastlaneCore::CertChecker.installed?(cert_path)
+        if FastlaneCore::CertChecker.installed?(cert_path, params[:keychain_name], params[:keychain_password])
           UI.verbose "Certificate '#{File.basename(cert_path)}' is already installed on this machine"
         else
           Utils.import(cert_path, params[:keychain_name], password: params[:keychain_password])

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -69,7 +69,7 @@ describe Match do
       expect(Match::GitHelper).to_not receive(:commit_changes)
 
       # To also install the certificate, fake that
-      expect(FastlaneCore::CertChecker).to receive(:installed?).with(cert_path).and_return(false)
+      expect(FastlaneCore::CertChecker).to receive(:installed?).with(cert_path, keychain, nil).and_return(false)
       expect(Match::Utils).to receive(:import).with(cert_path, keychain, password: nil).and_return(nil)
 
       spaceship = "spaceship"


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
#10321 added an regression on match as it was not passing the params for the keychain.

### Description
The installed? method was updated and we need to parse the params as shown in PR #10321