### PR TITLE
Support all App Services

### DIFF
--- a/spaceship/docs/DeveloperPortal.md
+++ b/spaceship/docs/DeveloperPortal.md
@@ -56,6 +56,10 @@ passbook.(on|off)
 push_notification.(on|off)
 siri_kit.(on|off)
 vpn_configuration.(on|off)
+network_extension.(on|off)
+hotspot.(on|off)
+multipath.(on|off)
+nfc_tag_reading.(on|off)
 ```
 
 Examples:

--- a/spaceship/lib/spaceship/portal/app_service.rb
+++ b/spaceship/lib/spaceship/portal/app_service.rb
@@ -94,6 +94,22 @@ module Spaceship
         def vpn_configuration
           self::VPNConfiguration
         end
+
+        def network_extension
+          self::NetworkExtension
+        end
+
+        def hotspot
+          self::Hotspot
+        end
+
+        def multipath
+          self::Multipath
+        end
+
+        def nfc_tag_reading
+          self::NFCTagReading
+        end
       end
 
       def ==(other)
@@ -271,6 +287,46 @@ module Spaceship
 
         def self.on
           AppService.new("V66P55NK2I", true)
+        end
+      end
+
+      module NetworkExtension
+        def self.off
+          AppService.new("NWEXT04537", false)
+        end
+
+        def self.on
+          AppService.new("NWEXT04537", true)
+        end
+      end
+
+      module Hotspot
+        def self.off
+          AppService.new("HSC639VEI8", false)
+        end
+
+        def self.on
+          AppService.new("HSC639VEI8", true)
+        end
+      end
+
+      module Multipath
+        def self.off
+          AppService.new("MP49FN762P", false)
+        end
+
+        def self.on
+          AppService.new("MP49FN762P", true)
+        end
+      end
+
+      module NFCTagReading
+        def self.off
+          AppService.new("NFCTRMAY17", false)
+        end
+
+        def self.on
+          AppService.new("NFCTRMAY17", true)
         end
       end
     end


### PR DESCRIPTION
This includes:
- network_extension
- hotspot
- multipath
- nfc_tag_reading

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This addresses https://github.com/fastlane/fastlane/issues/10383 by adding the missing app services available from the Apple Developer Center

### Description
Service IDs have been fetched directly from the Developer Center webpage and compared to the existing ones. Code structure has been preserved and I've just added the missing services, which are of kind on|off, so very basic.

Changes have been tested by invoking spaceship directly from a ruby script.

