### PR TITLE
Fix for issue #11162

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -651,10 +651,8 @@ module Spaceship
       parse_response(r)
     end
 
-    def repair_provisioning_profile!(profile_id, name, distribution_method, app_id, certificate_ids, device_ids, mac: false, sub_platform: nil, template_name: nil)
-      ensure_csrf(Spaceship::ProvisioningProfile) do
-        fetch_csrf_token_for_provisioning
-      end
+    def repair_provisioning_profile!(profile_id, name, distribution_method, app_id, certificate_ids, device_ids, mac: false, sub_platform: nil, template_name: nil)      
+      fetch_csrf_token_for_provisioning
 
       params = {
           teamId: team_id,

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -651,7 +651,7 @@ module Spaceship
       parse_response(r)
     end
 
-    def repair_provisioning_profile!(profile_id, name, distribution_method, app_id, certificate_ids, device_ids, mac: false, sub_platform: nil, template_name: nil)      
+    def repair_provisioning_profile!(profile_id, name, distribution_method, app_id, certificate_ids, device_ids, mac: false, sub_platform: nil, template_name: nil)
       fetch_csrf_token_for_provisioning
 
       params = {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
It looks like Apple has some limit on calls while the CSRF token is valid, even if those calls are made in different "domains." As a result, call to profile.update! will fail in some conditions. See #11162 for details.

### Description
The easiest fix is to force the token update by always calling `PortalClient::fetch_csrf_token_for_provisioning` at the beginning of `PortalClient::repair_provisioning_profile!`, regardless to cache state. 
That will fix the issues keeping CSRF token caching in place.