### PR TITLE
Use provisioning profile name instead of UUID for .mobileprovision

### DIFF
--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -154,7 +154,12 @@ module Match
                                      env_name: "MATCH_PROVISIONING_PROFILE_TEMPLATE_NAME",
                                      description: "The name of provisioning profile template. If the developer account has provisioning profile templates, template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile",
                                      optional: true,
-                                     default_value: nil)
+                                     default_value: nil),
+        FastlaneCore::ConfigItem.new(key: :provisioning_profile_names_mode,
+                                     short_option: "-m",
+                                     env_name: "FASTLANE_MOBILE_PROVISION_FILES_NAMES_MODE",
+                                     description: "Using regular UUID based names for provisioning profile names (default value for the option is 'UUID') or use a name that is unique, but will reduce the number of profiles stored when they are recreated (provide the following value for the option 'PROFILES_NAME')",
+                                     default_value: "UUID")
       ]
     end
   end

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -167,7 +167,7 @@ module Match
         self.files_to_commmit << profile
       end
 
-      installed_profile = FastlaneCore::ProvisioningProfile.install(profile)
+      installed_profile = FastlaneCore::ProvisioningProfile.install(profile, params[:provisioning_profile_names_mode])
 
       parsed = FastlaneCore::ProvisioningProfile.parse(profile)
       uuid = parsed["UUID"]

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -6,6 +6,7 @@ describe Match do
       allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with('MATCH_KEYCHAIN_NAME').and_return(keychain)
       allow(ENV).to receive(:[]).with('MATCH_KEYCHAIN_PASSWORD').and_return(nil)
+      allow(ENV).to receive(:[]).with('FASTLANE_MOBILE_PROVISION_FILES_NAMES_MODE').and_return('UUID')
     end
 
     it "creates a new profile and certificate if it doesn't exist yet", requires_security: true do
@@ -29,7 +30,7 @@ describe Match do
                                                                             prov_type: :appstore,
                                                                        certificate_id: "something",
                                                                        app_identifier: values[:app_identifier]).and_return(profile_path)
-      expect(FastlaneCore::ProvisioningProfile).to receive(:install).with(profile_path).and_return(destination)
+      expect(FastlaneCore::ProvisioningProfile).to receive(:install).with(profile_path, "UUID").and_return(destination)
       expect(Match::GitHelper).to receive(:commit_changes).with(
         repo_dir,
         "[fastlane] Updated appstore and platform ios",
@@ -97,6 +98,110 @@ describe Match do
       expect(ENV[Match::Utils.environment_variable_name_profile_name(app_identifier: "tools.fastlane.app",
                                                                      type: "appstore")]).to eql('match AppStore tools.fastlane.app 1449198835')
       profile_path = File.expand_path('~/Library/MobileDevice/Provisioning Profiles/736590c3-dfe8-4c25-b2eb-2404b8e65fb8.mobileprovision')
+      expect(ENV[Match::Utils.environment_variable_name_profile_path(app_identifier: "tools.fastlane.app",
+                                                                     type: "appstore")]).to eql(profile_path)
+    end
+  end
+
+  describe Match::Runner do
+    let(:keychain) { 'login.keychain' }
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('MATCH_KEYCHAIN_NAME').and_return(keychain)
+      allow(ENV).to receive(:[]).with('MATCH_KEYCHAIN_PASSWORD').and_return(nil)
+      allow(ENV).to receive(:[]).with('FASTLANE_MOBILE_PROVISION_FILES_NAMES_MODE').and_return('PROFILES_NAME')
+    end
+
+    it "creates a new profile and certificate if it doesn't exist yet [PROFILES_NAME mode]", requires_security: true do
+      git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
+      values = {
+        app_identifier: "tools.fastlane.app",
+        type: "appstore",
+        git_url: git_url,
+        shallow_clone: true
+      }
+
+      config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+      repo_dir = Dir.mktmpdir
+      cert_path = File.join(repo_dir, "something.cer")
+      profile_path = "./match/spec/fixtures/test.mobileprovision"
+      destination = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/439BBM9367_test.mobileprovision")
+
+      expect(Match::GitHelper).to receive(:clone).with(git_url, true, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil, clone_branch_directly: false).and_return(repo_dir)
+      expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution).and_return(cert_path)
+      expect(Match::Generator).to receive(:generate_provisioning_profile).with(params: config,
+                                                                            prov_type: :appstore,
+                                                                       certificate_id: "something",
+                                                                       app_identifier: values[:app_identifier]).and_return(profile_path)
+      expect(FastlaneCore::ProvisioningProfile).to receive(:install).with(profile_path, "PROFILES_NAME").and_return(destination)
+      expect(Match::GitHelper).to receive(:commit_changes).with(
+        repo_dir,
+        "[fastlane] Updated appstore and platform ios",
+        git_url,
+        "master",
+        [
+          File.join(repo_dir, "something.cer"),
+          File.join(repo_dir, "something.p12"), # this is important, as a cert consists out of 2 files
+          "./match/spec/fixtures/test.mobileprovision"
+        ]
+      )
+
+      spaceship = "spaceship"
+      expect(Match::SpaceshipEnsure).to receive(:new).and_return(spaceship)
+      expect(spaceship).to receive(:certificate_exists).and_return(true)
+      expect(spaceship).to receive(:profile_exists).and_return(true)
+      expect(spaceship).to receive(:bundle_identifier_exists).and_return(true)
+
+      Match::Runner.new.run(config)
+
+      expect(ENV[Match::Utils.environment_variable_name(app_identifier: "tools.fastlane.app",
+                                                        type: "appstore")]).to eql('98264c6b-5151-4349-8d0f-66691e48ae35')
+      expect(ENV[Match::Utils.environment_variable_name_team_id(app_identifier: "tools.fastlane.app",
+                                                                type: "appstore")]).to eql('439BBM9367')
+      expect(ENV[Match::Utils.environment_variable_name_profile_name(app_identifier: "tools.fastlane.app",
+                                                                     type: "appstore")]).to eql('tools.fastlane.app AppStore')
+      profile_path = File.expand_path('~/Library/MobileDevice/Provisioning Profiles/439BBM9367_test.mobileprovision')
+      expect(ENV[Match::Utils.environment_variable_name_profile_path(app_identifier: "tools.fastlane.app",
+                                                                     type: "appstore")]).to eql(profile_path)
+    end
+
+    it "uses existing certificates and profiles if they exist [PROFILES_NAME mode]", requires_security: true do
+      git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
+      values = {
+        app_identifier: "tools.fastlane.app",
+        type: "appstore",
+        git_url: git_url
+      }
+
+      config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+      repo_dir = "./match/spec/fixtures/existing"
+      cert_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.cer"
+      key_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.p12"
+
+      expect(Match::GitHelper).to receive(:clone).with(git_url, false, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil, clone_branch_directly: false).and_return(repo_dir)
+      expect(Match::Utils).to receive(:import).with(key_path, keychain, password: nil).and_return(nil)
+      expect(Match::GitHelper).to_not(receive(:commit_changes))
+
+      # To also install the certificate, fake that
+      expect(FastlaneCore::CertChecker).to receive(:installed?).with(cert_path).and_return(false)
+      expect(Match::Utils).to receive(:import).with(cert_path, keychain, password: nil).and_return(nil)
+
+      spaceship = "spaceship"
+      expect(Match::SpaceshipEnsure).to receive(:new).and_return(spaceship)
+      expect(spaceship).to receive(:certificate_exists).and_return(true)
+      expect(spaceship).to receive(:profile_exists).and_return(true)
+      expect(spaceship).to receive(:bundle_identifier_exists).and_return(true)
+
+      Match::Runner.new.run(config)
+
+      expect(ENV[Match::Utils.environment_variable_name(app_identifier: "tools.fastlane.app",
+                                                        type: "appstore")]).to eql('736590c3-dfe8-4c25-b2eb-2404b8e65fb8')
+      expect(ENV[Match::Utils.environment_variable_name_team_id(app_identifier: "tools.fastlane.app",
+                                                                type: "appstore")]).to eql('439BBM9367')
+      expect(ENV[Match::Utils.environment_variable_name_profile_name(app_identifier: "tools.fastlane.app",
+                                                                     type: "appstore")]).to eql('match AppStore tools.fastlane.app 1449198835')
+      profile_path = File.expand_path('~/Library/MobileDevice/Provisioning Profiles/439BBM9367_AppStore_tools.fastlane.app.mobileprovision')
       expect(ENV[Match::Utils.environment_variable_name_profile_path(app_identifier: "tools.fastlane.app",
                                                                      type: "appstore")]).to eql(profile_path)
     end

--- a/sigh/lib/sigh/local_manage.rb
+++ b/sigh/lib/sigh/local_manage.rb
@@ -20,6 +20,7 @@ module Sigh
     def self.install_profile(profile)
       UI.message("Installing provisioning profile...")
       profile_path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
+
       uuid = ENV["SIGH_UUID"] || ENV["SIGH_UDID"]
       profile_filename = uuid + ".mobileprovision"
       destination = profile_path + profile_filename
@@ -29,13 +30,28 @@ module Sigh
         FileUtils.mkdir_p(profile_path)
       end
 
-      # copy to Xcode provisioning profile directory
-      FileUtils.copy(profile, destination)
+      if ENV['FASTLANE_MOBILE_PROVISION_FILES_MODE'] == "PROFILES_NAME"
+        # Remove previous generation provisioning profile name
+        #  to avoid installing the same file twice with different file names
+        FileUtils.remove_entry(destination, force: true)
 
-      if File.exist?(destination)
-        UI.success("Profile installed at \"#{destination}\"")
+        # Calculate new name
+        name = ENV["SIGH_TEAM_ID"] + "_" + ENV["SIGH_PROFILE_FILE_NAME"] + ".mobileprovision"
+        profile_filename = File.basename(name)
+        destination = profile_path + profile_filename
+
+        # Copy to Xcode provisioning profile directory and delete previous file if present
+        FileUtils.remove_entry(destination, force: true)
+        FileUtils.copy(profile, destination)
       else
-        UI.user_error!("Failed installation of provisioning profile at location: #{destination}")
+        # copy to Xcode provisioning profile directory
+        FileUtils.copy(profile, destination)
+
+        if File.exist?(destination)
+          UI.success("Profile installed at \"#{destination}\"")
+        else
+          UI.user_error!("Failed installation of provisioning profile at location: #{destination}")
+        end
       end
     end
 

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -9,7 +9,8 @@ require_relative 'du/du_stubbing'
 set_auth_vars = [
   'FASTLANE_SESSION',
   'FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD',
-  'FASTLANE_PASSWORD'
+  'FASTLANE_PASSWORD',
+  'FASTLANE_MOBILE_PROVISION_FILES_MODE'
 ].select { |var| ENV.key?(var) }
 
 if set_auth_vars.any?


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
By default fastlane match generates the profiles with a descriptive name with Profile type (App Store, Enterprise, Development), and bundle id. 
Whenever profiles are recreated, which can happen for a multitude of reasons, such as adding new devices to the portal, a new entry appears inside the user's ~/"Library/MobileDevices/Provisioning Profiles" folder as each profile will have a different filename currently based on the profile UUID. With enough applications and enough variations of the profiles (One team for InHouse Distribution can have its enterprise, adhoc, and development profiles) which may easily lead to a folder growing a fair bit each time.

For the same reasons we use full manual signing with match or with our own match like setups, being able to have a single copy of a certain provisioning profile and not having to rely on Xcode or other tools to use the latest profiles created with all the devices you have just added, for example, it would be nice to have clear names for the profiles we install on our computer and replace the older one with the contents of the new one we have recreated. 

I am not sure if this Xcode behaviour was always there or if it occurred when the support for Provisioning Profile names instead of their UUID in your Xcode project signing settings landed (Xcode 8.x), but I have noticed that simply copying the files I downloaded from the Developer Portal in my ~/"Library/MobileDevices/Provisioning Profiles" folder ended up working just fine from Xcode's point of view. I also do realise that fastlane is a tool used by people that not only may have an appreciation for automation and DevOps-y stuff in general, but that have scaling needs (tons of apps, several Apple Developer Teams, mixing company and personal work, etc...).

This pull requests aims to have match copy the filename it has created as is, but adding a factor of uniqueness that should satisfy the needs we have. This would make the apparent structure of the final destination filename to be the following: 

> **<Apple_Dev_Team_ID>\_**<InHouse/Development/AppStore>\_<App_Bundle_ID>.mobileprovision

Part in bold is what this PR adds, the rest is the name match was already using.

The filename is calculated with the Team ID and the original name Fastlane created for the profile, helping the profile be unique (containing the risk of collisions), but not in such a way that we are providing protection from collision from itself, i.e. we allow by design the new profile name to be equal to the old profile name for the same Team ID, the same profile type, and the same bundle ID as before and we delete the older file if present before copying the new one.
In order to prevent duplicates, i.e. if the sync process installs a profiles that is already installed and has not been regenerated just with the new name instead of the old UUID style based name, the old style filename is calculated and if the file is available on the destination folder it is deleted before copying the new file.

In order to improve backward compatibility, this behaviour is only activated when either the **FASTLANE_MOBILE_PROVISION_FILES_NAMES_MODE** environment variable is set or when the **-m** flag is passed to fastlane match.

### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran the unit tests, followed the instructions in https://github.com/fastlane/fastlane/blob/master/YourFirstPR.md#test-the-changes-for-your-application and used the local fastlane modified version  to sync all the provisioning profiles from the App Store, Enterprise, and Development provisioning profiles types 
```bash
#!/bin/bash

BUNDLE_IDS=("com.company.corp.app1" "com.company.corp.app2" "com.company.corp.app3" "com.company.corp.app4" "com.company.corp.app5" "com.company.corp.app6" "com.company.corp.app7" "com.company.corp.app8" "com.company.corp.app9" "com.company.corp.app10" "com.company.corp.app11" "com.company.corp.app12" "com.company.corp.app13" "com.company.corp.app14" "com.company.corp.app15")

if [ "${1}" == "PROFILES_NAME" ]; then
	optionProfiles="${1}"
	echo "optionProfiles = ${optionProfiles}"
	fastlane match development --readonly -a $BUNDLE_IDS --team_name "<CompanyName>" --skip_docs -m ${optionProfiles}
else
	fastlane match development --readonly -a $BUNDLE_IDS --team_name "<Company Name>" --skip_docs
fi

[...]
```

```ruby
bundle exec rspec Match
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Changing stdout to /tmp/fastlane_tests, set `DEBUG` environment variable to print to stdout (e.g. when using `pry`)

[...]

Spaceship::Tunes::Members
  members
    should return a list with members
    finds one member by email
    creates a new member
      role: admin, apps: all
      role: developer apps: all
      role: appmanager, apps: 898536088
    updates roles and apps for an existing member
      role: admin, apps: all
      role: developer apps: all
      role: appmanager, apps: 898536088

Spaceship::Tunes::Territory
  supported_territories
    inspect works
    correctly creates all territories
    correctly parses the territories

Spaceship::Tunes::SandboxTester
  Sandbox testers
    listing
      loads sandbox testers correctly
    creation
      creates sandbox testers correctly
    deletion
      deletes a user
      deletes all users

Spaceship::TunesClient
  #login
    raises an exception if authentication failed
  client
    exposes the session cookie
  Logged in
    stores the username
    #hostname
    #handle_itc_response
      raises an exception if something goes wrong
      does nothing if everything works as expected and returns the original data
      identifies try again later responses
  CI
    crashes when running in non-interactive shell

Spaceship::Tunes
  InsufficientPermissions
    raises an appropriate iTunes Connect error when user doesn't have enough permission to do something

Supply
  Supply::Client
    AndroidPublisher
      has all the expected Google API methods

Supply::CommandsGenerator
  :run options handling
    can use the skip_upload_metadata flag from tool options
  :init options handling
    can use the package_name short flag from tool options

Supply
  Supply::Uploader
    #find_obbs
      finds no obb when there's none to find
      skips unrecognized obbs
      finds one match and one patch obb
      finds zero obb if too main mains
      finds zero obb if too many patches
    metadata encoding
      prints a user friendly error message if metadata is not UTF-8 encoded
    all_languages
      only grabs directories
    check superseded tracks
      remove lesser than the greatest of any later (i.e. production) track
      remove lesser than the currently being uploaded if it is in an earlier (i.e. alpha) track
      combined case

Finished in 5 minutes 55 seconds (files took 6.12 seconds to load)
4745 examples, 0 failures
```

Robocop detected no issues:
```bash
bundle exec rubocop -a
Inspecting 1018 files
................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................./Users/goff.marocchi/Programming/workspace/gitGamesys/GitHub/Signing/fastlaneSigning/fastlane/spaceship/lib/spaceship/ui.rb: Naming/MethodName has the wrong namespace - should be Style
/Users/goff.marocchi/Programming/workspace/gitGamesys/GitHub/Signing/fastlaneSigning/fastlane/spaceship/lib/spaceship/ui.rb: Naming/MethodName has the wrong namespace - should be Style
.........................................................................................................................

1018 files inspected, no offenses detected
```

When running all tests on my machine I have 4 failures in portions of the code I have not touched and also occur if I do a clean clone of the official fastlane repo's master branch, install dependencies with bundler, and execute the tests. These are the results:
```bash
[...]

Failures:

  1) FastlaneCore::TagVersion correct? returns true for versions supported by Gem::Version
     Failure/Error: expect(FastlaneCore::TagVersion.correct?(tag)).to be true

       expected true
            got #<Fixnum:1> => 0
     # ./fastlane_core/spec/tag_version_spec.rb:20:in `block (3 levels) in <top (required)>'

  2) FastlaneCore::TagVersion correct? returns true for tags that can be converted to a Gem::Version using version_number_from_tag
     Failure/Error: expect(FastlaneCore::TagVersion.correct?(tag)).to be true

       expected true
            got #<Fixnum:1> => 0
     # ./fastlane_core/spec/tag_version_spec.rb:25:in `block (3 levels) in <top (required)>'

  3) FastlaneCore::TagVersion correct? returns false for tags that are not versions
     Failure/Error: expect(FastlaneCore::TagVersion.correct?(tag)).to be false

       expected false
            got nil
     # ./fastlane_core/spec/tag_version_spec.rb:30:in `block (3 levels) in <top (required)>'

Finished in 4 minutes 41.1 seconds (files took 2.83 seconds to load)
4735 examples, 3 failures

Failed examples:

rspec ./fastlane_core/spec/tag_version_spec.rb:18 # FastlaneCore::TagVersion correct? returns true for versions supported by Gem::Version
rspec ./fastlane_core/spec/tag_version_spec.rb:23 # FastlaneCore::TagVersion correct? returns true for tags that canbe converted to a Gem::Version using version_number_from_tag
rspec ./fastlane_core/spec/tag_version_spec.rb:28 # FastlaneCore::TagVersion correct? returns false for tags that are not versions
```

This is my gem env
```bash
RubyGems Environment:
  - RUBYGEMS VERSION: 2.6.14
  - RUBY VERSION: 2.3.3 (2016-11-21 patchlevel 222) [x86_64-darwin16]
  - INSTALLATION DIRECTORY: /Users/goff.marocchi/.rvm/gems/ruby-2.3.3
  - USER INSTALLATION DIRECTORY: /Users/goff.marocchi/.gem/ruby/2.3.0
  - RUBY EXECUTABLE: /Users/goff.marocchi/.rvm/rubies/ruby-2.3.3/bin/ruby
  - EXECUTABLE DIRECTORY: /Users/goff.marocchi/.rvm/gems/ruby-2.3.3/bin
  - SPEC CACHE DIRECTORY: /Users/goff.marocchi/.gem/specs
  - SYSTEM CONFIGURATION DIRECTORY: /Users/goff.marocchi/.rvm/rubies/ruby-2.3.3/etc
  - RUBYGEMS PLATFORMS:
    - ruby
    - x86_64-darwin-16
  - GEM PATHS:
     - /Users/goff.marocchi/.rvm/gems/ruby-2.3.3
     - /Users/goff.marocchi/.rvm/gems/ruby-2.3.3@global
  - GEM CONFIGURATION:
     - :update_sources => true
     - :verbose => true
     - :backtrace => false
     - :bulk_threshold => 1000
  - REMOTE SOURCES:
     - https://rubygems.org/
  - SHELL PATH:
     - /Users/goff.marocchi/.rvm/gems/ruby-2.3.3/bin
     - /Users/goff.marocchi/.rvm/gems/ruby-2.3.3@global/bin
```

### Changes Description
<!-- Describe your changes in detail -->
The major change in the code is really in the file that manages the provisioning profiles (provisioning_profiles.rb in fastlane_core):
```ruby
      # @return [String] The UUID of the given provisioning profile
      def uuid(path)
        parse(path).fetch("UUID")
      end

      # @return [String] The Name of the given provisioning profile
      def name(path)
        parse(path).fetch("Name")
      end

      # @return [String] The Apple TeamIdentifier of the given provisioning profile
      def team_identifier(path)
        parse(path).fetch("Entitlements").fetch("com.apple.developer.team-identifier")
      end

      def profiles_path
        path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
        # If the directory doesn't exist, create it first
        unless File.directory?(path)
          FileUtils.mkdir_p(path)
        end

        return path
      end

      # Installs a provisioning profile for Xcode to use
      def install(path, provisioning_profiles_mode_option = nil)
        UI.message("Installing provisioning profile...")
        profile_filename = uuid(path) + ".mobileprovision"
        destination = File.join(profiles_path, profile_filename)

        if path != destination

          if ENV['FASTLANE_MOBILE_PROVISION_FILES_NAMES_MODE'] == "PROFILES_NAME" || provisioning_profiles_mode_option == "PROFILES_NAME"
            # Remove previous generation provisioning profile name
            #  to avoid installing the same file twice with different file names
            FileUtils.remove_entry(destination, force: true)

            # Copy to Xcode provisioning profile directory and delete previous file if present
            profile_filename = team_identifier(path) + "_" + File.basename(path)
            destination = File.join(profiles_path, profile_filename)

            FileUtils.remove_entry(destination, force: true)
            FileUtils.copy(path, destination)
          else
            FileUtils.copy(path, destination)
            unless File.exist?(destination)
              UI.user_error!("Failed installation of provisioning profile at location: '#{destination}'")
            end
          end
        end
```

The filename is calculated with the Team ID and the original name Fastlane created for the profile, helping the profile be unique (containing the risk of collisions), but not in such a way that we are providing protection from collision from itself, i.e. we allow by design the new profile name to be equal to the old profile name for the same Team ID, the same profile type, and the same bundle ID as before and we delete the older file if present before copying the new one.
In order to prevent duplicates, i.e. if the sync process installs a profiles that is already installed and has not been regenerated just with the new name instead of the old UUID style based name, the old style filename is calculated and if the file is available on the destination folder it is deleted before copying the new file.

  