### PR TITLE
Further improvements to sh

### DIFF
--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -94,8 +94,8 @@ module Fastlane
     end
 
     # to allow a simple `sh` in the custom actions
-    def self.sh(command, print_command: true, print_command_output: true, error_callback: nil)
-      Fastlane::Actions.sh_control_output(command, print_command: print_command, print_command_output: print_command_output, error_callback: error_callback)
+    def self.sh(*command, print_command: true, print_command_output: true, error_callback: nil)
+      Fastlane::Actions.sh_control_output(*command, print_command: print_command, print_command_output: print_command_output, error_callback: error_callback)
     end
 
     # Documentation category, available values defined in AVAILABLE_CATEGORIES

--- a/fastlane/lib/fastlane/actions/sh.rb
+++ b/fastlane/lib/fastlane/actions/sh.rb
@@ -54,7 +54,7 @@ module Fastlane
       def self.example_code
         [
           'sh("ls")',
-          'sh("git commit -m \'My message\'")'
+          'sh("git", "commit", "-m", "My message")'
         ]
       end
 

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -175,10 +175,9 @@ module Fastlane
 
     # Execute shell command
     def sh(*command, log: true, error_callback: nil)
-      command = Actions.shell_command_from_args(*command)
-      command_header = log ? command : "shell command"
+      command_header = log ? Actions.shell_command_from_args(*command) : "shell command"
       Actions.execute_action(command_header) do
-        Actions.sh_no_action(command, log: log, error_callback: error_callback)
+        Actions.sh_no_action(*command, log: log, error_callback: error_callback)
       end
     end
 

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -175,7 +175,7 @@ module Fastlane
 
     # Execute shell command
     def sh(*command, log: true, error_callback: nil)
-      command = Actions.command_from_args(*command)
+      command = Actions.shell_command_from_args(*command)
       command_header = log ? command : "shell command"
       Actions.execute_action(command_header) do
         Actions.sh_no_action(command, log: log, error_callback: error_callback)

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -174,8 +174,8 @@ module Fastlane
     end
 
     # Execute shell command
-    def sh(command, log: true, error_callback: nil)
-      command = Shellwords.join(command) if command.kind_of?(Array)
+    def sh(*command, log: true, error_callback: nil)
+      command = Actions.command_from_args(*command)
       command_header = log ? command : "shell command"
       Actions.execute_action(command_header) do
         Actions.sh_no_action(command, log: log, error_callback: error_callback)

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -70,6 +70,7 @@ module Fastlane
     end
 
     def self.command_from_args(*args)
+      raise ArgumentError, "sh requires at least one argument" unless args.count > 0
       if args.count == 1
         command = args.first
         command = command.shelljoin if command.kind_of?(Array)

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -27,7 +27,7 @@ module Fastlane
       Encoding.default_external = Encoding::UTF_8
       Encoding.default_internal = Encoding::UTF_8
 
-      command = command_from_args(*command)
+      command = shell_command_from_args(*command)
       UI.command(command) if print_command
 
       result = ''
@@ -69,7 +69,7 @@ module Fastlane
       Encoding.default_internal = previous_encoding.last
     end
 
-    def self.command_from_args(*args)
+    def self.shell_command_from_args(*args)
       raise ArgumentError, "sh requires at least one argument" unless args.count > 0
       if args.count == 1
         command = args.first

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -8,26 +8,26 @@ module Fastlane
     # When running this in tests, it will return the actual command instead of executing it
     # @param log [Boolean] should fastlane print out the executed command
     # @param error_callback [Block] a callback invoked with the command output if there is a non-zero exit status
-    def self.sh(command, log: true, error_callback: nil)
-      sh_control_output(command, print_command: log, print_command_output: log, error_callback: error_callback)
+    def self.sh(*command, log: true, error_callback: nil)
+      sh_control_output(*command, print_command: log, print_command_output: log, error_callback: error_callback)
     end
 
-    def self.sh_no_action(command, log: true, error_callback: nil)
-      sh_control_output(command, print_command: log, print_command_output: log, error_callback: error_callback)
+    def self.sh_no_action(*command, log: true, error_callback: nil)
+      sh_control_output(*command, print_command: log, print_command_output: log, error_callback: error_callback)
     end
 
-    # @param command [String] The command to be executed
+    # @param command [String, Array] The command to be executed
     # @param print_command [Boolean] Should we print the command that's being executed
     # @param print_command_output [Boolean] Should we print the command output during execution
     # @param error_callback [Block] A block that's called if the command exits with a non-zero status
-    def self.sh_control_output(command, print_command: true, print_command_output: true, error_callback: nil)
+    def self.sh_control_output(*command, print_command: true, print_command_output: true, error_callback: nil)
       print_command = print_command_output = true if $troubleshoot
       # Set the encoding first, the user might have set it wrong
       previous_encoding = [Encoding.default_external, Encoding.default_internal]
       Encoding.default_external = Encoding::UTF_8
       Encoding.default_internal = Encoding::UTF_8
 
-      command = Shellwords.join(command) if command.kind_of?(Array) # since it's an array of one element when running from the Fastfile
+      command = command_from_args(*command)
       UI.command(command) if print_command
 
       result = ''
@@ -67,6 +67,16 @@ module Fastlane
     ensure
       Encoding.default_external = previous_encoding.first
       Encoding.default_internal = previous_encoding.last
+    end
+
+    def self.command_from_args(*args)
+      if args.count == 1
+        command = args.first
+        command = command.shelljoin if command.kind_of?(Array)
+      else
+        command = args.shelljoin
+      end
+      command
     end
   end
 end

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -67,7 +67,7 @@ module Fastlane
           end
         end
       else
-        result << command # only for the tests
+        result << shell_command # only for the tests
       end
 
       result

--- a/fastlane/spec/helper/sh_helper_spec.rb
+++ b/fastlane/spec/helper/sh_helper_spec.rb
@@ -45,8 +45,8 @@ describe Fastlane::Actions do
       end
 
       it "allows override of argv[0]" do
-        expect_command ["/usr/local/bin", "git"], "commit", "-m", "A message"
-        Fastlane::Actions.sh ["/usr/local/bin", "git"], "commit", "-m", "A message"
+        expect_command ["/usr/local/bin/git", "git"], "commit", "-m", "A message"
+        Fastlane::Actions.sh ["/usr/local/bin/git", "git"], "commit", "-m", "A message"
       end
     end
   end

--- a/fastlane/spec/helper/sh_helper_spec.rb
+++ b/fastlane/spec/helper/sh_helper_spec.rb
@@ -58,25 +58,25 @@ describe Fastlane::Actions do
     end
   end
 
-  describe "command_from_args" do
+  describe "shell_command_from_args" do
     it "returns the string without shell escaping if a string is passed" do
-      command = Fastlane::Actions.command_from_args "cmd arg1 arg 2"
+      command = Fastlane::Actions.shell_command_from_args "cmd arg1 arg 2"
       expect(command).to eq "cmd arg1 arg 2"
     end
 
     it "returns a shelljoined string if an array is passed" do
-      command = Fastlane::Actions.command_from_args ["cmd", "arg1", "arg 2", 42]
+      command = Fastlane::Actions.shell_command_from_args ["cmd", "arg1", "arg 2", 42]
       expect(command).to eq 'cmd arg1 arg\ 2 42'
     end
 
     it "returns a shelljoined string if multiple arguments are passed" do
-      command = Fastlane::Actions.command_from_args "cmd", "arg1", "arg 2", 42
+      command = Fastlane::Actions.shell_command_from_args "cmd", "arg1", "arg 2", 42
       expect(command).to eq 'cmd arg1 arg\ 2 42'
     end
 
     it "raises ArgumentError with no arguments" do
       expect do
-        Fastlane::Actions.command_from_args
+        Fastlane::Actions.shell_command_from_args
       end.to raise_error ArgumentError
     end
   end

--- a/fastlane/spec/helper/sh_helper_spec.rb
+++ b/fastlane/spec/helper/sh_helper_spec.rb
@@ -57,6 +57,23 @@ describe Fastlane::Actions do
       end
     end
   end
+
+  describe "command_from_args" do
+    it "returns the string without shell escaping if a string is passed" do
+      command = Fastlane::Actions.command_from_args "cmd arg1 arg 2"
+      expect(command).to eq "cmd arg1 arg 2"
+    end
+
+    it "returns a shelljoined string if an array is passed" do
+      command = Fastlane::Actions.command_from_args ["cmd", "arg1", "arg 2", 42]
+      expect(command).to eq 'cmd arg1 arg\ 2 42'
+    end
+
+    it "returns a shelljoined string if multiple arguments are passed" do
+      command = Fastlane::Actions.command_from_args "cmd", "arg1", "arg 2", 42
+      expect(command).to eq 'cmd arg1 arg\ 2 42'
+    end
+  end
 end
 
 def expect_command(command, exitstatus = 0)

--- a/fastlane/spec/helper/sh_helper_spec.rb
+++ b/fastlane/spec/helper/sh_helper_spec.rb
@@ -73,6 +73,12 @@ describe Fastlane::Actions do
       command = Fastlane::Actions.command_from_args "cmd", "arg1", "arg 2", 42
       expect(command).to eq 'cmd arg1 arg\ 2 42'
     end
+
+    it "raises ArgumentError with no arguments" do
+      expect do
+        Fastlane::Actions.command_from_args
+      end.to raise_error ArgumentError
+    end
   end
 end
 

--- a/fastlane/spec/helper/sh_helper_spec.rb
+++ b/fastlane/spec/helper/sh_helper_spec.rb
@@ -50,6 +50,11 @@ describe Fastlane::Actions do
         expect_command 'git commit . -m a\ message'
         Fastlane::Actions.sh(["git", "commit", pathname, "-m", "a message"])
       end
+
+      it "converts a list of arguments" do
+        expect_command 'git commit -m a\ message'
+        Fastlane::Actions.sh("git", "commit", "-m", "a message")
+      end
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

**Updated**

### Motivation and Context

This change permits complete passthrough of a variadic argument list to `Open3.popen2e`, which interprets the the list in the same was as `Process.spawn` and `Kernel#system`.

```Ruby
sh "ls", "-la"
sh "cat", path, error_callback: ->(result) { ... }
sh { "FOO" => "Hello" }, "echo $FOO"
```

This makes `sh` much more flexible and powerful, while at the same time simplifying the code and removing any need for argument handling to enable this.

See http://ruby-doc.org/core-2.4.2/Process.html#method-c-spawn for details on the arguments that can be passed.

### Description

The variadic argument list is simply passed through from every variant of `sh` directly to `popen2e`. And that's it.

To construct a command to display, `Actions.shell_command_from_args` was introduced. This uses shell escaping and joining to produce a shell command equivalent to what is being executed. This method is well tested. It is also largely cosmetic, so issues can reasonably be addressed later if they arise.

It's worth mentioning one important change that applies to all variadic methods that handle commands, like `system`. If the command to be executed (ignoring any optional leading environment hash) is a single string, the string is passed to the shell to be executed. In all other cases, the arguments are passed directly to exec as the argv. No shell is invoked. There is no shell escaping and no shell to convert the escaped arguments back to the argv. This also saves a child process, since a shell forks each command.

This change also breaks the Array handling that was introduced in 2.68.0 but not yet advertised or documented. The reason is that `system` and friends allow overriding `argv[0]`. For example:

```Ruby
sh [ "/usr/local/bin/foo", "foo" ], "-x"
```

This executes the binary `/usr/local/bin/foo` but passes "foo" as `argv[0]`. This is how `popen2e` and `system` will interpret any array passed. I think it's just as well to proceed with this change, since the Array support is a half-measure. I don't think anyone will miss the brackets.

There is one syntactic corner case that may somehow be made to work and is probably not worth supporting if it does not. However, it's difficult. Because `sh` accepts its own keywords, e.g.
`error_callback`, it is difficult to pass a trailing options Hash. Compare:

```Ruby
system "ls", "-la", chdir: "/tmp"
```

This changes directory to `/tmp` and runs the command.

```Ruby
sh "ls", "-la", chdir: "/tmp"
```

This generates `no such keyword: chdir`. It's difficult and maybe impossible to pass this hash to a method with keyword arguments. I think I have a fix, but this may not be worth supporting. Other options can be used to redirect output, e.g., which would at least be confusing and possibly cause errors. For now, I've ignored any handling of a trailing options hash to `popen2e`.

This change makes `sh` much more like the `system` call. Here's a comparison:

|sh|system|
|--|-------|
|Raises Errno::ENOENT if command to be executed is not found|Raises Errno::ENOENT if command to be executed is not found|
|Output is returned on success. An exception is raised on error.|true is returned on success. false is returned on error.|
|$? is set to the Process::Status of the command|$? is set to the Process::Status of the command|
|calls error_callback on error||
|does not accept a trailing options Hash|accepts a trailing options Hash|
|outputs the command and formatted output via UI|does not output the command or format the output|
|shorter method name|longer method name|
