### PR TITLE
Update Carthage action for new-resolver option

### DIFF
--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -28,6 +28,7 @@ module Fastlane
         cmd << "--toolchain #{params[:toolchain]}" if params[:toolchain]
         cmd << "--project-directory #{params[:project_directory]}" if params[:project_directory]
         cmd << "--cache-builds" if params[:cache_builds]
+        cmd << "--new-resolver" if params[:new_resolver]
 
         Actions.sh(cmd.join(' '))
       end
@@ -151,7 +152,15 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :project_directory,
                                        env_name: "FL_CARTHAGE_PROJECT_DIRECTORY",
                                        description: "Define the directory containing the Carthage project",
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :new_resolver,
+                                       env_name: "FL_CARTHAGE_NEW_RESOLVER",
+                                       description: "Use new resolver when resolving dependency graph",
+                                       is_string: false,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Please pass a valid value for new_resolver. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+                                       end),
         ]
       end
 
@@ -173,6 +182,7 @@ module Fastlane
             configuration: "Release",                       # Build configuration to use when building
             cache_builds: true,                             # By default Carthage will rebuild a dependency regardless of whether its the same resolved version as before.
             toolchain: "com.apple.dt.toolchain.Swift_2_3"   # Specify the xcodebuild toolchain
+            new_resolver: false                             # Use the new resolver to resolve depdendency graph
           )'
         ]
       end
@@ -186,7 +196,7 @@ module Fastlane
       end
 
       def self.authors
-        ["bassrock", "petester42", "jschmid", "JaviSoto", "uny", "phatblat", "bfcrampton", "antondomashnev"]
+        ["bassrock", "petester42", "jschmid", "JaviSoto", "uny", "phatblat", "bfcrampton", "antondomashnev", "gbrhaz"]
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -160,7 +160,7 @@ module Fastlane
                                        optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Please pass a valid value for new_resolver. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
-                                       end),
+                                       end)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -158,9 +158,7 @@ module Fastlane
                                        description: "Use new resolver when resolving dependency graph",
                                        is_string: false,
                                        optional: true,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("Please pass a valid value for new_resolver. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
-                                       end)
+                                       type: Boolean)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -179,7 +179,7 @@ module Fastlane
             platform: "all",                                # Define which platform to build for (one of ‘all’, ‘Mac’, ‘iOS’, ‘watchOS’, ‘tvOS‘, or comma-separated values of the formers except for ‘all’)
             configuration: "Release",                       # Build configuration to use when building
             cache_builds: true,                             # By default Carthage will rebuild a dependency regardless of whether its the same resolved version as before.
-            toolchain: "com.apple.dt.toolchain.Swift_2_3"   # Specify the xcodebuild toolchain
+            toolchain: "com.apple.dt.toolchain.Swift_2_3",  # Specify the xcodebuild toolchain
             new_resolver: false                             # Use the new resolver to resolve depdendency graph
           )'
         ]

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -421,6 +421,21 @@ describe Fastlane do
         end.not_to raise_error
       end
 
+      it "works with new resolver" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              use_ssh: true,
+              use_submodules: true,
+              use_binaries: false,
+              cache_builds: true,
+              platform: 'iOS',
+              new_resolver: true
+            )
+          end").runner.execute(:test)
+        end.not_to raise_error
+      end
+
       context "when specify framework" do
         let(:command) { 'archive' }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], [✔], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Carthage has been updated to include a new resolver; add functionality for it in fastlane

### Description
Added the '--new-resolver' option for Carthage action


Rubocop is complaining because this action now has more than 18 options. Is this a breaker for an action? What's the resolution?
