### PR TITLE
Add basic configuration for AppVeyor Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # https://www.appveyor.com/docs/appveyor-yml/
 
-version: {build}-{branch}
+version: {build}
 
 init:
   - git config --global core.autocrlf true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+environment:
+  LC_ALL: en_US.UTF-8
+  LANG: en_US.UTF-8
+  FASTLANE_ITUNES_TRANSPORTER_PATH: C:/tmp
+
+init:
+  - git config --global core.autocrlf true
+
+install:
+  - set PATH=C:\Ruby24-x64\bin;%PATH%
+  - bundle install
+
+build: off
+
+test_script:
+  - bundle exec fastlane test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # https://www.appveyor.com/docs/appveyor-yml/
 
-version: {build}
+version: "{build}"
 
 init:
   - git config --global core.autocrlf true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,20 @@
-environment:
-  LC_ALL: en_US.UTF-8
-  LANG: en_US.UTF-8
-  FASTLANE_ITUNES_TRANSPORTER_PATH: C:/tmp
+# https://www.appveyor.com/docs/appveyor-yml/
+
+version: {build}-{branch}
 
 init:
   - git config --global core.autocrlf true
 
+# cloning the repository happens here
+
 install:
   - set PATH=C:\Ruby24-x64\bin;%PATH%
   - bundle install
+
+environment:
+  LC_ALL: en_US.UTF-8
+  LANG: en_US.UTF-8
+  FASTLANE_ITUNES_TRANSPORTER_PATH: C:/tmp
 
 build: off
 


### PR DESCRIPTION
This PR adds a minimal configuration for AppVeyor CI:

- better version number/string
- use ruby environment
- disable default build and run fastlane test script
- change default git checkout newlines to Linux style
- set ENV variables that will be needed by the test script

The tests at AppVeyor are failing, but that is expected. We will need several additional PRs to make the test suite actually pass. (The failing checks are not blocking merges, so this is more a cosmetic problem.)


  