### PR TITLE
Version bump to 2.66.2

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.66.1'.freeze
+  VERSION = '2.66.2'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.66.1':**

* Search for app version platform using symbol instead of string (#10984) via Joshua Liebowitz
* Don't assume date is integer (#10981) via Joshua Liebowitz
