### PR TITLE
In two-stage Hockey action, do not set the status to 2 (downloadable) until after the app is uploaded

### DIFF
--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -82,8 +82,8 @@ module Fastlane
 
         # https://support.hockeyapp.net/discussions/problems/83559
         # Should not set status to "2" (downloadable) until after the app is uploaded.
-        final_status = options[:status]
-        options[:status] = "1"
+        update_status = options[:status]
+        options[:status] = options[:create_status]
 
         response = connection.get do |req|
           req.url("/api/2/apps/#{app_id}/app_versions/new")
@@ -105,7 +105,7 @@ module Fastlane
           options[:dsym] = dsym_io
         end
 
-        options[:status] = final_status
+        options[:status] = update_status
 
         connection.put do |req|
           req.options.timeout = options.delete(:timeout)
@@ -245,6 +245,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :status,
                                        env_name: "FL_HOCKEY_STATUS",
                                        description: "Download status: \"1\" = No user can download; \"2\" = Available for download (only possible with full-access token)",
+                                       default_value: "2"),
+          FastlaneCore::ConfigItem.new(key: :create_status,
+                                       env_name: "FL_HOCKEY_CREATE_STATUS",
+                                       description: "Download status for initial version creation when create_update is true: \"1\" = No user can download; \"2\" = Available for download (only possible with full-access token)",
                                        default_value: "2"),
           FastlaneCore::ConfigItem.new(key: :notes_type,
                                       env_name: "FL_HOCKEY_NOTES_TYPE",

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -81,7 +81,8 @@ module Fastlane
         end
 
         # https://support.hockeyapp.net/discussions/problems/83559
-        # Should not set status to "2" (downloadable) until after the app is uploaded.
+        # Should not set status to "2" (downloadable) until after the app is uploaded, so allow the caller
+        # to specify a different status for the `create` step
         update_status = options[:status]
         options[:status] = options[:create_status]
 

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -80,6 +80,11 @@ module Fastlane
           dsym_io = Faraday::UploadIO.new(dsym, 'application/octet-stream') if dsym and File.exist?(dsym)
         end
 
+        # https://support.hockeyapp.net/discussions/problems/83559
+        # Should not set status to "2" (downloadable) until after the app is uploaded.
+        final_status = options[:status]
+        options[:status] = "1"
+
         response = connection.get do |req|
           req.url("/api/2/apps/#{app_id}/app_versions/new")
           req.headers['X-HockeyAppToken'] = api_token
@@ -99,6 +104,8 @@ module Fastlane
         if dsym
           options[:dsym] = dsym_io
         end
+
+        options[:status] = final_status
 
         connection.put do |req|
           req.options.timeout = options.delete(:timeout)

--- a/fastlane/spec/actions_specs/hockey_spec.rb
+++ b/fastlane/spec/actions_specs/hockey_spec.rb
@@ -64,6 +64,7 @@ describe Fastlane do
 
         expect(values[:notify]).to eq(1.to_s)
         expect(values[:status]).to eq(2.to_s)
+        expect(values[:create_status]).to eq(2.to_s)
         expect(values[:notes]).to eq("No changelog given")
         expect(values[:release_type]).to eq(0.to_s)
         expect(values.key?(:tags)).to eq(false)
@@ -117,6 +118,7 @@ describe Fastlane do
 
         expect(values[:notify]).to eq("1")
         expect(values[:status]).to eq("2")
+        expect(values[:create_status]).to eq(2.to_s)
         expect(values[:notes]).to eq("No changelog given")
         expect(values[:release_type]).to eq("0")
         expect(values.key?(:tags)).to eq(false)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

When using the two-stage Hockey upload process (create a new version and then upload app assets to the newly created version), you should not set the version's status to "2" -- which means it's downloadable -- until you've uploaded the app.

My understanding from my [Hockey support request](https://support.hockeyapp.net/discussions/problems/83559) is that  Hockey will only fire "New Release" webhooks when a version's status is first set to "2" _iff_ there's an app to download.

I've tested these changes with my app, and Hockey correctly fires the "Release" webhook. Before this change, that webhook doesn't fire.

### Description
<!--- Describe your changes in detail -->

Before creating the new version, we save the fastlane user's requested `status` and set the status to `"1"` ([Don't allow users to download or install the version](https://support.hockeyapp.net/kb/api/api-versions#-u-post-api-2-apps-app_id-app_versions-new-u-)). Then, when uploading the app, set `status` back to the user's requested status.
