### PR TITLE
Extend ErbTemplateHelper with trim_mode parameter

### DIFF
--- a/fastlane/lib/fastlane/erb_template_helper.rb
+++ b/fastlane/lib/fastlane/erb_template_helper.rb
@@ -13,13 +13,18 @@ module Fastlane
       File.read(template_filepath)
     end
 
-    def self.render(template, template_vars_hash)
-      Fastlane::ErbalT.new(template_vars_hash).render(template)
+    def self.render(template, template_vars_hash, trim_mode = nil)
+      Fastlane::ErbalT.new(template_vars_hash, trim_mode).render(template)
     end
   end
   class ErbalT < OpenStruct
+    def initialize(hash, trim_mode)
+      super(hash)
+      @trim_mode = trim_mode
+    end
+
     def render(template)
-      ERB.new(template).result(binding)
+      ERB.new(template, nil, @trim_mode).result(binding)
     end
   end
 end

--- a/fastlane/spec/erb_template_helper_spec.rb
+++ b/fastlane/spec/erb_template_helper_spec.rb
@@ -1,6 +1,6 @@
 describe Fastlane do
   describe Fastlane::ErbTemplateHelper do
-    describe ".load_template" do
+    describe "load_template" do
       it "raises an error if file does not exist" do
         expect do
           Fastlane::ErbTemplateHelper.load('invalid_name')
@@ -13,16 +13,19 @@ describe Fastlane do
       end
     end
 
-    describe "#render_template" do
-      before do
-        @template = File.read("./fastlane/spec/fixtures/templates/dummy_html_template.erb")
-      end
-
-      it "return true if it's a platform" do
-        rendered_template = Fastlane::ErbTemplateHelper.render(@template, {
+    describe "render_template" do
+      it "renders hash values in HTML template" do
+        template = File.read("./fastlane/spec/fixtures/templates/dummy_html_template.erb")
+        rendered_template = Fastlane::ErbTemplateHelper.render(template, {
           template_name: "name"
         }).delete!("\n")
         expect(rendered_template).to eq("<h1>name</h1>")
+      end
+
+      it "renders with defined trim_mode" do
+        template = File.read("./fastlane/spec/fixtures/templates/trim_mode_template.erb")
+        rendered_template = Fastlane::ErbTemplateHelper.render(template, {}, '-')
+        expect(rendered_template).to eq("line\n")
       end
     end
   end

--- a/fastlane/spec/fixtures/templates/trim_mode_template.erb
+++ b/fastlane/spec/fixtures/templates/trim_mode_template.erb
@@ -1,0 +1,3 @@
+<% if true -%>
+line
+<% end -%>


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (do: [x], don't: [x ], [ x], [✔️]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
Current implementation of **ErbTemplateHelper** doesn't allow to pass **trim_mode** parameter to **Erb** initializer. It makes this class impossible to use with more or less advanced erb files eliminating empty lines. There is a workaround - Erb trim_mode could be defined globally, but it's not the way I'd like to follow.

A simple test is added to check if trim_mode parameter are actually used. Other tests in the same file was slightly changed to keep file syntax consistent.

### Description
**ErbTemplateHelper** now have a new parameter - **trim_mode** - which is passed to **ErbalT** object and then passed to **Erb** initializer.