### PR TITLE
[test_sample_code] Respect skip_type_validation when testing sample code.

### DIFF
--- a/fastlane/actions/test_sample_code.rb
+++ b/fastlane/actions/test_sample_code.rb
@@ -61,7 +61,7 @@ module Fastlane
             config_item = available_options.find { |a| a.key == current_argument }
             UI.user_error!("Unknown parameter '#{current_argument}' for action '#{method_sym}'") if config_item.nil?
 
-            if config_item.data_type && !value.kind_of?(config_item.data_type) && !config_item.optional
+            if config_item.data_type && !value.kind_of?(config_item.data_type) && !config_item.optional && !config_item.skip_type_validation
               UI.user_error!("'#{current_argument}' value must be a #{config_item.data_type}! Found #{value.class} instead.")
             end
           end

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -23,6 +23,9 @@ module FastlaneCore
     # [Boolean] is false by default. If set to true, also string values will not be asked to the user
     attr_accessor :optional
 
+    # [Boolean] is false by default. If set to true, type of the parameter will not be validated.
+    attr_accessor :skip_type_validation
+
     # [Array] array of conflicting option keys(@param key). This allows to resolve conflicts intelligently
     attr_accessor :conflicting_options
 
@@ -53,6 +56,7 @@ module FastlaneCore
     #   You have to raise a specific exception if something goes wrong. Append .red after the string
     # @param is_string *DEPRECATED: Use `type` instead* (Boolean) is that parameter a string? Defaults to true. If it's true, the type string will be verified.
     # @param type (Class) the data type of this config item. Takes precedence over `is_string`. Use `:shell_string` to allow types `String`, `Hash` and `Array` that will be converted to shell-escaped strings
+    # @param skip_type_validation (Boolean) is false by default. If set to true, type of the parameter will not be validated.
     # @param optional (Boolean) is false by default. If set to true, also string values will not be asked to the user
     # @param conflicting_options ([]) array of conflicting option keys(@param key). This allows to resolve conflicts intelligently
     # @param conflict_block an optional block which is called when options conflict happens


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
fastlane ConfigItem's can be marked as having their type checking disabled (`skip_type_validation`). This is done for legacy reasons - some ConfigItems have traditionally received data of various types and then switch their behavior based on the type of data received. However, we were not respecting this config item flag when test-running sample code in the test_sample_code action.

### Description
<!-- Describe your changes in detail -->
Disable the type-check when skip_type_validation is set for a ConfigItem.