### PR TITLE
Allow shell conversion when type is :shell_string

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -175,7 +175,7 @@ module Fastlane
 
     # Execute shell command
     def sh(command, log: true, error_callback: nil)
-      command = command.map(&:to_s).map(&:shellescape).join(" ") if command.kind_of?(Array)
+      command = Shellwords.join(command) if command.kind_of?(Array)
       command_header = log ? command : "shell command"
       Actions.execute_action(command_header) do
         Actions.sh_no_action(command, log: log, error_callback: error_callback)

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -175,6 +175,7 @@ module Fastlane
 
     # Execute shell command
     def sh(command, log: true, error_callback: nil)
+      command = command.map(&:to_s).map(&:shellescape).join(" ") if command.kind_of?(Array)
       command_header = log ? command : "shell command"
       Actions.execute_action(command_header) do
         Actions.sh_no_action(command, log: log, error_callback: error_callback)

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -39,7 +39,6 @@ module Fastlane
             UI.command_output(line.strip) if print_command_output
             result << line
           end
-          io.close
           exit_status = thread.value.exitstatus
         end
 

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -25,7 +25,7 @@ module Fastlane
       Encoding.default_external = Encoding::UTF_8
       Encoding.default_internal = Encoding::UTF_8
 
-      command = command.join(' ') if command.kind_of?(Array) # since it's an array of one element when running from the Fastfile
+      command = command.map(&:to_s).map(&:shellescape).join(' ') if command.kind_of?(Array) # since it's an array of one element when running from the Fastfile
       UI.command(command) if print_command
 
       result = ''

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -27,7 +27,7 @@ module Fastlane
       Encoding.default_external = Encoding::UTF_8
       Encoding.default_internal = Encoding::UTF_8
 
-      command = command.map(&:to_s).map(&:shellescape).join(' ') if command.kind_of?(Array) # since it's an array of one element when running from the Fastfile
+      command = Shellwords.join(command) if command.kind_of?(Array) # since it's an array of one element when running from the Fastfile
       UI.command(command) if print_command
 
       result = ''

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -1,3 +1,5 @@
+require "open3"
+
 module Fastlane
   module Actions
     # Execute a shell command
@@ -31,14 +33,14 @@ module Fastlane
       result = ''
       if Helper.sh_enabled?
         exit_status = nil
-        IO.popen(command, err: [:child, :out]) do |io|
+        Open3.popen2e(command) do |stdin, io, thread|
           io.sync = true
           io.each do |line|
             UI.command_output(line.strip) if print_command_output
             result << line
           end
           io.close
-          exit_status = $?.exitstatus
+          exit_status = thread.value.exitstatus
         end
 
         if exit_status != 0

--- a/fastlane/spec/helper/sh_helper_spec.rb
+++ b/fastlane/spec/helper/sh_helper_spec.rb
@@ -1,15 +1,13 @@
 describe Fastlane::Actions do
   describe "#sh" do
     let (:mock_input) { double :input }
-    let (:mock_output) { double :output }
     let (:mock_status) { double :status }
     let (:mock_thread) { double :thread, value: mock_status }
+    # Just open an empty file to mock command output
+    let (:mock_output) { File.open(File.expand_path(File.join("..", "..", "fixtures", "appfiles", "Appfile_empty"), __FILE__)) }
 
     before do
       allow(FastlaneCore::Helper).to receive(:sh_enabled?).and_return(true)
-      allow(mock_output).to receive(:sync=).with(true)
-      allow(mock_output).to receive(:each)
-      allow(mock_output).to receive(:close)
     end
 
     context "external commands are failed" do

--- a/fastlane/spec/helper/sh_helper_spec.rb
+++ b/fastlane/spec/helper/sh_helper_spec.rb
@@ -1,7 +1,15 @@
 describe Fastlane::Actions do
   describe "#sh" do
+    let (:mock_input) { double :input }
+    let (:mock_output) { double :output }
+    let (:mock_status) { double :status }
+    let (:mock_thread) { double :thread, value: mock_status }
+
     before do
       allow(FastlaneCore::Helper).to receive(:sh_enabled?).and_return(true)
+      allow(mock_output).to receive(:sync=).with(true)
+      allow(mock_output).to receive(:each)
+      allow(mock_output).to receive(:close)
     end
 
     context "external commands are failed" do
@@ -9,6 +17,7 @@ describe Fastlane::Actions do
         it "doesn't raise shell_error" do
           allow(FastlaneCore::UI).to receive(:error)
           called = false
+          expect_command "exit 1", 1
           Fastlane::Actions.sh("exit 1", error_callback: ->(_) { called = true })
 
           expect(called).to be true
@@ -19,11 +28,37 @@ describe Fastlane::Actions do
       context "without error_callback" do
         it "raise shell_error" do
           allow(FastlaneCore::UI).to receive(:shell_error!)
+          expect_command "exit 1", 1
           Fastlane::Actions.sh("exit 1")
 
           expect(UI).to have_received(:shell_error!).with("Exit status of command 'exit 1' was 1 instead of 0.\n")
         end
       end
     end
+
+    context "handling of array arguments" do
+      it "joins arrays into a single string" do
+        expect_command "git commit"
+        Fastlane::Actions.sh(%w(git commit))
+      end
+
+      it "shell escapes array elements" do
+        expect_command 'git commit -m a\ message'
+        Fastlane::Actions.sh(["git", "commit", "-m", "a message"])
+      end
+
+      it "converts array elements to strings" do
+        pathname = Pathname.new "."
+        expect_command 'git commit . -m a\ message'
+        Fastlane::Actions.sh(["git", "commit", pathname, "-m", "a message"])
+      end
+    end
   end
+end
+
+def expect_command(command, exitstatus = 0)
+  require "open3"
+
+  allow(mock_status).to receive(:exitstatus) { exitstatus }
+  expect(Open3).to receive(:popen2e).with(command).and_yield mock_input, mock_output, mock_thread
 end

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -157,7 +157,7 @@ module FastlaneCore
         return value.to_i if value.to_i.to_s == value.to_s
       elsif data_type == Float
         return value.to_f if value.to_f.to_s == value.to_s
-      elsif data_type == String && allow_shell_conversion
+      elsif allow_shell_conversion
         return value.map(&:to_s).map(&:shellescape).join(' ') if value.kind_of?(Array)
         return value.map { |k, v| "#{k.to_s.shellescape}=#{v.shellescape}" }.join(' ') if value.kind_of?(Hash)
       else
@@ -175,7 +175,9 @@ module FastlaneCore
 
     # Determines the defined data type of this ConfigItem
     def data_type
-      if @data_type
+      if @data_type.kind_of?(Symbol)
+        nil
+      elsif @data_type
         @data_type
       else
         (@is_string ? String : nil)

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -158,7 +158,7 @@ module FastlaneCore
       elsif data_type == Float
         return value.to_f if value.to_f.to_s == value.to_s
       elsif allow_shell_conversion
-        return value.map(&:to_s).map(&:shellescape).join(' ') if value.kind_of?(Array)
+        return Shellwords.join(value) if value.kind_of?(Array)
         return value.map { |k, v| "#{k.to_s.shellescape}=#{v.shellescape}" }.join(' ') if value.kind_of?(Hash)
       else
         # Special treatment if the user specified true, false or YES, NO


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

There is an attr_accessor called `:allow_shell_conversion` in `FastlaneCore::ConfigItem`. When I was writing up recent docs, I documented it but then discovered it didn't work, at least not as I expected. (So I deleted it from the docs.)  And in particular, the `sh` action does not allow array arguments. I expected to be able to do this:

```Ruby
sh ["git", "commit", "-m", message, *changes]
```

Which would result in all arguments being shell-escaped. The fact that this doesn't work is quite surprising. This seems like the action this processing was made for.

These changes make both those things work, though there are other ways to make them work as well, and perhaps some of these choices are deliberate.

### Description

The reason the `allow_shell_conversion` option doesn't seem to work is because:

- It cannot be passed to the initializer.
- The initializer sets it to true if `type` is `:shell_string`.
- The `allow_shell_conversion` option is only consulted in `#auto_convert_value` if `type` is `String`. But then, of course it will be false because `type != :shell_string`.

It is actually possible to enable it currently this way:

```Ruby
config_item = FastlaneCore::ConfigItem.new(
  key: :shell_command,
  type: String
)
config_item.allow_shell_conversion = true
```

This is because it is an `attr_accessor`. But this is a little inconvenient when declaring an array of literals.

I like the idea of using a symbol for `type`. This would also be a nicer way to support Boolean options than using `is_string: false`, e.g. `type: :boolean`.

But there are other ways of doing this, such as passing `allow_shell_conversion` directly to the initializer.

Also updated `Actions.sh` to split and shell-escape arrays so you can now run the command in the description as indicated from anywhere this functionality is supported. This includes the `sh` "action" (not really any action, just a method in `FastFile`) and the `Actions.sh` method, which is available within all actions by just calling `sh`. (This is preferable to calling `other_action.sh`, which entails a directory change.)

To make this more testable, also updated the implementation of `Actions.sh` to use `Open3.popen2e`, which doesn't rely on the global variable `$?` to determine the process exit status. This makes it easy to mock the return value in tests without actually executing any subshell in tests.