### PR TITLE
[FrameIt] Multiple layout improvements (including iPhone X, multiline labels)

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/frameit.md
+++ b/fastlane/lib/fastlane/actions/docs/frameit.md
@@ -131,7 +131,7 @@ The `show_complete_frame` value specifies whether _frameit_ should shrink the de
 
 The `title_below_image` value specifies whether _frameit_ should place the title below the screenshot. If it is false, it will be placed above the screenshot.
 
-The `filter` value is a part of the screenshot named for which the given option should be used. If a screenshot is named `iPhone5_Brainstorming.png` the first entry in the `data` array will be used.
+The `filter` value is a part of the screenshot named for which the given option should be used. If a screenshot is named `iPhone5_Brainstorming.png` the first entry in the `data` array will be used. If there are more than one `filter` matching an entry, they will all be applied in order (which means that the last one has the highest precedence).
 
 You can find a more complex [configuration](https://github.com/fastlane/examples/blob/master/MindNode/screenshots/Framefile.json) to also support Chinese, Japanese and Korean languages.
 

--- a/fastlane/lib/fastlane/actions/docs/frameit.md
+++ b/fastlane/lib/fastlane/actions/docs/frameit.md
@@ -131,6 +131,8 @@ The `show_complete_frame` value specifies whether _frameit_ should shrink the de
 
 The `title_below_image` value specifies whether _frameit_ should place the title below the screenshot. If it is false, it will be placed above the screenshot.
 
+The `title_min_height` value specifies whether _frameit_ should keep a minimum height for the text area, even if the text's actual height is smaller.
+
 The `filter` value is a part of the screenshot named for which the given option should be used. If a screenshot is named `iPhone5_Brainstorming.png` the first entry in the `data` array will be used. If there are more than one `filter` matching an entry, they will all be applied in order (which means that the last one has the highest precedence).
 
 You can find a more complex [configuration](https://github.com/fastlane/examples/blob/master/MindNode/screenshots/Framefile.json) to also support Chinese, Japanese and Korean languages.

--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -24,11 +24,14 @@ module Frameit
     # Fetches the finished configuration for a given path. This will try to look for a specific value
     # and fallback to a default value if nothing was found
     def fetch_value(path)
-      specific = @data['data'].find { |a| path.include? a['filter'] }
+      specifics = @data['data'].select { |a| path.include? a['filter'] }
 
       default = @data['default']
 
-      values = default.fastlane_deep_merge(specific || {})
+      values = default.clone
+      specifics.each do |specific|
+        values = values.fastlane_deep_merge(specific)
+      end
 
       change_paths_to_absolutes!(values)
       validate_values(values)

--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -61,6 +61,10 @@ module Frameit
       end
     end
 
+    def is_absolute_or_percentage(value)
+      value.kind_of?(Integer) || (value.end_with?('%') && value.to_f > 0)
+    end
+
     # Make sure the paths/colors are valid
     def validate_values(values)
       values.each do |key, value|
@@ -83,11 +87,11 @@ module Frameit
           when 'color'
             UI.user_error!("Invalid color '#{value}'. Must be valid Hex #123123") unless value.include?("#")
           when 'padding'
-            unless value.kind_of?(Integer) || value.split('x').length == 2 || (value.end_with?('%') && value.to_f > 0)
+            unless is_absolute_or_percentage(value) || value.split('x').length == 2
               UI.user_error!("padding must be type integer or pair of integers of format 'AxB' or a percentage of screen size")
             end
           when 'title_min_height'
-            unless value.kind_of?(Integer) || (value.end_with?('%') && value.to_f > 0)
+            unless is_absolute_or_percentage(value)
               UI.user_error!("padding must be type integer or a percentage of screen size")
             end
           when 'show_complete_frame', 'title_below_image'

--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -86,6 +86,10 @@ module Frameit
             unless value.kind_of?(Integer) || value.split('x').length == 2 || (value.end_with?('%') && value.to_f > 0)
               UI.user_error!("padding must be type integer or pair of integers of format 'AxB' or a percentage of screen size")
             end
+          when 'title_min_height'
+            unless value.kind_of?(Integer) || (value.end_with?('%') && value.to_f > 0)
+              UI.user_error!("padding must be type integer or a percentage of screen size")
+            end
           when 'show_complete_frame', 'title_below_image'
             UI.user_error! "'#{key}' must be a Boolean" unless [true, false].include?(value)
           when 'font_scale_factor'

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -3,7 +3,7 @@ module Frameit
     attr_accessor :screenshot # reference to the screenshot object to fetch the path, title, etc.
     attr_accessor :frame # the frame of the device
     attr_accessor :image # the current image used for editing
-    attr_accessor :space_to_device
+    attr_accessor :height_device_cannot_use
 
     def frame!(screenshot)
       self.screenshot = screenshot
@@ -104,7 +104,7 @@ module Frameit
     def complex_framing
       background = generate_background
 
-      self.space_to_device = vertical_frame_padding
+      self.height_device_cannot_use = vertical_frame_padding
 
       if fetch_config['title']
         background = put_title_into_background(background, fetch_config['stack_title'])
@@ -116,7 +116,7 @@ module Frameit
 
         # Decrease the size of the framed screenshot to fit into the defined padding + background
         frame_width = background.width - horizontal_frame_padding * 2
-        frame_height = background.height - space_to_device - vertical_frame_padding
+        frame_height = background.height - effective_text_height - vertical_frame_padding
 
         if fetch_config['show_complete_frame']
           # calculate the final size of the screenshot to resize in one go
@@ -156,6 +156,17 @@ module Frameit
       return scale_padding(padding)
     end
 
+    # Minimum height for the title
+    def title_min_height
+      @title_min_height ||= begin
+        height = fetch_config['title_min_height'] || 0
+        if height.kind_of?(String) && height.end_with?('%')
+          height = ([image.width, image.height].min * height.to_f * 0.01).ceil
+        end
+        height
+      end
+    end
+
     def scale_padding(padding)
       if padding.kind_of?(String) && padding.end_with?('%')
         padding = ([image.width, image.height].min * padding.to_f * 0.01).ceil
@@ -163,6 +174,24 @@ module Frameit
       multi = 1.0
       multi = 1.7 if self.screenshot.triple_density?
       return padding * multi
+    end
+
+    def effective_text_height
+      [height_device_cannot_use, title_min_height].max
+    end
+
+    def device_top(background)
+      @device_top ||= begin
+        if title_below_image
+          background.height - effective_text_height - image.height
+        else
+          effective_text_height
+        end
+      end
+    end
+
+    def title_below_image
+      @title_below_image ||= fetch_config['title_below_image']
     end
 
     # Returns a correctly sized background image
@@ -178,17 +207,10 @@ module Frameit
 
     def put_device_into_background(background)
       left_space = (background.width / 2.0 - image.width / 2.0).round
-      title_below_image = fetch_config['title_below_image']
 
       @image = background.composite(image, "png") do |c|
         c.compose "Over"
-        if title_below_image
-          show_complete_frame = fetch_config['show_complete_frame']
-          c.geometry "+#{left_space}+#{background.height - image.height - space_to_device}" unless show_complete_frame
-          c.geometry "+#{left_space}+#{vertical_frame_padding}" if show_complete_frame
-        else
-          c.geometry "+#{left_space}+#{space_to_device}"
-        end
+        c.geometry "+#{left_space}+#{device_top(background)}"
       end
 
       return image
@@ -223,27 +245,30 @@ module Frameit
       keyword_width = keyword.width
 
       vertical_padding = vertical_frame_padding
-      keyword_top_space = vertical_padding
 
       spacing_between_title_and_keyword = (title.height / 2)
-      title_top_space = vertical_padding + keyword.height + spacing_between_title_and_keyword
       title_left_space = (background.width / 2.0 - title_width / 2.0).round
       keyword_left_space = (background.width / 2.0 - keyword_width / 2.0).round
 
-      self.space_to_device += title.height + keyword.height + spacing_between_title_and_keyword + vertical_padding
-      title_below_image = fetch_config['title_below_image']
+      self.height_device_cannot_use += title.height + keyword.height + spacing_between_title_and_keyword + vertical_padding
+
+      if title_below_image
+        keyword_top = background.height - effective_text_height / 2 - (keyword.height + spacing_between_title_and_keyword + title.height) / 2
+      else
+        keyword_top = device_top(background) / 2 - spacing_between_title_and_keyword / 2 - keyword.height
+      end
+      title_top = keyword_top + keyword.height + spacing_between_title_and_keyword
+
       # keyword
       background = background.composite(keyword, "png") do |c|
         c.compose "Over"
-        c.geometry "+#{keyword_left_space}+#{keyword_top_space}" unless title_below_image
-        c.geometry "+#{keyword_left_space}+#{background.height - space_to_device + keyword_top_space}" if title_below_image
+        c.geometry "+#{keyword_left_space}+#{keyword_top}"
       end
       # Then, put the title on top of the screenshot next to the keyword
       # Then, put the title above/below of the screenshot next to the keyword
       background = background.composite(title, "png") do |c|
         c.compose "Over"
-        c.geometry "+#{title_left_space}+#{title_top_space}" unless title_below_image
-        c.geometry "+#{title_left_space}+#{background.height - space_to_device + title_top_space}" if title_below_image
+        c.geometry "+#{title_left_space}+#{title_top}"
       end
       background
     end
@@ -279,19 +304,21 @@ module Frameit
         sum_width *= smaller
       end
 
-      vertical_padding = vertical_frame_padding
-      top_space = vertical_padding
       left_space = (background.width / 2.0 - sum_width / 2.0).round
-      title_below_image = fetch_config['title_below_image']
 
-      self.space_to_device += title_height + vertical_padding
+      self.height_device_cannot_use += title_height + vertical_frame_padding
+
+      if title_below_image
+        title_top = background.height - effective_text_height / 2 - title_height / 2
+      else
+        title_top = device_top(background) / 2 - title_height / 2
+      end
 
       # First, put the keyword on top of the screenshot, if we have one
       if keyword
         background = background.composite(keyword, "png") do |c|
           c.compose "Over"
-          c.geometry "+#{left_space}+#{top_space}" unless title_below_image
-          c.geometry "+#{left_space}+#{background.height - space_to_device + top_space}" if title_below_image
+          c.geometry "+#{left_space}+#{title_top}"
         end
 
         left_space += keyword.width + (keyword_padding * smaller)
@@ -300,8 +327,7 @@ module Frameit
       # Then, put the title on top of the screenshot next to the keyword
       background = background.composite(title, "png") do |c|
         c.compose "Over"
-        c.geometry "+#{left_space}+#{top_space}" unless title_below_image
-        c.geometry "+#{left_space}+#{background.height - space_to_device + top_space}" if title_below_image
+        c.geometry "+#{left_space}+#{title_top}"
       end
       background
     end

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -266,6 +266,7 @@ module Frameit
       # Resize the 2 labels if necessary
       smaller = 1.0 # default
       ratio = (sum_width + (keyword_padding + horizontal_frame_padding) * 2) / image.width.to_f
+      title_height = title.height
       if ratio > 1.0
         # too large - resizing now
         smaller = (1.0 / ratio)
@@ -274,15 +275,16 @@ module Frameit
 
         title.resize "#{(smaller * title.width).round}x"
         keyword.resize "#{(smaller * keyword.width).round}x" if keyword
+        title_height *= smaller
         sum_width *= smaller
       end
 
       vertical_padding = vertical_frame_padding
-      top_space = vertical_padding + (actual_font_size - title.height) / 2
+      top_space = vertical_padding
       left_space = (background.width / 2.0 - sum_width / 2.0).round
       title_below_image = fetch_config['title_below_image']
 
-      self.space_to_device += actual_font_size + vertical_padding
+      self.space_to_device += title_height + vertical_padding
 
       # First, put the keyword on top of the screenshot, if we have one
       if keyword


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

_frameit_ has some limitations to its layout engine. With new devices such as the iPhone X, this sometimes results in awkward results. This PR addresses a couple of these layout issues and adds options to customize the layout. This are all useful changes that I applied for the latest version of our app Genius Scan.

### Description

This addresses multiple layout issues:

#### Multi-lines labels were improperly laid out

A multiline label is a string with a `\n`.

<img src="https://user-images.githubusercontent.com/792706/32884609-2d4cd988-cabb-11e7-8daa-0ae29d3b1838.png" alt="before" width="30%"><img src="https://user-images.githubusercontent.com/792706/32884553-0744dd76-cabb-11e7-8704-957b1936b258.png" alt="after" width="30%">

Note that the layout isn't particularly "beautiful" but I have set the padding to 0 to be clear about the consequences. With a large padding, the problem was less visible.

This is fixed by not relying on the font size anymore (it would always return the height of 1 line) but on the actual title height which returns the height for the multiple lines.

#### Add title_min_height param to avoid iPhone X layout issues

This enables to have the device tops being all at the same height even if the title/keyword are taller on a given screenshot. This can happen with multiline titles but also titles were the size was adjusted (see example). **Having devices at different heights is not super nice when the user scrolls horizontally between the screenshots on the App Store.**

Additionally, it's another way to add some breathing room to the screenshots, independently from the `padding` option.

_Before_

<img src="https://user-images.githubusercontent.com/792706/33180631-a50973a2-d06d-11e7-854a-9c4782234ebc.png" width="50%"><img src="https://user-images.githubusercontent.com/792706/33180633-a51f738c-d06d-11e7-97b4-cf9094d80766.png" width="50%">

_After_, with `"title_min_height" : "20%"`

<img src="https://user-images.githubusercontent.com/792706/33180744-096ee174-d06e-11e7-8452-9628f4c64e3e.png" width="50%"><img src="https://user-images.githubusercontent.com/792706/33180746-098e32d6-d06e-11e7-8a12-1722a0a616cf.png" width="50%">


#### Add cascading filters

You may want to adjust the layout not only based on the screenshot number/name, but also on the device. Currently, only the first filter matching the screenshot path is applied. With this change, the filters are applied in order.

This lets modify the iPad screenshot without modifying the iPhone's:

```
{
  "device_frame_version": "latest",
  "default": {
    "title": {
      "color": "#ffffff"
    },
    "background": "./Frameit-background.png",
    "padding": "3%",
    "show_complete_frame": false,
    "stack_title" : true,
    "title_below_image": false,
    "font_scale_factor": 0.05
  },
   "data": [
    {
      "filter": "scan"
    },
    {
      "filter": "edit"
    },
    {
      "filter": "multipage_pdf"
    },
    {
      "filter": "organize"
    },
    {
      "filter": "export"
    },
    {
      "filter" : "iPad",
      "show_complete_frame" : true,
      "font_scale_factor": 0.035
    }
  ]
}
```

_Before_
<img src="https://user-images.githubusercontent.com/792706/32885662-6f2dffdc-cabe-11e7-823b-637f233b97e5.png" alt="before" width="45%"><img src="https://user-images.githubusercontent.com/792706/32885739-afa38ef6-cabe-11e7-9f4c-2cff74c9f7fb.png" width="30%">

_After_
<img src="https://user-images.githubusercontent.com/792706/32885366-94654a18-cabd-11e7-9fe4-0b7d628c1f7a.png" alt="after" width="45%"><img src="https://user-images.githubusercontent.com/792706/32885739-afa38ef6-cabe-11e7-9f4c-2cff74c9f7fb.png" width="30%">

Another example is how this lets us improve the iPhone X screenshots together with the `title_min_height` feature: 

```
    {
      "filter" : "iPhone X",
      "title_min_height" : "30%"
    }
```

_Before_

<img src="https://user-images.githubusercontent.com/792706/33180276-6e793d50-d06c-11e7-8b2c-af26f2ae8e27.png" width="30%"> 

_After_

<img src="https://user-images.githubusercontent.com/792706/33180060-cbc97f2a-d06b-11e7-9a45-3bd91641cc7d.png" width="30%">

