### PR TITLE
Version bump to 2.59.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.58.0'.freeze
+  VERSION = '2.59.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.58.0':**

* Add output of the last few lines of transporter output on failure (#10397) via Felix Krause
* download_dsym stopped setting correct build number which resulted in overwriting multiple zips (#10392) via Andrii Shpak
* Show prettier error message when user has insufficient permissions in iTunes Connect (#10313) via Morten Gregersen
* Adding beta review info to AppTestInfo. (#10388) via pav1790
* [Gym] code_signing_mapping ignore target with unset bundle identifier (#10386) via Nicolas Braun
* Add new App Services (#10385) via Alain Caltieri
