### PR TITLE
Remove redundant let declaration for a discardable result

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -153,7 +153,7 @@ open class Snapshot: NSObject {
 
         let networkLoadingIndicator = XCUIApplication().otherElements.deviceStatusBars.networkLoadingIndicators.element
         let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
-        let _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
+        _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
     }
 
     class func pathPrefix() throws -> URL? {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

Compiler warns about a redundant let declaration.

### Description
<!--- Describe your changes in detail -->

Results can be discarded without a redundant `let` and by just using `_ =`. Use the short version to fix the compiler warning.
