### PR TITLE
Flatten application_id in match

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -31,6 +31,10 @@ module Match
         app_identifiers = params[:app_identifier].to_s.split(/\s*,\s*/).uniq
       end
 
+      # sometimes we get an array with arrays, this is a bug. To unblock people using match, I suggest we flatten!
+      # then in the future address the root cause of https://github.com/fastlane/fastlane/issues/11324
+      app_identifiers.flatten!
+
       # Verify the App ID (as we don't want 'match' to fail at a later point)
       if spaceship
         app_identifiers.each do |app_identifier|


### PR DESCRIPTION
- workaround for #11324
Sometimes it's an array of arrays ¯\\_(ツ)_/¯