### PR TITLE
Option descriptions cannot include newlines

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -115,10 +115,10 @@ module Fastlane
                              end),
           FastlaneCore::ConfigItem.new(key: :scheme,
                              env_name: "FL_VERSION_NUMBER_SCHEME",
-                             description: "Specify a specific scheme if you have multiple per project, optional.
-                                          This parameter is deprecated and will be removed in a future release.
-                                          Please use the 'target' parameter instead. The behavior of this parameter
-                                          is currently undefined if your scheme name doesn't match your target name",
+                             description: "Specify a specific scheme if you have multiple per project, optional. " \
+                                          "This parameter is deprecated and will be removed in a future release. " \
+                                          "Please use the 'target' parameter instead. The behavior of this parameter " \
+                                          "is currently undefined if your scheme name doesn't match your target name",
                              optional: true,
                              deprecated: true),
           FastlaneCore::ConfigItem.new(key: :target,


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

https://docs.fastlane.tools/actions/get_version_number/#parameters

Parameter listing is screwed up.

### Description

Remove newlines from the description field.