### PR TITLE
Fix query parameters for get_ratings

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -330,11 +330,12 @@ module Spaceship
 
     def get_ratings(app_id, platform, version_id = '', storefront = '')
       # if storefront or version_id is empty api fails
-      rating_url = "ra/apps/#{app_id}/platforms/#{platform}/reviews/summary?"
-      rating_url << "storefront=#{storefront}" unless storefront.empty?
-      rating_url << "version_id=#{version_id}" unless version_id.empty?
+      rating_url = "ra/apps/#{app_id}/platforms/#{platform}/reviews/summary"
+      params = {}
+      params['storefront'] = storefront unless storefront.empty?
+      params['version_id'] = version_id unless version_id.empty?
 
-      r = request(:get, rating_url)
+      r = request(:get, rating_url, params)
       parse_response(r, 'data')
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When specifying both a storefront and a review ID, the URL was not constructed properly: the `&` was missing.

This fixes the issue by letting Faraday construct the URL for us