### PR TITLE
Add support for reset rating

### DIFF
--- a/spaceship/docs/iTunesConnect.md
+++ b/spaceship/docs/iTunesConnect.md
@@ -129,6 +129,7 @@ attr_accessor :can_reject_version
 attr_accessor :can_prepare_for_upload
 attr_accessor :can_send_version_live
 attr_accessor :release_on_approval
+attr_accessor :ratings_reset
 attr_accessor :can_beta_test
 attr_accessor :supports_apple_watch
 attr_accessor :app_icon_url

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -50,6 +50,9 @@ module Spaceship
       #   for release_on_approval to be used.
       attr_accessor :auto_release_date
 
+      # @return (Bool) Should the rating of the app be reset?
+      attr_accessor :ratings_reset
+
       # @return (Bool)
       attr_accessor :can_beta_test
 
@@ -208,6 +211,7 @@ module Spaceship
         'largeAppIcon.value.url' => :app_icon_url,
         'releaseOnApproval.value' => :release_on_approval,
         'autoReleaseDate.value' => :auto_release_date,
+        'ratingsReset.value' => :ratings_reset,
         'status' => :raw_status,
         'preReleaseBuild.buildVersion' => :build_version,
         'supportsAppleWatch' => :supports_apple_watch,

--- a/spaceship/spec/tunes/app_version_spec.rb
+++ b/spaceship/spec/tunes/app_version_spec.rb
@@ -23,6 +23,7 @@ describe Spaceship::AppVersion, all: true do
       expect(version.can_send_version_live).to eq(false)
       expect(version.release_on_approval).to eq(true)
       expect(version.auto_release_date).to eq(nil)
+      expect(version.ratings_reset).to eq(false)
       expect(version.can_beta_test).to eq(true)
       expect(version.version).to eq('0.9.13')
       expect(version.supports_apple_watch).to eq(false)

--- a/spaceship/spec/tunes/fixtures/app_version.json
+++ b/spaceship/spec/tunes/fixtures/app_version.json
@@ -825,6 +825,12 @@
             "isEditable": false,
             "isRequired": false,
             "errorKeys": null
+        },
+        "ratingsReset": {
+            "value": false,
+            "isEditable": false,
+            "isRequired": false,
+            "errorKeys": null
         }
     },
     "messages": {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
This fixes issue #10422 
### Description
<!--- Describe your changes in detail -->
As title, it add support of the recent feature for resetting or not the rating of an app in iTunesConnect