### PR TITLE
Keychain created with incorrect path

### DIFF
--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -12,7 +12,7 @@ module Fastlane
 
         if params[:name]
           escaped_name = params[:name].shellescape
-          keychain_path = "~/Library/Keychains/#{escaped_name}"
+          keychain_path = "~/Library/Keychains/#{escaped_name}.keychain-db"
         else
           keychain_path = params[:path].shellescape
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Should use the standard set in sierra when creating keys.

Without this, keychain is literally called "name-db" and you get unexpected results 👍 