### PR TITLE
Unify param loading

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -208,11 +208,11 @@ module FastlaneCore
       option = verify_options_key!(key)
 
       # Same order as https://docs.fastlane.tools/advanced/#priorities-of-parameters-and-options
-      value = if @values.key? key and !@values[key].nil?
+      value = if @values.key?(key) and !@values[key].nil?
                 @values[key]
               elsif option.env_name and !ENV[option.env_name].nil?
                 ENV[option.env_name].dup
-              elsif self.config_file_options.key? key
+              elsif self.config_file_options.key?(key)
                 self.config_file_options[key]
               else
                 option.default_value

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -14,6 +14,9 @@ module FastlaneCore
     # @return [String] The name of the configuration file (not the path). Optional!
     attr_accessor :config_file_name
 
+    # @return [Hash] Options that were set from a config file using load_configuration_file. Optional!
+    attr_accessor :config_file_options
+
     def self.create(available_options, values)
       UI.user_error!("values parameter must be a hash") unless values.kind_of?(Hash)
       v = values.dup
@@ -43,6 +46,7 @@ module FastlaneCore
     def initialize(available_options, values)
       self.available_options = available_options || []
       self.values = values || {}
+      self.config_file_options = {}
 
       # used for pushing and popping values to provide nesting configuration contexts
       @values_stack = []
@@ -75,14 +79,10 @@ module FastlaneCore
       # Make sure the given value keys exist
       @values.each do |key, value|
         next if key == :trace # special treatment
-        option = option_for_key(key)
-        if option
-          @values[key] = option.auto_convert_value(value)
-          UI.deprecated("Using deprecated option: '--#{key}' (#{option.deprecated})") if option.deprecated
-          option.verify!(@values[key]) # Call the verify block for it too
-        else
-          UI.user_error!("Could not find option '#{key}' in the list of available options: #{@available_options.collect(&:key).join(', ')}")
-        end
+        option = self.verify_options_key!(key)
+        @values[key] = option.auto_convert_value(value)
+        UI.deprecated("Using deprecated option: '--#{key}' (#{option.deprecated})") if option.deprecated
+        option.verify!(@values[key]) # Call the verify block for it too
       end
     end
 
@@ -171,8 +171,28 @@ module FastlaneCore
       return if paths.count == 0
 
       path = paths.first
-      configuration_file = ConfigurationFile.new(self, path, block_for_missing, skip_printing_values)
+      begin
+        configuration_file = ConfigurationFile.new(self, path, block_for_missing, skip_printing_values)
+        options = configuration_file.options
+      rescue FastlaneCore::ConfigurationFile::ExceptionWhileParsingError => e
+        options = e.recovered_options
+        wrapped_exception = e.wrapped_exception
+      end
+
+      # Make sure all the values set in the config file pass verification
+      options.each do |key, val|
+        option = self.verify_options_key!(key)
+        option.verify!(val)
+      end
+
+      # Merge the new options into the old ones, keeping all previously set keys
+      self.config_file_options = options.merge(self.config_file_options)
+
       verify_conflicts # important, since user can set conflicting options in configuration file
+
+      # Now that everything is verified, re-raise an exception that was raised in the config file
+      raise wrapped_exception unless wrapped_exception.nil?
+
       configuration_file
     end
 
@@ -185,33 +205,22 @@ module FastlaneCore
     def fetch(key, ask: true)
       UI.user_error!("Key '#{key}' must be a symbol. Example :app_id.") unless key.kind_of?(Symbol)
 
-      option = option_for_key(key)
-      UI.user_error!("Could not find option for key :#{key}. Available keys: #{@available_options.collect(&:key).join(', ')}") unless option
+      option = verify_options_key!(key)
 
-      value = @values[key]
+      # Same order as https://docs.fastlane.tools/advanced/#priorities-of-parameters-and-options
+      value = if @values.key? key and !@values[key].nil?
+                @values[key]
+              elsif option.env_name and !ENV[option.env_name].nil?
+                ENV[option.env_name].dup
+              elsif self.config_file_options.key? key
+                self.config_file_options[key]
+              else
+                option.default_value
+              end
 
       value = option.auto_convert_value(value)
-
-      # `if value == nil` instead of ||= because false is also a valid value
-      if value.nil? and option.env_name and ENV[option.env_name]
-
-        # We want to inform the user that we took the value
-        # from an environment variable
-        # however we don't print the actual value, as it may contain sensitive information
-        # The user can easily find the actual value by print out the environment
-        UI.verbose("Taking value for '#{key}' from environment variable '#{option.env_name}'")
-
-        value = option.auto_convert_value(ENV[option.env_name].dup)
-        option.verify!(value) if value
-      end
-
-      value = option.default_value if value.nil?
       value = nil if value.nil? and !option.string? # by default boolean flags are false
-
-      return value unless value.nil? # we already have a value
-      return value if option.optional # as this value is not required, just return what we have
-
-      return value unless ask
+      return value unless value.nil? and !option.optional and ask
 
       # fallback to asking
       if Helper.is_test? or !UI.interactive?
@@ -298,5 +307,11 @@ module FastlaneCore
     # Aliases `[key]` to `fetch(key)` because Ruby can do it.
     alias [] fetch
     alias []= set
+
+    def verify_options_key!(key)
+      option = option_for_key(key)
+      UI.user_error!("Could not find option '#{key}' in the list of available options: #{@available_options.collect(&:key).join(', ')}") unless option
+      option
+    end
   end
 end

--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -1,17 +1,31 @@
 module FastlaneCore
   # Responsible for loading configuration files
   class ConfigurationFile
-    # A reference to the actual configuration
-    attr_accessor :config
+    class ExceptionWhileParsingError < RuntimeError
+      attr_reader :wrapped_exception
+      attr_reader :recovered_options
+
+      def initialize(wrapped_ex, options)
+        @wrapped_exception = wrapped_ex
+        @recovered_options = options
+      end
+    end
+
+    # Available keys from the config file
+    attr_accessor :available_keys
+
+    # After loading, contains all the found options
+    attr_accessor :options
 
     # Path to the config file represented by the current object
     attr_accessor :configfile_path
 
-    # @param config [FastlaneCore::Configuration] is stored to save the resulting values
+    # @param config [FastlaneCore::Configuration] is used to gather required information about the configuration
     # @param path [String] The path to the configuration file to use
     def initialize(config, path, block_for_missing, skip_printing_values = false)
-      self.config = config
+      self.available_keys = config.all_keys
       self.configfile_path = path
+      self.options = {}
 
       @block_for_missing = block_for_missing
       content = File.read(path)
@@ -33,6 +47,8 @@ module FastlaneCore
       rescue SyntaxError => ex
         line = ex.to_s.match(/\(eval\):(\d+)/)[1]
         UI.user_error!("Syntax error in your configuration file '#{path}' on line #{line}: #{ex}")
+      rescue => ex
+        raise ExceptionWhileParsingError.new(ex, self.options), "Error while parsing config file at #{path}"
       end
     end
 
@@ -63,9 +79,9 @@ module FastlaneCore
 
     def method_missing(method_sym, *arguments, &block)
       # First, check if the key is actually available
-      if self.config.all_keys.include?(method_sym)
-        # This silently prevents a value from having its value set more than once.
-        return unless self.config._values[method_sym].to_s.empty?
+      return if self.options.key? method_sym
+
+      if self.available_keys.include?(method_sym)
 
         value = arguments.first
         value = yield if value.nil? && block_given?
@@ -101,7 +117,7 @@ module FastlaneCore
           # Nothing specific to do here, if we can't dupe, we just
           # deal with it (boolean values can't be from env variables anyway)
         end
-        self.config[method_sym] = value
+        self.options[method_sym] = value
       else
         # We can't set this value, maybe the tool using this configuration system has its own
         # way of handling this block, as this might be a special block (e.g. ipa block) that's only
@@ -109,7 +125,7 @@ module FastlaneCore
         if @block_for_missing
           @block_for_missing.call(method_sym, arguments, block)
         else
-          self.config[method_sym] = '' # important, since this will raise a good exception for free
+          self.options[method_sym] = '' # important, since this will raise a good exception for free
         end
       end
     end
@@ -149,11 +165,12 @@ module FastlaneCore
     # (once) again. Those values are then merged into the surrounding
     # configuration as the block completes
     def with_a_clean_config_merged_when_complete
-      self.config.push_values!
+      previous_config = self.options.dup
+      self.options = {}
       begin
         yield
       ensure
-        self.config.pop_values!
+        self.options = previous_config.merge(self.options)
       end
     end
   end

--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -79,7 +79,7 @@ module FastlaneCore
 
     def method_missing(method_sym, *arguments, &block)
       # First, check if the key is actually available
-      return if self.options.key? method_sym
+      return if self.options.key?(method_sym)
 
       if self.available_keys.include?(method_sym)
 

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -568,7 +568,7 @@ describe FastlaneCore do
           it "raises an error if this option does not exist" do
             expect do
               @config[:asdfasdf]
-            end.to raise_error "Could not find option for key :asdfasdf. Available keys: cert_name, output, wait_processing_interval"
+            end.to raise_error "Could not find option 'asdfasdf' in the list of available options: cert_name, output, wait_processing_interval"
           end
 
           it "returns the value for the given key if given" do


### PR DESCRIPTION
Mostly did some refactoring. Two main things: 

1. Decoupled the `Configuration` and `ConfigurationFile` classes so that after parsing all parameters that were successfully set are now available as a Hash in `ConfigurationFile`
2. Split the parameters in `Configuration` so that it is possible to differentiate between a parameter passed via CLI (in `values`) and one passed via the `ConfigurationFile` (in `config_file_options`)

This makes it easier and straight forward to model the actual parameter loading order from the [docs](https://docs.fastlane.tools/advanced/#priorities-of-parameters-and-options) in the `fetch` function - it's basically a 1:1 mapping between that list in the docs and the actual code now. 