### PR TITLE
Improve command timeouts

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -394,8 +394,8 @@ module FastlaneCore
         retries = FastlaneCore::Project.xcode_list_retries
         @raw = FastlaneCore::Project.run_command(command, timeout: timeout, retries: retries, print: !silent)
       rescue Timeout::Error
-      UI.user_error!("xcodebuild -list timed out after #{retries + 1} retries with a base timeout of #{timeout}. You might need to recreate the user schemes." \
-          " You can override the base timeout value with the environment variable FASTLANE_XCODE_LIST_TIMEOUT")
+        UI.user_error!("xcodebuild -list timed out after #{retries + 1} retries with a base timeout of #{timeout}. You might need to recreate the user schemes." \
+            " You can override the base timeout value with the environment variable FASTLANE_XCODE_LIST_TIMEOUT")
       end
 
       UI.user_error!("Error parsing xcode file using `#{command}`") if @raw.length == 0

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -317,8 +317,8 @@ module FastlaneCore
             UI.error("Could not read build settings. Make sure that the scheme \"#{options[:scheme]}\" is configured for running by going to Product → Scheme → Edit Scheme…, selecting the \"Build\" section, checking the \"Run\" checkbox and closing the scheme window.")
           end
         rescue Timeout::Error
-          raise FastlaneCore::Interface::FastlaneDependencyCausedException.new, "xcodebuild -showBuildSettings timed-out after #{timeout} seconds and #{retries} retries." \
-            " You can override the timeout value with the environment variable FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT," \
+          raise FastlaneCore::Interface::FastlaneDependencyCausedException.new, "xcodebuild -showBuildSettings timed out after #{retries + 1} retries with a base timeout of #{timeout}." \
+            " You can override the base timeout value with the environment variable FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT," \
             " and the number of retries with the environment variable FASTLANE_XCODEBUILD_SETTINGS_RETRIES ".red
         end
       end
@@ -394,8 +394,8 @@ module FastlaneCore
         retries = FastlaneCore::Project.xcode_list_retries
         @raw = FastlaneCore::Project.run_command(command, timeout: timeout, retries: retries, print: !silent)
       rescue Timeout::Error
-        UI.user_error!("xcodebuild -list timed-out after #{timeout * retries} seconds. You might need to recreate the user schemes." \
-          " You can override the timeout value with the environment variable FASTLANE_XCODE_LIST_TIMEOUT")
+      UI.user_error!("xcodebuild -list timed out after #{retries + 1} retries with a base timeout of #{timeout}. You might need to recreate the user schemes." \
+          " You can override the base timeout value with the environment variable FASTLANE_XCODE_LIST_TIMEOUT")
       end
 
       UI.user_error!("Error parsing xcode file using `#{command}`") if @raw.length == 0
@@ -405,7 +405,7 @@ module FastlaneCore
 
     # @internal to module
     def self.xcode_list_timeout
-      (ENV['FASTLANE_XCODE_LIST_TIMEOUT'] || 10).to_i
+      (ENV['FASTLANE_XCODE_LIST_TIMEOUT'] || 3).to_i
     end
 
     # @internal to module
@@ -415,7 +415,7 @@ module FastlaneCore
 
     # @internal to module
     def self.xcode_build_settings_timeout
-      (ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] || 10).to_i
+      (ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] || 3).to_i
     end
 
     # @internal to module
@@ -438,22 +438,27 @@ module FastlaneCore
 
       total_tries = retries + 1
       try = 1
+      try_timeout = timeout
       begin
-        Timeout.timeout(timeout) do
+        Timeout.timeout(try_timeout) do
           # Using Helper.backticks didn't work here. `Timeout` doesn't time out, and the command hangs forever
           result = `#{command}`.to_s
         end
       rescue Timeout::Error
         try_limit_reached = try >= total_tries
 
-        message = "Command timed out after #{timeout} seconds on try #{try} of #{total_tries}"
-        message += ", trying again..." unless try_limit_reached
+        # Try harder on each iteration
+        next_timeout = try_timeout * 2
+
+        message = "Command timed out after #{try_timeout} seconds on try #{try} of #{total_tries}"
+        message += ", trying again with #{next_timeout} second timeout..." unless try_limit_reached
 
         UI.important(message)
 
         raise if try_limit_reached
 
         try += 1
+        try_timeout = next_timeout
         retry
       end
 

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -424,7 +424,9 @@ module FastlaneCore
     end
 
     # @internal to module
-    # runs the specified command with the specified number of retries, killing each run if it times out
+    # runs the specified command with the specified number of retries, killing each run if it times out.
+    # the first run times out after specified timeout elapses, and each successive run times out after
+    # a doubling of the previous timeout has elapsed.
     # @raises Timeout::Error if all tries result in a timeout
     # @returns the output of the command
     # Note: - currently affected by https://github.com/fastlane/fastlane/issues/1504
@@ -451,7 +453,7 @@ module FastlaneCore
         next_timeout = try_timeout * 2
 
         message = "Command timed out after #{try_timeout} seconds on try #{try} of #{total_tries}"
-        message += ", trying again with #{next_timeout} second timeout..." unless try_limit_reached
+        message += ", trying again with a #{next_timeout} second timeout..." unless try_limit_reached
 
         UI.important(message)
 

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -301,7 +301,7 @@ describe FastlaneCore do
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
         expect(FastlaneCore::Helper).to receive(:xcode_at_least?).and_return(true)
         command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
-        expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
+        expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 3, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
         expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")
       end
 
@@ -310,7 +310,7 @@ describe FastlaneCore do
         @project = FastlaneCore::Project.new(options, xcodebuild_list_silent: true, xcodebuild_suppress_stderr: true)
         expect(FastlaneCore::Helper).to receive(:xcode_at_least?).and_return(false)
         command = "xcodebuild clean -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2> /dev/null"
-        expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 10, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
+        expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 3, retries: 3, print: false }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
         expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")
       end
     end
@@ -353,7 +353,7 @@ describe FastlaneCore do
         ENV['FASTLANE_XCODE_LIST_TIMEOUT'] = nil
       end
       it "returns default value" do
-        expect(FastlaneCore::Project.xcode_list_timeout).to eq(10)
+        expect(FastlaneCore::Project.xcode_list_timeout).to eq(3)
       end
       it "returns specified value" do
         ENV['FASTLANE_XCODE_LIST_TIMEOUT'] = '5'
@@ -374,7 +374,7 @@ describe FastlaneCore do
         ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = nil
       end
       it "returns default value" do
-        expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(10)
+        expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(3)
       end
       it "returns specified value" do
         ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '5'
@@ -453,7 +453,7 @@ describe FastlaneCore do
         expect(FastlaneCore::Project).to receive(:`).and_call_original.exactly(4).times
 
         expect do
-          FastlaneCore::Project.run_command(cmd, timeout: 1, retries: 3)
+          FastlaneCore::Project.run_command(cmd, timeout: 0.2, retries: 3)
         end.to raise_error(Timeout::Error)
       end
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This proposed change improves the timeout behavior when executing commands that extract schemes and build settings from Xcode projects.

By changing from a timeout strategy where a fixed timeout is applied repeatedly to the same command (likely to fail by timing out repeatedly), to one in which the timeout is progressively increased with each iteration, it is more likely that users of fastlane will have a successful initialization of a new project.

This pull request fixes issue #11524.

I tested these changes first by manually confirming that the timeout value increases as expected while repeatedly iterating on one of my more complicated Xcode project files, then by setting an artificially low timeout value for each of FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT and FASTLANE_XCODE_LIST_TIMEOUT, and observing that after exhausting increasingly greater timeouts, the commands fail with as similar failure mode to before.

Finally I updated existing unit tests covering retry and timeout behavior so that they pass in the context of the new behavior.

### Description

1. The base timeout defaults for FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT and FASTLANE_XCODE_LIST_TIMEOUT are each lowered from 10 to 3.

2. On each recurring try to run a command (4 tries by default, unchanged), the timeout is doubled so that by default a command will run with timeouts of 3, 6, 12, and 24 seconds.

3. The changed strategy increases _maximum_ default timeout that will be tried from 10 seconds to 24 seconds, while increasing the _total_ elapsed time from exhausting 4 tries in 40 seconds to 45 seconds.

Typical users will likely see fastlane init succeed in the 3, 6, or 12 second timeout iteration, while users with more complex projects are now much more likely to succeed without having to specify a custom environment variable value.

The choice of a new default "3" is made with some consideration to wanting to preserve the same rough total elapsed time before erroring out (40 seconds), while improving the chances that users whose projects are only moderately complex will reach a successful command completion sooner.