### PR TITLE
[supply] replace hardcoded string `en-US` with actual language

### DIFF
--- a/supply/lib/supply/setup.rb
+++ b/supply/lib/supply/setup.rb
@@ -44,7 +44,7 @@ module Supply
       IMAGES_TYPES.each do |image_type|
         if ['featureGraphic'].include?(image_type)
           # we don't get all files in full resolution :(
-          UI.message("Due to a limitation of the Google Play API, there is no way for `supply` to download your existing feature graphic. Please copy your feature graphic to `metadata/android/en-US/images/featureGraphic.png`")
+          UI.message("Due to a limitation of the Google Play API, there is no way for `supply` to download your existing feature graphic. Please copy your feature graphic to `metadata/android/#{listing.language}/images/featureGraphic.png`")
           next
         end
 

--- a/supply/lib/supply/setup.rb
+++ b/supply/lib/supply/setup.rb
@@ -71,7 +71,7 @@ module Supply
         FileUtils.mkdir_p(File.join(containing, IMAGES_FOLDER_NAME, screenshot_type))
       end
 
-      UI.message("Due to a limitation of the Google Play API, there is no way for `supply` to download your existing screenshots. Please copy your screenshots into `metadata/android/en-US/images/`")
+      UI.message("Due to a limitation of the Google Play API, there is no way for `supply` to download your existing screenshots. Please copy your screenshots into `metadata/android/#{listing.language}/images/`")
     end
 
     def store_apk_listing(apk_listing)


### PR DESCRIPTION
Error messages currently always output `en-US`.
This replaces it with the actual language being handled at the moment.

(fixes #9962)