### PR TITLE
Don't let users know twice that they've used a tool name as a lane name

### DIFF
--- a/fastlane/lib/fastlane/lane.rb
+++ b/fastlane/lib/fastlane/lane.rb
@@ -51,6 +51,7 @@ module Fastlane
           UI.error "It is recommended to not use '#{name}' as the name of your lane"
           # We still allow it, because we're nice
           # Otherwise we might break existing setups
+          return
         end
 
         self.ensure_name_not_conflicts(name.to_s)

--- a/fastlane/spec/tools_spec.rb
+++ b/fastlane/spec/tools_spec.rb
@@ -14,7 +14,6 @@ describe Fastlane do
       ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/Fastfile1')
       expect(UI).to receive(:error).with("Lane name 'gym' should not be used because it is the name of a fastlane tool")
       expect(UI).to receive(:error).with("It is recommended to not use 'gym' as the name of your lane")
-      expect(UI).to receive(:important).with("Name of the lane 'gym' is already taken by the action named 'gym'")
       ff.lane :gym do
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Currently, if a user has a lane with the same name as a tool, they get two warnings, for instance assume a lane named `:pilot`:

Current behavior:
```
$ bundle exec fastlane pilot
[11:39:34]: Lane name 'pilot' should not be used because it is the name of a fastlane tool
[11:39:34]: It is recommended to not use 'pilot' as the name of your lane
[11:39:34]: Name of the lane 'pilot' is already taken by the action named 'pilot'
[11:39:34]: Driving the lane 'pilot' 🚀
...
```

New behavior:
```
$ bundle exec fastlane pilot
[11:40:16]: Lane name 'pilot' should not be used because it is the name of a fastlane tool
[11:40:16]: It is recommended to not use 'pilot' as the name of your lane
[11:40:16]: Driving the lane 'pilot' 🚀
...
```
