### PR TITLE
match/sigh/sync_code_signing: Improving documentation on profile templates.

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
+++ b/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
@@ -248,6 +248,16 @@ match(app_identifier: ["tools.fastlane.app", "tools.fastlane.app.today_widget"],
 
 _match_ can even use the same one Git repository for all bundle identifiers.
 
+##### Templates (aka: custom entitlements)
+
+Match can generate profiles that contain custom entitlements by passing in the entitlement's name with the `template_name` parameter.
+
+```
+match(git_url: "https://github.com/fastlane/certificates",
+      type: "development",
+      template_name: "Apple Pay Pass Suppression Development")
+```
+
 ### Setup Xcode project
 
 [Docs on how to set up your Xcode project](/codesigning/xcode-project/)

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -152,7 +152,7 @@ module Match
                                      end),
         FastlaneCore::ConfigItem.new(key: :template_name,
                                      env_name: "MATCH_PROVISIONING_PROFILE_TEMPLATE_NAME",
-                                     description: "The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile",
+                                     description: "The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. \"Apple Pay Pass Suppression Development\")",
                                      optional: true,
                                      default_value: nil)
       ]

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -152,7 +152,7 @@ module Match
                                      end),
         FastlaneCore::ConfigItem.new(key: :template_name,
                                      env_name: "MATCH_PROVISIONING_PROFILE_TEMPLATE_NAME",
-                                     description: "The name of provisioning profile template. If the developer account has provisioning profile templates, template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile",
+                                     description: "The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile",
                                      optional: true,
                                      default_value: nil)
       ]

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -138,7 +138,7 @@ module Sigh
                                      end),
         FastlaneCore::ConfigItem.new(key: :template_name,
                                      env_name: "SIGH_PROVISIONING_PROFILE_TEMPLATE_NAME",
-                                     description: "The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile",
+                                     description: "The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. \"Apple Pay Pass Suppression Development\")",
                                      optional: true,
                                      default_value: nil)
       ]

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -138,7 +138,7 @@ module Sigh
                                      end),
         FastlaneCore::ConfigItem.new(key: :template_name,
                                      env_name: "SIGH_PROVISIONING_PROFILE_TEMPLATE_NAME",
-                                     description: "The name of provisioning profile template. If the developer account has provisioning profile templates, template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile",
+                                     description: "The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile",
                                      optional: true,
                                      default_value: nil)
       ]


### PR DESCRIPTION
Improving documentation on profile templates where also known as custom entitlements.

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Struggled for over a month trying to add custom entitlements to a fastlane ci setup, only to find out that it was already supported just under a different name.

Resolves #11049 

### Description
Updated docs to mention 'custom entitlements' so that the `template_name` key is searchable using 'custom entitlements'.
