### PR TITLE
Add linter for Swift code

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,7 @@
+disabled_rules:
+  - line_length
+
+custom_rules:
+  equal_sign_whitespace:
+    message: "Expected only one space before and after ="
+    regex: "(([ ]{2,}=)|(=[ ]{2,}))"

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ machine:
 dependencies:
   pre:
     - brew install shellcheck
+    - brew install swiftlint
   override:
     - bundle check || bundle install --jobs=4 --retry=3 --path .bundle
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -15,4 +15,5 @@ test:
   override:
     - bundle exec danger || echo "danger failed, moving on" # for quick, instant feedback of PR body and title
     - bundle exec fastlane test
+    - bundle exec fastlane lint
     - bundle exec danger || echo "danger failed, moving on" # for posting the test results to GitHub

--- a/circle.yml
+++ b/circle.yml
@@ -15,5 +15,4 @@ test:
   override:
     - bundle exec danger || echo "danger failed, moving on" # for quick, instant feedback of PR body and title
     - bundle exec fastlane test
-    - bundle exec fastlane lint
     - bundle exec danger || echo "danger failed, moving on" # for posting the test results to GitHub

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -269,6 +269,7 @@ private_lane :validate_repo do
   ensure_no_debug_code(text: " UI\\.", path: "credentials_manager/lib", extension: ".rb", exclude_dirs: ["\.bundle"])
 
   rubocop
+  swiftlint(strict: true)
 
   # Verifying the --help command
   #

--- a/snapshot/example/ExampleMacOS/AppDelegate.swift
+++ b/snapshot/example/ExampleMacOS/AppDelegate.swift
@@ -13,7 +13,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @IBOutlet weak var window: NSWindow!
 
-
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
     }
@@ -22,6 +21,4 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Insert code here to tear down your application
     }
 
-
 }
-

--- a/snapshot/example/ExampleMacOSUITests/ExampleMacOSUITests.swift
+++ b/snapshot/example/ExampleMacOSUITests/ExampleMacOSUITests.swift
@@ -9,17 +9,17 @@
 import XCTest
 
 class ExampleMacOSUITests: XCTestCase {
-        
+
     override func setUp() {
         super.setUp()
-        
+
         let app = XCUIApplication()
         setupSnapshot(app)
         app.launch()
     }
-    
+
     func testExample() {
         snapshot("0Launch")
     }
-    
+
 }

--- a/snapshot/example/ExampleTVUITests/ExampleTVUITests.swift
+++ b/snapshot/example/ExampleTVUITests/ExampleTVUITests.swift
@@ -19,8 +19,7 @@ class ExampleTVUITests: XCTestCase {
     app.launch()
   }
 
-  func testExample()
-  {
+  func testExample() {
     snapshot("0Launch")
   }
 }

--- a/snapshot/example/ExampleUITests/ExampleUITests.swift
+++ b/snapshot/example/ExampleUITests/ExampleUITests.swift
@@ -10,24 +10,23 @@ import Foundation
 import XCTest
 
 class ExampleUITests: XCTestCase {
-        
+
     override func setUp() {
         super.setUp()
-        
+
         let app = XCUIApplication()
         setupSnapshot(app)
         app.launch()
     }
-    
-    func testExample()
-    {
+
+    func testExample() {
         snapshot("0Launch")
         let tabBar = XCUIApplication().tabBars
         let secondButton = tabBar.buttons.element(boundBy: 1)
 
         XCUIDevice().orientation = UIDeviceOrientation.landscapeLeft
         snapshot("1LandscapeLeft")
-        
+
         secondButton.tap()
         XCUIDevice().orientation = UIDeviceOrientation.landscapeRight
         snapshot("2LandscapeRight")

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -112,7 +112,7 @@ open class Snapshot: NSObject {
         do {
             let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
             let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
-            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location:0, length:launchArguments.characters.count))
+            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.characters.count))
             let results = matches.map { result -> String in
                 (launchArguments as NSString).substring(with: result.range)
             }

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -165,7 +165,7 @@ open class Snapshot: NSObject {
                 throw SnapshotError.cannotDetectUser
             }
 
-            guard let usersDir =  FileManager.default.urls(for: .userDirectory, in: .localDomainMask).first else {
+            guard let usersDir = FileManager.default.urls(for: .userDirectory, in: .localDomainMask).first else {
                 throw SnapshotError.cannotFindHomeDirectory
             }
 

--- a/snapshot/lib/assets/SnapshotHelperXcode8.swift
+++ b/snapshot/lib/assets/SnapshotHelperXcode8.swift
@@ -137,7 +137,7 @@ open class Snapshot: NSObject {
                 return nil
             }
 
-            guard let usersDir =  FileManager.default.urls(for: .userDirectory, in: .localDomainMask).first else {
+            guard let usersDir = FileManager.default.urls(for: .userDirectory, in: .localDomainMask).first else {
                 print("Couldn't find Snapshot configuration files - can't detect `Users` dir")
                 return nil
             }

--- a/snapshot/lib/assets/SnapshotHelperXcode8.swift
+++ b/snapshot/lib/assets/SnapshotHelperXcode8.swift
@@ -86,7 +86,7 @@ open class Snapshot: NSObject {
         do {
             let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
             let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
-            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location:0, length:launchArguments.characters.count))
+            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.characters.count))
             let results = matches.map { result -> String in
                 (launchArguments as NSString).substring(with: result.range)
             }


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
As result of integrating Fastlane Snapshot into my project I found a few linter warnings.

At the moment Fastlane ensures Ruby code style making use of rubocop, but Swift code style is not yet validated.

### Description
Add Swift linter to ensure the code style of Swift code