### PR TITLE
Allow device-specific data

### DIFF
--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -23,12 +23,15 @@ module Frameit
 
     # Fetches the finished configuration for a given path. This will try to look for a specific value
     # and fallback to a default value if nothing was found
-    def fetch_value(path)
+    def fetch_value(path, device_name = nil)
+      device_specific = @data['data'].find { |a| a['device_filter'] && device_name.include?(a['device_filter']) } unless device_name.nil?
+
       specific = @data['data'].find { |a| path.include? a['filter'] }
 
       default = @data['default']
 
-      values = default.fastlane_deep_merge(specific || {})
+      values = default.fastlane_deep_merge(device_specific || {})
+      values = values.fastlane_deep_merge(specific || {})
 
       change_paths_to_absolutes!(values)
       validate_values(values)

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -363,7 +363,7 @@ module Frameit
       config_path = File.join(File.expand_path("../..", screenshot.path), "Framefile.json") unless File.exist?(config_path)
       file = ConfigParser.new.load(config_path)
       return {} unless file # no config file at all
-      @config = file.fetch_value(screenshot.path)
+      @config = file.fetch_value(screenshot.path, screenshot.device_name)
     end
 
     # Fetches the title + keyword for this particular screenshot


### PR DESCRIPTION
Before this, the Framefile.json could have defaults, and screenshot-specific overrides. Here we can add device-specific overrides.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context

In some instances, you may want the screenshots to render a bit differently for difference device types.

I have reprocessed my screenshots with and without the changes. Also the change is falling back to the default, so only affects if it's explicitly added in the Framefile.json. This should eliminate any potential regressions.

### Description

A typical usage would be to be able to use `show_complete_frame` for the iPad.

To achieve this, I introduce a new filter: `device_filter`.

```
{
  "device_frame_version": "latest",
  "default": {
    "title": {
      "color": "#ffffff"
    },
    "background": "./Frameit-background.png",
    "padding": "3%",
    "show_complete_frame": false,
    "stack_title" : true,
    "title_below_image": false,
    "font_scale_factor": 0.05,
    "title_padding": "5%x15%"
  },
   "data": [
    {
      "filter": "scan"
    },
    {
      "filter": "edit"
    },
    {
      "filter": "multipage_pdf"
    },
    {
      "filter": "organize"
    },
    {
      "filter": "export"
    },
    {
      "device_filter" : "iPad",
      "show_complete_frame" : true,
      "font_scale_factor": 0.035
    }
  ]
}
```

### Visually, without and with the filter

This lets modify the iPad screenshot without modifying the iPhone's

**Before**
<img src="https://user-images.githubusercontent.com/792706/32885662-6f2dffdc-cabe-11e7-823b-637f233b97e5.png" alt="before" width="45%"><img src="https://user-images.githubusercontent.com/792706/32885739-afa38ef6-cabe-11e7-9f4c-2cff74c9f7fb.png" width="30%">

**After**
<img src="https://user-images.githubusercontent.com/792706/32885366-94654a18-cabd-11e7-9fe4-0b7d628c1f7a.png" alt="after" width="45%"><img src="https://user-images.githubusercontent.com/792706/32885739-afa38ef6-cabe-11e7-9f4c-2cff74c9f7fb.png" width="30%">