### PR TITLE
Revert "[BuildWatcher] Handle parse error while waiting for build processing (#10621)"

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -7,24 +7,16 @@ module FastlaneCore
         watched_build = watching_build(app_id: app_id, platform: platform)
         UI.crash!("Could not find a build for app: #{app_id} on platform: #{platform}") if watched_build.nil?
 
-        parse_errors_count = 0
         loop do
-          begin
-            UI.crash!("Internal server error while querying build status. Error threshold met") if parse_errors_count >= 10
+          matched_build = matching_build(watched_build: watched_build, app_id: app_id, platform: platform)
 
-            matched_build = matching_build(watched_build: watched_build, app_id: app_id, platform: platform)
+          report_status(build: matched_build)
 
-            report_status(build: matched_build)
-
-            if matched_build && matched_build.processed?
-              return matched_build
-            end
-
-            sleep poll_interval
-          rescue Faraday::ParsingError
-            parse_errors_count += 1
-            UI.message("Internal server error while querying build status. Number of errors: #{parse_errors_count}")
+          if matched_build && matched_build.processed?
+            return matched_build
           end
+
+          sleep poll_interval
         end
       end
 

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -63,18 +63,6 @@ describe FastlaneCore::BuildWatcher do
       )
     end
 
-    it 'continues after receiving internal server error' do
-      expect(Spaceship::TestFlight::Build).to receive(:all_processing_builds).and_return([])
-      expect(Spaceship::TestFlight::Build).to receive(:latest).and_return(ready_build)
-      allow(Spaceship::TestFlight::Build).to receive(:builds_for_train) { raise Faraday::ParsingError, 'Boom!' }
-
-      expect(UI).to receive(:message).with(/Internal server error while querying build status. Number of errors: /).exactly(10).times
-      begin
-        FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
-      rescue
-      end
-    end
-
     it 'returns an already-active build' do
       expect(Spaceship::TestFlight::Build).to receive(:all_processing_builds).and_return([])
       expect(Spaceship::TestFlight::Build).to receive(:latest).and_return(active_build)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This reverts commit 5bc713691a767dc8afaf5fc1db02bd33147524a7.
See discussion in fastlane/fastlane#10646
