### PR TITLE
[WIP] Tests: Mark skipped tests as pending (with reason)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-gems-{{ checksum "Gemfile" }}
+          key: fastlane-ubuntu-gems-{{ checksum "Gemfile" }}
       - run:
           name: Setup Build
           command: |
@@ -23,7 +23,7 @@ jobs:
             brew install shellcheck
             bundle check || bundle install --jobs=4 --retry=3 --path .bundle
       - save_cache:
-          key: v1-gems-{{ checksum "Gemfile" }}
+          key: fastlane-v2-gems-{{ checksum "Gemfile" }}-b
           paths:
             - .bundle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     macos:
       xcode: "9.0.0"
     environment:
-      CIRCLE_TEST_RESULTS: $HOME/test-results
+      CIRCLE_TEST_REPORTS: ~/test-results
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
     shell: /bin/bash --login -eo pipefail
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Setup Build
           command: |
-            mkdir -p $CIRCLE_TEST_RESULTS
+            mkdir -p ~/test-results
             echo "2.3" > .ruby-version
             gem update --system
             brew install shellcheck
@@ -34,7 +34,10 @@ jobs:
       - run: bundle exec fastlane test
 
       - store_test_results:
-          path: /Users/distiller/test-results
+          path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/rspec
+          destination: test-results
 
       - run:
           name: Post Test Results to GitHub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     macos:
       xcode: "9.0.0"
     environment:
-      CIRCLE_TEST_REPORTS: ~/test-results
+      CIRCLE_TEST_REPORTS: ~/test-reports
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
     shell: /bin/bash --login -eo pipefail
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Setup Build
           command: |
-            mkdir -p ~/test-results
+            mkdir -p ~/test-reports
             echo "2.3" > .ruby-version
             gem update --system
             brew install shellcheck
@@ -34,10 +34,10 @@ jobs:
       - run: bundle exec fastlane test
 
       - store_test_results:
-          path: ~/test-results
+          path: ~/test-reports
       - store_artifacts:
-          path: ~/test-results/rspec
-          destination: test-results
+          path: ~/test-reports/rspec
+          destination: test-reports
 
       - run:
           name: Post Test Results to GitHub
@@ -46,7 +46,7 @@ jobs:
   
   "Ubuntu":
     environment:
-      CIRCLE_TEST_REPORTS: ~/test-results
+      CIRCLE_TEST_REPORTS: ~/test-reports
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
       FASTLANE_ITUNES_TRANSPORTER_PATH: .bundle
@@ -60,7 +60,7 @@ jobs:
       - run:
           name: Setup Build
           command: |
-            mkdir -p ~/test-results
+            mkdir -p ~/test-reports
             bundle check || bundle install --jobs=4 --retry=3 --path .bundle
             sudo apt-get install shellcheck
       - save_cache:
@@ -89,10 +89,10 @@ jobs:
       - run: bundle exec fastlane test
 
       - store_test_results:
-          path: ~/test-results
+          path: ~/test-reports
       - store_artifacts:
-          path: ~/test-results/rspec
-          destination: test-results
+          path: ~/test-reports/rspec
+          destination: test-reports
 
       - run:
           name: Post Test Results to GitHub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,6 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-results
-            echo "2.3" > .ruby-version
             gem update --system
             bundle check || bundle install --jobs=4 --retry=3 --path .bundle
             sudo apt-get install shellcheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,6 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-results
-            gem update --system
             bundle check || bundle install --jobs=4 --retry=3 --path .bundle
             sudo apt-get install shellcheck
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       CIRCLE_TEST_REPORTS: ~/test-results
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
+      FASTLANE_ITUNES_TRANSPORTER_PATH: .bundle
     docker:
       - image: circleci/ruby:2.3
     shell: /bin/bash --login -eo pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ jobs:
   build:
     environment:
       CIRCLE_TEST_REPORTS: ~/test-results
-      LC_ALL: en_US.UTF-8
-      LANG: en_US.UTF-8
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
     docker:
       - image: circleci/ruby:2.3
     shell: /bin/bash --login -eo pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,19 @@ jobs:
             gem update --system
             bundle check || bundle install --jobs=4 --retry=3 --path .bundle
             sudo apt-get install shellcheck
+      - run:
+          name: Install additional dependency xar
+          command: |
+            cd /tmp
+            mkdir download
+            cd download
+            wget https://github.com/downloads/mackyle/xar/xar-1.6.1.tar.gz
+            tar -xzf xar-1.6.1.tar.gz
+            cd xar-1.6.1
+            ./autogen.sh --noconfigure
+            ./configure
+            make
+            sudo make install
       - save_cache:
           key: fastlane-v2-gems-{{ checksum "Gemfile" }}-b
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,47 @@
 version: 2
 
 jobs:
-  build:
+  "macOS":
+    macos:
+      xcode: "9.0.0"
+    environment:
+      CIRCLE_TEST_RESULTS: $HOME/test-results
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+    shell: /bin/bash --login -eo pipefail
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: fastlane-macos-gems-{{ checksum "Gemfile" }}
+      - run:
+          name: Setup Build
+          command: |
+            mkdir -p $CIRCLE_TEST_RESULTS
+            echo "2.3" > .ruby-version
+            gem update --system
+            brew install shellcheck
+            bundle check || bundle install --jobs=4 --retry=3 --path .bundle
+      - save_cache:
+          key: fastlane-macos-gems-{{ checksum "Gemfile" }}
+          paths:
+            - .bundle
+
+      - run:
+          name: Check PR Metadata
+          command: bundle exec danger || echo "danger failed"
+
+      - run: bundle exec fastlane test
+
+      - store_test_results:
+          path: /Users/distiller/test-results
+
+      - run:
+          name: Post Test Results to GitHub
+          command: bundle exec danger || echo "danger failed"
+          when: always # Run this even when tests fail
+  
+  "Ubuntu":
     environment:
       CIRCLE_TEST_REPORTS: ~/test-results
       LC_ALL: C.UTF-8
@@ -37,7 +77,7 @@ jobs:
             make
             sudo make install
       - save_cache:
-          key: fastlane-v2-gems-{{ checksum "Gemfile" }}-b
+          key: fastlane-ubuntu-gems-{{ checksum "Gemfile" }}
           paths:
             - .bundle
 
@@ -57,3 +97,10 @@ jobs:
           name: Post Test Results to GitHub
           command: bundle exec danger || echo "danger failed"
           when: always # Run this even when tests fail
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - "macOS"
+      - "Ubuntu"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: fastlane-macos-gems-{{ checksum "Gemfile" }}
+          key: v1-macos-gems-{{ checksum "Gemfile" }}
       - run:
           name: Setup Build
           command: |
@@ -23,7 +23,7 @@ jobs:
             brew install shellcheck
             bundle check || bundle install --jobs=4 --retry=3 --path .bundle
       - save_cache:
-          key: fastlane-macos-gems-{{ checksum "Gemfile" }}
+          key: v1-macos-gems-{{ checksum "Gemfile" }}
           paths:
             - .bundle
 
@@ -54,7 +54,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: fastlane-ubuntu-gems-{{ checksum "Gemfile" }}
+          key: v1-ubuntu-gems-{{ checksum "Gemfile" }}
       - run:
           name: Setup Build
           command: |
@@ -63,6 +63,11 @@ jobs:
             gem update --system
             bundle check || bundle install --jobs=4 --retry=3 --path .bundle
             sudo apt-get install shellcheck
+      - save_cache:
+          key: v1-ubuntu-gems-{{ checksum "Gemfile" }}
+          paths:
+            - .bundle
+
       - run:
           name: Install additional dependency xar
           command: |
@@ -76,10 +81,6 @@ jobs:
             ./configure
             make
             sudo make install
-      - save_cache:
-          key: fastlane-ubuntu-gems-{{ checksum "Gemfile" }}
-          paths:
-            - .bundle
 
       - run:
           name: Check PR Metadata

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
             mkdir -p ~/test-results
             echo "2.3" > .ruby-version
             gem update --system
-            brew install shellcheck
             bundle check || bundle install --jobs=4 --retry=3 --path .bundle
+            sudo apt-get install shellcheck
       - save_cache:
           key: fastlane-v2-gems-{{ checksum "Gemfile" }}-b
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,12 @@ version: 2
 
 jobs:
   build:
-    macos:
-      xcode: "9.0.0"
     environment:
       CIRCLE_TEST_REPORTS: ~/test-results
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
+    docker:
+      - image: circleci/ruby:2.3
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,6 @@ jobs:
       FASTLANE_ITUNES_TRANSPORTER_PATH: .bundle
     docker:
       - image: circleci/ruby:2.3
-    shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
 

--- a/scan/spec/xcpretty_reporter_options_generator_spec.rb
+++ b/scan/spec/xcpretty_reporter_options_generator_spec.rb
@@ -1,5 +1,5 @@
 describe Scan do
-  describe Scan::XCPrettyReporterOptionsGenerator do
+  describe Scan::XCPrettyReporterOptionsGenerator, requires_xcodebuild: true do
     before(:all) do
       options = { project: "./scan/examples/standard/app.xcodeproj" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
@@ -7,7 +7,7 @@ describe Scan do
     end
 
     describe "xcpretty reporter options generation" do
-      it "generates options for the junit tempfile report required by scan", requires_xcodebuild: true do
+      it "generates options for the junit tempfile report required by scan" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html", "report.html", "/test_output", false)
         reporter_options = generator.generate_reporter_options
         temp_junit_report = Scan.cache[:temp_junit_report]
@@ -19,7 +19,7 @@ describe Scan do
                                              ])
       end
 
-      it "generates options for a custom junit report with default file name", requires_xcodebuild: true do
+      it "generates options for a custom junit report with default file name" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "junit", nil, "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -29,7 +29,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom junit report with custom file name", requires_xcodebuild: true do
+      it "generates options for a custom junit report with custom file name" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "junit", "junit.xml", "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -39,7 +39,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom html report with default file name", requires_xcodebuild: true do
+      it "generates options for a custom html report with default file name" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html", nil, "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -49,7 +49,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom html report with custom file name", requires_xcodebuild: true do
+      it "generates options for a custom html report with custom file name" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html", "custom_report.html", "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -59,7 +59,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom json-compilation-database file with default file name", requires_xcodebuild: true do
+      it "generates options for a custom json-compilation-database file with default file name" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "json-compilation-database", nil, "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -69,7 +69,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom json-compilation-database file with a custom file name", requires_xcodebuild: true do
+      it "generates options for a custom json-compilation-database file with a custom file name" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "json-compilation-database", "custom_report.json", "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -79,7 +79,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom json-compilation-database file with a clang naming convention", requires_xcodebuild: true do
+      it "generates options for a custom json-compilation-database file with a clang naming convention" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "json-compilation-database", "ignore_custom_name_here.json", "/test_output", true)
         reporter_options = generator.generate_reporter_options
 
@@ -89,7 +89,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a multiple reports with default file names", requires_xcodebuild: true do
+      it "generates options for a multiple reports with default file names" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html,junit", nil, "/test_output", true)
         reporter_options = generator.generate_reporter_options
 
@@ -101,7 +101,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a multiple reports with default file names", requires_xcodebuild: true do
+      it "generates options for a multiple reports with default file names" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html,junit", "custom_report.html,junit.xml", "/test_output", true)
         reporter_options = generator.generate_reporter_options
 
@@ -114,7 +114,7 @@ describe Scan do
       end
 
       context "options passed as arrays" do
-        it "generates options for the junit tempfile report required by scan", requires_xcodebuild: true do
+        it "generates options for the junit tempfile report required by scan" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html"], ["report.html"], "test_output", false)
           reporter_options = generator.generate_reporter_options
           temp_junit_report = Scan.cache[:temp_junit_report]
@@ -126,7 +126,7 @@ describe Scan do
                                                ])
         end
 
-        it "generates options for a custom junit report with default file name", requires_xcodebuild: true do
+        it "generates options for a custom junit report with default file name" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["junit"], nil, "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -136,7 +136,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom junit report with custom file name", requires_xcodebuild: true do
+        it "generates options for a custom junit report with custom file name" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["junit"], ["junit.xml"], "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -146,7 +146,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom html report with default file name", requires_xcodebuild: true do
+        it "generates options for a custom html report with default file name" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html"], nil, "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -156,7 +156,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom html report with custom file name", requires_xcodebuild: true do
+        it "generates options for a custom html report with custom file name" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html"], ["custom_report.html"], "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -166,7 +166,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom json-compilation-database file with default file name", requires_xcodebuild: true do
+        it "generates options for a custom json-compilation-database file with default file name" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["json-compilation-database"], nil, "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -176,7 +176,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom json-compilation-database file with a custom file name", requires_xcodebuild: true do
+        it "generates options for a custom json-compilation-database file with a custom file name" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["json-compilation-database"], ["custom_report.json"], "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -186,7 +186,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom json-compilation-database file with a clang naming convention", requires_xcodebuild: true do
+        it "generates options for a custom json-compilation-database file with a clang naming convention" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["json-compilation-database"], ["ignore_custom_name_here.json"], "/test_output", true)
           reporter_options = generator.generate_reporter_options
 
@@ -199,7 +199,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a multiple reports with default file names", requires_xcodebuild: true do
+        it "generates options for a multiple reports with default file names" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html", "junit"], nil, "/test_output", true)
           reporter_options = generator.generate_reporter_options
 
@@ -211,7 +211,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a multiple reports with custom file names", requires_xcodebuild: true do
+        it "generates options for a multiple reports with custom file names" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html", "junit"], ["custom_report.html", "junit.xml"], "/test_output", true)
           reporter_options = generator.generate_reporter_options
 
@@ -225,7 +225,7 @@ describe Scan do
       end
 
       context "generator created from Scan.config" do
-        it "generates options for a single reports while using custom_report_file_name", requires_xcodebuild: true do
+        it "generates options for a single reports while using custom_report_file_name" do
           options = {
             project: "./scan/examples/standard/app.xcodeproj",
             output_types: "junit,html",

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -66,11 +66,21 @@ RSpec.configure do |config|
 
   # disable/filter some tests if not running on mac
   unless FastlaneCore::Helper.is_mac?
-    config.filter_run_excluding requires_xcode: true
-    config.filter_run_excluding requires_xcodebuild: true
-    config.filter_run_excluding requires_plistbuddy: true
-    config.filter_run_excluding requires_keychain: true
-    config.filter_run_excluding requires_security: true
+    config.define_derived_metadata(:requires_xcode) do |meta|
+      meta[:skip] = "Requires Xcode to be installed which is not possible on this platform"
+    end
+    config.define_derived_metadata(:requires_xcodebuild) do |meta|
+      meta[:skip] = "Requires `xcodebuild` to be installed which is not possible on this platform"
+    end
+    config.define_derived_metadata(:requires_plistbuddy) do |meta|
+      meta[:skip] = "Requires `plistbuddy` to be installed which is not possible on this platform"
+    end
+    config.define_derived_metadata(:requires_keychain) do |meta|
+      meta[:skip] = "Requires `keychain` to be installed which is not possible on this platform"
+    end
+    config.define_derived_metadata(:requires_security) do |meta|
+      meta[:skip] = "Requires `security` to be installed which is not possible on this platform"
+    end
   end
 end
 

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -67,25 +67,25 @@ RSpec.configure do |config|
   # skip some tests if not running on mac
   unless FastlaneCore::Helper.is_mac?
 
-    # define metadata tags that also implie :skip
+    # define metadata tags that also imply :skip
     config.define_derived_metadata(:requires_xcode) do |meta|
-      meta[:skip] = "Skipped: Requires Xcode to be installed which is not possible on this platform and no workaround has beend implemented"
+      meta[:skip] = "Skipped: Requires Xcode to be installed (which is not possible on this platform and no workaround has been implemented)"
     end
     config.define_derived_metadata(:requires_xcodebuild) do |meta|
-      meta[:skip] = "Skipped: Requires `xcodebuild` to be installed which is not possible on this platform and no workaround has beend implemented"
+      meta[:skip] = "Skipped: Requires `xcodebuild` to be installed (which is not possible on this platform and no workaround has been implemented)"
     end
     config.define_derived_metadata(:requires_plistbuddy) do |meta|
-      meta[:skip] = "Skipped: Requires `plistbuddy` to be installed which is not possible on this platform and no workaround has beend implemented"
+      meta[:skip] = "Skipped: Requires `plistbuddy` to be installed (which is not possible on this platform and no workaround has been implemented)"
     end
     config.define_derived_metadata(:requires_keychain) do |meta|
-      meta[:skip] = "Skipped: Requires `keychain` to be installed which is not possible on this platform and no workaround has beend implemented"
+      meta[:skip] = "Skipped: Requires `keychain` to be installed (which is not possible on this platform and no workaround has been implemented)"
     end
     config.define_derived_metadata(:requires_security) do |meta|
-      meta[:skip] = "Skipped: Requires `security` to be installed which is not possible on this platform and no workaround has beend implemented"
+      meta[:skip] = "Skipped: Requires `security` to be installed (which is not possible on this platform and no workaround has been implemented)"
     end
 
     # also skip `before()` for test groups that are skipped because of their tags
-    # does not work if the tag is set on `it`, only parent `describe` of `before()`
+    # only works for `describe` groups (that are parents of the `before`, not if the tag is set on `it`
     # caution! has unexpected side effect on usage of `skip: false` for individual examples
     # see https://groups.google.com/d/msg/rspec/5qeKQr_7G7k/Pb3ss2hOAAAJ
     module HookOverrides

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -64,23 +64,37 @@ RSpec.configure do |config|
 
   config.example_status_persistence_file_path = "/tmp/rspec_failed_tests.txt"
 
-  # disable/filter some tests if not running on mac
+  # skip some tests if not running on mac
   unless FastlaneCore::Helper.is_mac?
+
+    # define metadata tags that also implie :skip
     config.define_derived_metadata(:requires_xcode) do |meta|
-      meta[:skip] = "Requires Xcode to be installed which is not possible on this platform"
+      meta[:skip] = "Skipped: Requires Xcode to be installed which is not possible on this platform and no workaround has beend implemented"
     end
     config.define_derived_metadata(:requires_xcodebuild) do |meta|
-      meta[:skip] = "Requires `xcodebuild` to be installed which is not possible on this platform"
+      meta[:skip] = "Skipped: Requires `xcodebuild` to be installed which is not possible on this platform and no workaround has beend implemented"
     end
     config.define_derived_metadata(:requires_plistbuddy) do |meta|
-      meta[:skip] = "Requires `plistbuddy` to be installed which is not possible on this platform"
+      meta[:skip] = "Skipped: Requires `plistbuddy` to be installed which is not possible on this platform and no workaround has beend implemented"
     end
     config.define_derived_metadata(:requires_keychain) do |meta|
-      meta[:skip] = "Requires `keychain` to be installed which is not possible on this platform"
+      meta[:skip] = "Skipped: Requires `keychain` to be installed which is not possible on this platform and no workaround has beend implemented"
     end
     config.define_derived_metadata(:requires_security) do |meta|
-      meta[:skip] = "Requires `security` to be installed which is not possible on this platform"
+      meta[:skip] = "Skipped: Requires `security` to be installed which is not possible on this platform and no workaround has beend implemented"
     end
+
+    # also skip `before()` for test groups that are skipped because of their tags
+    # does not work if the tag is set on `it`, only parent `describe` of `before()`
+    # caution! has unexpected side effect on usage of `skip: false` for individual examples
+    # see https://groups.google.com/d/msg/rspec/5qeKQr_7G7k/Pb3ss2hOAAAJ
+    module HookOverrides
+      def before(*args)
+        super unless metadata[:skip]
+      end
+    end
+    config.extend HookOverrides
+
   end
 end
 


### PR DESCRIPTION
Skip examples that don't work on non-macOS platforms instead of filtering them (which marks and reports them as pending). also offer reasons for skipping.

Gives output:

> [17:45:21]: ▸ 4704 examples, 0 failures, 175 pending

(Implementation details via discussion at http://groups.google.com/forum/#!topic/rspec/5qeKQr_7G7k)

(has to be rebased after #11242 is merged or updated)