### PR TITLE
Filter tests on non-mac OS

### DIFF
--- a/fastlane/spec/env_spec.rb
+++ b/fastlane/spec/env_spec.rb
@@ -25,7 +25,7 @@ describe Fastlane do
       expect(env).to include("xcpretty")
     end
 
-    it "contains main information about the stack" do
+    it "contains main information about the stack", requires_xcode: true do
       expect(env).to include("Bundler?")
       expect(env).to include("Xcode Path")
       expect(env).to include("Xcode Version")
@@ -44,7 +44,7 @@ describe Fastlane do
         allow(FastlaneCore::Helper).to receive(:xcode_version).and_raise("Boom!")
       end
 
-      it 'contains stack information other than Xcode Version' do
+      it 'contains stack information other than Xcode Version', requires_xcode: true do
         expect(env).to include("Bundler?")
         expect(env).to include("Xcode Path")
         expect(env).not_to include("Xcode Version")

--- a/fastlane/spec/setup/crashlytics_project_parser_spec.rb
+++ b/fastlane/spec/setup/crashlytics_project_parser_spec.rb
@@ -1,6 +1,6 @@
 describe Fastlane::CrashlyticsProjectParser do
   describe 'parses .xcproject files' do
-    it 'fetches path & keys from valid Crashlytics Beta project' do
+    it 'fetches path & keys from valid Crashlytics Beta project', requires_xcode: true do
       project_path = './fastlane/spec/fixtures/xcodeproj/crashlytics_beta_project.xcodeproj'
       parser = Fastlane::CrashlyticsProjectParser.new({ project: project_path })
       values = parser.parse
@@ -16,7 +16,7 @@ describe Fastlane::CrashlyticsProjectParser do
       end.to raise_error(/Could not find project at path/)
     end
 
-    it 'fails if target_name is invalid' do
+    it 'fails if target_name is invalid', requires_xcodebuild: true do
       project_path = './fastlane/spec/fixtures/xcodeproj/crashlytics_beta_project.xcodeproj'
       project = FastlaneCore::Project.new(
         { project: project_path },
@@ -31,20 +31,20 @@ describe Fastlane::CrashlyticsProjectParser do
       end.to raise_error("Unable to locate a target by the name of invalid_target_name")
     end
 
-    it 'fails with project with no run script build phase' do
+    it 'fails with project with no run script build phase', requires_xcode: true do
       project_path = './fastlane/spec/fixtures/xcodeproj/crashlytics_beta_project_no_run_script_build_phase.xcodeproj'
       expect do
         Fastlane::CrashlyticsProjectParser.new({ project: project_path }).parse
       end.to raise_error("Unable to find Crashlytics Run Script Build Phase")
     end
 
-    it 'finds no values in project with non-Crashlytics run script build phase' do
+    it 'finds no values in project with non-Crashlytics run script build phase', requires_xcode: true do
       project_path = './fastlane/spec/fixtures/xcodeproj/crashlytics_beta_project_invalid_run_script_build_phase.xcodeproj'
       parser = Fastlane::CrashlyticsProjectParser.new({ project: project_path })
       expect(parser.parse).to eq({ schemes: [] })
     end
 
-    it 'returns 2 schemes from a project' do
+    it 'returns 2 schemes from a project', requires_xcode: true do
       # We have to name this file all obfuscated-like (skeem) because FastlaneCore::Project
       # will reject any value that includes the word 'scheme'
       project_path = './fastlane/spec/fixtures/xcodeproj/crashlytics_beta_project_two_skeems.xcodeproj'

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -87,22 +87,19 @@ describe FastlaneCore do
       end
     end
 
-    # macOS only (to work on Linux)
-    if FastlaneCore::Helper.is_mac?
-      describe "Xcode" do
-        # Those tests also work when using a beta version of Xcode
-        it "#xcode_path" do
-          expect(FastlaneCore::Helper.xcode_path[-1]).to eq('/')
-          expect(FastlaneCore::Helper.xcode_path).to match(%r{/Applications/Xcode.*.app/Contents/Developer/})
-        end
+    describe "Xcode" do
+      # Those tests also work when using a beta version of Xcode
+      it "#xcode_path", requires_xcode: true do
+        expect(FastlaneCore::Helper.xcode_path[-1]).to eq('/')
+        expect(FastlaneCore::Helper.xcode_path).to match(%r{/Applications/Xcode.*.app/Contents/Developer/})
+      end
 
-        it "#transporter_path" do
-          expect(FastlaneCore::Helper.transporter_path).to match(%r{/Applications/Xcode.*.app/Contents/Applications/Application Loader.app/Contents/itms/bin/iTMSTransporter})
-        end
+      it "#transporter_path", requires_xcode: true do
+        expect(FastlaneCore::Helper.transporter_path).to match(%r{/Applications/Xcode.*.app/Contents/Applications/Application Loader.app/Contents/itms/bin/iTMSTransporter})
+      end
 
-        it "#xcode_version" do
-          expect(FastlaneCore::Helper.xcode_version).to match(/^\d[\.\d]+$/)
-        end
+      it "#xcode_version", requires_xcode: true do
+        expect(FastlaneCore::Helper.xcode_version).to match(/^\d[\.\d]+$/)
       end
     end
   end

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -179,27 +179,27 @@ describe FastlaneCore do
         expect(@project.project_name).to eq("Example")
       end
 
-      it "#schemes returns all available schemes" do
+      it "#schemes returns all available schemes", requires_xcodebuild: true do
         expect(@project.schemes).to eq(["Example"])
       end
 
-      it "#configurations returns all available configurations" do
+      it "#configurations returns all available configurations", requires_xcodebuild: true do
         expect(@project.configurations).to eq(["Debug", "Release", "SpecialConfiguration"])
       end
 
-      it "#app_name" do
+      it "#app_name", requires_xcode: true do
         expect(@project.app_name).to eq("ExampleProductName")
       end
 
-      it "#mac?" do
+      it "#mac?", requires_xcode: true do
         expect(@project.mac?).to eq(false)
       end
 
-      it "#ios?" do
+      it "#ios?", requires_xcode: true do
         expect(@project.ios?).to eq(true)
       end
 
-      it "#tvos?" do
+      it "#tvos?", requires_xcode: true do
         expect(@project.tvos?).to eq(false)
       end
     end
@@ -213,11 +213,11 @@ describe FastlaneCore do
         @workspace = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
       end
 
-      it "#schemes returns all schemes" do
+      it "#schemes returns all schemes", requires_xcodebuild: true do
         expect(@workspace.schemes).to eq(["Example"])
       end
 
-      it "#schemes returns all configurations" do
+      it "#schemes returns all configurations", requires_xcodebuild: true do
         expect(@workspace.configurations).to eq([])
       end
     end
@@ -228,19 +228,19 @@ describe FastlaneCore do
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
       end
 
-      it "#mac?" do
+      it "#mac?", requires_xcode: true do
         expect(@project.mac?).to eq(true)
       end
 
-      it "#ios?" do
+      it "#ios?", requires_xcode: true do
         expect(@project.ios?).to eq(false)
       end
 
-      it "#tvos?" do
+      it "#tvos?", requires_xcode: true do
         expect(@project.tvos?).to eq(false)
       end
 
-      it "schemes" do
+      it "schemes", requires_xcodebuild: true do
         expect(@project.schemes).to eq(["Mac"])
       end
     end
@@ -251,19 +251,19 @@ describe FastlaneCore do
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
       end
 
-      it "#mac?" do
+      it "#mac?", requires_xcode: true do
         expect(@project.mac?).to eq(false)
       end
 
-      it "#ios?" do
+      it "#ios?", requires_xcode: true do
         expect(@project.ios?).to eq(false)
       end
 
-      it "#tvos?" do
+      it "#tvos?", requires_xcode: true do
         expect(@project.tvos?).to eq(true)
       end
 
-      it "schemes" do
+      it "schemes", requires_xcodebuild: true do
         expect(@project.schemes).to eq(["ExampleTVOS"])
       end
     end
@@ -274,23 +274,23 @@ describe FastlaneCore do
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
       end
 
-      it "supported_platforms" do
+      it "supported_platforms", requires_xcode: true do
         expect(@project.supported_platforms).to eq([:macOS, :iOS, :tvOS, :watchOS])
       end
 
-      it "#mac?" do
+      it "#mac?", requires_xcode: true do
         expect(@project.mac?).to eq(true)
       end
 
-      it "#ios?" do
+      it "#ios?", requires_xcode: true do
         expect(@project.ios?).to eq(true)
       end
 
-      it "#tvos?" do
+      it "#tvos?", requires_xcode: true do
         expect(@project.tvos?).to eq(true)
       end
 
-      it "schemes" do
+      it "schemes", requires_xcodebuild: true do
         expect(@project.schemes).to eq(["CrossPlatformFramework"])
       end
     end
@@ -321,11 +321,11 @@ describe FastlaneCore do
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
       end
 
-      it "IPHONEOS_DEPLOYMENT_TARGET should be 9.0" do
+      it "IPHONEOS_DEPLOYMENT_TARGET should be 9.0", requires_xcode: true do
         expect(@project.build_settings(key: "IPHONEOS_DEPLOYMENT_TARGET")).to eq("9.0")
       end
 
-      it "PRODUCT_BUNDLE_IDENTIFIER should be tools.fastlane.app" do
+      it "PRODUCT_BUNDLE_IDENTIFIER should be tools.fastlane.app", requires_xcode: true do
         expect(@project.build_settings(key: "PRODUCT_BUNDLE_IDENTIFIER")).to eq("tools.fastlane.app")
       end
     end
@@ -339,11 +339,11 @@ describe FastlaneCore do
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
       end
 
-      it "IPHONEOS_DEPLOYMENT_TARGET should be 9.0" do
+      it "IPHONEOS_DEPLOYMENT_TARGET should be 9.0", requires_xcode: true do
         expect(@project.build_settings(key: "IPHONEOS_DEPLOYMENT_TARGET")).to eq("9.0")
       end
 
-      it "PRODUCT_BUNDLE_IDENTIFIER should be tools.fastlane.app.special" do
+      it "PRODUCT_BUNDLE_IDENTIFIER should be tools.fastlane.app.special", requires_xcode: true do
         expect(@project.build_settings(key: "PRODUCT_BUNDLE_IDENTIFIER")).to eq("tools.fastlane.app.special")
       end
     end
@@ -458,7 +458,7 @@ describe FastlaneCore do
       end
     end
 
-    describe 'xcodebuild_list_silent option' do
+    describe 'xcodebuild_list_silent option', requires_xcodebuild: true do
       it 'is not silent by default' do
         project = FastlaneCore::Project.new(
           { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" },
@@ -470,7 +470,7 @@ describe FastlaneCore do
         project.configurations
       end
 
-      it 'makes the raw_info method be silent if configured' do
+      it 'makes the raw_info method be silent if configured', requires_xcodebuild: true do
         project = FastlaneCore::Project.new(
           { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" },
           xcodebuild_list_silent: true,
@@ -482,7 +482,7 @@ describe FastlaneCore do
       end
     end
 
-    describe 'xcodebuild_suppress_stderr option' do
+    describe 'xcodebuild_suppress_stderr option', requires_xcode: true do
       it 'generates an xcodebuild -list command without stderr redirection by default' do
         project = FastlaneCore::Project.new({ project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" })
         expect(project.build_xcodebuild_list_command).not_to match(%r{2> /dev/null})
@@ -501,7 +501,7 @@ describe FastlaneCore do
         expect(project.build_xcodebuild_showbuildsettings_command).not_to match(%r{2> /dev/null})
       end
 
-      it 'generates an xcodebuild -showBuildSettings command that redirects stderr to /dev/null' do
+      it 'generates an xcodebuild -showBuildSettings command that redirects stderr to /dev/null', requires_xcode: true do
         project = FastlaneCore::Project.new(
           { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" },
           xcodebuild_suppress_stderr: true

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -16,7 +16,7 @@ describe Gym do
       end.to raise_error "Project file not found at path '/notExistent'"
     end
 
-    it "supports additional parameters" do
+    it "supports additional parameters", requires_xcodebuild: true do
       log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 
       xcargs = { DEBUG: "1", BUNDLE_NAME: "Example App" }
@@ -40,7 +40,7 @@ describe Gym do
                            ])
     end
 
-    it "disables xcpretty formatting" do
+    it "disables xcpretty formatting", requires_xcodebuild: true do
       log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 
       xcargs = { DEBUG: "1", BUNDLE_NAME: "Example App" }
@@ -62,7 +62,7 @@ describe Gym do
                            ])
     end
 
-    it "enables unicode" do
+    it "enables unicode", requires_xcodebuild: true do
       log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 
       xcargs = { DEBUG: "1", BUNDLE_NAME: "Example App" }
@@ -92,7 +92,7 @@ describe Gym do
         Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
       end
 
-      it "uses the correct build command with the example project with no additional parameters" do
+      it "uses the correct build command with the example project with no additional parameters", requires_xcodebuild: true do
         log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 
         result = Gym::BuildCommandGenerator.generate
@@ -109,38 +109,38 @@ describe Gym do
                              ])
       end
 
-      it "#project_path_array" do
+      it "#project_path_array", requires_xcodebuild: true do
         result = Gym::BuildCommandGenerator.project_path_array
         expect(result).to eq(["-scheme Example", "-project ./gym/examples/standard/Example.xcodeproj"])
       end
 
-      it "default #build_path" do
+      it "default #build_path", requires_xcodebuild: true do
         result = Gym::BuildCommandGenerator.build_path
         regex = %r{Library/Developer/Xcode/Archives/\d\d\d\d\-\d\d\-\d\d}
         expect(result).to match(regex)
       end
 
-      it "user provided #build_path" do
+      it "user provided #build_path", requires_xcodebuild: true do
         options = { project: "./gym/examples/standard/Example.xcodeproj", build_path: "/tmp/my/build_path", scheme: 'Example' }
         Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
         result = Gym::BuildCommandGenerator.build_path
         expect(result).to eq("/tmp/my/build_path")
       end
 
-      it "#archive_path" do
+      it "#archive_path", requires_xcodebuild: true do
         result = Gym::BuildCommandGenerator.archive_path
         regex = %r{Library/Developer/Xcode/Archives/\d\d\d\d\-\d\d\-\d\d/ExampleProductName \d\d\d\d\-\d\d\-\d\d \d\d\.\d\d\.\d\d.xcarchive}
         expect(result).to match(regex)
       end
 
-      it "#buildlog_path is used when provided" do
+      it "#buildlog_path is used when provided", requires_xcodebuild: true do
         options = { project: "./gym/examples/standard/Example.xcodeproj", buildlog_path: "/tmp/my/path", scheme: 'Example' }
         Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
         result = Gym::BuildCommandGenerator.xcodebuild_log_path
         expect(result).to include("/tmp/my/path")
       end
 
-      it "#buildlog_path is not used when not provided" do
+      it "#buildlog_path is not used when not provided", requires_xcodebuild: true do
         result = Gym::BuildCommandGenerator.xcodebuild_log_path
         expect(result.to_s).to include(File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym"))
       end
@@ -152,7 +152,7 @@ describe Gym do
         Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
       end
 
-      it "uses the correct build command with the example project" do
+      it "uses the correct build command with the example project", requires_xcodebuild: true do
         log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 
         result = Gym::BuildCommandGenerator.generate
@@ -172,7 +172,7 @@ describe Gym do
     end
 
     describe "Result Bundle Example" do
-      it "uses the correct build command with the example project" do
+      it "uses the correct build command with the example project", requires_xcodebuild: true do
         log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 
         options = { project: "./gym/examples/standard/Example.xcodeproj", result_bundle: true, scheme: 'Example' }
@@ -195,7 +195,7 @@ describe Gym do
     end
 
     describe "Analyze Build Time Example" do
-      it "uses the correct build command with the example project" do
+      it "uses the correct build command with the example project", requires_xcodebuild: true do
         log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 
         options = { project: "./gym/examples/standard/Example.xcodeproj", analyze_build_time: true, scheme: 'Example' }

--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -26,7 +26,7 @@ describe Gym::CodeSigningMapping do
   end
 
   describe "#detect_project_profile_mapping" do
-    it "returns the mapping of the selected provisioning profiles" do
+    it "returns the mapping of the selected provisioning profiles", requires_xcode: true do
       workspace_path = "gym/spec/fixtures/projects/cocoapods/Example.xcworkspace"
       project = FastlaneCore::Project.new({
         workspace: workspace_path
@@ -37,7 +37,7 @@ describe Gym::CodeSigningMapping do
   end
 
   describe "#detect_project_profile_mapping_for_tv_os" do
-    it "returns the mapping of the selected provisioning profiles for tv_os" do
+    it "returns the mapping of the selected provisioning profiles for tv_os", requires_xcode: true do
       workspace_path = "gym/spec/fixtures/projects/cocoapods/Example.xcworkspace"
       project = FastlaneCore::Project.new({
         workspace: workspace_path

--- a/gym/spec/detect_values_spec.rb
+++ b/gym/spec/detect_values_spec.rb
@@ -2,7 +2,7 @@ describe Gym do
   describe Gym::DetectValues do
     day = Time.now.strftime("%F")
 
-    describe 'Xcode config handling', :stuff do
+    describe 'Xcode config handling', :stuff, requires_xcodebuild: true do
       it "fetches the custom build path from the Xcode config" do
         expect(Gym::DetectValues).to receive(:has_xcode_preferences_plist?).and_return(true)
         expect(Gym::DetectValues).to receive(:xcode_preferences_dictionary).and_return({ "IDECustomDistributionArchivesLocation" => "/test/path" })

--- a/gym/spec/error_handler_spec.rb
+++ b/gym/spec/error_handler_spec.rb
@@ -11,7 +11,7 @@ describe Gym do
 %)
   end
 
-  describe Gym::ErrorHandler do
+  describe Gym::ErrorHandler, requires_xcodebuild: true do
     before(:each) { Gym.config = @config }
 
     def mock_gym_path(content)

--- a/gym/spec/gymfile_spec.rb
+++ b/gym/spec/gymfile_spec.rb
@@ -5,7 +5,7 @@ describe Gym do
     @project = FastlaneCore::Project.new(@config)
   end
 
-  describe "Project with multiple Schemes and Gymfile" do
+  describe "Project with multiple Schemes and Gymfile", requires_xcodebuild: true do
     before(:each) { Gym.config = @config }
 
     it "#schemes returns all available schemes" do

--- a/gym/spec/options_spec.rb
+++ b/gym/spec/options_spec.rb
@@ -7,21 +7,21 @@ describe Gym do
       end.to raise_error "You can only pass either a 'project' or a 'workspace', not both"
     end
 
-    it "removes the `ipa` from the output name if given" do
+    it "removes the `ipa` from the output name if given", requires_xcodebuild: true do
       options = { output_name: "Example.ipa", project: "./gym/examples/standard/Example.xcodeproj" }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 
       expect(Gym.config[:output_name]).to eq("Example")
     end
 
-    it "automatically chooses an existing scheme if the the defined one is not available" do
+    it "automatically chooses an existing scheme if the the defined one is not available", requires_xcodebuild: true do
       options = { project: "./gym/examples/standard/Example.xcodeproj", scheme: "NotHere" }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 
       expect(Gym.config[:scheme]).to eq("Example")
     end
 
-    it "replaces SEPARATOR (i.e. /) character with underscore(_) in output name" do
+    it "replaces SEPARATOR (i.e. /) character with underscore(_) in output name", requires_xcodebuild: true do
       options = { output_name: "feature" + File::SEPARATOR + "Example.ipa", project: "./gym/examples/standard/Example.xcodeproj" }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 

--- a/gym/spec/package_command_generator_xcode7_spec.rb
+++ b/gym/spec/package_command_generator_xcode7_spec.rb
@@ -8,7 +8,7 @@ describe Gym do
     allow(Gym).to receive(:project).and_return(@project)
   end
 
-  describe Gym::PackageCommandGeneratorXcode7 do
+  describe Gym::PackageCommandGeneratorXcode7, requires_xcodebuild: true do
     it "passes xcargs through to xcode build wrapper " do
       options = {
         project: "./gym/examples/standard/Example.xcodeproj",

--- a/gym/spec/xcodebuild_fixes/generic_archive_fix_spec.rb
+++ b/gym/spec/xcodebuild_fixes/generic_archive_fix_spec.rb
@@ -3,7 +3,7 @@ describe Gym do
     let (:watch_app) { 'gym/spec/fixtures/xcodebuild_fixes/ios_watch_app.app' }
     let (:ios_app) { 'gym/spec/fixtures/xcodebuild_fixes/ios_app.app' }
 
-    it "can detect watch application" do
+    it "can detect watch application", requires_plistbuddy: true do
       expect(Gym::XcodebuildFixes.is_watchkit_app?(watch_app)).to eq(true)
     end
 

--- a/match/spec/generator_spec.rb
+++ b/match/spec/generator_spec.rb
@@ -1,6 +1,6 @@
 describe Match::Generator do
-  describe 'calling through to other tools ' do
-    it 'configures cert correctly for nested execution' do
+  describe 'calling through to other tools' do
+    it 'configures cert correctly for nested execution', requires_keychain: true do
       require 'cert'
 
       config = FastlaneCore::Configuration.create(Cert::Options.available_options, {

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -8,7 +8,7 @@ describe Match do
       allow(ENV).to receive(:[]).with('MATCH_KEYCHAIN_PASSWORD').and_return(nil)
     end
 
-    it "creates a new profile and certificate if it doesn't exist yet" do
+    it "creates a new profile and certificate if it doesn't exist yet", requires_security: true do
       git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
       values = {
         app_identifier: "tools.fastlane.app",
@@ -61,7 +61,7 @@ describe Match do
                                                                      type: "appstore")]).to eql(profile_path)
     end
 
-    it "uses existing certificates and profiles if they exist" do
+    it "uses existing certificates and profiles if they exist", requires_security: true do
       git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
       values = {
         app_identifier: "tools.fastlane.app",

--- a/scan/spec/detect_values_spec.rb
+++ b/scan/spec/detect_values_spec.rb
@@ -7,14 +7,14 @@ describe Scan do
         @project = FastlaneCore::Project.new(Scan.config)
       end
 
-      it "fetches the path from the Xcode config" do
+      it "fetches the path from the Xcode config", requires_xcodebuild: true do
         derived_data = Scan.config[:derived_data_path]
         expect(derived_data).to match(%r{/.*Xcode/DerivedData/app-\w*$})
       end
     end
 
     describe "validation" do
-      it "advises of problems with multiple output_types and a custom_report_file_name" do
+      it "advises of problems with multiple output_types and a custom_report_file_name", requires_xcodebuild: true do
         options = {
           project: "./scan/examples/standard/app.xcodeproj",
           # use default output types
@@ -24,7 +24,7 @@ describe Scan do
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
-      it "does not advise of a problem with one output_type and a custom_report_file_name" do
+      it "does not advise of a problem with one output_type and a custom_report_file_name", requires_xcodebuild: true do
         options = {
           project: "./scan/examples/standard/app.xcodeproj",
           output_types: 'junit',
@@ -36,7 +36,7 @@ describe Scan do
     end
 
     describe "value coercion" do
-      it "coerces only_testing to be an array" do
+      it "coerces only_testing to be an array", requires_xcodebuild: true do
         options = {
           project: "./scan/examples/standard/app.xcodeproj",
           only_testing: "Bundle/SuiteA"
@@ -45,7 +45,7 @@ describe Scan do
         expect(Scan.config[:only_testing]).to eq(["Bundle/SuiteA"])
       end
 
-      it "coerces skip_testing to be an array" do
+      it "coerces skip_testing to be an array", requires_xcodebuild: true do
         options = {
           project: "./scan/examples/standard/app.xcodeproj",
           skip_testing: "Bundle/SuiteA,Bundle/SuiteB"
@@ -54,7 +54,7 @@ describe Scan do
         expect(Scan.config[:skip_testing]).to eq(["Bundle/SuiteA", "Bundle/SuiteB"])
       end
 
-      it "leaves skip_testing as an array" do
+      it "leaves skip_testing as an array", requires_xcodebuild: true do
         options = {
           project: "./scan/examples/standard/app.xcodeproj",
           skip_testing: ["Bundle/SuiteA", "Bundle/SuiteB"]

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -20,7 +20,7 @@ describe Scan do
       end
 
       describe "with scan option :include_simulator_logs set to false" do
-        it "does not copy any device logs to the output directory" do
+        it "does not copy any device logs to the output directory", requires_xcodebuild: true do
           # Circle CI is setting the SCAN_INCLUDE_SIMULATOR_LOGS env var, so just leaving
           # the include_simulator_logs option out does not let it default to false
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
@@ -35,7 +35,7 @@ describe Scan do
       end
 
       describe "with scan option :include_simulator_logs set to true" do
-        it "copies any device logs to the output directory" do
+        it "copies any device logs to the output directory", requires_xcodebuild: true do
           # Circle CI is setting the SCAN_INCLUDE_SIMULATOR_LOGS env var, so just leaving
           # the include_simulator_logs option out does not let it default to false
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
@@ -50,7 +50,7 @@ describe Scan do
       end
 
       describe "Test Failure" do
-        it "raises a FastlaneTestFailure instead of a crash or UserError" do
+        it "raises a FastlaneTestFailure instead of a crash or UserError", requires_xcodebuild: true do
           expect do
             Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
               output_directory: '/tmp/scan_results',
@@ -85,14 +85,14 @@ describe Scan do
         @scan = Scan::Runner.new
       end
 
-      it "still proceeds successfully if the temp junit report was deleted" do
+      it "still proceeds successfully if the temp junit report was deleted", requires_xcodebuild: true do
         Scan.cache[:temp_junit_report] = '/var/folders/non_existent_file.junit'
         expect(@scan.test_results).to_not be_nil
         expect(Scan.cache[:temp_junit_report]).to_not eq('/var/folders/non_existent_file.junit')
       end
 
       describe "when output_style is raw" do
-        it "still proceeds successfully and generates a temp junit report" do
+        it "still proceeds successfully and generates a temp junit report", requires_xcodebuild: true do
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
             output_directory: '/tmp/scan_results',
             project: './scan/examples/standard/app.xcodeproj',

--- a/scan/spec/slack_poster_spec.rb
+++ b/scan/spec/slack_poster_spec.rb
@@ -4,7 +4,7 @@ require 'slack-notifier'
 describe Scan::SlackPoster do
   describe "slack_url handling" do
     describe "without a slack_url set" do
-      it "skips Slack posting" do
+      it "skips Slack posting", requires_xcodebuild: true do
         # ensures that people's local environment variable doesn't interfere with this test
         with_env_values('SLACK_URL' => nil) do
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
@@ -19,7 +19,7 @@ describe Scan::SlackPoster do
     end
 
     describe "with the slack_url option set but skip_slack set to true" do
-      it "skips Slack posting" do
+      it "skips Slack posting", requires_xcodebuild: true do
         # ensures that people's local environment variable doesn't interfere with this test
         with_env_values('SLACK_URL' => nil) do
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
@@ -36,7 +36,7 @@ describe Scan::SlackPoster do
     end
 
     describe "with the SLACK_URL ENV var set but skip_slack set to true" do
-      it "skips Slack posting" do
+      it "skips Slack posting", requires_xcodebuild: true do
         with_env_values('SLACK_URL' => 'https://slack/hook/url') do
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
             project: './scan/examples/standard/app.xcodeproj',
@@ -51,7 +51,7 @@ describe Scan::SlackPoster do
     end
 
     describe "with the SLACK_URL ENV var set to empty string" do
-      it "skips Slack posting" do
+      it "skips Slack posting", requires_xcodebuild: true do
         with_env_values('SLACK_URL' => '') do
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
             project: './scan/examples/standard/app.xcodeproj'
@@ -65,7 +65,7 @@ describe Scan::SlackPoster do
     end
 
     describe "with the slack_url option set to empty string" do
-      it "skips Slack posting" do
+      it "skips Slack posting", requires_xcodebuild: true do
         # ensures that people's local environment variable doesn't interfere with this test
         with_env_values('SLACK_URL' => nil) do
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
@@ -90,7 +90,7 @@ describe Scan::SlackPoster do
     end
 
     describe "with slack_url option set to a URL value" do
-      it "does Slack posting" do
+      it "does Slack posting", requires_xcodebuild: true do
         expect_slack_posting
 
         # ensures that people's local environment variable doesn't interfere with this test
@@ -106,7 +106,7 @@ describe Scan::SlackPoster do
     end
 
     describe "with SLACK_URL ENV var set to a URL value" do
-      it "does Slack posting" do
+      it "does Slack posting", requires_xcodebuild: true do
         expect_slack_posting
 
         with_env_values('SLACK_URL' => 'https://slack/hook/url') do

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -98,7 +98,7 @@ describe Scan do
         end.to raise_error("Unresolved conflict between options: 'toolchain' and 'xctestrun'")
       end
 
-      it "passes the toolchain option to xcodebuild" do
+      it "passes the toolchain option to xcodebuild", requires_xcodebuild: true do
         options = { project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0", toolchain: "com.apple.dt.toolchain.Swift_2_3" }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
@@ -118,7 +118,7 @@ describe Scan do
       end
     end
 
-    it "supports additional parameters" do
+    it "supports additional parameters", requires_xcodebuild: true do
       log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
       xcargs = { DEBUG: "1", BUNDLE_NAME: "Example App" }
@@ -140,7 +140,7 @@ describe Scan do
                                    ])
     end
 
-    it "supports custom xcpretty formatter" do
+    it "supports custom xcpretty formatter", requires_xcodebuild: true do
       options = { formatter: "custom-formatter", project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
@@ -154,7 +154,7 @@ describe Scan do
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
-      it "uses the correct build command with the example project with no additional parameters" do
+      it "uses the correct build command with the example project with no additional parameters", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         result = @test_command_generator.generate
@@ -170,25 +170,25 @@ describe Scan do
                                      ])
       end
 
-      it "#project_path_array" do
+      it "#project_path_array", requires_xcodebuild: true do
         result = @test_command_generator.project_path_array
         expect(result).to eq(["-scheme app", "-project ./scan/examples/standard/app.xcodeproj"])
       end
 
-      it "#build_path" do
+      it "#build_path", requires_xcodebuild: true do
         result = @test_command_generator.build_path
         regex = %r{Library/Developer/Xcode/Archives/\d\d\d\d\-\d\d\-\d\d}
         expect(result).to match(regex)
       end
 
-      it "#buildlog_path is used when provided" do
+      it "#buildlog_path is used when provided", requires_xcodebuild: true do
         options = { project: "./scan/examples/standard/app.xcodeproj", buildlog_path: "/tmp/my/path" }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
         result = @test_command_generator.xcodebuild_log_path
         expect(result).to include("/tmp/my/path")
       end
 
-      it "#buildlog_path is not used when not provided" do
+      it "#buildlog_path is not used when not provided", requires_xcodebuild: true do
         result = @test_command_generator.xcodebuild_log_path
         expect(result.to_s).to include(File.expand_path("#{FastlaneCore::Helper.buildlog_path}/scan"))
       end
@@ -200,7 +200,7 @@ describe Scan do
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
-      it "uses the correct build command with the example project" do
+      it "uses the correct build command with the example project", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         result = @test_command_generator.generate
@@ -219,7 +219,7 @@ describe Scan do
 
     describe "with Scan option :include_simulator_logs" do
       context "extract system.logarchive" do
-        it "copies all device logs to the output directory" do
+        it "copies all device logs to the output directory", requires_xcodebuild: true do
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
             output_directory: '/tmp/scan_results',
             include_simulator_logs: true,
@@ -254,7 +254,7 @@ describe Scan do
     end
 
     describe "Result Bundle Example" do
-      it "uses the correct build command with the example project" do
+      it "uses the correct build command with the example project", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         options = { project: "./scan/examples/standard/app.xcodeproj", result_bundle: true, scheme: 'app' }
@@ -276,7 +276,7 @@ describe Scan do
     end
 
     describe "Test Exclusion Example" do
-      it "only tests the test bundle/suite/cases specified in only_testing when the input is an array" do
+      it "only tests the test bundle/suite/cases specified in only_testing when the input is an array", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
@@ -299,7 +299,7 @@ describe Scan do
                                      ])
       end
 
-      it "only tests the test bundle/suite/cases specified in only_testing when the input is a string" do
+      it "only tests the test bundle/suite/cases specified in only_testing when the input is a string", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
@@ -321,7 +321,7 @@ describe Scan do
                                      ])
       end
 
-      it "does not the test bundle/suite/cases specified in skip_testing when the input is an array" do
+      it "does not the test bundle/suite/cases specified in skip_testing when the input is an array", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
@@ -344,7 +344,7 @@ describe Scan do
                                      ])
       end
 
-      it "does not the test bundle/suite/cases specified in skip_testing when the input is a string" do
+      it "does not the test bundle/suite/cases specified in skip_testing when the input is a string", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
@@ -367,7 +367,7 @@ describe Scan do
       end
     end
 
-    it "uses a device without version specifier" do
+    it "uses a device without version specifier", requires_xcodebuild: true do
       options = { project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 6s" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
@@ -385,7 +385,7 @@ describe Scan do
                                    ])
     end
 
-    it "rejects devices with versions below deployment target" do
+    it "rejects devices with versions below deployment target", requires_xcodebuild: true do
       options = { project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 5 (8.4)" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
@@ -402,7 +402,7 @@ describe Scan do
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
-      it "should build-for-testing" do
+      it "should build-for-testing", requires_xcodebuild: true do
         Scan.config[:build_for_testing] = true
         result = @test_command_generator.generate
         expect(result).to start_with([
@@ -416,7 +416,7 @@ describe Scan do
                                        "build-for-testing"
                                      ])
       end
-      it "should test-without-building" do
+      it "should test-without-building", requires_xcodebuild: true do
         Scan.config[:test_without_building] = true
         result = @test_command_generator.generate
         expect(result).to start_with([
@@ -430,7 +430,7 @@ describe Scan do
                                        "test-without-building"
                                      ])
       end
-      it "should raise an exception if two build_modes are set" do
+      it "should raise an exception if two build_modes are set", requires_xcodebuild: true do
         allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(".")
         expect do
           Fastlane::FastFile.new.parse("lane :test do
@@ -443,7 +443,7 @@ describe Scan do
         end.to raise_error("Unresolved conflict between options: 'test_without_building' and 'build_for_testing'")
       end
 
-      it "should run tests from xctestrun file" do
+      it "should run tests from xctestrun file", requires_xcodebuild: true do
         Scan.config[:xctestrun] = "/folder/mytests.xctestrun"
         result = @test_command_generator.generate
         expect(result).to start_with([
@@ -459,7 +459,7 @@ describe Scan do
     end
 
     describe "Multiple devices example" do
-      it "uses multiple destinations" do
+      it "uses multiple destinations", requires_xcodebuild: true do
         options = { project: "./scan/examples/standard/app.xcodeproj", destination: [
           "platform=iOS Simulator,name=iPhone 6s,OS=9.3",
           "platform=iOS Simulator,name=iPad Air 2,OS=9.2"
@@ -480,7 +480,7 @@ describe Scan do
                                      ])
       end
 
-      it "uses multiple devices" do
+      it "uses multiple devices", requires_xcodebuild: true do
         options = { project: "./scan/examples/standard/app.xcodeproj", devices: [
           "iPhone 6s (9.3)",
           "iPad Air (9.3)"
@@ -501,7 +501,7 @@ describe Scan do
                                      ])
       end
 
-      it "de-duplicates devices matching same simulator" do
+      it "de-duplicates devices matching same simulator", requires_xcodebuild: true do
         options = { project: "./scan/examples/standard/app.xcodeproj", devices: [
           "iPhone 5 (9.0)",
           "iPhone 5 (9.0.0)"

--- a/scan/spec/xcpretty_reporter_options_generator_spec.rb
+++ b/scan/spec/xcpretty_reporter_options_generator_spec.rb
@@ -7,7 +7,7 @@ describe Scan do
     end
 
     describe "xcpretty reporter options generation" do
-      it "generates options for the junit tempfile report required by scan" do
+      it "generates options for the junit tempfile report required by scan", requires_xcodebuild: true do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html", "report.html", "/test_output", false)
         reporter_options = generator.generate_reporter_options
         temp_junit_report = Scan.cache[:temp_junit_report]
@@ -19,7 +19,7 @@ describe Scan do
                                              ])
       end
 
-      it "generates options for a custom junit report with default file name" do
+      it "generates options for a custom junit report with default file name", requires_xcodebuild: true do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "junit", nil, "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -29,7 +29,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom junit report with custom file name" do
+      it "generates options for a custom junit report with custom file name", requires_xcodebuild: true do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "junit", "junit.xml", "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -39,7 +39,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom html report with default file name" do
+      it "generates options for a custom html report with default file name", requires_xcodebuild: true do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html", nil, "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -49,7 +49,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom html report with custom file name" do
+      it "generates options for a custom html report with custom file name", requires_xcodebuild: true do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html", "custom_report.html", "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -59,7 +59,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom json-compilation-database file with default file name" do
+      it "generates options for a custom json-compilation-database file with default file name", requires_xcodebuild: true do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "json-compilation-database", nil, "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -69,7 +69,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom json-compilation-database file with a custom file name" do
+      it "generates options for a custom json-compilation-database file with a custom file name", requires_xcodebuild: true do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "json-compilation-database", "custom_report.json", "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -79,7 +79,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom json-compilation-database file with a clang naming convention" do
+      it "generates options for a custom json-compilation-database file with a clang naming convention", requires_xcodebuild: true do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "json-compilation-database", "ignore_custom_name_here.json", "/test_output", true)
         reporter_options = generator.generate_reporter_options
 
@@ -89,7 +89,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a multiple reports with default file names" do
+      it "generates options for a multiple reports with default file names", requires_xcodebuild: true do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html,junit", nil, "/test_output", true)
         reporter_options = generator.generate_reporter_options
 
@@ -101,7 +101,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a multiple reports with default file names" do
+      it "generates options for a multiple reports with default file names", requires_xcodebuild: true do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html,junit", "custom_report.html,junit.xml", "/test_output", true)
         reporter_options = generator.generate_reporter_options
 
@@ -114,7 +114,7 @@ describe Scan do
       end
 
       context "options passed as arrays" do
-        it "generates options for the junit tempfile report required by scan" do
+        it "generates options for the junit tempfile report required by scan", requires_xcodebuild: true do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html"], ["report.html"], "test_output", false)
           reporter_options = generator.generate_reporter_options
           temp_junit_report = Scan.cache[:temp_junit_report]
@@ -126,7 +126,7 @@ describe Scan do
                                                ])
         end
 
-        it "generates options for a custom junit report with default file name" do
+        it "generates options for a custom junit report with default file name", requires_xcodebuild: true do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["junit"], nil, "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -136,7 +136,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom junit report with custom file name" do
+        it "generates options for a custom junit report with custom file name", requires_xcodebuild: true do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["junit"], ["junit.xml"], "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -146,7 +146,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom html report with default file name" do
+        it "generates options for a custom html report with default file name", requires_xcodebuild: true do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html"], nil, "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -156,7 +156,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom html report with custom file name" do
+        it "generates options for a custom html report with custom file name", requires_xcodebuild: true do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html"], ["custom_report.html"], "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -166,7 +166,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom json-compilation-database file with default file name" do
+        it "generates options for a custom json-compilation-database file with default file name", requires_xcodebuild: true do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["json-compilation-database"], nil, "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -176,7 +176,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom json-compilation-database file with a custom file name" do
+        it "generates options for a custom json-compilation-database file with a custom file name", requires_xcodebuild: true do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["json-compilation-database"], ["custom_report.json"], "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -186,7 +186,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom json-compilation-database file with a clang naming convention" do
+        it "generates options for a custom json-compilation-database file with a clang naming convention", requires_xcodebuild: true do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["json-compilation-database"], ["ignore_custom_name_here.json"], "/test_output", true)
           reporter_options = generator.generate_reporter_options
 
@@ -199,7 +199,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a multiple reports with default file names" do
+        it "generates options for a multiple reports with default file names", requires_xcodebuild: true do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html", "junit"], nil, "/test_output", true)
           reporter_options = generator.generate_reporter_options
 
@@ -211,7 +211,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a multiple reports with custom file names" do
+        it "generates options for a multiple reports with custom file names", requires_xcodebuild: true do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html", "junit"], ["custom_report.html", "junit.xml"], "/test_output", true)
           reporter_options = generator.generate_reporter_options
 
@@ -225,7 +225,7 @@ describe Scan do
       end
 
       context "generator created from Scan.config" do
-        it "generates options for a single reports while using custom_report_file_name" do
+        it "generates options for a single reports while using custom_report_file_name", requires_xcodebuild: true do
           options = {
             project: "./scan/examples/standard/app.xcodeproj",
             output_types: "junit,html",

--- a/snapshot/spec/commands_generator_spec.rb
+++ b/snapshot/spec/commands_generator_spec.rb
@@ -35,7 +35,7 @@ describe Snapshot::CommandsGenerator do
   end
 
   describe ":reset_simulators option handling" do
-    it "can use the ios_version short flag" do
+    it "can use the ios_version short flag", requires_xcodebuild: true do
       stub_commander_runner_args(['reset_simulators', '-i', '9.3.5,10.0'])
 
       allow(Snapshot::DetectValues).to receive(:set_additional_default_values)
@@ -44,7 +44,7 @@ describe Snapshot::CommandsGenerator do
       Snapshot::CommandsGenerator.start
     end
 
-    it "can use the ios_version flag" do
+    it "can use the ios_version flag", requires_xcodebuild: true do
       stub_commander_runner_args(['reset_simulators', '--ios_version', '9.3.5,10.0'])
 
       allow(Snapshot::DetectValues).to receive(:set_additional_default_values)
@@ -53,7 +53,7 @@ describe Snapshot::CommandsGenerator do
       Snapshot::CommandsGenerator.start
     end
 
-    it "can use the force flag" do
+    it "can use the force flag", requires_xcodebuild: true do
       stub_commander_runner_args(['reset_simulators', '--ios_version', '9.3.5,10.0', '--force'])
 
       allow(Snapshot::DetectValues).to receive(:set_additional_default_values)

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -94,7 +94,7 @@ describe Snapshot do
         })
       end
 
-      it 'copies all device log archives to the output directory on macOS 10.12 (Sierra)' do
+      it 'copies all device log archives to the output directory on macOS 10.12 (Sierra)', requires_xcode: true do
         Snapshot.config = @config
         launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
 
@@ -115,7 +115,7 @@ describe Snapshot do
         Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6s (10.1)"], "en-US", nil, 0)
       end
 
-      it 'copies all iOS 9 device log files to the output directory on macOS 10.12 (Sierra)' do
+      it 'copies all iOS 9 device log files to the output directory on macOS 10.12 (Sierra)', requires_xcode: true do
         Snapshot.config = @config
         launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
 
@@ -132,7 +132,7 @@ describe Snapshot do
         Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6"], "en-US", nil, 0)
       end
 
-      it 'copies all device log files to the output directory on macOS 10.11 (El Capitan)' do
+      it 'copies all device log files to the output directory on macOS 10.11 (El Capitan)', requires_xcode: true do
         Snapshot.config = @config
         launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
 
@@ -158,7 +158,7 @@ describe Snapshot do
       end
 
       context 'default options' do
-        it "uses the default parameters" do
+        it "uses the default parameters", requires_xcode: true do
           configure options
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
           command = Snapshot::TestCommandGenerator.generate(
@@ -185,7 +185,7 @@ describe Snapshot do
           )
         end
 
-        it "allows to supply custom xcargs" do
+        it "allows to supply custom xcargs", requires_xcode: true do
           configure options.merge(xcargs: "-only-testing:TestBundle/TestSuite/Screenshots")
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
           command = Snapshot::TestCommandGenerator.generate(
@@ -213,7 +213,7 @@ describe Snapshot do
           )
         end
 
-        it "uses the default parameters on tvOS too" do
+        it "uses the default parameters on tvOS too", requires_xcode: true do
           configure options.merge(devices: ["Apple TV 1080p"])
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
           command = Snapshot::TestCommandGenerator.generate(
@@ -246,7 +246,7 @@ describe Snapshot do
           configure options.merge(derived_data_path: 'fake/derived/path')
         end
 
-        it 'uses the fixed derivedDataPath if given' do
+        it 'uses the fixed derivedDataPath if given', requires_xcode: true do
           expect(Dir).not_to receive(:mktmpdir)
           command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
           expect(command.join('')).to include("-derivedDataPath 'fake/derived/path'")
@@ -257,7 +257,7 @@ describe Snapshot do
     describe "Valid macOS Configuration" do
       let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleMacOS", namespace_log_files: true } }
 
-      it "uses default parameters on macOS" do
+      it "uses default parameters on macOS", requires_xcode: true do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options.merge(devices: ["Mac"]))
         expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
         command = Snapshot::TestCommandGenerator.generate(
@@ -292,21 +292,21 @@ describe Snapshot do
         return simulator_launcher = Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config)
       end
 
-      it 'uses correct name and language' do
+      it 'uses correct name and language', requires_xcode: true do
         log_path = simulator_launcher.xcodebuild_log_path(language: "pt", locale: nil)
         expect(log_path).to eq(
           File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt.log").to_s
         )
       end
 
-      it 'uses includes locale if specified' do
+      it 'uses includes locale if specified', requires_xcode: true do
         log_path = simulator_launcher.xcodebuild_log_path(language: "pt", locale: "pt_BR")
         expect(log_path).to eq(
           File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt-pt_BR.log").to_s
         )
       end
 
-      it 'can work without parameters' do
+      it 'can work without parameters', requires_xcode: true do
         simulator_launcher.launcher_config.devices = []
         log_path = simulator_launcher.xcodebuild_log_path
         expect(log_path).to eq(
@@ -324,7 +324,7 @@ describe Snapshot do
         return simulator_launcher = Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config)
       end
 
-      it 'uses correct file name' do
+      it 'uses correct file name', requires_xcode: true do
         log_path = simulator_launcher.xcodebuild_log_path(language: "pt", locale: nil)
         expect(log_path).to eq(
           File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log").to_s

--- a/snapshot/spec/test_command_generator_xcode_8_spec.rb
+++ b/snapshot/spec/test_command_generator_xcode_8_spec.rb
@@ -55,7 +55,7 @@ describe Snapshot do
         })
       end
 
-      it 'copies all device log archives to the output directory on macOS 10.12 (Siera)' do
+      it 'copies all device log archives to the output directory on macOS 10.12 (Siera)', requires_xcode: true do
         Snapshot.config = @config
         launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
 
@@ -76,7 +76,7 @@ describe Snapshot do
         Snapshot::SimulatorLauncherXcode8.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6s (10.1)"], "en-US", nil, 0)
       end
 
-      it 'copies all iOS 9 device log files to the output directory on macOS 10.12 (Sierra)' do
+      it 'copies all iOS 9 device log files to the output directory on macOS 10.12 (Sierra)', requires_xcode: true do
         Snapshot.config = @config
         launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
 
@@ -93,7 +93,7 @@ describe Snapshot do
         Snapshot::SimulatorLauncherXcode8.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6"], "en-US", nil, 0)
       end
 
-      it 'copies all device log files to the output directory on macOS 10.11 (El Capitan)' do
+      it 'copies all device log files to the output directory on macOS 10.11 (El Capitan)', requires_xcode: true do
         Snapshot.config = @config
         launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
 
@@ -119,7 +119,7 @@ describe Snapshot do
       end
 
       context 'default options' do
-        it "uses the default parameters" do
+        it "uses the default parameters", requires_xcode: true do
           configure options
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
           command = Snapshot::TestCommandGeneratorXcode8.generate(device_type: "iPhone 6", language: "en", locale: nil)
@@ -141,7 +141,7 @@ describe Snapshot do
           )
         end
 
-        it "allows to supply custom xcargs" do
+        it "allows to supply custom xcargs", requires_xcode: true do
           configure options.merge(xcargs: "-only-testing:TestBundle/TestSuite/Screenshots")
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
           command = Snapshot::TestCommandGeneratorXcode8.generate(device_type: "iPhone 6", language: "en", locale: nil)
@@ -164,7 +164,7 @@ describe Snapshot do
           )
         end
 
-        it "uses the default parameters on tvOS too" do
+        it "uses the default parameters on tvOS too", requires_xcode: true do
           configure options.merge(devices: ["Apple TV 1080p"])
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
           command = Snapshot::TestCommandGeneratorXcode8.generate(device_type: "Apple TV 1080p", language: "en", locale: nil)
@@ -192,7 +192,7 @@ describe Snapshot do
           configure options.merge(derived_data_path: 'fake/derived/path')
         end
 
-        it 'uses the fixed derivedDataPath if given' do
+        it 'uses the fixed derivedDataPath if given', requires_xcode: true do
           expect(Dir).not_to receive(:mktmpdir)
           command = Snapshot::TestCommandGeneratorXcode8.generate(device_type: "iPhone 6", language: "en", locale: nil)
           expect(command.join('')).to include("-derivedDataPath 'fake/derived/path'")
@@ -203,7 +203,7 @@ describe Snapshot do
     describe "Valid macOS Configuration" do
       let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleMacOS", namespace_log_files: true } }
 
-      it "uses default parameters on macOS" do
+      it "uses default parameters on macOS", requires_xcode: true do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options.merge(devices: ["Mac"]))
         expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
         command = Snapshot::TestCommandGeneratorXcode8.generate(device_type: "Mac", language: "en", locale: nil)
@@ -227,7 +227,7 @@ describe Snapshot do
     describe "Unique logs" do
       let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", namespace_log_files: true } }
 
-      it 'uses correct name and language' do
+      it 'uses correct name and language', requires_xcode: true do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
         log_path = Snapshot::TestCommandGeneratorXcode8.xcodebuild_log_path(device_type: "iPhone 6", language: "pt", locale: nil)
         expect(log_path).to eq(
@@ -235,7 +235,7 @@ describe Snapshot do
         )
       end
 
-      it 'uses includes locale if specified' do
+      it 'uses includes locale if specified', requires_xcode: true do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
         log_path = Snapshot::TestCommandGeneratorXcode8.xcodebuild_log_path(device_type: "iPhone 6", language: "pt", locale: "pt_BR")
         expect(log_path).to eq(
@@ -243,7 +243,7 @@ describe Snapshot do
         )
       end
 
-      it 'can work without parameters' do
+      it 'can work without parameters', requires_xcode: true do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
         log_path = Snapshot::TestCommandGeneratorXcode8.xcodebuild_log_path
         expect(log_path).to eq(
@@ -255,7 +255,7 @@ describe Snapshot do
     describe "Unique logs disabled" do
       let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests" } }
 
-      it 'uses correct file name' do
+      it 'uses correct file name', requires_xcode: true do
         Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
         log_path = Snapshot::TestCommandGeneratorXcode8.xcodebuild_log_path(device_type: "iPhone 6", language: "pt", locale: nil)
         expect(log_path).to eq(

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -63,6 +63,15 @@ RSpec.configure do |config|
   end
 
   config.example_status_persistence_file_path = "/tmp/rspec_failed_tests.txt"
+
+  # disable/filter some tests if not running on mac
+  unless FastlaneCore::Helper.is_mac?
+    config.filter_run_excluding requires_xcode: true
+    config.filter_run_excluding requires_xcodebuild: true
+    config.filter_run_excluding requires_plistbuddy: true
+    config.filter_run_excluding requires_keychain: true
+    config.filter_run_excluding requires_security: true
+  end
 end
 
 module FastlaneSpec


### PR DESCRIPTION
This PR makes the test suite pass on WSL/Ubuntu by filtering/excluding them based on "tags" added to the examples.

5 Tags are added that correspond to software, that is not available on non-Mac platforms:

- 96x xcodebuild
- 52x xcode
- 2x security
- 1x plistbuddy
- 1x keychain

For now these "filters" are activated for all non-Mac platforms. In later PRs this would probably be refined and made more flexible.