### PR TITLE
Gym: add option to skip profile detection

### DIFF
--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -65,9 +65,11 @@ module Gym
       Gym.config[:export_options] ||= {}
       hash_to_use = (Gym.config[:export_options][:provisioningProfiles] || {}).dup || {} # dup so we can show the original values in `verbose` mode
 
-      mapping_object = CodeSigningMapping.new(project: Gym.project)
-      hash_to_use = mapping_object.merge_profile_mapping(primary_mapping: hash_to_use,
+      unless Gym.config[:skip_profile_detection]
+        mapping_object = CodeSigningMapping.new(project: Gym.project)
+        hash_to_use = mapping_object.merge_profile_mapping(primary_mapping: hash_to_use,
                                                            export_method: Gym.config[:export_method])
+      end
 
       return if hash_to_use.count == 0 # We don't want to set a mapping if we don't have one
       Gym.config[:export_options][:provisioningProfiles] = hash_to_use

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -234,7 +234,13 @@ module Gym
                                      env_name: "XCPRETTY_UTF",
                                      description: "Have xcpretty use unicode encoding when reporting builds",
                                      optional: true,
-                                     is_string: false)
+                                     is_string: false),
+        FastlaneCore::ConfigItem.new(key: :skip_profile_detection,
+                                     env_name: "GYM_SKIP_PROFILE_DETECTION",
+                                     description: "Do not try to build a profile mapping from the xcodeproj. Match or a manually provided mapping should be used",
+                                     optional: true,
+                                     is_string: false,
+                                     default_value: false)
       ]
     end
   end


### PR DESCRIPTION
As an agency in same cases we do not have access to Apple Developer and the cert and PP are provided to use by our client.

In that case we are using them locally to sign with gym and, since Xcode9, manually building the export_option as suggested in the Doc https://docs.fastlane.tools/codesigning/xcode-project/

Our projects are dynamical so profile identifiers in the build settings contains evar.
Even if we explicitly set the options[:export_options] value, this is overriden by Gym --> Adding an option to prevent Gym from trying to build the mapping from the xcodeproj.

## A bit of code

```ruby
# [some code to generate the mapping]
  options[:export_options] = {
    provisioningProfiles: { 
      ENV["APP_BUNDLE"] => ENV['PROFILE_UDID']
    }
  }
# -> Results in {:provisioningProfiles=>{"com.applidium.FrMusique"=>"match InHouse com.applidium.FrMusique"}

gym(
[...],
export_options: options[:export_options]
)
```
## Logs

```
18:53:36 [18:53:36]: Manually generated export options: {:provisioningProfiles=>{"com.applidium.FrMusique"=>"match InHouse com.applidium.FrMusique"}}
18:53:37 [18:53:37]: -----------------
18:53:37 [18:53:37]: --- Step: gym ---
18:53:37 [18:53:37]: -----------------
18:53:38 [18:53:38]: Detected provisioning profile mapping: {:"com.applidium.FrMusique"=>"PROFILE_UDID", :"com.applidium.radiofrance"=>"PROFILE_UDID", :"com.applidium.FrBleu"=>"PROFILE_UDID", :"com.applidium.Fip"=>"PROFILE_UDID", :"com.applidium.FrCulture"=>"PROFILE_UDID"}
18:53:38 [18:53:38]: $ xcodebuild -list -workspace RadioFrance.xcworkspace -configuration Development
18:53:40 [18:53:40]: $ xcodebuild -showBuildSettings -workspace RadioFrance.xcworkspace -scheme RadioFrance_Musique -configuration Development
18:53:42 
18:53:42 +---------------------------------------------------------------+---------------------------------------+
18:53:42 |                                        Summary for gym 2.59.0                                         |
18:53:42 +---------------------------------------------------------------+---------------------------------------+
18:53:42 | workspace                                                     | RadioFrance.xcworkspace               |
18:53:42 | configuration                                                 | Development                           |
18:53:42 | scheme                                                        | RadioFrance_Musique                   |
18:53:42 | clean                                                         | true                                  |
18:53:42 | build_path                                                    | .                                     |
18:53:42 | include_bitcode                                               | false                                 |
18:53:42 | export_method                                                 | enterprise                            |
18:53:42 | xcargs                                                        | -DVTCodeSigningAllTheThingsLogLevel=3 |
18:53:42 | export_options.provisioningProfiles.com.applidium.FrMusique   | PROFILE_UDID                          |
18:53:42 | export_options.provisioningProfiles.com.applidium.radiofrance | PROFILE_UDID                          |
18:53:42 | export_options.provisioningProfiles.com.applidium.FrBleu      | PROFILE_UDID                          |
18:53:42 | export_options.provisioningProfiles.com.applidium.Fip         | PROFILE_UDID                          |
18:53:42 | export_options.provisioningProfiles.com.applidium.FrCulture   | PROFILE_UDID                          |
18:53:42 | destination                                                   | generic/platform=iOS                  |
18:53:42 | output_name                                                   | France Musique                        |
18:53:42 | output_directory                                              | .                                     |
18:53:42 | silent                                                        | false                                 |
18:53:42 | skip_package_ipa                                              | false                                 |
18:53:42 | buildlog_path                                                 | ~/Library/Logs/gym                    |
18:53:42 | xcode_path                                                    | /Applications/Xcode.app               |
18:53:42 +---------------------------------------------------------------+---------------------------------------+
```
## Tough
I believe this options give the user flexibility. It would have been useful to bypass bugs like  #10355, #10387 that i fixed yesterday