### PR TITLE
Fix gym `GYM_OUTPUT_NAME` with `.ipa` extension causes duplicate `.ipa` extension

### DIFF
--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -30,6 +30,11 @@ module Gym
 
       config[:build_path] ||= archive_path_from_local_xcode_preferences
 
+      # Make sure the output name is valid and remove a trailing `.ipa` extension
+      # as it will be added by gym for free
+      config[:output_name].gsub!(".ipa", "")
+      config[:output_name].gsub!(File::SEPARATOR, "_")
+
       return config
     end
 

--- a/gym/lib/gym/manager.rb
+++ b/gym/lib/gym/manager.rb
@@ -8,11 +8,6 @@ module Gym
       values = Gym.config.values(ask: false)
       values[:xcode_path] = File.expand_path("../..", FastlaneCore::Helper.xcode_path)
 
-      # Make sure the output name is valid and remove a trailing `.ipa` extension
-      # as it will be added by gym for free
-      values[:output_name].gsub!(".ipa", "")
-      values[:output_name].gsub!(File::SEPARATOR, "_")
-
       FastlaneCore::PrintTable.print_values(config: values,
                                          hide_keys: [],
                                              title: "Summary for gym #{Fastlane::VERSION}")

--- a/gym/lib/gym/manager.rb
+++ b/gym/lib/gym/manager.rb
@@ -7,6 +7,12 @@ module Gym
       # We go 2 folders up, to not show "Contents/Developer/"
       values = Gym.config.values(ask: false)
       values[:xcode_path] = File.expand_path("../..", FastlaneCore::Helper.xcode_path)
+
+      # Make sure the output name is valid and remove a trailing `.ipa` extension
+      # as it will be added by gym for free
+      values[:output_name].gsub!(".ipa", "")
+      values[:output_name].gsub!(File::SEPARATOR, "_")
+
       FastlaneCore::PrintTable.print_values(config: values,
                                          hide_keys: [],
                                              title: "Summary for gym #{Fastlane::VERSION}")

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -61,11 +61,7 @@ module Gym
                                      short_option: "-n",
                                      env_name: "GYM_OUTPUT_NAME",
                                      description: "The name of the resulting ipa file",
-                                     optional: true,
-                                     verify_block: proc do |value|
-                                       value.gsub!(".ipa", "")
-                                       value.gsub!(File::SEPARATOR, "_")
-                                     end),
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :configuration,
                                      short_option: "-q",
                                      env_name: "GYM_CONFIGURATION",


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/11356