### PR TITLE
prevent nil crasher in associated_groups

### DIFF
--- a/spaceship/lib/spaceship/portal/app.rb
+++ b/spaceship/lib/spaceship/portal/app.rb
@@ -107,7 +107,7 @@ module Spaceship
       end
 
       def associated_groups
-        return unless raw_data.key?('associatedApplicationGroups')
+        return unless raw_data['associatedApplicationGroups']
 
         @associated_groups ||= raw_data['associatedApplicationGroups'].map do |info|
           Spaceship::Portal::AppGroup.new(info)


### PR DESCRIPTION
Key may be present while value is nil, in these cases this method will crash on nil

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When running SpaceShip::Portall.app.all and using output lane would crash as associated_groups key was present but value was nil

### Description
Simply preventing nil crasher
