### PR TITLE
Expose the swift Snapshot class to Objective-C

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -58,6 +58,7 @@ enum SnapshotError: Error, CustomDebugStringConvertible {
     }
 }
 
+@objcMembers
 open class Snapshot: NSObject {
     static var app: XCUIApplication!
     static var cacheDirectory: URL!
@@ -242,4 +243,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.7]
+// SnapshotHelperVersion [1.8]


### PR DESCRIPTION
Explicitly annotate the Snapshot class with `@objcMembers` since Swift 3 `@objc` inference is deprecated in Swift 4.

This is required for Objective-C developers to be able to use [Snapshot snapshot:@"Screenshot" timeWaitingForIdle:20];

It is not required to add `@objcMembers` in the SnapshotHelperXcode8Version.swift file since Xcode < 9 does not support Swift 4.