### PR TITLE
[WIP] Enable simple, single word params that default to `true`

### DIFF
--- a/fastlane/lib/fastlane/command_line_handler.rb
+++ b/fastlane/lib/fastlane/command_line_handler.rb
@@ -26,12 +26,12 @@ module Fastlane
         lane = platform_lane_info.delete_at(0)
       end
 
-      # convert remaining platform_lane_info values into parameters
+      # convert remaining platform_lane_info values into `:true` parameters
       platform_lane_info.each do |key|
-        UI.verbose("Using #{key}: true (!)")
+        UI.verbose("Using (!) #{key}: true")
         lane_parameters[key.to_sym] = true
       end
-      
+
       dot_env = Helper.is_test? ? nil : options.env
       Fastlane::LaneManager.cruise_lane(platform, lane, lane_parameters, dot_env)
     end

--- a/fastlane/lib/fastlane/command_line_handler.rb
+++ b/fastlane/lib/fastlane/command_line_handler.rb
@@ -19,13 +19,19 @@ module Fastlane
       end
 
       platform = nil
-      lane = platform_lane_info[1]
+      lane = platform_lane_info.delete_at(1)
       if lane
-        platform = platform_lane_info[0]
+        platform = platform_lane_info.delete_at(0)
       else
-        lane = platform_lane_info[0]
+        lane = platform_lane_info.delete_at(0)
       end
 
+      # convert remaining platform_lane_info values into parameters
+      platform_lane_info.each do |key|
+        UI.verbose("Using #{key}: true (!)")
+        lane_parameters[key.to_sym] = true
+      end
+      
       dot_env = Helper.is_test? ? nil : options.env
       Fastlane::LaneManager.cruise_lane(platform, lane, lane_parameters, dot_env)
     end

--- a/fastlane/spec/command_line_handler_spec.rb
+++ b/fastlane/spec/command_line_handler_spec.rb
@@ -18,5 +18,12 @@ describe Fastlane do
                                                                   nil)
       Fastlane::CommandLineHandler.handle(["ios", "deploy", "key:true", "key2:false"], {})
     end
+    
+    it "properly handles calls with custom 'simple' parameters" do
+      expect(Fastlane::LaneManager).to receive(:cruise_lane).with("ios", "deploy",
+                                                                  { bool: true },
+                                                                  nil)
+      Fastlane::CommandLineHandler.handle(["ios", "deploy", "bool"], {})
+    end
   end
 end

--- a/fastlane/spec/command_line_handler_spec.rb
+++ b/fastlane/spec/command_line_handler_spec.rb
@@ -18,7 +18,7 @@ describe Fastlane do
                                                                   nil)
       Fastlane::CommandLineHandler.handle(["ios", "deploy", "key:true", "key2:false"], {})
     end
-    
+
     it "properly handles calls with custom 'simple' parameters" do
       expect(Fastlane::LaneManager).to receive(:cruise_lane).with("ios", "deploy",
                                                                   { bool: true },


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context

Right now the only way to supply parameters when executing lanes is in the `key:value` format. It would be neat to also be able to just call it with a single word that gets interpreted as a `true` bool variable.

### Description

Right now all params with `:` are by default used as params, those without for the platform selection and lane name. This PR just takes the leftover entries from that array and adds them to the params array with value `true`.
