### PR TITLE
Update Fastfile templates to use new core action names.

### DIFF
--- a/fastlane/lib/assets/DefaultFastfileTemplate
+++ b/fastlane/lib/assets/DefaultFastfileTemplate
@@ -24,15 +24,15 @@ platform :ios do
 
   desc "Runs all the tests"
   lane :test do
-    scan
+    run_tests
   end
 
   desc "Submit a new Beta Build to Apple TestFlight"
   desc "This will also make sure the profile is up to date"
   lane :beta do
     # match(type: "appstore") # more information: https://codesigning.guide
-    gym[[SCHEME]] # Build your app - more options available
-    pilot
+    build_app[[SCHEME]] # more options available
+    upload_to_testflight
 
     # sh "your_script.sh"
     # You can also use other beta testing services here (run `fastlane actions`)
@@ -40,11 +40,11 @@ platform :ios do
 
   desc "Deploy a new version to the App Store"
   lane :release do
-    # match(type: "appstore")
-    snapshot
-    gym[[SCHEME]] # Build your app - more options available
-    deliver(force: true)
-    # frameit
+    # sync_code_signing(type: "appstore")
+    capture_screenshots
+    build_app[[SCHEME]] # Build your app - more options available
+    upload_to_app_store(force: true)
+    # frame_screenshots
   end
 
   # You can define as many lanes as you want

--- a/fastlane/lib/assets/FastfileTemplateAndroid
+++ b/fastlane/lib/assets/FastfileTemplateAndroid
@@ -37,7 +37,7 @@ platform :android do
   desc "Deploy a new version to the Google Play"
   lane :deploy do
     gradle(task: "assembleRelease")
-    supply
+    upload_to_play_store
   end
 
   # You can define as many lanes as you want

--- a/fastlane/spec/setup_spec.rb
+++ b/fastlane/spec/setup_spec.rb
@@ -62,9 +62,9 @@ describe Fastlane do
 
           content = File.read(File.join(FastlaneCore::FastlaneFolder.path, 'Fastfile'))
           expect(content).to include "# update_fastlane"
-          expect(content).to include "deliver"
-          expect(content).to include "scan"
-          expect(content).to include "gym(scheme: \"MyScheme\")"
+          expect(content).to include "upload_to_app_store"
+          expect(content).to include "run_tests"
+          expect(content).to include "build_app(scheme: \"MyScheme\")"
 
           content = File.read(File.join(FastlaneCore::FastlaneFolder.path, 'Appfile'))
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (do: [x], don't: [x ], [ x], [✔️]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
In order to make `Fastfile`s more readable, #10939 renames the core actions to names that are more clear. This changes the `Fastfile` templates (used by `fastlane init`) to use the new core action names.

### Description
<!-- Describe your changes in detail -->
Update core action names inside of `Fastfile` templates to reference the new core actions.