### PR TITLE
Add support for `fastlane update` command

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -159,9 +159,16 @@ module Fastlane
       UI.crash!('No key given') unless key
 
       return false if self.runner.lanes.fetch(nil, {}).fetch(key.to_sym, nil)
-      return true if self.runner.lanes[key.to_sym].kind_of? Hash
+      return true if self.runner.lanes[key.to_sym].kind_of?(Hash)
 
-      UI.user_error!("Could not find '#{key}'. Available lanes: #{self.runner.available_lanes.join(', ')}")
+      if key.to_sym == :update
+        # The user ran `fastlane update`, instead of `fastlane update_fastlane`
+        # We're gonna be nice and understand what the user is trying to do
+        require 'fastlane/one_off'
+        Fastlane::OneOff.run(action: "update_fastlane", parameters: {})
+      else
+        UI.user_error!("Could not find '#{key}'. Available lanes: #{self.runner.available_lanes.join(', ')}")
+      end
     end
 
     def actions_path(path)

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -29,7 +29,12 @@ describe Fastlane do
 
       it "raises an exception if key doesn't exist at all" do
         expect(UI).to receive(:user_error!).with("Could not find 'asdf'. Available lanes: test, anotherroot, mac beta, ios beta, ios release, android beta, android witherror, android unsupported_action")
-        @ff.is_platform_block? "asdf"
+        @ff.is_platform_block?("asdf")
+      end
+
+      it "has an alias for `update`, if there is no lane called `update`" do
+        expect(Fastlane::OneOff).to receive(:run).with({ action: "update_fastlane", parameters: {} })
+        @ff.is_platform_block?("update")
       end
     end
 


### PR DESCRIPTION
The key here was to not break any setups that have a lane called `update`, so we check for the `:update` command pretty late on the stack