### PR TITLE
Add bootsnap to optimize boot time

### DIFF
--- a/bin/fastlane
+++ b/bin/fastlane
@@ -4,6 +4,20 @@ if RUBY_VERSION < '2.0.0'
   abort "fastlane requires Ruby 2.0.0 or higher"
 end
 
+begin
+  require 'bootsnap'
+  require 'fastlane/version'
+  Bootsnap.setup(
+    cache_dir: "/tmp/fastlane-#{RUBY_VERSION}-#{Fastlane::VERSION}",
+    load_path_cache: true,
+    autoload_paths_cache: false,
+    disable_trace: true,
+    compile_cache_iseq: true,
+    compile_cache_yaml: true
+  )
+rescue LoadError
+end
+
 $LOAD_PATH.push File.expand_path("../../lib", __FILE__)
 
 require "fastlane/cli_tools_distributor"

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -43,6 +43,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'public_suffix', '~> 2.0.0' # https://github.com/fastlane/fastlane/issues/10162
 
+  spec.add_dependency 'bootsnap', '>= 1.1.3', '< 2.0.0'
+
   # TTY dependencies
   spec.add_dependency 'tty-screen', '~> 0.5.0' # detect the terminal width
 


### PR DESCRIPTION
Currentry, `fastlane` takes a time nearly 1 sec even if it displays help message.

```
$ time bundle exec fastlane -h > /dev/null
bundle exec fastlane -h > /dev/null  0.73s user 0.22s system 98% cpu 0.966 total
```

If you create new lane/action by trial and error, I think it is useful if boot time will be reduced.
This patch will reduce the boot time 0.966 sec -> 0.584 sec using `bootsnap` gem.
https://github.com/Shopify/bootsnap

Seems `fastlane` requires many Ruby files such as plugins/helpers and it takes a time where parses/generates AST and Ruby instruction sequences.

`bootsnap` gem generates Ruby instruction sequences cache and it will be able to reduce boot time.

At first boot, `bootsnap` generates Ruby instruction sequences cache and it take a time.

```
$ time bundle exec fastlane -h > /dev/null
bundle exec fastlane -h > /dev/null  0.94s user 0.45s system 98% cpu 1.420 total
```

But, after generated Ruby instruction sequences cache, boot time will be reduced.

```
$ time bundle exec fastlane -h > /dev/null
bundle exec fastlane -h > /dev/null  0.43s user 0.14s system 97% cpu 0.584 total
```

My environment is
* MacBook 2017
* CPU : 1.4 GHz Core i7
* Memory : 16 GB
* OS : macOS 10.13

----

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
