### PR TITLE
Add basic Ruby-to-Swift migration

### DIFF
--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -115,6 +115,7 @@ module Fastlane
         c.description = 'Helps you with your initial fastlane setup'
 
         c.option('-u STRING', '--user STRING', String, 'iOS projects only: Your Apple ID')
+        c.option('--swift', 'Generates fastlane configuration files in Swift instead of Ruby')
 
         # CrashlyticsBetaCommandLineHandler.apply_options(c)
 
@@ -123,7 +124,7 @@ module Fastlane
           #   beta_info = CrashlyticsBetaCommandLineHandler.info_from_options(options)
           #   Fastlane::CrashlyticsBeta.new(beta_info, Fastlane::CrashlyticsBetaUi.new).run
           # else
-          is_swift_fastfile = args.include?("swift")
+          is_swift_fastfile = options.swift || false
           Fastlane::Setup.start(user: options.user, is_swift_fastfile: is_swift_fastfile)
           # end
         end

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -35,15 +35,7 @@ module Fastlane
     # rubocop:disable Metrics/BlockNesting
     def self.start(user: nil, is_swift_fastfile: false)
       if FastlaneCore::FastlaneFolder.setup? and !Helper.test?
-        require 'fastlane/lane_list'
-        Fastlane::LaneList.output(FastlaneCore::FastlaneFolder.fastfile_path)
-        UI.important("------------------")
-        UI.important("fastlane is already set up at path `#{FastlaneCore::FastlaneFolder.path}`, see the available lanes above")
-        UI.message("")
-
-        setup_ios = self.new
-        setup_ios.add_or_update_gemfile(update_gemfile_if_needed: false)
-        setup_ios.suggest_next_steps
+        self.already_set_up(user: user, is_swift_fastfile: is_swift_fastfile)
         return
       end
 
@@ -122,6 +114,33 @@ module Fastlane
       end
     end
     # rubocop:enable Metrics/BlockNesting
+
+    def self.already_set_up(user: nil, is_swift_fastfile: false)
+      if is_swift_fastfile && !FastlaneCore::FastlaneFolder.swift?
+        UI.important("fastlane is already configured using Ruby.")
+        UI.message("If you want to switch to Swift, I can reinitialize your fastlane project:")
+        UI.message(" 1️⃣  The fastlane directory (at #{FastlaneCore::FastlaneFolder.path}) would be renamed `fastlane.old`")
+        UI.message(" 2️⃣  I would run the fastlane Swift initialization")
+        UI.message(" 3️⃣  You'd need to port your customizations from Ruby to Swift by hand.")
+        if UI.confirm("Should I rename your folder \"fastlane.old\" and initialize a new Swift fastlane project?")
+          FastlaneCore::FastlaneFolder.append_old!
+          self.start(user: user, is_swift_fastfile: is_swift_fastfile)
+        else
+          UI.important("OK, I didn't change anything.")
+        end
+        return
+      end
+
+      require 'fastlane/lane_list'
+      Fastlane::LaneList.output(FastlaneCore::FastlaneFolder.fastfile_path)
+      UI.important("------------------")
+      UI.important("fastlane is already set up at path `#{FastlaneCore::FastlaneFolder.path}`, see the available lanes above")
+      UI.message("")
+
+      setup_ios = self.new
+      setup_ios.add_or_update_gemfile(update_gemfile_if_needed: false)
+      setup_ios.suggest_next_steps
+    end
 
     def initialize(is_swift_fastfile: nil, user: nil, project_path: nil, had_multiple_projects_to_choose_from: nil, preferred_setup_method: nil)
       self.is_swift_fastfile = is_swift_fastfile

--- a/fastlane_core/lib/fastlane_core/fastlane_folder.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_folder.rb
@@ -67,5 +67,12 @@ module FastlaneCore
       FileUtils.mkdir_p(path)
       UI.success("Created new folder '#{path}'.")
     end
+
+    def self.append_old!
+      return unless File.directory?(path)
+      # for Ruby-to-Swift migrations
+      FileUtils.move(path, 'fastlane.old')
+      FileUtils.chdir('..') if self.setup?
+    end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation, Context, and Description
For @taquitos to review (and anyone else interested)

For the Fastfile-in-Swift feature, this change:

1. Gives a helpful error message if users run `fastlane init --swift` when they already have a Ruby fastlane project
2. Offers to rename their fastlane directory to `fastlane.old` and create a new Swift-based setup if they so desire