### PR TITLE
Fix layout of multi-line labels

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -266,6 +266,7 @@ module Frameit
       # Resize the 2 labels if necessary
       smaller = 1.0 # default
       ratio = (sum_width + (keyword_padding + horizontal_frame_padding) * 2) / image.width.to_f
+      title_height = title.height
       if ratio > 1.0
         # too large - resizing now
         smaller = (1.0 / ratio)
@@ -274,15 +275,16 @@ module Frameit
 
         title.resize "#{(smaller * title.width).round}x"
         keyword.resize "#{(smaller * keyword.width).round}x" if keyword
+        title_height *= smaller
         sum_width *= smaller
       end
 
       vertical_padding = vertical_frame_padding
-      top_space = vertical_padding + (actual_font_size - title.height) / 2
+      top_space = vertical_padding
       left_space = (background.width / 2.0 - sum_width / 2.0).round
       title_below_image = fetch_config['title_below_image']
 
-      self.space_to_device += actual_font_size + vertical_padding
+      self.space_to_device += title_height + vertical_padding
 
       # First, put the keyword on top of the screenshot, if we have one
       if keyword


### PR DESCRIPTION
Multi-lines labels were improperly laid out:

```
{
  "device_frame_version": "latest",
  "default": {
    "title": {
      "color": "#ffffff"
    },
    "background": "./Frameit-background.png",
    "padding": 0,
    "show_complete_frame": false,
    "stack_title" : true,
    "title_below_image": false
  },
   "data": [
    {
      "filter": "scan"
    },
    {
      "filter": "edit"
    },
    {
      "filter": "multipage_pdf"
    },
    {
      "filter": "organize"
    },
    {
      "filter": "export"
    }
  ]

}
```

### Before and After, visually

<img src="https://user-images.githubusercontent.com/792706/32884609-2d4cd988-cabb-11e7-8daa-0ae29d3b1838.png" alt="before" width="30%"><img src="https://user-images.githubusercontent.com/792706/32884553-0744dd76-cabb-11e7-8704-957b1936b258.png" alt="after" width="30%">

Note that the layout isn't particularly "beautiful" but I have set the padding to 0 to be clear about the consequences. With a large padding, the problem was less visible.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Fixes a bug with multi-line titles.

### Description

- I have visually tested with and without keywords as well, stacked and not stacked.