### PR TITLE
Comment out carthage, cocoapods actions instead of removing

### DIFF
--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -276,8 +276,8 @@ module Fastlane
       end
 
       template.gsub!('snapshot', '# snapshot') unless self.tools[:snapshot]
-      template.gsub!('    cocoapods', '') unless self.tools[:cocoapods]
-      template.gsub!('    carthage', '') unless self.tools[:carthage]
+      template.gsub!('cocoapods', '# cocoapods') unless self.tools[:cocoapods]
+      template.gsub!('carthage', '# carthage') unless self.tools[:carthage]
       template.gsub!('[[FASTLANE_VERSION]]', Fastlane::VERSION)
 
       self.tools.each do |key, value|

--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -276,8 +276,8 @@ module Fastlane
       end
 
       template.gsub!('snapshot', '# snapshot') unless self.tools[:snapshot]
-      template.gsub!('cocoapods', '') unless self.tools[:cocoapods]
-      template.gsub!('carthage', '') unless self.tools[:carthage]
+      template.gsub!('    cocoapods', '') unless self.tools[:cocoapods]
+      template.gsub!('    carthage', '') unless self.tools[:carthage]
       template.gsub!('[[FASTLANE_VERSION]]', Fastlane::VERSION)
 
       self.tools.each do |key, value|


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
When I running `fastlane init`, a awesome Fastfile is generated, but I found missing deleting spaces with not contain `cocoapods` and `carthage`, so Fastfile should be more beautiful.

![screen shot 2017-09-26 at 21 47 42](https://user-images.githubusercontent.com/20222809/30862456-125825d0-a309-11e7-83c5-65a6bea3369f.png)


### Description
<!--- Describe your changes in detail -->
remove pre 4 spaces from Fastfile when gsub cocoapods and carthage with ''.