### PR TITLE
Enable to specify the tag to push to remote

### DIFF
--- a/fastlane/lib/fastlane/actions/push_git_tags.rb
+++ b/fastlane/lib/fastlane/actions/push_git_tags.rb
@@ -5,14 +5,12 @@ module Fastlane
         command = [
           'git',
           'push',
-          '--tags'
+          params[:remote],
+          params[:tag] || '--tags'
         ]
 
         # optionally add the force component
         command << '--force' if params[:force]
-
-        # optionally add the remote component
-        command << params[:remote] if params[:remote]
 
         result = Actions.sh(command.join(' '))
         UI.success('Tags pushed to remote')
@@ -38,6 +36,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :remote,
                                        env_name: "FL_GIT_PUSH_REMOTE",
                                        description: "The remote to push tags to",
+                                       default_value: "origin",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :tag,
+                                       env_name: "FL_GIT_PUSH_TAG",
+                                       description: "The tag to push to remote",
                                        optional: true)
         ]
       end

--- a/fastlane/spec/actions_specs/push_git_tags_spec.rb
+++ b/fastlane/spec/actions_specs/push_git_tags_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane do
           push_git_tags
         end").runner.execute(:test)
 
-        expect(result).to eq("git push --tags")
+        expect(result).to eq("git push origin --tags")
       end
 
       it "uses the correct comand when forced" do
@@ -14,7 +14,7 @@ describe Fastlane do
           push_git_tags(force: true)
         end").runner.execute(:test)
 
-        expect(result).to eq("git push --tags --force")
+        expect(result).to eq("git push origin --tags --force")
       end
 
       it "uses the correct comand when remote set" do
@@ -22,7 +22,7 @@ describe Fastlane do
           push_git_tags(remote: 'foo')
         end").runner.execute(:test)
 
-        expect(result).to eq("git push --tags foo")
+        expect(result).to eq("git push foo --tags")
       end
 
       it "uses the correct comand when remote set and forced" do
@@ -30,7 +30,15 @@ describe Fastlane do
           push_git_tags(remote: 'foo', force: true)
         end").runner.execute(:test)
 
-        expect(result).to eq("git push --tags --force foo")
+        expect(result).to eq("git push foo --tags --force")
+      end
+
+      it "uses the correct command when tag set" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          push_git_tags(remote: 'foo', tag: 'v1.0')
+        end").runner.execute(:test)
+
+        expect(result).to eq("git push foo v1.0")
       end
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Want to push a specific tag.

### Description

Add an option to `push_git_tags` to specify tag to push to remote.