### PR TITLE
[fastlane_core] When fetching app_identifier or package name, disable asking the user

### DIFF
--- a/fastlane_core/lib/fastlane_core/android_package_name_guesser.rb
+++ b/fastlane_core/lib/fastlane_core/android_package_name_guesser.rb
@@ -44,7 +44,7 @@ module FastlaneCore
         # 3rd parameter "true" disables the printout of the contents of the
         # configuration file, which is noisy and confusing in this case
         options.load_configuration_file(file_name, proc {}, true)
-        return options[package_name_key]
+        return options.fetch(package_name_key, ask: false)
       rescue
         # any option/file error here should just be treated as identifier not found
         nil

--- a/fastlane_core/lib/fastlane_core/ios_app_identifier_guesser.rb
+++ b/fastlane_core/lib/fastlane_core/ios_app_identifier_guesser.rb
@@ -35,7 +35,7 @@ module FastlaneCore
         # 3rd parameter "true" disables the printout of the contents of the
         # configuration file, which is noisy and confusing in this case
         options.load_configuration_file(file_name, proc {}, true)
-        return options[:app_identifier]
+        return options.fetch(:app_identifier, ask: false)
       rescue
         # any option/file error here should just be treated as identifier not found
         nil


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
When trying to guess the application identifier (iOS) or package name (Android) from configuration files (`Gymfile`, `Deliverfile`, `Supplyfile`, etc), disable asking the user when fetching the value.