### PR TITLE
Change gym reference to be surrounded by underscores

### DIFF
--- a/fastlane/lib/fastlane/actions/copy_artifacts.rb
+++ b/fastlane/lib/fastlane/actions/copy_artifacts.rb
@@ -97,7 +97,7 @@ module Fastlane
           reset_git_repo(
             exclude: "artifacts"
           )',
-          '# Copy the .ipa created by `gym` if it was successfully created
+          '# Copy the .ipa created by _gym_ if it was successfully created
           artifacts = []
           artifacts << lane_context[SharedValues::IPA_OUTPUT_PATH] if lane_context[SharedValues::IPA_OUTPUT_PATH]
           copy_artifacts(


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (do: [x], don't: [x ], [ x], [✔️]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
Referencing `gym` rather than _gym_ in example code causes errors when building docs.

### Description
<!-- Describe your changes in detail -->
Change `gym` to _gym_.