### PR TITLE
Limit testing of Timeout-Process-Bug to macOS only

### DIFF
--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -430,18 +430,20 @@ describe FastlaneCore do
         text = "FOOBAR" # random text
         count = count_processes(text)
         cmd = "ruby -e 'sleep 3; puts \"#{text}\"'"
-        # this doesn't work
         expect do
           FastlaneCore::Project.run_command(cmd, timeout: 1)
         end.to raise_error(Timeout::Error)
 
-        # this shows the current implementation issue
-        # Timeout doesn't kill the running process
-        # i.e. see fastlane/fastlane_core#102
-        expect(count_processes(text)).to eq(count + 1)
-        sleep(5)
-        expect(count_processes(text)).to eq(count)
-        # you would be expected to be able to see the number of processes go back to count right away.
+        # on mac this before only partially works as expected
+        if FastlaneCore::Helper.is_mac?
+          # this shows the current implementation issue
+          # Timeout doesn't kill the running process
+          # i.e. see fastlane/fastlane_core#102
+          expect(count_processes(text)).to eq(count + 1)
+          sleep(5)
+          expect(count_processes(text)).to eq(count)
+          # you would be expected to be able to see the number of processes go back to count right away.
+        end
       end
 
       it "retries and kills" do


### PR DESCRIPTION
disable unkilled-process-after-timeout-tests for non-macOS platforms.
this was causing tests to fail on other platforms/environments, where this bug does not exist.
(Background: https://github.com/fastlane/fastlane/issues/1504)