### PR TITLE
Adding beta review info to AppTestInfo.

### DIFF
--- a/spaceship/lib/spaceship/test_flight/app_test_info.rb
+++ b/spaceship/lib/spaceship/test_flight/app_test_info.rb
@@ -5,6 +5,7 @@ module Spaceship::TestFlight
     # is test information about the application
 
     attr_accessor :test_info
+    attr_accessor :beta_review_info
 
     def self.find(app_id: nil)
       raw_app_test_info = client.get_app_test_info(app_id: app_id)
@@ -17,6 +18,14 @@ module Spaceship::TestFlight
 
     def test_info=(value)
       raw_data.set(['details'], value.raw_data)
+    end
+
+    def beta_review_info
+      Spaceship::TestFlight::BetaReviewInfo.new(raw_data['betaReviewInfo'])
+    end
+
+    def beta_review_info=(value)
+      raw_data.set(['betaReviewInfo'], value.raw_data)
     end
 
     # saves the changes to the App Test Info object to TestFlight

--- a/spaceship/lib/spaceship/test_flight/beta_review_info.rb
+++ b/spaceship/lib/spaceship/test_flight/beta_review_info.rb
@@ -1,7 +1,7 @@
 module Spaceship::TestFlight
   class BetaReviewInfo < Base
     attr_accessor :contact_first_name, :contact_last_name, :contact_phone, :contact_email
-    attr_accessor :demo_account_name, :demo_account_password, :demo_account_required
+    attr_accessor :demo_account_name, :demo_account_password, :demo_account_required, :notes
 
     attr_mapping({
       'contactFirstName' => :contact_first_name,
@@ -10,7 +10,8 @@ module Spaceship::TestFlight
       'contactEmail' => :contact_email,
       'demoAccountName' => :demo_account_name,
       'demoAccountPassword' => :demo_account_password,
-      'demoAccountRequired' => :demo_account_required
+      'demoAccountRequired' => :demo_account_required,
+      'notes' => :notes
     })
   end
 end

--- a/spaceship/lib/spaceship/test_flight/build.rb
+++ b/spaceship/lib/spaceship/test_flight/build.rb
@@ -179,6 +179,10 @@ module Spaceship::TestFlight
       client.post_for_testflight_review(app_id: app_id, build_id: id, build: self)
     end
 
+    def expire!
+      client.expire_build(app_id: app_id, build_id: id, build: self)
+    end
+
     def add_group!(group)
       client.add_group_to_build(app_id: app_id, group_id: group.id, build_id: id)
     end

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -68,6 +68,17 @@ module Spaceship::TestFlight
       handle_response(response)
     end
 
+    def expire_build(app_id: nil, build_id: nil, build: nil)
+      assert_required_params(__method__, binding)
+
+      response = request(:post) do |req|
+        req.url "providers/#{team_id}/apps/#{app_id}/builds/#{build_id}/expire"
+        req.body = build.to_json
+        req.headers['Content-Type'] = 'application/json'
+      end
+      handle_response(response)
+    end
+
     ##
     # @!group Groups API
     ##

--- a/spaceship/spec/test_flight/app_test_info_spec.rb
+++ b/spaceship/spec/test_flight/app_test_info_spec.rb
@@ -46,6 +46,19 @@ describe Spaceship::TestFlight::AppTestInfo do
                                         ])
   end
 
+  let(:beta_review_info) do
+    Spaceship::TestFlight::BetaReviewInfo.new({
+                                                 'contactFirstName' => 'Test_First',
+                                                 'contactLastName' => 'Test_Last',
+                                                 'contactPhone' => '2345678901',
+                                                 'contactEmail' => 'test_contact@email.com',
+                                                 'demoAccountName' => 'Test User Name',
+                                                 'demoAccountPassword' => 'Test_Password',
+                                                 'demoAccountRequired' => true,
+                                                 'notes' => 'test_notes!!'
+                                             })
+  end
+
   let(:mock_client) { double('MockClient') }
 
   before do
@@ -63,6 +76,23 @@ describe Spaceship::TestFlight::AppTestInfo do
   it 'sets the TestInfo' do
     app_test_info.test_info = test_info
     expect(app_test_info.raw_data['details']).to eq(test_info.raw_data)
+  end
+
+  it 'gets beta review info' do
+    expect(app_test_info.beta_review_info).to be_instance_of(Spaceship::TestFlight::BetaReviewInfo)
+    expect(app_test_info.beta_review_info.contact_first_name).to eq("First")
+    expect(app_test_info.beta_review_info.contact_last_name).to eq("Last")
+    expect(app_test_info.beta_review_info.contact_phone).to eq("1234567890")
+    expect(app_test_info.beta_review_info.contact_email).to eq("contact@email.com")
+    expect(app_test_info.beta_review_info.demo_account_name).to eq("User Name")
+    expect(app_test_info.beta_review_info.demo_account_password).to eq("Password")
+    expect(app_test_info.beta_review_info.demo_account_required).to eq(false)
+    expect(app_test_info.beta_review_info.notes).to eq("notes!!")
+  end
+
+  it 'sets beta review info' do
+    app_test_info.beta_review_info = beta_review_info
+    expect(app_test_info.raw_data['betaReviewInfo']).to eq(beta_review_info.raw_data)
   end
 
   context 'client interactions' do

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -102,6 +102,15 @@ describe Spaceship::TestFlight::Client do
     end
   end
 
+  context '#expire_build' do
+    let(:build) { double('Build', to_json: "") }
+    it 'executes the request' do
+      MockAPI::TestFlightServer.post('/testflight/v2/providers/fake-team-id/apps/some-app-id/builds/1/expire') {}
+      subject.expire_build(app_id: app_id, build_id: 1, build: build)
+      expect(WebMock).to have_requested(:post, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/builds/1/expire')
+    end
+  end
+
   ##
   # @!group Groups API
   ##


### PR DESCRIPTION
Adding notes to beta review info.
Adding functionality to expire build. + tests

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- :white_check_mark: I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- :white_check_mark: I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- :white_check_mark: I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- :white_check_mark: I've updated the documentation if necessary.

### Motivation and Context

AppTestInfo contains review notes - which are necessary for external test flight review if : 

- The login is required 
- Login flow is non-standard ( i.e. Login does not pop up at the launch of the application )

Expiring a testflight build : In order to provide access to an older build in a build train the newer build needs to be expired. 

### Description
Added `notes` to `BetaReviewInfo`
Added `beta_review_info` to `AppTestInfo` and related parsing
Added method `expire!` to `Spaceship::TestFlight::Build`
Added method `expire_build` to `Spaceship::Tunes::Client`
Added related tests to `client_spec` and `app_test_info_spec`
