### PR TITLE
Add support for a postfix block with sh

### DIFF
--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -19,14 +19,13 @@ module Fastlane
       :deprecated # This should be the last item
     ]
 
-
     class << self
       attr_accessor :runner
 
       extend Forwardable
 
       # to allow a simple `sh` in the custom actions
-      def_delegator "Fastlane::Actions", :sh_control_output, :sh
+      def_delegator Fastlane::Actions, :sh_control_output, :sh
     end
 
     def self.run(params)

--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -25,7 +25,7 @@ module Fastlane
       extend Forwardable
 
       # to allow a simple `sh` in the custom actions
-      def_delegator Fastlane::Actions, :sh_control_output, :sh
+      def_delegator Actions, :sh_control_output, :sh
     end
 
     def self.run(params)

--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -1,4 +1,5 @@
 require 'fastlane/actions/actions_helper'
+require 'forwardable'
 
 module Fastlane
   class Action
@@ -18,8 +19,14 @@ module Fastlane
       :deprecated # This should be the last item
     ]
 
+
     class << self
       attr_accessor :runner
+
+      extend Forwardable
+
+      # to allow a simple `sh` in the custom actions
+      def_delegator "Fastlane::Actions", :sh_control_output, :sh
     end
 
     def self.run(params)
@@ -91,11 +98,6 @@ module Fastlane
     # Return nil if you don't want any logging in the terminal/JUnit Report
     def self.step_text
       self.action_name
-    end
-
-    # to allow a simple `sh` in the custom actions
-    def self.sh(*command, print_command: true, print_command_output: true, error_callback: nil, &b)
-      Fastlane::Actions.sh_control_output(*command, print_command: print_command, print_command_output: print_command_output, error_callback: error_callback, &b)
     end
 
     # Documentation category, available values defined in AVAILABLE_CATEGORIES

--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -94,8 +94,8 @@ module Fastlane
     end
 
     # to allow a simple `sh` in the custom actions
-    def self.sh(*command, print_command: true, print_command_output: true, error_callback: nil)
-      Fastlane::Actions.sh_control_output(*command, print_command: print_command, print_command_output: print_command_output, error_callback: error_callback)
+    def self.sh(*command, print_command: true, print_command_output: true, error_callback: nil, &b)
+      Fastlane::Actions.sh_control_output(*command, print_command: print_command, print_command_output: print_command_output, error_callback: error_callback, &b)
     end
 
     # Documentation category, available values defined in AVAILABLE_CATEGORIES

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -174,10 +174,10 @@ module Fastlane
     end
 
     # Execute shell command
-    def sh(*command, log: true, error_callback: nil)
+    def sh(*command, log: true, error_callback: nil, &b)
       command_header = log ? Actions.shell_command_from_args(*command) : "shell command"
       Actions.execute_action(command_header) do
-        Actions.sh_no_action(*command, log: log, error_callback: error_callback)
+        Actions.sh_no_action(*command, log: log, error_callback: error_callback, &b)
       end
     end
 

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -23,7 +23,7 @@ module Fastlane
     # @yield [status, result] The return status of the command and all output from the command
     # @yieldparam [Process::Status] status A Process::Status indicating the status of the completed command
     # @yieldparam [String] result The complete output to stdout and stderr of the completed command
-    def self.sh_control_output(*command, print_command: true, print_command_output: true, error_callback: nil, &b)
+    def self.sh_control_output(*command, print_command: true, print_command_output: true, error_callback: nil)
       print_command = print_command_output = true if $troubleshoot
       # Set the encoding first, the user might have set it wrong
       previous_encoding = [Encoding.default_external, Encoding.default_internal]

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -70,7 +70,7 @@ module Fastlane
           if error_callback || block_given?
             UI.error(message)
             # block already notified above, on success or failure
-            error_callback.call(result) if error_callback
+            error_callback && error_callback.call(result)
           else
             UI.shell_error!(message)
           end

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -20,9 +20,10 @@ module Fastlane
     # @param print_command [Boolean] Should we print the command that's being executed
     # @param print_command_output [Boolean] Should we print the command output during execution
     # @param error_callback [Block] A block that's called if the command exits with a non-zero status
-    # @yield [status, result] The return status of the command and all output from the command
+    # @yield [status, result, cmd] The return status of the command, all output from the command and an equivalent shell command
     # @yieldparam [Process::Status] status A Process::Status indicating the status of the completed command
     # @yieldparam [String] result The complete output to stdout and stderr of the completed command
+    # @yieldparam [String] cmd A shell command equivalent to the arguments passed
     def self.sh_control_output(*command, print_command: true, print_command_output: true, error_callback: nil)
       print_command = print_command_output = true if $troubleshoot
       # Set the encoding first, the user might have set it wrong
@@ -55,7 +56,7 @@ module Fastlane
           exit_status = thread.value.exitstatus
 
           if block_given?
-            block_return = yield thread.value, result
+            block_return = yield thread.value, result, shell_command
           end
         end
 

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -67,10 +67,11 @@ module Fastlane
                     end
           message += "\n#{result}" if print_command_output
 
-          if error_callback
+          if error_callback || block_given?
             UI.error(message)
-            error_callback.call(result)
-          elsif !block_given?
+            # block already notified above, on success or failure
+            error_callback.call(result) if error_callback
+          else
             UI.shell_error!(message)
           end
         end

--- a/fastlane/spec/action_spec.rb
+++ b/fastlane/spec/action_spec.rb
@@ -94,5 +94,16 @@ describe Fastlane do
         end.to raise_error("To call another action from an action use `other_action.rocket` instead")
       end
     end
+
+    describe "Action.sh" do
+      it "delegates to Actions.sh_control_output" do
+        mock_status = double :status, exitstatus: 0
+        expect(Fastlane::Actions).to receive(:sh_control_output).with("ls", "-la").and_yield mock_status, "Command output"
+        Fastlane::Action.sh "ls", "-la" do |status, result|
+          expect(status.exitstatus).to eq 0
+          expect(result).to eq "Command output"
+        end
+      end
+    end
   end
 end

--- a/fastlane/spec/actions_specs/gradle_spec.rb
+++ b/fastlane/spec/actions_specs/gradle_spec.rb
@@ -9,7 +9,7 @@ describe Fastlane do
         let(:expected_command) { "#{File.expand_path('README.md').shellescape} tasks -p ." }
 
         it "prints the command and the command's output by default" do
-          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: true, print_command_output: true, error_callback: nil).and_call_original
+          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: true, print_command_output: true).and_call_original
 
           Fastlane::FastFile.new.parse("lane :build do
             gradle(
@@ -20,7 +20,7 @@ describe Fastlane do
         end
 
         it "suppresses the command text and prints the command's output" do
-          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: true, error_callback: nil).and_call_original
+          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: true).and_call_original
 
           Fastlane::FastFile.new.parse("lane :build do
             gradle(
@@ -32,7 +32,7 @@ describe Fastlane do
         end
 
         it "prints the command text and suppresses the command's output" do
-          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: true, print_command_output: false, error_callback: nil).and_call_original
+          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: true, print_command_output: false).and_call_original
 
           Fastlane::FastFile.new.parse("lane :build do
             gradle(
@@ -44,7 +44,7 @@ describe Fastlane do
         end
 
         it "suppresses the command text and suppresses the command's output" do
-          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: false, error_callback: nil).and_call_original
+          expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: false).and_call_original
 
           Fastlane::FastFile.new.parse("lane :build do
             gradle(

--- a/fastlane/spec/helper/sh_helper_spec.rb
+++ b/fastlane/spec/helper/sh_helper_spec.rb
@@ -53,11 +53,12 @@ describe Fastlane::Actions do
     end
 
     context "with a postfix block" do
-      it "yields the status and result" do
+      it "yields the status, result and command" do
         expect_command "ls", "-la"
-        Fastlane::Actions.sh "ls", "-la" do |status, result|
+        Fastlane::Actions.sh "ls", "-la" do |status, result, command|
           expect(status.exitstatus).to eq 0
           expect(result).to be_empty
+          expect(command).to eq "ls -la"
         end
       end
 

--- a/fastlane/spec/helper/sh_helper_spec.rb
+++ b/fastlane/spec/helper/sh_helper_spec.rb
@@ -1,3 +1,5 @@
+require "stringio"
+
 describe Fastlane::Actions do
   describe "#sh" do
     before do
@@ -49,6 +51,40 @@ describe Fastlane::Actions do
         Fastlane::Actions.sh ["/usr/local/bin/git", "git"], "commit", "-m", "A message"
       end
     end
+
+    context "with a postfix block" do
+      it "yields the status and result" do
+        expect_command "ls", "-la"
+        Fastlane::Actions.sh "ls", "-la" do |status, result|
+          expect(status.exitstatus).to eq 0
+          expect(result).to be_empty
+        end
+      end
+
+      it "yields any error result" do
+        expect_command "ls", "-la", exitstatus: 1
+        Fastlane::Actions.sh "ls", "-la" do |status, result|
+          expect(status.exitstatus).to eq 1
+          expect(result).to be_empty
+        end
+      end
+
+      it "yields command output" do
+        expect_command "ls", "-la", exitstatus: 1, output: "Heeeelp! Something went wrong."
+        Fastlane::Actions.sh "ls", "-la" do |status, result|
+          expect(status.exitstatus).to eq 1
+          expect(result).to eq "Heeeelp! Something went wrong."
+        end
+      end
+
+      it "returns the return value of the block if present" do
+        expect_command "ls", "-la"
+        return_value = Fastlane::Actions.sh "ls", "-la" do |status, result|
+          42
+        end
+        expect(return_value).to eq 42
+      end
+    end
   end
 
   describe "shell_command_from_args" do
@@ -94,9 +130,9 @@ def command_from_args(*args)
   Fastlane::Actions.shell_command_from_args(*args)
 end
 
-def expect_command(*command, exitstatus: 0)
+def expect_command(*command, exitstatus: 0, output: "")
   mock_input = double :input
-  mock_output = File.open(File.expand_path(File.join("..", "..", "fixtures", "appfiles", "Appfile_empty"), __FILE__))
+  mock_output = StringIO.new output
   mock_status = double :status, exitstatus: exitstatus
   mock_thread = double :thread, value: mock_status
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Partly this is motivated by @janpio's [issue](https://github.com/fastlane/fastlane/issues/11140) and partly by spending quality time with Rake.

Working with Procs can be awkward. To have a multiline `error_callback`, you have choices like:

```Ruby
callback = Proc.new do |result|
  # multiline error handler
end

sh command, error_callback: callback
```

or

```Ruby
sh(command, error_callback: ->(result) { handle_error(result) }) # call a method
```

Postfix blocks are easier to use syntactically and more idiomatic. Rake supports something like this in its `sh` method. I've often thought it would be nice to allow blocks with actions, but it would require some work in the runner context. However, `sh` is not an action, so this is fairly trivial.

With this change:

```Ruby
sh command do |status, result|
  if status.success?
    UI.success "Command succeeded"
  else
    UI.user_error "Command failed with status #{status.exitstatus}"
  end
end
```

### Description

This just passes blocks from all variants of `sh` down to `Actions.sh_control_output`, which yields if `block_given?`.

This also replaces the empty fixture file in the unit tests with a more general `StringIO` that allows for mocking output.