### PR TITLE
[FrameIt] Add missing HTML tag

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/frameit.md
+++ b/fastlane/lib/fastlane/actions/docs/frameit.md
@@ -44,7 +44,7 @@ Here is a nice gif, that shows ``_frameit_`` in action:
 
 ![img/actions/MacExample.png](/img/actions/MacExample.png?raw=1)
 
-<h5 align="center">The <code>frameit</code> 2.0 update was kindly sponsored by <a href="https://mindnode.com/">MindNode</a>, seen in the screenshots above.
+<h5 align="center">The <code>frameit</code> 2.0 update was kindly sponsored by <a href="https://mindnode.com/">MindNode</a>, seen in the screenshots above.</h5>
 
 
 The first time that ``_frameit_`` is executed the frames will be downloaded automatically. Originally the frames are coming from [Facebook frameset](http://facebook.design/devices) and they are kept on this repo: https://github.com/fastlane/frameit-frames


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<img width="1394" alt="31797117-ec8df484-b52c-11e7-8b13-a05cf30b4f43" src="https://user-images.githubusercontent.com/2320840/31831805-0eae4396-b5c5-11e7-9aec-c2423a484938.png">

### Description
Fix [FrameIt documentation](https://docs.fastlane.tools/actions/frameit/) adding a missing HTML tag.
