### PR TITLE
Version bump to 2.74.1

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.74.0'.freeze
+  VERSION = '2.74.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -11,4 +11,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.73.0
+// Generated with fastlane 2.74.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -3067,6 +3067,18 @@ func splunkmint(dsym: String? = nil,
                                                                                             RubyCommand.Argument(name: "proxy_port", value: proxyPort)])
   _ = runner.executeCommand(command)
 }
+func spm(command: String = "build",
+         buildPath: String? = nil,
+         packagePath: String? = nil,
+         configuration: String? = nil,
+         verbose: Bool = false) {
+  let command = RubyCommand(commandID: "", methodName: "spm", className: nil, args: [RubyCommand.Argument(name: "command", value: command),
+                                                                                     RubyCommand.Argument(name: "build_path", value: buildPath),
+                                                                                     RubyCommand.Argument(name: "package_path", value: packagePath),
+                                                                                     RubyCommand.Argument(name: "configuration", value: configuration),
+                                                                                     RubyCommand.Argument(name: "verbose", value: verbose)])
+  _ = runner.executeCommand(command)
+}
 func ssh(username: String,
          password: String? = nil,
          host: String,

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -11,4 +11,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.73.0
+// Generated with fastlane 2.74.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -11,4 +11,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.73.0
+// Generated with fastlane 2.74.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -11,4 +11,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.73.0
+// Generated with fastlane 2.74.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -11,4 +11,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.73.0
+// Generated with fastlane 2.74.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -11,4 +11,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.73.0
+// Generated with fastlane 2.74.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -11,4 +11,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.73.0
+// Generated with fastlane 2.74.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.74.0':**

* Revert "FastlaneCore::PTY to replace PTY (#11384)" (#11476) via Felix Krause
* Add missing brackets (#11473) via Felix Krause
* FastlaneCore::PTY to replace PTY (#11384) via Jan Piotrowski
* release: use upcoming version number when generating swift files (relates to #11458) (#11467) via Jerome Lacoste
