### PR TITLE
[docs] Fix typo: exiting -> existing

### DIFF
--- a/fastlane/docs/Plugins.md
+++ b/fastlane/docs/Plugins.md
@@ -113,7 +113,7 @@ fastlane new_plugin [plugin_name]
 
 ##### New plugin for existing gem
 
-If you already have an exiting gem you want to provide a `fastlane` plugin for, you'll still have to create a new Ruby gem. The reason for that is the way plugins are imported.
+If you already have an existing gem you want to provide a `fastlane` plugin for, you'll still have to create a new Ruby gem. The reason for that is the way plugins are imported.
 
 The example project [xcake](https://github.com/jcampbell05/xcake) contains a folder named `fastlane-plugin-xcake`.
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
when reading the Plugins documentation, I stumbed across a typo which may confuse other readers. 
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
Fixes a small typo in the Plugins documentation
