### PR TITLE
set tests output dir in a cross platform way

### DIFF
--- a/spaceship/spec/tunes/iap_detail_spec.rb
+++ b/spaceship/spec/tunes/iap_detail_spec.rb
@@ -96,7 +96,7 @@ describe Spaceship::Tunes::IAPDetail do
     end
 
     it "saved and changed screenshot" do
-      detailed.review_screenshot = "/tmp/fastlane_tests"
+      detailed.review_screenshot = "#{Dir.tmpdir}/fastlane_tests"
       expect(client.du_client).to receive(:upload_purchase_review_screenshot).and_return({ "token" => "tok", "height" => 100, "width" => 200, "md5" => "xxxx" })
       expect(client.du_client).to receive(:get_picture_type).and_return("MZPFT.SortedScreenShot")
       expect(Spaceship::Utilities).to receive(:content_type).and_return("image/jpg")

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -12,8 +12,9 @@ require "fastlane"
 UI = FastlaneCore::UI
 
 unless ENV["DEBUG"]
-  $stdout.puts "Changing stdout to /tmp/fastlane_tests, set `DEBUG` environment variable to print to stdout (e.g. when using `pry`)"
-  $stdout = File.open("/tmp/fastlane_tests", "w")
+  fastlane_tests_tmpdir = "#{Dir.tmpdir}/fastlane_tests"
+  $stdout.puts "Changing stdout to #{fastlane_tests_tmpdir}, set `DEBUG` environment variable to print to stdout (e.g. when using `pry`)"
+  $stdout = File.open(fastlane_tests_tmpdir, "w")
 end
 
 if FastlaneCore::Helper.is_mac?


### PR DESCRIPTION
`/tmp` is not available on all systems, but `Dir.tmpdir` can return a directory that is.