### PR TITLE
Fix: can't create instances of Client because of: `instance variable @client not initialized`

### DIFF
--- a/spaceship/lib/spaceship/base.rb
+++ b/spaceship/lib/spaceship/base.rb
@@ -191,8 +191,8 @@ module Spaceship
       #   Certificate.factory(attrs)
       #   #=> #<PushCertificate ... >
       #
-      def factory(attrs, existing_client: self.class.client)
-        self.new(attrs, existing_client: existing_client)
+      def factory(attrs, existing_client = nil)
+        self.new(attrs, existing_client)
       end
     end
 
@@ -210,12 +210,12 @@ module Spaceship
     # attributes that are defined by `attr_mapping`
     #
     # Do not override `initialize` in your own models.
-    def initialize(attrs = {}, existing_client: self.class.client)
+    def initialize(attrs = {}, existing_client = nil)
       attrs.each do |key, val|
         self.send("#{key}=", val) if respond_to?("#{key}=")
       end
       self.raw_data = DataHash.new(attrs)
-      @client = existing_client
+      @client = existing_client || self.class.client
       self.setup
     end
 

--- a/spaceship/lib/spaceship/base.rb
+++ b/spaceship/lib/spaceship/base.rb
@@ -191,8 +191,8 @@ module Spaceship
       #   Certificate.factory(attrs)
       #   #=> #<PushCertificate ... >
       #
-      def factory(attrs)
-        self.new(attrs)
+      def factory(attrs, existing_client: self.class.client)
+        self.new(attrs, existing_client: existing_client)
       end
     end
 
@@ -210,12 +210,12 @@ module Spaceship
     # attributes that are defined by `attr_mapping`
     #
     # Do not override `initialize` in your own models.
-    def initialize(attrs = {})
+    def initialize(attrs = {}, existing_client: self.class.client)
       attrs.each do |key, val|
         self.send("#{key}=", val) if respond_to?("#{key}=")
       end
       self.raw_data = DataHash.new(attrs)
-      @client = self.class.client
+      @client = existing_client
       self.setup
     end
 

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -692,7 +692,7 @@ module Spaceship
     # so we cache it
     # @return [UserDetail] the response
     def user_detail_data
-      @_cached_user_detail_data ||= Spaceship::Tunes::UserDetail.factory(user_details_data)
+      @_cached_user_detail_data ||= Spaceship::Tunes::UserDetail.factory(user_details_data, existing_client: self)
     end
 
     #####################################################

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -692,7 +692,7 @@ module Spaceship
     # so we cache it
     # @return [UserDetail] the response
     def user_detail_data
-      @_cached_user_detail_data ||= Spaceship::Tunes::UserDetail.factory(user_details_data, existing_client: self)
+      @_cached_user_detail_data ||= Spaceship::Tunes::UserDetail.factory(user_details_data, self)
     end
 
     #####################################################


### PR DESCRIPTION
Creating an instance of a client needs to plumb self through factory methods

This is a followup to:
https://github.com/fastlane/fastlane/issues/10434
because adding `client.team_id  = <somthing>` triggers the error message