### PR TITLE
Version bump to 2.70.1

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.70.0'.freeze
+  VERSION = '2.70.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.70.0':**

* Filter tests on non-mac OS (#11186) via Jan Piotrowski
* Readme templates: Replace html tables with markdown tables, swith orientation to vertical (#11198) via Rylan Hazelton
* Make tests multi platform by overwriting hardcoded OS names in fixtures (#11180) via Jan Piotrowski
