### PR TITLE
Version bump to 2.57.2

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.57.1'.freeze
+  VERSION = '2.57.2'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.57.1':**

* Add missing "Apple TV" device in snapshot report generator devices (see #10365) (#10366) via Julien Quéré
* Allow snapshot to handle multiple tvOS devices (closes #10347) (#10350) via Julien Quéré
