### PR TITLE
[backup_xcarchive] Add custom xcarchive zip filename option

### DIFF
--- a/fastlane/lib/fastlane/actions/backup_xcarchive.rb
+++ b/fastlane/lib/fastlane/actions/backup_xcarchive.rb
@@ -12,6 +12,7 @@ module Fastlane
         xcarchive = params[:xcarchive]
         base_destination = params[:destination]
         zipped = params[:zip]
+        zip_filename = params[:zip_filename]
         versioned = params[:versioned]
 
         # Prepare destionation folder
@@ -32,7 +33,11 @@ module Fastlane
             UI.message("Compressing #{xcarchive}")
             xcarchive_folder = File.expand_path(File.dirname(xcarchive))
             xcarchive_file = File.basename(xcarchive)
-            zip_file = File.join(dir, "#{xcarchive_file}.zip")
+            zip_file = if zip_filename
+              File.join(dir, "#{zip_filename}.xcarchive.zip")
+            else
+              File.join(dir, "#{xcarchive_file}.zip")
+            end
 
             # Create zip
             Actions.sh(%(cd "#{xcarchive_folder}" && zip -r -X "#{zip_file}" "#{xcarchive_file}" > /dev/null))
@@ -81,6 +86,10 @@ module Fastlane
                                        default_value: true,
                                        optional: true,
                                        env_name: 'BACKUP_XCARCHIVE_ZIP'),
+          FastlaneCore::ConfigItem.new(key: :zip_filename,
+                                       description: 'Filename of the compressed archive. Will be appended by `.xcarchive.zip`. Default value is the output xcarchive filename',
+                                       optional: true,
+                                       env_name: 'BACKUP_XCARCHIVE_ZIP_FILENAME'),
           FastlaneCore::ConfigItem.new(key: :versioned,
                                        description: 'Create a versioned (date and app version) subfolder where to put the archive. Default value `true`',
                                        is_string: false,

--- a/fastlane/lib/fastlane/actions/backup_xcarchive.rb
+++ b/fastlane/lib/fastlane/actions/backup_xcarchive.rb
@@ -34,10 +34,10 @@ module Fastlane
             xcarchive_folder = File.expand_path(File.dirname(xcarchive))
             xcarchive_file = File.basename(xcarchive)
             zip_file = if zip_filename
-              File.join(dir, "#{zip_filename}.xcarchive.zip")
-            else
-              File.join(dir, "#{xcarchive_file}.zip")
-            end
+                         File.join(dir, "#{zip_filename}.xcarchive.zip")
+                       else
+                         File.join(dir, "#{xcarchive_file}.zip")
+                       end
 
             # Create zip
             Actions.sh(%(cd "#{xcarchive_folder}" && zip -r -X "#{zip_file}" "#{xcarchive_file}" > /dev/null))

--- a/fastlane/spec/actions_specs/backup_xcarchive_spec.rb
+++ b/fastlane/spec/actions_specs/backup_xcarchive_spec.rb
@@ -63,6 +63,36 @@ describe Fastlane do
           File.delete(File.join(destination_path, zip_file))
         end
       end
+
+      context "zipped backup with custom filename" do
+        let(:custom_zip_filename) { "App_1.0.0" }
+        let(:zip_file) { "#{custom_zip_filename}.xcarchive.zip" }
+        before :each do
+          FileUtils.mkdir_p(source_path)
+          FileUtils.mkdir_p(destination_path)
+          File.write(File.join(source_path, xcarchive_file), file_content)
+          File.write(File.join(tmp_path, zip_file), file_content)
+          expect(Dir).to receive(:mktmpdir).with("backup_xcarchive").and_yield(tmp_path)
+        end
+
+        it "make zip with custom filename and copy to destination" do
+          allow(Fastlane::Actions).to receive(:sh).with("cd \"#{source_path}\" && zip -r -X \"#{tmp_path}/#{custom_zip_filename}.xcarchive.zip\" \"#{xcarchive_file}\" > /dev/null").and_return("")
+          result = Fastlane::FastFile.new.parse("lane :test do
+            backup_xcarchive(
+              versioned: false,
+              xcarchive: '#{source_xcarchive_path}',
+              destination: '#{destination_path}',
+              zip: true,
+              zip_filename: '#{custom_zip_filename}'
+            )
+          end").runner.execute(:test)
+        end
+
+        after :each do
+          File.delete(File.join(source_path, xcarchive_file))
+          File.delete(File.join(destination_path, zip_file))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Current action outputs the zip with the filename based out of Xcode's output xcarchive filename, which is app name followed by date and time of the build (e.g. `App 2017-10-07 23.19.31.xcarchive.zip`). There are cases you want to backup the zipped xcarchive based on app version and build number.

### Description
<!--- Describe your changes in detail -->
This adds an optional `zip_filename` option  so that we can specify the backup xcarchive's zip filename.