### PR TITLE
Add "fastlane update_fastlane" command to tab autocompletion

### DIFF
--- a/fastlane/lib/assets/completions/completion.bash
+++ b/fastlane/lib/assets/completions/completion.bash
@@ -16,6 +16,7 @@ _fastlane_complete() {
 
   # parse 'beta' out of 'lane :beta do', etc
   completions=$(grep "^\s*lane \:" $file | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}')
+  completions="$completions update_fastlane"
 
   COMPREPLY=( $(compgen -W "$completions" -- "$word") )
 }

--- a/fastlane/lib/assets/completions/completion.fish
+++ b/fastlane/lib/assets/completions/completion.fish
@@ -34,4 +34,6 @@ for line in $commands
   end
 end
 
+set commands_string "$commands_string update_fastlane"
+
 complete -c fastlane -n '__fish_fastlane_needs_subcommand' -a (string trim $commands_string) -f

--- a/fastlane/lib/assets/completions/completion.zsh
+++ b/fastlane/lib/assets/completions/completion.zsh
@@ -15,6 +15,7 @@ _fastlane_complete() {
 
   # parse 'beta' out of 'lane :beta do', etc
   completions=`cat $file | grep "^\s*lane \:" | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}'`
+  completions="$completions update_fastlane"
 
   reply=( "${(ps:\n:)completions}" )
 }


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I got lazy typing fastlane update_fastlane all the time and needed it to autocomplete :)

### Description
I don't know if this is necessary to be in fastlane. I set it up for myself and wanted to share in case anyone else needs it.

_Notice: I am a total noob for scripting so if I have done it wrong, or this PR is not necessary at all, I apologise for the time wasted._