### PR TITLE
Sometimes we can get a value that doesn't support .to_sym

### DIFF
--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -121,7 +121,7 @@ module Gym
       def keys_to_symbols(hash)
         # Convert keys to symbols
         hash = hash.each_with_object({}) do |(k, v), memo|
-          memo[k.to_sym] = v
+          memo[k.b.to_s.to_sym] = v
           memo
         end
         hash


### PR DESCRIPTION
.to_s first, then .to_sym
Fixes the exception found in https://github.com/fastlane/fastlane/issues/11138