### PR TITLE
Fix match enterprise profile mapping

### DIFF
--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -69,7 +69,7 @@ module Gym
     # We do some `gsub`bing, because we can't really know the profile type, so we'll just look at the name and see if it includes
     # the export method (which it usually does, but with different notations)
     def app_identifier_contains?(str, contains)
-      return str.to_s.gsub("-", "").gsub(" ", "").downcase.include?(contains.to_s.gsub("-", "").gsub(" ", "").downcase)
+      return str.to_s.gsub("-", "").gsub(" ", "").gsub("InHouse", "enterprise").downcase.include?(contains.to_s.gsub("-", "").gsub(" ", "").downcase)
     end
 
     # Array of paths to all project files

--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -41,6 +41,12 @@ describe Gym::CodeSigningMapping do
       return_value = csm.app_identifier_contains?("Ad-HocValue", "ad-hoc")
       expect(return_value).to eq(true)
     end
+
+    it "Replace the inhouse keyword for enterprise profiles" do
+      csm = Gym::CodeSigningMapping.new(project: nil)
+      return_value = csm.app_identifier_contains?("match InHouse bundle", "enterprise")
+      expect(return_value).to eq(true)
+    end
   end
 
   describe "#detect_project_profile_mapping" do


### PR DESCRIPTION
When trying to find matching profiles in `merge_profile_mapping` we are searching from profiles in the match response that contains the export-method (case 3.2).

match enterprise profile contain the InHouse word instead of enterprise. Fixing the `app_identifier_contains?` helper to better map match profile.

```
(byebug) primary_mapping
{:"com.applidium.keepcool-dev"=>"match InHouse com.applidium.keepcool-dev"} # match output
(byebug) secondary_mapping
{:"com.applidium.keepcool-dev"=>"PROFILE_UDID"} # xcode detected
```
should result in {:"com.applidium.keepcool-dev"=>"match InHouse com.applidium.keepcool-dev"}

