### PR TITLE
Version bump to 2.60.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.59.0'.freeze
+  VERSION = '2.60.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.59.0':**

* Gym profile matching : ignore profile that do not match the correct platform (#10387) via Nicolas Braun
* Fix match enterprise profile mapping (#10455) via Nicolas Braun
* Update CI to Xcode 9 (#8948) via Danielle Tomlinson
* Use GEM_HOME for update_fastlane action (#10450) via Emilio Pavia
* [Actions] Add setup_circle_ci action (#10415) via Danielle Tomlinson
* add instructions on how to _not_ use local fastlane installation and remove Gemfile (#10432) via Jan Piotrowski
* [deliver] Show team name in the error message (#10339) via Rishabh Tayal
* remove space when cocoapods and carthage disable to use (#10417) via Daiki Matsudate
* Update docs for set_changelog action (#10368) via Felix Krause
* Add support for `fastlane update` command (#10384) via Felix Krause
* Update scan description for latest Xcode (#10399) via Felix Krause
