### PR TITLE
Fix tool name convention in action descriptions

### DIFF
--- a/fastlane/lib/fastlane/actions/build_ios_app.rb
+++ b/fastlane/lib/fastlane/actions/build_ios_app.rb
@@ -86,7 +86,7 @@ module Fastlane
       end
 
       def self.description
-        "Easily build and sign your app (via gym)"
+        "Easily build and sign your app (via _gym_)"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/capture_android_screenshots.rb
+++ b/fastlane/lib/fastlane/actions/capture_android_screenshots.rb
@@ -20,7 +20,7 @@ module Fastlane
       end
 
       def self.description
-        'Automated localized screenshots of your Android app (via `screengrab`)'
+        'Automated localized screenshots of your Android app (via _screengrab_)'
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/actions/capture_ios_screenshots.rb
+++ b/fastlane/lib/fastlane/actions/capture_ios_screenshots.rb
@@ -19,7 +19,7 @@ module Fastlane
       end
 
       def self.description
-        "Generate new localized screenshots on multiple devices (via `snapshot`)"
+        "Generate new localized screenshots on multiple devices (via _snapshot_)"
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/actions/check_app_store_metadata.rb
+++ b/fastlane/lib/fastlane/actions/check_app_store_metadata.rb
@@ -11,7 +11,7 @@ module Fastlane
       end
 
       def self.description
-        "Check your app's metadata before you submit your app to review (via `precheck`)"
+        "Check your app's metadata before you submit your app to review (via _precheck_)"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/create_app_online.rb
+++ b/fastlane/lib/fastlane/actions/create_app_online.rb
@@ -22,12 +22,12 @@ module Fastlane
       end
 
       def self.description
-        "Creates the given application on iTC and the Dev Portal (via `produce`)"
+        "Creates the given application on iTC and the Dev Portal (via _produce_)"
       end
 
       def details
         [
-          'Create new apps on iTunes Connect and Apple Developer Portal via `produce`.',
+          'Create new apps on iTunes Connect and Apple Developer Portal via _produce_.',
           'If the app already exists, `create_app_online` will not do anything.',
           'For more information about produce, visit its GitHub page:',
           'https://github.com/fastlane/fastlane/tree/master/produce'

--- a/fastlane/lib/fastlane/actions/frame_screenshots.rb
+++ b/fastlane/lib/fastlane/actions/frame_screenshots.rb
@@ -15,7 +15,7 @@ module Fastlane
       end
 
       def self.description
-        "Adds device frames around all screenshots (via `frameit`)"
+        "Adds device frames around all screenshots (via _frameit_)"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/get_certificates.rb
+++ b/fastlane/lib/fastlane/actions/get_certificates.rb
@@ -27,7 +27,7 @@ module Fastlane
       end
 
       def self.description
-        "Create new iOS code signing certificates (via `cert`)"
+        "Create new iOS code signing certificates (via _cert_)"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
@@ -44,7 +44,7 @@ module Fastlane
       end
 
       def self.description
-        "Generates a provisioning profile, saving it in the current folder (via `sigh`)"
+        "Generates a provisioning profile, saving it in the current folder (via _sigh_)"
       end
 
       def self.author

--- a/fastlane/lib/fastlane/actions/get_push_certificate.rb
+++ b/fastlane/lib/fastlane/actions/get_push_certificate.rb
@@ -22,7 +22,7 @@ module Fastlane
       end
 
       def self.description
-        "Ensure a valid push profile is active, creating a new one if needed (via `pem`)"
+        "Ensure a valid push profile is active, creating a new one if needed (via _pem_)"
       end
 
       def self.author

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -38,7 +38,7 @@ module Fastlane
       end
 
       def self.description
-        "Easily run tests of your iOS app (via `scan`)"
+        "Easily run tests of your iOS app (via _scan_)"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -55,7 +55,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Easily sync your certificates and profiles across your team (via `match`)"
+        "Easily sync your certificates and profiles across your team (via _match_)"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/upload_to_app_store.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_app_store.rb
@@ -18,7 +18,7 @@ module Fastlane
       end
 
       def self.description
-        "Upload metadata and binary to iTunes Connect (via `deliver`)"
+        "Upload metadata and binary to iTunes Connect (via _deliver_)"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/upload_to_play_store.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_play_store.rb
@@ -26,7 +26,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Upload metadata, screenshots and binaries to Google Play (via `supply`)"
+        "Upload metadata, screenshots and binaries to Google Play (via _supply_)"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/upload_to_testflight.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_testflight.rb
@@ -21,7 +21,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Upload a new binary to iTunes Connect for TestFlight beta testing (via `pilot`)"
+        "Upload a new binary to iTunes Connect for TestFlight beta testing (via _pilot_)"
       end
 
       def self.details


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (do: [x], don't: [x ], [ x], [✔️]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
The new tool actions created in #10939 have incorrect formatting in their `description` fields. This is causing the documentation task to fail.

### Description
<!-- Describe your changes in detail -->
This PR changes the action `descriptions` to properly surround _fastlane_ tool names in underscores.