### PR TITLE
Gym profile matching : ignore profile that do not match the correct platform

### DIFF
--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -125,6 +125,7 @@ module Gym
               next unless specified_configuration == build_configuration.name
 
               bundle_identifier = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER")
+              next unless bundle_identifier
               provisioning_profile_specifier = build_configuration.resolve_build_setting("PROVISIONING_PROFILE_SPECIFIER")
               provisioning_profile_uuid = build_configuration.resolve_build_setting("PROVISIONING_PROFILE")
 

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -111,9 +111,9 @@ module Gym
       case destination
       when "macosx"
         sdkroot = "macosx"
-      when "iOS" 
+      when "iOS"
         sdkroot = "iphoneos"
-      when "tvOS" 
+      when "tvOS"
         sdkroot = "appletvos"
       end
       return build_settings["SDKROOT"] != sdkroot

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -104,6 +104,20 @@ module Gym
       return (!build_settings["TEST_TARGET_NAME"].nil? || !build_settings["TEST_HOST"].nil?)
     end
 
+    def other_platform?(build_settings)
+      Gym.config[:destination].slice! "generic/platform="
+      sdkroot = ""
+      case Gym.config[:destination]
+      when "macosx"
+        sdkroot = "macosx"
+      when "iOS" 
+        sdkroot = "iphoneos"
+      when "tvOS" 
+        sdkroot = "appletvos"
+      end
+      return(build_settings["SDKROOT"] != sdkroot)
+    end
+
     def detect_project_profile_mapping
       provisioning_profile_mapping = {}
       specified_configuration = Gym.config[:configuration] || Gym.project.default_build_settings(key: "CONFIGURATION")
@@ -122,6 +136,7 @@ module Gym
             target.build_configuration_list.build_configurations.each do |build_configuration|
               current = build_configuration.build_settings
               next if test_target?(current)
+              next if other_platform?(current)
               next unless specified_configuration == build_configuration.name
 
               bundle_identifier = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER")

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -106,7 +106,7 @@ module Gym
 
     def same_platform?(sdkroot)
       destination = Gym.config[:destination].dup
-      destination.slice! "generic/platform="
+      destination.slice!("generic/platform=")
       destination_sdkroot = []
       case destination
       when "macosx"
@@ -116,7 +116,7 @@ module Gym
       when "tvOS"
         destination_sdkroot = ["appletvos"]
       end
-      return destination_sdkroot.include? sdkroot
+      return destination_sdkroot.include?(sdkroot)
     end
 
     def detect_project_profile_mapping

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -116,7 +116,7 @@ module Gym
       when "tvOS" 
         sdkroot = "appletvos"
       end
-      return(build_settings["SDKROOT"] != sdkroot)
+      return build_settings["SDKROOT"] != sdkroot
     end
 
     def detect_project_profile_mapping

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -105,9 +105,10 @@ module Gym
     end
 
     def other_platform?(build_settings)
-      Gym.config[:destination].slice! "generic/platform="
+      destination = Gym.config[:destination].dup
+      destination.slice! "generic/platform="
       sdkroot = ""
-      case Gym.config[:destination]
+      case destination
       when "macosx"
         sdkroot = "macosx"
       when "iOS" 

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -104,19 +104,19 @@ module Gym
       return (!build_settings["TEST_TARGET_NAME"].nil? || !build_settings["TEST_HOST"].nil?)
     end
 
-    def other_platform?(build_settings)
+    def other_platform?(sdkroot)
       destination = Gym.config[:destination].dup
       destination.slice! "generic/platform="
-      sdkroot = ""
+      destination_sdkroot = ""
       case destination
       when "macosx"
-        sdkroot = "macosx"
+        destination_sdkroot = "macosx"
       when "iOS"
-        sdkroot = "iphoneos"
+        destination_sdkroot = "iphoneos"
       when "tvOS"
-        sdkroot = "appletvos"
+        destination_sdkroot = "appletvos"
       end
-      return build_settings["SDKROOT"] != sdkroot
+      return sdkroot != destination_sdkroot
     end
 
     def detect_project_profile_mapping
@@ -137,7 +137,8 @@ module Gym
             target.build_configuration_list.build_configurations.each do |build_configuration|
               current = build_configuration.build_settings
               next if test_target?(current)
-              next if other_platform?(current)
+              sdkroot = build_configuration.resolve_build_setting("SDKROOT")
+              next if other_platform?(sdkroot)
               next unless specified_configuration == build_configuration.name
 
               bundle_identifier = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER")

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -104,19 +104,19 @@ module Gym
       return (!build_settings["TEST_TARGET_NAME"].nil? || !build_settings["TEST_HOST"].nil?)
     end
 
-    def other_platform?(sdkroot)
+    def same_platform?(sdkroot)
       destination = Gym.config[:destination].dup
       destination.slice! "generic/platform="
-      destination_sdkroot = ""
+      destination_sdkroot = []
       case destination
       when "macosx"
-        destination_sdkroot = "macosx"
+        destination_sdkroot = ["macosx"]
       when "iOS"
-        destination_sdkroot = "iphoneos"
+        destination_sdkroot = ["iphoneos", "watchos"]
       when "tvOS"
-        destination_sdkroot = "appletvos"
+        destination_sdkroot = ["appletvos"]
       end
-      return sdkroot != destination_sdkroot
+      return destination_sdkroot.include? sdkroot
     end
 
     def detect_project_profile_mapping
@@ -138,7 +138,7 @@ module Gym
               current = build_configuration.build_settings
               next if test_target?(current)
               sdkroot = build_configuration.resolve_build_setting("SDKROOT")
-              next if other_platform?(sdkroot)
+              next unless same_platform?(sdkroot)
               next unless specified_configuration == build_configuration.name
 
               bundle_identifier = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER")

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -14,8 +14,6 @@ module Gym
       FastlaneCore::Project.detect_projects(config)
       Gym.project = FastlaneCore::Project.new(config)
 
-      detect_selected_provisioning_profiles
-
       # Go into the project's folder, as there might be a Gymfile there
       Dir.chdir(File.expand_path("..", Gym.project.path)) do
         config.load_configuration_file(Gym.gymfile_name)
@@ -23,6 +21,7 @@ module Gym
 
       detect_scheme
       detect_platform # we can only do that *after* we have the scheme
+      detect_selected_provisioning_profiles # we can only do that *aftet* we have the platform
       detect_configuration
       detect_toolchain
 

--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -50,7 +50,19 @@ describe Gym::CodeSigningMapping do
         workspace: workspace_path
       })
       csm = Gym::CodeSigningMapping.new(project: project)
-      expect(csm.detect_project_profile_mapping).to eq({ "family.wwdc.app" => "match AppStore family.wwdc.app" })
+      expect(csm.detect_project_profile_mapping).to eq({ "family.wwdc.app" => "match AppStore family.wwdc.app", "family.wwdc.app.watchkitapp" => "match AppStore family.wwdc.app.watchkitapp", "family.wwdc.app.watchkitapp.watchkitextension" => "match AppStore family.wwdc.app.watchkitappextension" })
+    end
+  end
+
+  describe "#detect_project_profile_mapping_for_tv_os" do
+    it "returns the mapping of the selected provisioning profiles for tv_os" do
+      workspace_path = "gym/spec/fixtures/projects/cocoapods/Example.xcworkspace"
+      project = FastlaneCore::Project.new({
+        workspace: workspace_path
+      })
+      csm = Gym::CodeSigningMapping.new(project: project)
+      Gym.config[:destination] = "generic/platform=tvOS"
+      expect(csm.detect_project_profile_mapping).to eq({ "family.wwdc.app" => "match AppStore family.wwdc.app.tvos" })
     end
   end
 

--- a/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/project.pbxproj
+++ b/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/project.pbxproj
@@ -16,6 +16,18 @@
 		CAC1E1AB1B6A326100A8B23A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CAC1E1A91B6A326100A8B23A /* LaunchScreen.storyboard */; };
 		CAC1E1B61B6A326200A8B23A /* ExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CAC1E1B51B6A326200A8B23A /* ExampleTests.m */; };
 		CAC1E1C11B6A326200A8B23A /* ExampleUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = CAC1E1C01B6A326200A8B23A /* ExampleUITests.m */; };
+		F828205F1F74189B00B0DC54 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F828205E1F74189B00B0DC54 /* AppDelegate.swift */; };
+		F82820611F74189B00B0DC54 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82820601F74189B00B0DC54 /* ViewController.swift */; };
+		F82820641F74189B00B0DC54 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F82820621F74189B00B0DC54 /* Main.storyboard */; };
+		F82820661F74189B00B0DC54 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F82820651F74189B00B0DC54 /* Assets.xcassets */; };
+		F8F2CF8F1F74244000B0C495 /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8F2CF8D1F74244000B0C495 /* Interface.storyboard */; };
+		F8F2CF911F74244000B0C495 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F8F2CF901F74244000B0C495 /* Assets.xcassets */; };
+		F8F2CF981F74244100B0C495 /* ExampleWatchOS Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F8F2CF971F74244100B0C495 /* ExampleWatchOS Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		F8F2CF9D1F74244100B0C495 /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F2CF9C1F74244100B0C495 /* InterfaceController.swift */; };
+		F8F2CF9F1F74244100B0C495 /* ExtensionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F2CF9E1F74244100B0C495 /* ExtensionDelegate.swift */; };
+		F8F2CFA11F74244100B0C495 /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F2CFA01F74244100B0C495 /* NotificationController.swift */; };
+		F8F2CFA31F74244100B0C495 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F8F2CFA21F74244100B0C495 /* Assets.xcassets */; };
+		F8F2CFA81F74244100B0C495 /* ExampleWatchOS.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = F8F2CF8B1F74244000B0C495 /* ExampleWatchOS.app */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -33,7 +45,46 @@
 			remoteGlobalIDString = CAC1E1971B6A326100A8B23A;
 			remoteInfo = Example;
 		};
+		F8F2CF991F74244100B0C495 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CAC1E1901B6A326100A8B23A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F8F2CF961F74244100B0C495;
+			remoteInfo = "ExampleWatchOS Extension";
+		};
+		F8F2CFA61F74244100B0C495 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CAC1E1901B6A326100A8B23A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F8F2CF8A1F74244000B0C495;
+			remoteInfo = ExampleWatchOS;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		F8F2CFAE1F74244100B0C495 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				F8F2CF981F74244100B0C495 /* ExampleWatchOS Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8F2CFB01F74244100B0C495 /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				F8F2CFA81F74244100B0C495 /* ExampleWatchOS.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		BDC4BE00FA30F698E5A28354 /* libPods-Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -53,6 +104,23 @@
 		CAC1E1BC1B6A326200A8B23A /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAC1E1C01B6A326200A8B23A /* ExampleUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExampleUITests.m; sourceTree = "<group>"; };
 		CAC1E1C21B6A326200A8B23A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F828205C1F74189B00B0DC54 /* ExampletvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampletvOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F828205E1F74189B00B0DC54 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		F82820601F74189B00B0DC54 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		F82820631F74189B00B0DC54 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		F82820651F74189B00B0DC54 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		F82820671F74189B00B0DC54 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F8F2CF8B1F74244000B0C495 /* ExampleWatchOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleWatchOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8F2CF8E1F74244000B0C495 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
+		F8F2CF901F74244000B0C495 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		F8F2CF921F74244000B0C495 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F8F2CF971F74244100B0C495 /* ExampleWatchOS Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "ExampleWatchOS Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8F2CF9C1F74244100B0C495 /* InterfaceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceController.swift; sourceTree = "<group>"; };
+		F8F2CF9E1F74244100B0C495 /* ExtensionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDelegate.swift; sourceTree = "<group>"; };
+		F8F2CFA01F74244100B0C495 /* NotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationController.swift; sourceTree = "<group>"; };
+		F8F2CFA21F74244100B0C495 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		F8F2CFA41F74244100B0C495 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F8F2CFA51F74244100B0C495 /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -72,6 +140,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		CAC1E1B91B6A326200A8B23A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F82820591F74189B00B0DC54 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8F2CF941F74244100B0C495 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -102,6 +184,9 @@
 				CAC1E19A1B6A326100A8B23A /* Example */,
 				CAC1E1B41B6A326100A8B23A /* ExampleTests */,
 				CAC1E1BF1B6A326200A8B23A /* ExampleUITests */,
+				F828205D1F74189B00B0DC54 /* ExampletvOS */,
+				F8F2CF8C1F74244000B0C495 /* ExampleWatchOS */,
+				F8F2CF9B1F74244100B0C495 /* ExampleWatchOS Extension */,
 				CAC1E1991B6A326100A8B23A /* Products */,
 				BADC4719675AA7E88BB4142C /* Pods */,
 				9E1FB1D1D5F20339E5A8AFF2 /* Frameworks */,
@@ -114,6 +199,9 @@
 				CAC1E1981B6A326100A8B23A /* ExampleProductName.app */,
 				CAC1E1B11B6A326100A8B23A /* ExampleTests.xctest */,
 				CAC1E1BC1B6A326200A8B23A /* ExampleUITests.xctest */,
+				F828205C1F74189B00B0DC54 /* ExampletvOS.app */,
+				F8F2CF8B1F74244000B0C495 /* ExampleWatchOS.app */,
+				F8F2CF971F74244100B0C495 /* ExampleWatchOS Extension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -160,6 +248,41 @@
 			path = ExampleUITests;
 			sourceTree = "<group>";
 		};
+		F828205D1F74189B00B0DC54 /* ExampletvOS */ = {
+			isa = PBXGroup;
+			children = (
+				F828205E1F74189B00B0DC54 /* AppDelegate.swift */,
+				F82820601F74189B00B0DC54 /* ViewController.swift */,
+				F82820621F74189B00B0DC54 /* Main.storyboard */,
+				F82820651F74189B00B0DC54 /* Assets.xcassets */,
+				F82820671F74189B00B0DC54 /* Info.plist */,
+			);
+			path = ExampletvOS;
+			sourceTree = "<group>";
+		};
+		F8F2CF8C1F74244000B0C495 /* ExampleWatchOS */ = {
+			isa = PBXGroup;
+			children = (
+				F8F2CF8D1F74244000B0C495 /* Interface.storyboard */,
+				F8F2CF901F74244000B0C495 /* Assets.xcassets */,
+				F8F2CF921F74244000B0C495 /* Info.plist */,
+			);
+			path = ExampleWatchOS;
+			sourceTree = "<group>";
+		};
+		F8F2CF9B1F74244100B0C495 /* ExampleWatchOS Extension */ = {
+			isa = PBXGroup;
+			children = (
+				F8F2CF9C1F74244100B0C495 /* InterfaceController.swift */,
+				F8F2CF9E1F74244100B0C495 /* ExtensionDelegate.swift */,
+				F8F2CFA01F74244100B0C495 /* NotificationController.swift */,
+				F8F2CFA21F74244100B0C495 /* Assets.xcassets */,
+				F8F2CFA41F74244100B0C495 /* Info.plist */,
+				F8F2CFA51F74244100B0C495 /* PushNotificationPayload.apns */,
+			);
+			path = "ExampleWatchOS Extension";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -171,10 +294,12 @@
 				CAC1E1941B6A326100A8B23A /* Sources */,
 				CAC1E1951B6A326100A8B23A /* Frameworks */,
 				CAC1E1961B6A326100A8B23A /* Resources */,
+				F8F2CFB01F74244100B0C495 /* Embed Watch Content */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				F8F2CFA71F74244100B0C495 /* PBXTargetDependency */,
 			);
 			name = Example;
 			productName = Example;
@@ -217,12 +342,64 @@
 			productReference = CAC1E1BC1B6A326200A8B23A /* ExampleUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		F828205B1F74189B00B0DC54 /* ExampletvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F828206A1F74189B00B0DC54 /* Build configuration list for PBXNativeTarget "ExampletvOS" */;
+			buildPhases = (
+				F82820581F74189B00B0DC54 /* Sources */,
+				F82820591F74189B00B0DC54 /* Frameworks */,
+				F828205A1F74189B00B0DC54 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ExampletvOS;
+			productName = ExampletvOS;
+			productReference = F828205C1F74189B00B0DC54 /* ExampletvOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		F8F2CF8A1F74244000B0C495 /* ExampleWatchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F8F2CFAF1F74244100B0C495 /* Build configuration list for PBXNativeTarget "ExampleWatchOS" */;
+			buildPhases = (
+				F8F2CF891F74244000B0C495 /* Resources */,
+				F8F2CFAE1F74244100B0C495 /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F8F2CF9A1F74244100B0C495 /* PBXTargetDependency */,
+			);
+			name = ExampleWatchOS;
+			productName = ExampleWatchOS;
+			productReference = F8F2CF8B1F74244000B0C495 /* ExampleWatchOS.app */;
+			productType = "com.apple.product-type.application.watchapp2";
+		};
+		F8F2CF961F74244100B0C495 /* ExampleWatchOS Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F8F2CFAD1F74244100B0C495 /* Build configuration list for PBXNativeTarget "ExampleWatchOS Extension" */;
+			buildPhases = (
+				F8F2CF931F74244100B0C495 /* Sources */,
+				F8F2CF941F74244100B0C495 /* Frameworks */,
+				F8F2CF951F74244100B0C495 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ExampleWatchOS Extension";
+			productName = "ExampleWatchOS Extension";
+			productReference = F8F2CF971F74244100B0C495 /* ExampleWatchOS Extension.appex */;
+			productType = "com.apple.product-type.watchkit2-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		CAC1E1901B6A326100A8B23A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0900;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Felix Krause";
 				TargetAttributes = {
@@ -241,6 +418,18 @@
 						ProvisioningStyle = Manual;
 						TestTargetID = CAC1E1971B6A326100A8B23A;
 					};
+					F828205B1F74189B00B0DC54 = {
+						CreatedOnToolsVersion = 9.0;
+						ProvisioningStyle = Manual;
+					};
+					F8F2CF8A1F74244000B0C495 = {
+						CreatedOnToolsVersion = 9.0;
+						ProvisioningStyle = Automatic;
+					};
+					F8F2CF961F74244100B0C495 = {
+						CreatedOnToolsVersion = 9.0;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = CAC1E1931B6A326100A8B23A /* Build configuration list for PBXProject "Example" */;
@@ -257,8 +446,11 @@
 			projectRoot = "";
 			targets = (
 				CAC1E1971B6A326100A8B23A /* Example */,
+				F828205B1F74189B00B0DC54 /* ExampletvOS */,
 				CAC1E1B01B6A326100A8B23A /* ExampleTests */,
 				CAC1E1BB1B6A326200A8B23A /* ExampleUITests */,
+				F8F2CF8A1F74244000B0C495 /* ExampleWatchOS */,
+				F8F2CF961F74244100B0C495 /* ExampleWatchOS Extension */,
 			);
 		};
 /* End PBXProject section */
@@ -285,6 +477,32 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F828205A1F74189B00B0DC54 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F82820661F74189B00B0DC54 /* Assets.xcassets in Resources */,
+				F82820641F74189B00B0DC54 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8F2CF891F74244000B0C495 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8F2CF911F74244000B0C495 /* Assets.xcassets in Resources */,
+				F8F2CF8F1F74244000B0C495 /* Interface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8F2CF951F74244100B0C495 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8F2CFA31F74244100B0C495 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -335,6 +553,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F82820581F74189B00B0DC54 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F82820611F74189B00B0DC54 /* ViewController.swift in Sources */,
+				F828205F1F74189B00B0DC54 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8F2CF931F74244100B0C495 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8F2CFA11F74244100B0C495 /* NotificationController.swift in Sources */,
+				F8F2CF9F1F74244100B0C495 /* ExtensionDelegate.swift in Sources */,
+				F8F2CF9D1F74244100B0C495 /* InterfaceController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -347,6 +584,16 @@
 			isa = PBXTargetDependency;
 			target = CAC1E1971B6A326100A8B23A /* Example */;
 			targetProxy = CAC1E1BD1B6A326200A8B23A /* PBXContainerItemProxy */;
+		};
+		F8F2CF9A1F74244100B0C495 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F8F2CF961F74244100B0C495 /* ExampleWatchOS Extension */;
+			targetProxy = F8F2CF991F74244100B0C495 /* PBXContainerItemProxy */;
+		};
+		F8F2CFA71F74244100B0C495 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F8F2CF8A1F74244000B0C495 /* ExampleWatchOS */;
+			targetProxy = F8F2CFA61F74244100B0C495 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -365,6 +612,22 @@
 				CAC1E1AA1B6A326100A8B23A /* Base */,
 			);
 			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		F82820621F74189B00B0DC54 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F82820631F74189B00B0DC54 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		F8F2CF8D1F74244000B0C495 /* Interface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F8F2CF8E1F74244000B0C495 /* Base */,
+			);
+			name = Interface.storyboard;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
@@ -540,6 +803,213 @@
 			};
 			name = Release;
 		};
+		F82820681F74189B00B0DC54 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ExampletvOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = family.wwdc.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore family.wwdc.app.tvos";
+				SDKROOT = appletvos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
+			};
+			name = Debug;
+		};
+		F82820691F74189B00B0DC54 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ExampletvOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = family.wwdc.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore family.wwdc.app.tvos";
+				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
+			};
+			name = Release;
+		};
+		F8F2CFA91F74244100B0C495 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				IBSC_MODULE = ExampleWatchOS_Extension;
+				INFOPLIST_FILE = ExampleWatchOS/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = family.wwdc.app.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore family.wwdc.app.watchkitapp";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = Debug;
+		};
+		F8F2CFAA1F74244100B0C495 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				IBSC_MODULE = ExampleWatchOS_Extension;
+				INFOPLIST_FILE = ExampleWatchOS/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = family.wwdc.app.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore family.wwdc.app.watchkitapp";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = Release;
+		};
+		F8F2CFAB1F74244100B0C495 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "ExampleWatchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = family.wwdc.app.watchkitapp.watchkitextension;
+				PRODUCT_NAME = "${TARGET_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore family.wwdc.app.watchkitappextension";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = Debug;
+		};
+		F8F2CFAC1F74244100B0C495 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "ExampleWatchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = family.wwdc.app.watchkitapp.watchkitextension;
+				PRODUCT_NAME = "${TARGET_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore family.wwdc.app.watchkitappextension";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -575,6 +1045,33 @@
 			buildConfigurations = (
 				CAC1E1CC1B6A326200A8B23A /* Debug */,
 				CAC1E1CD1B6A326200A8B23A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F828206A1F74189B00B0DC54 /* Build configuration list for PBXNativeTarget "ExampletvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F82820681F74189B00B0DC54 /* Debug */,
+				F82820691F74189B00B0DC54 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F8F2CFAD1F74244100B0C495 /* Build configuration list for PBXNativeTarget "ExampleWatchOS Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F8F2CFAB1F74244100B0C495 /* Debug */,
+				F8F2CFAC1F74244100B0C495 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F8F2CFAF1F74244100B0C495 /* Build configuration list for PBXNativeTarget "ExampleWatchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F8F2CFA91F74244100B0C495 /* Debug */,
+				F8F2CFAA1F74244100B0C495 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
### Motivation and Context
When a project has an iOS and a tvOS target the bundle identifier are the same.
It should not result in a duplicate error when matching.

Fixes: #10341

This PR includes PR #10386 but as it may lead to more discussion I made 2 PRs

### What did I do
- Detect what should be the base SDK in the build_settings based on the destination option in gym
- Filter target based on this configuration