### PR TITLE
Add setup_circle_ci action

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_circle_ci.rb
+++ b/fastlane/lib/fastlane/actions/setup_circle_ci.rb
@@ -1,0 +1,102 @@
+module Fastlane
+  module Actions
+    class SetupCircleCiAction < Action
+      def self.run(params)
+        unless should_run?(params)
+          UI.message "Not running on CI, skipping `setup_circle_ci`"
+          return
+        end
+
+        setup_keychain
+        setup_output_paths(params)
+      end
+
+      def self.setup_output_paths(params)
+        unless ENV["FL_OUTPUT_DIR"]
+          UI.message "Skipping Log Path setup as FL_OUTPUT_DIR is unset"
+          return
+        end
+
+        root = Pathname.new(ENV["FL_OUTPUT_DIR"])
+        ENV["SCAN_OUTPUT_DIRECTORY"] = (root + "scan").to_s
+        ENV["GYM_OUTPUT_DIRECTORY"] = (root + "gym").to_s
+        ENV["FL_BUILDLOG_PATH"] = (root + "buildlogs").to_s
+        ENV["SCAN_INCLUDE_SIMULATOR_LOGS"] = true.to_s
+      end
+
+      def self.setup_keychain
+        unless ENV["MATCH_KEYCHAIN_NAME"].nil?
+          UI.message "Skipping Keychain setup as a keychain was already specified"
+          return
+        end
+
+        keychain_name = "fastlane_tmp_keychain"
+        ENV["MATCH_KEYCHAIN_NAME"] = keychain_name
+        ENV["MATCH_KEYCHAIN_PASSWORD"] = ""
+
+        UI.message "Creating temporary keychain: \"#{keychain_name}\"."
+        Actions::CreateKeychainAction.run(
+          name: keychain_name,
+          default_keychain: true,
+          unlock: true,
+          timeout: 3600,
+          lock_when_sleeps: true,
+          password: ""
+        )
+
+        UI.message("Enabling match readonly mode.")
+        ENV["MATCH_READONLY"] = true.to_s
+      end
+
+      def self.should_run?(params)
+        Helper.is_ci? || params[:force]
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Setup the keychain and match to work with CircleCI"
+      end
+
+      def self.details
+        [
+          "- Creates a new temporary keychain for use with match",
+          "- Switches match to `readonly` mode to not create new profiles/cert on CI",
+          "- Sets up log and test result paths to be easily collectible",
+          "",
+          "This action helps with CircleCI integration, add this to the top of your Fastfile if you use CircleCI"
+        ].join("\n")
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :force,
+                                       env_name: "FL_SETUP_CIRCLECI_FORCE",
+                                       description: "Force setup, even if not executed by CircleCI",
+                                       is_string: false,
+                                       default_value: false)
+        ]
+      end
+
+      def self.authors
+        ["dantoml"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+
+      def self.example_code
+        [
+          'setup_circle_ci'
+        ]
+      end
+
+      def self.category
+        :misc
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/setup_circle_ci_spec.rb
+++ b/fastlane/spec/actions_specs/setup_circle_ci_spec.rb
@@ -1,0 +1,86 @@
+describe Fastlane do
+  describe Fastlane::Actions::SetupCircleCiAction do
+    describe "#setup_output_paths" do
+      before do
+        stub_const("ENV", { "FL_OUTPUT_DIR" => "/dev/null" })
+      end
+
+      it "sets the SCAN_OUTPUT_DIRECTORY" do
+        described_class.setup_output_paths(nil)
+        expect(ENV["SCAN_OUTPUT_DIRECTORY"]).to eql("/dev/null/scan")
+      end
+
+      it "sets the GYM_OUTPUT_DIRECTORY" do
+        described_class.setup_output_paths(nil)
+        expect(ENV["GYM_OUTPUT_DIRECTORY"]).to eql("/dev/null/gym")
+      end
+
+      it "sets the FL_BUILDLOG_PATH" do
+        described_class.setup_output_paths(nil)
+        expect(ENV["FL_BUILDLOG_PATH"]).to eql("/dev/null/buildlogs")
+      end
+    end
+
+    describe "#should_run" do
+      context "when running on CI" do
+        before do
+          expect(Fastlane::Helper).to receive(:is_ci?).and_return(true)
+        end
+
+        it "returns true when :force is true" do
+          expect(described_class.should_run?({ force: true })).to eql(true)
+        end
+
+        it "returns true when :force is false" do
+          expect(described_class.should_run?({ force: false })).to eql(true)
+        end
+      end
+
+      context "when not running on CI" do
+        before do
+          expect(Fastlane::Helper).to receive(:is_ci?).and_return(false)
+        end
+
+        it "returns false when :force is not set" do
+          expect(described_class.should_run?({ force: false })).to eql(false)
+        end
+
+        it "returns true when :force is set" do
+          expect(described_class.should_run?({ force: true })).to eql(true)
+        end
+      end
+    end
+
+    describe "#setup_keychain" do
+      context "when MATCH_KEYCHAIN_NAME is set" do
+        it "skips the setup process" do
+          stub_const("ENV", { "MATCH_KEYCHAIN_NAME" => "anything" })
+          expect(Fastlane::UI).to receive(:message).with "Skipping Keychain setup as a keychain was already specified"
+          described_class.setup_keychain
+        end
+      end
+
+      describe "Setting up the environment" do
+        before do
+          stub_const("ENV", {})
+          allow(Fastlane::Actions::CreateKeychainAction).to receive(:run).and_return(nil)
+        end
+
+        it "sets the MATCH_KEYCHAIN_NAME env var" do
+          described_class.setup_keychain
+          expect(ENV["MATCH_KEYCHAIN_NAME"]).to eql("fastlane_tmp_keychain")
+        end
+
+        it "sets the MATCH_KEYCHAIN_PASSWORD env var" do
+          described_class.setup_keychain
+          expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to eql("")
+        end
+
+        it "sets the MATCH_READONLY env var" do
+          described_class.setup_keychain
+          expect(ENV["MATCH_READONLY"]).to eql("true")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
In CircleCI 1.0, we automatically set many of these env vars, and automatically collected output and simulator logs as artefacts, and put test results into the correct directories.

On CircleCI 2.0, we don't do any of this, to give users ultimate control of everything in their build as part of their configuration. We're also now recommending the use of fastlane match for codesigning, and scan/gym for running tests and building binaries [wip CircleCI docs pr](https://github.com/circleci/circleci-docs/pull/1557).

This PR adds a `setup_circle_ci` action for CircleCI 2.0 macOS builds, similar to the `setup_travis` or `setup_jenkins` actions. With the intention of making it simple and easy for users to get set up, with minimal configuration in their Fastlane and CircleCI configurations.