### PR TITLE
Make update_app_identifier accept info plist paths with $(SRCROOT)/$(PROJECT_DIR)

### DIFF
--- a/fastlane/lib/fastlane/actions/update_app_identifier.rb
+++ b/fastlane/lib/fastlane/actions/update_app_identifier.rb
@@ -9,7 +9,7 @@ module Fastlane
         identifier_key = 'PRODUCT_BUNDLE_IDENTIFIER'
 
         # Read existing plist file
-        info_plist_path = File.join(params[:xcodeproj], '..', params[:plist_path])
+        info_plist_path = resolve_path(params[:plist_path], params[:xcodeproj])
         UI.user_error!("Couldn't find info plist file at path '#{params[:plist_path]}'") unless File.exist?(info_plist_path)
         plist = Plist.parse_xml(info_plist_path)
 
@@ -45,6 +45,16 @@ module Fastlane
 
           UI.success("Updated #{params[:plist_path]} 💾.")
         end
+      end
+
+      def self.resolve_path(path, xcodeproj_path)
+        project_dir = File.dirname(xcodeproj_path)
+        # SRCROOT and PROJECT_DIR are the same
+        %w{SRCROOT PROJECT_DIR}.each do |variable_name|
+          path = path.sub("$(#{variable_name})", project_dir)
+        end
+        path = File.join(project_dir, path) unless path.start_with?('/')
+        path
       end
 
       #####################################################

--- a/fastlane/lib/fastlane/actions/update_app_identifier.rb
+++ b/fastlane/lib/fastlane/actions/update_app_identifier.rb
@@ -49,11 +49,11 @@ module Fastlane
 
       def self.resolve_path(path, xcodeproj_path)
         project_dir = File.dirname(xcodeproj_path)
-        # SRCROOT and PROJECT_DIR are the same
-        %w{SRCROOT PROJECT_DIR}.each do |variable_name|
+        # SRCROOT, SOURCE_ROOT and PROJECT_DIR are the same
+        %w{SRCROOT SOURCE_ROOT PROJECT_DIR}.each do |variable_name|
           path = path.sub("$(#{variable_name})", project_dir)
         end
-        path = File.join(project_dir, path) unless path.start_with?('/')
+        path = File.absolute_path(path, project_dir)
         path
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

You were not able to use `update_app_identifier` if the path to Info.plist specified in your project file included `$(SRCROOT)` or `$(PROJECT_DIR)`.

As a workaround you could use relative paths in the project file, but that makes the path less explicit, and actions like `update_app_identifier` should not require to modify the project file by hand before using them.

### Description

The path to Info.plist given to `update_app_identifier` can now include `$(SRCROOT)` or `$(PROJECT_DIR)` and will be resolved correctly.