### PR TITLE
Allow PATCH method in github_api requests

### DIFF
--- a/fastlane/lib/fastlane/actions/github_api.rb
+++ b/fastlane/lib/fastlane/actions/github_api.rb
@@ -97,7 +97,7 @@ module Fastlane
                                          default_value: "GET",
                                          optional: true,
                                          verify_block: proc do |value|
-                                           unless %w(GET POST PUT DELETE HEAD CONNECT).include?(value.to_s.upcase)
+                                           unless %w(GET POST PUT DELETE HEAD CONNECT PATCH).include?(value.to_s.upcase)
                                              UI.user_error!("Unrecognised HTTP method")
                                            end
                                          end),


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
There are API calls in the GitHub API that require the `PATCH` verb. [Editing a release](https://developer.github.com/v3/repos/releases/#edit-a-release) is one example. Fastlane currently unnecessarily disallows these as part of a validation before the call is made.

### Description
This change adds `PATCH` to the list of valid HTTP methods.
<!--- Describe your changes in detail -->
