### PR TITLE
Add caching of Apple sessions to avoid rate limits

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -428,6 +428,7 @@ module Spaceship
       # tools in a lane (e.g. call match 5 times), this would mean it locks you out of the account
       # for a while.
       # By loading existing sessions and checking if they're valid, we're sending less login requests
+      # More context on why this change was necessary https://github.com/fastlane/fastlane/pull/11108
       #
       if load_session_from_file
         # Check if the session is still valid here

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -109,7 +109,11 @@ module Spaceship
 
     def send_login_request(user, password)
       clear_user_cached_data
-      send_shared_login_request(user, password)
+      result = send_shared_login_request(user, password)
+
+      store_cookie
+
+      return result
     end
 
     # Sometimes we get errors or info nested in our data

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -9,7 +9,7 @@ describe Spaceship::Client do
   describe '#login' do
     it 'sets the session cookies' do
       response = subject.login(username, password)
-      expect(response.env.request_headers['Cookie']).to eq('myacinfo=abcdef')
+      expect(subject.cookie).to eq("myacinfo=abcdef")
     end
 
     it 'raises an exception if authentication failed' do


### PR DESCRIPTION
This PR introduces session caching in-between spaceship calls to avoid running into the newly introduced rate limit on the server side. The rate limit is implemented with some flaws, as it also affects successful auth requests. I'll file a radar to inform Apple of this issue and see if we can get it resolved. Either way, we can leave this change in, to make spaceship calls faster, e.g. when calling _match_ multiple times from within a single lane.

- Fixes https://github.com/fastlane/fastlane/issues/10812
- Fixes https://github.com/fastlane/fastlane/pull/10826
- Closes https://github.com/fastlane/fastlane/pull/10826

How to reproduce the original issue

`Rakefile` in the root of _fastlane_:

```ruby
task :yolo do
  require 'spaceship'

  30.times do
    puts "Start login"
    Spaceship::Tunes.login("felix@sunapps.net")
    Spaceship::Portal::login("felix@sunapps.net")
    Spaceship::Tunes.login("apple@krausefx.com")
    Spaceship::Portal::login("apple@krausefx.com")
  end
end
```

After a few seconds, you'll get an auth error, indicating that you can't login any more. This lock is based on the combination of your IP address and the Apple ID you're using. It's easy to reset your rate-limiting by using a VPN and logging in successfully again.

I used Charles to make sure no unnecessary requests are sent any more. The `olympus` request is not rate limited, and is a great way to solve 2 problems at the same time:
1) Ensure the loaded session is valid. This way _spaceship_ automatically detects when the loaded session is from a few days ago, and will send an actual login request only if necessary
2) We get the `olympus` session, which we need to send any other requests to the Apple backend.

To ensure `1)` works as expected, I modified my local cache file to something invalid, resulting in _spacesip_ noticing the session isn't valid any more, causing the actual login request to be sent again for the first iteration of the `Rakefile` only.

It's important to note that _spaceship_ keeps the session cache for each Apple ID separately, to enable developers to use _fastlane_ easily with different accounts.

Separate follow-up tasks
- [ ] File a radar
- [ ] Unify the login methods, currently it seems like we have `Spaceship::Tunes.login` and `Spaceship::Portal.login`