### PR TITLE
Fetch the correct prices from the new API

### DIFF
--- a/spaceship/lib/spaceship/tunes/iap_detail.rb
+++ b/spaceship/lib/spaceship/tunes/iap_detail.rb
@@ -98,7 +98,7 @@ module Spaceship
             }
           }
         end
-        raw_data.set(["pricingIntervals"], new_intervals)
+        raw_data.set(["subscriptions"], new_intervals)
       end
 
       # @return (Array) pricing intervals
@@ -112,7 +112,7 @@ module Spaceship
       #    }
       #  ]
       def pricing_intervals
-        @pricing_intervals ||= raw_data["pricingIntervals"].map do |interval|
+        @pricing_intervals ||= raw_data["subscriptions"].map do |interval|
           {
             tier: interval["value"]["tierStem"].to_i,
             begin_date: interval["value"]["priceTierEffectiveDate"],

--- a/spaceship/lib/spaceship/tunes/iap_list.rb
+++ b/spaceship/lib/spaceship/tunes/iap_list.rb
@@ -53,13 +53,27 @@ module Spaceship
       end
 
       def edit
-        attrs = client.load_iap(app_id: application.apple_id, purchase_id: self.purchase_id)
-        attrs[:application] = application
-        Tunes::IAPDetail.new(attrs)
+        Tunes::IAPDetail.new(build_iap)
       end
 
       def delete!
         client.delete_iap!(app_id: application.apple_id, purchase_id: self.purchase_id)
+      end
+
+      private
+
+      def build_iap
+        attrs = [*iap_prices, *iap_details].to_h
+        attrs[:application] = application
+        attrs
+      end
+
+      def iap_prices
+        client.load_iap_prices(app_id: application.apple_id, purchase_id: self.purchase_id)
+      end
+
+      def iap_details
+        client.load_iap_details(app_id: application.apple_id, purchase_id: self.purchase_id)
       end
     end
   end

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -534,7 +534,7 @@ module Spaceship
     end
 
     def price_tier(app_id)
-      r = request(:get, "ra/apps/#{app_id}/pricing/intervals")
+      r = request(:get, "ra/apps/#{app_id}/pricing")
       data = parse_response(r, 'data')
 
       begin
@@ -1043,8 +1043,14 @@ module Spaceship
       handle_itc_response(r)
     end
 
-    # Loads the full In-App-Purchases
-    def load_iap(app_id: nil, purchase_id: nil)
+    # Loads the iap prices for specific product
+    def load_iap_prices(app_id: nil, purchase_id: nil)
+      r = request(:get, "ra/apps/#{app_id}/iaps/#{purchase_id}/pricing")
+      parse_response(r, 'data')
+    end
+
+    # Loads iap full details
+    def load_iap_details(app_id: nil, purchase_id: nil)
       r = request(:get, "ra/apps/#{app_id}/iaps/#{purchase_id}")
       parse_response(r, 'data')
     end

--- a/spaceship/spec/tunes/fixtures/iap_detail.json
+++ b/spaceship/spec/tunes/fixtures/iap_detail.json
@@ -34,18 +34,6 @@
       "errorKeys": null
     },
     "pricingDurationType": null,
-    "pricingIntervals": [{
-      "value": {
-        "tierStem": "1",
-        "priceTierEffectiveDate": null,
-        "priceTierEndDate": null,
-        "country": "WW",
-        "grandfathered": null
-      },
-      "isEditable": true,
-      "isRequired": false,
-      "errorKeys": null
-    }],
     "ungrandfatheredIntervals": null,
     "freeTrialDurationType": null,
     "bonusPeriodDurationType": null,

--- a/spaceship/spec/tunes/fixtures/iap_prices.json
+++ b/spaceship/spec/tunes/fixtures/iap_prices.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "subscriptions": [
+      {
+        "value": {
+          "tierStem": "1",
+          "priceTierEffectiveDate": null,
+          "priceTierEndDate": null,
+          "country": "WW",
+          "grandfathered": null
+        },
+        "isEditable": true,
+        "isRequired": false,
+        "errorKeys": null
+      }],
+    "introOffers": [],
+    "freeTrials": null
+  },
+  "messages": {
+    "warn": null,
+    "error": null,
+    "info": null
+  },
+  "statusCode": "SUCCESS"
+}

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -361,6 +361,11 @@ class TunesStubbing
         to_return(status: 200, body: itc_read_fixture_file("iap_detail.json"),
                 headers: { "Content-Type" => "application/json" })
 
+      # iap pricing
+      stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/iaps/1194457865/pricing").
+        to_return(status: 200, body: itc_read_fixture_file("iap_prices.json"),
+                headers: { "Content-Type" => "application/json" })
+
       # list families
       stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/iaps/families").
         to_return(status: 200, body: itc_read_fixture_file("iap_families.json"),


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
After the new introduced changes by apple this year, mainly the introductory prices, the APIs for itunes-connect got changed. This PR aims to fix the [issues](https://github.com/fastlane/fastlane/issues/11189) happened by apple changes, which are:
1- Fetching prices.
2- Fetching IAP details.

Linked issue: #11189 
### Please describe in detail how you tested your changes.
I adapted the tests to the work with the new code and APIs changes, I also manually tested the output of the new APIs.


### Description
I broke the method for fetching the IAP details which used previously, to 2 new methods in the client.

1- `load_iap_details` which fetches the essential details for the IAP purchase.
2- `load_iap_prices` which fetches the prices for this specific IAP from the new endpoint

I adapted the processing of the JSON returned from these methods in the `IAPDetail` class, as the new returned JSON head is `subscriptions` instead of `pricingIntervals`

Then I adapted the specs with new introduced fixtures `iap_prices.json`

cc/ @taquitos

❤️ 