### PR TITLE
Convert plugin template to Circle CI 2.0

### DIFF
--- a/fastlane/lib/fastlane/plugins/template/%gem_name%.gemspec.erb
+++ b/fastlane/lib/fastlane/plugins/template/%gem_name%.gemspec.erb
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'

--- a/fastlane/lib/fastlane/plugins/template/.circleci/config.yml
+++ b/fastlane/lib/fastlane/plugins/template/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          - v1-dependencies-{{ checksum "Gemfile" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
@@ -29,7 +29,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+          key: v1-dependencies-{{ checksum "Gemfile" }}
 
       # run tests!
       - run:

--- a/fastlane/lib/fastlane/plugins/template/.circleci/config.yml
+++ b/fastlane/lib/fastlane/plugins/template/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
 
       - run:
           name: install dependencies
-          command: bundle install --jobs=4 --retry=3 --path vendor/bundle
+          command: bundle check || bundle install --jobs=4 --retry=3 --path vendor/bundle
 
       - save_cache:
           paths:

--- a/fastlane/lib/fastlane/plugins/template/.circleci/config.yml
+++ b/fastlane/lib/fastlane/plugins/template/.circleci/config.yml
@@ -23,19 +23,17 @@ jobs:
 
       - run:
           name: install dependencies
-          command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+          command: bundle install --jobs=4 --retry=3 --path vendor/bundle
 
       - save_cache:
           paths:
-            - ./venv
+            - ./vendor
           key: v1-dependencies-{{ checksum "Gemfile" }}
 
       # run tests!
       - run:
           name: run tests
-          command: |
-            bundle exec rake
+          command: bundle exec rake
 
       # collect reports
       - store_test_results:

--- a/fastlane/lib/fastlane/plugins/template/.circleci/config.yml
+++ b/fastlane/lib/fastlane/plugins/template/.circleci/config.yml
@@ -1,0 +1,45 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+       - image: circleci/ruby:2.4.2
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            bundle exec rake
+
+      # collect reports
+      - store_test_results:
+          path: ~/repo/test-results
+      - store_artifacts:
+          path: ~/repo/test-results
+          destination: test-results

--- a/fastlane/lib/fastlane/plugins/template/.gitignore
+++ b/fastlane/lib/fastlane/plugins/template/.gitignore
@@ -9,3 +9,4 @@ Gemfile.lock
 fastlane/README.md
 fastlane/report.xml
 coverage
+test-results

--- a/fastlane/lib/fastlane/plugins/template/.rspec
+++ b/fastlane/lib/fastlane/plugins/template/.rspec
@@ -1,3 +1,5 @@
 --require spec_helper
 --color
 --format d
+--format RspecJunitFormatter
+--out test-results/rspec/rspec.xml

--- a/fastlane/lib/fastlane/plugins/template/circle.yml
+++ b/fastlane/lib/fastlane/plugins/template/circle.yml
@@ -1,9 +1,0 @@
-test:
-  override:
-    - bundle exec rake
-machine:
-  ruby:
-    version: 2.2.4
-# Enable xcode below if you need macOS
-#   xcode:
-#     version: "7.3"

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -223,6 +223,7 @@ describe Fastlane::PluginGenerator do
           Gem::Dependency.new("pry", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("bundler", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("rspec", Gem::Requirement.new([">= 0"]), :development),
+          Gem::Dependency.new("rspec_junit_formatter", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("rake", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("rubocop", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("simplecov", Gem::Requirement.new([">= 0"]), :development),


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Related to #10563. This updates the plugin template to use Circle CI 2.0, including test reporting.

### Description

Replaced circle.yml with .circleci/config.yml.

To enable test reporting, added `rspec_junit_formatter` as a dev dependency. RSpec now generates both doc-style output and a JUnit-style report.xml. The latter is used by CI for test reporting.

I played around with a number of options until I found all the right info in various places in the Circle docs to produce results like this:

![screen shot 2017-10-15 at 9 21 35 am](https://user-images.githubusercontent.com/121951/31586771-757f7eee-b18a-11e7-941b-aeec2131537f.png)

https://circleci.com/docs/2.0/configuration-reference/#store_test_results

Linked from that page ("classic CircleCI test metadata directory layout"):

https://circleci.com/docs/1.0/test-metadata/
https://circleci.com/docs/1.0/test-metadata/#rspec