### PR TITLE
Version bump to 2.69.1

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.69.0'.freeze
+  VERSION = '2.69.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.69.0':**

* Fix issue with wrong #to_plist in package_command_generator_xcode7.rb (#11208) via Jimmy Dee
* Fix the property list workaround for ruby ~2.0 (#11202) via Manu Wallner
* fix: revert https://github.com/fastlane/fastlane/pull/4631 (#11184) via Jan Piotrowski
* Change sync_code_signing example to use an array type (#11195) via Mark Pirri
* Fix some documentation typos (#11193) via Nate West
