### PR TITLE
Version bump to 2.70.2

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.70.1'.freeze
+  VERSION = '2.70.2'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -11,4 +11,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.70.0
+// Generated with fastlane 2.70.1

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1123,7 +1123,8 @@ func danger(useBundleExec: Bool = true,
             failOnErrors: Bool = false,
             newComment: Bool = false,
             base: String? = nil,
-            head: String? = nil) {
+            head: String? = nil,
+            pr: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "danger", className: nil, args: [RubyCommand.Argument(name: "use_bundle_exec", value: useBundleExec),
                                                                                         RubyCommand.Argument(name: "verbose", value: verbose),
                                                                                         RubyCommand.Argument(name: "danger_id", value: dangerId),
@@ -1132,7 +1133,8 @@ func danger(useBundleExec: Bool = true,
                                                                                         RubyCommand.Argument(name: "fail_on_errors", value: failOnErrors),
                                                                                         RubyCommand.Argument(name: "new_comment", value: newComment),
                                                                                         RubyCommand.Argument(name: "base", value: base),
-                                                                                        RubyCommand.Argument(name: "head", value: head)])
+                                                                                        RubyCommand.Argument(name: "head", value: head),
+                                                                                        RubyCommand.Argument(name: "pr", value: pr)])
   _ = runner.executeCommand(command)
 }
 func deleteKeychain(name: String? = nil,
@@ -2856,7 +2858,8 @@ func slack(message: String? = nil,
            payload: String = "{}",
            defaultPayloads: [String]? = nil,
            attachmentProperties: String = "{}",
-           success: Bool = true) {
+           success: Bool = true,
+           failOnError: Bool = true) {
   let command = RubyCommand(commandID: "", methodName: "slack", className: nil, args: [RubyCommand.Argument(name: "message", value: message),
                                                                                        RubyCommand.Argument(name: "channel", value: channel),
                                                                                        RubyCommand.Argument(name: "use_webhook_configured_username_and_icon", value: useWebhookConfiguredUsernameAndIcon),
@@ -2866,7 +2869,8 @@ func slack(message: String? = nil,
                                                                                        RubyCommand.Argument(name: "payload", value: payload),
                                                                                        RubyCommand.Argument(name: "default_payloads", value: defaultPayloads),
                                                                                        RubyCommand.Argument(name: "attachment_properties", value: attachmentProperties),
-                                                                                       RubyCommand.Argument(name: "success", value: success)])
+                                                                                       RubyCommand.Argument(name: "success", value: success),
+                                                                                       RubyCommand.Argument(name: "fail_on_error", value: failOnError)])
   _ = runner.executeCommand(command)
 }
 func slackTrain() {

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -11,4 +11,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.70.0
+// Generated with fastlane 2.70.1

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -11,4 +11,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.70.0
+// Generated with fastlane 2.70.1

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -11,4 +11,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.70.0
+// Generated with fastlane 2.70.1

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -11,4 +11,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.70.0
+// Generated with fastlane 2.70.1

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -11,4 +11,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.70.0
+// Generated with fastlane 2.70.1

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -11,4 +11,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.70.0
+// Generated with fastlane 2.70.1


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.70.1':**

* Deploying fastlane should bump and commit fastlane swift files (#11289) via Joshua Liebowitz
* [supply] improve check_superseded_tracks(#10927) via Marcelo Oliveira
* [supply] add filename of Feature Graphic in output (#11283) via Luke Williams
* [Fastlane.swift] Fix missing return type for more actions (#11293) via Thi
* Use correct sdk name in build_ios_app docs (#11282) via Rob Moorman
* Expose the swift Snapshot class to Objective-C (#11291) via Cédric Luthi
* Fix app_id detection for swift projects (#11288) via Joshua Liebowitz
* Option to fail on errors posting slack notification (#11281) via Dan Cohn
* remove test file (#11287) via David Ohayon
* default to unknown when app id is not available (#11285) via David Ohayon
* Fix for #11266, get_build_number missing return type (#11269) via Joshua Liebowitz
* testing packaged fastlane ci (#11279) via David Ohayon
* Add option to run danger on a specific pull request (#11263) via Dan Cohn
* [Fastlane.swift] Fix gitBranch() has no return type (#11277) via Thi
* non-macOS platform: always return emptry string as xcode_path (#11265) via Jan Piotrowski
* Choose `find` syntax depending on OS (no `find -E` on Ubuntu) (#11264) via Jan Piotrowski
* When generating Swift files, add new line to end of file (#11261) via Joshua Liebowitz
