### PR TITLE
Sets the installed profile name from sigh in an environment variable …

### DIFF
--- a/fastlane/lib/fastlane/actions/sigh.rb
+++ b/fastlane/lib/fastlane/actions/sigh.rb
@@ -5,6 +5,7 @@ module Fastlane
       SIGH_PROFILE_PATHS = :SIGH_PROFILE_PATHS
       SIGH_UDID = :SIGH_UDID # deprecated
       SIGH_UUID = :SIGH_UUID
+      SIGH_NAME = :SIGH_NAME
       SIGH_PROFILE_TYPE = :SIGH_PROFILE_TYPE
     end
 
@@ -22,7 +23,9 @@ module Fastlane
         Actions.lane_context[SharedValues::SIGH_PROFILE_PATHS] << path
 
         uuid = ENV["SIGH_UUID"] || ENV["SIGH_UDID"] # the UUID of the profile
+        name = ENV["SIGH_NAME"] # the name of the profile
         Actions.lane_context[SharedValues::SIGH_UUID] = Actions.lane_context[SharedValues::SIGH_UDID] = uuid if uuid
+        Actions.lane_context[SharedValues::SIGH_NAME] = Actions.lane_context[SharedValues::SIGH_NAME] = name if name
 
         set_profile_type(values, ENV["SIGH_PROFILE_ENTERPRISE"])
 

--- a/fastlane/spec/actions_specs/sigh_spec.rb
+++ b/fastlane/spec/actions_specs/sigh_spec.rb
@@ -10,6 +10,7 @@ describe Fastlane do
 
       it "properly stores the resulting path in the lane environment" do
         ENV["SIGH_UUID"] = "uuid"
+        ENV["SIGH_NAME"] = "name"
 
         result = Fastlane::FastFile.new.parse("lane :test do
           sigh
@@ -21,6 +22,7 @@ describe Fastlane do
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::SIGH_PROFILE_PATHS]).to eq([@profile_path])
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::SIGH_PROFILE_TYPE]).to eq("app-store")
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::SIGH_UUID]).to eq("uuid")
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::SIGH_NAME]).to eq("name")
       end
 
       describe "The different profile types" do

--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -37,6 +37,11 @@ module FastlaneCore
         parse(path).fetch("UUID")
       end
 
+      # @return [String] The Name of the given provisioning profile
+      def name(path)
+        parse(path).fetch("Name")
+      end
+
       def profiles_path
         path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
         # If the directory doesn't exist, create it first

--- a/sigh/lib/sigh/manager.rb
+++ b/sigh/lib/sigh/manager.rb
@@ -36,7 +36,9 @@ module Sigh
 
     def self.install_profile(profile)
       uuid = FastlaneCore::ProvisioningProfile.uuid(profile)
+      name = FastlaneCore::ProvisioningProfile.name(profile)
       ENV["SIGH_UDID"] = ENV["SIGH_UUID"] = uuid if uuid
+      ENV["SIGH_NAME"] = name if name
 
       FastlaneCore::ProvisioningProfile.install(profile)
     end


### PR DESCRIPTION
…and lane context

## Why
Because we used to need the `UUID` in the past for really ugly reasons but now Xcode likes the have the name so yolo

## Example Usage
```rb
sigh
profile_name = Actions.lane_context[SharedValues::SIGH_NAME]

fastlane_require 'xcodeproj'
project_path = File.absolute_path File.join(path, "MyProject.xcodeproj")
xcproj = Xcodeproj::Project.open(project_path)
xcproj.targets.each do |target|
  target.build_configuration_list.set_setting 'PROVISIONING_PROFILE_SPECIFIER', profile_name
end
xcproj.save
```