### PR TITLE
Xcode is not required for all actions

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -142,6 +142,7 @@ module FastlaneCore
     def self.xcode_version
       return nil unless self.is_mac?
       return @xcode_version if @xcode_version && @developer_dir == ENV['DEVELOPER_DIR']
+      return nil unless File.exist?("#{xcode_path}/usr/bin/xcodebuild")
 
       begin
         output = `DEVELOPER_DIR='' "#{xcode_path}/usr/bin/xcodebuild" -version`


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], [✔], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

We use "sigh" by itself; it does not require Xcode.  A new version of fastlane was failing with the following, which was annoying since this command does not require Xcode.
```
sh: /Library/Developer/CommandLineTools//usr/bin/xcodebuild: No such file or directory
ERROR [2017-12-13 12:22:40.21]: undefined method `split' for nil:NilClass
sh: /Library/Developer/CommandLineTools//usr/bin/xcodebuild: No such file or directory
ERROR [2017-12-13 12:22:40.24]: undefined method `split' for nil:NilClass
/Users/jenkins/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/fastlane-2.69.2/fastlane_core/lib/fastlane_core/ui/interface.rb:131:in `user_error!': [!] Error detecting currently used Xcode installation, please ensure that you have Xcode installed and set it using `sudo xcode-select -s [path]` (FastlaneCore::Interface::FastlaneError)
```

### Description
<!-- Describe your changes in detail -->
Return nil as the xcode_version if usr/bin/xcodebuild does not exist at the xcode-select path