### PR TITLE
Version bump to 2.70.2

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.70.1'.freeze
+  VERSION = '2.70.2'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.70.1':**

* [supply] add filename of Feature Graphic in output (#11283) via Luke Williams
* [Fastlane.swift] Fix missing return type for more actions (#11293) via Thi
* Use correct sdk name in build_ios_app docs (#11282) via Rob Moorman
* Expose the swift Snapshot class to Objective-C (#11291) via Cédric Luthi
* Fix app_id detection for swift projects (#11288) via Joshua Liebowitz
* Option to fail on errors posting slack notification (#11281) via Dan Cohn
* remove test file (#11287) via David Ohayon
* default to unknown when app id is not available (#11285) via David Ohayon
* Fix for #11266, get_build_number missing return type (#11269) via Joshua Liebowitz
* testing packaged fastlane ci (#11279) via David Ohayon
* Add option to run danger on a specific pull request (#11263) via Dan Cohn
* [Fastlane.swift] Fix gitBranch() has no return type (#11277) via Thi
* non-macOS platform: always return emptry string as xcode_path (#11265) via Jan Piotrowski
* Choose `find` syntax depending on OS (no `find -E` on Ubuntu) (#11264) via Jan Piotrowski
* When generating Swift files, add new line to end of file (#11261) via Joshua Liebowitz
