### PR TITLE
Version bump to 2.61.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.60.1'.freeze
+  VERSION = '2.61.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.60.1':**

* Add `try_repo_update_on_error` option to `cocoapods` action (#10504) via Siarhei Fiedartsou
* Update fastlane plugins only on update_plugins command (#10441) via Kohki Miki
* Sets the installed profile name from sigh in an environment variable and lane context (#10515) via Josh Holtz
* Add warning about sensitive or private information (#10505) via Iulian Onofrei
* [spaceship] Add pagination support to Client#request (#10451) via Renzo
