### PR TITLE
Don't cache pem options (needed to reevaluated defaults)

### DIFF
--- a/fastlane/lib/fastlane/actions/pem.rb
+++ b/fastlane/lib/fastlane/actions/pem.rb
@@ -46,13 +46,11 @@ module Fastlane
         require 'pem'
         require 'pem/options'
 
-        unless @options
-          @options = PEM::Options.available_options
-          @options << FastlaneCore::ConfigItem.new(key: :new_profile,
-                                       description: "Block that is called if there is a new profile",
-                                       optional: true,
-                                       is_string: false)
-        end
+        @options = PEM::Options.available_options
+        @options << FastlaneCore::ConfigItem.new(key: :new_profile,
+                                     description: "Block that is called if there is a new profile",
+                                     optional: true,
+                                     is_string: false)
         @options
       end
 

--- a/pem/lib/pem/options.rb
+++ b/pem/lib/pem/options.rb
@@ -5,9 +5,7 @@ module PEM
   class Options
     def self.available_options
       user = CredentialsManager::AppfileConfig.try_fetch_value(:apple_dev_portal_id)
-      puts "user 1: #{user}"
       user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
-      puts "user 2: #{user}"
 
       [
         FastlaneCore::ConfigItem.new(key: :development,

--- a/pem/lib/pem/options.rb
+++ b/pem/lib/pem/options.rb
@@ -5,7 +5,9 @@ module PEM
   class Options
     def self.available_options
       user = CredentialsManager::AppfileConfig.try_fetch_value(:apple_dev_portal_id)
+      puts "user 1: #{user}"
       user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
+      puts "user 2: #{user}"
 
       [
         FastlaneCore::ConfigItem.new(key: :development,


### PR DESCRIPTION
### Problem
Couldn't run `pem` twice in one run with different iOS developer accounts. The first username/email was always being used when trying to log in no matter what.

Only evaluating this once... https://github.com/fastlane/fastlane/blob/6dd5fb455e89f387c285ab430f0ddf7ada41e96b/pem/lib/pem/options.rb#L7-L8
Because of... https://github.com/fastlane/fastlane/blob/6dd5fb455e89f387c285ab430f0ddf7ada41e96b/fastlane/lib/fastlane/actions/pem.rb#L49

### Solution 
💣 the `unless`