### PR TITLE
Improve behavior of cfpropertylist extension

### DIFF
--- a/fastlane_core/lib/fastlane_core/core_ext/cfpropertylist.rb
+++ b/fastlane_core/lib/fastlane_core/core_ext/cfpropertylist.rb
@@ -12,7 +12,9 @@ require "plist"
 # CFPropertyList also adds Enumerator#to_plist, but there is no such
 # method from Plist, so leave it.
 [Array, Hash].each do |c|
-  c.send(:alias_method, :to_binary_plist, :to_plist)
-  c.send(:remove_method, :to_plist) if c.method_defined?(:remove_method)
+  if c.method_defined?(:to_plist)
+    c.send(:alias_method, :to_binary_plist, :to_plist)
+    c.send(:remove_method, :to_plist)
+  end
   c.module_eval("include Plist::Emit")
 end

--- a/fastlane_core/lib/fastlane_core/core_ext/cfpropertylist.rb
+++ b/fastlane_core/lib/fastlane_core/core_ext/cfpropertylist.rb
@@ -13,8 +13,11 @@ require "plist"
 # method from Plist, so leave it.
 [Array, Hash].each do |c|
   if c.method_defined?(:to_plist)
-    c.send(:alias_method, :to_binary_plist, :to_plist)
-    c.send(:remove_method, :to_plist)
+    begin
+      c.send(:alias_method, :to_binary_plist, :to_plist)
+      c.send(:remove_method, :to_plist)
+    rescue NameError
+    end
   end
   c.module_eval("include Plist::Emit")
 end

--- a/fastlane_core/lib/fastlane_core/core_ext/cfpropertylist.rb
+++ b/fastlane_core/lib/fastlane_core/core_ext/cfpropertylist.rb
@@ -13,6 +13,6 @@ require "plist"
 # method from Plist, so leave it.
 [Array, Hash].each do |c|
   c.send(:alias_method, :to_binary_plist, :to_plist)
-  c.send(:remove_method, :to_plist)
+  c.send(:remove_method, :to_plist) if c.method_defined?(:remove_method)
   c.module_eval("include Plist::Emit")
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This extension sometimes causes problems when used with RVM gemsets.

### Description

Be careful about removing the `#to_plist` method in case it was already removed.