### PR TITLE
[Supply] Apk check_superseded_tracks improvements

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -192,6 +192,7 @@ module Supply
         end
 
         next if removed_version_codes.empty?
+
         keep_version_codes = track_version_codes - removed_version_codes
         max_tracks_version_code = keep_version_codes[0] unless keep_version_codes.empty?
         client.update_track(track, 1.0, keep_version_codes)

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -168,7 +168,7 @@ module Supply
     #  - Lesser than the greatest of any later (i.e. production) track
     #  - Or lesser than the currently being uploaded if it's in an earlier (i.e. alpha) track
     def check_superseded_tracks(apk_version_codes)
-      UI.message("Checking superseded tracks...")
+      UI.message("Checking superseded tracks, uploading '#{apk_version_codes}' to '#{Supply.config[:track]}'...")
       max_apk_version_code = apk_version_codes.max
       max_tracks_version_code = nil
 
@@ -176,26 +176,26 @@ module Supply
       config_track_index = tracks.index(Supply.config[:track])
 
       tracks.each_index do |track_index|
-        next if track_index.eql? config_track_index
         track = tracks[track_index]
-
         track_version_codes = client.track_version_codes(track).sort
+        UI.verbose("Found '#{track_version_codes}' on track '#{track}'")
+
+        next if track_index.eql? config_track_index
         next if track_version_codes.empty?
 
         if max_tracks_version_code.nil?
           max_tracks_version_code = track_version_codes.max
-        else
-          removed_version_codes = track_version_codes.take_while do |v|
-            v < max_tracks_version_code || (v < max_apk_version_code && track_index > config_track_index)
-          end
-
-          unless removed_version_codes.empty?
-            keep_version_codes = track_version_codes - removed_version_codes
-            max_tracks_version_code = keep_version_codes[0] unless keep_version_codes.empty?
-            client.update_track(track, 1.0, keep_version_codes)
-            UI.message("Superseded track '#{track}', removed '#{removed_version_codes}'")
-          end
         end
+
+        removed_version_codes = track_version_codes.take_while do |v|
+          v < max_tracks_version_code || (v < max_apk_version_code && track_index > config_track_index)
+        end
+
+        next if removed_version_codes.empty?
+        keep_version_codes = track_version_codes - removed_version_codes
+        max_tracks_version_code = keep_version_codes[0] unless keep_version_codes.empty?
+        client.update_track(track, 1.0, keep_version_codes)
+        UI.message("Superseded track '#{track}', removed '#{removed_version_codes}'")
       end
     end
 

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -90,5 +90,77 @@ describe Supply do
         expect(only_directories).to eq(['en-US', 'fr-FR', 'ja-JP'])
       end
     end
+
+    describe 'check superseded tracks' do
+      let(:client) { double('client') }
+
+      before do
+        allow(Supply::Client).to receive(:make_from_config).and_return(client)
+      end
+
+      it 'remove lesser than the greatest of any later (i.e. production) track' do
+        allow(client).to receive(:track_version_codes) do |track|
+          next [103] if track.eql? 'production'
+          next [102] if track.eql? 'rollout'
+          next [101] if track.eql? 'beta'
+          []
+        end
+
+        allow(client).to receive(:update_track) do |track, rollout, apk_version_code|
+          expect(track).to eq('beta').or eq('rollout')
+          expect(rollout).to eq(1.0)
+          expect(apk_version_code).to be_empty
+        end
+
+        expect(client).to receive(:update_track).exactly(2).times
+
+        Supply.config = {
+          track: 'alpha'
+        }
+        Supply::Uploader.new.check_superseded_tracks([104])
+      end
+
+      it 'remove lesser than the currently being uploaded if it is in an earlier (i.e. alpha) track' do
+        allow(client).to receive(:track_version_codes) do |track|
+          next [100] if track.eql? 'alpha'
+          []
+        end
+
+        allow(client).to receive(:update_track) do |track, rollout, apk_version_code|
+          expect(track).to eq('alpha')
+          expect(rollout).to eq(1.0)
+          expect(apk_version_code).to be_empty
+        end
+
+        expect(client).to receive(:update_track).exactly(1).times
+
+        Supply.config = {
+          track: 'beta'
+        }
+        Supply::Uploader.new.check_superseded_tracks([101])
+      end
+
+      it 'combined case' do
+        allow(client).to receive(:track_version_codes) do |track|
+          next [102] if track.eql? 'production'
+          next [101] if track.eql? 'rollout'
+          next [103] if track.eql? 'alpha'
+          []
+        end
+
+        allow(client).to receive(:update_track) do |track, rollout, apk_version_code|
+          expect(track).to eq('rollout').or eq('alpha')
+          expect(rollout).to eq(1.0)
+          expect(apk_version_code).to be_empty
+        end
+
+        expect(client).to receive(:update_track).exactly(2).times
+
+        Supply.config = {
+          track: 'beta'
+        }
+        Supply::Uploader.new.check_superseded_tracks([104])
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Improvements to Supply check_superseded_tracks, try to fix and help debugging some users has having, such as in #9574 

### Description
- Added some UI.verbosity messages
- Fixes a bug in which a superseded track may not be computed
- Added tests
