### PR TITLE
Fixes image reference in pilot's README.

### DIFF
--- a/pilot/README.md
+++ b/pilot/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://docs.fastlane.tools/actions/pilot">
-    <img src="https://raw.githubusercontent.com/fastlane/fastlane/master/pilot/assets/pilot.png" height="110">
+    <img src="https://raw.githubusercontent.com/fastlane/fastlane/master/pilot/assets/PilotTextTransparent.png" height="110">
   </a>
 </p>
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I've noticed that pilot's README references a non-existing image: `pilot.png`.

### Description
I've found other images in `fastlane/pilot/assets` directory and changed the image reference to and existing one.
