### PR TITLE
Pin rubocop in new plugins to the same version as the main repo.

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -81,7 +81,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard', '~> 0.8.7.4'
   spec.add_development_dependency 'webmock', '~> 2.3.2'
   spec.add_development_dependency 'coveralls', '~> 0.8.13'
-  spec.add_development_dependency 'rubocop', '0.49.1'
+  spec.add_development_dependency 'rubocop', Fastlane::RUBOCOP_REQUIREMENT
   spec.add_development_dependency 'rb-readline' # https://github.com/deivid-rodriguez/byebug/issues/289#issuecomment-251383465
   spec.add_development_dependency 'rest-client', '>= 1.8.0'
   spec.add_development_dependency 'fakefs', '~> 0.8.1'

--- a/fastlane/lib/fastlane/plugins/template/%gem_name%.gemspec.erb
+++ b/fastlane/lib/fastlane/plugins/template/%gem_name%.gemspec.erb
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '<%= Fastlane::RUBOCOP_REQUIREMENT %>'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'fastlane', '>= <%= Fastlane::VERSION %>'
 end

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -2,4 +2,5 @@ module Fastlane
   VERSION = '2.62.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
+  RUBOCOP_REQUIREMENT = '0.49.1'.freeze
 end

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -1,4 +1,3 @@
-require 'fastlane/plugins/plugin_info'
 require 'rubygems'
 
 initialized = false

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -1,3 +1,4 @@
+require 'fastlane/plugins/plugin_info'
 require 'rubygems'
 
 initialized = false
@@ -224,7 +225,7 @@ describe Fastlane::PluginGenerator do
           Gem::Dependency.new("bundler", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("rspec", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("rake", Gem::Requirement.new([">= 0"]), :development),
-          Gem::Dependency.new("rubocop", Gem::Requirement.new([">= 0"]), :development),
+          Gem::Dependency.new("rubocop", Gem::Requirement.new([Fastlane::RUBOCOP_REQUIREMENT]), :development),
           Gem::Dependency.new("simplecov", Gem::Requirement.new([">= 0"]), :development),
           Gem::Dependency.new("fastlane", Gem::Requirement.new([">= #{Fastlane::VERSION}"]), :development)
         )


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Whenever a new minor version of RuboCop is released, new Cops are added, and Cops often change namespaces, generating warnings and errors from RuboCop. This is avoided in the main repo by pinning to a specific version of RuboCop, but the plugin template does not include the same version requirement. The same .rubocop.yml is used in both places. The result is often that in a new plugin, the most recent version of RuboCop is installed, and the generated code doesn't pass with the .rubocop.yml from the repo. The simplest solution seems to be pinning new plugins to the same version as the repo.

### Description

Added a `Fastlane::RUBOCOP_REQUIREMENT` constant, used in `fastlane.gemspec`, plugin generator tests and the plugin template itself. This is probably the simplest solution.

Originally I was pulling it out of the gemspec, but that is not present when installed via RubyGems.