### PR TITLE
Add -D system properties to gradle

### DIFF
--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -36,6 +36,7 @@ module Fastlane
         flags = []
         flags << "-p #{project_dir.shellescape}"
         flags << params[:properties].map { |k, v| "-P#{k.to_s.shellescape}=#{v.to_s.shellescape}" }.join(' ') unless params[:properties].nil?
+        flags << params[:system_properties].map { |k, v| "-D#{k.to_s.shellescape}=#{v.to_s.shellescape}" }.join(' ') unless params[:system_properties].nil?
         flags << params[:flags] unless params[:flags].nil?
 
         # Run the actual gradle task
@@ -123,6 +124,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :properties,
                                        env_name: 'FL_GRADLE_PROPERTIES',
                                        description: 'Gradle properties to be exposed to the gradle script',
+                                       optional: true,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :system_properties,
+                                       env_name: 'FL_GRADLE_SYSTEM_PROPERTIES',
+                                       description: 'Gradle system properties to be exposed to the gradle script',
                                        optional: true,
                                        is_string: false),
           FastlaneCore::ConfigItem.new(key: :serial,

--- a/fastlane/spec/actions_specs/gradle_spec.rb
+++ b/fastlane/spec/actions_specs/gradle_spec.rb
@@ -88,10 +88,10 @@ describe Fastlane do
         notes_key = 'Release Notes' # this value is interesting because it contains a space in the key
         notes_result = 'World Domination Achieved!' # this value is interesting because it contains multiple spaces
         result = Fastlane::FastFile.new.parse("lane :build do
-          gradle(task: 'assemble', flavor: 'WorldDomination', build_type: 'Release', properties: { 'versionCode' => 200, '#{notes_key}' => '#{notes_result}'}, gradle_path: './README.md')
+          gradle(task: 'assemble', flavor: 'WorldDomination', build_type: 'Release', properties: { 'versionCode' => 200, '#{notes_key}' => '#{notes_result}'}, system_properties: { 'org.gradle.daemon' => 'true' } , gradle_path: './README.md')
         end").runner.execute(:build)
 
-        expect(result).to eq("#{File.expand_path('README.md').shellescape} assembleWorldDominationRelease -p . -PversionCode=200 -P#{notes_key.shellescape}=#{notes_result.shellescape}")
+        expect(result).to eq("#{File.expand_path('README.md').shellescape} assembleWorldDominationRelease -p . -PversionCode=200 -P#{notes_key.shellescape}=#{notes_result.shellescape} -Dorg.gradle.daemon=true")
       end
 
       it "correctly uses the serial" do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Currently, gradle supports both `system properties` (-D) and `project propreties` (-P). Fastlane only supports the latter one.

The idea is to be able to change JVM specs from the gradle script.

Eg. 
Bash: `./gradlew build -Dorg.gradle.daemon=true`
Fastlane: `gradle(task: build, system_properties: { 'org.gradle.daemon' => true }, project_dir: ...)`

It doesnt fixes anything. Its a new feature.

Documentation of this new flag was updated in PR https://github.com/fastlane/docs/pull/450

### Description

I have simply added to the params a map `system_properties`, that will join each of them in the form of: `-Dkey=value` all shellescaped since this will be ran from a shell