### PR TITLE
Version bump to 2.64.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.63.0'.freeze
+  VERSION = '2.64.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.63.0':**

* Fixed instruction for update plugin (#10809) via Rishabh Tayal
* Support App Preview for iPhone X (#10799) via Fumiya Nakamura
* Fix mismatched <th> tags in docs_generator (#10797) via David Vanoni
* Add auto_release_date option to deliver (#10768) via Joshua Liebowitz
* Support for iPhone X in frameit (#10533) via Alfredo Delli Bovi
* Snapshot - fix String character count deprecation warning in SnapshotHelper (#10761) via xta
* Remove redundant let declaration for a discardable result (#10762) via Sampsa Kuronen
* Allow in app purchases check to be disabled via deliver (#10758) via Iulian Onofrei
* Update AppfileTemplate (#10759) via Aaron Brager
* Added is_string: false to active_days_limit config entry (#10763) via vspac
* Commit version bump enhancements (#9483) via Jimmy Dee
* issue template fix (#10673) via Rishabh Tayal
* [Deliver] Fix uses idfa limits tracking (#10715) via Jorge
* Allow snapshots on older iOS versions when no specified/latest found (see #10211) (#10755) via Ely Alvarado
* In two-stage Hockey action, do not set the status to 2 (downloadable) until after the app is uploaded (#10706) via Steve Rubin
* Fix colon styling in SnapshotHelper (#10736) via Sampsa Kuronen
