### PR TITLE
[CircleCI] Fix failing "Uploading test results"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     macos:
       xcode: "9.0.0"
     environment:
-      CIRCLE_TEST_RESULTS: $HOME/test-results
+      CIRCLE_TEST_REPORTS: ~/test-results
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
     shell: /bin/bash --login -eo pipefail
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Setup Build
           command: |
-            mkdir -p $CIRCLE_TEST_RESULTS
+            mkdir -p ~/test-results
             echo "2.3" > .ruby-version
             gem update --system
             brew install shellcheck
@@ -34,7 +34,10 @@ jobs:
       - run: bundle exec fastlane test
 
       - store_test_results:
-          path: /Users/distiller/test-results
+          path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/rspec
+          destination: test-results
 
       - run:
           name: Post Test Results to GitHub

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ end
 
 task :test_all do
   formatter = "--format progress"
-  formatter += " -r rspec_junit_formatter --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec/fastlane-junit-results.xml" if ENV["CIRCLE_TEST_REPORTS"]
+  formatter += " -r rspec_junit_formatter --format RspecJunitFormatter -o #{ENV['CIRCLE_TEST_REPORTS']}/rspec/fastlane-junit-results.xml" if ENV["CIRCLE_TEST_REPORTS"]
   sh "rspec --pattern ./**/*_spec.rb #{formatter}"
 end
 


### PR DESCRIPTION
The "Uploading test results" step failed in the tests:

```
Unable to save test results from /Users/distiller/test-results
Error stat /Users/distiller/test-results: no such file or directory
Found no path with test results, skipping
```
Source: https://circleci.com/gh/fastlane/fastlane/12658

This PR fixes this by:

* Replace CIRCLE_TEST_RESULTS with CIRCLE_TEST_REPORTS (that is used by the `Rakefile`)
* Define CIRCLE_TEST_REPORTS as ~/test-results
* Reuse that explicit path (not via env var as Circle doesn't support this in 2.0 any more :/) in `mkdir` and `store_test_results`
* Add `store_artifacts` to also upload and make accessible the whole .xml file with results
* Rakefile: Use ENV var in string directly via ruby instead of shell command

Now the test results get written to the defined file, uploaded as test results and artifacts, and displayed in Circle CI UI:

> Test Summary
> Your build ran 4718 tests in RSpec with 0 failures
Slowest test: fastlane_core.spec.build_watcher_spec FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete returns specified build when strict watch is enabled (took 10.01 seconds).

![image](https://user-images.githubusercontent.com/183673/34234338-ce75990e-e5ea-11e7-8614-9aa11646eb75.png)


> Artifacts
>  Container 0
 test-results/
fastlane-junit-results.xml

![image](https://user-images.githubusercontent.com/183673/34234345-da55d4fa-e5ea-11e7-9394-6ecdf148227f.png)


fixes #11303