### PR TITLE
Fix deliver crash when overwriting images for a language not activated

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -17,6 +17,8 @@ module Deliver
         UI.message("Removing all previously uploaded screenshots...")
         # First, clear all previously uploaded screenshots
         screenshots_per_language.keys.each do |language|
+          # We have to nil check for languages not activated
+          next if v.screenshots[language].nil?
           v.screenshots[language].each_with_index do |t, index|
             v.upload_screenshot!(nil, t.sort_order, t.language, t.device_type, false)
           end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I have suffered this error several times.
<!--- If it fixes an open issue, please link to the issue here. -->
The issue was closed due to inactivity but it was not resolved. The same thing happened to me and I found the problem.

Issue: https://github.com/fastlane/fastlane/issues/10032
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->

The problem is when trying to delete the images of a language that is not activated yet in iTunes. This happens when you upload screenshots for certain language with the --overwrite_screenshots option without having that language activated in iTunes.