### PR TITLE
Version bump to 2.62.1

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.62.0'.freeze
+  VERSION = '2.62.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
 end


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.62.0':**

* Dont count lane switches in metrics (#10659) via David Ohayon
* Add missing html tag (#10657) via David Cordero
* Deprecates add_id_info_limits_tracking in favor of add_id_info_uses_idfa (#10653) via Jorge
* [fastlane core] fix unit tests when Xcode 9.0 not installed (#10655) via Mark Pirri
* Add automatic commiting of mkdocs.yml for docs generation (#10578) via Felix Krause
* [Client] Handle Faraday::ParsingError as part of Client#with_retry logic (#10646) via Renzo
* Revert "[BuildWatcher] Handle parse error while waiting for build processing (#10621)" (#10647) via Renzo
* [BuildWatcher] Handle parse error while waiting for build processing (#10621) via Renzo
* Remove 'zip' example from update_info_plist (#10494) via Sahil Bajaj
* Make plugin details optional (#10628) via Felix Krause
* fix leaking sw_vers (#10630) via Joseph Petersen
* Update snapshot instructions (#10626) via Felix Krause
* Update update instructions of snapshot (#10627) via Felix Krause
* Don't add unneeded new-line when asking for user input (#10629) via Felix Krause
* Forward match keychain password into cert (#10619) via Josh Holtz
* SW_VERS should be lowercase (#10625) via David Ohayon
