### PR TITLE
Version bump first, then generate swift

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,14 +29,14 @@ lane :bump do |options|
   bump_type ||= 'minor' if prompt(text: "New feature, method or API?", boolean: true)
   bump_type ||= 'patch'
 
+  slug = "fastlane/fastlane"
+  new_version = version_bump_podspec(path: version_file_path, bump_type: bump_type)
+
   # Everything looks good, let's generate the Swift API
   generated_files = generate_swift_api
 
   # Add all changed files to the version bump commit
   paths_for_commit += generated_files
-
-  slug = "fastlane/fastlane"
-  new_version = version_bump_podspec(path: version_file_path, bump_type: bump_type)
 
   # Add version file path to change set
   paths_for_commit << version_file_path


### PR DESCRIPTION
- Swift files have a "generated by fastlane x" comment
    having it be one version behind can be confusing now it will be
    the same version as the version of fastlane that they are shipped in
Thanks to @jdee for pointing this confusion out 