### PR TITLE
[WIP] [frameit] Ensure both texts use same baseline

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -319,7 +319,7 @@ module Frameit
       words = [:keyword, :title].keep_if { |a| fetch_text(a) } # optional keyword/title
       results = {}
       trim_boxes = {}
-      min_vertical_trim_offset = Float::INFINITY    # Init at a large value, as the code will search for a minimal value.
+      min_vertical_trim_offset = Float::INFINITY # Init at a large value, as the code will search for a minimal value.
       words.each do |key|
         # Create empty background
         empty_path = File.join(Frameit::ROOT, "lib/assets/empty.png")
@@ -349,55 +349,55 @@ module Frameit
           i.interline_spacing interline_spacing if interline_spacing
           i.fill fetch_config[key.to_s]['color']
         end
-                            
+
         # title_image.trim # remove white space
-           
+
         results[key] = title_image
-                            
+
         # Trimming of each individual image will result in the loss of the common baseline between both texts.
         # Hence retrieve the calculated trim bounding box, which can be used later to apply a crop on both images, while maintaining the same vertical top offset based on the smallest value from the trim box:
         calculated_trim_box = title_image.identify do |b|
-        b.format("%@")    # CALCULATED: trim bounding box (without actually trimming), see: http://www.imagemagick.org/script/escape.php
+          b.format("%@") # CALCULATED: trim bounding box (without actually trimming), see: http://www.imagemagick.org/script/escape.php
         end
-                            
+
         # Get minimum vertical top offset from both trim boxes by converting it from string to an integer array:
-        trim_values = calculated_trim_box.split(/[\sx+]/).map { |s| s.to_i }    # The format is "wxh+X+y", so use multiple string separators: the "x", "+" and a whitespace "\s"
+        trim_values = calculated_trim_box.split(/[\sx+]/).map(&:to_i) # The format is "wxh+X+y", so use multiple string separators: the "x", "+" and a whitespace "\s"
         print "Calculated trim box = #{calculated_trim_box} => #{trim_values}\n"
         if trim_values[3] < min_vertical_trim_offset
           min_vertical_trim_offset = trim_values[3]
         end
-                            
+
         # Store for the crop action:
         trim_boxes[key] = trim_values
       end
-      
+
       print "min_vertical_trim_offset = #{min_vertical_trim_offset}\n"
-                            
+
       # Crop images based on min_vertical_trim_offset to maintain text baseline:
       words.each do |key|
         # Get matching trim box:
         trim_box = trim_boxes[key]
         print "Trim box for key \"#{key}\" = #{trim_box}\n"
-                            
+
         # Determine trim area:
-        if (trim_box[3] > min_vertical_trim_offset)
+        if trim_box[3] > min_vertical_trim_offset
           # The 4th parameter is the vertical top offset. When it's larger than the smallest vertical top offset, set it equal and compensate the crop height (2nd parameter):
           trim_box[1] += (trim_box[3] - min_vertical_trim_offset) # Increase the height of the crop area with the difference in vertical offset
-          trim_box[3] = min_vertical_trim_offset              # Set vertical top offset
-                            
+          trim_box[3] = min_vertical_trim_offset # Set vertical top offset
+
           print "Trim box for key \"#{key}\" is adjusted to maintain baseline: #{trim_box}\n"
         end
-                            
+
         # Convert trim box parameters to string for crop method (format: wxh+X+y):
         crop_input = "#{trim_box[0]}x#{trim_box[1]}+#{trim_box[2]}+#{trim_box[3]}"
         print "crop_input = #{crop_input}\n"
-                            
+
         # Get text image:
         image_to_crop = results[key]
-                            
+
         # Crop image:
         image_to_crop.crop(crop_input)
-                            
+
         # Store image:
         results[key] = image_to_crop
       end

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -357,9 +357,8 @@ module Frameit
         results[key] = title_image
 
         # Hence retrieve the calculated trim bounding box:
-        calculated_trim_box = title_image.identify do |b|
-          b.format("%@") # CALCULATED: trim bounding box (without actually trimming), see: http://www.imagemagick.org/script/escape.php
-        end
+        # CALCULATED: trim bounding box (without actually trimming), see: http://www.imagemagick.org/script/escape.php
+        calculated_trim_box = title_image.identify { |b| b.format("%@") }
 
         # Get vertical top offset from the trim box by converting it from string to an integer array:
         trim_values = calculated_trim_box.split(/[\sx+]/).map(&:to_i) # The format is "wxh+X+Y", so use multiple string separators: the whitespace "\s", "x" and "+"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (do: [x], don't: [x ], [ x], [✔️]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
Output: 
```
Finished in 6 minutes 46 seconds (files took 3.7 seconds to load)
4675 examples, 0 failures
```
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
Output: 
```
973 files inspected, no offenses detected
```
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
Not applicable

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This solves issue https://github.com/fastlane/fastlane/issues/10440
<!-- If it fixes an open issue, please link to the issue here. -->
The current implementation applies a `.trim` to both images for Keyword and Title.
Due to typography differences (for example the "L" that needs more vertical space than an "e") the generic baseline between 2 texts is lost. This can be seen in the excellent analysis of @janpio in this comment: https://github.com/fastlane/fastlane/issues/10440#issuecomment-348010988

_Before_
![iphone6-01_remotetab_framed](https://user-images.githubusercontent.com/2139844/33526905-fee7d936-d847-11e7-8fba-85fb829fc25d.png)

This solution requests the calculated trim box and offset for each image **without applying it**.
By comparing the vertical top offsets and heights of both trim boxes, the vertical offset between them can be calculated. The box with the biggest offset will be compensated to equal the same of the other, so their text baseline will be equal. After this the height is made equal, so they share the same bottom offset.
Finally a `.crop` will be applied with the (compensated) trim boxes.

_After_
![iphone6-01_remotetab_framed](https://user-images.githubusercontent.com/2139844/33526915-2c586160-d848-11e7-9a26-a0bd6ca78ad9.png)

<!-- Please describe in detail how you tested your changes. -->
Test results can be found in issue comment: https://github.com/fastlane/fastlane/issues/10440#issuecomment-348760923

Here the difference is clear, while highlighting the trim box in yellow:

Original code with `.trim`:
![iphone6-01_remotetab_framed trim](https://user-images.githubusercontent.com/2139844/33548783-a7a2fe0c-d8e8-11e7-9ec5-85ffe32e9172.png)

My initial commit with `.crop` to align top:
![iphone6-01_remotetab_framed vertical top](https://user-images.githubusercontent.com/2139844/33548811-c8363d82-d8e8-11e7-8e18-bef2c5104a06.png)

My robust solution with `.crop` for both align top and align bottom:
![iphone6-01_remotetab_framed vertical bottom](https://user-images.githubusercontent.com/2139844/33548816-cde0f060-d8e8-11e7-961a-4b936f286d69.png)

It also works when only one of the images needs to be adjusted both on the top **and** bottom side. In this case for "en":
![iphone6-01_remotetab_framed](https://user-images.githubusercontent.com/2139844/33549011-7536f846-d8e9-11e7-8e62-c2ad323157c8.png)

### Description
<!-- Describe your changes in detail -->
The changes can be found in issue comment: https://github.com/fastlane/fastlane/issues/10440#issuecomment-348760717

Please note that:

- This will supersede PR #11096 as I committed that anonymously.
- I've no Ruby skills, so this might not be proper Production code. But the description and the code show the intended behaviour.
- Hence @janpio offered to help, so I added [WIP] to the title of the PR.