### PR TITLE
[spaceship] Fixed and improved upload_trailer! method

### DIFF
--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -38,8 +38,8 @@ module Spaceship
       upload_file(app_version: app_version, upload_file: upload_file, path: '/upload/purple-video', content_provider_id: content_provider_id, sso_token: sso_token_for_video)
     end
 
-    def upload_trailer_preview(app_version, upload_file, content_provider_id, sso_token_for_image)
-      upload_file(app_version: app_version, upload_file: upload_file, path: '/upload/app-screenshot-image', content_provider_id: content_provider_id, sso_token: sso_token_for_image)
+    def upload_trailer_preview(app_version, upload_file, content_provider_id, sso_token_for_image, device)
+      upload_file(app_version: app_version, upload_file: upload_file, path: '/upload/image', content_provider_id: content_provider_id, sso_token: sso_token_for_image, du_validation_rule_set: screenshot_picture_type(device, nil))
     end
 
     private

--- a/spaceship/lib/spaceship/du/utilities.rb
+++ b/spaceship/lib/spaceship/du/utilities.rb
@@ -66,8 +66,8 @@ module Spaceship
       video_infos = output.split("\n").select { |l| l =~ /Stream.*Video/ }
       raise "Unable to find Stream Video information from ffmpeg output of #{command}" if video_infos.count == 0
       video_info = video_infos[0]
-      res = video_info.match(/.* ([0-9]+)x([0-9]+),.*/)
-      raise "Unable to parse resolution information from #{video_info}" if res.count < 3
+      res = video_info.match(/.* ([0-9]+)x([0-9]+).*/)
+      raise "Unable to parse resolution information from #{video_info}" if res.size < 3
       [res[1].to_i, res[2].to_i]
     end
 

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -516,30 +516,34 @@ module Spaceship
         setup_screenshots
       end
 
-      # Uploads, removes a trailer video or change its preview image
+      # Uploads, removes a trailer video
       #
       # A preview image for the video is required by ITC and is usually automatically extracted by your browser.
-      # This method will either automatically extract it from the video (using `ffmpeg) or allow you
+      # This method will either automatically extract it from the video (using `ffmpeg`) or allow you
       # to specify it using +preview_image_path+.
-      # If the preview image is specified, ffmpeg` will ot be used. The image resolution will be checked against
+      # If the preview image is specified, `ffmpeg` will not be used. The image resolution will be checked against
       # expectations (which might be different from the trailer resolution.
       #
       # It is recommended to extract the preview image using the spaceship related tools in order to ensure
       # the appropriate format and resolution are used.
       #
-      # Note: if the video is already set, the +trailer_path+ is only used to grab the preview screenshot.
       # Note: to extract its resolution and a screenshot preview, the `ffmpeg` tool will be used
       #
-      # @param icon_path (String): The path to the screenshot. Use nil to remove it
+      # @param trailer_path (String): The path to the trailer. Use nil to remove it
       # @param sort_order (Fixnum): The sort_order, from 1 to 5
       # @param language (String): The language for this screenshot
       # @param device (String): The device for this screenshot
       # @param timestamp (String): The optional timestamp of the screenshot to grab
-      def upload_trailer!(trailer_path, language, device, timestamp = "05.00", preview_image_path = nil)
+      # @param preview_image_path (String): The optional image path for the video preview
+      def upload_trailer!(trailer_path, sort_order, language, device, timestamp = "05.00", preview_image_path = nil)
         raise "No app trailer supported for iphone35" if device == 'iphone35'
+        raise "sort_order must be higher than 0" unless sort_order > 0
+        raise "sort_order must not be > 3" if sort_order > 3
 
-        device_lang_trailer = trailer_data_for_language_and_device(language, device, is_messages)
-        if trailer_path # adding / replacing trailer / replacing preview
+        device_lang_trailers = trailer_data_for_language_and_device(language, device)["value"]
+        existing_sort_orders = device_lang_trailers.map { |s| s["value"]["sortPosition"] }
+
+        if trailer_path # adding / replacing trailer
           raise "Invalid timestamp #{timestamp}" if (timestamp =~ /^[0-9][0-9].[0-9][0-9]$/).nil?
 
           if preview_image_path
@@ -551,33 +555,38 @@ module Spaceship
             video_preview_path = Utilities.grab_video_preview(trailer_path, timestamp, video_preview_resolution)
           end
           video_preview_file = UploadFile.from_path video_preview_path
-          video_preview_data = client.upload_trailer_preview(self, video_preview_file)
+          video_preview_data = client.upload_trailer_preview(self, video_preview_file, device)
 
-          trailer = device_lang_trailer["value"]
-          if trailer.nil? # add trailer
-            upload_file = UploadFile.from_path trailer_path
-            trailer_data = client.upload_trailer(self, upload_file)
-            trailer_data = trailer_data['responses'][0]
-            trailer = {
-                "videoAssetToken" => trailer_data["token"],
-                "descriptionXML" => trailer_data["descriptionDoc"],
-                "contentType" => upload_file.content_type
-            }
-            device_lang_trailer["value"] = trailer
-          end
-          # add / update preview
-          # different format required
+          upload_file = UploadFile.from_path trailer_path
+          trailer_data = client.upload_trailer(self, upload_file)
+
           ts = "00:00:#{timestamp}"
           ts[8] = ':'
 
-          trailer.merge!({
-            "pictureAssetToken" => video_preview_data["token"],
-            "previewFrameTimeCode" => ts.to_s,
-            "isPortrait" => Utilities.portrait?(video_preview_path)
-          })
+          new_trailer = {
+            "value" => {
+              "videoAssetToken" => trailer_data["responses"][0]["token"],
+              "descriptionXML" => trailer_data["responses"][0]["descriptionDoc"],
+              "contentType" => upload_file.content_type,
+              "sortPosition" => sort_order,
+              "size" => video_preview_data["length"],
+              "width" => video_preview_data["width"],
+              "height" => video_preview_data["height"],
+              "checksum" => video_preview_data["md5"],
+              "pictureAssetToken" => video_preview_data["token"],
+              "previewFrameTimeCode" => ts.to_s,
+              "isPortrait" => Utilities.portrait?(video_preview_path)
+            }
+          }
+
+          if existing_sort_orders.include?(sort_order) # replace
+            device_lang_trailers[existing_sort_orders.index(sort_order)] = new_trailer
+          else # add
+            device_lang_trailers << new_trailer
+          end
         else # removing trailer
-          raise "cannot remove non existing trailer" if device_lang_trailer["value"].nil?
-          device_lang_trailer["value"] = nil
+          raise "cannot remove trailer with non existing sort_order" unless existing_sort_orders.include?(sort_order)
+          device_lang_trailers.delete_at(existing_sort_orders.index(sort_order))
         end
         setup_trailers
       end
@@ -657,7 +666,7 @@ module Spaceship
       end
 
       def trailer_data_for_language_and_device(language, device)
-        container_data_for_language_and_device("appTrailers", language, device)
+        container_data_for_language_and_device("trailers", language, device)
       end
 
       def container_data_for_language_and_device(data_field, language, device)
@@ -838,15 +847,14 @@ module Spaceship
         result = []
 
         display_families.each do |display_family|
-          trailer_raw = display_family["trailer"]
-          next if trailer_raw.nil?
-          trailer_data = trailer_raw["value"]
-          next if trailer_data.nil?
-          data = {
-            device_type: display_family['name'],
-            language: row["language"]
-          }.merge(trailer_data)
-          result << Tunes::AppTrailer.factory(data)
+          display_family.fetch("trailers", {}).fetch("value", []).each do |trailer|
+            trailer_data = trailer["value"]
+            data = {
+              device_type: display_family['name'],
+              language: row["language"]
+            }.merge(trailer_data)
+            result << Tunes::AppTrailer.factory(data)
+          end
         end
 
         return result

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -672,12 +672,14 @@ module Spaceship
     # Uploads the trailer preview
     # @param app_version (AppVersion): The version of your app
     # @param upload_trailer_preview (UploadFile): The trailer preview to upload
+    # @param device (string): The target device
     # @return [JSON] the response
-    def upload_trailer_preview(app_version, upload_trailer_preview)
+    def upload_trailer_preview(app_version, upload_trailer_preview, device)
       raise "app_version is required" unless app_version
       raise "upload_trailer_preview is required" unless upload_trailer_preview
+      raise "device is required" unless device
 
-      du_client.upload_trailer_preview(app_version, upload_trailer_preview, content_provider_id, sso_token_for_image)
+      du_client.upload_trailer_preview(app_version, upload_trailer_preview, content_provider_id, sso_token_for_image, device)
     end
 
     # Fetches the App Version Reference information from ITC


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change fixes and improves upload_trailer! method in spaceship. The current method wasn't working, I have fixed it and I have added the new feature to upload up to 3 videos. Now you can replace existing trailers and select the sort order.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
To test the new upload_trailer! method:
* I have uploaded up to 3 videos. 
* I have removed 1-3 videos.
* I have replaced 1-3 videos.
### Description
<!--- Describe your changes in detail -->
* I have updated du_client.rb to change the path and the validation rules from upload_trailer_preview to pass iTunes Connect validation.
* I have fixed video_resolution method in utilities.rb
* I have updated tunes_client.rb upload_trailer_preview method to match the new du_client signature.
* I have fixed and updated app_version.rb for the new validation rules of iTunes Connect and to introduce the feature to upload up to 3 videos. 