### PR TITLE
Fix app_id detection for swift projects

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -163,14 +163,9 @@ module FastlaneCore
 
       self.config_file_name = config_file_name
 
-      paths = []
-      paths += Dir["./fastlane/#{self.config_file_name}"]
-      paths += Dir["./.fastlane/#{self.config_file_name}"]
-      paths += Dir["./#{self.config_file_name}"]
-      paths += Dir["./fastlane_core/spec/fixtures/#{self.config_file_name}"] if Helper.is_test?
-      return if paths.count == 0
+      path = FastlaneCore::Configuration.find_configuration_file_path(config_file_name: config_file_name)
+      return if path.nil?
 
-      path = paths.first
       begin
         configuration_file = ConfigurationFile.new(self, path, block_for_missing, skip_printing_values)
         options = configuration_file.options
@@ -194,6 +189,16 @@ module FastlaneCore
       raise wrapped_exception unless wrapped_exception.nil?
 
       configuration_file
+    end
+
+    def self.find_configuration_file_path(config_file_name: nil)
+      paths = []
+      paths += Dir["./fastlane/#{config_file_name}"]
+      paths += Dir["./.fastlane/#{config_file_name}"]
+      paths += Dir["./#{config_file_name}"]
+      paths += Dir["./fastlane_core/spec/fixtures/#{config_file_name}"] if Helper.is_test?
+      return nil if paths.count == 0
+      return paths.first
     end
 
     #####################################################

--- a/fastlane_core/lib/fastlane_core/ios_app_identifier_guesser.rb
+++ b/fastlane_core/lib/fastlane_core/ios_app_identifier_guesser.rb
@@ -61,10 +61,10 @@ module FastlaneCore
           application_id = match_swift_application_id(text_line: line)
           return application_id if application_id
         end
-        nil
+        return nil
       rescue
         # any option/file error here should just be treated as identifier not found
-        nil
+        return nil
       end
 
       def match_swift_application_id(text_line: nil)

--- a/fastlane_core/lib/fastlane_core/ios_app_identifier_guesser.rb
+++ b/fastlane_core/lib/fastlane_core/ios_app_identifier_guesser.rb
@@ -70,7 +70,7 @@ module FastlaneCore
       def match_swift_application_id(text_line: nil)
         text_line.strip!
         application_id_match = APP_ID_REGEX.match(text_line)
-        return application_id_match[1] if application_id_match
+        return application_id_match[1].strip if application_id_match
 
         return nil
       end

--- a/fastlane_core/spec/ios_app_identifier_guesser_spec.rb
+++ b/fastlane_core/spec/ios_app_identifier_guesser_spec.rb
@@ -61,6 +61,19 @@ describe FastlaneCore::IOSAppIdentifierGuesser do
     end
 
     it 'catches common permuations of application id with swift matcher' do
+      expected_app_ids = [
+        "a.c.b",
+        "a.c.b",
+        "a.c.b",
+        "a.c.b",
+        "a.c.b",
+        "a.c.b",
+        "a-c-b",
+        "a",
+        "ad",
+        "a--.--.b"
+      ]
+
       valid_id_strings = [
         "var appIdentifier: String { return \"a.c.b\" }",
         "var appIdentifier: String? { return \"a.c.b\" }",
@@ -74,8 +87,9 @@ describe FastlaneCore::IOSAppIdentifierGuesser do
         "var appIdentifier: String { return \"a--.--.b\" }"
       ]
 
-      valid_id_strings.each do |line|
-        expect(FastlaneCore::IOSAppIdentifierGuesser.match_swift_application_id(text_line: line)).to_not be_nil
+      valid_id_strings.zip(expected_app_ids).each do |line, expected_app_id|
+        app_id = FastlaneCore::IOSAppIdentifierGuesser.match_swift_application_id(text_line: line)
+        expect(app_id).to eq(expected_app_id)
       end
     end
 

--- a/fastlane_core/spec/ios_app_identifier_guesser_spec.rb
+++ b/fastlane_core/spec/ios_app_identifier_guesser_spec.rb
@@ -60,6 +60,44 @@ describe FastlaneCore::IOSAppIdentifierGuesser do
       expect(FastlaneCore::IOSAppIdentifierGuesser.guess_app_identifier([])).to eq("Deliverfile.bundle.id")
     end
 
+    it 'catches common permuations of application id with swift matcher' do
+      valid_id_strings = [
+        "var appIdentifier: String { return \"a.c.b\" }",
+        "var appIdentifier: String? { return \"a.c.b\" }",
+        "var appIdentifier: String[] { return [\"a.c.b\"] }",
+        "var appIdentifier: String {return \"a.c.b\"}",
+        "var appIdentifier: String {return \"a.c.b\"} ",
+        "var  appIdentifier:  String {  return  \"a.c.b \"  }",
+        "var appIdentifier: String { return \"a-c-b\" }",
+        "var appIdentifier: String { return \"a\" }",
+        "var appIdentifier: String { return \"ad\" }",
+        "var appIdentifier: String { return \"a--.--.b\" }"
+      ]
+
+      valid_id_strings.each do |line|
+        expect(FastlaneCore::IOSAppIdentifierGuesser.match_swift_application_id(text_line: line)).to_not be_nil
+      end
+    end
+
+    it 'ignores non-application ids with swift matcher' do
+      valid_id_strings = [
+        "var appIdentifier: String { return \"\" }",
+        "var appIdentifier: String",
+        "var appIdentifier: String { get }",
+        "var appIdentifier: String? { return nil }",
+        "var appIdentifier: String? { get }",
+        "var appIdentifier: String[] { return [] }",
+        "var appIdentifier: String[] { get }",
+        "var appIdentifier: String [ ] {get }",
+        "var appId: String { return \"\" }",
+        "var appId: String { get }"
+      ]
+
+      valid_id_strings.each do |line|
+        expect(FastlaneCore::IOSAppIdentifierGuesser.match_swift_application_id(text_line: line)).to be_nil
+      end
+    end
+
     it 'returns iOS app_identifier found in Gymfile' do
       allow_target_configuration_file("Gymfile")
       allow_non_target_configuration_file("Deliverfile")


### PR DESCRIPTION
We weren't detecting the app_id in the `IOSAppIdentifierGuesser`
- updated to scan the swift config files (Matchfile.swift, Appfile.swift, Deliverfile.swift, Snapfile.swift)
