### PR TITLE
Adds new precheck rule to check for iPhone X.

### DIFF
--- a/precheck/lib/assets/PrecheckfileTemplate
+++ b/precheck/lib/assets/PrecheckfileTemplate
@@ -25,4 +25,5 @@
 # test_words(level: :error)
 # unreachable_urls(level: :error)
 # custom_text(data: ["fabric"], level: :warn)
+# pre_release_apple_sw_hw(level: warn)
 

--- a/precheck/lib/precheck/options.rb
+++ b/precheck/lib/precheck/options.rb
@@ -15,7 +15,8 @@ module Precheck
         FreeStuffIAPRule,
         CustomTextRule,
         CopyrightDateRule,
-        UnreachableURLRule
+        UnreachableURLRule,
+        PreReleaseAppleSoftwareHardware
       ].map(&:new)
     end
 

--- a/precheck/lib/precheck/rules/pre_release_apple_sw_hw.rb
+++ b/precheck/lib/precheck/rules/pre_release_apple_sw_hw.rb
@@ -1,0 +1,28 @@
+require 'precheck/rule'
+require 'precheck/rules/abstract_text_match_rule'
+
+module Precheck
+  class PreReleaseAppleSoftwareHardware < AbstractTextMatchRule
+    def self.key
+      :pre_release_apple_sw_hw
+    end
+
+    def self.env_name
+      "RULE_PRE_RELEASE_APPLE_SW_HW"
+    end
+
+    def self.friendly_name
+      "No words containing pre-release Apple software or hardware"
+    end
+
+    def self.description
+      "mentioning any pre-release Apple software or hardware"
+    end
+
+    def lowercased_words_to_look_for
+      [
+        "iPhone X"
+      ].map(&:downcase)
+    end
+  end
+end


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
  - I've run it but there are some failures with `AnalyticsSession` that seems completely unrelated to this change.
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Tonight we had a rejection with an app of ours with the following reason.

> Please remove all references to pre-release versions of Apple software and hardware from your app and its metadata.
>
> Specifically, your metadata states “Improved iPhone X support.”

This PR aims to add a new rule which could be updated regularly with pre-release Apple software and hardware names.

### Description
I've added a new rule subclassing the existing `AbstractTextMatchRule`. I saw that tests already exist for `AbstractTextMatchRule` and there are no separate test for `TestWordsRule`, so I didn't write any new ones.