### PR TITLE
Version bump to 2.68.2

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.68.1'.freeze
+  VERSION = '2.68.2'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.68.1':**

* Fix: can't create instances of Client because of: `instance variable @client not initialized` (#10439) via Joshua Liebowitz
* Add check & error message if gym provided plist can't be found (#10825) via Felix Krause
* missing colon in appium sample code (#11107) via David Ohayon
