### PR TITLE
Fixed instruction for update plugin

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_update_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_update_manager.rb
@@ -47,7 +47,7 @@ module Fastlane
         headings: ["Plugin", "Your Version", "Latest Version"]
       })
       UI.message "To update all plugins, just run"
-      UI.command "fastlane update_plugins"
+      UI.command "bundle exec fastlane update_plugins"
       puts ''
       @server_results = nil
     end


### PR DESCRIPTION

### Motivation and Context
If you are using plugins in your `fastlane` setup and the used plugin have a new version available, it will show the message `To update all plugins, just run fastlane update_plugins` to update the plugin. From my understanding, when using the plugin we always need to use `bundle exec` since the `Gemfile` is to be used.

The instructions should change to `To update all plugins, just run bundle exec fastlane update_plugins`. This PR changes the instructions shown to the user to update the plugin. 