### PR TITLE
issue template fix

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,8 +7,8 @@
 
 ### Issue Description
 
-<!--- Complete output when running fastlane, including the stack trace and command used
-You can use: `--capture_output` as the last commandline argument to get that collected for you--->
+##### Complete output when running fastlane, including the stack trace and command used
+<!--- You can use: `--capture_output` as the last commandline argument to get that collected for you--->
 
 [INSERT OUTPUT HERE]
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,14 +7,14 @@
 
 ### Issue Description
 
-##### Complete output when running fastlane, including the stack trace and command used
-> You can use: `--capture_output` as the last commandline argument to get that collected for you
+<!--- Complete output when running fastlane, including the stack trace and command used
+You can use: `--capture_output` as the last commandline argument to get that collected for you--->
 
 [INSERT OUTPUT HERE]
 
 ### Environment
 
-Please run `fastlane env` and copy the output below. This will help us help you :+1:
-If you used `--capture_output` option please remove this block - as it is already included there.
+<!--- Please run `fastlane env` and copy the output below. This will help us help you :+1:
+If you used `--capture_output` option please remove this block - as it is already included there.--->
 
 [INSERT OUTPUT HERE]


### PR DESCRIPTION
In the current ISSUE_TEMPLATE.md there are some instructions for the issue author. Those instructions need to be deleted by author every time. We can add those instructions as commented code instead. This PR achieves that. Hope to get this merged. 👍

Followup of existing PR: https://github.com/fastlane/fastlane/pull/10437