### PR TITLE
[copy_artifacts] Fix documentation

### DIFF
--- a/fastlane/lib/fastlane/actions/copy_artifacts.rb
+++ b/fastlane/lib/fastlane/actions/copy_artifacts.rb
@@ -43,7 +43,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Copy and save your build artifacts (Useful when you use reset_git_repo)"
+        "Copy and save your build artifacts (useful when you use reset_git_repo)"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/copy_artifacts.rb
+++ b/fastlane/lib/fastlane/actions/copy_artifacts.rb
@@ -43,7 +43,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Small action to copy and save your build artifacts. Useful when you use reset_git_repo"
+        "Copy and save your build artifacts (Useful when you use reset_git_repo)"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/copy_artifacts.rb
+++ b/fastlane/lib/fastlane/actions/copy_artifacts.rb
@@ -43,7 +43,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Small action to save your build artifacts. Useful when you use reset_git_repo"
+        "Small action to copy and save your build artifacts. Useful when you use reset_git_repo"
       end
 
       def self.details
@@ -56,7 +56,7 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :keep_original,
-                                       description: "Set this to true if you want copy, rather than move, semantics",
+                                       description: "Set this to false if you want move, rather than copy, the found artifacts",
                                        is_string: false,
                                        optional: true,
                                        default_value: true),
@@ -90,7 +90,7 @@ module Fastlane
         [
           'copy_artifacts(
             target_path: "artifacts",
-            artifacts: ["*.cer", "*.mobileprovision", "*.ipa", "*.dSYM.zip"]
+            artifacts: ["*.cer", "*.mobileprovision", "*.ipa", "*.dSYM.zip", "path/to/file.txt", "another/path/*.extension"]
           )
 
           # Reset the git repo to a clean state, but leave our artifacts in place


### PR DESCRIPTION
While working with `copy_artifacts` I encountered a few docs problems with it. This PR fixes these:

- Fix wrong `keep_original` description - default is `true`, so by default the files are copied, not moved.
- Add `example_code` showing paths
- Add default functionality (copy) to `description`