### PR TITLE
Workaround hardcoded OS names in fixtures

### DIFF
--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -161,10 +161,7 @@ module FastlaneCore
     end
 
     def operating_system
-      return "macOS" if RUBY_PLATFORM.downcase.include?("darwin")
-      return "Windows" if RUBY_PLATFORM.downcase.include?("mswin")
-      return "Linux" if RUBY_PLATFORM.downcase.include?("linux")
-      return "Unknown"
+      return Helper.operating_system
     end
 
     def install_method

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -86,6 +86,13 @@ module FastlaneCore
       return false
     end
 
+    def self.operating_system
+      return "macOS" if RUBY_PLATFORM.downcase.include?("darwin")
+      return "Windows" if RUBY_PLATFORM.downcase.include?("mswin")
+      return "Linux" if RUBY_PLATFORM.downcase.include?("linux")
+      return "Unknown"
+    end
+
     def self.windows?
       # taken from: https://stackoverflow.com/a/171011/1945875
       (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil

--- a/fastlane_core/spec/analytics/analytics_session_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_session_spec.rb
@@ -186,7 +186,7 @@ describe FastlaneCore::AnalyticsSession do
           expected_final_array[2]['primary_target']['detail'] = `uname`.strip
           expected_final_array[11]['primary_target']['detail'] = `uname`.strip
         end
-        
+
         parsed_events.zip(expected_final_array).each do |parsed, fixture|
           expect(parsed).to eq(fixture)
         end

--- a/fastlane_core/spec/analytics/analytics_session_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_session_spec.rb
@@ -46,6 +46,11 @@ describe FastlaneCore::AnalyticsSession do
 
         session.action_launched(launch_context: launch_context)
 
+        # Modify Fixture if not on Mac
+        unless FastlaneCore::Helper.is_mac?
+          fixture_data[2]['primary_target']['detail'] = `uname`.strip
+        end
+
         parsed_events = JSON.parse(session.events.to_json)
         parsed_events.zip(fixture_data).each do |parsed, fixture|
           expect(parsed).to eq(fixture)
@@ -176,6 +181,12 @@ describe FastlaneCore::AnalyticsSession do
         expected_final_array = fixture_data_action_1_launched + [fixture_data_action_1_completed] + fixture_data_action_2_launched + [fixture_data_action_2_completed]
         parsed_events = JSON.parse(session.events.to_json)
 
+        # Modify Fixture if not on Mac
+        unless FastlaneCore::Helper.is_mac?
+          expected_final_array[2]['primary_target']['detail'] = `uname`.strip
+          expected_final_array[11]['primary_target']['detail'] = `uname`.strip
+        end
+        
         parsed_events.zip(expected_final_array).each do |parsed, fixture|
           expect(parsed).to eq(fixture)
         end

--- a/fastlane_core/spec/analytics/analytics_session_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_session_spec.rb
@@ -48,7 +48,7 @@ describe FastlaneCore::AnalyticsSession do
 
         # Modify Fixture if not on Mac
         unless FastlaneCore::Helper.is_mac?
-          fixture_data[2]['primary_target']['detail'] = `uname`.strip
+          fixture_data[2]['primary_target']['detail'] = FastlaneCore::Helper.operating_system
         end
 
         parsed_events = JSON.parse(session.events.to_json)
@@ -183,8 +183,9 @@ describe FastlaneCore::AnalyticsSession do
 
         # Modify Fixture if not on Mac
         unless FastlaneCore::Helper.is_mac?
-          expected_final_array[2]['primary_target']['detail'] = `uname`.strip
-          expected_final_array[11]['primary_target']['detail'] = `uname`.strip
+          os = FastlaneCore::Helper.operating_system
+          expected_final_array[2]['primary_target']['detail'] = os
+          expected_final_array[11]['primary_target']['detail'] = os
         end
 
         parsed_events.zip(expected_final_array).each do |parsed, fixture|


### PR DESCRIPTION
Some text fixtures have a hardcoded OS `macOS`. This of course makes these tests only work on this platform.

This PR overwrites the fields with the actual OS the test is running in _while_ the test is running, at runtime.