### PR TITLE
Workaround for missing/delayed file after `system("openssl ...")`

### DIFF
--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -93,7 +93,11 @@ module Match
       success = system(command.join(' '))
 
       UI.crash!("Error decrypting '#{path}'") unless success
-      sleep 0.1 until File.exist?(tmpfile)
+
+      # On non-Mac systems it might take some time for the file to actually be there
+      if FastlaneCore::Helper.is_mac?
+        sleep 0.1 until File.exist?(tmpfile)
+
       FileUtils.mv(tmpfile, path)
     end
   end

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -93,9 +93,7 @@ module Match
       success = system(command.join(' '))
 
       UI.crash!("Error decrypting '#{path}'") unless success
-      until File.exist?(tmpfile)
-        sleep 0.1
-      end 
+      sleep 0.1 until File.exist?(tmpfile)
       FileUtils.mv(tmpfile, path)
     end
   end

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -97,6 +97,7 @@ module Match
       # On non-Mac systems it might take some time for the file to actually be there
       unless FastlaneCore::Helper.is_mac?
         sleep 0.1 until File.exist?(tmpfile)
+      end
 
       FileUtils.mv(tmpfile, path)
     end

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -93,6 +93,9 @@ module Match
       success = system(command.join(' '))
 
       UI.crash!("Error decrypting '#{path}'") unless success
+      until File.exist?(tmpfile)
+        sleep 0.1
+      end 
       FileUtils.mv(tmpfile, path)
     end
   end

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -94,7 +94,8 @@ module Match
 
       UI.crash!("Error decrypting '#{path}'") unless success
 
-      # On non-Mac systems it might take some time for the file to actually be there (#11182)
+      # On non-Mac systems (more specific Ubuntu Linux) it might take some time for the file to actually be there (see #11182).
+      # To try to circumvent this flakyness (in tests), we wait a bit until the file appears (max 2s) (usually only 0.1 is actually waited)
       unless FastlaneCore::Helper.is_mac?
         count = 0
         # sleep until file exists or 20*0.1s (=2s) passed

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -94,9 +94,14 @@ module Match
 
       UI.crash!("Error decrypting '#{path}'") unless success
 
-      # On non-Mac systems it might take some time for the file to actually be there
+      # On non-Mac systems it might take some time for the file to actually be there (#11182)
       unless FastlaneCore::Helper.is_mac?
-        sleep 0.1 until File.exist?(tmpfile)
+        count = 0
+        # sleep until file exists or 20*0.1s (=2s) passed
+        until (File.exist?(tmpfile) || count == 20)
+          sleep(0.1)
+          count += 1
+        end
       end
 
       FileUtils.mv(tmpfile, path)

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -98,7 +98,7 @@ module Match
       unless FastlaneCore::Helper.is_mac?
         count = 0
         # sleep until file exists or 20*0.1s (=2s) passed
-        until (File.exist?(tmpfile) || count == 20)
+        until File.exist?(tmpfile) || count == 20
           sleep(0.1)
           count += 1
         end

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -95,7 +95,7 @@ module Match
       UI.crash!("Error decrypting '#{path}'") unless success
 
       # On non-Mac systems it might take some time for the file to actually be there
-      if FastlaneCore::Helper.is_mac?
+      unless FastlaneCore::Helper.is_mac?
         sleep 0.1 until File.exist?(tmpfile)
 
       FileUtils.mv(tmpfile, path)


### PR DESCRIPTION
This is a curious one:

The `FileUtils.mv` can fail because `tmpfile` is not immediately available after `system("openssl ...")` returns on some systems. This causes an exception like this:

```
 1) Match Match::Encrypt encrypt
     Failure/Error: @e.encrypt_repo(path: @directory, git_url: @git_url)

     Errno::ENOENT:
       No such file or directory @ rb_file_s_rename - (/tmp/d20171210-12500-1a0jemh/temporary, /tmp/d20171210-12500-1a0jemh/randomFile.mobileprovision)
     # ./match/lib/match/encrypt.rb:106:in `crypt'
     # ./match/lib/match/encrypt.rb:45:in `block in encrypt_repo'
     # ./match/lib/match/encrypt.rb:76:in `block in iterate'
     # ./match/lib/match/encrypt.rb:74:in `each'
     # ./match/lib/match/encrypt.rb:74:in `iterate'
     # ./match/lib/match/encrypt.rb:44:in `encrypt_repo'
     # ./match/spec/encrypt_spec.rb:17:in `block (3 levels) in <top (required)>'
```

Read this StackOverflow question about how I debugged this and found out it is a timing problem:
https://stackoverflow.com/questions/47735995/fileutils-mv-fails-if-run-directly-after-systemopenssl-on-a-file-thi