### PR TITLE
Integrate Mindera's cosigner plugin into fastlane

### DIFF
--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -16,7 +16,7 @@ module Fastlane
           return false
         end
 
-        target_dictionary = project.targets.map { |f| { name: f.name, uuid: f.uuid } }
+        target_dictionary = project.targets.map { |f| { name: f.name, uuid: f.uuid, build_configuration_list: f.build_configuration_list } }
         changed_targets = []
         project.root_object.attributes["TargetAttributes"].each do |target, sett|
           found_target = target_dictionary.detect { |h| h[:uuid] == target }
@@ -29,15 +29,32 @@ module Fastlane
           end
 
           style_value = params[:use_automatic_signing] ? 'Automatic' : 'Manual'
-          target = project.targets.find { |t| t.name == found_target[:name] }
-          target.build_configurations.each do |configuration|
-            configuration.build_settings["CODE_SIGN_STYLE"] = style_value
-          end
+          build_configuration_list = found_target[:build_configuration_list]
+          build_configuration_list.set_setting("CODE_SIGN_STYLE", style_value)
           sett["ProvisioningStyle"] = style_value
+
           if params[:team_id]
             sett["DevelopmentTeam"] = params[:team_id]
             UI.important("Set Team id to: #{params[:team_id]} for target: #{found_target[:name]}")
           end
+          if params[:code_sign_identity]
+            build_configuration_list.set_setting("CODE_SIGN_IDENTITY", params[:code_sign_identity])
+            UI.important("Set Code Sign identity to: #{params[:code_sign_identity]} for target: #{found_target[:name]}")
+          end
+          if params[:profile_name]
+            build_configuration_list.set_setting("PROVISIONING_PROFILE_SPECIFIER", params[:profile_name])
+            UI.important("Set Provisioning Profile name to: #{params[:profile_name]} for target: #{found_target[:name]}")
+          end
+          # Since Xcode 8, this is no longer needed, you simply use PROVISIONING_PROFILE_SPECIFIER
+          if params[:profile_uuid]
+            build_configuration_list.set_setting("PROVISIONING_PROFILE", params[:profile_uuid])
+            UI.important("Set Provisioning Profile UUID to: #{params[:profile_uuid]} for target: #{found_target[:name]}")
+          end
+          if params[:bundle_identifier]
+            build_configuration_list.set_setting("PRODUCT_BUNDLE_IDENTIFIER", params[:bundle_identifier])
+            UI.important("Set Bundle identifier to: #{params[:bundle_identifier]} for target: #{found_target[:name]}")
+          end
+
           changed_targets << found_target[:name]
         end
         project.save
@@ -49,7 +66,7 @@ module Fastlane
             UI.important("\t* #{target[:name]}")
           end
         else
-          UI.success("Successfully updated project settings to use ProvisioningStyle '#{params[:use_automatic_signing] ? 'Automatic' : 'Manual'}'")
+          UI.success("Successfully updated project settings to use Code Sign Style = '#{params[:use_automatic_signing] ? 'Automatic' : 'Manual'}'")
           UI.success("Modified Targets:")
           changed_targets.each do |target|
             UI.success("\t * #{target}")
@@ -68,11 +85,11 @@ module Fastlane
       end
 
       def self.description
-        "Updates the Xcode 8 Automatic Codesigning Flag"
+        "Configures Xcode's Codesigning options"
       end
 
       def self.details
-        "Updates the Xcode 8 Automatic Codesigning Flag of all targets in the project"
+        "Configures Xcode's Codesigning options of all targets in the project"
       end
 
       def self.available_options
@@ -91,16 +108,36 @@ module Fastlane
                                        is_string: false,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :team_id,
-                                        env_name: "FASTLANE_TEAM_ID",
-                                        optional: true,
-                                        description: "Team ID, is used when upgrading project",
-                                        is_string: true),
+                                       env_name: "FASTLANE_TEAM_ID",
+                                       optional: true,
+                                       description: "Team ID, is used when upgrading project",
+                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :targets,
                                        env_name: "FL_PROJECT_SIGNING_TARGETS",
                                        optional: true,
                                        type: Array,
                                        description: "Specify targets you want to toggle the signing mech. (default to all targets)",
-                                       is_string: false)
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :code_sign_identity,
+                                       env_name: "FL_CODE_SIGN_IDENTITY",
+                                       description: "Code signing identity type (iPhone Development, iPhone Distribution)",
+                                       optional: true,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :profile_name,
+                                       env_name: "FL_PROVISIONING_PROFILE_SPECIFIER",
+                                       description: "Provisioning profile name to use for code signing",
+                                       optional: true,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :profile_uuid,
+                                       env_name: "FL_PROVISIONING_PROFILE",
+                                       description: "Provisioning profile UUID to use for code signing",
+                                       optional: true,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :bundle_identifier,
+                                       env_name: "FL_APP_IDENTIFIER",
+                                       description: "Application Product Bundle Identifier",
+                                       optional: true,
+                                       is_string: true)
         ]
       end
 
@@ -153,7 +190,7 @@ module Fastlane
       end
 
       def self.authors
-        ["mathiasAichinger", "hjanuschka"]
+        ["mathiasAichinger", "hjanuschka", "p4checo", "portellaa", "aeons"]
       end
 
       def self.is_supported?(platform)

--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -9,7 +9,7 @@ describe Fastlane do
 
     it "enable_automatic_code_signing" do
       allow(UI).to receive(:success)
-      expect(UI).to receive(:success).with("Successfully updated project settings to use ProvisioningStyle 'Automatic'")
+      expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Automatic'")
       result = Fastlane::FastFile.new.parse("lane :test do
         enable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'XXXX')
       end").runner.execute(:test)
@@ -22,16 +22,17 @@ describe Fastlane do
 
       expect(root_attrs["771D79501D9E69C900D840FA"]["DevelopmentTeam"]).to eq("XXXX")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["DevelopmentTeam"]).to eq("XXXX")
+
       project.targets.each do |target|
-        target.build_configurations.each do |configuration|
-          expect(configuration.build_settings["CODE_SIGN_STYLE"]).to eq("Automatic")
+        target.build_configuration_list.get_setting("CODE_SIGN_STYLE").map do |build_config, value|
+          expect(value).to eq("Automatic")
         end
       end
     end
 
     it "disable_automatic_code_signing for specific target" do
       allow(UI).to receive(:success)
-      expect(UI).to receive(:success).with("Successfully updated project settings to use ProvisioningStyle 'Manual'")
+      expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
       expect(UI).to receive(:success).with("\t * today")
       expect(UI).to receive(:important).with("Skipping demo not selected (today)")
       result = Fastlane::FastFile.new.parse("lane :test do
@@ -43,19 +44,17 @@ describe Fastlane do
       root_attrs = project.root_object.attributes["TargetAttributes"]
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Automatic")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
-      automatic_target = project.targets.first
-      manual_target = project.targets.last
-      automatic_target.build_configurations.each do |configuration|
-        expect(configuration.build_settings["CODE_SIGN_STYLE"]).to eq("Automatic")
-      end
-      manual_target.build_configurations.each do |configuration|
-        expect(configuration.build_settings["CODE_SIGN_STYLE"]).to eq("Manual")
+
+      project.targets.each do |target|
+        target.build_configuration_list.get_setting("CODE_SIGN_STYLE").map do |build_config, value|
+          expect(value).to eq(target.name == 'today' ? "Manual" : "Automatic")
+        end
       end
     end
 
     it "disable_automatic_code_signing" do
       allow(UI).to receive(:success)
-      expect(UI).to receive(:success).with("Successfully updated project settings to use ProvisioningStyle 'Manual'")
+      expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
       result = Fastlane::FastFile.new.parse("lane :test do
         disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj')
       end").runner.execute(:test)
@@ -65,9 +64,10 @@ describe Fastlane do
       root_attrs = project.root_object.attributes["TargetAttributes"]
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
+
       project.targets.each do |target|
-        target.build_configurations.each do |configuration|
-          expect(configuration.build_settings["CODE_SIGN_STYLE"]).to eq("Manual")
+        target.build_configuration_list.get_setting("CODE_SIGN_STYLE").map do |build_config, value|
+          expect(value).to eq("Manual")
         end
       end
     end
@@ -75,7 +75,7 @@ describe Fastlane do
     it "sets team id" do
       # G3KGXDXQL9
       allow(UI).to receive(:success)
-      expect(UI).to receive(:success).with("Successfully updated project settings to use ProvisioningStyle 'Manual'")
+      expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
       expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: demo")
       expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: today")
       result = Fastlane::FastFile.new.parse("lane :test do
@@ -91,6 +91,140 @@ describe Fastlane do
 
       expect(root_attrs["771D79501D9E69C900D840FA"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
+
+      project.targets.each do |target|
+        target.build_configuration_list.get_setting("CODE_SIGN_STYLE").map do |build_config, value|
+          expect(value).to eq("Manual")
+        end
+      end
+    end
+
+    it "sets code sign identity" do
+      # G3KGXDXQL9
+      allow(UI).to receive(:success)
+      expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
+      expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: demo")
+      expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: today")
+      expect(UI).to receive(:important).with("Set Code Sign identity to: iPhone Distribution for target: demo")
+      expect(UI).to receive(:important).with("Set Code Sign identity to: iPhone Distribution for target: today")
+      result = Fastlane::FastFile.new.parse("lane :test do
+        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9', code_sign_identity: 'iPhone Distribution')
+      end").runner.execute(:test)
+      expect(result).to eq(false)
+
+      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      root_attrs = project.root_object.attributes["TargetAttributes"]
+
+      expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
+
+      expect(root_attrs["771D79501D9E69C900D840FA"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
+
+      project.targets.each do |target|
+        target.build_configuration_list.get_setting("CODE_SIGN_STYLE").map do |build_config, value|
+          expect(value).to eq("Manual")
+        end
+        target.build_configuration_list.get_setting("CODE_SIGN_IDENTITY").map do |build_config, value|
+          expect(value).to eq("iPhone Distribution")
+        end
+      end
+    end
+
+    it "sets profile name" do
+      # G3KGXDXQL9
+      allow(UI).to receive(:success)
+      expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
+      expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: demo")
+      expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: today")
+      expect(UI).to receive(:important).with("Set Provisioning Profile name to: Mindera for target: demo")
+      expect(UI).to receive(:important).with("Set Provisioning Profile name to: Mindera for target: today")
+      result = Fastlane::FastFile.new.parse("lane :test do
+        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9', profile_name: 'Mindera')
+      end").runner.execute(:test)
+      expect(result).to eq(false)
+
+      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      root_attrs = project.root_object.attributes["TargetAttributes"]
+
+      expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
+
+      expect(root_attrs["771D79501D9E69C900D840FA"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
+
+      project.targets.each do |target|
+        target.build_configuration_list.get_setting("CODE_SIGN_STYLE").map do |build_config, value|
+          expect(value).to eq("Manual")
+        end
+        target.build_configuration_list.get_setting("PROVISIONING_PROFILE_SPECIFIER").map do |build_config, value|
+          expect(value).to eq("Mindera")
+        end
+      end
+    end
+
+    it "sets profile uuid" do
+      # G3KGXDXQL9
+      allow(UI).to receive(:success)
+      expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
+      expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: demo")
+      expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: today")
+      expect(UI).to receive(:important).with("Set Provisioning Profile UUID to: 1337 for target: demo")
+      expect(UI).to receive(:important).with("Set Provisioning Profile UUID to: 1337 for target: today")
+      result = Fastlane::FastFile.new.parse("lane :test do
+        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9', profile_uuid: '1337')
+      end").runner.execute(:test)
+      expect(result).to eq(false)
+
+      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      root_attrs = project.root_object.attributes["TargetAttributes"]
+
+      expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
+
+      expect(root_attrs["771D79501D9E69C900D840FA"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
+
+      project.targets.each do |target|
+        target.build_configuration_list.get_setting("CODE_SIGN_STYLE").map do |build_config, value|
+          expect(value).to eq("Manual")
+        end
+        target.build_configuration_list.get_setting("PROVISIONING_PROFILE").map do |build_config, value|
+          expect(value).to eq("1337")
+        end
+      end
+    end
+
+    it "sets bundle identifier" do
+      # G3KGXDXQL9
+      allow(UI).to receive(:success)
+      expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
+      expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: demo")
+      expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: today")
+      expect(UI).to receive(:important).with("Set Bundle identifier to: com.fastlane.mindera.cosigner for target: demo")
+      expect(UI).to receive(:important).with("Set Bundle identifier to: com.fastlane.mindera.cosigner for target: today")
+      result = Fastlane::FastFile.new.parse("lane :test do
+        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9', bundle_identifier: 'com.fastlane.mindera.cosigner')
+      end").runner.execute(:test)
+      expect(result).to eq(false)
+
+      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      root_attrs = project.root_object.attributes["TargetAttributes"]
+
+      expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
+
+      expect(root_attrs["771D79501D9E69C900D840FA"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
+      expect(root_attrs["77C503031DD3175E00AC8FF0"]["DevelopmentTeam"]).to eq("G3KGXDXQL9")
+
+      project.targets.each do |target|
+        target.build_configuration_list.get_setting("CODE_SIGN_STYLE").map do |build_config, value|
+          expect(value).to eq("Manual")
+        end
+        target.build_configuration_list.get_setting("PRODUCT_BUNDLE_IDENTIFIER").map do |build_config, value|
+          expect(value).to eq("com.fastlane.mindera.cosigner")
+        end
+      end
     end
 
     it "targets not found notice" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

Following a suggestion by @hjanuschka, the Mindera cosigner plugin's ✍️
(https://github.com/Mindera/fastlane-plugin-cosigner) functionality was
integrated into the existing `automatic_code_signing` action, so that
it can be available to all fastlane users out of the box 💪.

It adds functionality to set:
 - `CODE_SIGN_IDENTITY` if `:code_sign_identity` set
 - `PROVISIONING_PROFILE_SPECIFIER` if `:profile_name` set
 - `PROVISIONING_PROFILE` if `:profile_uuid` set
 - `PRODUCT_BUNDLE_IDENTIFIER` if `:bundle_identifier` set

<!-- If it fixes an open issue, please link to the issue here. -->

It (finally 😅) closes the following issue on Mindera's cosigner plugin: https://github.com/Mindera/fastlane-plugin-cosigner/issues/8

<!-- Please describe in detail how you tested your changes. -->

Regarding testing, new unit tests were added to check if the new project settings are properly updated, following the existing tests structure.

### Description
<!-- Describe your changes in detail -->

The changes on this PR consist of enabling fastlane users more control over their code signing setup, besides simply switching between manual or automatic code signing.

In practice, additional target build configurations are defined with the new set of optional parameters, when defined. The new action parameters are:

| Parameter | Description | Environment Variable |
| --- | --- | --- |
| `code_sign_identity ` | Code signing identity type ("iPhone Development", "iPhone Distribution") |`FL_CODE_SIGN_IDENTITY ` |
| `profile_name ` | Provisioning profile name to use for code signing (Xcode 8+) | `FL_PROVISIONING_PROFILE_SPECIFIER ` |
| `profile_uuid ` | Provisioning profile UUID to use for code signing (Xcode 7 and earlier)  | `FL_PROVISIONING_PROFILE ` |
| `bundle_identifier ` | Application Product Bundle Identifier | `FL_APP_IDENTIFIER ` |

Thanks to @portellaa and @aeons for helping create and contributing to
cosigner, and to @hjanuschka for making the invitation to integrate into fastlane 🙇