### PR TITLE
[fastlane core] fix unit tests when Xcode 9.0 not installed

### DIFF
--- a/fastlane_core/spec/analytics/analytics_session_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_session_spec.rb
@@ -42,6 +42,8 @@ describe FastlaneCore::AnalyticsSession do
         expect(session).to receive(:operating_system_version).and_return('10.12')
         expect(session).to receive(:fastfile_id).and_return('')
 
+        expect(FastlaneCore::Helper).to receive(:xcode_version).and_return('9.0.1')
+
         session.action_launched(launch_context: launch_context)
 
         parsed_events = JSON.parse(session.events.to_json)
@@ -164,6 +166,8 @@ describe FastlaneCore::AnalyticsSession do
         expect(session).to receive(:operating_system_version).and_return('10.12').twice
         expect(session).to receive(:fastfile_id).and_return('').twice
 
+        expect(FastlaneCore::Helper).to receive(:xcode_version).and_return('9.0.1').twice
+
         session.action_launched(launch_context: action_1_launch_context)
         session.action_completed(completion_context: action_1_completion_context)
         session.action_launched(launch_context: action_2_launch_context)
@@ -210,6 +214,8 @@ describe FastlaneCore::AnalyticsSession do
       expect(FastlaneCore.session).to receive(:operating_system_version).and_return('10.12')
       expect(FastlaneCore.session).to receive(:session_id).and_return(session_id)
       expect(FastlaneCore.session).to receive(:fastfile_id).and_return('')
+
+      expect(FastlaneCore::Helper).to receive(:xcode_version).and_return('9.0.1')
 
       ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/SwitcherFastfile')
       ff.runner.execute(:lane1, :ios)

--- a/fastlane_core/spec/analytics/fixtures/launched.json
+++ b/fastlane_core/spec/analytics/fixtures/launched.json
@@ -78,7 +78,7 @@
     },
     "primary_target": {
       "name": "build_tool_version",
-      "detail": "Xcode 9.0"
+      "detail": "Xcode 9.0.1"
     },
     "millis_since_epoch": 1507142046000,
     "version": 1


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Several unit tests for Analytics Session have an implicit assumption that Xcode 9.0 is installed; after upgrading to Xcode 9.0.1 this has caused 3 test failures. This change decouples these 3 tests from the actual Xcode version installed.

### Description
<!--- Describe your changes in detail -->
To do this, we mock out the `FastlaneCore::Helper` `xcode_version` method to always return the exact string that is in our test fixture.
