### PR TITLE
[spaceship] Updating some outdated testflight examples

### DIFF
--- a/spaceship/docs/iTunesConnect.md
+++ b/spaceship/docs/iTunesConnect.md
@@ -206,20 +206,16 @@ To clarify:
 A build train contains all builds for a give `version number` (e.g. `0.9.21`). Within the build train you have *n* builds, each having a different `build number` (e.g. `99993`).
 
 ```ruby
+# Access all build trains for an app
+app.all_build_train_numbers   # => ["0.9.21"]
+
 # Access the build train via the version number
 train = app.build_trains["0.9.21"]
 
-train.version_string          # => "0.9.21"
-train.external_testing_enabled         # => false, as external testing is enabled for 0.9.20
-
 # Access all builds for a given train
-train.builds.count            # => 1
-build = train.builds.first
+train.count            # => 1
+build = train.first
 
-# Enable beta testing for a build train
-# This will put the latest build into beta testing mode
-# and turning off beta testing for all other build trains
-train.update_testing_status!(true, 'external')
 ```
 
 ## Builds
@@ -231,29 +227,13 @@ build.train_version           # => "0.9.21" (the version number)
 build.install_count           # => 1
 build.crash_count             # => 0
 
-build.testing_status          # => "Internal" or "External" or "Expired" or "Inactive"
+build.internal_state         # => testflight.build.state.testing.ready
+build.external_state         # => testflight.build.state.submit.ready
 ```
 
-You can even submit a build for external beta review
+You can even submit a build for external beta review (after you have set all necessary metadata - see above)
 ```ruby
-parameters = {
-  changelog: "Awesome new features",
-  description: "Why would I want to provide that?",
-  feedback_email: "contact@company.com",
-  marketing_url: "http://marketing.com",
-  first_name: "Felix",
-  last_name: "Krause",
-  review_email: "contact@company.com",
-  phone_number: "0123456789",
-  significant_change: false,
-
-  # Optional Metadata:
-  privacy_policy_url: nil,
-  review_user_name: nil,
-  review_password: nil,
-  encryption: false
-}
-build.submit_for_beta_review!(parameters)
+build.submit_for_testflight_review!
 ```
 
 ## Processing builds


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
People had a hard time when getting into spaceship for testflight, because of outdated docu
<!-- Please describe in detail how you tested your changes. -->
Executed and validated all commands with current version of fastlane

### Description
Access to the build in a build-train has changed, also some commands of build-object and train-object
