### PR TITLE
Enable nuking of Enterprise account and warn the user beforehand

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
+++ b/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
@@ -292,6 +292,7 @@ To revoke all certificates and provisioning profiles for a specific environment:
 ```no-highlight
 fastlane match nuke development
 fastlane match nuke distribution
+fastlane match nuke enterprise
 ```
 
 <img src="/img/actions/match_nuke.gif" width="550" />

--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -122,11 +122,11 @@ module Match
         c.syntax = "fastlane match nuke"
         c.description = "Delete all certificates and provisioning profiles from the Apple Dev Portal"
         c.action do |args, options|
-          FastlaneCore::UI.user_error!("Please run `fastlane match nuke [type], allowed values: distribution and development. For the 'adhoc' type, please use 'distribution' instead.")
+          FastlaneCore::UI.user_error!("Please run `fastlane match nuke [type], allowed values: development, distribution and enterprise. For the 'adhoc' type, please use 'distribution' instead.")
         end
       end
 
-      ["development", "distribution"].each do |type|
+      ["development", "distribution", "enterprise"].each do |type|
         command "nuke #{type}" do |c|
           c.syntax = "fastlane match nuke #{type}"
           c.description = "Delete all certificates and provisioning profiles from the Apple Dev Portal of the type #{type}"

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -73,10 +73,11 @@ module Match
       Spaceship.login(params[:username])
       Spaceship.select_team
 
-      if Spaceship.client.in_house? && type == "distribution"
+      if Spaceship.client.in_house? && (type == "distribution" || type == "enterprise")
         UI.error("---")
         UI.error("⚠️ Warning: This seems to be an Enterprise account!")
-        UI.error("By nuking your Enterprise account's distribution, all your in-house apps will stop working!")
+        UI.error("By nuking your account's distribution, all your apps deployed via ad-hoc will stop working!") if type == "distribution"
+        UI.error("By nuking your account's enterprise, all your in-house apps will stop working!") if type == "enterprise"
         UI.error("---")
 
         UI.user_error!("Enterprise account nuke cancelled") unless UI.confirm("Do you really want to nuke your Enterprise account?")

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -73,7 +73,14 @@ module Match
       Spaceship.login(params[:username])
       Spaceship.select_team
 
-      UI.user_error!("`fastlane match nuke` doesn't support enterprise accounts") if Spaceship.client.in_house?
+      if Spaceship.client.in_house
+        UI.error("---")
+        UI.error("⚠️ Warning: This seems to be an Enterprise account!")
+        UI.error("By nuking your Enterprise account, all your in-house apps will stop working!")
+        UI.error("---")
+
+        return unless UI.confirm("Do you really want to nuke your Enterprise account?")
+      end
 
       self.certs = certificate_type(cert_type).all
       self.profiles = []

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -73,13 +73,13 @@ module Match
       Spaceship.login(params[:username])
       Spaceship.select_team
 
-      if Spaceship.client.in_house
+      if Spaceship.client.in_house? && type == "distribution"
         UI.error("---")
         UI.error("⚠️ Warning: This seems to be an Enterprise account!")
-        UI.error("By nuking your Enterprise account, all your in-house apps will stop working!")
+        UI.error("By nuking your Enterprise account's distribution, all your in-house apps will stop working!")
         UI.error("---")
 
-        return unless UI.confirm("Do you really want to nuke your Enterprise account?")
+        UI.user_error!("Enterprise account nuke cancelled") unless UI.confirm("Do you really want to nuke your Enterprise account?")
       end
 
       self.certs = certificate_type(cert_type).all


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Nuking of the enterprise account is currently disabled. This PR will enable it but user will have to confirm this action beforehand.

### Description
<!-- Describe your changes in detail -->

Issue reference: #11463 
