### PR TITLE
Add app_id to launch and completion context

### DIFF
--- a/fastlane_core/lib/fastlane_core/analytics/action_completion_context.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/action_completion_context.rb
@@ -8,10 +8,12 @@ module FastlaneCore
 
   class ActionCompletionContext
     attr_accessor :p_hash
+    attr_accessor :app_id
     attr_accessor :action_name
     attr_accessor :status
 
-    def initialize(p_hash: nil, action_name: nil, status: nil)
+    def initialize(app_id: nil, p_hash: nil, action_name: nil, status: nil)
+      @app_id = app_id
       @p_hash = p_hash
       @action_name = action_name
       @status = status
@@ -21,6 +23,7 @@ module FastlaneCore
       app_id_guesser = FastlaneCore::AppIdentifierGuesser.new(args: args)
       return self.new(
         action_name: action_name,
+        app_id: app_id_guesser.app_id,
         p_hash: app_id_guesser.p_hash,
         status: status
       )

--- a/fastlane_core/lib/fastlane_core/analytics/action_launch_context.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/action_launch_context.rb
@@ -2,14 +2,17 @@ require 'fastlane_core/helper'
 
 module FastlaneCore
   class ActionLaunchContext
+    UNKNOWN_APP_ID = 'unknown'
     UNKNOWN_P_HASH = 'unknown'
 
     attr_accessor :action_name
+    attr_accessor :app_id
     attr_accessor :p_hash
     attr_accessor :platform
 
-    def initialize(action_name: nil, p_hash: UNKNOWN_P_HASH, platform: nil)
+    def initialize(action_name: nil, app_id: UNKNOWN_APP_ID, p_hash: UNKNOWN_P_HASH, platform: nil)
       @action_name = action_name
+      @app_id = app_id
       @p_hash = p_hash
       @platform = platform
     end
@@ -18,6 +21,7 @@ module FastlaneCore
       app_id_guesser = FastlaneCore::AppIdentifierGuesser.new(args: args)
       return self.new(
         action_name: action_name,
+        app_id: app_id_guesser.app_id,
         p_hash: app_id_guesser.p_hash,
         platform: app_id_guesser.platform
       )

--- a/fastlane_core/spec/analytics/analytics_session_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_session_spec.rb
@@ -1,5 +1,6 @@
 describe FastlaneCore::AnalyticsSession do
   let(:oauth_app_name) { 'fastlane-tests' }
+  let(:app_id) { 'some.app.id' }
   let(:p_hash) { 'some.phash.value' }
   let(:session_id) { 's0m3s3ss10n1D' }
   let(:timestamp_millis) { 1_507_142_046 }
@@ -20,6 +21,7 @@ describe FastlaneCore::AnalyticsSession do
       let(:launch_context) do
         FastlaneCore::ActionLaunchContext.new(
           action_name: action_name,
+          app_id: app_id,
           p_hash: p_hash,
           platform: 'ios'
         )
@@ -74,6 +76,7 @@ describe FastlaneCore::AnalyticsSession do
     context 'action completion' do
       let(:completion_context) do
         FastlaneCore::ActionCompletionContext.new(
+          app_id: app_id,
           p_hash: p_hash,
           status: FastlaneCore::ActionCompletionStatus::SUCCESS,
           action_name: action_name
@@ -108,12 +111,14 @@ describe FastlaneCore::AnalyticsSession do
       let(:action_1_launch_context) do
         FastlaneCore::ActionLaunchContext.new(
           action_name: action_1_name,
+          app_id: app_id,
           p_hash: p_hash,
           platform: 'ios'
         )
       end
       let(:action_1_completion_context) do
         FastlaneCore::ActionCompletionContext.new(
+          app_id: app_id,
           p_hash: p_hash,
           status: FastlaneCore::ActionCompletionStatus::SUCCESS,
           action_name: action_1_name
@@ -122,12 +127,14 @@ describe FastlaneCore::AnalyticsSession do
       let(:action_2_launch_context) do
         FastlaneCore::ActionLaunchContext.new(
           action_name: action_2_name,
+          app_id: app_id,
           p_hash: p_hash,
           platform: 'ios'
         )
       end
       let(:action_2_completion_context) do
         FastlaneCore::ActionCompletionContext.new(
+          app_id: app_id,
           p_hash: p_hash,
           status: FastlaneCore::ActionCompletionStatus::SUCCESS,
           action_name: action_2_name


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (do: [x], don't: [x ], [ x], [✔️]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

Add `app_id` to the _fastlane_ launched and completed context (though we are not sending it as part of analytics). This is only for debugging/internal purposes!