### PR TITLE
Fix snapshot so prepare only launches devices that are being tested this batch

### DIFF
--- a/snapshot/lib/snapshot/fixes/simulator_zoom_fix.rb
+++ b/snapshot/lib/snapshot/fixes/simulator_zoom_fix.rb
@@ -7,7 +7,7 @@ module Snapshot
 
     class SimulatorZoomFix
       def self.patch
-        UI.message "Patching all simulators '#{config_path}' to scale to 100%"
+        UI.message "Patching simulators '#{config_path}' to scale to 100%"
 
         FastlaneCore::DeviceManager.simulators.each do |simulator|
           simulator_name = simulator.name.tr("\s", "-")

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
@@ -48,7 +48,7 @@ module Snapshot
     end
 
     def launch_simultaneously(devices, language, locale, launch_arguments)
-      prepare_for_launch(language, locale, launch_arguments)
+      prepare_for_launch(devices, language, locale, launch_arguments)
 
       add_media(devices, :photo, launcher_config.add_photos) if launcher_config.add_photos
       add_media(devices, :video, launcher_config.add_videos) if launcher_config.add_videos

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -18,7 +18,7 @@ module Snapshot
       @current_number_of_retries_due_to_failing_simulator || 0
     end
 
-    def prepare_for_launch(language, locale, launch_arguments)
+    def prepare_for_launch(device_types, language, locale, launch_arguments)
       screenshots_path = TestCommandGenerator.derived_data_path
       FileUtils.rm_rf(File.join(screenshots_path, "Logs"))
       FileUtils.rm_rf(screenshots_path) if launcher_config.clean
@@ -31,10 +31,10 @@ module Snapshot
       File.write(File.join(CACHE_DIR, "locale.txt"), locale || "")
       File.write(File.join(CACHE_DIR, "snapshot-launch_arguments.txt"), launch_arguments.last)
 
-      prepare_simulators_for_launch(language: language, locale: locale)
+      prepare_simulators_for_launch(device_types, language: language, locale: locale)
     end
 
-    def prepare_simulators_for_launch(language: nil, locale: nil)
+    def prepare_simulators_for_launch(device_types, language: nil, locale: nil)
       # Kill and shutdown all currently running simulators so that the following settings
       # changes will be picked up when they are started again.
       Snapshot.kill_simulator # because of https://github.com/fastlane/snapshot/issues/337
@@ -43,8 +43,7 @@ module Snapshot
       Fixes::SimulatorZoomFix.patch
       Fixes::HardwareKeyboardFix.patch
 
-      devices = launcher_config.devices || []
-      devices.each do |type|
+      device_types.each do |type|
         if launcher_config.erase_simulator || launcher_config.localize_simulator
           erase_simulator(type)
           if launcher_config.localize_simulator

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_xcode_8.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_xcode_8.rb
@@ -46,7 +46,7 @@ module Snapshot
 
     # Returns true if it succeeded
     def launch_one_at_a_time(language, locale, device_type, launch_arguments)
-      prepare_for_launch(language, locale, launch_arguments)
+      prepare_for_launch([device_type], language, locale, launch_arguments)
 
       add_media([device_type], :photo, launcher_config.add_photos) if launcher_config.add_photos
       add_media([device_type], :video, launcher_config.add_videos) if launcher_config.add_videos


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
prepare_simulators_for_launch is called before every simulator batch run (Xcode 8 before every individual device, concurrent Xcode 9 before every batch of tests).

However prepare_simulators_for_launch was running preparation (media setup + erase/localize/uninstall) for every device in the device list.
This has two undesirable effects:
- Generally snapshot is very inefficient, pointlessly re-processing every single simulator on every run even when it is not going to be used: An (A, B) run will "Prepare A, Prepare B, Test A, Prepare A, Prepare B, Test B" instead of just "Prepare A, Test A, Prepare B, Test B"
- In concurrent mode, because simulators are not shut down after they are processed this results in all the devices in the list being left open even when not used sometimes resulting in failures due to system resources running out

### Description
This fixes both these issues by only preparing the simulator(s) that are about to be tested.

Fixes #10457 and #10185