### PR TITLE
[BuildWatcher] Handle parse error while waiting for build processing

### DIFF
--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -63,6 +63,18 @@ describe FastlaneCore::BuildWatcher do
       )
     end
 
+    it 'continues after receiving internal server error' do
+      expect(Spaceship::TestFlight::Build).to receive(:all_processing_builds).and_return([])
+      expect(Spaceship::TestFlight::Build).to receive(:latest).and_return(ready_build)
+      allow(Spaceship::TestFlight::Build).to receive(:builds_for_train) { raise Faraday::ParsingError, 'Boom!' }
+
+      expect(UI).to receive(:message).with(/Internal server error while querying build status. Number of errors: /).exactly(10).times
+      begin
+        FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
+      rescue
+      end
+    end
+
     it 'returns an already-active build' do
       expect(Spaceship::TestFlight::Build).to receive(:all_processing_builds).and_return([])
       expect(Spaceship::TestFlight::Build).to receive(:latest).and_return(active_build)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR should fix the issue described in https://github.com/fastlane/fastlane/issues/10097 and https://github.com/fastlane/fastlane/issues/10420.

### Description

The suggested approach by @thibaudrobelain in https://github.com/fastlane/fastlane/issues/10097#issuecomment-334335475 might be too generic. As far as I can tell, this only occurs during the loop in [`Build_watcher#wait_for_build_processing_to_be_complete `](https://github.com/fastlane/fastlane/blob/master/fastlane_core/lib/fastlane_core/build_watcher.rb#L10-L19), so I added a rescue statement inside the loop that should handle this error up to 10 times, as suggested by @mpirri.

I'm also happy to move this into [`Client#with_retry`](https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/client.rb#L528-L531).
