### PR TITLE
Forward match keychain password into cert

### DIFF
--- a/match/lib/match/generator.rb
+++ b/match/lib/match/generator.rb
@@ -11,7 +11,8 @@ module Match
         force: true, # we don't need a certificate without its private key, we only care about a new certificate
         username: params[:username],
         team_id: params[:team_id],
-        keychain_path: FastlaneCore::Helper.keychain_path(params[:keychain_name])
+        keychain_path: FastlaneCore::Helper.keychain_path(params[:keychain_name]),
+        keychain_password: params[:keychain_password]
       })
 
       Cert.config = arguments

--- a/match/spec/generator_spec.rb
+++ b/match/spec/generator_spec.rb
@@ -9,7 +9,8 @@ describe Match::Generator do
         force: true,
         username: 'username',
         team_id: 'team_id',
-        keychain_path: FastlaneCore::Helper.keychain_path("login.keychain")
+        keychain_path: FastlaneCore::Helper.keychain_path("login.keychain"),
+        keychain_password: 'password'
       })
 
       # This is the important part. We need to see the right configuration come through
@@ -27,7 +28,8 @@ describe Match::Generator do
         workspace: 'workspace',
         username: 'username',
         team_id: 'team_id',
-        keychain_name: 'login.keychain'
+        keychain_name: 'login.keychain',
+        keychain_password: 'password'
       }
 
       Match::Generator.generate_certificate(params, 'development')


### PR DESCRIPTION
Not forwarding the password was not allowing `security set-key-partition-list` to fail with my keychain name/password combo since the password was always empty string https://github.com/fastlane/fastlane/blob/1ad696f360b937e1881b5ca63e340c86ebe61cf8/fastlane_core/lib/fastlane_core/keychain_importer.rb#L16-L24

Using this in a way to prevent the "codesign allow" popup from showing when importing a new cert with a custom keychain but not passing in the password was preventing this from actually happening.