### PR TITLE
Clean up fixture for automatic_code_signing_spec after tests are done

### DIFF
--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -7,6 +7,16 @@ describe Fastlane do
       allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
     end
 
+    after :all do
+      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project.targets.each do |target|
+        target.build_configurations.each do |configuration|
+          configuration.build_settings.delete('CODE_SIGN_STYLE')
+        end
+      end
+      project.save
+    end
+
     it "enable_automatic_code_signing" do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use ProvisioningStyle 'Automatic'")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- ✅ I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- ✅ I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- ✅  I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- ✅  I've updated the documentation if necessary.

### Motivation and Context
This change fixes the issue raised here : https://github.com/fastlane/fastlane/issues/11348
I ran the tests by `bundle exec rspec` and checked the `git diff` and the file was no longer modified at the end of the tests.

### Description
I added an `after :all` block - which runs after the tests are done. In it, I deleted the entries added by the rspec tests. This was necessary, because the project needs to be modified in order for the successful testing. So the only way to have a clean project afterwards is to delete those entries.