### PR TITLE
Fix mismatch between match and gym

### DIFF
--- a/fastlane/lib/fastlane/actions/gym.rb
+++ b/fastlane/lib/fastlane/actions/gym.rb
@@ -9,9 +9,7 @@ module Fastlane
       def self.run(values)
         require 'gym'
 
-        unless Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE].to_s == "development"
-          values[:export_method] ||= Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE]
-        end
+        values[:export_method] ||= Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE] || Gym::PackageCommandGeneratorXcode7::DEFAULT_EXPORT_METHOD
 
         if Actions.lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING]
           # Since Xcode 9 you need to explicitly provide the provisioning profile per app target


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
When using `Match Development` from fastfile
And `Gym` without export method. assuming match will pass correct export_method.
Yet there is a mismatch with the `unless development` and the default of Gym which is app-store.

### Description
<!--- Describe your changes in detail -->
https://github.com/fastlane/fastlane/blob/e11dda6e18a64536446adbad665ff7409d786f51/fastlane/lib/fastlane/actions/gym.rb#L12-L14
there is a mismatch with the default export method: https://github.com/fastlane/fastlane/blob/46dc8d6c37e6e5519abb1baa85e3fea0a9873f38/gym/lib/gym/generators/package_command_generator_xcode7.rb#L13
So right now I am getting mismatched result when using match development with gym, when providing no export method, hoping it is set from `match development`

```
[19:08:35]: There seems to be a mismatch between your provided `export_method` in gym
[19:08:35]: and the selected provisioning profiles. You passed the following options:
[19:08:35]:   export_method:      app-store
[19:08:35]:   Bundle identifier:  com.widex.app
[19:08:35]:   Profile name:       match Development com.widex.app
[19:08:35]:   Profile type:       development
[19:08:35]: Make sure to either change the `export_method` passed from your Fastfile or CLI
[19:08:35]: or select the correct provisioning profiles by updating your Xcode project
[19:08:35]: or passing the profiles to use by using match or manually via the `export_options` hash
```

```ruby
lane :build do |options|
  xcversion version: '~> 9'
  scheme = options[:scheme] || ENV['scheme']
  configuration = options[:configuration] || 'Debug'
  type = options[:type] || 'development'
  app_identifier = options[:app_identifier] || ENV['APP_IDENTIFIER']
  git_branch = options[:git_branch] || 'widex'
  if is_jenkins
    setup_jenkins
    FileUtils.rm_rf('../output')
    ENV['FL_BUILDLOG_PATH'] = 'fastlane/logs'
    bump_build_number
    app_identifiers = [
      app_identifier,
      "#{app_identifier}.watchkitapp",
      "#{app_identifier}.watchkitapp.watchkitextension"
    ]
    update_project_team
    match(
      type: type,
      readonly: true,
      git_branch: git_branch,
      app_identifier: app_identifiers
    )
  end
  pods
  gym(
    scheme: scheme,
    configuration: configuration,
    # Commented out on purpose since I would like to avoid this :P export_method: Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE],
    xcargs: "APP_IDENTIFIER=#{app_identifier} -allowProvisioningUpdates",
    export_xcargs: '-allowProvisioningUpdates'
  )
end
```

Notice the missing export_method in Summary for gym:
```
+------------------------------------------------------------------------------------+------------------------------------------------------------------+
|                                                                Summary for gym 2.62.2                                                                 |
+------------------------------------------------------------------------------------+------------------------------------------------------------------+
| scheme                                                                             | appNative                                                     |
| configuration                                                                      | Release                                                          |
| xcargs                                                                             | APP_IDENTIFIER=com.widex.app -allowProvisioningUpdates        |
| export_xcargs                                                                      | -allowProvisioningUpdates                                        |
| export_options.provisioningProfiles.com.widex.app                               | match Development com.widex.app                               |
| export_options.provisioningProfiles.com.widex.app.watchkitapp                   | match Development com.widex.app.watchkitapp                   |
| export_options.provisioningProfiles.com.widex.app.watchkitapp.watchkitextension | match Development com.widex.app.watchkitapp.watchkitextension |
| workspace                                                                          | ./BeyondNative.xcworkspace                                       |
| destination                                                                        | generic/platform=iOS                                             |
| output_name                                                                        | appNative                                                     |
| clean                                                                              | false                                                            |
| output_directory                                                                   | ./output           |
| silent                                                                             | false                                                            |
| skip_package_ipa                                                                   | false                                                            |
| build_path                                                                         | ./output           |
| derived_data_path                                                                  | ./derivedData      |
| result_bundle                                                                      | true                                                             |
| buildlog_path                                                                      | fastlane/logs/gym                                                |
| skip_profile_detection                                                             | false                                                            |
| xcode_path                                                                         | /Applications/Xcode-9.app                                        |
+------------------------------------------------------------------------------------+------------------------------------------------------------------+
```

<details>
 <summary>Output from Jenkins</summary>

```
[19:06:34]: Successfully loaded './fastlane/Matchfile' 📄

+-----------------------+---------------------------------------------------------+
|                   Detected Values from './fastlane/Matchfile'                   |
+-----------------------+---------------------------------------------------------+
| git_url               | snip |
| clone_branch_directly | true                                                    |
| shallow_clone         | true                                                    |
+-----------------------+---------------------------------------------------------+


+-----------------------+--------------------------------------------------------------------------------------------------------+
|                                                    Summary for match 2.62.2                                                    |
+-----------------------+--------------------------------------------------------------------------------------------------------+
| type                  | development                                                                                            |
| readonly              | true                                                                                                   |
| git_branch            | widex                                                                                                  |
| app_identifier        | ["com.widex.app", "com.widex.app.watchkitapp", "com.widex.app.watchkitapp.watchkitextension"] |
| git_url               | snip                                                |
| clone_branch_directly | true                                                                                                   |
| shallow_clone         | true                                                                                                   |
| username              | SNIP                                                                              |
| keychain_name         | login.keychain                                                                                         |
| team_id               | SNIP                                                                                             |
| team_name             | Widex A/S                                                                                              |
| verbose               | false                                                                                                  |
| force                 | false                                                                                                  |
| skip_confirmation     | false                                                                                                  |
| force_for_new_devices | false                                                                                                  |
| skip_docs             | false                                                                                                  |
| platform              | ios                                                                                                    |
+-----------------------+--------------------------------------------------------------------------------------------------------+

[19:06:34]: Cloning remote git repo...
[19:06:34]: Checking out branch widex...
[19:06:35]: 🔓  Successfully decrypted certificates repo
[19:06:35]: Installing certificate...

+-------------------+------------------------------------------------+
|                       Installed Certificate                        |
+-------------------+------------------------------------------------+
| User ID           | 8W76PQUA3Z                                     |
| Common Name       | iPhone Developer: Wassapp Builder (68F952MPSH) |
| Organisation Unit | SNIP                                     |
| Organisation      | Widex A                                        |
| Country           | US                                             |
| Start Datetime    | Oct 10 16:29:32 2017 GMT                       |
| End Datetime      | Oct 10 16:29:32 2018 GMT                       |
+-------------------+------------------------------------------------+

[19:06:36]: Installing provisioning profile...
[19:06:36]: Installing provisioning profile...
[19:06:36]: Installing provisioning profile...

+---------------------+------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
|                                                                              Installed Provisioning Profile                                                                               |
+---------------------+------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
| Parameter           | Environment Variable                           | Value                                                                                                              |
+---------------------+------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
| App Identifier      |                                                | com.widex.app                                                                                                   |
| Type                |                                                | development                                                                                                        |
| Platform            |                                                | ios                                                                                                                |
| Profile UUID        | sigh_com.widex.app_development              | 216b5a2c-6bdd-4a36-80ed-e3f3996d95ac                                                                               |
| Profile Name        | sigh_com.widex.app_development_profile-name | match Development com.widex.app                                                                                 |
| Profile Path        | sigh_com.widex.app_development_profile-path | /Users/cpasbuilder/Library/MobileDevice/Provisioning Profiles/216b5a2c-6bdd-4a36-80ed-e3f3996d95ac.mobileprovision |
| Development Team ID | sigh_com.widex.app_development_team-id      | SNIP                                                                                                         |
+---------------------+------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+


+---------------------+------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
|                                                                                    Installed Provisioning Profile                                                                                     |
+---------------------+------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
| Parameter           | Environment Variable                                       | Value                                                                                                              |
+---------------------+------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
| App Identifier      |                                                            | com.widex.app.watchkitapp                                                                                       |
| Type                |                                                            | development                                                                                                        |
| Platform            |                                                            | ios                                                                                                                |
| Profile UUID        | sigh_com.widex.app.watchkitapp_development              | 33f9f7c6-8d81-46f0-9a17-08ba6378044f                                                                               |
| Profile Name        | sigh_com.widex.app.watchkitapp_development_profile-name | match Development com.widex.app.watchkitapp                                                                     |
| Profile Path        | sigh_com.widex.app.watchkitapp_development_profile-path | /Users/cpasbuilder/Library/MobileDevice/Provisioning Profiles/33f9f7c6-8d81-46f0-9a17-08ba6378044f.mobileprovision |
| Development Team ID | sigh_com.widex.app.watchkitapp_development_team-id      | SNIP                                                                                                         |
+---------------------+------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+


+---------------------+------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
|                                                                                             Installed Provisioning Profile                                                                                              |
+---------------------+------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
| Parameter           | Environment Variable                                                         | Value                                                                                                              |
+---------------------+------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
| App Identifier      |                                                                              | com.widex.app.watchkitapp.watchkitextension                                                                     |
| Type                |                                                                              | development                                                                                                        |
| Platform            |                                                                              | ios                                                                                                                |
| Profile UUID        | sigh_com.widex.app.watchkitapp.watchkitextension_development              | 559d7cba-1dfb-4b8e-84f1-3bb5242a56cf                                                                               |
| Profile Name        | sigh_com.widex.app.watchkitapp.watchkitextension_development_profile-name | match Development com.widex.app.watchkitapp.watchkitextension                                                   |
| Profile Path        | sigh_com.widex.app.watchkitapp.watchkitextension_development_profile-path | /Users/cpasbuilder/Library/MobileDevice/Provisioning Profiles/559d7cba-1dfb-4b8e-84f1-3bb5242a56cf.mobileprovision |
| Development Team ID | sigh_com.widex.app.watchkitapp.watchkitextension_development_team-id      | SNIP                                                                                                         |
+---------------------+------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+

[19:06:36]: All required keys, certificates and provisioning profiles are installed 🙌
[19:06:36]: Setting Provisioning Profile type to 'development'
[19:06:36]: ---------------------------------
[19:06:36]: --- Step: Switch to pods lane ---
[19:06:36]: ---------------------------------
[19:06:36]: Cruising over to lane 'pods' 🚖
[19:06:36]: -----------------------
[19:06:36]: --- Step: cocoapods ---
[19:06:36]: -----------------------
[19:06:37]: $ bundle exec pod install
[19:06:38]: ▸ Analyzing dependencies
[19:06:38]: ▸ Downloading dependencies
[19:06:38]: ▸ Using Changeset (2.1.2)
[19:06:38]: ▸ Using HockeySDK (4.1.6)
[19:06:38]: ▸ Using SwiftSocket (2.0.2)
[19:06:38]: ▸ Generating Pods project
[19:06:38]: ▸ Integrating client projects
[19:06:39]: ▸ Sending stats
[19:06:39]: ▸ Pod installation complete! There are 3 dependencies from the Podfile and 3 total pods installed.
[19:06:39]: Cruising back to lane 'build' 🚘
[19:06:39]: -----------------
[19:06:39]: --- Step: gym ---
[19:06:39]: -----------------
[19:06:39]: Successfully loaded './fastlane/Gymfile' 📄
[19:06:39]: No values defined in './fastlane/Gymfile'
[19:06:39]: Successfully loaded './fastlane/Gymfile' 📄
[19:06:39]: No values defined in './fastlane/Gymfile'
[19:06:39]: $ xcodebuild -list -workspace ./BeyondNative.xcworkspace -configuration Release
[19:06:40]: $ xcodebuild -showBuildSettings -workspace ./BeyondNative.xcworkspace -scheme appNative -configuration Release
[19:06:42]: Detected provisioning profile mapping: {:"com.widex.app"=>"match Development com.widex.app", :"com.widex.app.watchkitapp"=>"match Development com.widex.app.watchkitapp", :"com.widex.app.watchkitapp.watchkitextension"=>"match Development com.widex.app.watchkitapp.watchkitextension"}

+------------------------------------------------------------------------------------+------------------------------------------------------------------+
|                                                                Summary for gym 2.62.2                                                                 |
+------------------------------------------------------------------------------------+------------------------------------------------------------------+
| scheme                                                                             | appNative                                                     |
| configuration                                                                      | Release                                                          |
| xcargs                                                                             | APP_IDENTIFIER=com.widex.app -allowProvisioningUpdates        |
| export_xcargs                                                                      | -allowProvisioningUpdates                                        |
| export_options.provisioningProfiles.com.widex.app                               | match Development com.widex.app                               |
| export_options.provisioningProfiles.com.widex.app.watchkitapp                   | match Development com.widex.app.watchkitapp                   |
| export_options.provisioningProfiles.com.widex.app.watchkitapp.watchkitextension | match Development com.widex.app.watchkitapp.watchkitextension |
| workspace                                                                          | ./BeyondNative.xcworkspace                                       |
| destination                                                                        | generic/platform=iOS                                             |
| output_name                                                                        | appNative                                                     |
| clean                                                                              | false                                                            |
| output_directory                                                                   | ./output           |
| silent                                                                             | false                                                            |
| skip_package_ipa                                                                   | false                                                            |
| build_path                                                                         | ./output           |
| derived_data_path                                                                  | ./derivedData      |
| result_bundle                                                                      | true                                                             |
| buildlog_path                                                                      | fastlane/logs/gym                                                |
| skip_profile_detection                                                             | false                                                            |
| xcode_path                                                                         | /Applications/Xcode-9.app                                        |
+------------------------------------------------------------------------------------+------------------------------------------------------------------+

.........

[19:08:35]: There seems to be a mismatch between your provided `export_method` in gym
[19:08:35]: and the selected provisioning profiles. You passed the following options:
[19:08:35]:   export_method:      app-store
[19:08:35]:   Bundle identifier:  com.widex.app
[19:08:35]:   Profile name:       match Development com.widex.app
[19:08:35]:   Profile type:       development
[19:08:35]: Make sure to either change the `export_method` passed from your Fastfile or CLI
[19:08:35]: or select the correct provisioning profiles by updating your Xcode project
[19:08:35]: or passing the profiles to use by using match or manually via the `export_options` hash
```

</details>
