### PR TITLE
Version bump to 2.68.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.67.0'.freeze
+  VERSION = '2.68.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.67.0':**

* Fix require for frame_screenshots (#11064) via Jimmy Dee
* Allow shell conversion when type is :shell_string (#10946) via Jimmy Dee
* Update Fastfile templates to use new core action names. (#11061) via Mark Pirri
* [Docs template] Actions: Linkable headline instead of bolded text (#11053) via Jan Piotrowski
* Docs: Tiny fixes for frameit (#11060) via Jan Piotrowski
* Update updated T&Cs instructions (#11058) via Michał Ordon
* Fastlane core action rename & aliases (#10939) via Mark Pirri
* Fix FastlaneCore::Helper.xcode_path for non-Mac environments (#11043) via Jan Piotrowski
* Only check for valid Xcode path when run on Mac (#11045) via Jan Piotrowski
* Extended tab auto complete to work with bundler and custom commands (#11004) via Iulian Onofrei
