### PR TITLE
Fix error handler if user passed a custom export_options plist file path

### DIFF
--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -153,6 +153,7 @@ module Gym
 
       def print_xcode9_plist_warning
         return unless Helper.xcode_at_least?("9.0")
+        return unless Gym.config[:export_options].kind_of?(Hash)
 
         export_options = Gym.config[:export_options] || {}
         provisioning_profiles = export_options[:provisioningProfiles] || []
@@ -220,7 +221,7 @@ module Gym
           UI.error("Please make sure to define the correct export methods when calling")
           UI.error("gym in your Fastfile or from the command line")
           UI.message("")
-        elsif Gym.config[:export_options]
+        elsif Gym.config[:export_options] && Gym.config[:export_options].kind_of?(Hash)
           # We want to tell the user if there is an obvious mismatch between the selected
           # `export_method` and the selected provisioning profiles
           selected_export_method = Gym.config[:export_method].to_s

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -153,6 +153,8 @@ module Gym
 
       def print_xcode9_plist_warning
         return unless Helper.xcode_at_least?("9.0")
+
+        # prevent crash in case of packaging error AND if you have set export_options to a path.
         return unless Gym.config[:export_options].kind_of?(Hash)
 
         export_options = Gym.config[:export_options] || {}


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
Gym failed when a user passed custom plist path has export_options parameter and something goes wrong with the signing. This generates a `TypeError` error in `error_handler.rb`.

### Description
`Gym.config[:export_options][:provisioningProfiles]` is null when user set a file path for export_options. This is the same fix applied in #9701
