### PR TITLE
Fix waiting during network activity for iPhone X

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/snapshot.md
+++ b/fastlane/lib/fastlane/actions/docs/snapshot.md
@@ -91,7 +91,7 @@ Here a few links to get started:
 - In your UI Test class, click the `Record` button on the bottom left and record your interaction
 - To take a snapshot, call the following between interactions
  -  Swift: `snapshot("01LoginScreen")`
- -  Objective C: `[Snapshot snapshot:@"01LoginScreen" waitForLoadingIndicator:YES];`
+ -  Objective C: `[Snapshot snapshot:@"01LoginScreen" timeWaitingForIdle:10];`
 - Add the following code to your `setUp()` method
 
 **Swift**

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -19,17 +19,24 @@ import XCTest
 var deviceLanguage = ""
 var locale = ""
 
-@available(*, deprecated, message: "use setupSnapshot: instead")
-func setLanguage(_ app: XCUIApplication) {
-    setupSnapshot(app)
-}
-
 func setupSnapshot(_ app: XCUIApplication) {
     Snapshot.setupSnapshot(app)
 }
 
-func snapshot(_ name: String, waitForLoadingIndicator: Bool = true) {
-    Snapshot.snapshot(name, waitForLoadingIndicator: waitForLoadingIndicator)
+@available(*, deprecated, renamed: "snapshot(_:timeWaitingForIdle:)")
+func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
+    if waitForLoadingIndicator {
+        Snapshot.snapshot(name)
+    } else {
+        Snapshot.snapshot(name, timeWaitingForIdle: 0)
+    }
+}
+
+/// - Parameters:
+///   - name: The name of the snapshot
+///   - timeout: Amount of seconds to wait until the network loading indicator disappears. Pass `0` if you don't want to wait.
+func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+    Snapshot.snapshot(name, timeWaitingForIdle: timeout)
 }
 
 enum SnapshotError: Error, CustomDebugStringConvertible {
@@ -116,9 +123,9 @@ open class Snapshot: NSObject {
         }
     }
 
-    open class func snapshot(_ name: String, waitForLoadingIndicator: Bool = true) {
-        if waitForLoadingIndicator {
-            waitForLoadingIndicatorToDisappear()
+    open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+        if timeout > 0 {
+            waitForLoadingIndicatorToDisappear(within: timeout)
         }
 
         print("snapshot: \(name)") // more information about this, check out https://github.com/fastlane/fastlane/tree/master/snapshot#how-does-it-work
@@ -140,17 +147,14 @@ open class Snapshot: NSObject {
         #endif
     }
 
-    class func waitForLoadingIndicatorToDisappear() {
+    class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
         #if os(tvOS)
             return
         #endif
 
-        let query = XCUIApplication().statusBars.children(matching: .other).element(boundBy: 1).children(matching: .other)
-
-        while (0..<query.count).map({ query.element(boundBy: $0) }).contains(where: { $0.isLoadingIndicator }) {
-            sleep(1)
-            print("Waiting for loading indicator to disappear...")
-        }
+        let networkLoadingIndicator = XCUIApplication().otherElements.deviceStatusBars.networkLoadingIndicators.element
+        let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
+        XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
     }
 
     class func pathPrefix() throws -> URL? {
@@ -180,16 +184,65 @@ open class Snapshot: NSObject {
     }
 }
 
-extension XCUIElement {
-    var isLoadingIndicator: Bool {
-        let whiteListedLoaders = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
-        if whiteListedLoaders.contains(self.identifier) {
-            return false
+private extension XCUIElementAttributes {
+    var isNetworkLoadingIndicator: Bool {
+        let oldLoadingIndicatorSize = CGSize(width: 10, height: 20)
+        
+        let hasOldLoadingIndicatorSize = frame.size == oldLoadingIndicatorSize
+        let hasNewLoadingIndicatorSize = frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
+        
+        return !hasWhiteListedIdentifier && (hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize)
+    }
+    
+    var hasWhiteListedIdentifier: Bool {
+        let whiteListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+        
+        return whiteListedIdentifiers.contains(identifier)
+    }
+    
+    func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
+        if elementType == .statusBar {
+            return true
         }
-        return self.frame.size == CGSize(width: 10, height: 20)
+        
+        let positionedAtTopLeft = frame.origin == .zero
+        let hasOldStatusBarSize = frame.size == CGSize(width: deviceWidth, height: 20)
+        let hasNewStatusBarSize = frame.size == CGSize(width: deviceWidth, height: 44)
+        
+        return positionedAtTopLeft && (hasOldStatusBarSize || hasNewStatusBarSize)
+    }
+}
+
+private extension XCUIElementQuery {
+    var networkLoadingIndicators: XCUIElementQuery {
+        let isNetworkLoadingIndicator = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isNetworkLoadingIndicator
+        }
+        
+        return self.containing(isNetworkLoadingIndicator)
+    }
+    
+    var deviceStatusBars: XCUIElementQuery {
+        let deviceWidth = XCUIApplication().frame.width
+        
+        let isStatusBar = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isStatusBar(deviceWidth)
+        }
+        
+        return self.containing(isStatusBar)
+    }
+}
+
+private extension CGFloat {
+    func isBetween(_ numberA: CGFloat, and numberB: CGFloat) -> Bool {
+        return numberA...numberB ~= self
     }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.5]
+// SnapshotHelperVersion [1.6]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR resolves #10539. 

As described in the issue, the current SnapshotHelper.swift will not wait for the network activity indicator to disappear, because the size of the indicator changed.

I tested my changes using Xcode 9 with an iPhone 8 and an iPhone X simulator. I tested both cases where the network activity indicator was active and inactive when `snapshot("screenshot name")` was called.

### Description
* I extended the `isLoadingIndicator` computed property to not only look for `CGSize(width: 10, height: 20)`, but also for the new one, which is oddly `CGSize(width: 46.3333333333333, height: 2.66666666666667)`.
* I also added a new computed property that helps to find the status bar, because on the iPhone X, the status bar is of type `other` and can't be found with `XCUIApplication().statusBars`.
* Finally, I replaced the while loop that calls `sleep(1)` while looking for a disappearing element of `CGSize(width: 10, height: 20)` with the new XCTWaiter that evaluates a predicate.