### PR TITLE
Hotfix for TestFlight related crashes

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -502,7 +502,7 @@ module Spaceship
         end
 
         provider = body["provider"]
-        self.provider = Spaceship::Provider.new(provider_hash: provider)
+        self.provider = Spaceship::Provider.new(provider_hash: provider) unless provider.nil?
         self.available_providers = body["availableProviders"].map do |provider_hash|
           Spaceship::Provider.new(provider_hash: provider_hash)
         end


### PR DESCRIPTION
See #10960. For some people the provider accessed in `fetch_olympus_session` is nil. 

Predictably, this kills the fastlane run. I've rummaged around on iTunes Connect and looked at the requests/responses and it seems that `provider_id` is always equal to the `team_id` for me. As a result this hotfix returns the `provider_id` if it is available and the `team_id` otherwise, and ignores the provider during initialisation of the client if it is not available. 