### PR TITLE
Allow snapshots on older iOS versions when no specified/latest found

### DIFF
--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -40,8 +40,12 @@ module Snapshot
 
         destinations = devices.map do |d|
           device = find_device(d, os_version)
-          UI.user_error!("No device found named '#{d}' for version '#{os_version}'") if device.nil?
-          "-destination 'platform=#{os} Simulator,name=#{device.name},OS=#{os_version}'"
+          if device.nil?
+            UI.user_error!("No device found named '#{d}' for version '#{os_version}'") if device.nil?
+          elsif device.os_version != os_version
+            UI.important("Using device named '#{device.name}' with version '#{device.os_version}' because no match was found for version '#{os_version}'")
+          end
+          "-destination 'platform=#{os} Simulator,name=#{device.name},OS=#{device.os_version}'"
         end
 
         return [destinations.join(' ')]

--- a/snapshot/lib/snapshot/test_command_generator_xcode_8.rb
+++ b/snapshot/lib/snapshot/test_command_generator_xcode_8.rb
@@ -39,7 +39,7 @@ module Snapshot
         elsif device.os_version != os_version
           UI.important("Using device named '#{device_name}' with version '#{device.os_version}' because no match was found for version '#{os_version}'")
         end
-        value = "platform=#{os} Simulator,id=#{device.udid},OS=#{os_version}"
+        value = "platform=#{os} Simulator,id=#{device.udid},OS=#{device.os_version}"
 
         return ["-destination '#{value}'"]
       end

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -7,13 +7,27 @@ describe Snapshot do
     let(:iphone6_9_2) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 6", os_version: '9.2', udid: "11111", state: "Don't Care", is_simulator: true) }
     let(:iphone6_10_1) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 6 (10.1)", os_version: '10.1', udid: "33333", state: "Don't Care", is_simulator: true) }
     let(:iphone6s_10_1) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 6s (10.1)", os_version: '10.1', udid: "98765", state: "Don't Care", is_simulator: true) }
+    let(:iphone4s_9_0) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 4s", os_version: '9.0', udid: "4444", state: "Don't Care", is_simulator: true) }
     let(:ipad_air_9_1) { FastlaneCore::DeviceManager::Device.new(name: "iPad Air", os_version: '9.1', udid: "12345", state: "Don't Care", is_simulator: true) }
     let(:appleTV) { FastlaneCore::DeviceManager::Device.new(name: "Apple TV 1080p", os_version: os_version, udid: "22222", state: "Don't Care", is_simulator: true) }
 
     before do
       allow(Snapshot::LatestOsVersion).to receive(:version).and_return(os_version)
-      allow(FastlaneCore::DeviceManager).to receive(:simulators).and_return([iphone6_9_0, iphone6_9_3, iphone6_9_2, appleTV, iphone6_9_3_2, iphone6_10_1, iphone6s_10_1, ipad_air_9_1])
+      allow(FastlaneCore::DeviceManager).to receive(:simulators).and_return([iphone6_9_0, iphone6_9_3, iphone6_9_2, appleTV, iphone6_9_3_2, iphone6_10_1, iphone6s_10_1, iphone4s_9_0, ipad_air_9_1])
       fake_out_xcode_project_loading
+    end
+
+    describe '#destination' do
+      it "returns the highest version available for device if no match for the specified/latest os_version" do
+        allow(Snapshot).to receive(:config).and_return({ ios_version: os_version })
+        devices = ["iPhone 4s", "iPhone 6", "iPhone 6s"]
+        result = Snapshot::TestCommandGenerator.destination(devices)
+        expect(result).to eq [[
+          "-destination 'platform=iOS Simulator,name=iPhone 4s,OS=9.0'",
+          "-destination 'platform=iOS Simulator,name=iPhone 6,OS=9.3'",
+          "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3'"
+        ].join(' ')]
+      end
     end
 
     describe '#verify_devices_share_os' do

--- a/snapshot/spec/test_command_generator_xcode_8_spec.rb
+++ b/snapshot/spec/test_command_generator_xcode_8_spec.rb
@@ -7,13 +7,23 @@ describe Snapshot do
     let(:iphone6_9_2) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 6", os_version: '9.2', udid: "11111", state: "Don't Care", is_simulator: true) }
     let(:iphone6_10_1) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 6 (10.1)", os_version: '10.1', udid: "33333", state: "Don't Care", is_simulator: true) }
     let(:iphone6s_10_1) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 6s (10.1)", os_version: '10.1', udid: "98765", state: "Don't Care", is_simulator: true) }
+    let(:iphone4s_9_0) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 4s", os_version: '9.0', udid: "4444", state: "Don't Care", is_simulator: true) }
     let(:ipad_air_9_1) { FastlaneCore::DeviceManager::Device.new(name: "iPad Air", os_version: '9.1', udid: "12345", state: "Don't Care", is_simulator: true) }
     let(:appleTV) { FastlaneCore::DeviceManager::Device.new(name: "Apple TV 1080p", os_version: os_version, udid: "22222", state: "Don't Care", is_simulator: true) }
 
     before do
       allow(Snapshot::LatestOsVersion).to receive(:version).and_return(os_version)
-      allow(FastlaneCore::DeviceManager).to receive(:simulators).and_return([iphone6_9_0, iphone6_9_3, iphone6_9_2, appleTV, iphone6_9_3_2, iphone6_10_1, iphone6s_10_1, ipad_air_9_1])
+      allow(FastlaneCore::DeviceManager).to receive(:simulators).and_return([iphone6_9_0, iphone6_9_3, iphone6_9_2, appleTV, iphone6_9_3_2, iphone6_10_1, iphone6s_10_1, iphone4s_9_0, ipad_air_9_1])
       fake_out_xcode_project_loading
+    end
+
+    describe '#destination' do
+      it "returns the highest version available for device if no match for the specified/latest os_version" do
+        allow(Snapshot).to receive(:config).and_return({ ios_version: os_version })
+        device = "iPhone 4s"
+        result = Snapshot::TestCommandGeneratorXcode8.destination(device)
+        expect(result).to eq ["-destination 'platform=iOS Simulator,id=4444,OS=9.0'"]
+      end
     end
 
     describe '#find_device' do


### PR DESCRIPTION
This commit fixes reported issue #10211 

This allows generating snapshots on older ios versions for a simulator if the specified or latest ios version is not found for that particular device. The work was already done by the find_device method but wasn't being used by the destination method.
This fixes iPhone 4s screenshots not being generated on XCode 9 (#10211)
Fixes #10211
It should also fix #10620 (not tested)

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
It fixes #10211 and #10620

### Description
Added specs for Xcode 9 and Xcode 8 to ensure the snapshot tests are run on older iOS versions for a device if the specified/latest device is not found.
Tested (on Xcode 9) passing the following in the Snapfile:
`devices([
   "iPhone 4s",
   "iPhone 5s",
   "iPhone 7",
   "iPhone 7 Plus"])`