### PR TITLE
Search for app version platform using symbol instead of string

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_version_common.rb
+++ b/spaceship/lib/spaceship/tunes/app_version_common.rb
@@ -12,6 +12,8 @@ module Spaceship
 
         def find_platform(versions, search_platform: nil)
           # We only support platforms that exist ATM
+          search_platform = search_platform.to_sym if search_platform
+
           platform = versions.detect do |p|
             ['ios', 'osx', 'appletvos'].include? p['platformString']
           end
@@ -21,9 +23,9 @@ module Spaceship
           # If your app has versions for both iOS and tvOS we will default to returning the iOS version for now.
           # This is intentional as we need to do more work to support apps that have hybrid versions.
           if versions.length > 1 && search_platform.nil?
-            platform = versions.detect { |p| p['platformString'] == "ios" }
+            platform = versions.detect { |p| p['platformString'].to_sym == :ios }
           elsif !search_platform.nil?
-            platform = versions.detect { |p| p['platformString'] == search_platform }
+            platform = versions.detect { |p| p['platformString'].to_sym == search_platform }
           end
           platform
         end


### PR DESCRIPTION
Fixes: #10957
