### PR TITLE
Fix app_store_build_number command

### DIFF
--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -53,6 +53,16 @@ module Fastlane
                                        env_name: "LATEST_VERSION",
                                        description: "The version number whose latest build number we want",
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :platform,
+                                       short_option: "-j",
+                                       env_name: "APPSTORE_PLATFORM",
+                                       description: "The platform to use (optional)",
+                                       optional: true,
+                                       is_string: true,
+                                       default_value: "ios",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("The platform can only be ios, or appletvos") unless %('ios', 'appletvos').include? value
+                                       end),
           FastlaneCore::ConfigItem.new(key: :initial_build_number,
                                        env_name: "INITIAL_BUILD_NUMBER",
                                        description: "sets the build number to given value if no build is in current train",

--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -267,7 +267,7 @@ module Spaceship
       # The numbers of all build trains that were uploaded
       # @return [Array] An array of train version numbers
       def all_build_train_numbers(platform: nil)
-        return self.build_trains.versions
+        return self.build_trains(platform: platform).versions
       end
 
       # Receive the build details for a specific build


### PR DESCRIPTION
Adopts internal changes that leverage the updated TestFlight APIs for getting build information.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The `latest_testflight_build_number` command is presently not working because the `app_store_build_number` command is unable to fetch build information. I believe the underlying TestFlight API changes are the root cause of this failure.

After looking at some of the recent commits for TestFlight compatibility changes, and experimenting with the updated commands in `irb`, it was reasonably clear how to get both of these commands working again.

I have tested this in a Fastfile with a project's iTC account via

```
    app_store_build_number(
      live: false,
      version: "3.10"
    )
```
as well as

```
    latest_build_number = latest_testflight_build_number(
      version: get_version_number,
      initial_build_number: 1
    )
```

and 

```
   app_store_build_number(
      live: false
    )
```

For this last situation it was also necessary to update `all_build_train_numbers` to avoid 

```
testflight_version = app.all_build_train_numbers(platform: platform).sort_by { |v| Gem::Version.new(v) }.last
```

throwing the following exception

```
`platform' is a required parameter
```

I believe this issue resolves #10923

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->

Leverage `all_build_train_numbers` and `all_builds_for_train` to determine the latest build number in TestFlight. Also adjusted `all_build_train_numbers` to leverage the expected `platform` named argument that `build_trains` now expects.

Thanks to @idyll for the help with the insight that `build_trains ` needed `platform` as a named argument for `all_build_train_numbers` to work correctly.