### PR TITLE
release: use upcoming version number when generating swift files (relates to #11458)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -137,6 +137,7 @@ end
 
 desc "Generate the Swift api and test it"
 lane :generate_swift_api do |options|
+  require "../fastlane/lib/fastlane/version.rb" # ensure we use the version we are releasing with
   require "../fastlane/lib/fastlane/swift_fastlane_api_generator.rb"
   swift_generator = Fastlane::SwiftFastlaneAPIGenerator.new
   generated_files = swift_generator.generate_swift


### PR DESCRIPTION
  We might have wanted to move that require at the place we do the version bump instead. I wasn't sure of the side effects.