### PR TITLE
Version bump to 2.73.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.72.0'.freeze
+  VERSION = '2.73.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -11,4 +11,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.71.1
+// Generated with fastlane 2.72.0

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -11,4 +11,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.71.1
+// Generated with fastlane 2.72.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -11,4 +11,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.71.1
+// Generated with fastlane 2.72.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -11,4 +11,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.71.1
+// Generated with fastlane 2.72.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -11,4 +11,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.71.1
+// Generated with fastlane 2.72.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -11,4 +11,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.71.1
+// Generated with fastlane 2.72.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -11,4 +11,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.71.1
+// Generated with fastlane 2.72.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.72.0':**

* Replace \`cp ...\` with FileUtils.cp ... (that works crossplatform) (#11417) via Jan Piotrowski
* Updated handling of Arrays that are passed as Strings (#11407) via Joshua Liebowitz
* Update issue template to call out people should be careful of sensitive information (#11412) via Joshua Liebowitz
* Add basic configuration for AppVeyor Windows CI (#11388) via Jan Piotrowski
* Update fixture project (#11316) via Joshua Liebowitz
* Improve code style of get_build_number.rb (#11398) via Felix Krause
* Work on copy of variable so mocks don't get retroactively changed (#11385) via Jan Piotrowski
* Restore support for array commands in sh. (#11393) via Jimmy Dee

  