### PR TITLE
Updated xcodeproj version to handle variable substitution on bundle id

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = Dir["*/lib"]
 
   spec.add_dependency 'slack-notifier', '>= 1.3', '< 2.0.0' # Slack notifications
-  spec.add_dependency 'xcodeproj', '>= 1.5.0', '< 2.0.0' # Needed for commit_version_bump action
+  spec.add_dependency 'xcodeproj', '>= 1.5.2', '< 2.0.0' # Needed for commit_version_bump action and gym code_signing_mapping
   spec.add_dependency 'xcpretty', '>= 0.2.4', '< 1.0.0' # prettify xcodebuild output
   spec.add_dependency 'terminal-notifier', '>= 1.6.2', '< 2.0.0' # macOS notifications
   spec.add_dependency 'terminal-table', '>= 1.4.5', '< 2.0.0' # Actions documentation


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
What's happening when you have a project variable inside the bundle id? *gym* generates the export options plist this way
```
[09:45:07]: Generated plist file with the following values:
[09:45:07]: ▸ -----------------------------------------
[09:45:07]: ▸ {
[09:45:07]: ▸   "provisioningProfiles": {
[09:45:07]: ▸     "com.spreaker.ConsoleIPad${BUNDLE_ID_SUFFIX}": "SpreakerStudio AppStore Distribution"
[09:45:07]: ▸   },
[09:45:07]: ▸   "method": "app-store",
[09:45:07]: ▸   "signingStyle": "manual"
[09:45:07]: ▸ }
[09:45:07]: ▸ -----------------------------------------
```
But then xcrun fails since the bundle id does not find a match inside the plist.

```
[09:45:07]: $ /usr/bin/xcrun /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.63.0/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh -exportArchive -exportOptionsPlist '/var/folders/tp/sprd0vmn59z943y4g15l0rs80000gn/T/gym_config20171109-2897-1nt1vly.plist' -archivePath /Users/alex/Library/Developer/Xcode/Archives/2017-11-09/Studio\ Prod\ 2017-11-09\ 09.37.52.xcarchive -exportPath '/var/folders/tp/sprd0vmn59z943y4g15l0rs80000gn/T/gym_output20171109-2897-1gfy2tz'
+ xcodebuild -exportArchive -exportOptionsPlist /var/folders/tp/sprd0vmn59z943y4g15l0rs80000gn/T/gym_config20171109-2897-1nt1vly.plist -archivePath '/Users/alex/Library/Developer/Xcode/Archives/2017-11-09/Studio Prod 2017-11-09 09.37.52.xcarchive' -exportPath /var/folders/tp/sprd0vmn59z943y4g15l0rs80000gn/T/gym_output20171109-2897-1gfy2tz
2017-11-09 09:45:08.309 xcodebuild[10586:58706] [MT] IDEDistribution: -[IDEDistributionLogging _createLoggingBundleAtPath:]: Created bundle at path '/var/folders/tp/sprd0vmn59z943y4g15l0rs80000gn/T/Studio Prod_2017-11-09_09-45-08.307.xcdistributionlogs'.
2017-11-09 09:45:10.378 xcodebuild[10586:58706] [MT] IDEDistribution: Step failed: <IDEDistributionSigningAssetsStep: 0x7f7fa4f1dfd0>: Error Domain=IDEDistributionSigningAssetStepErrorDomain Code=0 "Locating signing assets failed." UserInfo={NSLocalizedDescription=Locating signing assets failed., IDEDistributionSigningAssetStepUnderlyingErrors=(
"Error Domain=IDEProvisioningErrorDomain Code=9 \"\"Studio.app\" requires a provisioning profile with the Push Notifications and iCloud features.\" UserInfo={NSLocalizedDescription=\"Studio.app\" requires a provisioning profile with the Push Notifications and iCloud features., NSLocalizedRecoverySuggestion=Add a profile to the \"provisioningProfiles\" dictionary in your Export Options property list.}"
)}
error: exportArchive: "Studio.app" requires a provisioning profile with the Push Notifications and iCloud features.

Error Domain=IDEProvisioningErrorDomain Code=9 ""Studio.app" requires a provisioning profile with the Push Notifications and iCloud features." UserInfo={NSLocalizedDescription="Studio.app" requires a provisioning profile with the Push Notifications and iCloud features., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}

** EXPORT FAILED **
[09:45:10]: Exit status: 70
[09:45:10]: No provisioning profile provided
[09:45:10]: Make sure to pass a valid provisioning for each required target
...
```

The workaround for this was to passing to *gym*, inside `export_options`, the plain bundle id of the app

```
gym(
    scheme: "Studio Prod",
    output_name: "Studio Prod",
    configuration: "ProdRelease",
    export_method: "app-store",
    export_options = { provisioningProfiles: { "com.spreaker.ConsoleIPad": "SpreakerStudio AppStore Distribution" } }
    )
```

The result with the workaround in place was the following

```
[10:03:47]: Generated plist file with the following values:
[10:03:47]: ▸ -----------------------------------------
[10:03:47]: ▸ {
[10:03:47]: ▸   "provisioningProfiles": {
[10:03:47]: ▸     "com.spreaker.ConsoleIPad": "SpreakerStudio AppStore Distribution",
[10:03:47]: ▸     "com.spreaker.ConsoleIPad${BUNDLE_ID_SUFFIX}": "SpreakerStudio AppStore Distribution"
[10:03:47]: ▸   },
[10:03:47]: ▸   "method": "app-store",
[10:03:47]: ▸   "signingStyle": "manual"
[10:03:47]: ▸ }
[10:03:47]: ▸ -----------------------------------------
```

The real fix is to update `xcodeproj` dependency to version 1.5.2+, where the variable substitution was addressed and fixed.
https://github.com/CocoaPods/Xcodeproj/releases/tag/1.5.2

Here the result after updating `xcodeproj` and removing the workaround

```
[10:12:30]: Generated plist file with the following values:
[10:12:30]: ▸ -----------------------------------------
[10:12:30]: ▸ {
[10:12:30]: ▸   "provisioningProfiles": {
[10:12:30]: ▸     "com.spreaker.ConsoleIPad": "SpreakerStudio AppStore Distribution"
[10:12:30]: ▸   },
[10:12:30]: ▸   "method": "app-store",
[10:12:30]: ▸   "signingStyle": "manual"
[10:12:30]: ▸ }
[10:12:30]: ▸ -----------------------------------------
[10:12:30]: $ /usr/bin/xcrun /usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.63.0/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh -exportArchive -exportOptionsPlist '/var/folders/tp/sprd0vmn59z943y4g15l0rs80000gn/T/gym_config20171109-19083-1t3l7ak.plist' -archivePath /Users/alex/Library/Developer/Xcode/Archives/2017-11-09/Studio\ Prod\ 2017-11-09\ 10.05.37.xcarchive -exportPath '/var/folders/tp/sprd0vmn59z943y4g15l0rs80000gn/T/gym_output20171109-19083-1hio6yg'
[10:13:06]: Compressing 27 dSYM(s)
[10:13:06]: $ cd '/Users/alex/Library/Developer/Xcode/Archives/2017-11-09/Studio Prod 2017-11-09 10.05.37.xcarchive/dSYMs' && zip -r '/workspace/ios-studio/build/Studio Prod.app.dSYM.zip' *.dSYM
...
```

### Description
Just changed the dependency version of `xcodeproj` to be, at least 1.5.2
