### PR TITLE
Use correct sdk name in build_ios_app docs

### DIFF
--- a/fastlane/lib/fastlane/actions/build_ios_app.rb
+++ b/fastlane/lib/fastlane/actions/build_ios_app.rb
@@ -121,7 +121,7 @@ module Fastlane
             clean: true,
             output_directory: "path/to/dir", # Destination directory. Defaults to current directory.
             output_name: "my-app.ipa",       # specify the name of the .ipa file to generate (including file extension)
-            sdk: "iOS 11.1"                      # use SDK as the name or path of the base SDK when building the project.
+            sdk: "iOS 11.1"                  # use SDK as the name or path of the base SDK when building the project.
           )',
           'gym         # alias for "build_ios_app"',
           'build_app   # alias for "build_ios_app"'

--- a/fastlane/lib/fastlane/actions/build_ios_app.rb
+++ b/fastlane/lib/fastlane/actions/build_ios_app.rb
@@ -121,7 +121,7 @@ module Fastlane
             clean: true,
             output_directory: "path/to/dir", # Destination directory. Defaults to current directory.
             output_name: "my-app.ipa",       # specify the name of the .ipa file to generate (including file extension)
-            sdk: "10.0"                      # use SDK as the name or path of the base SDK when building the project.
+            sdk: "iOS 11.1"                      # use SDK as the name or path of the base SDK when building the project.
           )',
           'gym         # alias for "build_ios_app"',
           'build_app   # alias for "build_ios_app"'


### PR DESCRIPTION
Leaving 10.0 or 11.1 causes the build task to fail