### PR TITLE
Add missing "iPhone 4s" device in snapshot report generator for Xcode…

### DIFF
--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -78,6 +78,7 @@ module Snapshot
         'iPhone 6' => "iPhone 6 (4.7-Inch)",
         'iPhone 5s' => "iPhone 5 (4-Inch)",
         'iPhone SE' => "iPhone SE",
+        'iPhone 4s' => "iPhone 4 (3.5-Inch)",
         'iPad Air' => 'iPad Air',
         'iPad Air 2' => 'iPad Air 2',
         'iPad (5th generation)' => 'iPad (5th generation)',


### PR DESCRIPTION
This commit fixes reported issue #10747

Using Xcode 9 when downloading the iOS SDK version 9 is possible to run automated XCTests with iPhone 4s, and specifying ios_version to 9.3 to snapshot is possible to generete screenshots for it, however the report generator was missing the iPhone 4s device and therefore didn't generate the HTML for it.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
It fixes #10747 

### Description
Just added the "iPhone 4s" string to the list of device generators, and with a Snapfile including the iPhone 4s and specifying iOS version to 9.3 I was able to generate the proper HTML including the iPhone 4 screenshots