### PR TITLE
Add `FASTLANE_DISABLE_ANIMATION` to disable loading indicators across fastlane

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -15,24 +15,27 @@ module Fastlane
       def take_off
         before_import_time = Time.now
 
-        # Usually in the fastlane code base we use
-        #
-        #   Helper.show_loading_indicator
-        #   longer_taking_task_here
-        #   Helper.hide_loading_indicator
-        #
-        # but in this case we haven't required FastlaneCore yet
-        # so we'll have to access the raw API for now
-        require "tty-spinner"
-        require_fastlane_spinner = TTY::Spinner.new("[:spinner] 🚀 ", format: :dots)
-        require_fastlane_spinner.auto_spin
+        if !FastlaneCore::Env.truthy?("FASTLANE_DISABLE_ANIMATION")
+          # Usually in the fastlane code base we use
+          #
+          #   Helper.show_loading_indicator
+          #   longer_taking_task_here
+          #   Helper.hide_loading_indicator
+          #
+          # but in this case we haven't required FastlaneCore yet
+          # so we'll have to access the raw API for now
+          require "tty-spinner"
+          require_fastlane_spinner = TTY::Spinner.new("[:spinner] 🚀 ", format: :dots)
+          require_fastlane_spinner.auto_spin
 
-        # this might take a long time if there is no Gemfile :(
-        # That's why we show the loading indicator here also
-        require "fastlane"
+          # this might take a long time if there is no Gemfile :(
+          # That's why we show the loading indicator here also
+          require "fastlane"
 
-        require_fastlane_spinner.success
-
+          require_fastlane_spinner.success
+        else
+          require "fastlane"
+        end
         # We want to avoid printing output other than the version number if we are running `fastlane -v`
         unless running_version_command?
           print_bundle_exec_warning(is_slow: (Time.now - before_import_time > 3))

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -15,7 +15,7 @@ module Fastlane
       def take_off
         before_import_time = Time.now
 
-        if !FastlaneCore::Env.truthy?("FASTLANE_DISABLE_ANIMATION")
+        if !ENV["FASTLANE_DISABLE_ANIMATION"]
           # Usually in the fastlane code base we use
           #
           #   Helper.show_loading_indicator

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -281,6 +281,7 @@ module FastlaneCore
     end
 
     def self.hide_loading_indicator
+      return if FastlaneCore::Env.truthy?("FASTLANE_DISABLE_ANIMATION")
       @require_fastlane_spinner.success
     end
   end

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -275,6 +275,7 @@ module FastlaneCore
 
     # Show/Hide loading indicator
     def self.show_loading_indicator(text = "🚀")
+      return if FastlaneCore::Env.truthy?("FASTLANE_DISABLE_ANIMATION")
       @require_fastlane_spinner = TTY::Spinner.new("[:spinner] #{text} ", format: :dots)
       @require_fastlane_spinner.auto_spin
     end

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -274,15 +274,22 @@ module FastlaneCore
     end
 
     # Show/Hide loading indicator
-    def self.show_loading_indicator(text = "🚀")
-      return if FastlaneCore::Env.truthy?("FASTLANE_DISABLE_ANIMATION")
-      @require_fastlane_spinner = TTY::Spinner.new("[:spinner] #{text} ", format: :dots)
-      @require_fastlane_spinner.auto_spin
+    def self.show_loading_indicator(text = nil)
+      if FastlaneCore::Env.truthy?("FASTLANE_DISABLE_ANIMATION")
+        UI.message(text) if text
+      else
+        # we set the default here, instead of at the parameters
+        # as we don't want to `UI.message` a rocket that's just there for the loading indicator
+        text ||= "🚀"
+        @require_fastlane_spinner = TTY::Spinner.new("[:spinner] #{text} ", format: :dots)
+        @require_fastlane_spinner.auto_spin
+      end
     end
 
     def self.hide_loading_indicator
-      return if FastlaneCore::Env.truthy?("FASTLANE_DISABLE_ANIMATION")
-      @require_fastlane_spinner.success
+      if !FastlaneCore::Env.truthy?("FASTLANE_DISABLE_ANIMATION") && @require_fastlane_spinner
+        @require_fastlane_spinner.success
+      end
     end
   end
 end


### PR DESCRIPTION
Migrated from https://github.com/fastlane/fastlane/pull/11416
Sorry, messed up something on git and caused a new PR