### PR TITLE
Add option to force device frame orientation (fixes #10928)

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -1,5 +1,6 @@
 module Frameit
-  class Editor
+  # Currently the class is 2 lines too long. Reevaluate refactoring when it's length changes significantly
+  class Editor # rubocop:disable Metrics/ClassLength
     attr_accessor :screenshot # reference to the screenshot object to fetch the path, title, etc.
     attr_accessor :frame # the frame of the device
     attr_accessor :image # the current image used for editing

--- a/frameit/lib/frameit/options.rb
+++ b/frameit/lib/frameit/options.rb
@@ -39,7 +39,18 @@ module Frameit
                            env_name: "FRAMEIT_USE_LEGACY_IPHONE_6_S",
                            is_string: false,
                            description: "Use iPhone 6s frames instead of iPhone 7 frames",
-                           default_value: false)
+                           default_value: false),
+        FastlaneCore::ConfigItem.new(key: :force_orientation_block,
+                           type: Proc,
+                           description: "[Advanced] A block to customize your screnshots' device orientation",
+                           default_value: proc do |filename|
+                             f = filename.downcase
+                             if f.end_with?("force_landscapeleft")
+                               :landscape_left
+                             elsif f.end_with?("force_landscaperight")
+                               :landscape_right
+                             end
+                           end)
       ]
     end
   end

--- a/frameit/lib/frameit/options.rb
+++ b/frameit/lib/frameit/options.rb
@@ -43,6 +43,7 @@ module Frameit
         FastlaneCore::ConfigItem.new(key: :force_orientation_block,
                            type: Proc,
                            description: "[Advanced] A block to customize your screnshots' device orientation",
+                           display_in_shell: false,
                            default_value: proc do |filename|
                              f = filename.downcase
                              if f.end_with?("force_landscapeleft")

--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -73,11 +73,15 @@ module Frameit
 
     def frame_orientation
       filename = File.basename(self.path, ".*")
-      orientation = Frameit.config[:force_orientation_block].call(filename)
-      valid = [:landscape_left, :landscape_right, :portrait, nil]
-      UI.user_error("orientation_block must return #{valid[0..-2].join(', ')} or nil") unless valid.include?(orientation)
+      block = Frameit.config[:force_orientation_block]
 
-      puts "Forced orientation: #{orientation}"
+      unless block.nil?
+        orientation = block.call(filename)
+        valid = [:landscape_left, :landscape_right, :portrait, nil]
+        UI.user_error("orientation_block must return #{valid[0..-2].join(', ')} or nil") unless valid.include?(orientation)
+
+        puts "Forced orientation: #{orientation}"
+      end
 
       return orientation unless orientation.nil?
       return :portrait if self.orientation_name == Orientation::PORTRAIT

--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -71,8 +71,33 @@ module Frameit
       return Orientation::LANDSCAPE
     end
 
+    def frame_orientation
+      filename = File.basename(self.path, ".*")
+      orientation = Frameit.config[:force_orientation_block].call(filename)
+      valid = [:landscape_left, :landscape_right, :portrait, nil]
+      UI.user_error("orientation_block must return #{valid[0..-2].join(', ')} or nil") unless valid.include?(orientation)
+
+      puts "Forced orientation: #{orientation}"
+
+      return orientation unless orientation.nil?
+      return :portrait if self.orientation_name == Orientation::PORTRAIT
+      return :landscape_right # Default landscape orientation
+    end
+
     def portrait?
-      return (orientation_name == Orientation::PORTRAIT)
+      return (frame_orientation == :portrait)
+    end
+
+    def landscape_left?
+      return (frame_orientation == :landscape_left)
+    end
+
+    def landscape_right?
+      return (frame_orientation == :landscape_right)
+    end
+
+    def landscape?
+      return self.landscape_left? || self.landscape_right
     end
 
     def to_s


### PR DESCRIPTION
Currently for landscape the orientation is always landscape right. This makes it possible to configure a block that gets the filename and decides for the user which orientation to use. 

By default, screenshot filenames ending in `force_landscapeleft` or `force_landscaperight` (all case-insensitive) will be forced to the specified rotation