### PR TITLE
Wait for uploaded ipa to be processed instead of any build

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -2,13 +2,21 @@ module FastlaneCore
   class BuildWatcher
     class << self
       # @return The build we waited for. This method will always return a build
-      def wait_for_build_processing_to_be_complete(app_id: nil, platform: nil, poll_interval: 10)
-        # First, find the train and build version we want to watch for
-        watched_build = watching_build(app_id: app_id, platform: platform)
-        UI.crash!("Could not find a build for app: #{app_id} on platform: #{platform}") if watched_build.nil?
+      def wait_for_build_processing_to_be_complete(app_id: nil, platform: nil, train_version: nil, build_version: nil, poll_interval: 10, strict_build_watch: false)
+        unless strict_build_watch
+          # First, find the train and build version we want to watch for
+          watched_build = watching_build(app_id: app_id, platform: platform)
+          UI.crash!("Could not find a build for app: #{app_id} on platform: #{platform}") if watched_build.nil?
+
+          unless watched_build.train_version == train_version && watched_build.build_version == build_version
+            UI.important("Started watching build #{watched_build.train_version} - #{watched_build.build_version} but expected #{train_version} - #{build_version}")
+          end
+          train_version = watched_build.train_version
+          build_version = watched_build.build_version
+        end
 
         loop do
-          matched_build = matching_build(watched_build: watched_build, app_id: app_id, platform: platform)
+          matched_build = matching_build(watched_train_version: train_version, watched_build_version: build_version, app_id: app_id, platform: platform)
 
           report_status(build: matched_build)
 
@@ -29,9 +37,9 @@ module FastlaneCore
         watched_build || Spaceship::TestFlight::Build.latest(app_id: app_id, platform: platform)
       end
 
-      def matching_build(watched_build: nil, app_id: nil, platform: nil)
-        matched_builds = Spaceship::TestFlight::Build.builds_for_train(app_id: app_id, platform: platform, train_version: watched_build.train_version, retry_count: 2)
-        matched_builds.find { |build| build.build_version == watched_build.build_version }
+      def matching_build(watched_train_version: nil, watched_build_version: nil, app_id: nil, platform: nil)
+        matched_builds = Spaceship::TestFlight::Build.builds_for_train(app_id: app_id, platform: platform, train_version: watched_train_version, retry_count: 2)
+        matched_builds.find { |build| build.build_version == watched_build_version }
       end
 
       def report_status(build: nil)
@@ -44,7 +52,7 @@ module FastlaneCore
           UI.message("Build doesn't show up in the build list anymore, waiting for it to appear again")
         elsif build.active?
           UI.success("Build #{build.train_version} - #{build.build_version} is already being tested")
-        elsif build.ready_to_submit? || build.export_compliance_missing?
+        elsif build.ready_to_submit? || build.export_compliance_missing? || build.review_rejected?
           UI.success("Successfully finished processing the build #{build.train_version} - #{build.build_version}")
         else
           UI.message("Waiting for iTunes Connect to finish processing the new build (#{build.train_version} - #{build.build_version})")

--- a/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
@@ -17,6 +17,13 @@ module FastlaneCore
       return nil
     end
 
+    # Fetches the app build number from the given ipa file.
+    def self.fetch_app_build(path)
+      plist = self.fetch_info_plist_file(path)
+      return plist['CFBundleVersion'] if plist
+      return nil
+    end
+
     # Fetches the app platform from the given ipa file.
     def self.fetch_app_platform(path)
       plist = self.fetch_info_plist_file(path)

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -9,6 +9,7 @@ describe FastlaneCore::BuildWatcher do
         active?: false,
         ready_to_submit?: false,
         export_compliance_missing?: false,
+        review_rejected?: false,
         train_version: '1.0',
         build_version: '1',
         upload_date: 1
@@ -21,6 +22,7 @@ describe FastlaneCore::BuildWatcher do
         active?: false,
         ready_to_submit?: false,
         export_compliance_missing?: false,
+        review_rejected?: false,
         train_version: '1.0',
         build_version: '0',
         upload_date: 0
@@ -33,6 +35,7 @@ describe FastlaneCore::BuildWatcher do
         active?: true,
         ready_to_submit?: false,
         export_compliance_missing?: false,
+        review_rejected?: false,
         train_version: '1.0',
         build_version: '1',
         upload_date: 1
@@ -45,8 +48,22 @@ describe FastlaneCore::BuildWatcher do
         active?: false,
         ready_to_submit?: true,
         export_compliance_missing?: false,
+        review_rejected?: false,
         train_version: '1.0',
         build_version: '1',
+        upload_date: 1
+      )
+    end
+    let(:old_ready_build) do
+      double(
+        'Ready Build',
+        processed?: true,
+        active?: false,
+        ready_to_submit?: true,
+        export_compliance_missing?: false,
+        review_rejected?: false,
+        train_version: '1.0',
+        build_version: '0',
         upload_date: 1
       )
     end
@@ -57,6 +74,20 @@ describe FastlaneCore::BuildWatcher do
         active?: false,
         ready_to_submit?: false,
         export_compliance_missing?: true,
+        review_rejected?: false,
+        train_version: '1.0',
+        build_version: '1',
+        upload_date: 1
+      )
+    end
+    let(:review_rejected_build) do
+      double(
+        'Review Rejected Build',
+        processed?: true,
+        active?: false,
+        ready_to_submit?: false,
+        export_compliance_missing?: false,
+        review_rejected?: true,
         train_version: '1.0',
         build_version: '1',
         upload_date: 1
@@ -69,7 +100,7 @@ describe FastlaneCore::BuildWatcher do
       expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([active_build])
 
       expect(UI).to receive(:success).with("Build #{active_build.train_version} - #{active_build.build_version} is already being tested")
-      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1')
 
       expect(found_build).to eq(active_build)
     end
@@ -80,7 +111,7 @@ describe FastlaneCore::BuildWatcher do
       expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([ready_build])
 
       expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.train_version} - #{ready_build.build_version}")
-      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1')
 
       expect(found_build).to eq(ready_build)
     end
@@ -91,9 +122,20 @@ describe FastlaneCore::BuildWatcher do
       expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([export_compliance_required_build])
 
       expect(UI).to receive(:success).with("Successfully finished processing the build #{export_compliance_required_build.train_version} - #{export_compliance_required_build.build_version}")
-      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1')
 
       expect(found_build).to eq(export_compliance_required_build)
+    end
+
+    it 'returns an review rejected build' do
+      expect(Spaceship::TestFlight::Build).to receive(:all_processing_builds).and_return([])
+      expect(Spaceship::TestFlight::Build).to receive(:latest).and_return(export_compliance_required_build)
+      expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([review_rejected_build])
+
+      expect(UI).to receive(:success).with("Successfully finished processing the build #{review_rejected_build.train_version} - #{review_rejected_build.build_version}")
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1')
+
+      expect(found_build).to eq(review_rejected_build)
     end
 
     it 'waits when a build is still processing' do
@@ -103,7 +145,7 @@ describe FastlaneCore::BuildWatcher do
 
       expect(UI).to receive(:message).with("Waiting for iTunes Connect to finish processing the new build (#{ready_build.train_version} - #{ready_build.build_version})")
       expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.train_version} - #{ready_build.build_version}")
-      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1')
 
       expect(found_build).to eq(ready_build)
     end
@@ -115,7 +157,7 @@ describe FastlaneCore::BuildWatcher do
 
       expect(UI).to receive(:message).with("Build doesn't show up in the build list anymore, waiting for it to appear again")
       expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.train_version} - #{ready_build.build_version}")
-      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1')
 
       expect(found_build).to eq(ready_build)
     end
@@ -126,10 +168,45 @@ describe FastlaneCore::BuildWatcher do
       # Note that ready_build and processing_build have same build train and build number.
       expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([ready_build])
 
+      expect(UI).to_not receive(:important).with("Started watching build #{ready_build.train_version} - #{ready_build.build_version} but expected 1.0 - 0")
       expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.train_version} - #{ready_build.build_version}")
-      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1')
 
       expect(found_build).to eq(ready_build)
+    end
+
+    it 'watches the latest build and warns about expected build difference' do
+      expect(Spaceship::TestFlight::Build).to receive(:all_processing_builds).and_return([processing_build, old_processing_build])
+      # Mock `:builds_for_train` to return a build in the ready state because this will terminate the wait loop.
+      # Note that ready_build and processing_build have same build train and build number.
+      expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([ready_build])
+
+      expect(UI).to receive(:important).with("Started watching build #{ready_build.train_version} - #{ready_build.build_version} but expected #{old_processing_build.train_version} - #{old_processing_build.build_version}")
+      expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.train_version} - #{ready_build.build_version}")
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: old_processing_build.train_version, build_version: old_processing_build.build_version)
+
+      expect(found_build).to eq(ready_build)
+    end
+
+    it 'waits for specified build to be processed when strict watch is enabled' do
+      expect(Spaceship::TestFlight::Build).to_not receive(:all_processing_builds)
+      expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([ready_build], [old_ready_build])
+
+      expect(UI).to_not receive(:important)
+      expect(UI).to receive(:success).with("Successfully finished processing the build #{old_ready_build.train_version} - #{old_ready_build.build_version}")
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '0', strict_build_watch: true)
+
+      expect(found_build).to eq(old_ready_build)
+    end
+
+    it 'returns specified build when strict watch is enabled' do
+      expect(Spaceship::TestFlight::Build).to_not receive(:all_processing_builds)
+      expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([ready_build], [old_ready_build])
+
+      expect(UI).to receive(:success).with("Successfully finished processing the build #{old_ready_build.train_version} - #{old_ready_build.build_version}")
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '0', strict_build_watch: true)
+
+      expect(found_build).to eq(old_ready_build)
     end
 
     it 'watches the latest build when no builds are processing' do
@@ -138,7 +215,7 @@ describe FastlaneCore::BuildWatcher do
       expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([ready_build])
 
       expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.train_version} - #{ready_build.build_version}")
-      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1')
 
       expect(found_build).to eq(ready_build)
     end
@@ -148,7 +225,7 @@ describe FastlaneCore::BuildWatcher do
       expect(Spaceship::TestFlight::Build).to receive(:latest).and_return(nil)
 
       expect(UI).to receive(:crash!).with("Could not find a build for app: some-app-id on platform: ios").and_call_original
-      expect { FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios) }.to raise_error(FastlaneCore::Interface::FastlaneCrash)
+      expect { FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1') }.to raise_error(FastlaneCore::Interface::FastlaneCrash)
     end
 
     it 'sleeps 10 seconds by default' do
@@ -158,7 +235,7 @@ describe FastlaneCore::BuildWatcher do
 
       allow(UI).to receive(:message)
       allow(UI).to receive(:success)
-      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios)
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1')
     end
 
     it 'sleeps for the amount of time specified in poll_interval' do
@@ -168,7 +245,7 @@ describe FastlaneCore::BuildWatcher do
 
       allow(UI).to receive(:message)
       allow(UI).to receive(:success)
-      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, poll_interval: 123)
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1', poll_interval: 123)
     end
   end
 end

--- a/fastlane_core/spec/ipa_file_analyser_spec.rb
+++ b/fastlane_core/spec/ipa_file_analyser_spec.rb
@@ -10,5 +10,13 @@ describe FastlaneCore do
         it { is_expected.to eq 'com.example.Sample' }
       end
     end
+    describe '::fetch_app_build' do
+      subject { described_class.fetch_app_build(path) }
+      it { is_expected.to eq '1' }
+      context 'when contains embedded app bundle' do
+        let('ipa') { 'ContainsWatchApp' }
+        it { is_expected.to eq '1' }
+      end
+    end
   end
 end

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -35,7 +35,13 @@ module Pilot
       end
 
       UI.message("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-      latest_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: app.apple_id, platform: platform, poll_interval: config[:wait_processing_interval])
+      app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(config[:ipa])
+      app_build = FastlaneCore::IpaFileAnalyser.fetch_app_build(config[:ipa])
+      latest_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: app.apple_id, platform: platform, train_version: app_version, build_version: app_build, poll_interval: config[:wait_processing_interval], strict_build_watch: config[:wait_for_uploaded_build])
+
+      unless latest_build.train_version == app_version && latest_build.build_version == app_build
+        UI.important("Uploaded app #{app_version} - #{app_build}, but received build #{latest_build.train_version} - #{latest_build.build_version}. If you want to wait for uploaded build to be finished processing, use the `wait_for_uploaded_build` option")
+      end
 
       distribute(options, build: latest_build)
     end

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -158,7 +158,12 @@ module Pilot
                                      type: Array,
                                      verify_block: proc do |value|
                                        UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
-                                     end)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :wait_for_uploaded_build,
+                                     env_name: "PILOT_WAIT_FOR_UPLOADED_BUILD",
+                                     description: "Use version info from uploaded ipa file to determine what build to use for distribution. If set to false, latest processing or any latest build will be used",
+                                     is_string: false,
+                                     default_value: false)
       ]
     end
   end

--- a/spaceship/lib/spaceship/test_flight/build.rb
+++ b/spaceship/lib/spaceship/test_flight/build.rb
@@ -69,7 +69,8 @@ module Spaceship::TestFlight
       active: 'testflight.build.state.testing.active',
       ready_to_submit: 'testflight.build.state.submit.ready',
       ready_to_test: 'testflight.build.state.testing.ready',
-      export_compliance_missing: 'testflight.build.state.export.compliance.missing'
+      export_compliance_missing: 'testflight.build.state.export.compliance.missing',
+      review_rejected: 'testflight.build.state.review.rejected'
     }
 
     # Find a Build by `build_id`.
@@ -130,8 +131,12 @@ module Spaceship::TestFlight
       external_state == BUILD_STATES[:export_compliance_missing]
     end
 
+    def review_rejected?
+      external_state == BUILD_STATES[:review_rejected]
+    end
+
     def processed?
-      active? || ready_to_submit? || export_compliance_missing?
+      active? || ready_to_submit? || export_compliance_missing? || review_rejected?
     end
 
     # Getting builds from BuildTrains only gets a partial Build object

--- a/spaceship/spec/test_flight/build_spec.rb
+++ b/spaceship/spec/test_flight/build_spec.rb
@@ -217,6 +217,15 @@ describe Spaceship::TestFlight::Build do
         end
         expect(build).to be_processed
       end
+
+      it 'is processed on review rejected' do
+        mock_client_response(:get_build) do
+          {
+            'externalState' => 'testflight.build.state.review.rejected'
+          }
+        end
+        expect(build).to be_processed
+      end
     end
 
     context '#upload_date' do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
At the moment, there is a possibility for `BuildWatcher` to start watching a wrong build. This can happen when iTunes Connect fails to respond to one build train API call but does respond to others.
In this situation, `BuildWatcher` may match some older build and return it. And this in turn may cause `Pilot::BuildManager` to distribute wrong build.
Fixes https://github.com/fastlane/fastlane/issues/10750

### Description
I propose reading version and build info from uploaded ipa container and passing it as build train info to `BuildWatcher`. This removes the need to find latest processing build and its fallback to any latest build.
I also added `testflight.build.state.review.rejected` as possible external state for TestFlight build. This is considered as processed build state.