### PR TITLE
[copy_artifacts] additional code example

### DIFF
--- a/fastlane/lib/fastlane/actions/copy_artifacts.rb
+++ b/fastlane/lib/fastlane/actions/copy_artifacts.rb
@@ -96,6 +96,12 @@ module Fastlane
           # Reset the git repo to a clean state, but leave our artifacts in place
           reset_git_repo(
             exclude: "artifacts"
+          )',
+          '# Copy the .ipa created by `gym` if it was successfully created
+          artifacts = []
+          artifacts << lane_context[SharedValues::IPA_OUTPUT_PATH] if lane_context[SharedValues::IPA_OUTPUT_PATH]
+          copy_artifacts(
+             artifacts: artifacts
           )'
         ]
       end


### PR DESCRIPTION
adds an example how to use a shared value of `gym` to automatically get the path of the created .ipa file and copy it (and also "teaches" a user how to dynamically fill the array used to define the patterns)