### PR TITLE
Version bump to 2.63.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.62.1'.freeze
+  VERSION = '2.63.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.62.1':**

* Add missing "iPhone 4s" device in snapshot report generator for Xcode 9 (#10747) (#10753) via Ely Alvarado
* Support iPhone X screenshot (#10731) via Fumiya Nakamura
* Convert plugin template to Circle CI 2.0 (#10603) via Jimmy Dee
* Migrate config to 2.0 (#10563) via Danielle Tomlinson
* Add support for reset rating (#10708) via Alfredo Delli Bovi
* Move the plugin docs to the fastlane docs page (#10704) via Felix Krause
* Migrate CI docs over to new docs page (#10703) via Felix Krause
* Migrate more docs (#10705) via Felix Krause
* Fix iTunesConnect documentation (#10709) via Alfredo Delli Bovi
* Import from git versioning (#10612) via Bram Seynhaeve
* Don't cache pem options (needed to reevaluated defaults) (#10674) via Josh Holtz
* Don't let users know twice that they've used a tool name as a lane name (#10692) via Mark Pirri
* Fix typos and whitespace errors (#10690) via Frieder Bluemle
* [Build] Add retry_count to #all_processing_builds (#10656) via Renzo
* Pin rubocop in new plugins to the same version as the main repo. (#10687) via Jimmy Dee
* Fix snapshot so prepare only launches devices that are being tested this batch (#10459) via Daniel Friesen
* Update URLs to new docs page (#10648) via Felix Krause
* Adding wercker git_branch ENV variable check (#10683) via Takao Chiba
* Make Carthage action support dependencies for build command (#10245) via Jóhann Helgi Ólafsson
* Add readonly option to sigh (#10190) via Nicolas Braun
* Fix broken docs link (#10663) via Iulian Onofrei
* Fix typo in comment (#10681) via Iulian Onofrei
* Fix incorrect formatting in frameit documentation (#10682) via Iulian Onofrei
* [snapshot] Fix unused result warning in helper (#10662) via Miles Hollingsworth
* Typo Fix (#10661) via Dan Loewenherz
