### PR TITLE
Mock Helper.operating_system to always return `macOS` so comparison to fixture file succeeds on non-macOS platforms

### DIFF
--- a/fastlane_core/spec/analytics/analytics_session_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_session_spec.rb
@@ -12,6 +12,7 @@ describe FastlaneCore::AnalyticsSession do
   before(:each) do
     # This value needs to be set or our event fixtures will not match
     allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
+    allow(FastlaneCore::Helper).to receive(:operating_system).and_return('macOS')
   end
 
   context 'single action execution' do
@@ -47,11 +48,6 @@ describe FastlaneCore::AnalyticsSession do
         expect(FastlaneCore::Helper).to receive(:xcode_version).and_return('9.0.1')
 
         session.action_launched(launch_context: launch_context)
-
-        # Modify Fixture if not on Mac
-        unless FastlaneCore::Helper.is_mac?
-          fixture_data[2]['primary_target']['detail'] = FastlaneCore::Helper.operating_system
-        end
 
         parsed_events = JSON.parse(session.events.to_json)
         parsed_events.zip(fixture_data).each do |parsed, fixture|
@@ -184,13 +180,6 @@ describe FastlaneCore::AnalyticsSession do
 
         expected_final_array = fixture_data_action_1_launched + [fixture_data_action_1_completed] + fixture_data_action_2_launched + [fixture_data_action_2_completed]
         parsed_events = JSON.parse(session.events.to_json)
-
-        # Modify Fixture if not on Mac
-        unless FastlaneCore::Helper.is_mac?
-          os = FastlaneCore::Helper.operating_system
-          expected_final_array[2]['primary_target']['detail'] = os
-          expected_final_array[11]['primary_target']['detail'] = os
-        end
 
         parsed_events.zip(expected_final_array).each do |parsed, fixture|
           expect(parsed).to eq(fixture)


### PR DESCRIPTION
Previous method from #11180 is not reliable when `.json` fixture file is changed.