### PR TITLE
appledoc: accept multiple input paths

### DIFF
--- a/fastlane/lib/fastlane/actions/appledoc.rb
+++ b/fastlane/lib/fastlane/actions/appledoc.rb
@@ -71,9 +71,22 @@ module Fastlane
         appledoc_args = params_hash_to_cli_args(params_hash)
         UI.success("Generating documentation.")
         cli_args = appledoc_args.join(' ')
-        command = "appledoc #{cli_args}".strip + " \"#{params_hash[:input]}\""
+        input_cli_arg = input_param_to_cli_arg(params_hash[:input])
+        command = "appledoc #{cli_args}".strip + " " + input_cli_arg
         UI.verbose(command)
         Actions.sh command
+      end
+
+      def self.input_param_to_cli_arg(input_param)
+        cli_arg = ""
+        if input_param.kind_of?(Array)
+          input_param.map! {|path| quote_string_param(path)}
+          cli_arg = input_param.join(' ')
+        else
+          cli_arg = quote_string_param(input_param)
+        end
+
+        return cli_arg
       end
 
       def self.params_hash_to_cli_args(params)
@@ -100,8 +113,12 @@ module Fastlane
       end
 
       def self.cli_param(k, v)
-        value = (v != true && v.to_s.length > 0 ? "\"#{v}\"" : "")
+        value = quote_string_param(v)
         "#{k} #{value}".strip
+      end
+
+      def self.quote_string_param(s)
+        quoted_string = (s != true && s.to_s.length > 0 ? "\"#{s}\"" : "")
       end
 
       def self.create_output_dir_if_not_exists(output_path)
@@ -124,7 +141,7 @@ module Fastlane
       def self.available_options
         [
           # PATHS
-          FastlaneCore::ConfigItem.new(key: :input, env_name: "FL_APPLEDOC_INPUT", description: "Path to source file(s). Accepts a single string, or an array of strings.", is_string: false),
+          FastlaneCore::ConfigItem.new(key: :input, env_name: "FL_APPLEDOC_INPUT", description: "Path(s) to source files. Accepts a single string, or an array of strings", is_string: false),
           FastlaneCore::ConfigItem.new(key: :output, env_name: "FL_APPLEDOC_OUTPUT", description: "Output path", is_string: true, optional: true),
           FastlaneCore::ConfigItem.new(key: :templates, env_name: "FL_APPLEDOC_TEMPLATES", description: "Template files path", is_string: true, optional: true),
           FastlaneCore::ConfigItem.new(key: :docset_install_path, env_name: "FL_APPLEDOC_DOCSET_INSTALL_PATH", description: "DocSet installation path", is_string: true, optional: true),

--- a/fastlane/lib/fastlane/actions/appledoc.rb
+++ b/fastlane/lib/fastlane/actions/appledoc.rb
@@ -141,7 +141,7 @@ module Fastlane
       def self.available_options
         [
           # PATHS
-          FastlaneCore::ConfigItem.new(key: :input, env_name: "FL_APPLEDOC_INPUT", description: "Path(s) to source files. Accepts a single string, or an array of strings", is_string: false),
+          FastlaneCore::ConfigItem.new(key: :input, env_name: "FL_APPLEDOC_INPUT", description: "Path(s) to source files", is_string: false),
           FastlaneCore::ConfigItem.new(key: :output, env_name: "FL_APPLEDOC_OUTPUT", description: "Output path", is_string: true, optional: true),
           FastlaneCore::ConfigItem.new(key: :templates, env_name: "FL_APPLEDOC_TEMPLATES", description: "Template files path", is_string: true, optional: true),
           FastlaneCore::ConfigItem.new(key: :docset_install_path, env_name: "FL_APPLEDOC_DOCSET_INSTALL_PATH", description: "DocSet installation path", is_string: true, optional: true),
@@ -224,7 +224,10 @@ module Fastlane
           'appledoc(
             project_name: "MyProjectName",
             project_company: "Company Name",
-            input: "MyProjectSources",
+            input: [
+              "MyProjectSources",
+              "MyProjectSourceFile.h"
+            ],
             ignore: [
               "ignore/path/1",
               "ingore/path/2"

--- a/fastlane/lib/fastlane/actions/appledoc.rb
+++ b/fastlane/lib/fastlane/actions/appledoc.rb
@@ -71,22 +71,10 @@ module Fastlane
         appledoc_args = params_hash_to_cli_args(params_hash)
         UI.success("Generating documentation.")
         cli_args = appledoc_args.join(' ')
-        input_cli_arg = input_param_to_cli_arg(params_hash[:input])
+        input_cli_arg = Array(params_hash[:input]).map(&:shellescape).join(' ')
         command = "appledoc #{cli_args}".strip + " " + input_cli_arg
         UI.verbose(command)
         Actions.sh command
-      end
-
-      def self.input_param_to_cli_arg(input_param)
-        cli_arg = ""
-        if input_param.kind_of?(Array)
-          input_param.map! { |path| quote_string_param(path) }
-          cli_arg = input_param.join(' ')
-        else
-          cli_arg = quote_string_param(input_param)
-        end
-
-        return cli_arg
       end
 
       def self.params_hash_to_cli_args(params)
@@ -113,12 +101,8 @@ module Fastlane
       end
 
       def self.cli_param(k, v)
-        value = quote_string_param(v)
+        value = (v != true && v.to_s.length > 0 ? "\"#{v}\"" : "")
         "#{k} #{value}".strip
-      end
-
-      def self.quote_string_param(s)
-        s != true && s.to_s.length > 0 ? "\"#{s}\"" : ""
       end
 
       def self.create_output_dir_if_not_exists(output_path)

--- a/fastlane/lib/fastlane/actions/appledoc.rb
+++ b/fastlane/lib/fastlane/actions/appledoc.rb
@@ -141,7 +141,7 @@ module Fastlane
       def self.available_options
         [
           # PATHS
-          FastlaneCore::ConfigItem.new(key: :input, env_name: "FL_APPLEDOC_INPUT", description: "Path(s) to source files", is_string: false),
+          FastlaneCore::ConfigItem.new(key: :input, env_name: "FL_APPLEDOC_INPUT", description: "Path(s) to source file directories or individual source files. Accepts a single path or an array of paths", is_string: false),
           FastlaneCore::ConfigItem.new(key: :output, env_name: "FL_APPLEDOC_OUTPUT", description: "Output path", is_string: true, optional: true),
           FastlaneCore::ConfigItem.new(key: :templates, env_name: "FL_APPLEDOC_TEMPLATES", description: "Template files path", is_string: true, optional: true),
           FastlaneCore::ConfigItem.new(key: :docset_install_path, env_name: "FL_APPLEDOC_DOCSET_INSTALL_PATH", description: "DocSet installation path", is_string: true, optional: true),

--- a/fastlane/lib/fastlane/actions/appledoc.rb
+++ b/fastlane/lib/fastlane/actions/appledoc.rb
@@ -80,7 +80,7 @@ module Fastlane
       def self.input_param_to_cli_arg(input_param)
         cli_arg = ""
         if input_param.kind_of?(Array)
-          input_param.map! {|path| quote_string_param(path)}
+          input_param.map! { |path| quote_string_param(path) }
           cli_arg = input_param.join(' ')
         else
           cli_arg = quote_string_param(input_param)
@@ -118,7 +118,7 @@ module Fastlane
       end
 
       def self.quote_string_param(s)
-        quoted_string = (s != true && s.to_s.length > 0 ? "\"#{s}\"" : "")
+        s != true && s.to_s.length > 0 ? "\"#{s}\"" : ""
       end
 
       def self.create_output_dir_if_not_exists(output_path)

--- a/fastlane/lib/fastlane/actions/appledoc.rb
+++ b/fastlane/lib/fastlane/actions/appledoc.rb
@@ -124,7 +124,7 @@ module Fastlane
       def self.available_options
         [
           # PATHS
-          FastlaneCore::ConfigItem.new(key: :input, env_name: "FL_APPLEDOC_INPUT", description: "Path to source files", is_string: true),
+          FastlaneCore::ConfigItem.new(key: :input, env_name: "FL_APPLEDOC_INPUT", description: "Path to source file(s). Accepts a single string, or an array of strings.", is_string: false),
           FastlaneCore::ConfigItem.new(key: :output, env_name: "FL_APPLEDOC_OUTPUT", description: "Output path", is_string: true, optional: true),
           FastlaneCore::ConfigItem.new(key: :templates, env_name: "FL_APPLEDOC_TEMPLATES", description: "Template files path", is_string: true, optional: true),
           FastlaneCore::ConfigItem.new(key: :docset_install_path, env_name: "FL_APPLEDOC_DOCSET_INSTALL_PATH", description: "DocSet installation path", is_string: true, optional: true),

--- a/fastlane/spec/actions_specs/appledoc_spec.rb
+++ b/fastlane/spec/actions_specs/appledoc_spec.rb
@@ -10,7 +10,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" input/dir")
       end
 
       it "accepts an input path with spaces" do
@@ -22,7 +22,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" \"input/dir with spaces/file\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" input/dir\\ with\\ spaces/file")
       end
 
       it "accepts an array of input paths" do
@@ -34,7 +34,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" \"input/dir\" \"second/input dir with spaces\" \"third/input/file.h\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" input/dir second/input\\ dir\\ with\\ spaces third/input/file.h")
       end
 
       it "adds output param to command" do
@@ -47,7 +47,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --output \"~/Desktop\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --output \"~/Desktop\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds templates param to command" do
@@ -60,7 +60,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --templates \"path/to/templates\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --templates \"path/to/templates\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_install_path param to command" do
@@ -73,7 +73,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-install-path \"docs/install/path\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-install-path \"docs/install/path\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds include param to command" do
@@ -86,7 +86,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --include \"path/to/include\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --include \"path/to/include\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds ignore param to command" do
@@ -99,7 +99,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --ignore \"ignored/path\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --ignore \"ignored/path\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds multiple ignore params to command" do
@@ -112,7 +112,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --ignore \"ignored/path\" --ignore \"ignored/path2\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --ignore \"ignored/path\" --ignore \"ignored/path2\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds exclude_output param to command" do
@@ -125,7 +125,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exclude-output \"excluded/path\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exclude-output \"excluded/path\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds index_desc param to command" do
@@ -138,7 +138,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --index-desc \"index_desc/path\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --index-desc \"index_desc/path\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds project_version param to command" do
@@ -151,7 +151,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --project-version \"VERSION\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --project-version \"VERSION\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds company_id param to command" do
@@ -164,7 +164,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --company-id \"COMPANY ID\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --company-id \"COMPANY ID\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds create_html param to command" do
@@ -177,7 +177,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --create-html --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --create-html --exit-threshold \"2\" input/dir")
       end
 
       it "adds create_docset param to command" do
@@ -190,7 +190,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --create-docset --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --create-docset --exit-threshold \"2\" input/dir")
       end
 
       it "adds install_docset param to command" do
@@ -203,7 +203,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --install-docset --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --install-docset --exit-threshold \"2\" input/dir")
       end
 
       it "adds publish_docset param to command" do
@@ -216,7 +216,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --publish-docset --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --publish-docset --exit-threshold \"2\" input/dir")
       end
 
       it "adds no_create_docset param to command" do
@@ -229,7 +229,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --no-create-docset --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --no-create-docset --exit-threshold \"2\" input/dir")
       end
 
       it "adds html_anchors param to command" do
@@ -242,7 +242,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --html-anchors \"some anchors\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --html-anchors \"some anchors\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds clean_output param to command" do
@@ -255,7 +255,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --clean-output --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --clean-output --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_bundle_id param to command" do
@@ -268,7 +268,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-bundle-id \"com.bundle.id\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-bundle-id \"com.bundle.id\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_bundle_name param to command" do
@@ -281,7 +281,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-bundle-name \"Bundle name\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-bundle-name \"Bundle name\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_desc param to command" do
@@ -294,7 +294,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-desc \"DocSet description\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-desc \"DocSet description\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_copyright param to command" do
@@ -307,7 +307,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-copyright \"DocSet copyright\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-copyright \"DocSet copyright\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_feed_name param to command" do
@@ -320,7 +320,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-feed-name \"DocSet feed name\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-feed-name \"DocSet feed name\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_feed_url param to command" do
@@ -333,7 +333,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-feed-url \"http://docset-feed-url.com\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-feed-url \"http://docset-feed-url.com\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_feed_formats param to command" do
@@ -346,7 +346,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-feed-formats \"atom\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-feed-formats \"atom\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_package_url param to command" do
@@ -359,7 +359,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-package-url \"http://docset-package-url.com\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-package-url \"http://docset-package-url.com\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_fallback_url param to command" do
@@ -372,7 +372,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-fallback-url \"http://docset-fallback-url.com\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-fallback-url \"http://docset-fallback-url.com\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_publisher_id param to command" do
@@ -385,7 +385,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-publisher-id \"Publisher ID\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-publisher-id \"Publisher ID\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_publisher_name param to command" do
@@ -398,7 +398,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-publisher-name \"Publisher name\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-publisher-name \"Publisher name\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_min_xcode_version param to command" do
@@ -411,7 +411,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-min-xcode-version \"6.4\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-min-xcode-version \"6.4\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_platform_family param to command" do
@@ -424,7 +424,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-platform-family \"ios\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-platform-family \"ios\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_cert_issuer param to command" do
@@ -437,7 +437,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-cert-issuer \"Some issuer\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-cert-issuer \"Some issuer\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_cert_signer param to command" do
@@ -450,7 +450,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-cert-signer \"Some signer\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-cert-signer \"Some signer\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_bundle_filename param to command" do
@@ -463,7 +463,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-bundle-filename \"DocSet bundle filename\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-bundle-filename \"DocSet bundle filename\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_atom_filename param to command" do
@@ -476,7 +476,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-atom-filename \"DocSet atom feed filename\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-atom-filename \"DocSet atom feed filename\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_xml_filename param to command" do
@@ -489,7 +489,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-xml-filename \"DocSet xml feed filename\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-xml-filename \"DocSet xml feed filename\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docset_package_filename param to command" do
@@ -502,7 +502,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-package-filename \"DocSet package filename\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docset-package-filename \"DocSet package filename\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds options param to command" do
@@ -515,7 +515,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --use-single-star --keep-intermediate-files --search-undocumented-doc --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --use-single-star --keep-intermediate-files --search-undocumented-doc --exit-threshold \"2\" input/dir")
       end
 
       it "adds crossref_format param to command" do
@@ -528,7 +528,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --crossref-format \"some regex\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --crossref-format \"some regex\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds docs_section_title param to command" do
@@ -541,7 +541,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docs-section-title \"Section title\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --docs-section-title \"Section title\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds warnings param to command" do
@@ -554,7 +554,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --warn-missing-output-path --warn-missing-company-id --warn-undocumented-object --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --warn-missing-output-path --warn-missing-company-id --warn-undocumented-object --exit-threshold \"2\" input/dir")
       end
 
       it "adds logformat param to command" do
@@ -567,7 +567,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --logformat \"1\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --logformat \"1\" --exit-threshold \"2\" input/dir")
       end
 
       it "adds verbose param to command" do
@@ -580,7 +580,7 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --verbose \"1\" --exit-threshold \"2\" \"input/dir\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --verbose \"1\" --exit-threshold \"2\" input/dir")
       end
     end
   end

--- a/fastlane/spec/actions_specs/appledoc_spec.rb
+++ b/fastlane/spec/actions_specs/appledoc_spec.rb
@@ -14,7 +14,7 @@ describe Fastlane do
       end
 
       it "accepts an array of input paths" do
-        result = Fastlane::FastFile.new.prase("lane :test do
+        result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
             project_name: 'Project Name',
             project_company: 'Company',

--- a/fastlane/spec/actions_specs/appledoc_spec.rb
+++ b/fastlane/spec/actions_specs/appledoc_spec.rb
@@ -13,16 +13,28 @@ describe Fastlane do
         expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" \"input/dir\"")
       end
 
+      it "accepts an input path with spaces" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
+            input: 'input/dir with spaces/file'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" \"input/dir with spaces/file\"")
+      end
+
       it "accepts an array of input paths" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
             project_name: 'Project Name',
             project_company: 'Company',
-            input: ['input/dir', 'second/input/dir', 'third/input/file.h']
+            input: ['input/dir', 'second/input dir with spaces', 'third/input/file.h']
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" \"input/dir\" \"second/input/dir\" \"third/input/file.h\"")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" \"input/dir\" \"second/input dir with spaces\" \"third/input/file.h\"")
       end
 
       it "adds output param to command" do

--- a/fastlane/spec/actions_specs/appledoc_spec.rb
+++ b/fastlane/spec/actions_specs/appledoc_spec.rb
@@ -13,6 +13,18 @@ describe Fastlane do
         expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" \"input/dir\"")
       end
 
+      it "accepts an array of input paths" do
+        result = Fastlane::FastFile.new.prase("lane :test do
+          appledoc(
+            project_name: 'Project Name',
+            project_company: 'Company',
+            input: ['input/dir', 'second/input/dir', 'third/input/file.h']
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" \"input/dir\" \"second/input/dir\" \"third/input/file.h\"")
+      end
+
       it "adds output param to command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(

--- a/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
@@ -392,6 +392,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -404,6 +405,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -415,6 +417,7 @@
 		77C503131DD3175E00AC8FF0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = today/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
@@ -428,6 +431,7 @@
 		77C503141DD3175E00AC8FF0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = today/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;

--- a/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
@@ -392,7 +392,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -405,7 +404,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -417,7 +415,6 @@
 		77C503131DD3175E00AC8FF0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = today/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
@@ -431,7 +428,6 @@
 		77C503141DD3175E00AC8FF0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = today/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change adds the ability to specify multiple input source paths to the `appledoc` action. This is useful if your source code lives in a few different directories, or if you only want to document a subset of your source code.

fixes #11084.

Added two new test cases and ran this over my own projects as well.

### Description
The `input` parameter to the `appledoc` action now accepts paths as a single string or an array of strings. Each path string is quoted separately before being passed to the `appledoc` command line tool.

I'm a bit of a Ruby noob so please let me know if I've made any rookie mistakes.