### PR TITLE
Show verbose information for `fastlane snapshot reset_simulators`

### DIFF
--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -66,7 +66,9 @@ module Snapshot
     def self.create(device_type, os_versions, os_name = 'iOS')
       os_versions.each do |os_version|
         puts "Creating #{device_type[0]} for #{os_name} version #{os_version[0]}"
-        `xcrun simctl create '#{device_type[0]}' #{device_type[1]} #{os_version[1]}`
+        command = "xcrun simctl create '#{device_type[0]}' #{device_type[1]} #{os_version[1]}"
+        UI.command(command) if FastlaneCore::Globals.verbose?
+        `#{command}`
       end
     end
 


### PR DESCRIPTION
Show the command that is being run of `--verbose`