### PR TITLE
Improve error handling when parse plist file

### DIFF
--- a/fastlane/lib/fastlane/actions/get_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/get_info_plist_value.rb
@@ -10,7 +10,8 @@ module Fastlane
 
         begin
           path = File.expand_path(params[:path])
-          plist = Plist.parse_xml(path)
+
+          plist = File.open(path) { |f| Plist.parse_xml(f) }
 
           value = plist[params[:key]]
           Actions.lane_context[SharedValues::GET_INFO_PLIST_VALUE_CUSTOM_VALUE] = value
@@ -18,7 +19,6 @@ module Fastlane
           return value
         rescue => ex
           UI.error(ex)
-          UI.error("Unable to find plist file at '#{path}'")
         end
       end
 


### PR DESCRIPTION
The error is mis-leading. The plist file may exisits but in a format that we cannot parse(such as binary plist) leads to error like `invalid byte sequence in UTF-8`.

We need to handle this properly and output the correct error so user won't confuse.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->
