### PR TITLE
Add missing `highline` import in spaceship library

### DIFF
--- a/spaceship/lib/spaceship.rb
+++ b/spaceship/lib/spaceship.rb
@@ -4,6 +4,9 @@ require 'spaceship/client'
 require 'spaceship/provider'
 require 'spaceship/launcher'
 
+# For basic user inputs
+require 'highline/import'
+
 # Dev Portal
 require 'spaceship/portal/portal'
 require 'spaceship/portal/spaceship'


### PR DESCRIPTION
Fixes https://github.com/KrauseFx/xcode-install/issues/249