### PR TITLE
Work on copy of variable so mocks don't get retroactively changed

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -206,9 +206,8 @@ module FastlaneCore
       #
       # We also try to append `-db` at the end of the file path, as with Sierra the default Keychain name
       # has changed for some users: https://github.com/fastlane/fastlane/issues/5649
-      #
 
-      # Remove the ".keychain" at the end of the name
+      # Remove the ".keychain" at the end of the keychain name
       name = keychain_name.sub(/\.keychain$/, "")
 
       possible_locations = [

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -194,7 +194,7 @@ module FastlaneCore
       return File.join(self.itms_path, 'bin', 'iTMSTransporter')
     end
 
-    def self.keychain_path(name)
+    def self.keychain_path(keychain_name)
       # Existing code expects that a keychain name will be expanded into a default path to Library/Keychains
       # in the user's home directory. However, this will not allow the user to pass an absolute path
       # for the keychain value
@@ -209,7 +209,7 @@ module FastlaneCore
       #
 
       # Remove the ".keychain" at the end of the name
-      name = name.sub(/\.keychain$/, "")
+      name = keychain_name.sub(/\.keychain$/, "")
 
       possible_locations = [
         File.join(Dir.home, 'Library', 'Keychains', name),

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -209,7 +209,7 @@ module FastlaneCore
       #
 
       # Remove the ".keychain" at the end of the name
-      name.sub!(/\.keychain$/, "")
+      name = name.sub(/\.keychain$/, "")
 
       possible_locations = [
         File.join(Dir.home, 'Library', 'Keychains', name),


### PR DESCRIPTION
This helper figures out a list of locations to look for a file.
The variable it changes, was used to specify a mock in a test before - so this can mess with stuff.
Don't change the variable, but create a copy that is used in here.