### PR TITLE
Choose `find` syntax depending on OS (no `find -E` on Ubuntu)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -317,7 +317,11 @@ private_lane :validate_repo do
     sh "bundle exec rake test_all"
 
     # Verify shell code style
-    sh 'find -E . -regex ".*\.(sh|bash)" -not -name "Pods-*" -name ".bundle" -exec shellcheck {} +'
+    if FastlaneCore::Helper.is_mac?
+      sh 'find -E . -regex ".*\.(sh|bash)" -not -name "Pods-*" -name ".bundle" -exec shellcheck {} +'
+    else
+      sh 'find . -regextype posix-egrep -regex ".*\.(sh|bash)" -not -name "Pods-*" -name ".bundle" -exec shellcheck {} +'
+    end
   end
 
   # Test if generating the docs is successful


### PR DESCRIPTION
`find -E` only works on macOS, all the other unix like OS have no `-F` but use `-regextype`.