### PR TITLE
Fix genarate promocode

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -1250,11 +1250,12 @@ module Spaceship
     end
 
     def generate_app_version_promocodes!(app_id: nil, version_id: nil, quantity: nil)
-      data = {
-        numberOfCodes: { value: quantity },
-        agreedToContract: { value: true }
-      }
-      url = "ra/apps/#{app_id}/promocodes/versions/#{version_id}"
+      data = [{
+        numberOfCodes: quantity,
+        agreedToContract: true,
+        versionId: version_id
+      }]
+      url = "ra/apps/#{app_id}/promocodes/versions"
       r = request(:post) do |req|
         req.url url
         req.body = data.to_json

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -295,7 +295,7 @@ class TunesStubbing
     end
 
     def itc_stub_generate_promocodes
-      stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/promocodes/versions/812106519").
+      stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/promocodes/versions").
         to_return(status: 200, body: itc_read_fixture_file("promocodes_generated.json"),
                   headers: { "Content-Type" => "application/json" })
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], [✔], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Fixed an issue that failed to generate promo code.

<!-- If it fixes an open issue, please link to the issue here. -->

<!-- Please describe in detail how you tested your changes. -->
Using [Playground](https://github.com/fastlane/fastlane/tree/39c4d1b8187540e3b633a31b4a1dca97ed354427/spaceship#playground) of the spaceship, you can confirm this amendment.

```
$ bundle exec fastlane spaceship

1] pry(#<Spaceship::Playground>)> Spaceship::Tunes.client.generate_app_version_promocodes!(app_id: <YOUR_APP_ID>, version_id: <VERSION_ID>, quantity: 1)
```

### Description
Promotion code generation failed due to iTunes Connect API change.

##### before
api path: `ra/apps/<APP_ID>/promocodes/versions/<VERSION_ID>`
post params: `{numberOfCodes: <NUMBER_OF_CODES>, agreedToContract: true}`

##### after
api path: `ra/apps/<APP_ID>/promocodes/versions`
post params: `[{numberOfCodes: <NUMBER_OF_CODES>, agreedToContract: true, versionId: <VERSION_ID>}]`