### PR TITLE
fix the checking of URLs containing non-ASCII characters and a fragment identifier

### DIFF
--- a/precheck/lib/precheck/rules/unreachable_urls_rule.rb
+++ b/precheck/lib/precheck/rules/unreachable_urls_rule.rb
@@ -24,7 +24,9 @@ module Precheck
         return RuleReturn.new(validation_state: Precheck::VALIDATION_STATES[:failed], failure_data: "empty url") if url.empty?
 
         begin
-          request = Faraday.new(URI.encode(url)) do |connection|
+          uri = Addressable::URI.parse(url)
+          uri.fragment = nil
+          request = Faraday.new(URI.encode(uri.to_s)) do |connection|
             connection.use FaradayMiddleware::FollowRedirects
             connection.adapter :net_http
           end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change correctly checks whether you can access that URLs that contain non-ASCII characters and fragment identifiers. e.g. https://foobar.com/テスト#anchor


### Description
Before:   

use `URI.encode` only

```ruby
uri = URI.encode('https://foobar.com/テスト#anchor') # dummy url
uri  # => https://foobar.com/%E3%83%86%E3%82%B9%E3%83%88%23anchor
request = Faraday.new(uri) do |connection|
  connection.use FaradayMiddleware::FollowRedirects
  connection.adapter :net_http
end
request.head.status == 200 # => false
```

After:  

remove a fragment identifier

```ruby
uri = Addressable::URI.parse('https://foobar.com/テスト#anchor')
uri.fragment = nil # remove a fragment identifier
uri = URI.encode(uri.to_s)
uri # => https://foobar.com/%E3%83%86%E3%82%B9%E3%83%88
request = Faraday.new(uri) do |connection|
  connection.use FaradayMiddleware::FollowRedirects
  connection.adapter :net_http
end

request.head.status == 200 # => true
```

The reason I used `Addressable::URI.parse` is that` URI.parse` is not support for non-ASCII characters.

```ruby
url = 'https://foobar.com/テスト#anchor'
URI.parse(url)
# => /.../uri/rfc3986_parser.rb:21:in `split': URI must be ascii only "https://foobar.com/\u30C6\u30B9\u30C8#anchor" (URI::InvalidURIError)
```
