### PR TITLE
Update set_info_plist_value.rb Examples

### DIFF
--- a/fastlane/lib/fastlane/actions/set_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/set_info_plist_value.rb
@@ -79,8 +79,8 @@ module Fastlane
 
       def self.example_code
         [
-          'set_info_plist_value(path: "./Info.plist", key: "CFBundleIdentifier", value: "com.krausefx.app.beta")',
-          'set_info_plist_value(path: "./MyApp-Info.plist", key: "NSAppTransportSecurity", subkey: "NSAllowsArbitraryLoads", value: true, output_file_name: "./Info.plist")'
+          'set_info_plist_value(key: "CFBundleIdentifier", value: "com.krausefx.app.beta", path: "./Info.plist")',
+          'set_info_plist_value(key: "NSAppTransportSecurity", subkey: "NSAllowsArbitraryLoads", value: true, path: "./MyApp-Info.plist", output_file_name: "./Info.plist")'
         ]
       end
 


### PR DESCRIPTION
Example params were in the wrong order, and fastlane will error with invalid params unless they are ordered correctly.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change is only to documentation. I was attempting to write plist values using the example code, and got an error because my method params were out of order.

### Description
I updated the example code for this action to reflect the correct ordering of the params
