### PR TITLE
Add auto_release_date option to deliver

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -111,6 +111,15 @@ module Deliver
                                      description: "Should the app be automatically released once it's approved?",
                                      is_string: false,
                                      default_value: false),
+        FastlaneCore::ConfigItem.new(key: :auto_release_date,
+                                     env_name: "DELIVER_AUTO_RELEASE_DATE",
+                                     description: "Time to release when release on approval is used in milliseconds GMT",
+                                     is_string: false,
+                                     optional: true,
+                                     conflicting_options: [:automatic_release],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("You can't use 'auto_release_date' and '#{value.key}' options together.")
+                                     end),
         FastlaneCore::ConfigItem.new(key: :phased_release,
                                      description: "Enable the phased release feature of iTC",
                                      optional: true,

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -2,6 +2,7 @@ require 'fastlane_core'
 require 'credentials_manager'
 
 module Deliver
+  # rubocop:disable Metrics/ClassLength
   class Options
     def self.available_options
       user = CredentialsManager::AppfileConfig.try_fetch_value(:itunes_connect_id)
@@ -113,7 +114,7 @@ module Deliver
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :auto_release_date,
                                      env_name: "DELIVER_AUTO_RELEASE_DATE",
-                                     description: "Time to release when release on approval is used in milliseconds GMT",
+                                     description: "Date in milliseconds for automatically releasing on pending approval",
                                      is_string: false,
                                      optional: true,
                                      conflicting_options: [:automatic_release],
@@ -341,4 +342,5 @@ module Deliver
       ]
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -115,6 +115,7 @@ module Deliver
       end
 
       v.release_on_approval = options[:automatic_release]
+      v.auto_release_date = options[:auto_release_date] unless options[:auto_release_date].nil?
       v.toggle_phased_release(enabled: !!options[:phased_release]) unless options[:phased_release].nil?
 
       set_trade_representative_contact_information(v, options)

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -134,6 +134,37 @@ describe Deliver::UploadMetadata do
     end
   end
 
+  context "with auto_release_date" do
+    let(:app) { double('app') }
+    let(:version) { double('version') }
+    let(:details) { double('details') }
+    before do
+      allow(uploader).to receive(:verify_available_languages!)
+      allow(version).to receive(:save!)
+      allow(version).to receive(:release_on_approval=)
+      allow(version).to receive(:toggle_phased_release)
+      allow(version).to receive(:auto_release_date=)
+      allow(app).to receive(:edit_version).and_return(version)
+      allow(app).to receive(:details).and_return(details)
+      allow(details).to receive(:save!)
+    end
+    context 'with date' do
+      it "auto_release_date is called" do
+        options = { auto_release_date: 2, app: app }
+        uploader.upload(options)
+        expect(version).to have_received(:auto_release_date=).with(2)
+      end
+    end
+
+    context 'without date' do
+      it "auto_release_date is not called" do
+        options = { app: app }
+        uploader.upload(options)
+        expect(version).to_not have_received(:auto_release_date=).with(2)
+      end
+    end
+  end
+
   context "with phased_release" do
     let(:app) { double('app') }
     let(:version) { double('version') }
@@ -143,6 +174,7 @@ describe Deliver::UploadMetadata do
       allow(version).to receive(:save!)
       allow(version).to receive(:release_on_approval=)
       allow(version).to receive(:toggle_phased_release)
+      allow(version).to receive(:auto_release_date=)
       allow(app).to receive(:edit_version).and_return(version)
       allow(app).to receive(:details).and_return(details)
       allow(details).to receive(:save!)


### PR DESCRIPTION
We have `auto_release_date` on the app version so let's create an option so we can pass it through 🎈 