### PR TITLE
[WIP] Install iTMSTransporter on Circle/Ubuntu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-gems-{{ checksum "Gemfile" }}
+          key: fastlane-ubuntu-gems-{{ checksum "Gemfile" }}
       - run:
           name: Setup Build
           command: |
@@ -23,7 +23,7 @@ jobs:
             brew install shellcheck
             bundle check || bundle install --jobs=4 --retry=3 --path .bundle
       - save_cache:
-          key: v1-gems-{{ checksum "Gemfile" }}
+          key: fastlane-v2-gems-{{ checksum "Gemfile" }}-b
           paths:
             - .bundle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       CIRCLE_TEST_RESULTS: $HOME/test-results
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
+      FASTLANE_ITUNES_TRANSPORTER_PATH: .bundle
     docker:
       - image: circleci/ruby:2.3
     shell: /bin/bash --login -eo pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ jobs:
   build:
     environment:
       CIRCLE_TEST_RESULTS: $HOME/test-results
-      LC_ALL: en_US.UTF-8
-      LANG: en_US.UTF-8
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
     docker:
       - image: circleci/ruby:2.3
     shell: /bin/bash --login -eo pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,19 @@ jobs:
             gem update --system
             bundle check || bundle install --jobs=4 --retry=3 --path .bundle
             sudo apt-get install shellcheck
+      - run:
+          name: Install additional dependency xar
+          command: |
+            cd /tmp
+            mkdir download
+            cd download
+            wget https://github.com/downloads/mackyle/xar/xar-1.6.1.tar.gz
+            tar -xzf xar-1.6.1.tar.gz
+            cd xar-1.6.1
+            ./autogen.sh --noconfigure
+            ./configure
+            make
+            sudo make install
       - save_cache:
           key: fastlane-v2-gems-{{ checksum "Gemfile" }}-b
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
             mkdir -p $CIRCLE_TEST_RESULTS
             echo "2.3" > .ruby-version
             gem update --system
-            brew install shellcheck
             bundle check || bundle install --jobs=4 --retry=3 --path .bundle
+            sudo apt-get install shellcheck
       - save_cache:
           key: fastlane-v2-gems-{{ checksum "Gemfile" }}-b
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       CIRCLE_TEST_RESULTS: $HOME/test-results
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
-      FASTLANE_ITUNES_TRANSPORTER_PATH: .bundle
+      FASTLANE_ITUNES_TRANSPORTER_PATH: /usr/local/itms
     docker:
       - image: circleci/ruby:2.3
     shell: /bin/bash --login -eo pipefail
@@ -76,6 +76,15 @@ jobs:
             ./configure
             make
             sudo make install
+      - run:
+          name: Install additional dependency iTMSTransporter
+          command: |
+            cd /tmp
+            wget https://github.com/janpio/fastlane-ubuntu-foo/raw/master/iTMSTransporter_installer_linux_1.9.7.sh
+            sudo sh iTMSTransporter_installer_linux_1.9.7.sh --target itms --noexec
+            cd itms
+            sudo sed -e '15,43d' -i install_script.sh
+            sudo ./install_script.sh
       - save_cache:
           key: fastlane-ubuntu-gems-{{ checksum "Gemfile" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,12 @@ version: 2
 
 jobs:
   build:
-    macos:
-      xcode: "9.0.0"
     environment:
       CIRCLE_TEST_RESULTS: $HOME/test-results
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
+    docker:
+      - image: circleci/ruby:2.3
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,47 @@
 version: 2
 
 jobs:
-  build:
+  "macOS":
+    macos:
+      xcode: "9.0.0"
+    environment:
+      CIRCLE_TEST_RESULTS: $HOME/test-results
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+    shell: /bin/bash --login -eo pipefail
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: fastlane-macos-gems-{{ checksum "Gemfile" }}
+      - run:
+          name: Setup Build
+          command: |
+            mkdir -p $CIRCLE_TEST_RESULTS
+            echo "2.3" > .ruby-version
+            gem update --system
+            brew install shellcheck
+            bundle check || bundle install --jobs=4 --retry=3 --path .bundle
+      - save_cache:
+          key: fastlane-macos-gems-{{ checksum "Gemfile" }}
+          paths:
+            - .bundle
+
+      - run:
+          name: Check PR Metadata
+          command: bundle exec danger || echo "danger failed"
+
+      - run: bundle exec fastlane test
+
+      - store_test_results:
+          path: /Users/distiller/test-results
+
+      - run:
+          name: Post Test Results to GitHub
+          command: bundle exec danger || echo "danger failed"
+          when: always # Run this even when tests fail
+  
+  "Ubuntu":
     environment:
       CIRCLE_TEST_RESULTS: $HOME/test-results
       LC_ALL: C.UTF-8
@@ -37,7 +77,7 @@ jobs:
             make
             sudo make install
       - save_cache:
-          key: fastlane-v2-gems-{{ checksum "Gemfile" }}-b
+          key: fastlane-ubuntu-gems-{{ checksum "Gemfile" }}
           paths:
             - .bundle
 
@@ -54,3 +94,10 @@ jobs:
           name: Post Test Results to GitHub
           command: bundle exec danger || echo "danger failed"
           when: always # Run this even when tests fail
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - "macOS"
+      - "Ubuntu"


### PR DESCRIPTION
This is not really a PR, I am more looking for feedback.

The relevant part is this:

```
     - run:
          name: Install additional dependency iTMSTransporter
          command: |
            cd /tmp
            wget https://github.com/janpio/fastlane-ubuntu-foo/raw/master/iTMSTransporter_installer_linux_1.9.7.sh
            sudo sh iTMSTransporter_installer_linux_1.9.7.sh --target itms --noexec
            cd itms
            sudo sed -e '15,43d' -i install_script.sh
            sudo ./install_script.sh
```

This is a step on Circle CI that is run on Ubuntu, more or less a Shell script.

Problem with this are:
1. I downloaded the `iTMSTransporter_installer_linux_1.9.7.sh` from the developer portal of Apple and put it on Github as a login is required to download.
2. `sudo sed -e '15,43d' -i install_script.sh` deletes parts of the install script that requires paging though some Terms of Services and typing "yes" twice.

Is there a better way to get this dependency fulfilled on a CI server that I am not seeing?