### PR TITLE
Fix FastlaneCore::Helper.xcode_path for non-Mac environments

### DIFF
--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -1,3 +1,7 @@
+# This module is only used to check the environment is currently a testing env
+module SpecHelper
+end
+
 require "coveralls"
 Coveralls.wear! unless ENV["FASTLANE_SKIP_UPDATE_CHECK"]
 
@@ -6,10 +10,6 @@ WebMock.disable_net_connect!(allow: 'coveralls.io')
 
 require "fastlane"
 UI = FastlaneCore::UI
-
-# This module is only used to check the environment is currently a testing env
-module SpecHelper
-end
 
 unless ENV["DEBUG"]
   $stdout.puts "Changing stdout to /tmp/fastlane_tests, set `DEBUG` environment variable to print to stdout (e.g. when using `pry`)"

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -12,6 +12,10 @@ unless ENV["DEBUG"]
   $stdout = File.open("/tmp/fastlane_tests", "w")
 end
 
+# This module is only used to check the environment is currently a testing env
+module SpecHelper
+end
+
 xcode_path = FastlaneCore::Helper.xcode_path
 unless xcode_path.include?("Contents/Developer")
   UI.error("Seems like you didn't set the developer tools path correctly")
@@ -20,10 +24,6 @@ unless xcode_path.include?("Contents/Developer")
   UI.command("sudo xcode-select -s /Applications/Xcode.app")
   UI.error("Adapt the path if you have Xcode installed/named somewhere else")
   exit(1)
-end
-
-# This module is only used to check the environment is currently a testing env
-module SpecHelper
 end
 
 (Fastlane::TOOLS + [:spaceship, :fastlane_core]).each do |tool|

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -7,13 +7,13 @@ WebMock.disable_net_connect!(allow: 'coveralls.io')
 require "fastlane"
 UI = FastlaneCore::UI
 
+# This module is only used to check the environment is currently a testing env
+module SpecHelper
+end
+
 unless ENV["DEBUG"]
   $stdout.puts "Changing stdout to /tmp/fastlane_tests, set `DEBUG` environment variable to print to stdout (e.g. when using `pry`)"
   $stdout = File.open("/tmp/fastlane_tests", "w")
-end
-
-# This module is only used to check the environment is currently a testing env
-module SpecHelper
 end
 
 if FastlaneCore::Helper.is_mac?


### PR DESCRIPTION
`FastlaneCore::Helper.xcode_path` finds out if it is inside a test by checking for if `SpecHelper` is defined:
https://github.com/fastlane/fastlane/blob/5019acb53fc2adf050b4227c3e3216e365ba36ec/fastlane_core/lib/fastlane_core/helper.rb#L23-L25
If the module is only loaded after the check is first executed, it internally never realizes it is in a test and return the wrong value on non-Mac environments. Only on subsequent calls does it return the correct value.

Moving the SpecHelper module code before the first call to `FastlaneCore::Helper.xcode_path` fixes the problem.
