### PR TITLE
Docs: Fix (special) actions logo size

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/frameit.md
+++ b/fastlane/lib/fastlane/actions/docs/frameit.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="/img/actions/frameit.png" height="110">
+  <img src="/img/actions/frameit.png" width="250">
 </p>
 
 ###### Quickly put your screenshots into the right device frames

--- a/fastlane/lib/fastlane/actions/docs/match.md
+++ b/fastlane/lib/fastlane/actions/docs/match.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="/img/actions/match.png" height="110">
+  <img src="/img/actions/match.png" width="250">
 </p>
 
 ###### Easily sync your certificates and profiles across your team using git

--- a/fastlane/lib/fastlane/actions/docs/pem.md
+++ b/fastlane/lib/fastlane/actions/docs/pem.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="/img/actions/pem.png" height="110">
+  <img src="/img/actions/pem.png" width="250">
 </p>
 
 ###### Automatically generate and renew your push notification profiles

--- a/fastlane/lib/fastlane/actions/docs/precheck.md
+++ b/fastlane/lib/fastlane/actions/docs/precheck.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="/img/actions/precheck.png" height="110">
+  <img src="/img/actions/precheck.png" width="250">
 </p>
 
 Precheck

--- a/fastlane/lib/fastlane/actions/docs/produce.md
+++ b/fastlane/lib/fastlane/actions/docs/produce.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="/img/actions/produce.png" height="110">
+  <img src="/img/actions/produce.png" width="250">
 </p>
 
 ###### Create new iOS apps on iTunes Connect and Dev Portal using your command line

--- a/fastlane/lib/fastlane/actions/docs/scan.md
+++ b/fastlane/lib/fastlane/actions/docs/scan.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="/img/actions/scan.png" height="110">
+  <img src="/img/actions/scan.png" width="250">
 </p>
 
 ###### The easiest way to run tests of your iOS and Mac app

--- a/fastlane/lib/fastlane/actions/docs/screengrab.md
+++ b/fastlane/lib/fastlane/actions/docs/screengrab.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="/img/actions/screengrab.png" height="110">
+  <img src="/img/actions/screengrab.png" width="250">
 </p>
 
 ###### Automated localized screenshots of your Android app on every device

--- a/fastlane/lib/fastlane/actions/docs/sigh.md
+++ b/fastlane/lib/fastlane/actions/docs/sigh.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="/img/actions/sigh.png" height="110">
+  <img src="/img/actions/sigh.png" width="250">
 </p>
 
 ###### Because you would rather spend your time building stuff than fighting provisioning

--- a/fastlane/lib/fastlane/actions/docs/snapshot.md
+++ b/fastlane/lib/fastlane/actions/docs/snapshot.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="/img/actions/snapshot.png" height="110">
+  <img src="/img/actions/snapshot.png" width="250">
 </p>
 
 ###### Automate taking localized screenshots of your iOS and tvOS apps on every device

--- a/fastlane/lib/fastlane/actions/docs/supply.md
+++ b/fastlane/lib/fastlane/actions/docs/supply.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="/img/actions/supply.png" height="110">
+  <img src="/img/actions/supply.png" width="250">
 </p>
 
 ###### Command line tool for updating Android apps and their metadata on the Google Play Store


### PR DESCRIPTION
Right now most of the tools / actions with logo's logos are too big in the default view. Example: https://docs.fastlane.tools/actions/scan/

An exception is `deliver`, which looks better: https://docs.fastlane.tools/actions/deliver/

I adapted all other actions to use the same html code.