### PR TITLE
Unguard xcode version check in FastlaneCore::ItunesTransporter

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -304,7 +304,7 @@ module FastlaneCore
     def initialize(user = nil, password = nil, use_shell_script = false, provider_short_name = nil)
       # Xcode 6.x doesn't have the same iTMSTransporter Java setup as later Xcode versions, so
       # we can't default to using the better direct Java invocation strategy for those versions.
-      use_shell_script ||= Helper.is_mac? && Helper.xcode_version.start_with?('6.')
+      use_shell_script ||= Helper.xcode_version.start_with?('6.')
       use_shell_script ||= Feature.enabled?('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT')
 
       @user = user


### PR DESCRIPTION
Quite some time ago in #4631 ("Only query for xcode version on macs") a `Helper.is_mac? && ` was added as "guard" before `Helper.xcode_version.start_with?('6.')`, so only if run on mac, the xcode version is actually checked:
https://github.com/fastlane/fastlane/blob/c99910b79a8a22bd6423acd8ebd1a62d5e6b9e99/fastlane_core/lib/fastlane_core/itunes_transporter.rb#L307

Unfortunately I could not find out _why_ this was done. I assume it was done to make this code not crash on system that do not have Xcode installed - which may have raised an exception if you went to check for the version.

Unfortunately it has the side effect of also making tests, that mock this xcode version check to the required 6.x version so the `ShellScriptTransporterExecutor` is used, not pass on non-Mac platforms.

Fortunately `Helper.xcode_version` got its own guard a few months ago in PR https://github.com/fastlane/fastlane/pull/9998:
https://github.com/fastlane/fastlane/blob/5019acb53fc2adf050b4227c3e3216e365ba36ec/fastlane_core/lib/fastlane_core/helper.rb#L143
With this new check, the additional check in `ItunesTransporter` is not necessary any more (as the version will be returned as `nil` on non-Mac platforms instead of raising an exception) and can be removed - which this PR does.