### PR TITLE
Bump slack-notifier Gem Dependency

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   # spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = Dir["*/lib"]
 
-  spec.add_dependency 'slack-notifier', '>= 1.3', '< 2.0.0' # Slack notifications
+  spec.add_dependency 'slack-notifier', '>= 2.0.0', '< 3.0.0' # Slack notifications
   spec.add_dependency 'xcodeproj', '>= 1.5.2', '< 2.0.0' # Needed for commit_version_bump action and gym code_signing_mapping
   spec.add_dependency 'xcpretty', '>= 0.2.4', '< 1.0.0' # prettify xcodebuild output
   spec.add_dependency 'terminal-notifier', '>= 1.6.2', '< 2.0.0' # macOS notifications

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -43,12 +43,13 @@ module Fastlane
         return [notifier, slack_attachment] if Helper.is_test? # tests will verify the slack attachments and other properties
 
         begin
-          result = notifier.ping '',
-                                 icon_url: icon_url,
-                                 attachments: [slack_attachment]
+          results = notifier.ping '',
+                                  icon_url: icon_url,
+                                  attachments: [slack_attachment]
         rescue => exception
           UI.error("Exception: #{exception}")
         ensure
+          result = results.first
           if !result.nil? && result.code.to_i == 200
             UI.success('Successfully sent Slack notification')
           else

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -22,17 +22,21 @@ module Fastlane
         require 'slack-notifier'
 
         options[:message] = self.trim_message(options[:message].to_s || '')
-        options[:message] = Slack::Notifier::LinkFormatter.format(options[:message])
-
-        notifier = Slack::Notifier.new(options[:slack_url])
-
-        notifier.username = options[:use_webhook_configured_username_and_icon] ? nil : options[:username]
-        icon_url = options[:use_webhook_configured_username_and_icon] ? nil : options[:icon_url]
+        options[:message] = Slack::Notifier::Util::LinkFormatter.format(options[:message])
 
         if options[:channel].to_s.length > 0
-          notifier.channel = options[:channel]
-          notifier.channel = ('#' + notifier.channel) unless ['#', '@'].include?(notifier.channel[0]) # send message to channel by default
+          channel = options[:channel]
+          channel = ('#' + notifier.channel) unless ['#', '@'].include?(channel[0]) # send message to channel by default
         end
+
+        username = options[:use_webhook_configured_username_and_icon] ? nil : options[:username]
+
+        notifier = Slack::Notifier.new(options[:slack_url]) do
+          defaults channel: channel,
+                   username: username
+        end
+
+        icon_url = options[:use_webhook_configured_username_and_icon] ? nil : options[:icon_url]
 
         slack_attachment = generate_slack_attachments(options)
 
@@ -186,7 +190,7 @@ module Fastlane
         slack_attachment[:fields] += options[:payload].map do |k, v|
           {
             title: k.to_s,
-            value: Slack::Notifier::LinkFormatter.format(v.to_s),
+            value: Slack::Notifier::Util::LinkFormatter.format(v.to_s),
             short: false
           }
         end

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -32,8 +32,8 @@ describe Fastlane do
 
         notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
 
-        expect(notifier.default_payload[:username]).to eq('fastlane')
-        expect(notifier.default_payload[:channel]).to eq(channel)
+        expect(notifier.config.defaults[:username]).to eq('fastlane')
+        expect(notifier.config.defaults[:channel]).to eq(channel)
 
         expect(attachments[:color]).to eq('danger')
         expect(attachments[:text]).to eq(message)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
My project uses `slack-notifier` v2.3.1. fastlane's gemspec required < 2.0.0. This PR bumps the version requirement to 2.X. There were some minor API differences to the gem which are reflected in the code and spec changes.

### Description
This PR bumps the `slack-notifier` gem requirement to 2.X (from 1.X). It also updates the codebase and tests to reflect the API changes.