### PR TITLE
note: only `bundle exec ...` uses local fastlane

### DIFF
--- a/YourFirstPR.md
+++ b/YourFirstPR.md
@@ -75,7 +75,7 @@ bundle show fastlane
 
 which should print out the path to your local development environment.
 
-From now on, every time you introduce a change to your local _fastlane_ code base, you can immediately test it by running  (`bundle exec fastlane …`. (Note that just using `fastlane …` without `bundle exec` will **not** use your local _fastlane_ code base!)
+From now on, every time you introduce a change to your local _fastlane_ code base, you can immediately test it by running `bundle exec fastlane …`. (Note that just using `fastlane …` without `bundle exec` will **not** use your local _fastlane_ code base!)
 
 If you want to run a command with your normal _fastlane_ installation, simply do not run the command with the `bundle exec` prefix.
 

--- a/YourFirstPR.md
+++ b/YourFirstPR.md
@@ -75,7 +75,7 @@ bundle show fastlane
 
 which should print out the path to your local development environment.
 
-From now on, every time you introduce a change to your local _fastlane_ code base, you can immediately test it by running `bundle exec fastlane …`.
+From now on, every time you introduce a change to your local _fastlane_ code base, you can immediately test it by running  (`bundle exec fastlane …`. (Note that just using `fastlane …` without `bundle exec` will **not** use your local _fastlane_ code base!)
 
 If you want to run a command with your normal _fastlane_ installation, simply do not run the command with the `bundle exec` prefix.
 


### PR DESCRIPTION
Highlight that you have to use `bundle exec ...` for your local fastlane code checkout to be used.