### PR TITLE
Allow the user to select their scheme during fastlane init

### DIFF
--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -34,6 +34,9 @@ module Fastlane
           detect_if_app_is_available
         end
         print_config_table
+        if self.project.schemes.count > 1
+          UI.important("Note: If the values above are incorrect, it is possible the wrong scheme was selected")
+        end
         if UI.confirm("Please confirm the above values")
           default_setup
         else
@@ -137,6 +140,8 @@ module Fastlane
       config = {}
       FastlaneCore::Project.detect_projects(config)
       self.project = FastlaneCore::Project.new(config)
+      self.project.select_scheme(preferred_to_include: self.project.project_name)
+
       self.app_identifier = self.project.default_app_identifier # These two vars need to be accessed in order to be set
       self.app_name = self.project.default_app_name # They are set as a side effect, this could/should be changed down the road
     end

--- a/fastlane/spec/setup_spec.rb
+++ b/fastlane/spec/setup_spec.rb
@@ -54,6 +54,8 @@ describe Fastlane do
           allow(project).to receive(:default_app_name).and_return("Project Name")
           allow(project).to receive(:is_workspace).and_return(false)
           allow(project).to receive(:path).and_return("./path")
+          allow(project).to receive(:project_name).and_return("ProjectName")
+          allow(project).to receive(:select_scheme)
 
           expect(setup.run).to eq(true)
           expect(setup.tools).to eq({ snapshot: false, cocoapods: true, carthage: false })


### PR DESCRIPTION
See #10952. This will 

* Try to automatically select a scheme that matches the project name instead of the first one in the list, ask for the scheme otherwise
* Warn the user if there is more than one scheme that the selected one might be wrong