### PR TITLE
Separate concurrent simulators by OS version

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -109,6 +109,13 @@ module FastlaneCore
         end
       end
 
+      def latest_simulator_version_for_device(device)
+        simulators.select { |s| s.name == device }
+                  .sort_by { |s| Gem::Version.create(s.os_version) }
+                  .last
+                  .os_version
+      end
+
       # The code below works from Xcode 7 on
       # def all
       #   UI.verbose("Fetching available devices")

--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -19,6 +19,18 @@ module FastlaneCore
           output = stdout.read
         end
 
+        runtime_info = ''
+        Open3.popen3('xcrun simctl list runtimes') do |stdin, stdout, stderr, wait_thr|
+          # This regex outputs the version info in the format "<platform> <version><exact version>"
+          runtime_info = stdout.readlines.map { |v| v.sub(/(\w+ \S+)\s*\((\S+)\s[\S\s]*/, "\\1 \\2") }.drop(1)
+        end
+        exact_versions = {}
+        runtime_info.each do |r|
+          platform, general, exact = r.split
+          exact_versions[platform] = {} unless exact_versions.include?(platform)
+          exact_versions[platform][general] = exact
+        end
+
         unless output.include?("== Devices ==")
           UI.error("xcrun simctl CLI broken, run `xcrun simctl list devices` and make sure it works")
           UI.user_error!("xcrun simctl not working.")
@@ -40,7 +52,7 @@ module FastlaneCore
             name = matches.join(' ')
 
             if matches.count && (os_type == requested_os_type || requested_os_type == "")
-              @devices << Device.new(name: name, os_type: os_type, os_version: os_version, udid: udid, state: state, is_simulator: true)
+              @devices << Device.new(name: name, os_type: os_type, os_version: exact_versions[os_type][os_version], udid: udid, state: state, is_simulator: true)
             end
           end
         end

--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -22,9 +22,9 @@ module FastlaneCore
         runtime_info = ''
         Open3.popen3('xcrun simctl list runtimes') do |stdin, stdout, stderr, wait_thr|
           # This regex outputs the version info in the format "<platform> <version><exact version>"
-          runtime_info = stdout.readlines.map { |v| v.sub(/(\w+ \S+)\s*\((\S+)\s[\S\s]*/, "\\1 \\2") }.drop(1)
+          runtime_info = stdout.read.lines.map { |v| v.sub(/(\w+ \S+)\s*\((\S+)\s[\S\s]*/, "\\1 \\2") }.drop(1)
         end
-        exact_versions = {}
+        exact_versions = Hash.new({})
         runtime_info.each do |r|
           platform, general, exact = r.split
           exact_versions[platform] = {} unless exact_versions.include?(platform)
@@ -52,7 +52,7 @@ module FastlaneCore
             name = matches.join(' ')
 
             if matches.count && (os_type == requested_os_type || requested_os_type == "")
-              @devices << Device.new(name: name, os_type: os_type, os_version: exact_versions[os_type][os_version], udid: udid, state: state, is_simulator: true)
+              @devices << Device.new(name: name, os_type: os_type, os_version: (exact_versions[os_type][os_version] || os_version), udid: udid, state: state, is_simulator: true)
             end
           end
         end

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -14,8 +14,10 @@ describe FastlaneCore do
 
     it "raises an error if xcrun CLI prints garbage simulator" do
       response = "response"
-      expect(response).to receive(:read).and_return("💩")
-      expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
+      s = StringIO.new
+      s.puts response
+      expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, s, nil, nil)
+      allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, s, nil, nil)
 
       expect do
         devices = FastlaneCore::Simulator.all
@@ -27,6 +29,9 @@ describe FastlaneCore do
         response = "response"
         expect(response).to receive(:read).and_return(@simctl_output)
         expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
+        thing = {}
+        expect(thing).to receive(:read).and_return("line\n")
+        allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, thing, nil, nil)
 
         devices = FastlaneCore::Simulator.all
         expect(devices.count).to eq(6)
@@ -74,6 +79,9 @@ describe FastlaneCore do
         simctl_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode8')
         expect(response).to receive(:read).and_return(simctl_output)
         expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
+        thing = {}
+        expect(thing).to receive(:read).and_return("line\n")
+        allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, thing, nil, nil)
 
         devices = FastlaneCore::Simulator.all
         expect(devices.count).to eq(12)
@@ -103,6 +111,9 @@ describe FastlaneCore do
         simctl_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode9')
         expect(response).to receive(:read).and_return(simctl_output)
         expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
+        thing = {}
+        expect(thing).to receive(:read).and_return("line\n")
+        allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, thing, nil, nil)
 
         devices = FastlaneCore::Simulator.all
         expect(devices.count).to eq(15)
@@ -132,6 +143,9 @@ describe FastlaneCore do
       response = "response"
       expect(response).to receive(:read).and_return(@simctl_output)
       expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
+      thing = {}
+      expect(thing).to receive(:read).and_return("line\n")
+      allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, thing, nil, nil)
 
       devices = FastlaneCore::SimulatorTV.all
       expect(devices.count).to eq(1)
@@ -148,6 +162,9 @@ describe FastlaneCore do
       response = "response"
       expect(response).to receive(:read).and_return(@simctl_output)
       expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
+      thing = {}
+      expect(thing).to receive(:read).and_return("line\n")
+      allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, thing, nil, nil)
 
       devices = FastlaneCore::SimulatorWatch.all
       expect(devices.count).to eq(2)
@@ -170,6 +187,9 @@ describe FastlaneCore do
       response = "response"
       expect(response).to receive(:read).and_return(@simctl_output)
       expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
+      thing = {}
+      expect(thing).to receive(:read).and_return("line\n")
+      allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, thing, nil, nil)
 
       devices = FastlaneCore::DeviceManager.simulators
       expect(devices.count).to eq(9)
@@ -293,6 +313,9 @@ describe FastlaneCore do
 
       expect(response).to receive(:read).and_return(@simctl_output)
       expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
+      thing = {}
+      expect(thing).to receive(:read).and_return("line\n")
+      allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, thing, nil, nil)
 
       devices = FastlaneCore::DeviceManager.all('iOS')
       expect(devices.count).to eq(7)
@@ -339,6 +362,9 @@ describe FastlaneCore do
 
       expect(response).to receive(:read).and_return(@simctl_output)
       expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
+      thing = {}
+      expect(thing).to receive(:read).and_return("line\n")
+      allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, thing, nil, nil)
 
       devices = FastlaneCore::DeviceManager.all('tvOS')
       expect(devices.count).to eq(2)
@@ -351,6 +377,25 @@ describe FastlaneCore do
       )
       expect(devices[1]).to have_attributes(
         name: "Apple TV 1080p", os_type: "tvOS", os_version: "9.0",
+        udid: "D239A51B-A61C-4B60-B4D6-B7EC16595128",
+        state: "Shutdown",
+        is_simulator: true
+      )
+    end
+
+    it "parses runtime information properly to get the exact version information" do
+      response = "response"
+      expect(response).to receive(:read).and_return(@simctl_output)
+      expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
+      thing = {}
+      expect(thing).to receive(:read).and_return("== Runtimes ==\ntvOS 9.0 (9.0.1 - 13A345) - com.apple.CoreSimulator.SimRuntime.tvOS-9-0\n")
+      allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, thing, nil, nil)
+
+      devices = FastlaneCore::SimulatorTV.all
+      expect(devices.count).to eq(1)
+
+      expect(devices[0]).to have_attributes(
+        name: "Apple TV 1080p", os_type: "tvOS", os_version: "9.0.1",
         udid: "D239A51B-A61C-4B60-B4D6-B7EC16595128",
         state: "Shutdown",
         is_simulator: true

--- a/fastlane_core/spec/simulator_spec.rb
+++ b/fastlane_core/spec/simulator_spec.rb
@@ -21,6 +21,10 @@ describe FastlaneCore do
     Apple Watch - 38mm (66D1BF17-3003-465F-A165-E6E3A565E5EB) (Booted)
 "
       FastlaneCore::Simulator.clear_cache
+
+      rt_response = ""
+      allow(rt_response).to receive(:read).and_return("no\n")
+      allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, rt_response, nil, nil)
     end
 
     it "can launch Simulator.app for a simulator device" do

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -63,6 +63,10 @@ describe Scan do
     allow(response).to receive(:read).and_return(@valid_simulators)
     allow(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
 
+    rt_response = ""
+    allow(rt_response).to receive(:read).and_return("no\n")
+    allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, rt_response, nil, nil)
+
     allow(FastlaneCore::CommandExecutor).to receive(:execute).with(command: "sw_vers -productVersion", print_all: false, print_command: false).and_return('10.12.1')
 
     allow(Scan).to receive(:project).and_return(@project)

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
@@ -31,7 +31,10 @@ module Snapshot
           # Break up the array of devices into chunks that can
           # be run simultaneously.
           if launcher_config.concurrent_simulators?
-            device_batches = launcher_config.devices.each_slice(default_number_of_simultaneous_simulators).to_a
+            all_devices = launcher_config.devices
+            # We have to break up the concurrent simulators by device version too, otherwise there is an error (see #10969)
+            by_simulator_version = all_devices.group_by { |d| FastlaneCore::DeviceManager.latest_simulator_version_for_device(d) }.values
+            device_batches = by_simulator_version.flat_map { |a| a.each_slice(default_number_of_simultaneous_simulators).to_a }
           else
             # Put each device in it's own array to run tests one at a time
             device_batches = launcher_config.devices.map { |d| [d] }


### PR DESCRIPTION
See: #10969 

If Xcode tries to concurrently run multiple simulators with different versions it fails running some of them. This PR separates the devices by OS version so that when the devices are launched, only devices of the same version are launched together. 