### PR TITLE
Show plugin actions on the plugin page

### DIFF
--- a/fastlane/assets/render_plugin.md.erb
+++ b/fastlane/assets/render_plugin.md.erb
@@ -8,6 +8,19 @@
 
 > <%= @plugin.info %>
 
+<% if @plugin.data[:actions].count > 0 %>
+<details>
+<summary class="plugin-actions">Provided actions</summary>
+
+ Name | Category | Description
+------|----------|------------
+<%- @plugin.data[:actions].each do |action| -%>
+  **<%= action.name %>** | <%= action.category || "-" %> | <%= action.description || action.details || "-" %>
+<%- end -%>
+
+</details>
+<% end %>
+
 <details>
 <summary class="score-details">Score details</summary>
 

--- a/fastlane/helper/plugin_scores_helper.rb
+++ b/fastlane/helper/plugin_scores_helper.rb
@@ -15,6 +15,20 @@ module Fastlane
         end
       end
 
+      class FastlanePluginAction
+        attr_accessor :name
+        attr_accessor :category
+        attr_accessor :description
+        attr_accessor :details
+
+        def initialize(name: nil, category: nil, description: nil, details: nil)
+          self.name = name
+          self.category = category
+          self.description = description
+          self.details = details
+        end
+      end
+
       class FastlanePluginScore
         attr_accessor :name
         attr_accessor :downloads
@@ -44,7 +58,8 @@ module Fastlane
             has_github_page: has_github_page,
             has_mit_license: includes_license?("MIT"),
             has_gnu_license: includes_license?("GNU") || includes_license?("GPL"),
-            major_release: Gem::Version.new(hash["version"]) >= Gem::Version.new("1.0.0")
+            major_release: Gem::Version.new(hash["version"]) >= Gem::Version.new("1.0.0"),
+            actions: []
           }
 
           if has_github_page
@@ -154,6 +169,12 @@ module Fastlane
                 tests_count += File.read(spec_file).scan(/ it /).count
               end
               self.data[:tests] = tests_count
+
+              actions = Dir["**/actions/*.rb"].map do |action_file|
+                FastlaneActionFileParser.new.parse_file(action_file)
+              end
+              # Result of the above is an array of arrays, this merges all of them into data[:actions]
+              self.data[:actions].concat(*actions)
             end
           end
         end
@@ -199,6 +220,121 @@ module Fastlane
           puts ex
           puts ex.backtrace
           raise ex
+        end
+      end
+
+      class FastlaneActionFileParser
+        attr_accessor :state
+
+        def initialize
+          self.state = []
+        end
+
+        # Parses the file to find all included actions
+        def parse_file(file, debug_state: false)
+          lines = File.read(file).lines
+          actions = []
+
+          # Class state information
+          name = nil
+          description = nil
+          category = nil
+          details = nil
+          # Method state information
+          last_method_name = nil
+          last_string_statement = nil
+
+          lines.each do |line|
+            case self.state.last
+            when nil
+              name = action_name_from_line(line)
+              self.state << :in_class if is_class?(line)
+            when :in_class
+              if (method_name = method_name_from_line(line))
+                last_method_name = method_name
+                self.state << :in_method
+              end
+              if is_end?(line)
+                self.state.pop
+                # Make sure to skip helper classes where the name is nil
+                actions << FastlanePluginAction.new(name: name.fastlane_underscore, category: category, description: description, details: details) unless name.nil?
+                name = category = description = details = nil
+              end
+            when :in_method
+              if (string_statement = string_statement_from_line(line))
+                last_string_statement = string_statement
+              end
+              if is_block?(line)
+                self.state << :in_block
+              end
+              if is_end?(line)
+                category = last_string_statement if last_method_name == "category"
+                description = last_string_statement if last_method_name == "description"
+                details = last_string_statement if last_method_name == "details"
+                last_method_name = last_string_statement = nil
+                self.state.pop
+              end
+            when :in_block
+              if is_block?(line)
+                self.state << :in_block
+              end
+
+              self.state.pop if is_end?(line)
+            end
+            next unless debug_state
+            puts "Current line: #{line}"
+            puts "Full State: #{state}"
+            puts "Current action name: #{name}, category: #{category}, description: \"#{description}\", details: \"#{details}\""
+            puts "Last string statement: #{last_string_statement}, last method name: #{last_method_name}"
+          end
+          actions
+        end
+
+        def is_block?(line)
+          # Matches beginning block statement from the list of keywords
+          # `do` has to be handled separately because it can be preceded by a function call
+          line.match?(/^(?:[\s\w]*=)?\s*(if|unless|case|while|loop|for|until|begin)/) \
+          || line.match?(/^(?:[\s\w]*=)?\s*.*\s+do\s*(?:\|.*\|)?\s*(?:#.*)?$/)
+        end
+
+        def is_end?(line)
+          line.match?(/^\s*end\s*/)
+        end
+
+        def is_class?(line)
+          line.match?(/^\s*class\s+/)
+        end
+
+        def action_name_from_line(line)
+          # matches `class <action name>Action < Action` and returns action_name
+          line.match(/^\s*class\s+(\w+)Action\s+<\s+Action\s*(?:#.*)?$/) do |matching|
+            matching.captures.first
+          end
+        end
+
+        def method_name_from_line(line)
+          # matches `def <method>`, strips self. if is there, returns <method>
+          line.match(/^\s*def\s+(?:self\.)?(\w+)/) do |matching|
+            matching.captures.first
+          end
+        end
+
+        def string_statement_from_line(line)
+          # All the ways ruby can represent single-line strings
+          regex = [
+            "[\"]([^\"]+)\"",               # Matches strings with "
+            "[\']([^\']+)\'",               # Matches strings with '
+            ":([@$_a-zA-Z]\\w*[!=?\\w])",   # Matches `:<symbol>`
+            "%(?:[Q]?|[qs])(?:#{[           # Matches `%Q`, `%q`, `%s` and just `%`, with subexpression:
+              '([\\W_])([^\\4]*)\\4',       # Matches <symbol><string><symbol>, returns <string>
+              '\[([^\\]]*)\]',              # Matches [<string>]
+              '\(([^\\)]*)\)',              # Matches (<string>)
+              '\{([^\\]]*)\}'               # Matches {<string>}
+            ].join('|')})"
+          ].join('|')
+          line.match(regex) do |matching|
+            matching.captures.compact.last
+          end
         end
       end
     end


### PR DESCRIPTION
To help with plugin discovery and give a better preview of what each plugin does, this change lists all actions that a plugin provides, the description and category.

Preview:

![screen shot 2017-12-05 at 19 55 46](https://user-images.githubusercontent.com/279407/33625037-a0fc0080-d9f6-11e7-962e-a6693dc4e463.png)