### PR TITLE
Fixes the initialization of the csrf cache.

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -714,7 +714,7 @@ module Spaceship
 
     # This is a cache of entity type (App, AppGroup, Certificate, Device) to csrf_tokens
     def csrf_cache
-      @csrf_cache || {}
+      @csrf_cache ||= {}
     end
 
     # Ensures that there are csrf tokens for the appropriate entity type


### PR DESCRIPTION
Because @csrf_cache wasn't being initialized, it always used a new hash as the storage.
This means that no csrf headers were being reused, which forces the client to re-fetch them
for each request, slowing down the task.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
This makes tasks that make a lot of requests (like regenerating a bunch of provisioning profiles) faster by avoiding the 2 csrf fetch requests that are unnecessary.

Tested by logging connections using Charles Proxy and ensuring the csrf requests are not being repeated for each request.

### Description
Fixes the initialization of the csrf cache.

Because @csrf_cache wasn't being initialized, it always used a new hash as the storage.
This means that no csrf headers were being reused, which forces the client to re-fetch them
for each request, slowing down the task.
