### PR TITLE
Change sync_code_signing example to use an array type

### DIFF
--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -84,7 +84,7 @@ module Fastlane
 
       def self.example_code
         [
-          'sync_code_signing(type: "appstore", app_identifier: "tools.fastlane.app")',
+          'sync_code_signing(type: "appstore", app_identifier: ["tools.fastlane.app"])',
           'sync_code_signing(type: "development", readonly: true)',
           'sync_code_signing(app_identifier: ["tools.fastlane.app", "tools.fastlane.sleepy"])',
           'match   # alias for "sync_code_signing"'


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], [✔], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

Because the `sync_code_signing` exports the support ConfigItem types from the `match` tool, `app_identifier` is expected to be an Array. To prevent docs build from failing, change the sample code to use an array.