### PR TITLE
Tests: Mark skipped tests as pending (with reason)

### DIFF
--- a/scan/spec/xcpretty_reporter_options_generator_spec.rb
+++ b/scan/spec/xcpretty_reporter_options_generator_spec.rb
@@ -1,5 +1,5 @@
 describe Scan do
-  describe Scan::XCPrettyReporterOptionsGenerator do
+  describe Scan::XCPrettyReporterOptionsGenerator, requires_xcodebuild: true do
     before(:all) do
       options = { project: "./scan/examples/standard/app.xcodeproj" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
@@ -7,7 +7,7 @@ describe Scan do
     end
 
     describe "xcpretty reporter options generation" do
-      it "generates options for the junit tempfile report required by scan", requires_xcodebuild: true do
+      it "generates options for the junit tempfile report required by scan" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html", "report.html", "/test_output", false)
         reporter_options = generator.generate_reporter_options
         temp_junit_report = Scan.cache[:temp_junit_report]
@@ -19,7 +19,7 @@ describe Scan do
                                              ])
       end
 
-      it "generates options for a custom junit report with default file name", requires_xcodebuild: true do
+      it "generates options for a custom junit report with default file name" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "junit", nil, "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -29,7 +29,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom junit report with custom file name", requires_xcodebuild: true do
+      it "generates options for a custom junit report with custom file name" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "junit", "junit.xml", "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -39,7 +39,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom html report with default file name", requires_xcodebuild: true do
+      it "generates options for a custom html report with default file name" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html", nil, "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -49,7 +49,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom html report with custom file name", requires_xcodebuild: true do
+      it "generates options for a custom html report with custom file name" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html", "custom_report.html", "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -59,7 +59,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom json-compilation-database file with default file name", requires_xcodebuild: true do
+      it "generates options for a custom json-compilation-database file with default file name" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "json-compilation-database", nil, "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -69,7 +69,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom json-compilation-database file with a custom file name", requires_xcodebuild: true do
+      it "generates options for a custom json-compilation-database file with a custom file name" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "json-compilation-database", "custom_report.json", "/test_output", false)
         reporter_options = generator.generate_reporter_options
 
@@ -79,7 +79,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a custom json-compilation-database file with a clang naming convention", requires_xcodebuild: true do
+      it "generates options for a custom json-compilation-database file with a clang naming convention" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "json-compilation-database", "ignore_custom_name_here.json", "/test_output", true)
         reporter_options = generator.generate_reporter_options
 
@@ -89,7 +89,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a multiple reports with default file names", requires_xcodebuild: true do
+      it "generates options for a multiple reports with default file names" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html,junit", nil, "/test_output", true)
         reporter_options = generator.generate_reporter_options
 
@@ -101,7 +101,7 @@ describe Scan do
                                                ])
       end
 
-      it "generates options for a multiple reports with default file names", requires_xcodebuild: true do
+      it "generates options for a multiple reports with default file names" do
         generator = Scan::XCPrettyReporterOptionsGenerator.new(false, "html,junit", "custom_report.html,junit.xml", "/test_output", true)
         reporter_options = generator.generate_reporter_options
 
@@ -114,7 +114,7 @@ describe Scan do
       end
 
       context "options passed as arrays" do
-        it "generates options for the junit tempfile report required by scan", requires_xcodebuild: true do
+        it "generates options for the junit tempfile report required by scan" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html"], ["report.html"], "test_output", false)
           reporter_options = generator.generate_reporter_options
           temp_junit_report = Scan.cache[:temp_junit_report]
@@ -126,7 +126,7 @@ describe Scan do
                                                ])
         end
 
-        it "generates options for a custom junit report with default file name", requires_xcodebuild: true do
+        it "generates options for a custom junit report with default file name" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["junit"], nil, "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -136,7 +136,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom junit report with custom file name", requires_xcodebuild: true do
+        it "generates options for a custom junit report with custom file name" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["junit"], ["junit.xml"], "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -146,7 +146,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom html report with default file name", requires_xcodebuild: true do
+        it "generates options for a custom html report with default file name" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html"], nil, "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -156,7 +156,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom html report with custom file name", requires_xcodebuild: true do
+        it "generates options for a custom html report with custom file name" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html"], ["custom_report.html"], "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -166,7 +166,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom json-compilation-database file with default file name", requires_xcodebuild: true do
+        it "generates options for a custom json-compilation-database file with default file name" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["json-compilation-database"], nil, "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -176,7 +176,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom json-compilation-database file with a custom file name", requires_xcodebuild: true do
+        it "generates options for a custom json-compilation-database file with a custom file name" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["json-compilation-database"], ["custom_report.json"], "/test_output", false)
           reporter_options = generator.generate_reporter_options
 
@@ -186,7 +186,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a custom json-compilation-database file with a clang naming convention", requires_xcodebuild: true do
+        it "generates options for a custom json-compilation-database file with a clang naming convention" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["json-compilation-database"], ["ignore_custom_name_here.json"], "/test_output", true)
           reporter_options = generator.generate_reporter_options
 
@@ -199,7 +199,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a multiple reports with default file names", requires_xcodebuild: true do
+        it "generates options for a multiple reports with default file names" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html", "junit"], nil, "/test_output", true)
           reporter_options = generator.generate_reporter_options
 
@@ -211,7 +211,7 @@ describe Scan do
                                                  ])
         end
 
-        it "generates options for a multiple reports with custom file names", requires_xcodebuild: true do
+        it "generates options for a multiple reports with custom file names" do
           generator = Scan::XCPrettyReporterOptionsGenerator.new(false, ["html", "junit"], ["custom_report.html", "junit.xml"], "/test_output", true)
           reporter_options = generator.generate_reporter_options
 
@@ -225,7 +225,7 @@ describe Scan do
       end
 
       context "generator created from Scan.config" do
-        it "generates options for a single reports while using custom_report_file_name", requires_xcodebuild: true do
+        it "generates options for a single reports while using custom_report_file_name" do
           options = {
             project: "./scan/examples/standard/app.xcodeproj",
             output_types: "junit,html",

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -64,13 +64,37 @@ RSpec.configure do |config|
 
   config.example_status_persistence_file_path = "/tmp/rspec_failed_tests.txt"
 
-  # disable/filter some tests if not running on mac
+  # skip some tests if not running on mac
   unless FastlaneCore::Helper.is_mac?
-    config.filter_run_excluding requires_xcode: true
-    config.filter_run_excluding requires_xcodebuild: true
-    config.filter_run_excluding requires_plistbuddy: true
-    config.filter_run_excluding requires_keychain: true
-    config.filter_run_excluding requires_security: true
+
+    # define metadata tags that also imply :skip
+    config.define_derived_metadata(:requires_xcode) do |meta|
+      meta[:skip] = "Skipped: Requires Xcode to be installed (which is not possible on this platform and no workaround has been implemented)"
+    end
+    config.define_derived_metadata(:requires_xcodebuild) do |meta|
+      meta[:skip] = "Skipped: Requires `xcodebuild` to be installed (which is not possible on this platform and no workaround has been implemented)"
+    end
+    config.define_derived_metadata(:requires_plistbuddy) do |meta|
+      meta[:skip] = "Skipped: Requires `plistbuddy` to be installed (which is not possible on this platform and no workaround has been implemented)"
+    end
+    config.define_derived_metadata(:requires_keychain) do |meta|
+      meta[:skip] = "Skipped: Requires `keychain` to be installed (which is not possible on this platform and no workaround has been implemented)"
+    end
+    config.define_derived_metadata(:requires_security) do |meta|
+      meta[:skip] = "Skipped: Requires `security` to be installed (which is not possible on this platform and no workaround has been implemented)"
+    end
+
+    # also skip `before()` for test groups that are skipped because of their tags
+    # only works for `describe` groups (that are parents of the `before`, not if the tag is set on `it`
+    # caution! has unexpected side effect on usage of `skip: false` for individual examples
+    # see https://groups.google.com/d/msg/rspec/5qeKQr_7G7k/Pb3ss2hOAAAJ
+    module HookOverrides
+      def before(*args)
+        super unless metadata[:skip]
+      end
+    end
+    config.extend HookOverrides
+
   end
 end
 


### PR DESCRIPTION
Skip examples that don't work on non-macOS platforms instead of filtering them (which marks and reports them as pending). also offer reasons for skipping.

(Implementation details via discussion at http://groups.google.com/forum/#!topic/rspec/5qeKQr_7G7k)

Gives output for Ubuntu:

> [17:45:21]: ▸ 4704 examples, 0 failures, 175 pending

No change in test output on macOS of course, so a bit hard to review. Please just note that it doesn't break macOS and everything is fine ;)

