### PR TITLE
Fix incorrect auto complete options in zsh

### DIFF
--- a/fastlane/lib/assets/completions/completion.zsh
+++ b/fastlane/lib/assets/completions/completion.zsh
@@ -15,7 +15,8 @@ _fastlane_complete() {
 
   # parse 'beta' out of 'lane :beta do', etc
   completions=`cat $file | grep "^\s*lane \:" | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}'`
-  completions="$completions update_fastlane"
+  completions="$completions
+update_fastlane"
 
   reply=( "${(ps:\n:)completions}" )
 }


### PR DESCRIPTION
Before this, the "update_fastlane" option was being appended to
the last found option (lane name). So, having a lane named "test"
and typing "fastlane tes" and pressing the "tab" key auto
completed it to "fastlane test\ update_fastlane", where the space
character is escaped by a backslash.

The safest way to append a newline and the custom option that
should work in every zsh version is by adding a literal newline
in the string as described here:
http://zsh.sourceforge.net/FAQ/zshfaq03.html#313

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
