### PR TITLE
Update fastlane plugins only on update_plugins command

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -185,10 +185,13 @@ module Fastlane
     def update_dependencies!
       puts "Updating plugin dependencies..."
       ensure_plugins_attached!
+      plugins = available_plugins
+      if plugins.empty?
+        UI.user_error!("No plugins are installed")
+      end
       with_clean_bundler_env do
-        plugins = available_plugins
         cmd = "bundle update"
-        cmd << " #{plugins.join(" ")}"
+        cmd << " #{plugins.join(' ')}"
         cmd << " --quiet" unless FastlaneCore::Globals.verbose?
         cmd << " && echo 'Successfully updated plugins'"
         UI.command(cmd) if FastlaneCore::Globals.verbose?

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -186,7 +186,9 @@ module Fastlane
       puts "Updating plugin dependencies..."
       ensure_plugins_attached!
       with_clean_bundler_env do
+        plugins = available_plugins
         cmd = "bundle update"
+        cmd << " #{plugins.join(" ")}"
         cmd << " --quiet" unless FastlaneCore::Globals.verbose?
         cmd << " && echo 'Successfully updated plugins'"
         UI.command(cmd) if FastlaneCore::Globals.verbose?

--- a/fastlane/spec/plugins_specs/plugin_manager_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_manager_spec.rb
@@ -82,6 +82,18 @@ describe Fastlane do
       end
     end
 
+    describe "#update_dependencies!" do
+      before do
+        allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/Pluginfile1")
+      end
+
+      it "execs out the correct command" do
+        expect(plugin_manager).to receive(:ensure_plugins_attached!)
+        expect(plugin_manager).to receive(:exec).with("bundle update fastlane-plugin-xcversion --quiet && echo 'Successfully updated plugins'")
+        plugin_manager.update_dependencies!
+      end
+    end
+
     describe "#gem_dependency_suffix" do
       it "default to RubyGems if gem is available" do
         expect(Fastlane::PluginManager).to receive(:fetch_gem_info_from_rubygems).and_return({ anything: :really })


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

We are using `update_plugins` command to update installed plugins.

```
$ bundle exec fastlane update_plugins
```

However, this command updates all dependencies in the project.
We want to update plugin related dependencies only.

### Description

Modified executing command in `update_plugins`.

Before this PR, this command executes following.

```console
bundle install
```

This PR make updating about installed plugins.

```console
bundle install fastlane-plugin-foo fastlane-plugin-bar
```