### PR TITLE
Snapshot - fix String character count deprecation warning in SnapshotHelper

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -112,7 +112,7 @@ open class Snapshot: NSObject {
         do {
             let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
             let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
-            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.characters.count))
+            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.count))
             let results = matches.map { result -> String in
                 (launchArguments as NSString).substring(with: result.range)
             }

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -242,4 +242,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.6]
+// SnapshotHelperVersion [1.7]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Xcode 9.1 gives a Swift Compiler Warning with the notice `SnapshotHelper.swift:115:125: 'characters' is deprecated: Please use String or Substring directly`. This commit removes the deprecated usage of `characters` from the String instance.

Note: there are two files in *master* branch that use `launchArguments.characters.count`. I only modified *SnapshotHelper.swift*. The other file, *SnapshotHelperXcode8.swift*, I assume is for Xcode 8.

[Xcode 8 uses Swift 3](https://developer.apple.com/swift/blog/?id=36). The String `characters` [deprecation](https://developer.apple.com/documentation/swift/string/1540072-characters) happened as part of Swift 4 & Xcode 9.

### Description

By using the `count` method of the `launchArguments` String, instead of using the deprecated `characters.count`, the warning goes away.