### PR TITLE
Restore support for array commands in sh.

### DIFF
--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -24,6 +24,7 @@ module Fastlane
     # @yieldparam [Process::Status] status A Process::Status indicating the status of the completed command
     # @yieldparam [String] result The complete output to stdout and stderr of the completed command
     # @yieldparam [String] cmd A shell command equivalent to the arguments passed
+    # rubocop: disable Metrics/PerceivedComplexity
     def self.sh_control_output(*command, print_command: true, print_command_output: true, error_callback: nil)
       print_command = print_command_output = true if $troubleshoot
       # Set the encoding first, the user might have set it wrong
@@ -31,17 +32,17 @@ module Fastlane
       Encoding.default_external = Encoding::UTF_8
       Encoding.default_internal = Encoding::UTF_8
 
+      # Workaround to support previous Fastlane syntax.
+      # This has some limitations. For example, it requires the caller to shell escape
+      # everything because of usages like ["ls -la", "/tmp"] instead of ["ls", "-la", "/tmp"].
+      command = [command.first.join(" ")] if command.length == 1 && command.first.kind_of?(Array)
+
       shell_command = shell_command_from_args(*command)
       UI.command(shell_command) if print_command
 
       result = ''
       exit_status = nil
       if Helper.sh_enabled?
-        # Workaround to support previous Fastlane syntax.
-        # This has some limitations. For example, it requires the caller to shell escape
-        # everything because of usages like ["ls -la", "/tmp"] instead of ["ls", "-la", "/tmp"].
-        command = [command.first.join(" ")] if command.length == 1 && command.first.kind_of?(Array)
-
         # The argument list is passed directly to Open3.popen2e, which
         # handles the variadic argument list in the same way as Kernel#spawn.
         # (http://ruby-doc.org/core-2.4.2/Kernel.html#method-i-spawn) or
@@ -96,6 +97,7 @@ module Fastlane
       Encoding.default_external = previous_encoding.first
       Encoding.default_internal = previous_encoding.last
     end
+    # rubocop: enable Metrics/PerceivedComplexity
 
     # Used to produce a shell command string from a list of arguments that may
     # be passed to methods such as Kernel#system, Kernel#spawn and Open3.popen2e

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -37,6 +37,10 @@ module Fastlane
       result = ''
       exit_status = nil
       if Helper.sh_enabled?
+        # Workaround to support previous Fastlane syntax.
+        # This has some limitations. For example, it requires the caller to shell escape
+        # everything because of usages like ["ls -la", "/tmp"] instead of ["ls", "-la", "/tmp"].
+        command = [command.first.join(" ")] if command.length == 1 && command.first.kind_of?(Array)
 
         # The argument list is passed directly to Open3.popen2e, which
         # handles the variadic argument list in the same way as Kernel#spawn.

--- a/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
@@ -392,11 +392,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = demo.test.demo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.mindera.cosigner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = 1337;
+				PROVISIONING_PROFILE_SPECIFIER = Mindera;
 			};
 			name = Debug;
 		};
@@ -404,23 +408,31 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = demo.test.demo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.mindera.cosigner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = 1337;
+				PROVISIONING_PROFILE_SPECIFIER = Mindera;
 			};
 			name = Release;
 		};
 		77C503131DD3175E00AC8FF0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = today/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = demo.test.demo.today;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.mindera.cosigner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = 1337;
+				PROVISIONING_PROFILE_SPECIFIER = Mindera;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -428,12 +440,16 @@
 		77C503141DD3175E00AC8FF0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = today/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = demo.test.demo.today;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.mindera.cosigner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = 1337;
+				PROVISIONING_PROFILE_SPECIFIER = Mindera;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;

--- a/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
@@ -392,15 +392,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.mindera.cosigner;
+				PRODUCT_BUNDLE_IDENTIFIER = demo.test.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = 1337;
-				PROVISIONING_PROFILE_SPECIFIER = Mindera;
 			};
 			name = Debug;
 		};
@@ -408,31 +404,23 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.mindera.cosigner;
+				PRODUCT_BUNDLE_IDENTIFIER = demo.test.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = 1337;
-				PROVISIONING_PROFILE_SPECIFIER = Mindera;
 			};
 			name = Release;
 		};
 		77C503131DD3175E00AC8FF0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = today/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.mindera.cosigner;
+				PRODUCT_BUNDLE_IDENTIFIER = demo.test.demo.today;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = 1337;
-				PROVISIONING_PROFILE_SPECIFIER = Mindera;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -440,16 +428,12 @@
 		77C503141DD3175E00AC8FF0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = today/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.mindera.cosigner;
+				PRODUCT_BUNDLE_IDENTIFIER = demo.test.demo.today;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = 1337;
-				PROVISIONING_PROFILE_SPECIFIER = Mindera;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;

--- a/fastlane/spec/helper/sh_helper_spec.rb
+++ b/fastlane/spec/helper/sh_helper_spec.rb
@@ -50,6 +50,11 @@ describe Fastlane::Actions do
         expect_command ["/usr/local/bin/git", "git"], "commit", "-m", "A message"
         Fastlane::Actions.sh ["/usr/local/bin/git", "git"], "commit", "-m", "A message"
       end
+
+      it "allows a single array to be passed to support older Fastlane syntax" do
+        expect_command "ls -la /tmp"
+        Fastlane::Actions.sh ["ls -la", "/tmp"]
+      end
     end
 
     context "with a postfix block" do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Fix #11343.

This restores the previous support for array arguments in the `sh` method.

### Description

If the variadic `command` Array has 1 element and it is an Array, join with a space.

This is problematic and should probably be considered a temporary workaround. For example, I see some actions using constructions like:

```Ruby
command = ["ls -la", path.shellescape]
sh command
```

This will absolutely not work with related methods like `system`, e.g. `system *command` will barf because it will expect the command name to be `ls -la`, not just `ls`. This is equivalent to `ls\ -la...`. And since no shell is used with the variadic invocation of `system`, the shell escape for `path` will not be removed.

Doing things this way amounts to reinventing the wheel.

But for now there's too much risk not to fix this. A unit test was also added.