### PR TITLE
Add in-app purchase scanning support to precheck

### DIFF
--- a/precheck/lib/precheck/options.rb
+++ b/precheck/lib/precheck/options.rb
@@ -12,6 +12,7 @@ module Precheck
         FutureFunctionalityRule,
         TestWordsRule,
         CurseWordsRule,
+        FreeStuffIAPRule,
         CustomTextRule,
         CopyrightDateRule,
         UnreachableURLRule
@@ -56,7 +57,14 @@ module Precheck
                                      env_name: "PRECHECK_DEFAULT_RULE_LEVEL",
                                      description: "The default rule level unless otherwise configured",
                                      is_string: false,
-                                     default_value: RULE_LEVELS[:error])
+                                     default_value: RULE_LEVELS[:error]),
+        FastlaneCore::ConfigItem.new(key: :include_in_app_purchases,
+                                     short_option: "-i",
+                                     env_name: "PRECHECK_INCLUDE_IN_APP_PURCHASES",
+                                     description: "Should check in-app purchases?",
+                                     is_string: false,
+                                     optional: true,
+                                     default_value: true)
       ] + rules
     end
   end

--- a/precheck/lib/precheck/rule_processor.rb
+++ b/precheck/lib/precheck/rule_processor.rb
@@ -179,7 +179,7 @@ module Precheck
 
       should_include_iap = Precheck.config[:include_in_app_purchases]
       if should_include_iap
-        UI.message "Reading in-app purchases. If you have alot, this might take a while"
+        UI.message "Reading in-app purchases. If you have a lot, this might take a while"
         UI.message "You can disable IAP checking by adding the include_in_app_purchases flag"
         in_app_purchases = app.in_app_purchases.all
         in_app_purchases ||= []
@@ -203,7 +203,7 @@ module Precheck
       return items
     end
 
-    #   # a few attributes are LanguageItem this method creates a TextItemToCheck for each pair
+    # a few attributes are LanguageItem this method creates a TextItemToCheck for each pair
     def self.collect_text_items_from_language_item(hash: nil, item_name: nil, friendly_name_postfix: nil, is_optional: false)
       items = []
       hash.each do |key, value|

--- a/precheck/lib/precheck/rule_processor.rb
+++ b/precheck/lib/precheck/rule_processor.rb
@@ -180,11 +180,11 @@ module Precheck
       should_include_iap = Precheck.config[:include_in_app_purchases]
       if should_include_iap
         UI.message "Reading in-app purchases. If you have a lot, this might take a while"
-        UI.message "You can disable IAP checking by adding the include_in_app_purchases flag"
+        UI.message "You can disable IAP checking by setting the `include_in_app_purchases` flag to `false`"
         in_app_purchases = app.in_app_purchases.all
         in_app_purchases ||= []
         in_app_purchases.each do |purchase|
-          items += self.collect_iap_language_items(purchase_edit_versions: purchase.edit.versions)
+          items += collect_iap_language_items(purchase_edit_versions: purchase.edit.versions)
         end
         UI.message "Done reading in-app purchases"
       end

--- a/precheck/lib/precheck/rules/free_stuff_iap_rule.rb
+++ b/precheck/lib/precheck/rules/free_stuff_iap_rule.rb
@@ -1,0 +1,32 @@
+require 'precheck/rule'
+require 'precheck/rules/abstract_text_match_rule'
+
+module Precheck
+  class FreeStuffIAPRule < AbstractTextMatchRule
+    def self.key
+      :free_stuff_in_iap
+    end
+
+    def self.env_name
+      "RULE_FREE_STUFF_IN_IAP"
+    end
+
+    def self.friendly_name
+      "No words indicating your IAP is free"
+    end
+
+    def self.description
+      "using text indicating that your IAP is free"
+    end
+
+    def supported_fields_symbol_set
+      [:in_app_purchase].to_set
+    end
+
+    def lowercased_words_to_look_for
+      [
+        "free"
+      ].map(&:downcase)
+    end
+  end
+end

--- a/precheck/spec/rule_processor_spec.rb
+++ b/precheck/spec/rule_processor_spec.rb
@@ -7,6 +7,10 @@ describe Precheck do
     let(:fake_happy_app) { "fake_app_object" }
     let(:fake_happy_app_details) { "fake_app_details" }
     let(:fake_happy_app_version) { "fake_app_version_object" }
+    let(:fake_in_app_purchase) { "fake_in_app_purchase" }
+    let(:fake_in_app_purchase_edit) { "fake_in_app_purchase_edit" }
+    let(:fake_in_app_purchase_edit_version) { { :"de-DE" => { name: "iap name", description: "iap desc" } } }
+    let(:fake_in_app_purchases) { [fake_in_app_purchase] }
 
     before do
       setup_happy_app
@@ -17,6 +21,7 @@ describe Precheck do
     def setup_happy_app
       allow(fake_happy_app).to receive(:apple_id).and_return("com.whatever")
       allow(fake_happy_app).to receive(:name).and_return("My Fake App")
+      allow(fake_happy_app).to receive(:in_app_purchases).and_return(fake_in_app_purchases)
       allow(fake_happy_app).to receive(:details).and_return(fake_happy_app_details)
 
       allow(fake_happy_app_details).to receive(:name).and_return(fake_language_item_for_text_item(fieldname: "name"))
@@ -30,6 +35,10 @@ describe Precheck do
       allow(fake_happy_app_version).to receive(:release_notes).and_return(fake_language_item_for_text_item(fieldname: "release_notes"))
       allow(fake_happy_app_version).to receive(:support_url).and_return(fake_language_item_for_url_item(fieldname: "support_url"))
       allow(fake_happy_app_version).to receive(:marketing_url).and_return(fake_language_item_for_url_item(fieldname: "marketing_url"))
+
+      allow(fake_in_app_purchases).to receive(:all).and_return(fake_in_app_purchases)
+      allow(fake_in_app_purchase).to receive(:edit).and_return(fake_in_app_purchase_edit)
+      allow(fake_in_app_purchase_edit).to receive(:versions).and_return(fake_in_app_purchase_edit_version)
 
       setup_happy_url_rule_mock
     end


### PR DESCRIPTION
IAP sometimes fails review if you include the word "free" in your description. That's silly. Oh well, let's go ahead and scan all our IAP to make sure we're not going to get rejected!

- Add option to disable in-app purchase scanning
- Add rule to check for the word "free" in IAP

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid

