### PR TITLE
[Fastlane.swift] Fix gitBranch() has no return type

### DIFF
--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -44,6 +44,10 @@ module Fastlane
         ]
       end
 
+      def self.return_type
+        :string
+      end
+
       def self.category
         :source_control
       end

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1525,9 +1525,9 @@ func gitAdd(path: String? = nil,
                                                                                          RubyCommand.Argument(name: "pathspec", value: pathspec)])
   _ = runner.executeCommand(command)
 }
-func gitBranch() {
+@discardableResult func gitBranch() -> String {
   let command = RubyCommand(commandID: "", methodName: "git_branch", className: nil, args: [])
-  _ = runner.executeCommand(command)
+  return runner.executeCommand(command)
 }
 func gitCommit(path: String,
                message: String) {


### PR DESCRIPTION
Generated Swift API of `git_branch` action had no return type.