### PR TITLE
Fix issue with the order of where values are taken from

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -67,6 +67,14 @@ module FastlaneCore
         # This silently prevents a value from having its value set more than once.
         return unless self.config._values[method_sym].to_s.empty?
 
+        if ENV[self.config.option_for_key(method_sym).env_name].to_s.length > 0
+          # This fixes https://github.com/fastlane/fastlane/issues/10640
+          # where values taken from the config file will take priority over
+          # env variables
+          # https://docs.fastlane.tools/advanced/#priorities-of-parameters-and-options
+          return
+        end
+
         value = arguments.first
         value = yield if value.nil? && block_given?
 


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/10640

Documented here https://docs.fastlane.tools/advanced/#priorities-of-parameters-and-options

This PR doesn't change or add any tests yet

First, I want to have a discussion, as this change probably causes side effects for some setups: It seems like we haven't changed the behavior since many months (or years?), so I'd assume some setups already make "use" of that behavior.

Assuming that's true, and we haven't changed anything in that code for the last year, I'd propose to change the documentation, instead of applying this PR, as both solutions are fine, as long as we're consistent and have the proper documentation for it.