### PR TITLE
Fix issue with wrong #to_plist in package_command_generator_xcode7.rb

### DIFF
--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -5,6 +5,7 @@
 # `incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string) (Encoding::CompatibilityError)`
 
 require 'tempfile'
+require 'fastlane_core/core_ext/cfpropertylist'
 
 module Gym
   # Responsible for building the fully working xcodebuild command
@@ -159,8 +160,6 @@ module Gym
       end
 
       def config_content
-        require 'plist'
-
         hash = read_export_options
 
         # Overrides export options if needed


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

A related issue was reported in a comment: https://github.com/fastlane/fastlane/pull/11163#issuecomment-351264555. This is intended as an immediate fix for that problem.

It's likely that this is part of the general require issue the core contributors have been discussing. I have a feeling the ultimate solution is to hunt down every `to_plist` in Fastlane and add a require for this extension in every code unit that uses it. I'll work on that today.

### Description

Added `require "fastlane_core/core_ext/cfpropertylist"` to package_command_generator_xcode7.rb and removed a `require "plist"`.