### PR TITLE
[frameit] Ensure both texts use same baseline (issue #10440)

### DIFF
--- a/frameit/lib/frameit.rb
+++ b/frameit/lib/frameit.rb
@@ -11,6 +11,7 @@ require 'frameit/strings_parser'
 require 'frameit/mac_editor'
 require 'frameit/dependency_checker'
 require 'frameit/options'
+require 'frameit/trim_box'
 
 require 'fastlane_core'
 

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -318,6 +318,9 @@ module Frameit
     def build_title_images(max_width, max_height)
       words = [:keyword, :title].keep_if { |a| fetch_text(a) } # optional keyword/title
       results = {}
+      trim_boxes = {}
+      top_vertical_trim_offset = Float::INFINITY # Init at a large value, as the code will search for a minimal value.
+      bottom_vertical_trim_offset = 0
       words.each do |key|
         # Create empty background
         empty_path = File.join(Frameit::ROOT, "lib/assets/empty.png")
@@ -347,10 +350,64 @@ module Frameit
           i.interline_spacing interline_spacing if interline_spacing
           i.fill fetch_config[key.to_s]['color']
         end
-        title_image.trim # remove white space
+
+        # Trimming the image will result in the loss of the common baseline between the text in all images.
+        # title_image.trim # remove white space
 
         results[key] = title_image
+
+        # Hence retrieve the calculated trim bounding box:
+        # CALCULATED: trim bounding box (without actually trimming), see: http://www.imagemagick.org/script/escape.php
+        calculated_trim_box = title_image.identify { |b| b.format("%@") }
+
+        # Get vertical top offset from the trim box by converting it from string to an integer array:
+        trim_values = calculated_trim_box.split(/[\sx+]/).map(&:to_i) # The format is "wxh+X+Y", so use multiple string separators: the whitespace "\s", "x" and "+"
+
+        # Get the minimum top offset of the trim box:
+        if trim_values[3] < top_vertical_trim_offset
+          top_vertical_trim_offset = trim_values[3]
+        end
+
+        # Get the maximum bottom offset of the trimbox, this is the top offset + height:
+        if (trim_values[3] + trim_values[1]) > bottom_vertical_trim_offset
+          bottom_vertical_trim_offset = trim_values[3] + trim_values[1]
+        end
+
+        # Store for the crop action:
+        trim_boxes[key] = trim_values
       end
+
+      # Crop images based on top_vertical_trim_offset to maintain text baseline:
+      words.each do |key|
+        # Get matching trim box:
+        trim_box = trim_boxes[key]
+
+        # Determine the trim area by maintaining the same vertical top offset based on the smallest value from all trim boxes (top_vertical_trim_offset).
+        # The 4th parameter is the vertical top offset. When it's larger than the smallest vertical top offset, the trim box needs to be adjusted:
+        if trim_box[3] > top_vertical_trim_offset
+          # Increase the height of the trim box (2nd parameter) with the difference in vertical top offset:
+          trim_box[1] += trim_box[3] - top_vertical_trim_offset
+          # Change the vertical top offset to match that of the others:
+          trim_box[3] = top_vertical_trim_offset
+
+          UI.verbose("Trim box for key \"#{key}\" is adjusted to align top: #{trim_box}\n")
+        end
+
+        # Repeat the same for the bottom offset:
+        if (trim_box[3] + trim_box[1]) < bottom_vertical_trim_offset
+          # Set the height of the trim box (2nd parameter) to the difference between vertical bottom and top offset:
+          trim_box[1] = bottom_vertical_trim_offset - trim_box[3]
+
+          UI.verbose("Trim box for key \"#{key}\" is adjusted to align bottom: #{trim_box}\n")
+        end
+
+        # Convert trim box parameters to string for crop method (format: wxh+X+Y):
+        crop_input = "#{trim_box[0]}x#{trim_box[1]}+#{trim_box[2]}+#{trim_box[3]}"
+
+        # Crop image:
+        results[key].crop(crop_input)
+      end
+
       results
     end
 

--- a/frameit/lib/frameit/trim_box.rb
+++ b/frameit/lib/frameit/trim_box.rb
@@ -1,0 +1,33 @@
+module Frameit
+  # Represents the MiniMagick trim bounding box for cropping a text image
+  class Trimbox
+    attr_accessor :width # width of the trim box
+    attr_accessor :height # height of the trim box
+    attr_accessor :offset_x # horizontal offset from the canvas to the trim box
+    attr_accessor :offset_y # vertical offset from the canvas to the trim box
+
+    # identify_string: A string with syntax "<width>x<height>+<offset_x>+<offset_y>". This is returned by MiniMagick when using function .identify with format("%@"). It is also required for the MiniMagick .crop function.
+    def initialize(identify_string)
+      UI.user_error!("Trimbox can not be initialised with an empty 'identify_string'.") unless identify_string.length > 0
+
+      # Parse the input syntax "<width>x<height>+<offset_x>+<offset_y>".
+      # Extract these 4 parameters into an integer array, by using multiple string separators: "x" and "+":
+      trim_values = identify_string.split(/[x+]/).map(&:to_i)
+
+      # If 'identify_string' doesn't have the expected syntax with 4 parameters, show error:
+      UI.user_error!("Trimbox is initialised with an invalid value for 'identify_string'.") unless trim_values.length == 4
+
+      # Assign instance variables:
+      @width = trim_values[0]
+      @height = trim_values[1]
+      @offset_x = trim_values[2]
+      @offset_y = trim_values[3]
+    end
+
+    # Get the trimbox parameters in the MiniMagick string format
+    def string_format
+      # Convert trim box parameters to string with syntax: "<width>x<height>+<offset_x>+<offset_y>":
+      return "#{@width}x#{@height}+#{@offset_x}+#{@offset_y}"
+    end
+  end
+end

--- a/frameit/spec/screenshot_spec.rb
+++ b/frameit/spec/screenshot_spec.rb
@@ -9,6 +9,7 @@ describe Frameit do
         allow_any_instance_of(MiniMagick::Image).to receive(:composite) { |instance| instance }
         allow_any_instance_of(MiniMagick::Image).to receive(:format) {}
         allow_any_instance_of(MiniMagick::Image).to receive(:write) {}
+        allow_any_instance_of(MiniMagick::Image).to receive(:identify).and_return("0x0+0+0")
 
         expect(Frameit::Offsets).to receive(:image_offset).and_return({
           "offset" => "+60+225",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (do: [x], don't: [x ], [ x], [✔️]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
Output: 
```
Finished in 6 minutes 46 seconds (files took 3.7 seconds to load)
4675 examples, 0 failures
```
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
Output: 
```
973 files inspected, no offenses detected
```
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
Not applicable

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This solves issue https://github.com/fastlane/fastlane/issues/10440
<!-- If it fixes an open issue, please link to the issue here. -->
The current implementation applies a `.trim` to both images for Keyword and Title.
Due to typography differences (for example the "L" that needs more vertical space than an "e") the generic baseline between 2 texts is lost. This can be seen in the excellent analysis of @janpio in this comment: https://github.com/fastlane/fastlane/issues/10440#issuecomment-348010988

_Before_
![iphone6-01_remotetab_framed](https://user-images.githubusercontent.com/2139844/33526905-fee7d936-d847-11e7-8fba-85fb829fc25d.png)

This solution requests the calculated trim box and offset for each image **without applying it**.
By comparing the vertical top offsets and heights of both trim boxes, the vertical offset between them can be calculated. The box with the biggest offset will be compensated to equal the same of the other, so their text baseline will be equal. After this the height is made equal, so they share the same bottom offset.
Finally a `.crop` will be applied with the (compensated) trim boxes.

_After_
![iphone6-01_remotetab_framed](https://user-images.githubusercontent.com/2139844/33526915-2c586160-d848-11e7-9a26-a0bd6ca78ad9.png)

<!-- Please describe in detail how you tested your changes. -->
Test results can be found in issue comment: https://github.com/fastlane/fastlane/issues/10440#issuecomment-348760923

Here the difference is clear, while highlighting the trim box in yellow:

Original code with `.trim`:
![iphone6-01_remotetab_framed trim](https://user-images.githubusercontent.com/2139844/33548783-a7a2fe0c-d8e8-11e7-9ec5-85ffe32e9172.png)

My initial commit with `.crop` to align top:
![iphone6-01_remotetab_framed vertical top](https://user-images.githubusercontent.com/2139844/33548811-c8363d82-d8e8-11e7-8e18-bef2c5104a06.png)

My robust solution with `.crop` for both align top and align bottom:
![iphone6-01_remotetab_framed vertical bottom](https://user-images.githubusercontent.com/2139844/33548816-cde0f060-d8e8-11e7-961a-4b936f286d69.png)

It also works when only one of the images needs to be adjusted both on the top **and** bottom side. In this case for "en":
![iphone6-01_remotetab_framed](https://user-images.githubusercontent.com/2139844/33549011-7536f846-d8e9-11e7-8e62-c2ad323157c8.png)

### Description
<!-- Describe your changes in detail -->
The changes can be found in issue comment: https://github.com/fastlane/fastlane/issues/10440#issuecomment-348760717

Please note that:

- This will supersede PR #11096 as I committed that anonymously.
- I've no Ruby skills, so this might not be proper Production code. But the description and the code show the intended behaviour.
- Hence @janpio offered to help, so I added [WIP] to the title of the PR.