### PR TITLE
add java_home verification before calling java cmd

### DIFF
--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -43,7 +43,11 @@ module Fastlane
 
           UI.user_error!("The `crashlytics_path` must be a jar file for Android") unless params[:crashlytics_path].end_with?(".jar") || Helper.test?
 
-          command = ["java"]
+          if ENV['JAVA_HOME'].nil?
+            command = ["java"]
+          else
+            command = ["#{ENV['JAVA_HOME']}/bin/java}"]
+          end
           command << "-jar #{File.expand_path(params[:crashlytics_path])}"
           command << "-androidRes ."
           command << "-apiKey #{params[:api_token]}"


### PR DESCRIPTION
Add $JAVA_HOME verification before generating java command

if you work under a corporate proxy , and you can't upload Android app to Crashlytics a quick solution is to add the the java proxy params on "$JAVA_TOOL_OPTIONS"

-Dhttp.proxyHost=yourproxy.yourdomain -Dhttp.proxyPort=80 -Dhttps.proxyHost=yourproxy.yourdomain -Dhttps.proxyPort=80 -Dhttp.nonProxyHosts=”localhost|127.0.0.1|*.yourdomain"

a better solution is to update the fastlane/lib/fastlane/helper/crashlytics_helper.rb

to generate a java cmd which can check at least the $JAVA_HOME [subject of this commit]

and then include a $JAVA_OPTS params by default this will be usefull to prevent proxy param to be called fo all java process

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
