### PR TITLE
Add verbose output for upload_dsym

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -98,6 +98,7 @@ module Fastlane
             next unless result
             next unless result.kind_of?(Hash)
             params[:api_token] ||= result["APIKey"]
+            UI.verbose("found an APIKey in #{current}")
           end
         end
         UI.user_error!("Please provide an api_token using api_token:") unless params[:api_token]

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -83,7 +83,9 @@ module Fastlane
         command << "-p #{params[:platform] == 'appletvos' ? 'tvos' : params[:platform]}"
         command << File.expand_path(path).shellescape
         begin
-          Actions.sh(command.join(" "), log: false)
+          command_to_execute = command.join(" ")
+          UI.verbose("upload_dsym using command: #{command_to_execute}")
+          Actions.sh(command_to_execute, log: false)
         rescue => ex
           UI.error ex.to_s # it fails, however we don't want to fail everything just for this
         end


### PR DESCRIPTION
be able to see what command is failing when verbose output is on

It's difficult to debug why this would fail if we can't get verbose output.

NOTE: This will spit out an actual api token, so maybe we should think about how to protect that?