### PR TITLE
[Gym] code_signing_mapping ignore target with unset bundle identifier

### DIFF
--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -125,6 +125,7 @@ module Gym
               next unless specified_configuration == build_configuration.name
 
               bundle_identifier = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER")
+              next unless bundle_identifier
               provisioning_profile_specifier = build_configuration.resolve_build_setting("PROVISIONING_PROFILE_SPECIFIER")
               provisioning_profile_uuid = build_configuration.resolve_build_setting("PROVISIONING_PROFILE")
 


### PR DESCRIPTION
### Motivation and Context
In some projects we might have target that do not have a bundle_identifier, specifically targets that are built as .a lib and used as target dependencies for "real targets".
Those target cause the tentative to match profile and bundles to fail.
