### PR TITLE
download_dsym stopped setting correct build number which resulted in overwriting multiple zips

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -64,8 +64,8 @@ module Fastlane
 
             if download_url
               result = self.download download_url
-              path   = write_dsym(result, app.bundle_id, train_number, build_number, output_directory)
-              UI.success("🔑  Successfully downloaded dSYM file for #{train_number} - #{build_number} to '#{path}'")
+              path   = write_dsym(result, app.bundle_id, train_number, build.build_version, output_directory)
+              UI.success("🔑  Successfully downloaded dSYM file for #{train_number} - #{build.build_version} to '#{path}'")
 
               Actions.lane_context[SharedValues::DSYM_PATHS] ||= []
               Actions.lane_context[SharedValues::DSYM_PATHS] << File.expand_path(path)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
After the latest change in `download_dsym` that moved dSYM zip file creation into `write_dsym` instead of `build.build_version` the `build_number` script parameter was used. This resulted in all downloaded zip files being saved into the same destination overwriting file with each iteration.

### Description
Now `write_dsym` again receives `build.build_version` instead of `build_number`. And the log message updated as well.