### PR TITLE
Replace `fork` usage with cross-platform alternative

### DIFF
--- a/fastlane/lib/fastlane/actions/appium.rb
+++ b/fastlane/lib/fastlane/actions/appium.rb
@@ -37,7 +37,7 @@ module Fastlane
 
       def self.invoke_appium_server(params)
         appium = detect_appium(params)
-        fork do
+        Thread.new do
           Process.exec("#{appium} -a #{params[:host]} -p #{params[:port]}")
         end
       end

--- a/fastlane/lib/fastlane/actions/appium.rb
+++ b/fastlane/lib/fastlane/actions/appium.rb
@@ -37,9 +37,7 @@ module Fastlane
 
       def self.invoke_appium_server(params)
         appium = detect_appium(params)
-        Thread.new do
-          Process.exec("#{appium} -a #{params[:host]} -p #{params[:port]}")
-        end
+        Process.spawn("#{appium} -a #{params[:host]} -p #{params[:port]}")
       end
 
       def self.detect_appium(params)

--- a/fastlane/lib/fastlane/fastlane_require.rb
+++ b/fastlane/lib/fastlane/fastlane_require.rb
@@ -40,22 +40,21 @@ module Fastlane
 
       def gem_installed?(name, req = Gem::Requirement.default)
         installed = Gem::Specification.any? { |s| s.name == name and req =~ s.version }
-        unless installed
-          # In special cases a gem is already preinstalled, e.g. YAML.
-          # To find out we try to load a gem with that name in a child process
-          # (so we don't actually load anything we don't want to load)
-          # See https://github.com/fastlane/fastlane/issues/6951
-          require_tester = <<-RB.gsub(/^ */, '')
-            begin
-              require ARGV.first
-            rescue LoadError
-              exit(1)
-            end
-          RB
-          system(RbConfig.ruby, "-e", require_tester.lines.map(&:chomp).join("; "), name)
-          return true if $?.success?
-        end
-        return installed
+        return true if installed
+
+        # In special cases a gem is already preinstalled, e.g. YAML.
+        # To find out we try to load a gem with that name in a child process
+        # (so we don't actually load anything we don't want to load)
+        # See https://github.com/fastlane/fastlane/issues/6951
+        require_tester = <<-RB.gsub(/^ */, '')
+          begin
+            require ARGV.first
+          rescue LoadError
+            exit(1)
+          end
+        RB
+        system(RbConfig.ruby, "-e", require_tester.lines.map(&:chomp).join("; "), name)
+        return true if $?.success?
       end
 
       def find_gem_name(user_supplied_name)

--- a/fastlane/lib/fastlane/fastlane_require.rb
+++ b/fastlane/lib/fastlane/fastlane_require.rb
@@ -54,7 +54,7 @@ module Fastlane
           end
         RB
         system(RbConfig.ruby, "-e", require_tester.lines.map(&:chomp).join("; "), name)
-        return true if $?.success?
+        return $?.success?
       end
 
       def find_gem_name(user_supplied_name)

--- a/fastlane/spec/fastlane_require_spec.rb
+++ b/fastlane/spec/fastlane_require_spec.rb
@@ -13,5 +13,25 @@ describe Fastlane do
       gem_require_name = Fastlane::FastlaneRequire.format_gem_require_name(gem_name)
       expect(gem_require_name).to eq("rest-client")
     end
+
+    describe "checks if a gem is installed" do
+      it "true on known installed gem" do
+        gem_name = "fastlane"
+        gem_installed = Fastlane::FastlaneRequire.gem_installed?(gem_name)
+        expect(gem_installed).to be true
+      end
+
+      it "false on known missing gem" do
+        gem_name = "foobar"
+        gem_installed = Fastlane::FastlaneRequire.gem_installed?(gem_name)
+        expect(gem_installed).to be false
+      end
+
+      it "true on known preinstalled gem" do
+        gem_name = "yaml"
+        gem_installed = Fastlane::FastlaneRequire.gem_installed?(gem_name)
+        expect(gem_installed).to be true
+      end
+    end
   end
 end

--- a/fastlane/spec/fastlane_require_spec.rb
+++ b/fastlane/spec/fastlane_require_spec.rb
@@ -18,19 +18,19 @@ describe Fastlane do
       it "true on known installed gem" do
         gem_name = "fastlane"
         gem_installed = Fastlane::FastlaneRequire.gem_installed?(gem_name)
-        expect(gem_installed).to be true
+        expect(gem_installed).to be(true)
       end
 
       it "false on known missing gem" do
         gem_name = "foobar"
         gem_installed = Fastlane::FastlaneRequire.gem_installed?(gem_name)
-        expect(gem_installed).to be false
+        expect(gem_installed).to be(false)
       end
 
       it "true on known preinstalled gem" do
         gem_name = "yaml"
         gem_installed = Fastlane::FastlaneRequire.gem_installed?(gem_name)
-        expect(gem_installed).to be true
+        expect(gem_installed).to be(true)
       end
     end
   end

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_ingester_client.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_ingester_client.rb
@@ -6,7 +6,7 @@ module FastlaneCore
   class AnalyticsIngesterClient
     def post_events(events)
       unless Helper.test?
-        fork do
+        Thread.new do
           send_request(json: { analytics: events }.to_json)
         end
       end

--- a/fastlane_core/lib/fastlane_core/tool_collector.rb
+++ b/fastlane_core/lib/fastlane_core/tool_collector.rb
@@ -70,7 +70,7 @@ module FastlaneCore
 
       # Never generate web requests during tests
       unless Helper.test?
-        fork do
+        Thread.new do
           begin
             Excon.post(url,
                        body: analytic_event_body,

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -46,7 +46,7 @@ module FastlaneCore
     end
 
     def self.show_update_status(gem_name, current_version)
-      fork do
+      Thread.new do
         begin
           send_completion_events_for(gem_name)
         rescue


### PR DESCRIPTION
`fork` is not available on Windows. Fortunately almost all uses don't rely on the result anyway, so `Thread.new` is a appropriate replacement.

For the one case where it actually matters what happens in the forked process, I couldn't find a way to properly trigger the code. As it is an edge case anyway (as I understood it, requiring a gem that is already preinstalled) and not executed in tests in any way, I made the judgement call to "disable" the code on these platforms by checking for the existence of `Process.fork`.