### PR TITLE
Option to fail on errors posting Slack notification

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -38,15 +38,24 @@ module Fastlane
 
         return [notifier, slack_attachment] if Helper.is_test? # tests will verify the slack attachments and other properties
 
-        result = notifier.ping '',
-                               icon_url: icon_url,
-                               attachments: [slack_attachment]
-
-        if result.code.to_i == 200
-          UI.success('Successfully sent Slack notification')
-        else
-          UI.verbose(result)
-          UI.user_error!("Error pushing Slack message, maybe the integration has no permission to post on this channel? Try removing the channel parameter in your Fastfile, this is usually caused by a misspelled or changed group/channel name or an expired SLACK_URL")
+        begin
+          result = notifier.ping '',
+                                 icon_url: icon_url,
+                                 attachments: [slack_attachment]
+        rescue => exception
+          UI.error("Exception: #{exception}")
+        ensure
+          if !result.nil? && result.code.to_i == 200
+            UI.success('Successfully sent Slack notification')
+          else
+            UI.verbose(result) unless result.nil?
+            message = "Error pushing Slack message, maybe the integration has no permission to post on this channel? Try removing the channel parameter in your Fastfile, this is usually caused by a misspelled or changed group/channel name or an expired SLACK_URL"
+            if options[:fail_on_error]
+              UI.user_error!(message)
+            else
+              UI.error(message)
+            end
+          end
         end
       end
 
@@ -107,6 +116,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :success,
                                        env_name: "FL_SLACK_SUCCESS",
                                        description: "Was this build successful? (true/false)",
+                                       optional: true,
+                                       default_value: true,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :fail_on_error,
+                                       env_name: "FL_SLACK_FAIL_ON_ERROR",
+                                       description: "Should an error sending the slack notification cause a failure? (true/false)",
                                        optional: true,
                                        default_value: true,
                                        is_string: false)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Many of my lanes report informational Slack notifications but are not very important to the overall pipeline. If Slack is down or there is some other error posting, I'd like the rest of the lane to continue processing as normal.

### Description
This PR adds an option to not fail if there is an error posting to Slack. The default is true in order to not change the current behavior.