### PR TITLE
Fix pilot adding testers

### DIFF
--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -147,8 +147,9 @@ module Pilot
                                                           first_name: first_name || '',
                                                            last_name: last_name || '',
                                                                email: email)
-        return Spaceship::TestFlight::Tester.find(app_id: app.apple_id, email: email)
+
         UI.success("Successfully added tester: #{email} to app: #{app.name}")
+        return Spaceship::TestFlight::Tester.find(app_id: app.apple_id, email: email)
       else
         UI.user_error!("Current account doesn't have permission to create a tester")
       end


### PR DESCRIPTION
This is using the newer TestFlight::Tester objects instead of ones in the Tunes namespace.

Left to do is to make sure everything works when logged in as an app manager. And to make sure removal works as well.

Also, we need to enforce the `groups` parameter I think as that is now the way to determine where testers get added.