### PR TITLE
Appaloosa action - Enforce API_KEY on private signed form

### DIFF
--- a/fastlane/lib/fastlane/actions/appaloosa.rb
+++ b/fastlane/lib/fastlane/actions/appaloosa.rb
@@ -22,7 +22,7 @@ module Fastlane
       def self.upload_on_s3(file, api_key, store_id, group_ids = '')
         file_name = file.split('/').last
         uri = URI("#{APPALOOSA_SERVER}/upload_services/presign_form")
-        params = { file: file_name, store_id: store_id, group_ids: group_ids }
+        params = { file: file_name, store_id: store_id, group_ids: group_ids, api_key: api_key }
         uri.query = URI.encode_www_form(params)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true

--- a/fastlane/spec/actions_specs/appaloosa_spec.rb
+++ b/fastlane/spec/actions_specs/appaloosa_spec.rb
@@ -69,7 +69,7 @@ describe Fastlane do
 
       context 'when upload_service returns an error' do
         before do
-          stub_request(:get, "#{APPALOOSA_SERVER}/upload_services/presign_form?file=Fastfile1&group_ids=&store_id=556").
+          stub_request(:get, "#{APPALOOSA_SERVER}/upload_services/presign_form?api_key=xxx&file=Fastfile1&group_ids=&store_id=556").
             to_return(status: 200, body: '{ "errors": "A group id is incorrect" }', headers: {})
         end
 
@@ -88,7 +88,7 @@ describe Fastlane do
         let(:expect_error) { 'ERROR: A problem occurred with your API token and your store id. Please try again.' }
 
         before do
-          stub_request(:get, "#{APPALOOSA_SERVER}/upload_services/presign_form?file=Fastfile1&group_ids=&store_id=556").
+          stub_request(:get, "#{APPALOOSA_SERVER}/upload_services/presign_form?api_key=xxx&file=Fastfile1&group_ids=&store_id=556").
             to_return(status: 200, body: presign_payload)
           stub_request(:put, "http://appaloosa.com/test").
             to_return(status: 200)
@@ -111,7 +111,7 @@ describe Fastlane do
         let(:expect_error) { 'ERROR: A problem occurred with your API token and your store id. Please try again.' }
 
         before do
-          stub_request(:get, "#{APPALOOSA_SERVER}/upload_services/presign_form?file=Fastfile1&group_ids=&store_id=556").
+          stub_request(:get, "#{APPALOOSA_SERVER}/upload_services/presign_form?api_key=xxx&file=Fastfile1&group_ids=&store_id=556").
             to_return(status: 200, body: presign_payload)
           stub_request(:put, "http://appaloosa.com/test").
             to_return(status: 200)
@@ -140,7 +140,7 @@ describe Fastlane do
         end
 
         before do
-          stub_request(:get, "#{APPALOOSA_SERVER}/upload_services/presign_form?file=Fastfile1&group_ids=&store_id=556").
+          stub_request(:get, "#{APPALOOSA_SERVER}/upload_services/presign_form?api_key=xxx&file=Fastfile1&group_ids=&store_id=556").
             to_return(status: 200, body: presign_payload, headers: {})
           stub_request(:put, "http://appaloosa.com/test").
             to_return(status: 200, body: '', headers: {})


### PR DESCRIPTION
🔑

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
The presign_form was not requesting the api_key. We now do the same as `get_s3_url` we provide the `api_key` in query as query param. 

Thanks in advance for the review