### PR TITLE
Version bump to 2.75.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.74.1'.freeze
+  VERSION = '2.75.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -11,4 +11,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.74.0
+// Generated with fastlane 2.74.1

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -11,4 +11,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.74.0
+// Generated with fastlane 2.74.1

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -11,4 +11,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.74.0
+// Generated with fastlane 2.74.1

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -11,4 +11,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.74.0
+// Generated with fastlane 2.74.1

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -11,4 +11,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.74.0
+// Generated with fastlane 2.74.1

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -11,4 +11,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.74.0
+// Generated with fastlane 2.74.1

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -11,4 +11,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.74.0
+// Generated with fastlane 2.74.1


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.74.1':**

* Pin ruby version on Circle (#11488) via Manu Wallner
* Keep track of files modified when generating Swift API (#11482) via Joshua Liebowitz
* Add parentheses for all method calls (#11474) via Felix Krause
* Update all remaining links that still linked to old GitHub docs (#11483) via Felix Krause
* Add tests to verify the built-in actions follow the conventions (#11332) via Felix Krause
* spaceship and deliver: add support for the new iPad (#11330) via Felix Krause
* Check for missing requires  (#11472) via Manu Wallner
