### PR TITLE
Ci build number

### DIFF
--- a/fastlane/lib/fastlane/actions/ci_build_number.rb
+++ b/fastlane/lib/fastlane/actions/ci_build_number.rb
@@ -1,0 +1,64 @@
+module Fastlane
+  module Actions
+    class CiBuildNumberAction < Action
+      def self.run(params)
+        if ENV.key?('JENKINS_HOME') || ENV.key?('JENKINS_URL')
+          return ENV['BUILD_NUMBER']
+        end
+
+        if ENV.key?('TRAVIS')
+          return ENV['TRAVIS_BUILD_NUMBER']
+        end
+
+        if ENV.key?('CIRCLECI')
+          return ENV['CIRCLE_BUILD_NUM']
+        end
+
+        if ENV.key?('TEAMCITY_VERSION')
+          return ENV['BUILD_NUMBER']
+        end
+
+        if ENV.key?('GO_PIPELINE_NAME')
+          return ENV['GO_PIPELINE_COUNTER']
+        end
+
+        if ENV.key?('bamboo_buildKey')
+          return ENV['bamboo_buildNumber']
+        end
+
+        if ENV.key?('GITLAB_CI')
+          return ENV['CI_JOB_ID']
+        end
+
+        if ENV.key?('XCS')
+          return ENV['XCS_INTEGRATION_NUMBER']
+        end
+
+        UI.error("Cannot detect current CI build number. Use 1 by default.")
+        "1"
+      end
+
+      def self.description
+        "Detects current build number defined by CI system"
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.authors
+        ["Siarhei Fedartsou"]
+      end
+
+      def self.example_code
+        [
+          'ci_build_number'
+        ]
+      end
+
+      def self.category
+        :building
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -36,10 +36,16 @@ module Fastlane
           raise "Apple Generic Versioning is not enabled." unless agv_enabled
         end
 
+        if params[:use_ci_build_number]
+          build_number = Actions::CiBuildNumberAction.run({})
+        else
+          build_number = params[:build_number]
+        end
+
         command = [
           command_prefix,
           'agvtool',
-          params[:build_number] ? "new-version -all #{params[:build_number].to_s.strip}" : 'next-version -all',
+          build_number ? "new-version -all #{build_number.to_s.strip}" : 'next-version -all',
           command_suffix
         ].join(' ')
 
@@ -67,7 +73,16 @@ module Fastlane
                                        env_name: "FL_BUILD_NUMBER_BUILD_NUMBER",
                                        description: "Change to a specific version",
                                        optional: true,
-                                       is_string: false),
+                                       is_string: false,
+                                       conflicting_options: [:use_ci_build_number]),
+          FastlaneCore::ConfigItem.new(key: :use_ci_build_number,
+          env_name: "FL_BUILD_NUMBER_USE_CI_BUILD_NUMBER",
+          description: "Use build number returned by ci_build_number action",
+          optional: true,
+          is_string: false,
+          default_value: false,
+          conflicting_options: [:build_number]),
+
           FastlaneCore::ConfigItem.new(key: :xcodeproj,
                                        env_name: "FL_BUILD_NUMBER_PROJECT",
                                        description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",

--- a/fastlane/spec/actions_specs/ci_build_number_spec.rb
+++ b/fastlane/spec/actions_specs/ci_build_number_spec.rb
@@ -1,0 +1,125 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "ci_build_number" do
+      it "Returns build number defined in BUILD_NUMBER environment variable if running on Jenkins" do
+        ENV['JENKINS_HOME'] = "Users/user/hudson/workspace"
+        ENV['BUILD_NUMBER'] = '42'
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ci_build_number
+        end").runner.execute(:test)
+
+        expect(result).to eq('42')
+
+        ENV.delete('JENKINS_HOME')
+        ENV.delete('BUILD_NUMBER')
+      end
+
+      it "Returns build number defined in TRAVIS_BUILD_NUMBER environment variable if running on Travis CI" do
+        ENV['TRAVIS'] = '1'
+        ENV['TRAVIS_BUILD_NUMBER'] = '42'
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+            ci_build_number
+          end").runner.execute(:test)
+
+        expect(result).to eq('42')
+
+        ENV.delete('TRAVIS')
+        ENV.delete('TRAVIS_BUILD_NUMBER')
+      end
+
+      it "Returns build number defined in CIRCLE_BUILD_NUM environment variable if running on Circle CI" do
+        ENV['CIRCLECI'] = '1'
+        ENV['CIRCLE_BUILD_NUM'] = '42'
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+            ci_build_number
+          end").runner.execute(:test)
+
+        expect(result).to eq('42')
+
+        ENV.delete('CIRCLECI')
+        ENV.delete('CIRCLE_BUILD_NUM')
+      end
+
+      it "Returns build number defined in BUILD_NUMBER environment variable if running on TeamCity" do
+        ENV['TEAMCITY_VERSION'] = '1.0'
+        ENV['BUILD_NUMBER'] = '42'
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+            ci_build_number
+          end").runner.execute(:test)
+
+        expect(result).to eq('42')
+
+        ENV.delete('TEAMCITY_VERSION')
+        ENV.delete('BUILD_NUMBER')
+      end
+
+      it "Returns build number defined in GO_PIPELINE_COUNTER environment variable if running on GoCD" do
+        ENV['GO_PIPELINE_NAME'] = 'Job'
+        ENV['GO_PIPELINE_COUNTER'] = '42'
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+            ci_build_number
+          end").runner.execute(:test)
+
+        expect(result).to eq('42')
+
+        ENV.delete('GO_PIPELINE_NAME')
+        ENV.delete('GO_PIPELINE_COUNTER')
+      end
+
+      it "Returns build number defined in bamboo_buildNumber environment variable if running on Bamboo" do
+        ENV['bamboo_buildKey'] = 'JOB'
+        ENV['bamboo_buildNumber'] = '42'
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+            ci_build_number
+          end").runner.execute(:test)
+
+        expect(result).to eq('42')
+
+        ENV.delete('bamboo_buildKey')
+        ENV.delete('bamboo_buildNumber')
+      end
+
+      it "Returns build number defined in CI_JOB_ID environment variable if running on GitLab CI" do
+        ENV['GITLAB_CI'] = '1'
+        ENV['CI_JOB_ID'] = '42'
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+            ci_build_number
+          end").runner.execute(:test)
+
+        expect(result).to eq('42')
+
+        ENV.delete('GITLAB_CI')
+        ENV.delete('CI_JOB_ID')
+      end
+
+      it "Returns build number defined in XCS_INTEGRATION_NUMBER environment variable if running on Xcode Server" do
+        ENV['XCS'] = '1'
+        ENV['XCS_INTEGRATION_NUMBER'] = '42'
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+            ci_build_number
+          end").runner.execute(:test)
+
+        expect(result).to eq('42')
+
+        ENV.delete('XCS')
+        ENV.delete('XCS_INTEGRATION_NUMBER')
+      end
+
+      it "Uses 1 as a default build number if cannot detect" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ci_build_number
+        end").runner.execute(:test)
+
+        expect(result).to eq('1')
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/increment_build_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_build_number_action_spec.rb
@@ -19,6 +19,19 @@ describe Fastlane do
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool new-version -all 24/)
       end
 
+      it "pass a ci build number to the tool" do
+        ENV['CIRCLECI'] = '1'
+        ENV['CIRCLE_BUILD_NUM'] = '24'
+        result = Fastlane::FastFile.new.parse("lane :test do
+          increment_build_number(use_ci_build_number: true, xcodeproj: '.xcproject')
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool new-version -all 24/)
+
+        ENV.delete("CIRCLECI")
+        ENV.delete("CIRCLE_BUILD_NUM")
+      end
+
       it "raises an exception when use passes workspace" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
In each of our projects we have common code in lanes like this:
```
increment_build_number(build_number: ENV['BUILD_NUMBER'])
```
Currently we use Jenkins CI and it sets current build number to build number from our Jenkins job. But if we will decide to move to another CI system we will have to change it. I think it will be much better to have more or less CI independent way to get current build number from CI.
So, this pull request introduces new action `ci_build_number`, which returns current build number retrieved from CI using environment variables. It supports Jenkins, Travis CI, Circle CI, TeamCity, GoCD, Bamboo, Gitlab CI and Xcode Server. And also adds new option to `increment_build_number` action `use_ci_build_number` which allows to automatically set build number using value returned by `ci_build_number`.


