### PR TITLE
Improve team section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 
 ## _fastlane_ team
 
-<table>
+<table id='team'>
 <tr>
 <td id='jérôme-lacoste'>
 <a href='https://github.com/lacostej'>

--- a/README.md
+++ b/README.md
@@ -30,83 +30,83 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 
 <table>
 <tr>
-<td id='maksym-grebenets'>
-<img src='https://github.com/mgrebenets.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-<td id='manu-wallner'>
-<img src='https://github.com/milch.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+<td id='stefan-natchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 <td id='aaron-brager'>
-<img src='https://github.com/getaaron.png?size=200' width=140>
+<img src='https://github.com/getaaron.png?size=140'>
 <h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
-<td id='joshua-liebowitz'>
-<img src='https://github.com/taquitos.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+<td id='danielle-tomlinson'>
+<img src='https://github.com/DanToml.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
 </td>
-<td id='olivier-halligon'>
-<img src='https://github.com/AliSoftware.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+<td id='jérôme-lacoste'>
+<img src='https://github.com/lacostej.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+<td id='iulian-onofrei'>
+<img src='https://github.com/revolter.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
 </tr>
 <tr>
-<td id='iulian-onofrei'>
-<img src='https://github.com/revolter.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+<td id='josh-holtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
-<td id='stefan-natchev'>
-<img src='https://github.com/snatchev.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+<td id='joshua-liebowitz'>
+<img src='https://github.com/taquitos.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<img src='https://github.com/janpio.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='olivier-halligon'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='felix-krause'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+</tr>
+<tr>
+<td id='helmut-januschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
 <td id='jimmy-dee'>
-<img src='https://github.com/jdee.png?size=200' width=140>
+<img src='https://github.com/jdee.png?size=140'>
 <h4 align='center'>Jimmy Dee</h4>
 </td>
-<td id='kohki-miki'>
-<img src='https://github.com/giginet.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<td id='fumiya-nakamura'>
+<img src='https://github.com/nafu.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
-<td id='josh-holtz'>
-<img src='https://github.com/joshdholtz.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+<td id='maksym-grebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+<td id='manu-wallner'>
+<img src='https://github.com/milch.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
 </tr>
 <tr>
 <td id='luka-mirosevic'>
-<img src='https://github.com/lmirosevic.png?size=200' width=140>
+<img src='https://github.com/lmirosevic.png?size=140'>
 <h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
-<td id='helmut-januschka'>
-<img src='https://github.com/hjanuschka.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='jérôme-lacoste'>
-<img src='https://github.com/lacostej.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='felix-krause'>
-<img src='https://github.com/KrauseFx.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
 <td id='matthew-ellis'>
-<img src='https://github.com/matthewellis.png?size=200' width=140>
+<img src='https://github.com/matthewellis.png?size=140'>
 <h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-</tr>
-<tr>
-<td id='fumiya-nakamura'>
-<img src='https://github.com/nafu.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<img src='https://github.com/DanToml.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<img src='https://github.com/janpio.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+<td id='kohki-miki'>
+<img src='https://github.com/giginet.png?size=140'>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -30,83 +30,83 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 
 <table>
 <tr>
-<td>
-<img src='https://github.com/KrauseFx.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td>
-<img src='https://github.com/janpio.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td>
-<img src='https://github.com/joshdholtz.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td>
-<img src='https://github.com/matthewellis.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td>
-<img src='https://github.com/giginet.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-</tr>
-<tr>
-<td>
-<img src='https://github.com/lmirosevic.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-<td>
-<img src='https://github.com/milch.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-<td>
-<img src='https://github.com/lacostej.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td>
-<img src='https://github.com/getaaron.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td>
-<img src='https://github.com/nafu.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-</tr>
-<tr>
-<td>
-<img src='https://github.com/revolter.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td>
-<img src='https://github.com/jdee.png?size=200' width=140>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td>
-<img src='https://github.com/hjanuschka.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td>
-<img src='https://github.com/snatchev.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td>
-<img src='https://github.com/DanToml.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
-</td>
-</tr>
-<tr>
-<td>
+<td id='maksym-grebenets'>
 <img src='https://github.com/mgrebenets.png?size=200' width=140>
 <h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
-<td>
+<td id='manu-wallner'>
+<img src='https://github.com/milch.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='aaron-brager'>
+<img src='https://github.com/getaaron.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<img src='https://github.com/taquitos.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='olivier-halligon'>
 <img src='https://github.com/AliSoftware.png?size=200' width=140>
 <h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
 </td>
-<td>
-<img src='https://github.com/taquitos.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</tr>
+<tr>
+<td id='iulian-onofrei'>
+<img src='https://github.com/revolter.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='stefan-natchev'>
+<img src='https://github.com/snatchev.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+<td id='jimmy-dee'>
+<img src='https://github.com/jdee.png?size=200' width=140>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='kohki-miki'>
+<img src='https://github.com/giginet.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='josh-holtz'>
+<img src='https://github.com/joshdholtz.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+</tr>
+<tr>
+<td id='luka-mirosevic'>
+<img src='https://github.com/lmirosevic.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+<td id='helmut-januschka'>
+<img src='https://github.com/hjanuschka.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='jérôme-lacoste'>
+<img src='https://github.com/lacostej.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+<td id='felix-krause'>
+<img src='https://github.com/KrauseFx.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='matthew-ellis'>
+<img src='https://github.com/matthewellis.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+</tr>
+<tr>
+<td id='fumiya-nakamura'>
+<img src='https://github.com/nafu.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<img src='https://github.com/DanToml.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<img src='https://github.com/janpio.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -30,83 +30,119 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 
 <table>
 <tr>
-<td id='stefan-natchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td id='aaron-brager'>
-<img src='https://github.com/getaaron.png?size=140'>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<img src='https://github.com/DanToml.png?size=140'>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
-</td>
 <td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
 <img src='https://github.com/lacostej.png?size=140'>
+</a>
 <h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
-<td id='iulian-onofrei'>
-<img src='https://github.com/revolter.png?size=140'>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
 </tr>
 <tr>
-<td id='josh-holtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
 <td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
 <img src='https://github.com/taquitos.png?size=140'>
+</a>
 <h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
-<td id='jan-piotrowski'>
-<img src='https://github.com/janpio.png?size=140'>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
-<td id='olivier-halligon'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
 <td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
 <img src='https://github.com/KrauseFx.png?size=140'>
+</a>
 <h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
 </tr>
 <tr>
-<td id='helmut-januschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
-<td id='jimmy-dee'>
-<img src='https://github.com/jdee.png?size=140'>
-<h4 align='center'>Jimmy Dee</h4>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
-<td id='fumiya-nakamura'>
-<img src='https://github.com/nafu.png?size=140'>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/DanToml'>
+<img src='https://github.com/DanToml.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
 </td>
-<td id='maksym-grebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
-<td id='manu-wallner'>
-<img src='https://github.com/milch.png?size=140'>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 </tr>
 <tr>
-<td id='luka-mirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 <td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
 <img src='https://github.com/matthewellis.png?size=140'>
+</a>
 <h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td id='kohki-miki'>
-<img src='https://github.com/giginet.png?size=140'>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
 </table>
 

--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ task(:generate_team_table) do
 
     content << "<tr>" if counter % number_of_rows == 0
     content << "<td id='#{github_user_id}'>"
-    content << "<img src='https://github.com/#{github_user}.png?size=200' width=140>"
+    content << "<img src='https://github.com/#{github_user}.png?size=140'>"
     if user_content['twitter']
       content << "<h4 align='center'><a href='https://twitter.com/#{user_content['twitter']}'>#{github_user_name}</a></h4>"
     else

--- a/Rakefile
+++ b/Rakefile
@@ -35,14 +35,16 @@ task(:generate_team_table) do
 
   contributors.keys.shuffle.each do |github_user|
     user_content = contributors[github_user]
+    github_user_name = user_content['name']
+    github_user_id = github_user_name.downcase.gsub(' ', '-')
 
     content << "<tr>" if counter % number_of_rows == 0
-    content << "<td>"
+    content << "<td id='#{github_user_id}'>"
     content << "<img src='https://github.com/#{github_user}.png?size=200' width=140>"
     if user_content['twitter']
-      content << "<h4 align='center'><a href='https://twitter.com/#{user_content['twitter']}'>#{user_content['name']}</a></h4>"
+      content << "<h4 align='center'><a href='https://twitter.com/#{user_content['twitter']}'>#{github_user_name}</a></h4>"
     else
-      content << "<h4 align='center'>#{user_content['name']}</h4>"
+      content << "<h4 align='center'>#{github_user_name}</h4>"
     end
     # content << "<p align='center'>#{user_content['slogan']}</p>" if user_content['slogan'].to_s.length > 0
 

--- a/Rakefile
+++ b/Rakefile
@@ -37,10 +37,13 @@ task(:generate_team_table) do
     user_content = contributors[github_user]
     github_user_name = user_content['name']
     github_user_id = github_user_name.downcase.gsub(' ', '-')
+    github_profile_url = "https://github.com/#{github_user}"
 
     content << "<tr>" if counter % number_of_rows == 0
     content << "<td id='#{github_user_id}'>"
-    content << "<img src='https://github.com/#{github_user}.png?size=140'>"
+    content << "<a href='#{github_profile_url}'>"
+    content << "<img src='#{github_profile_url}.png?size=140'>"
+    content << "</a>"
     if user_content['twitter']
       content << "<h4 align='center'><a href='https://twitter.com/#{user_content['twitter']}'>#{github_user_name}</a></h4>"
     else

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ end
 
 task(:generate_team_table) do
   require 'json'
-  content = ["<table>"]
+  content = ["<table id='team'>"]
 
   contributors = JSON.parse(File.read("team.json"))
   counter = 0
@@ -59,7 +59,7 @@ task(:generate_team_table) do
   content << "</table>"
 
   readme = File.read("README.md")
-  readme.gsub!(%r{\<table\>.*\<\/table\>}m, content.join("\n"))
+  readme.gsub!(%r{\<table id='team'\>.*\<\/table\>}m, content.join("\n"))
   File.write("README.md", readme)
   puts("All done")
 end


### PR DESCRIPTION
Related to #11491.

With this:
- Clicking on the anchor next to a name, correctly jumps to the top of the image instead of the name
- Removes conflicting image size (`200` vs `140`)
- Replaces automatic link (added by GitHub) to the image file with a link to the GitHub profile