### PR TITLE
Fix an issue where new docs files/changes weren't committed

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 skip_docs
 
 desc "Runs the unit tests and other verifications for the fastlane repo"
@@ -168,7 +170,16 @@ lane :update_docs do
     docs_path = generate_markdown_docs(target_path: ".")
     actions_md_path = File.expand_path(File.join(docs_path, "docs/actions.md"))
     action_docs = Dir[File.join(docs_path, "docs", "actions", "*")].collect do |current|
-      File.expand_path(current)
+      File.expand_path(current) # to make sure we commit the change
+    end
+
+    # Copy over the custom assets
+    custom_action_docs = "lib/fastlane/actions/docs/"
+    custom_assets = Dir[File.join(Fastlane::ROOT, custom_action_docs, "assets", "*")].collect do |current_asset_path|
+      current_output_path = File.join("docs/img/actions", File.basename(current_asset_path))
+      FileUtils.cp(current_asset_path, current_output_path)
+
+      File.expand_path(current_output_path) # to make sure we commit the change
     end
 
     Bundler.with_clean_env do
@@ -186,7 +197,7 @@ lane :update_docs do
 
       Dir.chdir("fastlane") do # this is an assumption of fastlane, that we have to .. when shelling out
         # Commit the changes
-        changes_to_commit = [actions_md_path, "Gemfile.lock", plugins_path] + action_docs
+        changes_to_commit = [actions_md_path, "Gemfile.lock", plugins_path] + action_docs + custom_assets
         git_add(path: changes_to_commit)
         git_commit(path: changes_to_commit,
                 message: "Update actions.md for latest fastlane release 🚀")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -167,7 +167,7 @@ lane :update_docs do
   clone_docs do
     docs_path = generate_markdown_docs(target_path: ".")
     actions_md_path = File.expand_path(File.join(docs_path, "docs/actions.md"))
-    action_docs = Dir[File.join(docs_path, "actions", "*")].collect do |current|
+    action_docs = Dir[File.join(docs_path, "docs", "actions", "*")].collect do |current|
       File.expand_path(current)
     end
 
@@ -186,7 +186,9 @@ lane :update_docs do
 
       Dir.chdir("fastlane") do # this is an assumption of fastlane, that we have to .. when shelling out
         # Commit the changes
-        git_commit(path: [actions_md_path, "Gemfile.lock", plugins_path] + action_docs,
+        changes_to_commit = [actions_md_path, "Gemfile.lock", plugins_path] + action_docs
+        git_add(path: changes_to_commit)
+        git_commit(path: changes_to_commit,
                 message: "Update actions.md for latest fastlane release 🚀")
         # Push them to the git remote
         push_to_git_remote


### PR DESCRIPTION
This would result in not running `git add`, so no new files were added

- Fix an issue where new docs (`.md`) files/changes weren't committed
- Add support for automatic copying and committing of custom assets for docs