### PR TITLE
[snapshot] Fixes failure on physical device due to snapshot()

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -60,17 +60,19 @@ enum SnapshotError: Error, CustomDebugStringConvertible {
 
 @objcMembers
 open class Snapshot: NSObject {
-    static var app: XCUIApplication!
-    static var cacheDirectory: URL!
+    static var app: XCUIApplication?
+    static var cacheDirectory: URL?
     static var screenshotsDirectory: URL? {
-        return cacheDirectory.appendingPathComponent("screenshots", isDirectory: true)
+        return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
     }
 
     open class func setupSnapshot(_ app: XCUIApplication) {
+        
+        Snapshot.app = app
+
         do {
             let cacheDir = try pathPrefix()
             Snapshot.cacheDirectory = cacheDir
-            Snapshot.app = app
             setLanguage(app)
             setLocale(app)
             setLaunchArguments(app)
@@ -80,6 +82,11 @@ open class Snapshot: NSObject {
     }
 
     class func setLanguage(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            print("CacheDirectory is not set - probably runnig a physical device?")
+            return
+        }
+        
         let path = cacheDirectory.appendingPathComponent("language.txt")
 
         do {
@@ -92,6 +99,11 @@ open class Snapshot: NSObject {
     }
 
     class func setLocale(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            print("CacheDirectory is not set - probably runnig a physical device?")
+            return
+        }
+        
         let path = cacheDirectory.appendingPathComponent("locale.txt")
 
         do {
@@ -107,6 +119,11 @@ open class Snapshot: NSObject {
     }
 
     class func setLaunchArguments(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            print("CacheDirectory is not set - probably runnig a physical device?")
+            return
+        }
+        
         let path = cacheDirectory.appendingPathComponent("snapshot-launch_arguments.txt")
         app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
 
@@ -135,6 +152,12 @@ open class Snapshot: NSObject {
         #if os(OSX)
             XCUIApplication().typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
         #else
+            
+            guard let app = self.app else {
+                print("XCUIApplication is not set")
+                return
+            }
+            
             let screenshot = app.windows.firstMatch.screenshot()
             guard let simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
             let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -273,4 +273,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.8.1]
+// SnapshotHelperVersion [1.9]

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -86,7 +86,7 @@ open class Snapshot: NSObject {
 
     class func setLanguage(_ app: XCUIApplication) {
         guard let cacheDirectory = self.cacheDirectory else {
-            print("CacheDirectory is not set - probably runnig on a physical device?")
+            print("CacheDirectory is not set - probably running on a physical device?")
             return
         }
         
@@ -103,7 +103,7 @@ open class Snapshot: NSObject {
 
     class func setLocale(_ app: XCUIApplication) {
         guard let cacheDirectory = self.cacheDirectory else {
-            print("CacheDirectory is not set - probably runnig on a physical device?")
+            print("CacheDirectory is not set - probably running on a physical device?")
             return
         }
         
@@ -123,7 +123,7 @@ open class Snapshot: NSObject {
 
     class func setLaunchArguments(_ app: XCUIApplication) {
         guard let cacheDirectory = self.cacheDirectory else {
-            print("CacheDirectory is not set - probably runnig on a physical device?")
+            print("CacheDirectory is not set - probably running on a physical device?")
             return
         }
         

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -273,4 +273,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.8]
+// SnapshotHelperVersion [1.8.1]


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Running any XCUITest that contains a snapshot() call on a **physical device** will fail. That's because the app property inside setupSnaphot() is set after (!) the setting of cacheDirectory. Unfortunately cacheDirectory can't be computed using pathPrefix() on a physical device due to the missing SIMULATOR_HOST_HOME property. So pathPrefix() will fail and by that always skip the setting of the app property as well (unnecessarily).

### Description
- Makes app and cacheDirectory properties in SnapshotHelper.swift optional (like they should be)
- Sets app before setting cacheDirectory
- On a physical device the snapshot() still not works, but at least it doesn't fails / crashes the test anymore