### PR TITLE
Don't make Fastlane seem like it's 2 seconds slower than it actually is

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -122,8 +122,6 @@ module Fastlane
           UI.important "After creating the Gemfile and Gemfile.lock, commit those files into version control"
         end
         UI.important "Get started using a Gemfile for fastlane https://docs.fastlane.tools/getting-started/ios/setup/#use-a-gemfile"
-
-        sleep 2 # napping is life, otherwise the user might not see this message
       end
 
       # Returns an array of symbols for the available lanes for the Fastfile


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This sleep approximately doubles the startup time of Fastlane on my computer. Nope.