### PR TITLE
Fix - Hockey dSYM upload only

### DIFF
--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -50,7 +50,7 @@ module Fastlane
         end
       end
 
-      def self.upload_dsym(api_token, app_id, bundle_version, options)
+      def self.upload_ipa_dsym(api_token, app_id, bundle_version, options)
         connection = self.connection(options)
         response = connection.put do |req|
           req.options.timeout = options.delete(:timeout)
@@ -113,8 +113,8 @@ module Fastlane
 
         case response.status
         when 200...300
-          app_version_id = response.body['id']
-          UI.message("successfully created version with id #{app_version_id}")
+          bundle_version = response.body['id']
+          UI.message("successfully created version with id #{bundle_version}")
         else
           UI.user_error!("Error trying to create app version:  #{response.status} - #{response.body}")
         end
@@ -123,7 +123,7 @@ module Fastlane
         options[:dsym] = dsym_io
         options[:status] = update_status
 
-        self.upload_dsym(api_token, app_id, app_version_id, options)
+        self.upload_ipa_dsym(api_token, app_id, bundle_version, options)
       end
 
       def self.run(options)
@@ -164,7 +164,7 @@ module Fastlane
 
         if options[:upload_dsym_only]
           UI.success('Starting with dSYM upload to HockeyApp... this could take some time.')
-          self.upload_dsym(api_token, values[:public_identifier], values[:bundle_version], values)
+          self.upload_ipa_dsym(api_token, values[:public_identifier], values[:bundle_version], values)
         else
           UI.success('Starting with file(s) upload to HockeyApp... this could take some time.')
 

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -159,6 +159,8 @@ module Fastlane
         values[:dsym_filename] = dsym_filename
         values.delete_if { |k, v| v.nil? }
 
+        return values if Helper.test?
+
         if options[:upload_dsym_only]
           UI.success('Starting with dSYM upload to HockeyApp... this could take some time.')
           if dsym_filename

--- a/fastlane/spec/actions_specs/hockey_spec.rb
+++ b/fastlane/spec/actions_specs/hockey_spec.rb
@@ -57,6 +57,7 @@ describe Fastlane do
         values = Fastlane::FastFile.new.parse("lane :test do
             hockey({
               api_token: 'xxx',
+              bundle_version: '25',
               upload_dsym_only: true,
               dsym: './fastlane/spec/fixtures/dSYM/Themoji.dSYM.zip'
             })
@@ -75,6 +76,7 @@ describe Fastlane do
         expect(values[:notes_type]).to eq(1.to_s)
         expect(values[:upload_dsym_only]).to eq(true)
         expect(values[:strategy]).to eq("add")
+        expect(values[:bundle_version]).to eq("25")
       end
 
       it "raises an error if both ipa and apk provided" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR fix #10499 

Based on [Felix's post](https://krausefx.com/blog/download-dsym-symbolication-files-from-itunes-connect-for-bitcode-ios-apps), I want to be able to upload only dSYM files to HockeyApp with no need to send a new IPA.

Currently we have the option `upload_dsym_only` for `hockey` action that is not working properly since it's trying to use a wrong API URI and method, returning error `HTTP 422` from HockeyApp server.

### Description
 - Created a new method to upload dSYM only;
 - Replaced old `PUT` call to use the new method;
 - The method allows to send IPA also;
 - Removed some code complexity;