### PR TITLE
When building plugin scores, we should ignore repos that are private

### DIFF
--- a/fastlane/helper/plugin_scores_helper.rb
+++ b/fastlane/helper/plugin_scores_helper.rb
@@ -128,7 +128,7 @@ module Fastlane
         def append_git_data
           Dir.mktmpdir("fastlane-plugin") do |tmp|
             clone_folder = File.join(tmp, self.name)
-            `git clone '#{self.homepage}' '#{clone_folder}'`
+            `GIT_TERMINAL_PROMPT=0 git clone '#{self.homepage}' '#{clone_folder}'`
 
             break unless File.directory?(clone_folder)
 


### PR DESCRIPTION
sets GIT_TERMINAL_PROMPT=0 when we build plugin scores
