### PR TITLE
Fix require for frame_screenshots

### DIFF
--- a/fastlane/lib/fastlane/actions/frameit.rb
+++ b/fastlane/lib/fastlane/actions/frameit.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Actions
-    require 'fastlane/actions/frameit'
+    require 'fastlane/actions/frame_screenshots'
     class FrameitAction < FrameScreenshotsAction
       #####################################################
       # @!group Documentation


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

```
/Users/jdee/github/jdee/fastlane/fastlane/lib/fastlane/actions/frameit.rb:4:in `<module:Actions>': uninitialized constant Fastlane::Actions::FrameScreenshotsAction (NameError)
```

And just above that, in `frameit.rb`, `require 'fastlane/actions/frameit'`, which is the same file. It's not clear why this didn't fail in CI.

### Description

Changed the require to `'fastlane/actions/frame_screenshots'`.