### PR TITLE
Fix match requiring an Array for app_identifier

### DIFF
--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -33,7 +33,8 @@ module Match
                                      env_name: "MATCH_APP_IDENTIFIER",
                                      description: "The bundle identifier(s) of your app (comma-separated)",
                                      is_string: false,
-                                     type: Array,
+                                     type: Array, # we actually allow String and Array here
+                                     skip_type_validation: true,
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)),
         FastlaneCore::ConfigItem.new(key: :username,
                                      short_option: "-u",


### PR DESCRIPTION
- match accepts both, but type: Array is defined in options
- disable type checking until we have a better solution
fix for https://github.com/fastlane/fastlane/issues/11197