### PR TITLE
Add missing "Apple TV" device in snapshot report generator devices

### DIFF
--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -88,6 +88,7 @@ module Snapshot
         'Apple TV 1080p' => 'Apple TV',
         'Apple TV 4K (at 1080p)' => 'Apple TV 4K (at 1080p)',
         'Apple TV 4K' => 'Apple TV 4K',
+        'Apple TV' => 'Apple TV',
         'Mac' => 'Mac'
       }
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)

### Motivation and Context
This PR closes #10365 

### Description
Simply added "Apple TV" at the end of `xcode_9_and_above_device_name_mappings`. 