### PR TITLE
Allow in app purchases check to be disabled via deliver

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -322,7 +322,13 @@ module Deliver
                                      env_name: "DELIVER_IGNORE_LANGUAGE_DIRECTORY_VALIDATION",
                                      description: "Ignore errors when invalid languages are found in metadata and screeenshot directories",
                                      default_value: false,
-                                     is_string: false)
+                                     is_string: false),
+        FastlaneCore::ConfigItem.new(key: :precheck_include_in_app_purchases,
+                                     env_name: "PRECHECK_INCLUDE_IN_APP_PURCHASES",
+                                     description: "Should precheck check in-app purchases?",
+                                     is_string: false,
+                                     optional: true,
+                                     default_value: true)
       ]
     end
   end

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -49,6 +49,7 @@ module Deliver
 
       precheck_options = {
         default_rule_level: options[:precheck_default_rule_level],
+        include_in_app_purchases: options[:precheck_include_in_app_purchases],
         app_identifier: options[:app_identifier],
         username: options[:username]
       }


### PR DESCRIPTION
Related to #10372 

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Because the `include_in_app_purchases` option was added to `precheck` with a default value of `true`, running `deliver` also ran in app purchases check.

This allows to disable this check when running `deliver`.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
