### PR TITLE
Add `try_repo_update_on_error` option to `cocoapods` action

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -106,7 +106,7 @@ module Fastlane
                                        description: 'Retry with --repo-update if action was finished with error',
                                        optional: true,
                                        is_string: false,
-                                       default_value: false,
+                                       default_value: true,
                                        conflicting_options: [:repo_update])
         ]
         # Please don't add a version parameter to the `cocoapods` action. If you need to specify a version when running

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -24,14 +24,25 @@ module Fastlane
         cmd << '--verbose' if params[:verbose]
         cmd << '--no-ansi' unless params[:ansi]
 
+        Actions.sh(cmd.join(' '), error_callback: lambda { |result|
+          if params[:try_repo_update_on_error]
+            cmd << '--repo-update'
+            Actions.sh(cmd.join(' '), error_callback: lambda { |retry_result|
+              call_error_callback(params, retry_result)
+            })
+          else
+            call_error_callback(params, result)
+          end
+        })
+      end
+
+      def self.call_error_callback(params, result)
         if params[:error_callback]
-          Actions.sh(cmd.join(' '), error_callback: lambda { |result|
-            Dir.chdir(FastlaneCore::FastlaneFolder.path) do
-              params[:error_callback].call(result)
-            end
-          })
+          Dir.chdir(FastlaneCore::FastlaneFolder.path) do
+            params[:error_callback].call(result)
+          end
         else
-          Actions.sh(cmd.join(' '))
+          UI.shell_error!(result)
         end
       end
 
@@ -55,7 +66,8 @@ module Fastlane
                                        env_name: "FL_COCOAPODS_REPO_UPDATE",
                                        description: "Run `pod repo update` before install",
                                        is_string: false,
-                                       default_value: false),
+                                       default_value: false,
+                                       conflicting_options: [:try_repo_update_on_error]),
           FastlaneCore::ConfigItem.new(key: :silent,
                                        env_name: "FL_COCOAPODS_SILENT",
                                        description: "Execute command without logging output",
@@ -88,7 +100,14 @@ module Fastlane
                                        description: 'A callback invoked with the command output if there is a non-zero exit status',
                                        optional: true,
                                        is_string: false,
-                                       default_value: nil)
+                                       default_value: nil),
+          FastlaneCore::ConfigItem.new(key: :try_repo_update_on_error,
+                                       env_name: "FL_COCOAPODS_TRY_REPO_UPDATE_ON_ERROR",
+                                       description: 'Retry with --repo-update if action was finished with error',
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false,
+                                       conflicting_options: [:repo_update])
         ]
         # Please don't add a version parameter to the `cocoapods` action. If you need to specify a version when running
         # `cocoapods`, please start using a Gemfile and lock the version there

--- a/fastlane/spec/actions_specs/cocoapods_spec.rb
+++ b/fastlane/spec/actions_specs/cocoapods_spec.rb
@@ -119,6 +119,53 @@ describe Fastlane do
                                                                               hash_including(error_callback: error_callback))
         }
       end
+
+      it "retries with --repo-update on error if try_repo_update_on_error is true" do
+        allow(Fastlane::Actions).to receive(:sh_control_output) { |command, params|
+          if command == 'bundle exec pod install'
+            error_callback = params[:error_callback]
+            error_callback.call('error')
+          end
+        }
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          cocoapods(
+            try_repo_update_on_error: true
+          )
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions).to have_received(:sh_control_output).with("bundle exec pod install", hash_including(print_command: true)).ordered
+        expect(Fastlane::Actions).to have_received(:sh_control_output).with("bundle exec pod install --repo-update", hash_including(print_command: true)).ordered
+      end
+
+      it 'doesnt retry with --repo-update if there were no errors' do
+        allow(Fastlane::Actions).to receive(:sh_control_output) {}
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          cocoapods(
+            try_repo_update_on_error: true
+          )
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions).to have_received(:sh_control_output).with("bundle exec pod install", hash_including(print_command: true)).ordered
+        expect(Fastlane::Actions).to_not have_received(:sh_control_output).with("bundle exec pod install --repo-update", hash_including(print_command: true)).ordered
+      end
+
+      it "calls error_callback if retry with --repo-update finished with error" do
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return('.')
+        allow(Fastlane::Actions).to receive(:sh_control_output) { |_, params|
+          error_callback = params[:error_callback]
+          error_callback.call('error')
+        }
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            cocoapods(
+              try_repo_update_on_error: true,
+              error_callback: lambda { |r| raise r }
+            )
+          end").runner.execute(:test)
+        end.to raise_error('error')
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
A lot of CocoaPods users from time to time face issue when after updating some pod locally they have CocoaPods error on CI side, because it is needed to go there and run something like `bundle exec pod repo update`(because CI doesn't know that dependency has some new version). So, I propose to add `try_repo_update_on_error` option to `cocoapods` action, which will try to execute pod command one more time with `--repo-update` in case of error. 
Also, yes, I know about already implemented `repo_update` option. But while it is really worth to run in 5% of cases, it take significant time to wait while it performing every time(and also gives additional load on GitHub servers).
Thanks!
