### PR TITLE
fix leaking sw_vers

### DIFF
--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -191,7 +191,7 @@ module FastlaneCore
       os = self.operating_system
       case os
       when "macOS"
-        return system('sw_vers') ? `sw_vers -productVersion`.strip : 'unknown'
+        return system('sw_vers', out: File::NULL) ? `sw_vers -productVersion`.strip : 'unknown'
       else
         # Need to test in Windows and Linux... not sure this is enough
         return Gem::Platform.local.version


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
`system('sw_vers')` was leaking output:
```
ProductName:	Mac OS X
ProductVersion:	10.13
BuildVersion:	17A405
```

Simply running `fastlane` shows `sw_vers` info...
### Captured Output

Command Used: `fastlane`
<details><summary>Output/Log</summary>

```
                                                                                                                                                                                                    
[13:08:52]: Get started using a Gemfile for fastlane https://docs.fastlane.tools/getting-started/ios/setup/#use-a-gemfile
ProductName:	Mac OS X
ProductVersion:	10.13
BuildVersion:	17A405
[13:08:54]: Welcome to fastlane! Here's what your app is setup to do:
+--------+-----------------+------------------------------+
|                 Available lanes to run                  |
+--------+-----------------+------------------------------+
| Number | Lane Name       | Description                  |
+--------+-----------------+------------------------------+
| 1      | devices         |                              |
| 0      | cancel          | No selection, exit fastlane! |
+--------+-----------------+------------------------------+
[13:08:54]: Which number would you like run?
0

[!] Run `fastlane` the next time you need to build, test or release your app 🚀


```

</details>