### PR TITLE
non-macOS: always return emptry string as xcode_path

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -141,7 +141,7 @@ module FastlaneCore
     # @return the full path to the Xcode developer tools of the currently
     #  running system
     def self.xcode_path
-      return "" if self.is_test? and !self.is_mac?
+      return "" unless self.is_mac?
       `xcode-select -p`.delete("\n") + "/"
     end
 


### PR DESCRIPTION
Currently this method only returns an empty string if it a) is run not on a Mac and b) it is run during a test. 

This doesn't make any sense, why should it only return this during testing? Xcode always will be missing, so the path can always be returned as empty.

(This code has already been tested on macOS and Ubuntu via #11236 and passed)