### PR TITLE
[spaceship] Add pagination support to Client#request

### DIFF
--- a/spaceship/lib/spaceship/helper/rels_middleware.rb
+++ b/spaceship/lib/spaceship/helper/rels_middleware.rb
@@ -1,0 +1,26 @@
+module Faraday
+  class Env
+    attr_accessor :rels
+  end
+end
+
+module FaradayMiddleware
+  class RelsMiddleware < Faraday::Middleware
+    def initialize(app, options = {})
+      @app = app
+      @options = options
+    end
+
+    def call(environment)
+      @app.call(environment).on_complete do |env|
+        links = (env.response_headers["Link"] || "").split(', ').map do |link|
+          href, name = link.match(/<(.*?)>; rel="(\w+)"/).captures
+
+          [name.to_sym, href]
+        end
+
+        env.rels = Hash[*links.flatten]
+      end
+    end
+  end
+end

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -30,7 +30,7 @@ module Spaceship::TestFlight
     def get_builds_for_train(app_id: nil, platform: "ios", train_version: nil, retry_count: 0)
       assert_required_params(__method__, binding)
       with_retry(retry_count) do
-        response = request(:get, "providers/#{team_id}/apps/#{app_id}/platforms/#{platform}/trains/#{train_version}/builds")
+        response = request(:get, "providers/#{team_id}/apps/#{app_id}/platforms/#{platform}/trains/#{train_version}/builds", nil, {}, true)
         handle_response(response)
       end
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

We're using parts of the spaceship API to interact with TestFlight and we noticed that the method `get_builds_for_train` only returns the last 20 builds.

### Description

This PR adds an option to `Client#request` to auto-paginate results (inspired a bit by [Octokit](https://github.com/octokit/octokit.rb/blob/8404007e9e11d3695df0907adcb3514decd23287/lib/octokit/connection.rb#L87-L94)). This could be used in more methods besides `get_builds_for_train`, but it will add quite a lot of overhead. 

In the case of `get_builds_for_train`, it does make sense to return all builds available.