### PR TITLE
[Spaceship] Support all review screenshot resolutions - iOS In App Purchases

### DIFF
--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -44,11 +44,11 @@ module Spaceship
 
     def get_picture_type(upload_file)
       resolution = Utilities.resolution(upload_file.file_path)
-      result = device_resolution_map.find { |key, resolutions| 
+      result = device_resolution_map.find do |key, resolutions|
         resolutions.include? resolution
-      }
-      raise "Unknown device for screen resolution #{resolution}" unless result != nil
-      
+      end
+      raise "Unknown device for screen resolution #{resolution}" if result.nil?
+
       picture_type_map[result[0]]
     end
 

--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -47,7 +47,7 @@ module Spaceship
       result = device_resolution_map.find { |key, resolutions| 
         resolutions.include? resolution
       }
-      raise "Unknown picture type for resolution #{resolution}" unless result != nil
+      raise "Unknown device for screen resolution #{resolution}" unless result != nil
       
       picture_type_map[result[0]]
     end

--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -19,7 +19,7 @@ module Spaceship
     end
 
     def upload_purchase_review_screenshot(app_id, upload_file, content_provider_id, sso_token_for_image)
-      upload_file(app_id: app_id, upload_file: upload_file, path: '/upload/image', content_provider_id: content_provider_id, sso_token: sso_token_for_image, du_validation_rule_set: 'MZPFT.SortedScreenShot')
+      upload_file(app_id: app_id, upload_file: upload_file, path: '/upload/image', content_provider_id: content_provider_id, sso_token: sso_token_for_image, du_validation_rule_set: get_picture_type(upload_file))
     end
 
     def upload_large_icon(app_version, upload_file, content_provider_id, sso_token_for_image)
@@ -40,6 +40,16 @@ module Spaceship
 
     def upload_trailer_preview(app_version, upload_file, content_provider_id, sso_token_for_image, device)
       upload_file(app_version: app_version, upload_file: upload_file, path: '/upload/image', content_provider_id: content_provider_id, sso_token: sso_token_for_image, du_validation_rule_set: screenshot_picture_type(device, nil))
+    end
+
+    def get_picture_type(upload_file)
+      resolution = Utilities.resolution(upload_file.file_path)
+      result = device_resolution_map.find { |key, resolutions| 
+        resolutions.include? resolution
+      }
+      raise "Unknown picture type for resolution #{resolution}" unless result != nil
+      
+      picture_type_map[result[0]]
     end
 
     private
@@ -108,6 +118,21 @@ module Spaceship
         iphone6:      "MZPFT.SortedN61MessagesScreenShot",
         iphone6Plus:  "MZPFT.SortedN56MessagesScreenShot",
         iphone4:      "MZPFT.SortedN41MessagesScreenShot"
+      }
+    end
+
+    def device_resolution_map
+      # rubocop:enable Layout/ExtraSpacing
+      {
+        watch:        [[312, 390]],
+        ipad:         [[1024, 748], [1024, 768], [2048, 1496], [2048, 1536], [768, 1004], [768, 1024], [1536, 2008], [1536, 2048]],
+        ipadPro:      [[2048, 2732], [2732, 2048]],
+        iphone6:      [[750, 1334], [1334, 750]],
+        iphone6Plus:  [[1242, 2208], [2208, 1242]],
+        iphone4:      [[640, 1096], [640, 1136], [1136, 600], [1136, 640]],
+        iphone35:     [[640, 960], [640, 920], [960, 600], [960, 640]],
+        appleTV:      [[1920, 1080]],
+        desktop:      [[1280, 800], [1440, 900], [2560, 1600], [2880, 1800]]
       }
     end
 

--- a/spaceship/lib/spaceship/tunes/iap_detail.rb
+++ b/spaceship/lib/spaceship/tunes/iap_detail.rb
@@ -186,20 +186,7 @@ module Spaceship
           # Upload Screenshot
           upload_file = UploadFile.from_path @review_screenshot
           screenshot_data = client.upload_purchase_review_screenshot(application.apple_id, upload_file)
-          new_screenshot = {
-            "value" => {
-              "assetToken" => screenshot_data["token"],
-              "sortOrder" => 0,
-              "type" => "SortedScreenShot",
-              "originalFileName" => upload_file.file_name,
-              "size" => screenshot_data["length"],
-              "height" => screenshot_data["height"],
-              "width" => screenshot_data["width"],
-              "checksum" => screenshot_data["md5"]
-            }
-          }
-
-          raw_data["versions"][0]["reviewScreenshot"] = new_screenshot
+          raw_data["versions"][0]["reviewScreenshot"] = screenshot_data
         end
         # Update the Purchase
         client.update_iap!(app_id: application.apple_id, purchase_id: self.purchase_id, data: raw_data)

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -661,9 +661,21 @@ module Spaceship
     # Uploads an In-App-Purchase Review screenshot
     # @param app_id (AppId): The id of the app
     # @param upload_image (UploadFile): The icon to upload
-    # @return [JSON] the response
+    # @return [JSON] the screenshot data, ready to be added to an In-App-Purchase
     def upload_purchase_review_screenshot(app_id, upload_image)
-      du_client.upload_purchase_review_screenshot(app_id, upload_image, content_provider_id, sso_token_for_image)
+      data = du_client.upload_purchase_review_screenshot(app_id, upload_image, content_provider_id, sso_token_for_image)
+      {
+          "value" => {
+              "assetToken" => data["token"],
+              "sortOrder" => 0,
+              "type" => du_client.get_picture_type(upload_image),
+              "originalFileName" => upload_image.file_name,
+              "size" => data["length"],
+              "height" => data["height"],
+              "width" => data["width"],
+              "checksum" => data["md5"]
+          }
+      }
     end
 
     # Uploads a screenshot
@@ -1147,20 +1159,7 @@ module Spaceship
         # Upload Screenshot:
         upload_file = UploadFile.from_path review_screenshot
         screenshot_data = upload_purchase_review_screenshot(app_id, upload_file)
-        new_screenshot = {
-          "value" => {
-            "assetToken" => screenshot_data["token"],
-            "sortOrder" => 0,
-            "type" => "SortedScreenShot",
-            "originalFileName" => upload_file.file_name,
-            "size" => screenshot_data["length"],
-            "height" => screenshot_data["height"],
-            "width" => screenshot_data["width"],
-            "checksum" => screenshot_data["md5"]
-          }
-        }
-
-        data["versions"][0]["reviewScreenshot"] = new_screenshot
+        data["versions"][0]["reviewScreenshot"] = screenshot_data
       end
 
       # Now send back the modified hash

--- a/spaceship/spec/tunes/iap_detail_spec.rb
+++ b/spaceship/spec/tunes/iap_detail_spec.rb
@@ -98,6 +98,7 @@ describe Spaceship::Tunes::IAPDetail do
     it "saved and changed screenshot" do
       detailed.review_screenshot = "/tmp/fastlane_tests"
       expect(client.du_client).to receive(:upload_purchase_review_screenshot).and_return({ "token" => "tok", "height" => 100, "width" => 200, "md5" => "xxxx" })
+      expect(client.du_client).to receive(:get_picture_type).and_return("MZPFT.SortedScreenShot")
       expect(Spaceship::Utilities).to receive(:content_type).and_return("image/jpg")
       expect(client).to receive(:update_iap!).with(app_id: '898536088', purchase_id: "1195137656", data: detailed.raw_data)
       detailed.save!

--- a/spaceship/spec/tunes/iap_spec.rb
+++ b/spaceship/spec/tunes/iap_spec.rb
@@ -21,6 +21,7 @@ describe Spaceship::Tunes::IAP do
 
     describe "Create new IAP" do
       it "create consumable" do
+        expect(client.du_client).to receive(:get_picture_type).and_return("SortedScreenShot")
         expect(client.du_client).to receive(:upload_purchase_review_screenshot).and_return({ "token" => "tok", "height" => 100, "width" => 200, "md5" => "xxxx" })
         expect(Spaceship::UploadFile).to receive(:from_path).with("ftl_FAKEMD5_screenshot1024.jpg").and_return(du_uploadimage_correct_screenshot)
         app.in_app_purchases.create!(


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
In App Purchases in Spaceship required always to provide iPhone4 review screenshots, which was cumbersome to the user. This PR introduces support for all supported devices and exposes a way to retrieve the correct Apple validation rule given the screenshot file. 

It fixes this issue: https://github.com/fastlane/fastlane/issues/10713

I've updated the unit tests and tested the changes locally with the most common screen resolutions, including iPhone 6 plus, iPhone 6, iPad and iPad Pro. I also tested using screens without the status bar area (normally 40px less in height) and in portrait modes.

### Description
I've introduced a new public method in du_client.rb:  `get_picture_type(upload_file)` which provides Apple's picture_type code for screenshot validations (used also for uploading app screenshots). This method computes the correct validation rule starting from the UploadFile object, by leveraging Spaceship::Utilities  module to get the resolution of the screenshot file and map that to the proper device type. It then uses that to get the validation code with the already existing methods.

I've also slightly refactored the way iAP review screenshots data was retrieved by the itunes_client. This used to be the raw response, but then required to expose some information that only the du_client should have (namely the Apple's picture_type validation code). To avoid this, and reuse the code that was previously duplicated in iap_details and itunes_client itself, I wrapped the definition of the screenshot hash data to be sent to iTunesConnect to save a screenshot in itunes_client.rb's `upload_purchase_review_screenshot` method.

This change should not affect in any way the public apis of Spaceship and should thereby be transparent to the user. Users can simply provide the review screenshots with much more flexibility.

Hope this helps the community and gets merged soon! Let me know if I need to provide further details 😄 

