### PR TITLE
Remove pre-mono-gem code of deployment pipeline

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -259,16 +259,10 @@ private_lane :validate_repo do
 
   # Verifying the --help command
   #
-  # tools_to_test = Fastlane::TOOLS
-  tools_to_test = [:fastlane] # until we have the binaries for all tools included here
-  tools_to_test.each do |tool_name|
-    next if no_binary.include?(tool_name)
-    Dir.chdir("..") do
-      binary_path = File.join("bin", tool_name.to_s)
-      content = sh("PAGER=cat #{binary_path} --help")
-      ["--version", "https://fastlane.tools", tool_name.to_s].each do |current|
-        UI.user_error!("--help missing information: '#{current}'") unless content.include?(current)
-      end
+  Dir.chdir("..") do
+    content = sh("PAGER=cat bin/fastlane --help")
+    ["--version", "https://fastlane.tools", "fastlane"].each do |current|
+      UI.user_error!("--help missing information: '#{current}'") unless content.include?(current)
     end
   end
 
@@ -298,11 +292,6 @@ desc "Get the version number of the last release"
 private_lane :current_version do
   puts "Checking the latest version on RubyGems"
   download(url: "https://rubygems.org/api/v1/gems/fastlane.json")["version"]
-end
-
-desc "All repos that don't have a binary to test"
-private_lane :no_binary do
-  ['fastlane_core', 'spaceship', 'credentials_manager']
 end
 
 desc "Print out the changelog since the last tagged release and open the GitHub page with the changes"


### PR DESCRIPTION
This code wasn't used any more after the mono-gem migration