### PR TITLE
[Frameit] center-aspect-fill background image

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -170,7 +170,8 @@ module Frameit
       background = MiniMagick::Image.open(fetch_config['background'])
 
       if background.height != screenshot.size[1]
-        background.resize "#{screenshot.size[0]}x#{screenshot.size[1]}!" # `!` says it should ignore the ratio
+        background.resize "#{screenshot.size[0]}x#{screenshot.size[1]}^" # `^` says it should fill area
+        background.merge! ["-gravity", "center", "-crop", "#{screenshot.size[0]}x#{screenshot.size[1]}+0+0"] # crop from center
       end
       background
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fastlane's `frameit` tool currently accepts backgrounds to export the screenshots to the AppStore. However, the tool **resizes the backgrounds provided by the user without respecting aspect ratio**. In many cases, people seem to be using flat or gradient images where this processing may be unnoticeable. However, as soon as the provided background has more complexity (such as containing a texture) **this image processing distorts the image**.

Tried to find open issues/prs for this behavior but couldn't find any... so, here is my take on it. 
Hope it helps!

### Description
The change is quite simple: Rather than forcing a resize that omits the aspect ratio, the image is now resized to fill the screenshot target area while preserving the aspect ratio. The final crop is taken from the center of the resized image. 

This is what I would define as a **center-aspect-fill** which most tools usually simply describe as an aspect-fill.

### Warning
This should not affect people using flat-color images or vertical gradients whose seem to be the most common trend. But please beware it would affect horizontal gradient backgrounds depending on the aspect ratio of the background image. And, of course, will affect people with textured images... Positively!

Please check the following figures that explain this behavior visually 🎨😄 

![frameitexample1](https://user-images.githubusercontent.com/627312/32470802-0e8a6460-c30f-11e7-8b2c-5f8acaa6c2fb.png)
![frameitexample2](https://user-images.githubusercontent.com/627312/32470803-0ea24af8-c30f-11e7-954b-c91f5e7e64ce.png)