### PR TITLE
[frameit] Improve readability of file editor.rb by renaming several variables

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -263,10 +263,10 @@ module Frameit
     end
 
     def put_title_into_background(background, stack_title)
-      title_images = build_title_images(image.width - 2 * horizontal_frame_padding, image.height - 2 * vertical_frame_padding)
+      text_images = build_text_images(image.width - 2 * horizontal_frame_padding, image.height - 2 * vertical_frame_padding)
 
-      keyword = title_images[:keyword]
-      title = title_images[:title]
+      keyword = text_images[:keyword]
+      title = text_images[:title]
 
       if stack_title && !keyword.nil? && !title.nil? && keyword.width > 0 && title.width > 0
         background = put_title_into_background_stacked(background, title, keyword)
@@ -328,8 +328,8 @@ module Frameit
       (actual_font_size / 3.0).round
     end
 
-    # This will build 2 individual images with the title, which will then be added to the real image
-    def build_title_images(max_width, max_height)
+    # This will build up to 2 individual images with the title and optional keyword, which will then be added to the real image
+    def build_text_images(max_width, max_height)
       words = [:keyword, :title].keep_if { |a| fetch_text(a) } # optional keyword/title
       results = {}
       trim_boxes = {}
@@ -338,9 +338,9 @@ module Frameit
       words.each do |key|
         # Create empty background
         empty_path = File.join(Frameit::ROOT, "lib/assets/empty.png")
-        title_image = MiniMagick::Image.open(empty_path)
+        text_image = MiniMagick::Image.open(empty_path)
         image_height = max_height # gets trimmed afterwards anyway, and on the iPad the `y` would get cut
-        title_image.combine_options do |i|
+        text_image.combine_options do |i|
           # Oversize as the text might be larger than the actual image. We're trimming afterwards anyway
           i.resize("#{max_width * 5.0}x#{image_height}!") # `!` says it should ignore the ratio
         end
@@ -356,7 +356,7 @@ module Frameit
         interline_spacing = fetch_config['interline_spacing']
 
         # Add the actual title
-        title_image.combine_options do |i|
+        text_image.combine_options do |i|
           i.font(current_font) if current_font
           i.gravity("Center")
           i.pointsize(actual_font_size)
@@ -365,11 +365,11 @@ module Frameit
           i.fill(fetch_config[key.to_s]['color'])
         end
 
-        results[key] = title_image
+        results[key] = text_image
 
         # Natively trimming the image with .trim will result in the loss of the common baseline between the text in all images.
         # Hence retrieve the calculated trim bounding box without actually trimming:
-        calculated_trim_box = title_image.identify do |b|
+        calculated_trim_box = text_image.identify do |b|
           b.format("%@") # CALCULATED: trim bounding box (without actually trimming), see: http://www.imagemagick.org/script/escape.php
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
While working on frameit issue #11464, I found confusing variable names.
Several variables are called `title_image` or `title_images`, while it contains the data for either the keys "title" and "keyword". So it's either the "title image" or "keyword image". Using the variable name `title_image` for both is highly confusion, as it might contain the "keyword image".

### Description
<!-- Describe your changes in detail -->
The images are a graphical representation of the title and keyword text, so the variables (and 1 function) are renamed to `text_image` and `text_images`.

See also: https://github.com/fastlane/fastlane/issues/11464#issuecomment-356596105