### PR TITLE
Update all remaining links that still linked to old GitHub docs

### DIFF
--- a/cert/ManualSteps.md
+++ b/cert/ManualSteps.md
@@ -1,4 +1,4 @@
-# [cert](https://github.com/fastlane/fastlane/tree/master/cert)
+# [cert](https://docs.fastlane.tools/actions/cert/)
 
 #### To create a new certificate and a provisioning profile you have to do the following steps on the Apple Developer Portal
 

--- a/fastlane/lib/fastlane/actions/docs/cert.md
+++ b/fastlane/lib/fastlane/actions/docs/cert.md
@@ -56,9 +56,9 @@ Keep in mind, there is no way for _cert_ to download existing certificates + pri
 
 Run `fastlane action cert` to get a list of all available environment variables.
 
-## Use with [_sigh_](https://github.com/fastlane/fastlane/tree/master/sigh)
+## Use with [_sigh_](https://docs.fastlane.tools/actions/sigh)
 
-_cert_ becomes really interesting when used in [_fastlane_](https://github.com/fastlane/fastlane/tree/master/fastlane) in combination with [_sigh_](https://github.com/fastlane/fastlane/tree/master/sigh).
+_cert_ becomes really interesting when used in [_fastlane_](https://fastlane.tools) in combination with [_sigh_](https://docs.fastlane.tools/actions/sigh).
 
 Update your `Fastfile` to contain the following code:
 

--- a/fastlane/lib/fastlane/actions/docs/deliver.md
+++ b/fastlane/lib/fastlane/actions/docs/deliver.md
@@ -635,7 +635,7 @@ In this case, default values for keywords, urls, name and release notes are used
 
 ## Automatically create screenshots
 
-If you want to integrate _deliver_ with [snapshot](https://github.com/fastlane/fastlane/tree/master/snapshot), check out [fastlane](https://fastlane.tools)!
+If you want to integrate _deliver_ with [snapshot](https://docs.fastlane.tools/actions/snapshot), check out [fastlane](https://fastlane.tools)!
 
 ## Jenkins integration
 Detailed instructions about how to set up _deliver_ and _fastlane_ in `Jenkins` can be found in the [fastlane README](https://docs.fastlane.tools/best-practices/continuous-integration/#jenkins-integration).

--- a/fastlane/lib/fastlane/actions/docs/frameit.md
+++ b/fastlane/lib/fastlane/actions/docs/frameit.md
@@ -150,7 +150,7 @@ The `keyword.strings` and `title.strings` are standard `.strings` file you alrea
 
 #### Uploading screenshots to iTC
 
-Use [deliver](https://github.com/fastlane/fastlane/tree/master/deliver) to upload all screenshots to iTunes Connect completely automatically 🚀
+Use [deliver](https://docs.fastlane.tools/actions/deliver) to upload all screenshots to iTunes Connect completely automatically 🚀
 
 ### Mac
 
@@ -189,7 +189,7 @@ Check out the [MindNode example project](https://github.com/fastlane/examples/tr
 # Tips
 
 ## Generate localized screenshots
-Check out [_snapshot_](https://github.com/fastlane/fastlane/tree/master/snapshot) to automatically generate screenshots using ```UI Automation```.
+Check out [_snapshot_](https://docs.fastlane.tools/actions/snapshot) to automatically generate screenshots using ```UI Automation```.
 
 ## Alternative location to store device_frames
 

--- a/fastlane/lib/fastlane/actions/docs/gym.md
+++ b/fastlane/lib/fastlane/actions/docs/gym.md
@@ -194,8 +194,6 @@ in case you want to display the error in 3rd party tools such as Slack.
 
 You can then easily switch between the beta provider (e.g. `testflight`, `hockey`, `s3` and more).
 
-For more information visit the [fastlane GitHub page](https://github.com/fastlane/fastlane/tree/master/fastlane).
-
 # How does it work?
 
 _gym_ uses the latest APIs to build and sign your application. The 2 main components are
@@ -234,7 +232,7 @@ _gym_ makes use of the new Xcode 7 API which allows us to specify the export opt
 
 Using this method there are no workarounds for WatchKit or Swift required, as it uses the same technique Xcode uses when exporting your binary.
 
-Note: the [xcbuild-safe.sh script](https://github.com/fastlane/fastlane/tree/master/gym/lib//img/actions/wrap_xcodebuild/xcbuild-safe.sh) wraps around xcodebuild to workaround some incompatibilities.
+Note: the [xcbuild-safe.sh script](https://github.com/fastlane/fastlane/tree/master/gym/lib/img/actions/wrap_xcodebuild/xcbuild-safe.sh) wraps around xcodebuild to workaround some incompatibilities.
 
 ## Use the 'Provisioning Quicklook plugin'
 Download and install the [Provisioning Plugin](https://github.com/chockenberry/Provisioning).

--- a/fastlane/lib/fastlane/actions/docs/match.md
+++ b/fastlane/lib/fastlane/actions/docs/match.md
@@ -56,7 +56,7 @@ Before starting to use _match_, make sure to read the [codesigning.guide](https:
 💥  | Easily reset your existing profiles and certificates if your current account has expired or invalid profiles
 ♻️  | Automatically renew your provisioning profiles to include all your devices using the `--force` option
 👥  | Support for multiple Apple accounts and multiple teams
-✨ | Tightly integrated with [fastlane](https://fastlane.tools) to work seamlessly with [gym](https://github.com/fastlane/fastlane/tree/master/gym) and other build tools
+✨ | Tightly integrated with [fastlane](https://fastlane.tools) to work seamlessly with [gym](https://docs.fastlane.tools/actions/gym) and other build tools
 
 For more information about the concept, visit [codesigning.guide](https://codesigning.guide).
 
@@ -83,7 +83,7 @@ This will create a `Matchfile` in your current directory (or in your `./fastlane
 Example content (for more advanced setups check out the [fastlane section](#fastlane)):
 
 ```ruby-skip-tests
-git_url "https://github.com/fastlane/fastlane/tree/master/certificates"
+git_url "https://github.com/fastlane/certs"
 
 app_identifier "tools.fastlane.app"
 username "user@fastlane.tools"
@@ -138,7 +138,7 @@ If you have several targets with different bundle identifiers, supply them as a 
 fastlane match appstore -a tools.fastlane.app,tools.fastlane.app.watchkitapp
 ```
 
-You can make this even easier using [fastlane](https://github.com/fastlane/fastlane/tree/master/fastlane) by creating a `certificates` lane like this:
+You can make this even easier using [fastlane](https://fastlane.tools) by creating a `certificates` lane like this:
 
 ```ruby
 lane :certificates do
@@ -349,4 +349,4 @@ Because of the potentially dangerous nature of In-House profiles please use _mat
 - Even if your certificates are leaked, they can't be used to cause any harm without your iTunes Connect login credentials
 - Use In-House enterprise profile with _match_ with caution
 - If you use GitHub or Bitbucket we encourage enabling 2 factor authentication for all accounts that have access to the certificates repo
-- The complete source code of _match_ is fully open source on [GitHub](https://github.com/fastlane/fastlane/tree/master/match)
+- The complete source code of _match_ is fully open source on [GitHub](https://docs.fastlane.tools/actions/match)

--- a/fastlane/lib/fastlane/actions/docs/pem.md
+++ b/fastlane/lib/fastlane/actions/docs/pem.md
@@ -10,7 +10,7 @@ _pem_ does all that for you, just by simply running _pem_.
 
 _pem_ creates new .pem, .cer, and .p12 files to be uploaded to your push server if a valid push notification profile is needed. _pem_ does not cover uploading the file to your server.
 
-To automate iOS Provisioning profiles you can use [match](https://github.com/fastlane/fastlane/tree/master/match).
+To automate iOS Provisioning profiles you can use [match](https://docs.fastlane.tools/actions/match).
 
 -------
 

--- a/fastlane/lib/fastlane/actions/docs/precheck.md
+++ b/fastlane/lib/fastlane/actions/docs/precheck.md
@@ -70,9 +70,9 @@ custom_text(data: ["chrome", "webos"],
            level: :warn)
 ``` 
 
-### Use with [_fastlane_](https://github.com/fastlane/fastlane/tree/master/fastlane)
+### Use with [_fastlane_](https://fastlane.tools)
 
-_precheck_ is fully integrated with [_deliver_](https://github.com/fastlane/fastlane/tree/master/deliver) another [_fastlane_](https://github.com/fastlane/fastlane/tree/master/fastlane) tool.
+_precheck_ is fully integrated with [_deliver_](https://docs.fastlane.tools/actions/deliver) another [_fastlane_](https://fastlane.tools) tool.
 
 Update your `Fastfile` to contain the following code:
 

--- a/fastlane/lib/fastlane/actions/docs/produce.md
+++ b/fastlane/lib/fastlane/actions/docs/produce.md
@@ -224,7 +224,7 @@ apple_id ENV['PRODUCE_APPLE_ID']
 
 This will tell _deliver_, which `App ID` to use, since the app is not yet available in the App Store.
 
-You'll still have to fill out the remaining information (like screenshots, app description and pricing). You can use [deliver](https://github.com/fastlane/fastlane/tree/master/deliver) to upload your app metadata using a CLI
+You'll still have to fill out the remaining information (like screenshots, app description and pricing). You can use [deliver](https://docs.fastlane.tools/actions/deliver) to upload your app metadata using a CLI
 
 ## How is my password stored?
 

--- a/fastlane/lib/fastlane/actions/docs/scan.md
+++ b/fastlane/lib/fastlane/actions/docs/scan.md
@@ -141,5 +141,3 @@ lane :test do
   scan(scheme: "Example")
 end
 ```
-
-For more information visit the [fastlane GitHub page](https://github.com/fastlane/fastlane/tree/master/fastlane).

--- a/fastlane/lib/fastlane/actions/docs/sigh.md
+++ b/fastlane/lib/fastlane/actions/docs/sigh.md
@@ -28,7 +28,7 @@ _sigh_ can create, renew, download and repair provisioning profiles (with one co
 - Support for **multiple Teams**
 - Support for **Enterprise Profiles**
 
-To automate iOS Push profiles you can use [pem](https://github.com/fastlane/fastlane/tree/master/pem).
+To automate iOS Push profiles you can use [pem](https://docs.fastlane.tools/actions/pem).
 
 
 ### Why not let Xcode do the work?
@@ -44,7 +44,7 @@ See _sigh_ in action:
 
 # Usage
 
-**Note**: It is recommended to use [match](https://github.com/fastlane/fastlane/tree/master/match) according to the [codesigning.guide](https://codesigning.guide) for generating and maintaining your provisioning profiles. Use _sigh_ directly only if you want full control over what's going on and know more about codesigning.
+**Note**: It is recommended to use [match](https://docs.fastlane.tools/actions/match) according to the [codesigning.guide](https://codesigning.guide) for generating and maintaining your provisioning profiles. Use _sigh_ directly only if you want full control over what's going on and know more about codesigning.
 
 ```no-highlight
 fastlane sigh
@@ -107,9 +107,9 @@ For a list of available parameters and commands run
     fastlane action sigh
 
 
-### Use with [_fastlane_](https://github.com/fastlane/fastlane/tree/master/fastlane)
+### Use with [_fastlane_](https://fastlane.tools)
 
-_sigh_ becomes really interesting when used in [_fastlane_](https://github.com/fastlane/fastlane/tree/master/fastlane) in combination with [_cert_](https://github.com/fastlane/fastlane/tree/master/cert).
+_sigh_ becomes really interesting when used in [_fastlane_](https://fastlane.tools) in combination with [_cert_](https://docs.fastlane.tools/actions/cert).
 
 Update your `Fastfile` to contain the following code:
 
@@ -160,7 +160,7 @@ Or delete all `iOS Team Provisioning Profile` by using a regular expression
 
 Run `fastlane action sigh` to get a list of all available environment variables.
 
-If you're using [cert](https://github.com/fastlane/fastlane/tree/master/cert) in combination with [fastlane](https://github.com/fastlane/fastlane/tree/master/fastlane) the signing certificate will automatically be selected for you. (make sure to run _cert_ before _sigh_)
+If you're using [cert](https://docs.fastlane.tools/actions/cert) in combination with [fastlane](https://fastlane.tools) the signing certificate will automatically be selected for you. (make sure to run _cert_ before _sigh_)
 
 # How does it work?
 
@@ -180,7 +180,7 @@ It will show you the `mobileprovision` files like this:
 
 ## App Identifier couldn't be found
 
-If you also want to create a new App Identifier on the Apple Developer Portal, check out [produce](https://github.com/fastlane/fastlane/tree/master/produce), which does exactly that.
+If you also want to create a new App Identifier on the Apple Developer Portal, check out [produce](https://docs.fastlane.tools/actions/produce), which does exactly that.
 
 ## What happens to my Xcode managed profiles?
 

--- a/fastlane/lib/fastlane/actions/docs/snapshot.md
+++ b/fastlane/lib/fastlane/actions/docs/snapshot.md
@@ -10,7 +10,7 @@
 </h4>
 <hr />
 
-_snapshot_ generates localized iOS and tvOS screenshots for different device types and languages for the App Store and can be uploaded using ([_deliver_](https://github.com/fastlane/fastlane/tree/master/deliver)).
+_snapshot_ generates localized iOS and tvOS screenshots for different device types and languages for the App Store and can be uploaded using ([_deliver_](https://docs.fastlane.tools/actions/deliver)).
 
 You have to manually create 20 (languages) x 6 (devices) x 5 (screenshots) = **600 screenshots**.
 
@@ -20,7 +20,7 @@ It's hard to get everything right!
 - No loading indicators
 - Same content / screens
 - [Clean Status Bar](#use-a-clean-status-bar)
-- Uploading screenshots ([_deliver_](https://github.com/fastlane/fastlane/tree/master/deliver) is your friend)
+- Uploading screenshots ([_deliver_](https://docs.fastlane.tools/actions/deliver) is your friend)
 
 More information about [creating perfect screenshots](https://krausefx.com/blog/creating-perfect-app-store-screenshots-of-your-ios-app).
 
@@ -44,7 +44,7 @@ _snapshot_ runs completely in the background - you can do something else, while 
 - Take screenshots in multiple device simulators concurrently to cut down execution time (Xcode 9 only)
 - Configure it once, store the configuration in git
 - Do something else, while the computer takes the screenshots for you
-- Integrates with [_fastlane_](https://fastlane.tools) and [_deliver_](https://github.com/fastlane/fastlane/tree/master/deliver)
+- Integrates with [_fastlane_](https://fastlane.tools) and [_deliver_](https://docs.fastlane.tools/actions/deliver)
 - Generates a beautiful web page, which shows all screenshots on all devices. This is perfect to send to QA or the marketing team
 - _snapshot_ automatically waits for network requests to be finished before taking a screenshot (we don't want loading images in the App Store screenshots)
 
@@ -303,7 +303,7 @@ Radar [23062925](https://openradar.appspot.com/radar?id=5056366381105152) has be
 
 ## Frame the screenshots
 
-If you want to add frames around the screenshots and even put a title on top, check out [frameit](https://github.com/fastlane/fastlane/tree/master/frameit).
+If you want to add frames around the screenshots and even put a title on top, check out [frameit](https://docs.fastlane.tools/actions/frameit).
 
 ## Available language codes
 ```ruby

--- a/fastlane_core/README.md
+++ b/fastlane_core/README.md
@@ -1,29 +1,3 @@
-<h3 align="center">
-  <a href="https://github.com/fastlane/fastlane/tree/master/fastlane">
-    <img src="../fastlane/assets/fastlane.png" width="150" />
-    <br />
-    fastlane
-  </a>
-</h3>
-<p align="center">
-  <a href="https://github.com/fastlane/fastlane/tree/master/deliver">deliver</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/snapshot">snapshot</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/frameit">frameit</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/pem">pem</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/sigh">sigh</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/produce">produce</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/cert">cert</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/spaceship">spaceship</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/pilot">pilot</a> &bull;
-  <a href="https://github.com/fastlane/boarding">boarding</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/gym">gym</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/scan">scan</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/match">match</a> &bull;
-  <a href="https://github.com/fastlane/fastlane/tree/master/precheck">precheck</a>
-</p>
-
--------
-
 FastlaneCore
 ============
 

--- a/match/lib/assets/READMETemplate.md
+++ b/match/lib/assets/READMETemplate.md
@@ -1,4 +1,4 @@
-## [fastlane match](https://github.com/fastlane/fastlane/tree/master/match#readme)
+## [fastlane match](https://docs.fastlane.tools/actions/match)
 
 This repository contains all your certificates and provisioning profiles needed to build and sign your applications. They are encrypted using OpenSSL via a passphrase.
 
@@ -40,7 +40,7 @@ fastlane match development
 fastlane match enterprise
 ```
 
-For more information open [fastlane match git repo](https://github.com/fastlane/fastlane/tree/master/match#readme)
+For more information open [fastlane match git repo](https://docs.fastlane.tools/actions/match)
 
 ### Content
 
@@ -54,4 +54,4 @@ This directory contains all provisioning profiles
 
 ------------------------------------
 
-For more information open [fastlane match git repo](https://github.com/fastlane/fastlane/tree/master/match#readme)
+For more information open [fastlane match git repo](https://docs.fastlane.tools/actions/match)


### PR DESCRIPTION
I have no idea why we never updated those URLs...