### PR TITLE
[Docs template] Actions: Linkable headline instead of bolded text

### DIFF
--- a/fastlane/lib/assets/ActionDetails.md.erb
+++ b/fastlane/lib/assets/ActionDetails.md.erb
@@ -27,7 +27,7 @@ Returns | <%= action.return_value %>
 
 <% if (action.example_code || []).count > 0 %>
 
-**<%= action.example_code.count %> Example<%= (action.example_code.count > 1) ? "s" : "" %>**
+## <%= action.example_code.count %> Example<%= (action.example_code.count > 1) ? "s" : "" %>
 <% action.example_code.each do |current_sample| %>
 ```ruby
 <%= current_sample.gsub("          ", "") %>
@@ -37,7 +37,7 @@ Returns | <%= action.return_value %>
 
 <% if action.available_options && action.available_options.first.kind_of?(FastlaneCore::ConfigItem) %>
 
-**Parameters**
+## Parameters
 
 Key | Description
 ----|------------


### PR DESCRIPTION
Right now the "Parameters" table is not linkable with `#parameters` on action docs pages. 

This changes the headline above from a bolded text to a semantically correct headline - with the sideeffect to also generate a linkable id, similar to the main headline.