### PR TITLE
Clarify the filename of Feature Graphic

### DIFF
--- a/supply/lib/supply/setup.rb
+++ b/supply/lib/supply/setup.rb
@@ -44,7 +44,7 @@ module Supply
       IMAGES_TYPES.each do |image_type|
         if ['featureGraphic'].include?(image_type)
           # we don't get all files in full resolution :(
-          UI.message("Due to a limitation of the Google Play API, there is no way for `supply` to download your existing feature graphics. Please copy your feature graphics into `metadata/android/en-US/images/`")
+          UI.message("Due to a limitation of the Google Play API, there is no way for `supply` to download your existing feature graphic. Please copy your feature graphic to `metadata/android/en-US/images/featureGraphic.png`")
           next
         end
 


### PR DESCRIPTION
Currently it's unclear from the warning message where Feature Graphic should actually be saved to.  This change fixes that.

(This fixes https://github.com/fastlane/fastlane/issues/11262.)

(This change assumes Feature Graphic is always a .png - if that's not the case then this needs to be tweaked.)

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.