### PR TITLE
Support CODE_SIGN_STYLE on automatic_code_signing action.

### DIFF
--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -29,7 +29,7 @@ module Fastlane
           end
 
           style_value = params[:use_automatic_signing] ? 'Automatic' : 'Manual'
-          target = project.targets.find { |target| target.name == found_target[:name] }
+          target = project.targets.find { |t| t.name == found_target[:name] }
           target.build_configurations.each do |configuration|
             configuration.build_settings["CODE_SIGN_STYLE"] = style_value
           end

--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -28,7 +28,12 @@ module Fastlane
             end
           end
 
-          sett["ProvisioningStyle"] = params[:use_automatic_signing] ? 'Automatic' : 'Manual'
+          style_value = params[:use_automatic_signing] ? 'Automatic' : 'Manual'
+          target = project.targets.find { |target| target.name == found_target[:name] }
+          target.build_configurations.each do |configuration|
+            configuration.build_settings["CODE_SIGN_STYLE"] = style_value
+          end
+          sett["ProvisioningStyle"] = style_value
           if params[:team_id]
             sett["DevelopmentTeam"] = params[:team_id]
             UI.important("Set Team id to: #{params[:team_id]} for target: #{found_target[:name]}")

--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -22,6 +22,11 @@ describe Fastlane do
 
       expect(root_attrs["771D79501D9E69C900D840FA"]["DevelopmentTeam"]).to eq("XXXX")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["DevelopmentTeam"]).to eq("XXXX")
+      project.targets.each do |target|
+        target.build_configurations.each do |configuration|
+          expect(configuration.build_settings["CODE_SIGN_STYLE"]).to eq("Automatic")
+        end
+      end
     end
 
     it "disable_automatic_code_signing for specific target" do
@@ -38,6 +43,14 @@ describe Fastlane do
       root_attrs = project.root_object.attributes["TargetAttributes"]
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Automatic")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
+      automatic_target = project.targets.first
+      manual_target = project.targets.last
+      automatic_target.build_configurations.each do |configuration|
+        expect(configuration.build_settings["CODE_SIGN_STYLE"]).to eq("Automatic")
+      end
+      manual_target.build_configurations.each do |configuration|
+        expect(configuration.build_settings["CODE_SIGN_STYLE"]).to eq("Manual")
+      end
     end
 
     it "disable_automatic_code_signing" do
@@ -52,6 +65,11 @@ describe Fastlane do
       root_attrs = project.root_object.attributes["TargetAttributes"]
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
+      project.targets.each do |target|
+        target.build_configurations.each do |configuration|
+          expect(configuration.build_settings["CODE_SIGN_STYLE"]).to eq("Manual")
+        end
+      end
     end
 
     it "sets team id" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Since Xcode 9, `CODE_SIGN_STYLE` parameters are added to each build configurations.
https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW876

![screen shot 2017-12-14 at 17 00 13](https://user-images.githubusercontent.com/147051/33982438-df89e3ae-e0f3-11e7-8163-6dd21fa1fa1b.png)

Currently, `automatic_code_signing` action will only modify `ProvisioningStyle`.
In case, each values are different between `CODE_SIGN_STYLE` and `ProvisioningStyle`, folliwing error would be raised.

```console
[14:13:53]: ▸ Code Signing Error: XXXX has conflicting provisioning settings. XXXX is automatically signed, but provisioning profile XXXX has been manually specified. Set the provisioning profile value to "Automatic" in the build settings editor, or switch to manual signing in the project editor.
[14:13:53]: ▸ Code Signing Error: Code signing is required for product type 'Application' in SDK 'iOS 11.1'
```

### Description

This patch will also set `CODE_SIGN_STYLE` for all build configurations when `automatic_code_signing` action is called.

