### PR TITLE
[UpdateProjectTeamAction] default path value 

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_team.rb
+++ b/fastlane/lib/fastlane/actions/update_project_team.rb
@@ -32,6 +32,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :path,
                                        env_name: "FL_PROJECT_SIGNING_PROJECT_PATH",
                                        description: "Path to your Xcode project",
+                                       default_value: Dir['*.xcodeproj'].first,
                                        verify_block: proc do |value|
                                          UI.user_error!("Path is invalid") unless File.exist?(value)
                                        end),
@@ -52,6 +53,7 @@ module Fastlane
 
       def self.example_code
         [
+          'update_project_team',
           'update_project_team(
             path: "Example.xcodeproj",
             teamid: "A3ZZVJ7CNY"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Less parameters, let's fastlane be more clever.
It already defaults to `team_id` from `Appfile` why not nearest xcodeproj? 👍 

Makes me have to do this in our lane
```ruby
update_project_team(
  path: Dir['../*.xcodeproj'].first.sub!('../', '')
)
```
or like this
```ruby
update_project_team(
  path: 'ourSillyLongAppName.xcodeproj'
)
```