### PR TITLE
Replace `cp ...` with (cross-platform) FileUtils.cp ... 

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -6,7 +6,7 @@ require 'fastlane/version'
 
 # Copy over the latest .rubocop.yml style guide
 rubocop_config = File.expand_path('../.rubocop.yml', __FILE__)
-`cp #{rubocop_config} #{lib}/fastlane/plugins/template/.rubocop.yml`
+FileUtils.cp rubocop_config, "#{lib}/fastlane/plugins/template/.rubocop.yml"
 
 Gem::Specification.new do |spec|
   spec.name          = "fastlane"


### PR DESCRIPTION
`cp` as a command line tool is not available on Windows (except when somehow installed via MSYS, Cygwin or similar), so this fails on new systems. `FileUtils.cp` works all the time.
  