### PR TITLE
Add return type to get_version_number so it's accessible in Swift

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -78,10 +78,12 @@ module Fastlane
         end
 
         version_number = line.partition('=').last
-        return version_number if Helper.is_test?
 
         # Store the number in the shared hash
         Actions.lane_context[SharedValues::VERSION_NUMBER] = version_number
+
+        # Return the version number because Swift might need this return value
+        return version_number
       rescue => ex
         UI.error('Before being able to increment and read the version number from your Xcode project, you first need to setup your project properly. Please follow the guide at https://developer.apple.com/library/content/qa/qa1827/_index.html')
         raise ex
@@ -146,6 +148,10 @@ module Fastlane
         [
           'version = get_version_number(xcodeproj: "Project.xcodeproj")'
         ]
+      end
+
+      def self.return_type
+        :string
       end
 
       def self.category

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -11,4 +11,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.70.2
+// Generated with fastlane 2.70.3

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1513,13 +1513,13 @@ func getPushCertificate(development: Bool = false,
                                                                                                       RubyCommand.Argument(name: "new_profile", value: newProfile)])
   _ = runner.executeCommand(command)
 }
-func getVersionNumber(xcodeproj: String? = nil,
-                      scheme: String? = nil,
-                      target: String? = nil) {
+@discardableResult func getVersionNumber(xcodeproj: String? = nil,
+                                         scheme: String? = nil,
+                                         target: String? = nil) -> String {
   let command = RubyCommand(commandID: "", methodName: "get_version_number", className: nil, args: [RubyCommand.Argument(name: "xcodeproj", value: xcodeproj),
                                                                                                     RubyCommand.Argument(name: "scheme", value: scheme),
                                                                                                     RubyCommand.Argument(name: "target", value: target)])
-  _ = runner.executeCommand(command)
+  return runner.executeCommand(command)
 }
 func gitAdd(path: String? = nil,
             pathspec: String? = nil) {

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -11,4 +11,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.70.2
+// Generated with fastlane 2.70.3

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -11,4 +11,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.70.2
+// Generated with fastlane 2.70.3

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -11,4 +11,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.70.2
+// Generated with fastlane 2.70.3

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -11,4 +11,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.70.2
+// Generated with fastlane 2.70.3

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -11,4 +11,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.70.2
+// Generated with fastlane 2.70.3

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -11,4 +11,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.70.2
+// Generated with fastlane 2.70.3


### PR DESCRIPTION
Found as part of https://github.com/fastlane/fastlane/issues/11266#issuecomment-353434040