### PR TITLE
Revert "Change sync_code_signing example to use an array type"

### DIFF
--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -84,7 +84,7 @@ module Fastlane
 
       def self.example_code
         [
-          'sync_code_signing(type: "appstore", app_identifier: ["tools.fastlane.app"])',
+          'sync_code_signing(type: "appstore", app_identifier: "tools.fastlane.app")',
           'sync_code_signing(type: "development", readonly: true)',
           'sync_code_signing(app_identifier: ["tools.fastlane.app", "tools.fastlane.sleepy"])',
           'match   # alias for "sync_code_signing"'


### PR DESCRIPTION
Reverts fastlane/fastlane#11195

Keep the string example, because we are going to fix the root-cause, which is that we can't pass strings to the `match`/`sync_code_signing` action.