### PR TITLE
Add missing app services to produce

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/produce.md
+++ b/fastlane/lib/fastlane/actions/docs/produce.md
@@ -204,7 +204,11 @@ lane :release do
       passbook: "on",                # Valid values: "on", "off"
       push_notification: "on",       # Valid values: "on", "off"
       siri_kit: "on",                # Valid values: "on", "off"
-      vpn_configuration: "on"       # Valid values: "on", "off"
+      vpn_configuration: "on",       # Valid values: "on", "off"
+      network_extension: "on",       # Valid values: "on", "off"
+      hotspot: "on",                 # Valid values: "on", "off"
+      multipath: "on",               # Valid values: "on", "off"
+      nfc_tag_reading: "on",         # Valid values: "on", "off"
     }
   )
 

--- a/fastlane/lib/fastlane/actions/modify_services.rb
+++ b/fastlane/lib/fastlane/actions/modify_services.rb
@@ -58,7 +58,11 @@ module Fastlane
             passbook: 'passbook',
             push_notification: 'push_notification',
             siri_kit: 'sirikit',
-            vpn_configuration: 'vpn_conf'
+            vpn_configuration: 'vpn_conf',
+            network_extension: 'network_extension',
+            hotspot: 'hotspot',
+            multipath: 'multipath',
+            nfc_tag_reading: 'nfc_tag_reading'
         }
       end
 

--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -29,7 +29,11 @@ module Produce
       passbook: [SERVICE_ON, SERVICE_OFF],
       push_notification: [SERVICE_ON, SERVICE_OFF],
       siri_kit: [SERVICE_ON, SERVICE_OFF],
-      vpn_configuration: [SERVICE_ON, SERVICE_OFF]
+      vpn_configuration: [SERVICE_ON, SERVICE_OFF],
+      network_extension: [SERVICE_ON, SERVICE_OFF],
+      hotspot: [SERVICE_ON, SERVICE_OFF],
+      multipath: [SERVICE_ON, SERVICE_OFF],
+      nfc_tag_reading: [SERVICE_ON, SERVICE_OFF]
     }
 
     def run

--- a/produce/lib/produce/service.rb
+++ b/produce/lib/produce/service.rb
@@ -34,7 +34,8 @@ module Produce
 
     def valid_services_for(options)
       allowed_keys = [:app_group, :apple_pay, :associated_domains, :data_protection, :game_center, :healthkit, :homekit,
-                      :wireless_conf, :icloud, :in_app_purchase, :inter_app_audio, :passbook, :push_notification, :sirikit, :vpn_conf]
+                      :wireless_conf, :icloud, :in_app_purchase, :inter_app_audio, :passbook, :push_notification, :sirikit,
+                      :vpn_conf, :network_extension, :hotspot, :multipath, :nfc_tag_reading]
       options.__hash__.select { |key, value| allowed_keys.include? key }
     end
 
@@ -207,6 +208,46 @@ module Produce
           app.update_service(Spaceship.app_service.vpn_configuration.on)
         else
           app.update_service(Spaceship.app_service.vpn_configuration.off)
+        end
+      end
+
+      if options.network_extension
+        UI.message("\tNetwork Extension")
+
+        if on
+          app.update_service(Spaceship.app_service.network_extension.on)
+        else
+          app.update_service(Spaceship.app_service.network_extension.off)
+        end
+      end
+
+      if options.hotspot
+        UI.message("\tHotspot")
+
+        if on
+          app.update_service(Spaceship.app_service.hotspot.on)
+        else
+          app.update_service(Spaceship.app_service.hotspot.off)
+        end
+      end
+
+      if options.multipath
+        UI.message("\tMultipath")
+
+        if on
+          app.update_service(Spaceship.app_service.multipath.on)
+        else
+          app.update_service(Spaceship.app_service.multipath.off)
+        end
+      end
+
+      if options.nfc_tag_reading
+        UI.message("\tNFC Tag Reading")
+
+        if on
+          app.update_service(Spaceship.app_service.nfc_tag_reading.on)
+        else
+          app.update_service(Spaceship.app_service.nfc_tag_reading.off)
         end
       end
 


### PR DESCRIPTION
This adds support for network_extension, hotspot, multipath, nfc_tag_reading.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (do: [x], don't: [x ], [ x], [✔️]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

There are some newly added services in spaceship via #10385 that are not available in produce.
This fixes issue #10532.

<!-- Please describe in detail how you tested your changes. -->

### Description

Add all these services in all relevant places.