### PR TITLE
Feature: Swift Package Manager action

### DIFF
--- a/fastlane/lib/fastlane/actions/spm.rb
+++ b/fastlane/lib/fastlane/actions/spm.rb
@@ -1,0 +1,95 @@
+module Fastlane
+  module Actions
+    class SpmAction < Action
+      def self.run(params)
+        cmd = ["swift"]
+
+        cmd << (package_commands.include?(params[:command]) ? "package" : params[:command])
+        cmd << "--build-path #{params[:build_path]}" if params[:build_path]
+        cmd << "--package-path #{params[:package_path]}" if params[:package_path]
+        cmd << "--configuration #{params[:configuration]}" if params[:configuration]
+        cmd << "--verbose" if params[:verbose]
+        cmd << params[:command] if package_commands.include?(params[:command])
+
+        sh(cmd.join(" "))
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Runs Swift Package Manager on your project"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :command,
+                                       env_name: "FL_SPM_COMMAND",
+                                       description: "The swift command (one of: #{available_commands.join(', ')})",
+                                       default_value: "build",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Please pass a valid command. Use one of the following: #{available_commands.join(', ')}") unless available_commands.include? value
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :build_path,
+                                       env_name: "FL_SPM_BUILD_PATH",
+                                       description: "Specify build/cache directory [default: ./.build]",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :package_path,
+                                       env_name: "FL_SPM_PACKAGE_PATH",
+                                       description: "Change working directory before any other operation",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :configuration,
+                                       short_option: "-c",
+                                       env_name: "FL_SPM_CONFIGURATION",
+                                       description: "Build with configuration (debug|release) [default: debug]",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Please pass a valid configuration: (debug|release)") unless valid_configurations.include? value
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :verbose,
+                                       short_option: "-v",
+                                       env_name: "FL_SPM_VERBOSE",
+                                       description: "Increase verbosity of informational output",
+                                       is_string: false,
+                                       default_value: false)
+        ]
+      end
+
+      def self.authors
+        ["Flávio Caetano (@fjcaetano)"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.example_code
+        [
+          'spm',
+          'spm(
+            command: "build",
+            build_path: "./build",
+            configuration: "release"
+          )'
+        ]
+      end
+
+      def self.category
+        :building
+      end
+
+      def self.available_commands
+        %w(build test) + self.package_commands
+      end
+
+      def self.package_commands
+        %w(clean reset update)
+      end
+
+      def self.valid_configurations
+        %w(debug release)
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/spm_spec.rb
+++ b/fastlane/spec/actions_specs/spm_spec.rb
@@ -1,0 +1,193 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "SPM Integration" do
+      it "raises an error if command is invalid" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            spm(command: 'invalid_command')
+          end").runner.execute(:test)
+        end.to raise_error("Please pass a valid command. Use one of the following: build, test, clean, reset, update")
+      end
+
+      # Commands
+
+      it "default use case is build" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            spm
+          end").runner.execute(:test)
+
+        expect(result).to eq("swift build")
+      end
+
+      it "sets the command to build" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            spm(command: 'build')
+          end").runner.execute(:test)
+
+        expect(result).to eq("swift build")
+      end
+
+      it "sets the command to test" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            spm(command: 'test')
+          end").runner.execute(:test)
+
+        expect(result).to eq("swift test")
+      end
+
+      it "sets the command to update" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            spm(command: 'update')
+          end").runner.execute(:test)
+
+        expect(result).to eq("swift package update")
+      end
+
+      it "sets the command to clean" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            spm(command: 'clean')
+          end").runner.execute(:test)
+
+        expect(result).to eq("swift package clean")
+      end
+
+      it "sets the command to reset" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            spm(command: 'reset')
+          end").runner.execute(:test)
+
+        expect(result).to eq("swift package reset")
+      end
+
+      # Arguments
+
+      context "when command is not package related" do
+        it "adds verbose flag to command if verbose is set to true" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+              spm(verbose: true)
+            end").runner.execute(:test)
+
+          expect(result).to eq("swift build --verbose")
+        end
+
+        it "doesn't add a verbose flag to command if verbose is set to false" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+              spm(verbose: false)
+            end").runner.execute(:test)
+
+          expect(result).to eq("swift build")
+        end
+
+        it "adds build-path flag to command if build_path is set" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+              spm(build_path: 'foobar')
+            end").runner.execute(:test)
+
+          expect(result).to eq("swift build --build-path foobar")
+        end
+
+        it "adds package-path flag to command if package_path is set" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+              spm(package_path: 'foobar')
+            end").runner.execute(:test)
+
+          expect(result).to eq("swift build --package-path foobar")
+        end
+
+        it "adds configuration flag to command if configuration is set" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+              spm(configuration: 'release')
+            end").runner.execute(:test)
+
+          expect(result).to eq("swift build --configuration release")
+        end
+
+        it "raises an error if configuration is invalid" do
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              spm(configuration: 'foobar')
+            end").runner.execute(:test)
+          end.to raise_error("Please pass a valid configuration: (debug|release)")
+        end
+
+        it "works with no parameters" do
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              spm
+            end").runner.execute(:test)
+          end.not_to raise_error
+        end
+      end
+
+      context "when command is package related" do
+        let (:command) { 'update' }
+
+        it "adds verbose flag to package command if verbose is set to true" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+              spm(
+                command: '#{command}',
+                verbose: true
+              )
+            end").runner.execute(:test)
+
+          expect(result).to eq("swift package --verbose #{command}")
+        end
+
+        it "doesn't add a verbose flag to package command if verbose is set to false" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+              spm(
+                command: '#{command}',
+                verbose: false
+              )
+            end").runner.execute(:test)
+
+          expect(result).to eq("swift package #{command}")
+        end
+
+        it "adds build-path flag to package command if package_path is set to true" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+              spm(
+                command: '#{command}',
+                build_path: 'foobar'
+              )
+            end").runner.execute(:test)
+
+          expect(result).to eq("swift package --build-path foobar #{command}")
+        end
+
+        it "adds package-path flag to package command if package_path is set" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+              spm(
+                command: '#{command}',
+                package_path: 'foobar'
+              )
+            end").runner.execute(:test)
+
+          expect(result).to eq("swift package --package-path foobar #{command}")
+        end
+
+        it "adds configuration flag to package command if configuration is set" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+              spm(
+                command: '#{command}',
+                configuration: 'release'
+              )
+            end").runner.execute(:test)
+
+          expect(result).to eq("swift package --configuration release #{command}")
+        end
+
+        it "raises an error if configuration is invalid" do
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              spm(
+                command: '#{command}',
+                configuration: 'foobar'
+              )
+            end").runner.execute(:test)
+          end.to raise_error("Please pass a valid configuration: (debug|release)")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Adds a Swift Package Manager action to build and test Swift projects

### Description

| Key | Description               | Env Var              | Default |
|---------------|---------------------------|----------------------|---------|
| **command**       | The swift command (one of: build, test, clean, reset, update)    | `FL_SPM_COMMAND`       | build   |
| **build_path**    | Specify build/cache directory [default: ./.build]      | `FL_SPM_BUILD_PATH`    |         |
| **package_path**  | Change working directory before any other operation  | `FL_SPM_PACKAGE_PATH`  |         |
| **configuration** | Build with configuration (debug\|release) [default: debug]  | `FL_SPM_CONFIGURATION` |         |
| **verbose**       | Increase verbosity of informational output     | `FL_SPM_VERBOSE`       | false   |

This is a first draft. Suggestions and fixtures are more than welcome. I'm by no means a Ruby expert so, please, forgive any rude mistakes. I've also taken the liberty of including some basic testing for the current state of the action.

Fix #10877 
  
  