### PR TITLE
FIX: pathname on old ruby

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -1,6 +1,7 @@
 require 'logger'
 require 'colored'
 require 'tty-spinner'
+require 'pathname'
 
 require_relative 'fastlane_folder'
 require_relative 'ui/ui'


### PR DESCRIPTION
older ruby, in my case debians default shipped ruby version. does not provide pathname out of the box.

on lunch:
```
root@debianbuilder ~ $ pwd && fastlane help
/root
[⠋] 🚀 /var/lib/gems/2.1.0/gems/fastlane-2.74.0.beta.20180108010004/fastlane/lib/fastlane/cli_tools_distributor.rb:100:in `ensure in take_off': uninitialized constant FastlaneCore::UpdateChecker (NameError)
    from /var/lib/gems/2.1.0/gems/fastlane-2.74.0.beta.20180108010004/fastlane/lib/fastlane/cli_tools_distributor.rb:100:in `take_off'
    from /var/lib/gems/2.1.0/gems/fastlane-2.74.0.beta.20180108010004/bin/fastlane:20:in `<top (required)>'
    from /usr/local/bin/fastlane:23:in `load'
    from /usr/local/bin/fastlane:23:in `<main>'
```
  
 in IRB:

```
irb(main):001:0> require 'fastlane'
NameError: uninitialized constant FastlaneCore::Pathname
    from /var/lib/gems/2.1.0/gems/fastlane-2.74.0.beta.20180108010004/fastlane_core/lib/fastlane_core/module.rb:6:in `<module:FastlaneCore>'
    from /var/lib/gems/2.1.0/gems/fastlane-2.74.0.beta.20180108010004/fastlane_core/lib/fastlane_core/module.rb:5:in `<top (required)>'
    from /var/lib/gems/2.1.0/gems/fastlane-2.74.0.beta.20180108010004/fastlane_core/lib/fastlane_core/configuration/config_item.rb:4:in `require_relative'
    from /var/lib/gems/2.1.0/gems/fastlane-2.74.0.beta.20180108010004/fastlane_core/lib/fastlane_core/configuration/config_item.rb:4:in `<top (required)>'
    from /var/lib/gems/2.1.0/gems/fastlane-2.74.0.beta.20180108010004/fastlane_core/lib/fastlane_core/configuration/configuration.rb:3:in `require_relative'
    from /var/lib/gems/2.1.0/gems/fastlane-2.74.0.beta.20180108010004/fastlane_core/lib/fastlane_core/configuration/configuration.rb:3:in `<top (required)>'
    from /var/lib/gems/2.1.0/gems/fastlane-2.74.0.beta.20180108010004/fastlane_core/lib/fastlane_core.rb:10:in `require_relative'
    from /var/lib/gems/2.1.0/gems/fastlane-2.74.0.beta.20180108010004/fastlane_core/lib/fastlane_core.rb:10:in `<top (required)>'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /var/lib/gems/2.1.0/gems/fastlane-2.74.0.beta.20180108010004/fastlane/lib/fastlane.rb:1:in `<top (required)>'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `require'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:144:in `require'
    from (irb):1
    from /usr/bin/irb:11:in `<main>'
```