### PR TITLE
Use GEM_HOME in update_fastlane

### DIFF
--- a/fastlane/lib/fastlane/actions/update_fastlane.rb
+++ b/fastlane/lib/fastlane/actions/update_fastlane.rb
@@ -24,7 +24,11 @@ module Fastlane
         updater.options[:prerelease] = true if options[:nightly]
         cleaner = Gem::CommandManager.instance[:cleanup]
 
-        sudo_needed = !File.writable?(Gem.dir)
+        gem_dir = ENV['GEM_HOME']
+        unless gem_dir
+          gem_dir = Gem.dir
+        end
+        sudo_needed = !File.writable?(gem_dir)
 
         if sudo_needed
           UI.important("It seems that your Gem directory is not writable by your current User.")

--- a/fastlane/lib/fastlane/actions/update_fastlane.rb
+++ b/fastlane/lib/fastlane/actions/update_fastlane.rb
@@ -24,10 +24,7 @@ module Fastlane
         updater.options[:prerelease] = true if options[:nightly]
         cleaner = Gem::CommandManager.instance[:cleanup]
 
-        gem_dir = ENV['GEM_HOME']
-        unless gem_dir
-          gem_dir = Gem.dir
-        end
+        gem_dir = ENV['GEM_HOME'] || Gem.dir
         sudo_needed = !File.writable?(gem_dir)
 
         if sudo_needed


### PR DESCRIPTION
Until now the action used Gem.home to check for sudo requirement
when updating fastlane, but it fails if fastlane is installed with
the --user-install option.

With this commit the action first check for the GEM_HOME env var
and fallback to Gem.home if missing.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
Fixes #10429.