### PR TITLE
Arrange name of derived data path

### DIFF
--- a/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
+++ b/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
@@ -6,7 +6,7 @@ module Fastlane
 
         xcodebuild_configs = params[:xcodebuild]
         xcodebuild_configs[:sdk] = "iphonesimulator"
-        xcodebuild_configs[:derivedDataPath] = tmp_path
+        xcodebuild_configs[:derived_data_path] = tmp_path
         xcodebuild_configs[:xcargs] = "CONFIGURATION_BUILD_DIR=" + tmp_path
         xcodebuild_configs[:scheme] ||= params[:scheme] if params[:scheme].to_s.length > 0
 

--- a/fastlane/lib/fastlane/actions/device_grid/README.md
+++ b/fastlane/lib/fastlane/actions/device_grid/README.md
@@ -132,7 +132,7 @@ xcodebuild(
   workspace: "Themoji.xcworkspace",
   sdk: "iphonesimulator",
   scheme: "Themoji",
-  derivedDataPath: tmp_path
+  derived_data_path: tmp_path
 )
 
 app_path = Dir[File.join(tmp_path, "**", "*.app")].last

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -25,7 +25,7 @@ module Fastlane
         arch: "-arch",
         archive_path: "-archivePath",
         configuration: "-configuration",
-        derivedDataPath: "-derivedDataPath",
+        derived_data_path: "-derivedDataPath",
         destination_timeout: "-destination-timeout",
         dry_run: "-dry-run",
         enableAddressSanitizer: "-enableAddressSanitizer",
@@ -88,8 +88,8 @@ module Fastlane
         buildlog_path = ENV["XCODE_BUILDLOG_PATH"]
 
         # Set derived data path.
-        params[:derivedDataPath] ||= ENV["XCODE_DERIVED_DATA_PATH"]
-        Actions.lane_context[SharedValues::XCODEBUILD_DERIVED_DATA_PATH] = params[:derivedDataPath]
+        params[:derived_data_path] ||= ENV["XCODE_DERIVED_DATA_PATH"]
+        Actions.lane_context[SharedValues::XCODEBUILD_DERIVED_DATA_PATH] = params[:derived_data_path]
 
         # Append slash to build path, if needed
         if build_path && !build_path.end_with?("/")

--- a/fastlane/spec/actions_specs/xcodebuild_spec.rb
+++ b/fastlane/spec/actions_specs/xcodebuild_spec.rb
@@ -22,7 +22,7 @@ describe Fastlane do
             alltargets: true,
             archive_path: './build/MyApp.xcarchive',
             configuration: 'Debug',
-            derivedDataPath: '/derived/data/path',
+            derived_data_path: '/derived/data/path',
             destination: 'name=iPhone 5s,OS=8.1',
             destination_timeout: 240,
             dry_run: true,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This project has multiple name of derived data path (derived_data_path, derivedDataPath). 
The number of `derived_data_path` is bigger than one of `derivedDataPath` by grepping.
So I arrange name of derived data path to `derived_data_path`.

### Description
I fixed name of derived data path in xcodebuild.
