### PR TITLE
Add swift_version option to pod_push action

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_push.rb
+++ b/fastlane/lib/fastlane/actions/pod_push.rb
@@ -18,6 +18,11 @@ module Fastlane
           command << " --sources='#{sources}'"
         end
 
+        if params[:swift_version]
+          swift_version = params[:swift_version]
+          command << " --swift-version=#{swift_version}"
+        end
+
         if params[:allow_warnings]
           command << " --allow-warnings"
         end
@@ -74,6 +79,10 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Sources must be an array.") unless value.kind_of?(Array)
                                        end),
+          FastlaneCore::ConfigItem.new(key: :swift_version,
+                                       description: "The SWIFT_VERSION that should be used to lint the spec. This takes precedence over a .swift-version file",
+                                       optional: true,
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :verbose,
                                        description: "Show more debugging information",
                                        optional: true,

--- a/fastlane/spec/actions_specs/pod_push_spec.rb
+++ b/fastlane/spec/actions_specs/pod_push_spec.rb
@@ -29,6 +29,14 @@ describe Fastlane do
         expect(result).to eq("pod repo push MyRepo './fastlane/spec/fixtures/podspecs/test.podspec'")
       end
 
+      it "generates the correct pod push command with a repo parameter with the swift version flag" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_push(path: './fastlane/spec/fixtures/podspecs/test.podspec', repo: 'MyRepo', swift_version: 4.0)
+        end").runner.execute(:test)
+
+        expect(result).to eq("pod repo push MyRepo './fastlane/spec/fixtures/podspecs/test.podspec' --swift-version=4.0")
+      end
+
       it "generates the correct pod push command with a repo parameter with the allow warnings and use libraries flags" do
         result = Fastlane::FastFile.new.parse("lane :test do
           pod_push(path: './fastlane/spec/fixtures/podspecs/test.podspec', repo: 'MyRepo', allow_warnings: true, use_libraries: true)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I was unable to push a pod spec which uses swift 4.0 using the pod_push action even with a .swift-version file. I was only able to push the pod spec once I passed --swift-version=4.0 to the pod command. This allows swift-version for the pod command to be specified.

Referencing issue: https://github.com/fastlane/fastlane/issues/10569

### Description
The changes simply add a swift_version parameter to the pod_push action. The value of the parameter is passed to the --swift-version parameter of the pod command.