### PR TITLE
Version bump to 2.66.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.65.0'.freeze
+  VERSION = '2.66.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.65.0':**

* spaceship fixes for build trains (#10963) via Felix Krause
* Fix for not properly listing out a found tester (#10964) via Joshua Liebowitz
* Replace tunes with test flight (#10959) via Joshua Liebowitz
* Fix download dysms to be compatible with new testflight endpoints (#10961) via David Ohayon
* Fix app_store_build_number command (#10947) via Dave Anderson
* Allow the user to select their scheme during fastlane init (#10955) via Manu Wallner
* Change to upgrade tty-screen dependency in ref to issue #10820 (#10866) via Piotr Murach
