### PR TITLE
Fixing a spelling error in the config file test

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -81,7 +81,7 @@ module FastlaneCore
             # So we tell the user that they can provide a value
             warning = ["In the config file '#{self.configfile_path}'"]
             warning << "you have the line #{method_sym}, but didn't provide"
-            warning << "any value. Make sure to append a value rght after the"
+            warning << "any value. Make sure to append a value right after the"
             warning << "option name. Make sure to check the docs for more information"
             UI.important(warning.join(" "))
           end

--- a/fastlane_core/spec/configuration_file_spec.rb
+++ b/fastlane_core/spec/configuration_file_spec.rb
@@ -58,7 +58,7 @@ describe FastlaneCore do
       end
 
       it "prints a warning if no value is provided" do
-        important_message = "In the config file './fastlane_core/spec/fixtures/ConfigFileEmptyValue' you have the line apple_id, but didn't provide any value. Make sure to append a value rght after the option name. Make sure to check the docs for more information"
+        important_message = "In the config file './fastlane_core/spec/fixtures/ConfigFileEmptyValue' you have the line apple_id, but didn't provide any value. Make sure to append a value right after the option name. Make sure to check the docs for more information"
         expect(FastlaneCore::UI).to receive(:important).with(important_message)
         expect(FastlaneCore::UI).to receive(:important).with("No values defined in './fastlane_core/spec/fixtures/ConfigFileEmptyValue'")
 


### PR DESCRIPTION
Error's located here:
https://github.com/fastlane/fastlane/blob/13d2ab9c2b0dd1c6f200c913957261842a31a1e1/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb#L84

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- x[ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x ] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Just a spelling mistake
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
Just added the letter 'i' between 'r' and 'g'.