### PR TITLE
Check if the bundle id is already populated in the list of applications

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -293,7 +293,7 @@ module Spaceship
 
       # check if the bundle id exists in the list of bundle ids
       available_bundle_ids = data['bundleIds']
-      raise 'requested bundle id not available' unless available_bundle_ids.keys.include? bundle_id
+      raise 'requested bundle id not available' unless available_bundle_ids.keys.include?(bundle_id)
 
       # Now fill in the values we have
       # some values are nil, that's why there is a hash

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -291,6 +291,10 @@ module Spaceship
       r = request(:get, "ra/apps/create/v2/?platformString=#{platform}")
       data = parse_response(r, 'data')
 
+      # check if the bundle id exists in the list of bundle ids
+      available_bundle_ids = data['bundleIds']
+      raise 'requested bundle id not available' unless available_bundle_ids.keys.include? bundle_id
+
       # Now fill in the values we have
       # some values are nil, that's why there is a hash
       data['name'] = { value: name }

--- a/spaceship/spec/tunes/application_spec.rb
+++ b/spaceship/spec/tunes/application_spec.rb
@@ -79,7 +79,7 @@ describe Spaceship::Application do
           Spaceship::Tunes::Application.create!(name: "My Name",
                                                 sku: "SKU123",
                                                 bundle_id: "net.sunapps.100")
-        end.to raise_error "You must choose a primary language. You must choose a primary language."
+        end.to raise_error("You must choose a primary language. You must choose a primary language.")
       end
 
       it "raises an error if bundle is wildcard and bundle_id_suffix has not specified" do
@@ -88,7 +88,7 @@ describe Spaceship::Application do
           Spaceship::Tunes::Application.create!(name: "My Name",
                                                 sku: "SKU123",
                                                 bundle_id: "net.sunapps.*")
-        end.to raise_error "You must enter a Bundle ID Suffix. You must enter a Bundle ID Suffix."
+        end.to raise_error("You must enter a Bundle ID Suffix. You must enter a Bundle ID Suffix.")
       end
 
       it "raises an error if the bundle id is not populated" do
@@ -97,7 +97,7 @@ describe Spaceship::Application do
           Spaceship::Tunes::Application.create!(name: "My name",
                                                 sku: "SKU123",
                                                 bundle_id: "net.sunapps.123")
-        end.to raise_error "requested bundle id not available"
+        end.to raise_error("requested bundle id not available")
       end
     end
 
@@ -116,7 +116,7 @@ describe Spaceship::Application do
           Spaceship::Tunes::Application.create!(name: "My Name",
                                                 sku: "SKU123",
                                                 bundle_id: "net.sunapps.100")
-        end.to raise_error "You must provide a company name to use on the App Store. You must provide a company name to use on the App Store."
+        end.to raise_error("You must provide a company name to use on the App Store. You must provide a company name to use on the App Store.")
       end
     end
 

--- a/spaceship/spec/tunes/application_spec.rb
+++ b/spaceship/spec/tunes/application_spec.rb
@@ -67,9 +67,10 @@ describe Spaceship::Application do
 
     describe "#create!" do
       it "works with valid data and defaults to English" do
+        TunesStubbing.itc_stub_applications_first_create
         Spaceship::Tunes::Application.create!(name: "My name",
                                               sku: "SKU123",
-                                              bundle_id: "net.sunapps.123")
+                                              bundle_id: "net.sunapps.100")
       end
 
       it "raises an error if something is wrong" do
@@ -77,8 +78,8 @@ describe Spaceship::Application do
         expect do
           Spaceship::Tunes::Application.create!(name: "My Name",
                                                 sku: "SKU123",
-                                                bundle_id: "net.sunapps.123")
-        end.to raise_error("You must choose a primary language. You must choose a primary language.")
+                                                bundle_id: "net.sunapps.100")
+        end.to raise_error "You must choose a primary language. You must choose a primary language."
       end
 
       it "raises an error if bundle is wildcard and bundle_id_suffix has not specified" do
@@ -87,7 +88,16 @@ describe Spaceship::Application do
           Spaceship::Tunes::Application.create!(name: "My Name",
                                                 sku: "SKU123",
                                                 bundle_id: "net.sunapps.*")
-        end.to raise_error("You must enter a Bundle ID Suffix. You must enter a Bundle ID Suffix.")
+        end.to raise_error "You must enter a Bundle ID Suffix. You must enter a Bundle ID Suffix."
+      end
+
+      it "raises an error if the bundle id is not populated" do
+        TunesStubbing.itc_stub_create_invalid_bundle_id
+        expect do
+          Spaceship::Tunes::Application.create!(name: "My name",
+                                                sku: "SKU123",
+                                                bundle_id: "net.sunapps.123")
+        end.to raise_error "requested bundle id not available"
       end
     end
 
@@ -96,7 +106,7 @@ describe Spaceship::Application do
         TunesStubbing.itc_stub_applications_first_create
         Spaceship::Tunes::Application.create!(name: "My Name",
                                               sku: "SKU123",
-                                              bundle_id: "net.sunapps.123",
+                                              bundle_id: "net.sunapps.100",
                                               company_name: "SunApps GmbH")
       end
 
@@ -105,8 +115,8 @@ describe Spaceship::Application do
         expect do
           Spaceship::Tunes::Application.create!(name: "My Name",
                                                 sku: "SKU123",
-                                                bundle_id: "net.sunapps.123")
-        end.to raise_error("You must provide a company name to use on the App Store. You must provide a company name to use on the App Store.")
+                                                bundle_id: "net.sunapps.100")
+        end.to raise_error "You must provide a company name to use on the App Store. You must provide a company name to use on the App Store."
       end
     end
 
@@ -140,11 +150,11 @@ describe Spaceship::Application do
         mock_client_response(:get_builds_for_train, with: hash_including(train_version: '1.0')) do
           [
             {
-              id: 1,
-              appAdamId: 10,
-              trainVersion: '1.0',
-              uploadDate: '2017-01-01T12:00:00.000+0000',
-              externalState: 'testflight.build.state.export.compliance.missing'
+                id: 1,
+                appAdamId: 10,
+                trainVersion: '1.0',
+                uploadDate: '2017-01-01T12:00:00.000+0000',
+                externalState: 'testflight.build.state.export.compliance.missing'
             }
           ]
         end
@@ -152,18 +162,18 @@ describe Spaceship::Application do
         mock_client_response(:get_builds_for_train, with: hash_including(train_version: '1.1')) do
           [
             {
-              id: 2,
-              appAdamId: 10,
-              trainVersion: '1.1',
-              uploadDate: '2017-01-02T12:00:00.000+0000',
-              externalState: 'testflight.build.state.submit.ready'
+                id: 2,
+                appAdamId: 10,
+                trainVersion: '1.1',
+                uploadDate: '2017-01-02T12:00:00.000+0000',
+                externalState: 'testflight.build.state.submit.ready'
             },
             {
-              id: 3,
-              appAdamId: 10,
-              trainVersion: '1.1',
-              uploadDate: '2017-01-03T12:00:00.000+0000',
-              externalState: 'testflight.build.state.processing'
+                id: 3,
+                appAdamId: 10,
+                trainVersion: '1.1',
+                uploadDate: '2017-01-03T12:00:00.000+0000',
+                externalState: 'testflight.build.state.processing'
             }
           ]
         end

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -109,17 +109,30 @@ class TunesStubbing
         to_return(status: 200, body: itc_read_fixture_file('create_application_prefill_first_request.json'), headers: { 'Content-Type' => 'application/json' })
     end
 
+    def itc_stub_create_invalid_bundle_id
+      stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/create/v2/?platformString=ios").
+        to_return(status: 200, body: itc_read_fixture_file('create_application_prefill_first_request.json'), headers: { 'Content-Type' => 'application/json' })
+      stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/create/v2").
+        to_return(status: 200, body: itc_read_fixture_file('create_application_prefill_first_request.json'), headers: { 'Content-Type' => 'application/json' })
+    end
+
     def itc_stub_applications_broken_first_create
+      stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/create/v2/?platformString=ios").
+        to_return(status: 200, body: itc_read_fixture_file('create_application_prefill_first_request.json'), headers: { 'Content-Type' => 'application/json' })
       stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/create/v2").
         to_return(status: 200, body: itc_read_fixture_file('create_application_first_broken.json'), headers: { 'Content-Type' => 'application/json' })
     end
 
     def itc_stub_broken_create
+      stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/create/v2/?platformString=ios").
+        to_return(status: 200, body: itc_read_fixture_file('create_application_prefill_first_request.json'), headers: { 'Content-Type' => 'application/json' })
       stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/create/v2").
         to_return(status: 200, body: itc_read_fixture_file('create_application_broken.json'), headers: { 'Content-Type' => 'application/json' })
     end
 
     def itc_stub_broken_create_wildcard
+      stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/create/v2/?platformString=ios").
+        to_return(status: 200, body: itc_read_fixture_file('create_application_prefill_first_request.json'), headers: { 'Content-Type' => 'application/json' })
       stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/create/v2").
         to_return(status: 200, body: itc_read_fixture_file('create_application_wildcard_broken.json'), headers: { 'Content-Type' => 'application/json' })
     end


### PR DESCRIPTION
### Checklist
- :white_check_mark: I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- :white_check_mark: I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- :white_check_mark: I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- :white_check_mark: I've updated the documentation if necessary.

### Motivation and Context
Creating the application  using Tunes returns failure sometimes - and later on the applications are magically populated. I believe this issue happens when the appId is not available in the itunesconnect and we try to use it to create the app. at any rate, this is a nice check to have.

### Description
Adding a check to see available bundle ids in TunesClient create_application - and throwing an exception if the available bundle ids don't contain the bundle id requested. Updating the tests to run with this. 
