### PR TITLE
[frameit] Fix: Empty `keyword` breaks positioning and size of `title`

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -441,20 +441,21 @@ module Frameit
       strings_path = File.join(File.expand_path("..", screenshot.path), "#{type}.strings")
       if File.exist?(strings_path)
         parsed = StringsParser.parse(strings_path)
-        result = parsed.find { |k, v| screenshot.path.upcase.include?(k.upcase) }
-        return result.last if result
+        text_array = parsed.find { |k, v| screenshot.path.upcase.include?(k.upcase) }
+        return text_array.last if text_array && text_array.last.length > 0 # Ignore empty string
       end
+
+      UI.verbose("Falling back to text in Framefile.json as there was nothing specified in the #{type}.strings file")
 
       # No string files, fallback to Framefile config
-      result = fetch_config[type.to_s]['text'] if fetch_config[type.to_s]
-      UI.verbose("Falling back to default text as there was nothing specified in the .strings file")
+      text = fetch_config[type.to_s]['text'] if fetch_config[type.to_s] && fetch_config[type.to_s]['text'] && fetch_config[type.to_s]['text'].length > 0 # Ignore empty string
 
-      if type == :title and !result
+      if type == :title and !text
         # title is mandatory
-        UI.user_error!("Could not get title for screenshot #{screenshot.path}. Please provide one in your Framefile.json")
+        UI.user_error!("Could not get title for screenshot #{screenshot.path}. Please provide one in your Framefile.json or title.strings")
       end
 
-      return result
+      return text
     end
 
     # The font we want to use


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This fixes #11464:

- Ensure that function `fetch_text()` ignores empty strings to prevent that empty text images are created.
- As a result the `UI.user_error` for missing title is now also shown when an empty title string is defined.
- Improved `UI.user_error` to also mention _title.strings_ file
- Refactured variable names
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->

The code changes can be found here: https://github.com/fastlane/fastlane/issues/11464#issuecomment-356564429.

The tests are copied from this https://github.com/fastlane/fastlane/issues/11464#issuecomment-356571604:

**Verification**
I use the following requirements:

1. The `title` can be defined in either the _Framefile.json_ or in _title.strings_
2. The `keyword` can be defined in either the _Framefile.json_ or in _keyword.strings_
3. The definition in the _*.strings_ file takes precedence over the definition in _Framefile.json_
4. The `title` is mandatory. When no `title` is found in both files, or an empty string is defined, an error should be shown in Terminal and no screenshot should be created.
5. The `keyword` is optional. When specified, it should be shown left of the `title` in the screenshot.
6. The `title` and optional `keyword` should be horizontally aligned in the center of the screenshot (this issue).
7. The `title` and optional `keyword` should be vertically aligned in such a way that they share a common text baseline in the screenshot (issue #10440).

**Tests**

Description | 2.68.2 (before fix #10440) | 2.75.1 (latest incl. #10440)) | 2.74.1 + this fix
----------- | -------- | -- | --
No definition at all (not in _Framefile.json_ and no _*.strings_ files) | Proper error (E1) shown, no screenshot created = REQ-4 | Proper error (E1) shown, no screenshot created = REQ-4 | Improved error (E1+) shown, no screenshot created = REQ-4
Define a title in _Framefile.json_ only, no _*.strings_ files | Screenshot with correctly aligned title created = REQ-1 + REQ-6 | Screenshot with correctly aligned title created = REQ-1 + REQ-6 | Screenshot with correctly aligned title created = REQ-1 + REQ-6
Define an empty title in _Framefile.json_ only, no _*.strings_ files | Warning (W1) shown, screenshot with no text created. = **FAIL** for REQ-4 | Warning (W1) shown, screenshot with no text created. = **FAIL** for REQ-4 | Improved error (E1+) shown, no screenshot created = REQ-4
Define no title in _Framefile.json_ and one in _title.strings_, no _keyword.strings_ file | Screenshot with correctly aligned title created = REQ-1 + REQ-6  | Screenshot with correctly aligned title created = REQ-1 + REQ-6 | Screenshot with correctly aligned title created = REQ-1 + REQ-6
Define no title in _Framefile.json_ and an empty one in _title.strings_, no _keyword.strings_ file  | Warning (W1) shown, screenshot with no text created. = **FAIL** for REQ-4 | Warning (W2) shown, screenshot with no text created. = **FAIL** for REQ-4 | Improved error (E1+) shown, no screenshot created = REQ-4
Define a title in _Framefile.json_ and a different title in _title.strings_, no _keyword.strings_ file | Screenshot with correctly aligned title from _title.strings_ created = REQ-3 + REQ-6  | Screenshot with correctly aligned title from _title.strings_ created = REQ-3 + REQ-6 | Screenshot with correctly aligned title from _title.strings_ created = REQ-3 + REQ-6
No title definition at all (not in _Framefile.json_ and no _title.strings_ file, define a keyword in _keyword.strings_ file) | Proper error (E1) shown, no screenshot created = REQ-4 | Proper error (E1) shown, no screenshot created = REQ-4 | Improved error (E1+) shown, no screenshot created = REQ-4
Define a title and keyword in _Framefile.json_ only, no _*.strings_ files | Screenshot with correctly aligned title and keyword created = REQs: 1, 2, 5, 6, 7 | Screenshot with correctly aligned title and keyword created = REQs: 1, 2, 5, 6, 7 | Screenshot with correctly aligned title and keyword created = REQs: 1, 2, 5, 6, 7
Define a title and empty keyword in _Framefile.json_ only, no _*.strings_ files | Warning (W1) shown, screenshot with correctly aligned title created = REQs: 1, 2, 6 | Warning (W2) shown, screenshot created with a very tiny title in the top right corner. **FAIL** for REQs: 5, 6 | Screenshot with correctly aligned title created = REQs: 1, 2, 6
Define a title in _Framefile.json_, no keyword in _Framefile.json_ and a keyword in _keyword.strings_, no _title.strings_ file | Screenshot with correctly aligned title and keyword created = REQs: 1, 2, 5, 6, 7 | Screenshot with correctly aligned title and keyword created = REQs: 1, 2, 5, 6, 7 | Screenshot with correctly aligned title and keyword created = REQs: 1, 2, 5, 6, 7
Define a title in _Framefile.json_, no keyword in _Framefile.json_ and an empty keyword in _keyword.strings_, no _title.strings_ file | Warning (W1) shown, screenshot with correctly aligned title created = REQ-1 + REQ-6 | Warning (W2) shown, screenshot created with a very tiny title in the top right corner. **FAIL** for REQs: 5, 6 | Screenshot with correctly aligned title created = REQ-1 + REQ-6
Define a title in _Framefile.json_, a keyword in _Framefile.json_ and a different keyword in _keyword.strings_, no _title.strings_ file | Screenshot with correctly aligned title and keyword from _keyword.strings_ created = REQs: 1, 2, 3, 5, 6, 7 | Screenshot with correctly aligned title and keyword from _keyword.strings_ created = REQs: 1, 2, 3, 5, 6, 7 | Screenshot with correctly aligned title and keyword from _keyword.strings_ created = REQs: 1, 2, 3, 5, 6, 7

**Summary of fails**

FAIL | 2.68.2 (before fix #10440) | 2.75.1 (latest incl. #10440)) | 2.74.1 + this fix
-- | -- | -- | --
REQ-4: Empty title in _Framefile.json_ or in _title.strings_ doesn't show Error and writes screenshot with no title | yes | yes | no
REQ-5+6: Empty keyword in _Framefile.json_ or in _keyword.strings_ creates screenshot with a very tiny title in the top right corner | no | yes | no

**Warnings/Errors from Table**
W1 =
> [11:32:14]: Framing screenshot './en-US/iPhone SE-01_RemoteTab.png'
> mogrify: geometry does not contain image `/var/folders/7g/n55n1s5x3z931vflyvwp_7280000gn/T/mini_magick20180110-40105-1ky6nc2.png' @ warning/attribute.c/GetImageBoundingBox/240.
> mogrify: geometry does not contain image `/var/folders/7g/n55n1s5x3z931vflyvwp_7280000gn/T/mini_magick20180110-40105-j5eg7k.png' @ warning/attribute.c/GetImageBoundingBox/240.

W2 = 

> identify: geometry does not contain image `/var/folders/7g/n55n1s5x3z931vflyvwp_7280000gn/T/mini_magick20180110-42037-rd6j5j.png' @ warning/attribute.c/GetImageBoundingBox/240.
> mogrify: geometry does not contain image `/var/folders/7g/n55n1s5x3z931vflyvwp_7280000gn/T/mini_magick20180110-42037-rd6j5j.png' @ warning/transform.c/CropImage/641.

E1 =
> Could not get title for screenshot ./en-US/iPhone SE-01_RemoteTab.png. Please provide one in your Framefile.json  

E1+ =

> Could not get title for screenshot ./en-US/iPhone SE-01_RemoteTab.png. Please provide one in your Framefile.json or title.strings

**Conclusion**
The 2 fails are NOT present in this fix, while all REQs are met.
So this solution does not only repair the reported issue #11464 (small title in top right corner) but also an unreported issue that an empty title wasn't reported as erroneous.