### PR TITLE
Upload symbols get the latest file by default

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -131,7 +131,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :dsym_path,
                                        env_name: "FL_UPLOAD_SYMBOLS_TO_CRASHLYTICS_DSYM_PATH",
                                        description: "Path to the DSYM file or zip to upload",
-                                       default_value: ENV[SharedValues::DSYM_OUTPUT_PATH.to_s] || (Dir["./**/*.dSYM"] + Dir["./**/*.dSYM.zip"]).first,
+                                       default_value: ENV[SharedValues::DSYM_OUTPUT_PATH.to_s] || (Dir["./**/*.dSYM"] + Dir["./**/*.dSYM.zip"]).sort_by { |f| File.mtime(f) }.last,
                                        optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find file at path '#{File.expand_path(value)}'") unless File.exist?(value)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
This change avoid the need to manually specify the Dsym file when executing `upload_symbols_to_crashlytics` for multiple apps.
Example: Your dsyms folder is not empty, the commands `download_dsyms` and `upload_symbols_to_crashlytics` are executed, in this case Fastlane does not guarantee that the most recent one is picked to be uploaded.
A workaround would be to either clean the dsyms folder using `clean_build_artifacts` after any  `download_dsyms` or by specifying the file.
Since `clean_build_artifacts` is available, feel free to discard this PR if this change does not fit into Fastlane's philosophy.

### Description
<!--- Describe your changes in detail -->
The default value for dsym_path, now picks the latest added file.