### PR TITLE
[Spaceship] Ability to use existing IAP screenshots

### DIFF
--- a/spaceship/lib/spaceship/tunes/iap_detail.rb
+++ b/spaceship/lib/spaceship/tunes/iap_detail.rb
@@ -133,6 +133,12 @@ module Spaceship
         Tunes::IAPStatus.get_from_string(raw_data["versions"].first["status"])
       end
 
+      # @return (Hash) Hash containing existing review screenshot data
+      def review_screenshot
+        return nil unless raw_data && raw_data["versions"] && raw_data["versions"].first && raw_data["versions"].first["reviewScreenshot"] && raw_data['versions'].first["reviewScreenshot"]["value"]
+        raw_data['versions'].first['reviewScreenshot']['value']
+      end
+
       # Saves the current In-App-Purchase
       def save!
         # Transform localization versions back to original format.

--- a/spaceship/lib/spaceship/tunes/iap_detail.rb
+++ b/spaceship/lib/spaceship/tunes/iap_detail.rb
@@ -81,7 +81,7 @@ module Spaceship
           }
         end
 
-        raw_data.set(["versions"], [{ reviewNotes: { value: @review_notes }, contentHosting: raw_data['versions'].first['contentHosting'], "details" => { "value" => new_versions }, "id" => raw_data["versions"].first["id"], reviewScreenshot: { "value" => review_screenshot } }])
+        raw_data.set(["versions"], [{ reviewNotes: { value: @review_notes }, contentHosting: raw_data['versions'].first['contentHosting'], "details" => { "value" => new_versions }, "id" => raw_data["versions"].first["id"], "reviewScreenshot" => { "value" => review_screenshot } }])
       end
 
       # transforms user-set intervals to iTC ones

--- a/spaceship/lib/spaceship/tunes/iap_detail.rb
+++ b/spaceship/lib/spaceship/tunes/iap_detail.rb
@@ -81,7 +81,7 @@ module Spaceship
           }
         end
 
-        raw_data.set(["versions"], [{ reviewNotes: { value: @review_notes }, contentHosting: raw_data['versions'].first['contentHosting'], "details" => { "value" => new_versions }, "id" => raw_data["versions"].first["id"] }])
+        raw_data.set(["versions"], [{ reviewNotes: { value: @review_notes }, contentHosting: raw_data['versions'].first['contentHosting'], "details" => { "value" => new_versions }, "id" => raw_data["versions"].first["id"], reviewScreenshot: { "value" => review_screenshot } }])
       end
 
       # transforms user-set intervals to iTC ones
@@ -153,7 +153,7 @@ module Spaceship
           }
         end
 
-        raw_data.set(["versions"], [{ reviewNotes: { value: @review_notes }, contentHosting: raw_data['versions'].first[:contentHosting], "details" => { "value" => versions_array }, id: raw_data["versions"].first["id"] }])
+        raw_data.set(["versions"], [{ reviewNotes: { value: @review_notes }, contentHosting: raw_data['versions'].first[:contentHosting], "details" => { "value" => versions_array }, id: raw_data["versions"].first["id"], reviewScreenshot: { "value" => review_screenshot } }])
 
         # transform pricingDetails
         intervals_array = []

--- a/spaceship/lib/spaceship/tunes/iap_detail.rb
+++ b/spaceship/lib/spaceship/tunes/iap_detail.rb
@@ -81,7 +81,7 @@ module Spaceship
           }
         end
 
-        raw_data.set(["versions"], [{ reviewNotes: { value: @review_notes }, contentHosting: raw_data['versions'].first['contentHosting'], "details" => { "value" => new_versions }, "id" => raw_data["versions"].first["id"], "reviewScreenshot" => { "value" => review_screenshot } }])
+        raw_data.set(["versions"], [{ reviewNotes: { value: @review_notes }, "contentHosting" => raw_data['versions'].first['contentHosting'], "details" => { "value" => new_versions }, "id" => raw_data["versions"].first["id"], "reviewScreenshot" => { "value" => review_screenshot } }])
       end
 
       # transforms user-set intervals to iTC ones
@@ -153,7 +153,7 @@ module Spaceship
           }
         end
 
-        raw_data.set(["versions"], [{ reviewNotes: { value: @review_notes }, contentHosting: raw_data['versions'].first[:contentHosting], "details" => { "value" => versions_array }, id: raw_data["versions"].first["id"], reviewScreenshot: { "value" => review_screenshot } }])
+        raw_data.set(["versions"], [{ reviewNotes: { value: @review_notes }, contentHosting: raw_data['versions'].first['contentHosting'], "details" => { "value" => versions_array }, id: raw_data["versions"].first["id"], reviewScreenshot: { "value" => review_screenshot } }])
 
         # transform pricingDetails
         intervals_array = []


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context

Fixes issues #9826, #9630 and possibly #10743.

The current code does not allow editing an iOS IAPs (in-app purchases) without uploading a new screenshot as well. This change uses the existing uploaded screenshots by default unless the user specifies that they wish to upload a new one.

This can be tested by retrieving an existing IAP and immediately re-saving it. The current code will fail with an ```OPERATION_FAILED``` response due to the missing screenshots and a bug with the ```contentHosting``` variable missing. The new code fixes this bug.

```
app = Spaceship::Application.find("XXX")
iap = app.in_app_purchases.all.first.edit
iap.save!
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->

I've added a public accessor ```review_screenshot``` to allow users to retrieve the previously uploaded screenshot data. The new code now re-uses the retrieved values for the review screenshot by default, as well as reuses the existing ```contentHosting``` values which were previously missing when editing and causing saving errors.