### PR TITLE
Add loading indicator for fastlane startup time

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -44,7 +44,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'public_suffix', '~> 2.0.0' # https://github.com/fastlane/fastlane/issues/10162
 
   # TTY dependencies
-  spec.add_dependency 'tty-screen', '~> 0.6.3' # detect the terminal width
+  spec.add_dependency 'tty-screen', '>= 0.6.3', '< 1.0.0' # detect the terminal width
+  spec.add_dependency 'tty-spinner', '>= 0.7.0', '< 1.0.0' # loading indicators
 
   spec.add_dependency 'babosa', '>= 1.0.2', "< 2.0.0"
   spec.add_dependency 'colored' # colored terminal output

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -15,7 +15,12 @@ module Fastlane
       def take_off
         before_import_time = Time.now
 
+        require "tty-spinner"
+
+        require_fastlane_spinner = TTY::Spinner.new("[:spinner] 🚀 ", format: :dots)
+        require_fastlane_spinner.auto_spin
         require "fastlane" # this might take a long time if there is no Gemfile :(
+        require_fastlane_spinner.success
 
         # We want to avoid printing output other than the version number if we are running `fastlane -v`
         unless running_version_command?


### PR DESCRIPTION
- This adds a light-weight dependeny, part of the trusted `tty` tools
- I was thinking of adding more and more loading indicators as we go, but this one is the most obvious, as for people without a `Gemfile` wait for multiple seconds here without any output at all

GitHub doesn't support video attachments unfortunately