### PR TITLE
Support for iPhone X in frameit

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -115,11 +115,21 @@ module Deliver
     end
 
     def is_messages?
-      return [ScreenSize::IOS_40_MESSAGES, ScreenSize::IOS_47_MESSAGES, ScreenSize::IOS_55_MESSAGES, ScreenSize::IOS_58_MESSAGES, ScreenSize::IOS_IPAD_MESSAGES, ScreenSize::IOS_IPAD_PRO_MESSAGES].include?(self.screen_size)
+      return [
+        ScreenSize::IOS_40_MESSAGES,
+        ScreenSize::IOS_47_MESSAGES,
+        ScreenSize::IOS_55_MESSAGES,
+        ScreenSize::IOS_58_MESSAGES,
+        ScreenSize::IOS_IPAD_MESSAGES,
+        ScreenSize::IOS_IPAD_PRO_MESSAGES
+      ].include?(self.screen_size)
     end
 
     def self.device_messages
       return {
+        ScreenSize::IOS_58_MESSAGES => [
+          [1125, 2436]
+        ],
         ScreenSize::IOS_55_MESSAGES => [
           [1080, 1920],
           [1242, 2208]

--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -30,13 +30,16 @@ task :generate_device_frames do
 
   image_assets = []
   (Dir["raw/Phones/Apple*/Device/*.png"] + Dir["raw/Computers/Apple*/Device/*.png"] + Dir["raw/Tablets/Apple*/Device/*.png"]).each do |current_raw|
-    next if DEVICES_TO_SKIP.include?(File.basename(current_raw))
+    basename = File.basename(current_raw)
+    next if DEVICES_TO_SKIP.include?(basename)
 
     cp(current_raw, output)
-
-    output_file_path = File.join(output, File.basename(current_raw))
-    convert_image_resource(output_file_path)
-    image_assets << File.basename(current_raw)
+    output_file_path = File.join(output, basename)
+    sanitaized_basename = sanitize_filename(basename)
+    sanitaized_file_path = File.join(output, sanitaized_basename)
+    mv(output_file_path, sanitaized_file_path) unless output_file_path == sanitaized_file_path
+    convert_image_resource(sanitaized_file_path)
+    image_assets << sanitaized_basename
   end
 
   raise "Could not find any images, make sure to copy all extracted files into ./raw" if image_assets.count < 10
@@ -62,6 +65,10 @@ end
 def confirm
   puts "Press any key when you're ready to continue".yellow
   gets
+end
+
+def sanitize_filename(filename)
+  filename.gsub('Grey', 'Gray')
 end
 
 # This will remove the white space around the actual frame

--- a/frameit/frames_generator/offsets.json
+++ b/frameit/frames_generator/offsets.json
@@ -24,6 +24,10 @@
       "offset": "+104+380",
       "width": 1242
     },
+    "iPhone X": {
+      "offset": "+85+77",
+      "width": 1125
+    },
     "iPad Air 2": {
       "offset": "+111+224",
       "width": 1536

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -56,7 +56,7 @@ module Frameit
       end
 
       @image = frame.composite(image, "png") do |c|
-        c.compose "Over"
+        c.compose "DstOver"
         c.geometry offset['offset']
       end
 

--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -21,6 +21,8 @@ module Frameit
     def device_name
       sizes = Deliver::AppScreenshot::ScreenSize
       case @screen_size
+      when sizes::IOS_58
+        return 'iPhone X'
       when sizes::IOS_55
         return Frameit.config[:use_legacy_iphone6s] ? 'iPhone 6s Plus' : 'iPhone 7 Plus'
       when sizes::IOS_47
@@ -49,9 +51,9 @@ module Frameit
       return @color
     end
 
-    # Is the device a 3x device? (e.g. 6 Plus)
+    # Is the device a 3x device? (e.g. iPhone 6 Plus, iPhone X)
     def triple_density?
-      (screen_size == Deliver::AppScreenshot::ScreenSize::IOS_55)
+      (screen_size == Deliver::AppScreenshot::ScreenSize::IOS_55 || screen_size == Deliver::AppScreenshot::ScreenSize::IOS_58)
     end
 
     # Super old devices (iPhone 4)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
This add support for iPhone X in FrameIt and fixes #10501

### Description
<!--- Describe your changes in detail -->
The main change is in the ImageMagic alpha composition which is now "DstOver" this is needed in order to accommodate the round border of iPhone X.

I have two questions about this PR.
For the Product Images we will need to wait for Facebook Device Design to be updated, right?
Is there anything I should test in this PR?