### PR TITLE
Revert "Bump slack-notifier Gem Dependency (#11446)"

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   # spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = Dir["*/lib"]
 
-  spec.add_dependency 'slack-notifier', '>= 2.0.0', '< 3.0.0' # Slack notifications
+  spec.add_dependency 'slack-notifier', '>= 1.3', '< 2.0.0' # Slack notifications
   spec.add_dependency 'xcodeproj', '>= 1.5.2', '< 2.0.0' # Needed for commit_version_bump action and gym code_signing_mapping
   spec.add_dependency 'xcpretty', '>= 0.2.4', '< 1.0.0' # prettify xcodebuild output
   spec.add_dependency 'terminal-notifier', '>= 1.6.2', '< 2.0.0' # macOS notifications

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -32,8 +32,8 @@ describe Fastlane do
 
         notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
 
-        expect(notifier.config.defaults[:username]).to eq('fastlane')
-        expect(notifier.config.defaults[:channel]).to eq(channel)
+        expect(notifier.default_payload[:username]).to eq('fastlane')
+        expect(notifier.default_payload[:channel]).to eq(channel)
 
         expect(attachments[:color]).to eq('danger')
         expect(attachments[:text]).to eq(message)


### PR DESCRIPTION
This reverts commit f48d4745060c5e5dcf54ce17bc6f06c03d428db9.

Got this error
```
[22:27:09]: Unknown method 'notifier'
[22:27:09]: An error occurred while executing the `error` block:
[22:27:09]: To call another action from an action use `other_action.notifier` instead
 
```