### PR TITLE
Add option to run danger on a specific pull request

### DIFF
--- a/fastlane/lib/fastlane/actions/danger.rb
+++ b/fastlane/lib/fastlane/actions/danger.rb
@@ -13,12 +13,14 @@ module Fastlane
         dangerfile = params[:dangerfile]
         base = params[:base]
         head = params[:head]
+        pr = params[:pr]
         cmd << "--danger_id=#{danger_id}" if danger_id
         cmd << "--dangerfile=#{dangerfile}" if dangerfile
         cmd << "--fail-on-errors=true" if params[:fail_on_errors]
         cmd << "--new-comment" if params[:new_comment]
         cmd << "--base=#{base}" if base
         cmd << "--head=#{head}" if head
+        cmd << "pr #{pr}" if pr
 
         ENV['DANGER_GITHUB_API_TOKEN'] = params[:github_api_token] if params[:github_api_token]
 
@@ -84,6 +86,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :head,
                                        env_name: "FL_DANGER_HEAD",
                                        description: "A branch/tag/commit to use as the head. [master|dev|stable]",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :pr,
+                                       env_name: "FL_DANGER_PR",
+                                       description: "Run danger on a specific pull request. e.g. \"https://github.com/danger/danger/pull/518\"",
                                        is_string: true,
                                        optional: true)
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Since version 3.5.1, danger has supported execution against a specified pull request. Adding the ability to specify the PR from fastlane opens up additional possible workflows.

### Description
This PR adds the new config item `FL_DANGER_PR` for specifying a pull request URL for danger to run checks on.