### PR TITLE
[fastlane] Add option to generate random password for setup_travis add setup_circle_ci

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_travis.rb
+++ b/fastlane/lib/fastlane/actions/setup_travis.rb
@@ -10,6 +10,10 @@ module Fastlane
 
         # Create a temporary keychain
         password = "" # we don't need a password, as the keychain gets removed after each run anyway
+        if params[:random_password] # random password can be created optionally
+          password = SecureRandom.base64(12)
+        end
+
         keychain_name = "fastlane_tmp_keychain"
         ENV["MATCH_KEYCHAIN_NAME"] = keychain_name
         ENV["MATCH_KEYCHAIN_PASSWORD"] = password
@@ -53,6 +57,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :force,
                                        env_name: "FL_SETUP_TRAVIS_FORCE",
                                        description: "Force setup, even if not executed by travis",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :random_password,
+                                       env_name: "FL_SETUP_TRAVIS_RANDOM_PASSWORD",
+                                       description: "Generate a secure random password when creating keychain",
                                        is_string: false,
                                        default_value: false)
         ]

--- a/fastlane/spec/actions_specs/setup_circle_ci_spec.rb
+++ b/fastlane/spec/actions_specs/setup_circle_ci_spec.rb
@@ -56,7 +56,7 @@ describe Fastlane do
         it "skips the setup process" do
           stub_const("ENV", { "MATCH_KEYCHAIN_NAME" => "anything" })
           expect(Fastlane::UI).to receive(:message).with "Skipping Keychain setup as a keychain was already specified"
-          described_class.setup_keychain
+          described_class.setup_keychain(false)
         end
       end
 
@@ -67,17 +67,17 @@ describe Fastlane do
         end
 
         it "sets the MATCH_KEYCHAIN_NAME env var" do
-          described_class.setup_keychain
+          described_class.setup_keychain(false)
           expect(ENV["MATCH_KEYCHAIN_NAME"]).to eql("fastlane_tmp_keychain")
         end
 
         it "sets the MATCH_KEYCHAIN_PASSWORD env var" do
-          described_class.setup_keychain
+          described_class.setup_keychain(false)
           expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to eql("")
         end
 
         it "sets the MATCH_READONLY env var" do
-          described_class.setup_keychain
+          described_class.setup_keychain(false)
           expect(ENV["MATCH_READONLY"]).to eql("true")
         end
       end


### PR DESCRIPTION

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Cloud CI systems should never leak keychain data but it is possible that they could be attacked and keychains without passwords could leak distribution keys. This is a silm chance but genrating one time passwords for each build using these actions would mitigate this risk. 

### Description
<!--- Describe your changes in detail -->
The current default of a empty string has been respected but an option to enable a random password to be created has been added to both setup_travis and setup_circle_ci.
