### PR TITLE
Testflight: New method to create group

### DIFF
--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -111,6 +111,20 @@ module Spaceship::TestFlight
       handle_response(response)
     end
 
+    def create_group_for_app(app_id: nil, group_name: nil)
+      assert_required_params(__method__, binding)
+      body = {
+          'name' => group_name
+      }
+
+      response = request(:post) do |req|
+        req.url "providers/#{team_id}/apps/#{app_id}/groups"
+        req.body = body.to_json
+        req.headers['Content-Type'] = 'application/json'
+      end
+      handle_response(response)
+    end
+
     #####################################################
     # @!group Testers
     #####################################################

--- a/spaceship/lib/spaceship/test_flight/group.rb
+++ b/spaceship/lib/spaceship/test_flight/group.rb
@@ -21,6 +21,13 @@ module Spaceship::TestFlight
       'created' => :created
     })
 
+    def self.create!(app_id: nil, group_name: nil)
+      group = self.find(app_id: app_id, group_name: group_name)
+      return group unless group.nil?
+      data = client.create_group_for_app(app_id: app_id, group_name: group_name)
+      self.new(data)
+    end
+
     def self.all(app_id: nil)
       groups = client.get_groups(app_id: app_id)
       groups.map { |g| self.new(g) }

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -17,7 +17,6 @@ describe Spaceship::TestFlight::Client do
   subject { TestFlightTestClient.new(current_team_id: 'fake-team-id') }
   let(:app_id) { 'some-app-id' }
   let(:platform) { 'ios' }
-
   context '#assert_required_params' do
     it 'requires named parameters to be passed' do
       expect do
@@ -123,6 +122,15 @@ describe Spaceship::TestFlight::Client do
   ##
   # @!group Groups API
   ##
+
+  context '#create_group_for_app' do
+    let(:group_name) { 'some-group-name' }
+    it 'executes the request' do
+      MockAPI::TestFlightServer.post('/testflight/v2/providers/fake-team-id/apps/some-app-id/groups') {}
+      subject.create_group_for_app(app_id: app_id, group_name: group_name)
+      expect(WebMock).to have_requested(:post, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/groups')
+    end
+  end
 
   context '#get_groups' do
     it 'executes the request' do

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -17,6 +17,7 @@ describe Spaceship::TestFlight::Client do
   subject { TestFlightTestClient.new(current_team_id: 'fake-team-id') }
   let(:app_id) { 'some-app-id' }
   let(:platform) { 'ios' }
+
   context '#assert_required_params' do
     it 'requires named parameters to be passed' do
       expect do

--- a/spaceship/spec/test_flight/group_spec.rb
+++ b/spaceship/spec/test_flight/group_spec.rb
@@ -41,7 +41,7 @@ describe Spaceship::TestFlight::Group do
           }
         ]
       end
-      mock_client_response(:create_group_for_app, with: {app_id: 'app-id' , group_name: 'group-name'}) do
+      mock_client_response(:create_group_for_app, with: { app_id: 'app-id', group_name: 'group-name' }) do
         {
           id: 3,
           name: 'group-name',

--- a/spaceship/spec/test_flight/group_spec.rb
+++ b/spaceship/spec/test_flight/group_spec.rb
@@ -41,6 +41,13 @@ describe Spaceship::TestFlight::Group do
           }
         ]
       end
+      mock_client_response(:create_group_for_app, with: {app_id: 'app-id' , group_name: 'group-name'}) do
+        {
+          id: 3,
+          name: 'group-name',
+          isDefaultExternalGroup: false
+        }
+      end
     end
 
     context '.all' do
@@ -61,6 +68,22 @@ describe Spaceship::TestFlight::Group do
       it 'returns nil if no group matches' do
         group = Spaceship::TestFlight::Group.find(app_id: 'app-id', group_name: 'Group NaN')
         expect(group).to be_nil
+      end
+    end
+
+    context '.create!' do
+      it 'returns an existing group with the same name' do
+        group = Spaceship::TestFlight::Group.create!(app_id: 'app-id', group_name: 'Group 1')
+        expect(group.name).to eq('Group 1')
+        expect(group.id).to eq(1)
+        expect(group).to be_instance_of(Spaceship::TestFlight::Group)
+      end
+
+      it 'creates the group for correct parameters' do
+        group = Spaceship::TestFlight::Group.create!(app_id: 'app-id', group_name: 'group-name')
+        expect(group.name).to eq('group-name')
+        expect(group.id).to eq(3)
+        expect(group).to be_instance_of(Spaceship::TestFlight::Group)
       end
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- ✅  I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- ✅  I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- ✅  I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- ✅  I've updated the documentation if necessary.

### Motivation and Context
This new api will allow users to create a testing group in testflight.

I tested following scenarios on testflight : 
1. Created a group. - successfully created. 
2. Left parameters empty while calling this method. - error stating the parameter not provided.
3. Created a group with the name already present. - This returns a group that is already present. The post API creates a new group with the same name but different id and throws no warnings/errors, which might be an issue - so I am handling it here and returning the existing group.

From the above scenarios, I added spec tests for 1 & 3. Scenario 2 is common behaviour, which fastlane handles well as it is. 

### Description
I created a client method that takes the app id and group name and creates a group. I used this method in Spaceship::TestFlight::Group to implement a method called create!. I added spec tests where applicable. 