### PR TITLE
Update code gen default value ignore filters for new method names

### DIFF
--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -26,6 +26,7 @@ module Fastlane
 
       @default_values_to_ignore = {
         "cert" => ["keychain_path"].to_set,
+        "get_certificates" => ["keychain_path"].to_set,
         "set_github_release" => ["api_token"].to_set,
         "github_api" => ["api_token"].to_set,
         "create_pull_request" => ["api_token", "head", "api_url"].to_set,
@@ -33,7 +34,8 @@ module Fastlane
         "verify_xcode" => ["xcode_path"].to_set,
         "produce" => ["sku"].to_set,
         "create_app_online" => ["sku"].to_set,
-        "screengrab" => ["android_home"].to_set
+        "screengrab" => ["android_home"].to_set,
+        "capture_android_screenshots" => ["android_home"].to_set
       }
     end
 

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -11,4 +11,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.69.2
+// Generated with fastlane 2.70.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -143,6 +143,7 @@ func appledoc(input: String,
               createDocset: Bool = false,
               installDocset: Bool = false,
               publishDocset: Bool = false,
+              noCreateDocset: Bool = false,
               htmlAnchors: String? = nil,
               cleanOutput: Bool = false,
               docsetBundleId: String? = nil,
@@ -187,6 +188,7 @@ func appledoc(input: String,
                                                                                           RubyCommand.Argument(name: "create_docset", value: createDocset),
                                                                                           RubyCommand.Argument(name: "install_docset", value: installDocset),
                                                                                           RubyCommand.Argument(name: "publish_docset", value: publishDocset),
+                                                                                          RubyCommand.Argument(name: "no_create_docset", value: noCreateDocset),
                                                                                           RubyCommand.Argument(name: "html_anchors", value: htmlAnchors),
                                                                                           RubyCommand.Argument(name: "clean_output", value: cleanOutput),
                                                                                           RubyCommand.Argument(name: "docset_bundle_id", value: docsetBundleId),
@@ -639,7 +641,7 @@ func bundleInstall(binstubs: String? = nil,
                                                                                                 RubyCommand.Argument(name: "with", value: with)])
   _ = runner.executeCommand(command)
 }
-func captureAndroidScreenshots(androidHome: String = "/Users/liebowitz/Library/Android/sdk",
+func captureAndroidScreenshots(androidHome: String?,
                                buildToolsVersion: String? = nil,
                                locales: [String] = ["en-US"],
                                clearPreviousScreenshots: Bool = false,
@@ -1405,7 +1407,7 @@ func getCertificates(development: Bool = false,
                      teamId: String? = nil,
                      teamName: String? = nil,
                      outputPath: String = ".",
-                     keychainPath: String = "/Users/liebowitz/Library/Keychains/login.keychain-db",
+                     keychainPath: String,
                      keychainPassword: String? = nil,
                      platform: String = "ios") {
   let command = RubyCommand(commandID: "", methodName: "get_certificates", className: nil, args: [RubyCommand.Argument(name: "development", value: development),
@@ -2338,9 +2340,11 @@ func produce(username: String,
   return runner.executeCommand(command)
 }
 func pushGitTags(force: Bool = false,
-                 remote: String? = nil) {
+                 remote: String = "origin",
+                 tag: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "push_git_tags", className: nil, args: [RubyCommand.Argument(name: "force", value: force),
-                                                                                               RubyCommand.Argument(name: "remote", value: remote)])
+                                                                                               RubyCommand.Argument(name: "remote", value: remote),
+                                                                                               RubyCommand.Argument(name: "tag", value: tag)])
   _ = runner.executeCommand(command)
 }
 func pushToGitRemote(localBranch: String? = nil,
@@ -2895,6 +2899,7 @@ func slather(buildDirectory: String? = nil,
              simpleOutput: Bool? = nil,
              gutterJson: Bool? = nil,
              coberturaXml: Bool? = nil,
+             llvmCov: String? = nil,
              html: Bool? = nil,
              show: Bool = false,
              sourceDirectory: String? = nil,
@@ -2922,6 +2927,7 @@ func slather(buildDirectory: String? = nil,
                                                                                          RubyCommand.Argument(name: "simple_output", value: simpleOutput),
                                                                                          RubyCommand.Argument(name: "gutter_json", value: gutterJson),
                                                                                          RubyCommand.Argument(name: "cobertura_xml", value: coberturaXml),
+                                                                                         RubyCommand.Argument(name: "llvm_cov", value: llvmCov),
                                                                                          RubyCommand.Argument(name: "html", value: html),
                                                                                          RubyCommand.Argument(name: "show", value: show),
                                                                                          RubyCommand.Argument(name: "source_directory", value: sourceDirectory),

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -11,4 +11,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.69.2
+// Generated with fastlane 2.70.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -11,4 +11,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.69.2
+// Generated with fastlane 2.70.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -11,4 +11,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.69.2
+// Generated with fastlane 2.70.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -11,4 +11,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.69.2
+// Generated with fastlane 2.70.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -11,4 +11,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.69.2
+// Generated with fastlane 2.70.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -11,4 +11,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.69.2
+// Generated with fastlane 2.70.0


### PR DESCRIPTION
Code generation relies on default values set in the config items. Some things should be ignored like local paths that are specific to the developer's workstation. 
Updated the filters to include the new name alias actions.