### PR TITLE
[Build] Add retry_count to #all_processing_builds

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -23,7 +23,7 @@ module FastlaneCore
       private
 
       def watching_build(app_id: nil, platform: nil)
-        processing_builds = Spaceship::TestFlight::Build.all_processing_builds(app_id: app_id, platform: platform)
+        processing_builds = Spaceship::TestFlight::Build.all_processing_builds(app_id: app_id, platform: platform, retry_count: 2)
 
         watched_build = processing_builds.sort_by(&:upload_date).last
         watched_build || Spaceship::TestFlight::Build.latest(app_id: app_id, platform: platform)

--- a/spaceship/lib/spaceship/test_flight/build.rb
+++ b/spaceship/lib/spaceship/test_flight/build.rb
@@ -80,8 +80,8 @@ module Spaceship::TestFlight
       self.new(attrs)
     end
 
-    def self.all(app_id: nil, platform: nil)
-      trains = BuildTrains.all(app_id: app_id, platform: platform)
+    def self.all(app_id: nil, platform: nil, retry_count: 0)
+      trains = BuildTrains.all(app_id: app_id, platform: platform, retry_count: retry_count)
       trains.values.flatten
     end
 
@@ -91,8 +91,8 @@ module Spaceship::TestFlight
     end
 
     # Just the builds, as a flat array, that are still processing
-    def self.all_processing_builds(app_id: nil, platform: nil)
-      all(app_id: app_id, platform: platform).find_all(&:processing?)
+    def self.all_processing_builds(app_id: nil, platform: nil, retry_count: 0)
+      all(app_id: app_id, platform: platform, retry_count: retry_count).find_all(&:processing?)
     end
 
     def self.latest(app_id: nil, platform: nil)

--- a/spaceship/lib/spaceship/test_flight/build_trains.rb
+++ b/spaceship/lib/spaceship/test_flight/build_trains.rb
@@ -9,11 +9,11 @@ module Spaceship::TestFlight
     #
     # See `Spaceship::TestFlight::Build#reload`
 
-    def self.all(app_id: nil, platform: nil)
+    def self.all(app_id: nil, platform: nil, retry_count: 0)
       data = client.get_build_trains(app_id: app_id, platform: platform)
       trains = {}
       data.each do |train_version|
-        builds_data = client.get_builds_for_train(app_id: app_id, platform: platform, train_version: train_version)
+        builds_data = client.get_builds_for_train(app_id: app_id, platform: platform, train_version: train_version, retry_count: retry_count)
         trains[train_version] = builds_data.map { |attrs| Build.new(attrs) }
       end
 

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -79,6 +79,15 @@ describe Spaceship::TestFlight::Client do
       subject.get_builds_for_train(app_id: app_id, platform: platform, train_version: '1.0')
       expect(WebMock).to have_requested(:get, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/platforms/ios/trains/1.0/builds')
     end
+
+    it 'retries requests' do
+      allow(subject).to receive(:request) { raise Faraday::ParsingError, 'Boom!' }
+      expect(subject).to receive(:request).exactly(2).times
+      begin
+        subject.get_builds_for_train(app_id: app_id, platform: platform, train_version: '1.0', retry_count: 2)
+      rescue
+      end
+    end
   end
 
   ##


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Same motivations and context explained in https://github.com/fastlane/fastlane/pull/9331

Today fastlane raised `Spaceship::Client::UnexpectedResponse` with the following trace:

```
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/spaceship/lib/spaceship/test_flight/client.rb:227:in `handle_response'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/spaceship/lib/spaceship/test_flight/client.rb:27:in `get_build_trains'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/spaceship/lib/spaceship/test_flight/build_trains.rb:13:in `all'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/spaceship/lib/spaceship/test_flight/build.rb:84:in `all'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/spaceship/lib/spaceship/test_flight/build.rb:95:in `all_processing_builds'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane_core/lib/fastlane_core/build_watcher.rb:26:in `watching_build'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane_core/lib/fastlane_core/build_watcher.rb:7:in `wait_for_build_processing_to_be_complete'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/pilot/lib/pilot/build_manager.rb:38:in `upload'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/actions/pilot.rb:16:in `run'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/runner.rb:256:in `block (2 levels) in execute_action'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/actions/actions_helper.rb:50:in `execute_action'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/runner.rb:234:in `block in execute_action'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/runner.rb:230:in `chdir'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/runner.rb:230:in `execute_action'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/runner.rb:148:in `trigger_action_by_name'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/fast_file.rb:146:in `method_missing'
  Fastfile:67:in `block (2 levels) in parsing_binding'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/lane.rb:33:in `call'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/lane.rb:33:in `call'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/runner.rb:49:in `block in execute'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/runner.rb:45:in `chdir'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/runner.rb:45:in `execute'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/lane_manager.rb:54:in `cruise_lane'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/command_line_handler.rb:30:in `handle'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/commands_generator.rb:104:in `block (2 levels) in run'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/commander-fastlane-4.4.5/lib/commander/command.rb:178:in `call'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/commander-fastlane-4.4.5/lib/commander/command.rb:178:in `call'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/commander-fastlane-4.4.5/lib/commander/command.rb:153:in `run'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/commander-fastlane-4.4.5/lib/commander/runner.rb:476:in `run_active_command'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:66:in `run!'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/commander-fastlane-4.4.5/lib/commander/delegates.rb:15:in `run!'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/commands_generator.rb:303:in `run'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/commands_generator.rb:42:in `start'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/fastlane/lib/fastlane/cli_tools_distributor.rb:66:in `take_off'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/fastlane-04a84564ed32/bin/fastlane:20:in `<top (required)>'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/fastlane:23:in `load'
  /Users/bldadmin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/fastlane:23:in `<top (required)>'
```

The retry logic implemented in https://github.com/fastlane/fastlane/pull/9331 helps with `FastlaneCore::BuildWatcher#matching_build`, but not with `#watching_build`.

### Description

This PR adds `retry_count` argument to `Spaceship::TestFlight::Build#all_processing_builds`