### PR TITLE
Fix download_dsyms action

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -57,6 +57,8 @@ module Fastlane
             end
 
             begin
+              # need to call reload here or dsym_url is nil
+              build.reload
               download_url = build.dsym_url
             rescue Spaceship::TunesClient::ITunesConnectError => ex
               UI.error("Error accessing dSYM file for build\n\n#{build}\n\nException: #{ex}")


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The `download_dsyms` action was broken by iTunes Connect API changes. Spaceship was modified to reflect this but the `download_dsyms` broke in the process.

### Description
I added a reload step to the part that retrieves the `dsym_url`. This ensures that the URL is not nil if present.
