### PR TITLE
Enable rubocop cache on Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,6 @@ jobs:
 
       - restore_cache:
           key: v1-macos-gems-{{ checksum "Gemfile" }}
-      - restore_cache:
-          key: v1-{{ arch }}-rubocop
       - run:
           name: Setup Build
           command: |
@@ -32,6 +30,9 @@ jobs:
       - run:
           name: Check PR Metadata
           command: bundle exec danger || echo "danger failed"
+
+      - restore_cache:
+          key: v1-{{ arch }}-rubocop
 
       - run: bundle exec fastlane test
 
@@ -63,8 +64,6 @@ jobs:
 
       - restore_cache:
           key: v1-ubuntu-gems-{{ checksum "Gemfile" }}
-      - restore_cache:
-          key: v1-{{ arch }}-rubocop
       - run:
           name: Setup Build
           command: |
@@ -93,6 +92,9 @@ jobs:
       - run:
           name: Check PR Metadata
           command: bundle exec danger || echo "danger failed"
+
+      - restore_cache:
+          key: v1-{{ arch }}-rubocop
 
       - run: bundle exec fastlane test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             echo "2.3" > .ruby-version
             gem update --system
             brew install shellcheck
-            bundle check || bundle install --jobs=4 --retry=3 --path .bundle
+            bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
       - save_cache:
           key: v1-macos-gems-{{ checksum "Gemfile" }}
           paths:
@@ -69,7 +69,7 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            bundle check || bundle install --jobs=4 --retry=3 --path .bundle
+            bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
             sudo apt-get install shellcheck
       - save_cache:
           key: v1-ubuntu-gems-{{ checksum "Gemfile" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ jobs:
 
       - restore_cache:
           key: v1-macos-gems-{{ checksum "Gemfile" }}
+      - restore_cache:
+          key: v1-{{ arch }}-rubocop
       - run:
           name: Setup Build
           command: |
@@ -33,6 +35,10 @@ jobs:
 
       - run: bundle exec fastlane test
 
+      - save_cache:
+          key: v1-{{ arch }}-rubocop
+          paths:
+            - ~/.cache/rubocop_cache
       - store_test_results:
           path: ~/test-reports
       - store_artifacts:
@@ -57,6 +63,8 @@ jobs:
 
       - restore_cache:
           key: v1-ubuntu-gems-{{ checksum "Gemfile" }}
+      - restore_cache:
+          key: v1-{{ arch }}-rubocop
       - run:
           name: Setup Build
           command: |
@@ -88,6 +96,10 @@ jobs:
 
       - run: bundle exec fastlane test
 
+      - save_cache:
+          key: v1-{{ arch }}-rubocop
+          paths:
+            - ~/.cache/rubocop_cache
       - store_test_results:
           path: ~/test-reports
       - store_artifacts:


### PR DESCRIPTION
Rubocop has a cache which is used to speed up repeat processing of unchanged files. See their [manual entry](https://github.com/bbatsov/rubocop/blob/master/manual/caching.md) on caching.

From there:

> Later runs will be able to retrieve this information and present the
stored information instead of inspecting the file again. This will be
done if the cache for the file is still valid, which it is if there
are no changes in:
> * the contents of the inspected file
> * RuboCop configuration for the file
> * the options given to `rubocop`, with some exceptions that have no
>   bearing on which offenses are reported
> * the Ruby version used to invoke `rubocop`
> * version of the `rubocop` program (or to be precise, anything in the
>   source code of the invoked `rubocop` program)

So this cache should be easily reusable even between different branches, and would hopefully speed up Circle runs. 