### PR TITLE
Fixed duplicated simulators

### DIFF
--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -73,7 +73,7 @@ module Snapshot
     end
 
     def self.filter_runtimes(all_runtimes, os = 'iOS', versions = [])
-      all_runtimes.select { |v, id| v[/^#{os}/] }.select { |v, id| v[/#{versions.join("|")}$/] }
+      all_runtimes.select { |v, id| v[/^#{os}/] }.select { |v, id| v[/#{versions.join("|")}$/] }.uniq
     end
 
     def self.devices


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixed creation of duplicated simulators when calling `fastlane snapshot reset_simulators -f` if using multiple Xcodes.

### Description
When a user has multiple Xcode versions installed on mac (for example Xcode 9.2 and 9.1) it could have duplicated simulator runtimes:

```
DEVELOPER_DIR=/Applications/Xcode-9.1.app xcrun simctl list runtimes
== Runtimes ==
iOS 11.0 (11.0.1 - 15A8401) - com.apple.CoreSimulator.SimRuntime.iOS-11-0
iOS 11.1 (11.1 - 15B87) - com.apple.CoreSimulator.SimRuntime.iOS-11-1
iOS 11.1 (11.1 - 15B87) - com.apple.CoreSimulator.SimRuntime.iOS-11-1
tvOS 11.1 (11.1 - 15J580) - com.apple.CoreSimulator.SimRuntime.tvOS-11-1
watchOS 4.1 (4.1 - 15R844) - com.apple.CoreSimulator.SimRuntime.watchOS-4-1
```

One iOS 11.1 simulator runtime was created by Xcode 9.1, second iOS 11.1 runtime was created by Xcode 9.2 when the simulator was downloaded and installed.

In such configuration, resetting simulators by using snapshot will create duplicated iOS 11.1 simulators, because two matching runtimes were found.
```
DEVELOPER_DIR=/Applications/Xcode-9.1.app fastlane snapshot reset_simulators -f
Creating iPhone 5s for iOS version iOS 11.1
Creating iPhone 5s for iOS version iOS 11.1
Creating iPhone 6 for iOS version iOS 11.1
Creating iPhone 6 for iOS version iOS 11.1
Creating iPhone 6 Plus for iOS version iOS 11.1
Creating iPhone 6 Plus for iOS version iOS 11.1
...
```

This PR removes duplicated runtimes.