### PR TITLE
Version bump to 2.62.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.61.0'.freeze
+  VERSION = '2.62.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.61.0':**

* Refactoring metrics to be more understandable (#10488) via David Ohayon
* Updating options for docs update https://github.com/fastlane/docs/pull/432 (#10593) via Joshua Liebowitz
* [docs] fix links (#10591) via Jan Piotrowski
* Find nested errors messages (#10586) via Joshua Liebowitz
* [UpdateProjectTeam] default path value (#10583) via Joseph Petersen
* Fix waiting during network activity for iPhone X (#10541) via Florian Fittschen
* [hockey] clarify error message (#10568) via Jan Piotrowski
* Add swift_version option to pod_push action (#10570) via Marcus Wu
* Fix documentation URL in default Deliverfile (#10575) via Iulian Onofrei
* Add verbose output for upload_dsym (#10537) via Joshua Liebowitz
* Gym: add option to skip profile detection (#10463) via Nicolas Braun
* Make gym pass xcargs to xcbuild-safe.sh (#10571) via Joshua Liebowitz
* [spaceship] Fixed and improved upload_trailer! method (#10546) via Javier Agüera Cazorla
* Only query xcode version on macs when running itms (#10545) via znerol
*  update `:update_docs` commit and Slack message (#10544) via Jan Piotrowski
