### PR TITLE
Tests: replace hard coded (e.g. `/tmp`) paths

### DIFF
--- a/fastlane/spec/actions_specs/backup_xcarchive_spec.rb
+++ b/fastlane/spec/actions_specs/backup_xcarchive_spec.rb
@@ -1,7 +1,7 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Backup xcarchive Integration" do
-      let(:tmp_path) { "/tmp/fastlane/tests" }
+      let(:tmp_path) { Dir.mktmpdir }
       let(:source_path) { "#{tmp_path}/fastlane" }
       let(:destination_path) { "#{source_path}/dest" }
       let(:xcarchive_file) { "fake.xcarchive" }

--- a/fastlane/spec/actions_specs/commit_github_file_spec.rb
+++ b/fastlane/spec/actions_specs/commit_github_file_spec.rb
@@ -16,11 +16,13 @@ describe Fastlane do
         end
 
         it 'correctly submits to github' do
-          path = '/test/assets/TEST_FILE.md'
+          current_dir = Dir.pwd
+          path = "test/assets/TEST_FILE.md"
+          file = "#{current_dir}/fastlane/#{path}"
           content = 'test'
-          allow(File).to receive(:exist?).with(path).and_return(true).at_least(:once)
+          allow(File).to receive(:exist?).with(file).and_return(true).at_least(:once)
           allow(File).to receive(:exist?).and_return(:default)
-          allow(File).to receive(:open).with(path).and_return(StringIO.new(content))
+          allow(File).to receive(:open).with(file).and_return(StringIO.new(content))
 
           result = Fastlane::FastFile.new.parse("
             lane :test do
@@ -28,7 +30,7 @@ describe Fastlane do
                 api_token: '12345abcde',
                 repository_name: 'fastlane/fastlane',
                 message: 'Add my new file',
-                path: '/test/assets/TEST_FILE.md'
+                path: '#{path}'
               )
             end
           ").runner.execute(:test)

--- a/fastlane/spec/actions_specs/copy_artifacts_spec.rb
+++ b/fastlane/spec/actions_specs/copy_artifacts_spec.rb
@@ -2,92 +2,101 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Copy Artifacts Integration" do
       before do
-        # Reset directories
-        FileUtils.rm_rf('/tmp/fastlane')
-        FileUtils.rm_rf('/tmp/fastlane2')
-
         # Create base test directory
-        FileUtils.mkdir_p('/tmp/fastlane')
+        @tmp_path = Dir.mktmpdir
+        FileUtils.mkdir_p("#{@tmp_path}/source")
       end
 
       it "Copies a file to target path" do
-        FileUtils.touch('/tmp/fastlane/copy_artifacts')
+        FileUtils.touch("#{@tmp_path}/source/copy_artifacts")
 
         Fastlane::FastFile.new.parse("lane :test do
-          copy_artifacts(artifacts: '/tmp/fastlane/copy_artifacts', target_path: '/tmp/fastlane2')
+          copy_artifacts(artifacts: '#{@tmp_path}/source/copy_artifacts', target_path: '#{@tmp_path}/target')
         end").runner.execute(:test)
 
-        expect(File.exist?('/tmp/fastlane2/copy_artifacts')).to eq(true)
+        expect(File.exist?("#{@tmp_path}/target/copy_artifacts")).to eq(true)
       end
 
       it "Copies a directory and subfiles to target path" do
-        FileUtils.mkdir_p('/tmp/fastlane/dir')
-        FileUtils.touch('/tmp/fastlane/dir/copy_artifacts')
+        FileUtils.mkdir_p("#{@tmp_path}/source/dir")
+        FileUtils.touch("#{@tmp_path}/source/dir/copy_artifacts")
 
         Fastlane::FastFile.new.parse("lane :test do
-          copy_artifacts(artifacts: '/tmp/fastlane/*', target_path: '/tmp/fastlane2')
+          copy_artifacts(artifacts: '#{@tmp_path}/source/*', target_path: '#{@tmp_path}/target/')
         end").runner.execute(:test)
-        expect(Dir.exist?('/tmp/fastlane2/dir')).to eq(true)
-        expect(File.exist?('/tmp/fastlane2/dir/copy_artifacts')).to eq(true)
+
+        expect(Dir.exist?("#{@tmp_path}/target/dir")).to eq(true)
+        expect(File.exist?("#{@tmp_path}/target/dir/copy_artifacts")).to eq(true)
       end
 
       it "Copies a file with a space" do
-        FileUtils.touch('/tmp/fastlane/copy_artifacts\ with\ a\ space')
+        FileUtils.touch("#{@tmp_path}/source/copy_artifacts\ with\ a\ space")
 
         Fastlane::FastFile.new.parse("lane :test do
-          copy_artifacts(artifacts: '/tmp/fastlane/copy_artifacts with a space', target_path: '/tmp/fastlane2')
+          copy_artifacts(artifacts: '#{@tmp_path}/source/copy_artifacts\ with\ a\ space', target_path: '#{@tmp_path}/target')
         end").runner.execute(:test)
-        expect(File.exist?('/tmp/fastlane/copy_artifacts\ with\ a\ space')).to eq(true)
+
+        expect(File.exist?("#{@tmp_path}/target/copy_artifacts\ with\ a\ space")).to eq(true)
       end
 
       it "Copies a file with verbose" do
-        FileUtils.touch('/tmp/fastlane/copy_artifacts')
+        source_path = "#{@tmp_path}/source"
+        FileUtils.touch(source_path)
+        target_path = "#{@tmp_path}/target738"
 
-        expect(UI).to receive(:verbose).once.ordered.with('Copying artifacts /tmp/fastlane/copy_artifacts to /tmp/fastlane2')
+        expect(UI).to receive(:verbose).once.ordered.with("Copying artifacts #{source_path} to #{target_path}")
         expect(UI).to receive(:verbose).once.ordered.with('Keeping original files')
 
         with_verbose(true) do
           Fastlane::FastFile.new.parse("lane :test do
-            copy_artifacts(artifacts: '/tmp/fastlane/copy_artifacts', target_path: '/tmp/fastlane2')
+            copy_artifacts(artifacts: '#{source_path}', target_path: '#{target_path}')
           end").runner.execute(:test)
         end
 
-        expect(File.exist?('/tmp/fastlane/copy_artifacts')).to eq(true)
-        expect(File.exist?('/tmp/fastlane2/copy_artifacts')).to eq(true)
+        expect(File.exist?(source_path)).to eq(true)
+        expect(File.exist?(target_path)).to eq(true)
       end
 
       it "Copies a file without keeping original and verbose" do
-        FileUtils.touch('/tmp/fastlane/copy_artifacts')
+        source_path = "#{@tmp_path}/source"
+        FileUtils.touch(source_path)
+        target_path = "#{@tmp_path}/target987"
 
-        expect(UI).to receive(:verbose).once.ordered.with('Copying artifacts /tmp/fastlane/copy_artifacts to /tmp/fastlane2')
+        expect(UI).to receive(:verbose).once.ordered.with("Copying artifacts #{source_path} to #{target_path}")
         expect(UI).to receive(:verbose).once.ordered.with('Not keeping original files')
 
         with_verbose(true) do
           Fastlane::FastFile.new.parse("lane :test do
-            copy_artifacts(artifacts: '/tmp/fastlane/copy_artifacts', target_path: '/tmp/fastlane2', keep_original: false)
+            copy_artifacts(artifacts: '#{source_path}', target_path: '#{target_path}', keep_original: false)
           end").runner.execute(:test)
         end
 
-        expect(File.exist?('/tmp/fastlane2/copy_artifacts')).to eq(true)
-        expect(File.exist?('/tmp/fastlane/copy_artifacts')).to eq(false)
+        expect(File.exist?(source_path)).to eq(false)
+        expect(File.exist?(target_path)).to eq(true)
       end
 
       it "Copies a file with file missing does not fail (no flag set)" do
+        source_path = "#{@tmp_path}/source/missing"
+        target_path = "#{@tmp_path}/target123"
+
         Fastlane::FastFile.new.parse("lane :test do
-          copy_artifacts(artifacts: '/tmp/fastlane/not_going_to_be_there', target_path: '/tmp/fastlane2')
+          copy_artifacts(artifacts: '#{source_path}', target_path: '#{target_path}')
         end").runner.execute(:test)
 
-        expect(File.exist?('/tmp/fastlane2/not_going_to_be_there')).to eq(false)
+        expect(File.exist?(source_path)).to eq(false)
       end
 
       it "Copies a file with file missing fails (flag set)" do
+        source_path = "#{@tmp_path}/source/not_going_to_be_there"
+        target_path = "#{@tmp_path}/target456"
+
         expect do
           Fastlane::FastFile.new.parse("lane :test do
-            copy_artifacts(artifacts: '/tmp/fastlane/not_going_to_be_there', target_path: '/tmp/fastlane2', fail_on_missing: true)
+            copy_artifacts(artifacts: '#{source_path}', target_path: '#{target_path}', fail_on_missing: true)
           end").runner.execute(:test)
-        end.to raise_error "Not all files were present in copy artifacts. Missing /tmp/fastlane/not_going_to_be_there"
+        end.to raise_error "Not all files were present in copy artifacts. Missing #{source_path}"
 
-        expect(File.exist?('/tmp/fastlane2/not_going_to_be_there')).to eq(false)
+        expect(File.exist?(source_path)).to eq(false)
       end
     end
   end

--- a/fastlane/spec/actions_specs/gradle_spec.rb
+++ b/fastlane/spec/actions_specs/gradle_spec.rb
@@ -66,7 +66,8 @@ describe Fastlane do
       end
 
       it "correctly escapes the gradle path" do
-        gradle_path = '/fake gradle/path' # this value is interesting because it contains a space in the path
+        tmp_path = Dir.mktmpdir
+        gradle_path = "#{tmp_path}/fake gradle/path" # this value is interesting because it contains a space in the path
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with(gradle_path).and_return(true)
 

--- a/fastlane/spec/actions_specs/nexus_upload_spec.rb
+++ b/fastlane/spec/actions_specs/nexus_upload_spec.rb
@@ -55,10 +55,11 @@ describe Fastlane do
       end
 
       it "mandatory options are used correctly" do
-        file_path = '/tmp/file.ipa'
+        tmp_path = Dir.mktmpdir
+        file_path = "#{tmp_path}/file.ipa"
         FileUtils.touch file_path
         result = Fastlane::FastFile.new.parse("lane :test do
-          nexus_upload(file: '/tmp/file.ipa',
+          nexus_upload(file: '#{file_path}',
                       repo_id: 'artefacts',
                       repo_group_id: 'com.fastlane',
                       repo_project_name: 'myproject',
@@ -81,7 +82,7 @@ describe Fastlane do
         expect(result).to include('-F a=myproject')
         expect(result).to include('-F v=1.12')
         expect(result).to include('-F e=ipa')
-        expect(result).to include("-F file=@/tmp/file.ipa")
+        expect(result).to include("-F file=@#{tmp_path}")
         expect(result).to include('-u admin:admin123')
         expect(result).to include('--verbose')
         expect(result).to include('http://localhost:8081/nexus/service/local/artifact/maven/content')
@@ -91,10 +92,11 @@ describe Fastlane do
       end
 
       it "optional options are used correctly" do
-        file_path = '/tmp/file.ipa'
+        tmp_path = Dir.mktmpdir
+        file_path = "#{tmp_path}/file.ipa"
         FileUtils.touch file_path
         result = Fastlane::FastFile.new.parse("lane :test do
-          nexus_upload(file: '/tmp/file.ipa',
+          nexus_upload(file: '#{file_path}',
                       repo_id: 'artefacts',
                       repo_group_id: 'com.fastlane',
                       repo_project_name: 'myproject',
@@ -115,7 +117,7 @@ describe Fastlane do
         expect(result).to include('-F v=1.12')
         expect(result).to include('-F c=dSYM')
         expect(result).to include('-F e=ipa')
-        expect(result).to include("-F file=@/tmp/file.ipa")
+        expect(result).to include("-F file=@#{file_path}")
         expect(result).to include('-u admin:admin123')
         expect(result).to include('--verbose')
         expect(result).to include('http://localhost:8081/my-nexus/service/local/artifact/maven/content')

--- a/fastlane/spec/actions_specs/setup_jenkins_spec.rb
+++ b/fastlane/spec/actions_specs/setup_jenkins_spec.rb
@@ -129,31 +129,35 @@ describe Fastlane do
         end
 
         it "set output directory" do
+          tmp_path = Dir.mktmpdir
+          directory = "#{tmp_path}/output/directory"
           Fastlane::FastFile.new.parse("lane :test do
             setup_jenkins(
-              output_directory: '/tmp/output/directory'
+              output_directory: '#{directory}'
             )
           end").runner.execute(:test)
 
-          expect(ENV["BACKUP_XCARCHIVE_DESTINATION"]).to eq("/tmp/output/directory")
-          expect(ENV["GYM_BUILD_PATH"]).to eq("/tmp/output/directory")
-          expect(ENV["GYM_OUTPUT_DIRECTORY"]).to eq("/tmp/output/directory")
-          expect(ENV["SCAN_OUTPUT_DIRECTORY"]).to eq("/tmp/output/directory")
+          expect(ENV["BACKUP_XCARCHIVE_DESTINATION"]).to eq(directory)
+          expect(ENV["GYM_BUILD_PATH"]).to eq(directory)
+          expect(ENV["GYM_OUTPUT_DIRECTORY"]).to eq(directory)
+          expect(ENV["SCAN_OUTPUT_DIRECTORY"]).to eq(directory)
         end
 
         it "set derived data" do
+          tmp_path = Dir.mktmpdir
+          directory = "#{tmp_path}/derived_data"
           Fastlane::FastFile.new.parse("lane :test do
             setup_jenkins(
-              derived_data_path: '/tmp/derived_data'
+              derived_data_path: '#{directory}'
             )
           end").runner.execute(:test)
 
-          expect(ENV["DERIVED_DATA_PATH"]).to eq("/tmp/derived_data")
-          expect(ENV["FL_CARTHAGE_DERIVED_DATA"]).to eq("/tmp/derived_data")
-          expect(ENV["FL_SLATHER_BUILD_DIRECTORY"]).to eq("/tmp/derived_data")
-          expect(ENV["GYM_DERIVED_DATA_PATH"]).to eq("/tmp/derived_data")
-          expect(ENV["SCAN_DERIVED_DATA_PATH"]).to eq("/tmp/derived_data")
-          expect(ENV["XCODE_DERIVED_DATA_PATH"]).to eq("/tmp/derived_data")
+          expect(ENV["DERIVED_DATA_PATH"]).to eq(directory)
+          expect(ENV["FL_CARTHAGE_DERIVED_DATA"]).to eq(directory)
+          expect(ENV["FL_SLATHER_BUILD_DIRECTORY"]).to eq(directory)
+          expect(ENV["GYM_DERIVED_DATA_PATH"]).to eq(directory)
+          expect(ENV["SCAN_DERIVED_DATA_PATH"]).to eq(directory)
+          expect(ENV["XCODE_DERIVED_DATA_PATH"]).to eq(directory)
         end
 
         it "disable result bundle path" do

--- a/fastlane/spec/actions_specs/splunkmint_spec.rb
+++ b/fastlane/spec/actions_specs/splunkmint_spec.rb
@@ -112,10 +112,11 @@ describe Fastlane do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DSYM_OUTPUT_PATH] = nil
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DSYM_ZIP_PATH] = nil
 
-        file_path = '/tmp/file.dSYM.zip'
+        tmp_path = Dir.mktmpdir
+        file_path = "#{tmp_path}/file.dSYM.zip"
         FileUtils.touch file_path
         result = Fastlane::FastFile.new.parse("lane :test do
-          splunkmint(dsym: '/tmp/file.dSYM.zip',
+          splunkmint(dsym: '#{file_path}',
                       api_key: '33823d3a',
                       api_token: 'e05ba40754c4869fb7e0b61',
                       verbose: true,
@@ -125,7 +126,7 @@ describe Fastlane do
                       proxy_password: 'admin')
         end").runner.execute(:test)
 
-        expect(result).to include("-F file=@/tmp/file.dSYM.zip")
+        expect(result).to include("-F file=@#{file_path}")
         expect(result).to include('--verbose')
         expect(result).to include("--header 'X-Splunk-Mint-Auth-Token: e05ba40754c4869fb7e0b61'")
         expect(result).to include("--header 'X-Splunk-Mint-apikey: 33823d3a'")
@@ -139,16 +140,17 @@ describe Fastlane do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DSYM_OUTPUT_PATH] = nil
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DSYM_ZIP_PATH] = nil
 
-        file_path = '/tmp/file.dSYM.zip'
+        tmp_path = Dir.mktmpdir
+        file_path = "#{tmp_path}/file.dSYM.zip"
         FileUtils.touch file_path
         result = Fastlane::FastFile.new.parse("lane :test do
-          splunkmint(dsym: '/tmp/file.dSYM.zip',
+          splunkmint(dsym: '#{file_path}',
                       api_key: '33823d3a',
                       api_token: 'e05ba40754c4869fb7e0b61',
                       verbose: true)
         end").runner.execute(:test)
 
-        expect(result).to include("-F file=@/tmp/file.dSYM.zip")
+        expect(result).to include("-F file=@#{file_path}")
         expect(result).to include('--verbose')
         expect(result).to include("--header 'X-Splunk-Mint-Auth-Token: e05ba40754c4869fb7e0b61'")
         expect(result).to include("--header 'X-Splunk-Mint-apikey: 33823d3a'")
@@ -162,17 +164,18 @@ describe Fastlane do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DSYM_OUTPUT_PATH] = nil
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DSYM_ZIP_PATH] = nil
 
-        file_path = '/tmp/file.dSYM.zip'
+        tmp_path = Dir.mktmpdir
+        file_path = "#{tmp_path}/file.dSYM.zip"
         FileUtils.touch file_path
         result = Fastlane::FastFile.new.parse("lane :test do
-          splunkmint(dsym: '/tmp/file.dSYM.zip',
+          splunkmint(dsym: '#{file_path}',
                       api_key: '33823d3a',
                       api_token: 'e05ba40754c4869fb7e0b61',
                       verbose: true,
                       upload_progress: true)
         end").runner.execute(:test)
 
-        expect(result).to include("-F file=@/tmp/file.dSYM.zip")
+        expect(result).to include("-F file=@#{file_path}")
         expect(result).to include('--verbose')
         expect(result).to include("--header 'X-Splunk-Mint-Auth-Token: e05ba40754c4869fb7e0b61'")
         expect(result).to include("--header 'X-Splunk-Mint-apikey: 33823d3a'")

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -156,9 +156,11 @@ describe FastlaneCore do
     end
 
     it "raises an exception if path was not found" do
+      tmp_path = Dir.mktmpdir
+      path = "#{tmp_path}/notHere123"
       expect do
-        FastlaneCore::Project.new(project: "/tmp/notHere123")
-      end.to raise_error "Could not find project at path '/tmp/notHere123'"
+        FastlaneCore::Project.new(project: path)
+      end.to raise_error "Could not find project at path '#{path}'"
     end
 
     describe "Valid Standard Project" do

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -11,9 +11,11 @@ describe Gym do
 
   describe Gym::BuildCommandGenerator do
     it "raises an exception when project path wasn't found" do
+      tmp_path = Dir.mktmpdir
+      path = "#{tmp_path}/notExistent"
       expect do
-        Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, { project: "/notExistent" })
-      end.to raise_error "Project file not found at path '/notExistent'"
+        Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, { project: path })
+      end.to raise_error "Project file not found at path '#{path}'"
     end
 
     it "supports additional parameters", requires_xcodebuild: true do

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -23,20 +23,22 @@ describe Match do
       end
 
       it 'treats a keychain name it cannot find in ~/Library/Keychains as the full keychain path' do
-        expected_command = "security import item.path -k '/my/special.keychain' -P '' -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
+        tmp_path = Dir.mktmpdir
+        keychain = "#{tmp_path}/my/special.keychain"
+        expected_command = "security import item.path -k '#{keychain}' -P '' -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' /my/special.keychain &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{keychain} &> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
-        expect(File).to receive(:file?).with('/my/special.keychain').and_return(true)
+        expect(File).to receive(:file?).with(keychain).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with('item.path').and_return(true)
 
         allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: FastlaneCore::Globals.verbose?)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: FastlaneCore::Globals.verbose?)
 
-        Match::Utils.import('item.path', '/my/special.keychain')
+        Match::Utils.import('item.path', keychain)
       end
 
       it 'shows a user error if the keychain path cannot be resolved' do

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -78,10 +78,12 @@ describe Scan do
     end
 
     it "raises an exception when project path wasn't found" do
+      tmp_path = Dir.mktmpdir
+      path = "#{tmp_path}/notExistent"
       expect do
-        options = { project: "/notExistent" }
+        options = { project: path }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
-      end.to raise_error "Project file not found at path '/notExistent'"
+      end.to raise_error "Project file not found at path '#{path}'"
     end
 
     describe "Supports toolchain" do

--- a/sigh/spec/resign_spec.rb
+++ b/sigh/spec/resign_spec.rb
@@ -17,18 +17,20 @@ describe Sigh do
     end
 
     it "Create provisioning options from hash" do
+      tmp_path = Dir.mktmpdir
       provisioning_profiles = {
-        "at.fastlane" => "/folder/mobile.mobileprovision",
-        "at.fastlane.today" => "/folder/mobile.today.mobileprovision"
+        "at.fastlane" => "#{tmp_path}/folder/mobile.mobileprovision",
+        "at.fastlane.today" => "#{tmp_path}/folder/mobile.today.mobileprovision"
       }
       provisioning_options = @resign.create_provisioning_options(provisioning_profiles)
-      expect(provisioning_options).to eq("-p at.fastlane=/folder/mobile.mobileprovision -p at.fastlane.today=/folder/mobile.today.mobileprovision")
+      expect(provisioning_options).to eq("-p at.fastlane=#{tmp_path}/folder/mobile.mobileprovision -p at.fastlane.today=#{tmp_path}/folder/mobile.today.mobileprovision")
     end
 
     it "Create provisioning options from array" do
-      provisioning_profiles = ["/folder/mobile.mobileprovision"]
+      tmp_path = Dir.mktmpdir
+      provisioning_profiles = ["#{tmp_path}/folder/mobile.mobileprovision"]
       provisioning_options = @resign.create_provisioning_options(provisioning_profiles)
-      expect(provisioning_options).to eq("-p /folder/mobile.mobileprovision")
+      expect(provisioning_options).to eq("-p #{tmp_path}/folder/mobile.mobileprovision")
     end
 
     it "Installed identities parser" do

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -126,8 +126,9 @@ describe Spaceship::Client do
     end
 
     it "uses $SPACESHIP_COOKIE_PATH when set" do
-      ENV["SPACESHIP_COOKIE_PATH"] = "/custom_path"
-      expect(subject.persistent_cookie_path).to eq("/custom_path/spaceship/username/cookie")
+      tmp_path = Dir.mktmpdir
+      ENV["SPACESHIP_COOKIE_PATH"] = "#{tmp_path}/custom_path"
+      expect(subject.persistent_cookie_path).to eq("#{tmp_path}/custom_path/spaceship/username/cookie")
     end
 
     it "uses home dir by default" do
@@ -144,14 +145,14 @@ describe Spaceship::Client do
     it "uses /var/tmp if home not available" do
       allow(subject).to receive(:directory_accessible?).with(File.expand_path("~/.fastlane")).and_return(false)
       allow(subject).to receive(:directory_accessible?).with(File.expand_path("~")).and_return(false)
-      allow(subject).to receive(:directory_accessible?).with("/var/tmp").and_return(true)
-      expect(subject.persistent_cookie_path).to eq("/var/tmp/spaceship/username/cookie")
+      allow(subject).to receive(:directory_accessible?).with(File.expand_path("/var/tmp")).and_return(true)
+      expect(subject.persistent_cookie_path).to eq(File.expand_path("/var/tmp/spaceship/username/cookie"))
     end
 
     it "falls back to Dir.tmpdir as last resort" do
       allow(subject).to receive(:directory_accessible?).with(File.expand_path("~")).and_return(false)
       allow(subject).to receive(:directory_accessible?).with(File.expand_path("~/.fastlane")).and_return(false)
-      allow(subject).to receive(:directory_accessible?).with("/var/tmp").and_return(false)
+      allow(subject).to receive(:directory_accessible?).with(File.expand_path("/var/tmp")).and_return(false)
       allow(subject).to receive(:directory_accessible?).with(Dir.tmpdir).and_return(true)
       expect(subject.persistent_cookie_path).to eq("#{Dir.tmpdir}/spaceship/username/cookie")
     end


### PR DESCRIPTION
On macOS and Linux system you always have `/tmp`. On Windows you don't.

This PR fixes all the tests that assumed these and similar paths to also work on Windows.

TODO: Rebase when #11385 is merged