### PR TITLE
spec_helper.rb: Only check for valid Xcode path on Mac

### DIFF
--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -12,8 +12,7 @@ unless ENV["DEBUG"]
   $stdout = File.open("/tmp/fastlane_tests", "w")
 end
 
-is_mac = FastlaneCore::Helper.is_mac?
-if is_mac
+if FastlaneCore::Helper.is_mac?
   xcode_path = FastlaneCore::Helper.xcode_path
   unless xcode_path.include?("Contents/Developer")
     UI.error("Seems like you didn't set the developer tools path correctly")

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -12,14 +12,17 @@ unless ENV["DEBUG"]
   $stdout = File.open("/tmp/fastlane_tests", "w")
 end
 
-xcode_path = FastlaneCore::Helper.xcode_path
-unless xcode_path.include?("Contents/Developer")
-  UI.error("Seems like you didn't set the developer tools path correctly")
-  UI.error("Detected path '#{xcode_path}'") if xcode_path.to_s.length > 0
-  UI.error("Please run the following on your machine")
-  UI.command("sudo xcode-select -s /Applications/Xcode.app")
-  UI.error("Adapt the path if you have Xcode installed/named somewhere else")
-  exit(1)
+is_mac = FastlaneCore::Helper.is_mac?
+if is_mac
+  xcode_path = FastlaneCore::Helper.xcode_path
+  unless xcode_path.include?("Contents/Developer")
+    UI.error("Seems like you didn't set the developer tools path correctly")
+    UI.error("Detected path '#{xcode_path}'") if xcode_path.to_s.length > 0
+    UI.error("Please run the following on your machine")
+    UI.command("sudo xcode-select -s /Applications/Xcode.app")
+    UI.error("Adapt the path if you have Xcode installed/named somewhere else")
+    exit(1)
+  end
 end
 
 # This module is only used to check the environment is currently a testing env


### PR DESCRIPTION
### Motivation and Context
See #11044 

### Description
Added an additional if around the check that makes sure the code is only executed if the platform is Mac.

fixes #11044
