### PR TITLE
[Client] Handle Faraday::ParsingError as part of Client#with_retry logic

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -527,6 +527,7 @@ module Spaceship
     rescue \
         Faraday::Error::ConnectionFailed,
         Faraday::Error::TimeoutError,
+        Faraday::ParsingError, # <h2>Internal Server Error</h2> with content type json
         AppleTimeoutError,
         InternalServerError => ex # New Faraday version: Faraday::TimeoutError => ex
       tries -= 1

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -42,7 +42,8 @@ describe Spaceship::Client do
   describe 'retry' do
     [
       Faraday::Error::TimeoutError,
-      Faraday::Error::ConnectionFailed
+      Faraday::Error::ConnectionFailed,
+      Faraday::ParsingError
     ].each do |thrown|
       it "re-raises when retry limit reached throwing #{thrown}" do
         stub_client_request(thrown, 6, 200, nil)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This is related:

https://github.com/fastlane/fastlane/issues/10097: [pilot] Faraday::ParsingError: [!] 765: unexpected token at `'<!DOCTYPE html><html lang="en">`
https://github.com/fastlane/fastlane/issues/10420: Hit HTML parsing error in Pilot
https://github.com/fastlane/fastlane/pull/10621: [BuildWatcher] Handle parse error while waiting for build processing 
https://github.com/fastlane/fastlane/issues/10088: Pilot fails after successful upload: "Could not set changelog"

### Description

After using the fix proposed in https://github.com/fastlane/fastlane/pull/10621 for a couple of days we ran into https://github.com/fastlane/fastlane/issues/10088, so I think a more general solution might be needed for this, as proposed in https://github.com/fastlane/fastlane/issues/10097#issuecomment-334335475.

The whole reason why this happens is because iTunes Connect is not respecting `Content-Type` and returning HTML in the response, so I'm also not sure if this is something fastlane should handle.

https://github.com/fastlane/fastlane/pull/10621 might not be needed anymore if we decide to handle the error with this instead, because using both fixed would mean retry a lot during `wait_for_build_processing_to_be_complete`.