### PR TITLE
Correctly support version: "latest" for download_dsyms

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -5,6 +5,7 @@ module Fastlane
     end
 
     class DownloadDsymsAction < Action
+      # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         require 'spaceship'
         require 'net/http'
@@ -84,6 +85,7 @@ module Fastlane
           UI.error("No dSYM files found on iTunes Connect - this usually happens when no recompling happened yet")
         end
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       def self.write_dsym(data, bundle_id, train_number, build_number, output_directory)
         file_name = "#{bundle_id}-#{train_number}-#{build_number}.dSYM.zip"

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -29,8 +29,12 @@ module Fastlane
         # Set version if it is latest
         if version == 'latest'
           # Try to grab the edit version first, else fallback to live version
+          UI.message("Looking for latest version...")
           latest_version = app.edit_version(platform: platform) || app.live_version(platform: platform)
-          version = nil
+
+          UI.user_error!("Could not find latest version for your app, please try setting a specific version") if latest_version.version.nil?
+
+          version = latest_version.version
           build_number = latest_version.build_version
         end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
While trying to use the `download_dsyms` tool to download the Bitcoded dSYMs from iTC, I wanted to use the "latest" version as described in the documentation. Unfortunately it seems to ignore that option, and unless a specific version is stated, begins downloads dSYMs for *all* available versions in iTC.

I've tested this on my project locally and after the provided fix everything looks good
<img width="470" alt="2870df84-8c2e-4676-a81d-29cf63597f36" src="https://user-images.githubusercontent.com/605076/32519280-e2085300-c414-11e7-9cfd-c2e6fb3fa63d.png">

### Description
It seems the "latest" codepath doesn't actually set the version retrieved from the call to Spaceship, and also doesn't warn if it can't retrieve that latest version. 

_note:_ While running rubocop It complains about `Perceived complexity for run is too high. [19/18]`. This warning is removed if I get rid of the test to make sure there is an available version. I prefer not to remove that check but can if you prefer so. 

Let me know if there's any extra information needed !

Shai