### PR TITLE
[gradle] example how to sign and zipalign app

### DIFF
--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -191,8 +191,8 @@ module Fastlane
           You can use this to automatically [sign and zipalign](https://developer.android.com/studio/publish/app-signing.html) your app:
           ```ruby
           gradle(
-            task: 'assemble',
-            build_type: 'Release',
+            task: "assemble",
+            build_type: "Release",
             print_command: false,
             properties: {
               "android.injected.signing.store.file" => "keystore.jks",

--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -185,8 +185,23 @@ module Fastlane
               "versionName" => "1.0.0",
               # ...
             }
+          )
+          ```
+
+          You can use this to automatically [sign and zipalign](https://developer.android.com/studio/publish/app-signing.html) your app:
+          ```ruby
+          gradle(
+            task: 'assemble',
+            build_type: 'Release',
+            print_command: false,
+            properties: {
+              "android.injected.signing.store.file" => "keystore.jks",
+              "android.injected.signing.store.password" => "store_password",
+              "android.injected.signing.key.alias" => "key_alias",
+              "android.injected.signing.key.password" => "key_password",
+            }
           )',
-          '# If you need to pass sensitive information through the `gradle` action, and don"t want the generated command to be printed before it is run, you can suppress that:
+          '# If you need to pass sensitive information through the `gradle` action, and don\'t want the generated command to be printed before it is run, you can suppress that:
           gradle(
             # ...
             print_command: false


### PR DESCRIPTION
I looked for a way to sign and zipalign an app using Fastlane. Copypaste ready actions exist, but I hoped for a way to do this with `gradle`. And after some googling I indeed found a way to do that by supplying some properties to the gradle build process.

This PR:
- adds a code example how to sign and zipalign the app with `gradle`
- replaces wrong " with correct (and escaped) \'