### PR TITLE
Ensure CSRF tokens are cached.

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -439,7 +439,11 @@ module Spaceship
           sort: 'name=asc',
           includeRemovedDevices: include_disabled
         })
-        parse_response(r, 'devices')
+        result = parse_response(r, 'devices')
+
+        csrf_cache[Spaceship::Device] = self.csrf_tokens
+
+        result
       end
     end
 
@@ -558,7 +562,11 @@ module Spaceship
           onlyCountLists: true
         })
 
-        parse_response(req, 'provisioningProfiles')
+        result = parse_response(req, 'provisioningProfiles')
+
+        csrf_cache[Spaceship::ProvisioningProfile] = self.csrf_tokens
+
+        result
       end
     end
 
@@ -577,7 +585,11 @@ module Spaceship
         }
       end
 
-      parse_response(req, 'provisioningProfiles')
+      result = parse_response(req, 'provisioningProfiles')
+
+      csrf_cache[Spaceship::ProvisioningProfile] = self.csrf_tokens
+
+      result
     end
 
     def provisioning_profile_details(provisioning_profile_id: nil, mac: false)
@@ -714,7 +726,7 @@ module Spaceship
 
     # This is a cache of entity type (App, AppGroup, Certificate, Device) to csrf_tokens
     def csrf_cache
-      @csrf_cache || {}
+      @csrf_cache ||= {}
     end
 
     # Ensures that there are csrf tokens for the appropriate entity type
@@ -732,12 +744,6 @@ module Spaceship
 
       # If we directly create a new resource (e.g. app) without querying anything before
       # we don't have a valid csrf token, that's why we have to do at least one request
-      block_given? ? yield : klass.all
-
-      # Update 18th August 2016
-      # For some reason, we have to query the resource twice to actually get a valid csrf_token
-      # I couldn't find out why, the first response does have a valid Set-Cookie header
-      # But it still needs this second request
       block_given? ? yield : klass.all
 
       csrf_cache[klass] = self.csrf_tokens


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Numerous calls are made to retrieve CSRF tokens when performing operations with Devices and Profiles.  The current code is setup to try and perform caching of these CSRF tokens, but a bug prevents them from being cached.  This leads to CSRF tokens being requested each time an update operation is performed and these extra requests can slow down some operations considerably.

Some time ago (August 2016) a valid CSRF token was not returned on the first call to a resource.  I have tested removing this and the first CSRF token returned works perfectly fine now.  With this I have removed the second redundant call to load the resource when fetching the CSRF token for the first time.

During the publishing of a device, the list of devices is fetched to see if the device already has been published.  This same list devices request is made to fetch the CSRF token later on when the device is being added to the account.  I have made a optimization to cache the CSRF token when the initial list of devices is pulled rather than waiting to cache it later when the update operation is performed.  A similar optimization has also been made for caching of the CSRF token when listing profiles.

As an example here are the calls before and after the changes for the following scenario:

> Create 2 devices and add them to 1 profile.

Before:
```
Creating device 1
 >> POST: account/ios/device/listDevices.action (Ensure the device doesn't already exist)
                                                (Devices CSRF could be cached here)
 >> POST: account/ios/device/listDevices.action (Get CSRF #1)
 >> POST: account/ios/device/listDevices.action (Get CSRF #2)
 >> POST: account/ios/device/addDevices.action
 Creating device 2
 >> POST: account/ios/device/listDevices.action (Ensure the device doesn't already exist)
 >> POST: account/ios/device/listDevices.action (Get CSRF #1)
 >> POST: account/ios/device/listDevices.action (Get CSRF #2)
 >> POST: account/ios/device/addDevices.action
 Load the profile
 >> POST: account/ios/profile/listProvisioningProfiles.action (Profiles CSRF could be cached here)
 Adding 2 devices to profile
 >> POST: account/ios/profile/getProvisioningProfile.action
 Saving updates to profile.
 >> POST: account/ios/certificate/listCertRequests.action
 >> POST: account/ios/profile/listProvisioningProfiles.action (Get CSRF #1)
 >> POST: account/ios/profile/listProvisioningProfiles.action (Get CSRF #2)
 >> POST: account/ios/profile/regenProvisioningProfile.action
```

After:
```
Creating device 1
 >> POST: account/ios/device/listDevices.action (CSRF Token is cached)
 >> POST: account/ios/device/addDevices.action 
 Creating device 2
 >> POST: account/ios/device/listDevices.action 
 >> POST: account/ios/device/addDevices.action 
Load the profile
 >> POST: account/ios/profile/listProvisioningProfiles.action (CSRF Token is cached)
 Adding 2 devices to profile
 >> POST: account/ios/profile/getProvisioningProfile.action 
 Saving updates to profile.
 >> POST: account/ios/certificate/listCertRequests.action 
 >> POST: account/ios/profile/regenProvisioningProfile.action 
```

For this scenario, with these changes no extra requests are needed to load CSRF tokens as they have all been cached by the time they are needed.

To test these changes I have used Spaceship to create devices and update profiles in addition to running the tests.

### Description
- Update csrf_cache to return cache rather than new hash on each call.
- Cache CSRF tokens when calls are made to list Devices and Profiles
    - These are called under the covers if the cache doesn't have a CSRF token yet, so in cases where the have already been called there is no need to call it again as the CSRF token can be cached from the previous call.
- Remove second call to get CSRF token.
    - The note from over a year ago indicates that the first token that came back was not valid, but subsequent ones were valid.  Today when this is removed every thing works with the first CSRF token that comes back making the second call redundant.