### PR TITLE
`openssl` exit status is "wrong" on non-macOS platforms, fix code to work anyway

### DIFF
--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -91,10 +91,12 @@ module Match
       command << "-d" unless encrypt
       command << "&> /dev/null" unless FastlaneCore::Globals.verbose? # to show show an error message if something goes wrong
 
-      _out, err, _st = Open3.capture3(command.join(' '))
-      if err.to_s == ''
-        success = true
-      else
+      _out, err, st = Open3.capture3(command.join(' '))
+      success = st.success?
+
+      # Ubuntu `openssl` does not fail on failure
+      # but at least outputs an error message
+      if err.to_s != ''
         success = false
       end
 

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -89,8 +89,14 @@ module Match
       command << "-out #{tmpfile.shellescape}"
       command << "-a"
       command << "-d" unless encrypt
-      command << "&> /dev/null" unless FastlaneCore::Globals.verbose? # to show show an error message is something goes wrong
-      success = system(command.join(' '))
+      command << "&> /dev/null" unless FastlaneCore::Globals.verbose? # to show show an error message if something goes wrong
+     
+      out, err, st = Open3.capture3(command.join(' '))
+      if err.to_s == ''
+        success = true
+      else
+        success = false
+      end
 
       UI.crash!("Error decrypting '#{path}'") unless success
       FileUtils.mv(tmpfile, path)

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -96,7 +96,7 @@ module Match
 
       # Ubuntu `openssl` does not fail on failure
       # but at least outputs an error message
-      if err.to_s != ''
+      unless err.to_s.empty?
         success = false
       end
 

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -90,8 +90,8 @@ module Match
       command << "-a"
       command << "-d" unless encrypt
       command << "&> /dev/null" unless FastlaneCore::Globals.verbose? # to show show an error message if something goes wrong
-     
-      out, err, st = Open3.capture3(command.join(' '))
+
+      _out, err, _st = Open3.capture3(command.join(' '))
       if err.to_s == ''
         success = true
       else

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -89,7 +89,7 @@ module Match
       command << "-out #{tmpfile.shellescape}"
       command << "-a"
       command << "-d" unless encrypt
-      command << "&> /dev/null" unless FastlaneCore::Globals.verbose? # to show show an error message if something goes wrong
+      command << "&> /dev/null" unless FastlaneCore::Globals.verbose? # to show an error message if something goes wrong
 
       _out, err, st = Open3.capture3(command.join(' '))
       success = st.success?


### PR DESCRIPTION
The old code 
```
success = system(command.join(' '))
UI.crash!("Error decrypting '#{path}'") unless success
``` 
depends on the `command` (which is `openssl ...` in this case) to correctly return an "exit status" to initate the expected crash when decrypting fails:

> system returns true if the command gives zero exit status, false for non zero exit status. Returns nil if command execution fails.
https://ruby-doc.org/core-2.4.0/Kernel.html#method-i-system

For the macOS implementation of `openssl` this seems to be true. 
Unfortunately, it is not for the Ubuntu/WSL implementation where even if decryption fails, the exit status is `true` (but an error output is generated, which `system` didn't surface.).

Using `Open3.capture3` enables us to look at or for that error output and "fix" `success` to `false` if something is returned, which indicates a failure.

(First line of PR also fixes a tiny typo)