### PR TITLE
get home directory in a cross platform way

### DIFF
--- a/fastlane_core/lib/fastlane_core.rb
+++ b/fastlane_core/lib/fastlane_core.rb
@@ -78,7 +78,7 @@ module FastlaneCore
   # Since we don't want to access FastlaneCore from spaceship
   # this method is duplicated in spaceship/client.rb
   def self.fastlane_user_dir
-    path = File.expand_path(File.join("~", ".fastlane"))
+    path = File.expand_path(File.join(Dir.home, ".fastlane"))
     FileUtils.mkdir_p(path) unless File.directory?(path)
     return path
   end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -320,7 +320,7 @@ module Spaceship
 
     # This is a duplicate method of fastlane_core/fastlane_core.rb#fastlane_user_dir
     def fastlane_user_dir
-      path = File.expand_path(File.join("~", ".fastlane"))
+      path = File.expand_path(File.join(Dir.home, ".fastlane"))
       FileUtils.mkdir_p(path) unless File.directory?(path)
       return path
     end


### PR DESCRIPTION
`~` is the home dir in most OS, but not all.

https://ruby-doc.org/core-2.2.0/Dir.html#method-c-home