### PR TITLE
Use name instead of UUID for .mobileprovision copy

### DIFF
--- a/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
@@ -392,6 +392,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -404,6 +405,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -415,6 +417,7 @@
 		77C503131DD3175E00AC8FF0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = today/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
@@ -428,6 +431,7 @@
 		77C503141DD3175E00AC8FF0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = today/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;

--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -42,6 +42,11 @@ module FastlaneCore
         parse(path).fetch("Name")
       end
 
+      # @return [String] The Apple TeamIdentifier of the given provisioning profile
+      def team_identifier(path)
+        parse(path).fetch("Entitlements").fetch("com.apple.developer.team-identifier")
+      end
+
       def profiles_path
         path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
         # If the directory doesn't exist, create it first
@@ -55,15 +60,13 @@ module FastlaneCore
       # Installs a provisioning profile for Xcode to use
       def install(path)
         UI.message("Installing provisioning profile...")
-        profile_filename = uuid(path) + ".mobileprovision"
+        profile_filename = team_identifier(path) + "_" + File.basename(path)
         destination = File.join(profiles_path, profile_filename)
 
         if path != destination
-          # copy to Xcode provisioning profile directory
+          # copy to Xcode provisioning profile directory and delete previous file if present
+          FileUtils.remove_entry(destination, force: true)
           FileUtils.copy(path, destination)
-          unless File.exist?(destination)
-            UI.user_error!("Failed installation of provisioning profile at location: '#{destination}'")
-          end
         end
 
         destination

--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -64,7 +64,7 @@ module FastlaneCore
         destination = File.join(profiles_path, profile_filename)
 
         if path != destination
-          # copy to Xcode provisioning profile directory and delete previous file if present
+          # copy to Xcode provisioning profile directory and delete previous .mobileprovision file if present
           FileUtils.remove_entry(destination, force: true)
           FileUtils.copy(path, destination)
         end

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -21,7 +21,7 @@ describe Match do
       repo_dir = Dir.mktmpdir
       cert_path = File.join(repo_dir, "something.cer")
       profile_path = "./match/spec/fixtures/test.mobileprovision"
-      destination = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision")
+      destination = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/439BBM9367_test.mobileprovision")
 
       expect(Match::GitHelper).to receive(:clone).with(git_url, true, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil, clone_branch_directly: false).and_return(repo_dir)
       expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution).and_return(cert_path)
@@ -56,7 +56,7 @@ describe Match do
                                                                 type: "appstore")]).to eql('439BBM9367')
       expect(ENV[Match::Utils.environment_variable_name_profile_name(app_identifier: "tools.fastlane.app",
                                                                      type: "appstore")]).to eql('tools.fastlane.app AppStore')
-      profile_path = File.expand_path('~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision')
+      profile_path = File.expand_path('~/Library/MobileDevice/Provisioning Profiles/439BBM9367_test.mobileprovision')
       expect(ENV[Match::Utils.environment_variable_name_profile_path(app_identifier: "tools.fastlane.app",
                                                                      type: "appstore")]).to eql(profile_path)
     end
@@ -96,7 +96,7 @@ describe Match do
                                                                 type: "appstore")]).to eql('439BBM9367')
       expect(ENV[Match::Utils.environment_variable_name_profile_name(app_identifier: "tools.fastlane.app",
                                                                      type: "appstore")]).to eql('match AppStore tools.fastlane.app 1449198835')
-      profile_path = File.expand_path('~/Library/MobileDevice/Provisioning Profiles/736590c3-dfe8-4c25-b2eb-2404b8e65fb8.mobileprovision')
+      profile_path = File.expand_path('~/Library/MobileDevice/Provisioning Profiles/439BBM9367_AppStore_tools.fastlane.app.mobileprovision')
       expect(ENV[Match::Utils.environment_variable_name_profile_path(app_identifier: "tools.fastlane.app",
                                                                      type: "appstore")]).to eql(profile_path)
     end

--- a/sigh/lib/sigh/local_manage.rb
+++ b/sigh/lib/sigh/local_manage.rb
@@ -15,8 +15,8 @@ module Sigh
     def self.install_profile(profile)
       UI.message "Installing provisioning profile..."
       profile_path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
-      uuid = ENV["SIGH_UUID"] || ENV["SIGH_UDID"]
-      profile_filename = uuid + ".mobileprovision"
+      name = ENV["SIGH_TEAM_ID"] + "_" + ENV["SIGH_PROFILE_FILE_NAME"] + ".mobileprovision"
+      profile_filename = File.basename(name)
       destination = profile_path + profile_filename
 
       # If the directory doesn't exist, make it first
@@ -24,14 +24,9 @@ module Sigh
         FileUtils.mkdir_p(profile_path)
       end
 
-      # copy to Xcode provisioning profile directory
-      FileUtils.copy profile, destination
-
-      if File.exist? destination
-        UI.success "Profile installed at \"#{destination}\""
-      else
-        UI.user_error!("Failed installation of provisioning profile at location: #{destination}")
-      end
+      # copy to Xcode provisioning profile directory and delete previous file if present
+      FileUtils.remove_entry(destination, force: true)
+      FileUtils.copy(profile, destination)
     end
 
     def self.get_inputs(options, _args)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
By default fastlane match generates the profiles with a descriptive name with Profile type (App Store, Enterprise, Development), and bundle id. 
Whenever profiles are recreated, which can happen for a multitude of reasons, such as adding new devices to the portal, a new entry appears inside the user's ~/"Library/MobileDevices/Provisioning Profiles" folder as each profile will have a different filename currently based on the profile UUID. With enough applications and enough variations of the profiles (One team for InHouse Distribution can have its enterprise, adhoc, and development profiles) which may easily lead to a folder growing a fair bit each time.

For the same reasons we use full manual signing with match or with our own match like setups, being able to have a single copy of a certain provisioning profile and not having to rely on Xcode or other tools to use the latest profiles created with all the devices you have just added, for example, it would be nice to have clear names for the profiles we install on our computer and replace the older one with the contents of the new one we have recreated. 

I am not sure if this Xcode behaviour was always there or if it occurred when the support for Provisioning Profile names instead of their UUID in your Xcode project signing settings landed (Xcode 8.x), but I have noticed that simply copying the files I downloaded from the Developer Portal in my ~/"Library/MobileDevices/Provisioning Profiles" folder ended up working just fine from Xcode's point of view. I also do realise that fastlane is a tool used by people that not only may have an appreciation for automation and DevOps-y stuff in general, but that have scaling needs (tons of apps, several Apple Developer Teams, mixing company and personal work, etc...).

This pull requests aims to have match copy the filename it has created as is, but adding a factor of uniqueness that should satisfy the needs we have. This would make the apparent structure of the final destination filename to be the following: 

> **<Apple_Developer_Team_ID>\_**<InHouse/Development/AppStore>\_<App Bundle ID>.mobileprovision

Part in bold is what this PR adds, the rest is the name match was already using.

The filename is calculated with the Team ID and the original name Fastlane created for the profile, helping the profile be unique (containing the risk of collisions), but not in such a way that we are providing protection from collision from itself, i.e. we allow by design the new profile name to be equal to the old profile name for the same Team ID, the same profile type, and the same bundle ID as before and we delete the older file if present before copying the new one.

### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran the unit tests, followed the instructions in https://github.com/fastlane/fastlane/blob/master/YourFirstPR.md#test-the-changes-for-your-application and used the local fastlane modified version  to sync all the provisioning profiles from the App Store, Enterprise, and Development provisioning profiles types 
```bash
#!/bin/bash

BUNDLE_IDS=("com.company.corp.app1" "com.company.corp.app2" "com.company.corp.app3" "com.company.corp.app4" "com.company.corp.app5" "com.company.corp.app6" "com.company.corp.app7" "com.company.corp.app8" "com.company.corp.app9" "com.company.corp.app10" "com.company.corp.app11" "com.company.corp.app12" "com.company.corp.app13" "com.company.corp.app14" "com.company.corp.app15")

for bundle_id in "${BUNDLE_IDS[@]}"; do
	echo "Building venture with bundle id $bundle_id"
	fastlane match development --readonly -a $bundle_id --team_name "Company" --skip_docs
done

[...]
```

```ruby
bundle exec rspec Match
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Changing stdout to /tmp/fastlane_tests, set `DEBUG` environment variable to print to stdout (e.g. when using `pry`)

Match::CommandsGenerator
  :appstore option handling
    can use the git_url short flag from tool options
    can use the git_branch flag from tool options
  :adhoc option handling
    can use the git_url short flag from tool options
    can use the git_branch flag from tool options
  :development option handling
    can use the git_url short flag from tool options
    can use the git_branch flag from tool options
  :enterprise option handling
    can use the git_url short flag from tool options
    can use the git_branch flag from tool options
  :change_password option handling
    can use the git_url short flag from tool options
    can use the shallow_clone flag from tool options
  :decrypt option handling
    can use the git_url short flag from tool options
    can use the shallow_clone flag from tool options
  nuke development option handling
    can use the git_url short flag from tool options
    can use the git_branch flag from tool options
  nuke distribution option handling
    can use the git_url short flag from tool options
    can use the git_branch flag from tool options

Match
  Match::Encrypt
    encrypt
    raises an exception if invalid password is passed
    raises an exception if no password is supplied

Match::Generator
  calling through to other tools
    configures cert correctly for nested execution
    configures sigh correctly for nested execution

Match
  Match::GitHelper
    generate_commit_message
      works
    #clone
      skips README file generation if so requested
      clones the repo
      clones the repo (not shallow)
      checks out a branch

Match
  Match::Runner
    creates a new profile and certificate if it doesn't exist yet
    uses existing certificates and profiles if they exist

Match
  Match::Setup
    works

Match
  Match::Utils
    import
      finds a normal keychain name relative to ~/Library/Keychains
      treats a keychain name it cannot find in ~/Library/Keychains as the full keychain path
      shows a user error if the keychain path cannot be resolved
      tries to find the macOS Sierra keychain too
    fill_environment
      #environment_variable_name uses the correct env variable
      #environment_variable_name_team_id uses the correct env variable
      #environment_variable_name_profile_name uses the correct env variable
      #environment_variable_name_profile_path uses the correct env variable
      pre-fills the environment

Finished in 1.34 seconds (files took 1.52 seconds to load)
38 examples, 0 failures
```

Robocop detected no issues:
```bash
bundle exec rubocop -a
Inspecting 989 files
.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

989 files inspected, no offenses detected
```

When running all tests on my machine I have 4 failures in portions of the code I have not touched and also occur if I do a clean clone of the official fastlane repo's master branch, install dependencies with bundler, and execute the tests. These are the results:
```bash
[...]

Failures:

  1) FastlaneCore::TagVersion correct? returns true for versions supported by Gem::Version
     Failure/Error: expect(FastlaneCore::TagVersion.correct?(tag)).to be true

       expected true
            got #<Fixnum:1> => 0
     # ./fastlane_core/spec/tag_version_spec.rb:20:in `block (3 levels) in <top (required)>'

  2) FastlaneCore::TagVersion correct? returns true for tags that can be converted to a Gem::Version using version_number_from_tag
     Failure/Error: expect(FastlaneCore::TagVersion.correct?(tag)).to be true

       expected true
            got #<Fixnum:1> => 0
     # ./fastlane_core/spec/tag_version_spec.rb:25:in `block (3 levels) in <top (required)>'

  3) FastlaneCore::TagVersion correct? returns false for tags that are not versions
     Failure/Error: expect(FastlaneCore::TagVersion.correct?(tag)).to be false

       expected false
            got nil
     # ./fastlane_core/spec/tag_version_spec.rb:30:in `block (3 levels) in <top (required)>'

Finished in 4 minutes 41.1 seconds (files took 2.83 seconds to load)
4735 examples, 3 failures

Failed examples:

rspec ./fastlane_core/spec/tag_version_spec.rb:18 # FastlaneCore::TagVersion correct? returns true for versions supported by Gem::Version
rspec ./fastlane_core/spec/tag_version_spec.rb:23 # FastlaneCore::TagVersion correct? returns true for tags that canbe converted to a Gem::Version using version_number_from_tag
rspec ./fastlane_core/spec/tag_version_spec.rb:28 # FastlaneCore::TagVersion correct? returns false for tags that are not versions
```

This is my gem env
```bash
RubyGems Environment:
  - RUBYGEMS VERSION: 2.6.14
  - RUBY VERSION: 2.3.3 (2016-11-21 patchlevel 222) [x86_64-darwin16]
  - INSTALLATION DIRECTORY: /Users/goff.marocchi/.rvm/gems/ruby-2.3.3
  - USER INSTALLATION DIRECTORY: /Users/goff.marocchi/.gem/ruby/2.3.0
  - RUBY EXECUTABLE: /Users/goff.marocchi/.rvm/rubies/ruby-2.3.3/bin/ruby
  - EXECUTABLE DIRECTORY: /Users/goff.marocchi/.rvm/gems/ruby-2.3.3/bin
  - SPEC CACHE DIRECTORY: /Users/goff.marocchi/.gem/specs
  - SYSTEM CONFIGURATION DIRECTORY: /Users/goff.marocchi/.rvm/rubies/ruby-2.3.3/etc
  - RUBYGEMS PLATFORMS:
    - ruby
    - x86_64-darwin-16
  - GEM PATHS:
     - /Users/goff.marocchi/.rvm/gems/ruby-2.3.3
     - /Users/goff.marocchi/.rvm/gems/ruby-2.3.3@global
  - GEM CONFIGURATION:
     - :update_sources => true
     - :verbose => true
     - :backtrace => false
     - :bulk_threshold => 1000
  - REMOTE SOURCES:
     - https://rubygems.org/
  - SHELL PATH:
     - /Users/goff.marocchi/.rvm/gems/ruby-2.3.3/bin
     - /Users/goff.marocchi/.rvm/gems/ruby-2.3.3@global/bin
```

### Changes Description
<!-- Describe your changes in detail -->
The major change in the code is really in the file that manages the provisioning profiles (provisioning_profiles.rb in fastlane_core):
```ruby
      # @return [String] The Apple TeamIdentifier of the given provisioning profile
      def team_identifier(path)
        parse(path).fetch("Entitlements").fetch("com.apple.developer.team-identifier")
      end

      def profiles_path
        path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
        # If the directory doesn't exist, create it first
        unless File.directory?(path)
          FileUtils.mkdir_p(path)
        end

        return path
      end

      # Installs a provisioning profile for Xcode to use
      def install(path)
        UI.message("Installing provisioning profile...")
        profile_filename = team_identifier(path) + "_" + File.basename(path)
        destination = File.join(profiles_path, profile_filename)

        if path != destination
          # copy to Xcode provisioning profile directory and delete previous file if present
          FileUtils.remove_entry(destination, force: true)
          FileUtils.copy(path, destination)
        end

        destination
      end
```

The filename is calculated with the Team ID and the original name Fastlane created for the profile, helping the profile be unique (containing the risk of collisions), but not in such a way that we are providing protection from collision from itself, i.e. we allow by design the new profile name to be equal to the old profile name for the same Team ID, the same profile type, and the same bundle ID as before and we delete the older file if present before copying the new one.