### PR TITLE
[deliver] Fix for activating languages

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -235,7 +235,7 @@ module Deliver
       v.languages.each do |language_data|
         lang = language_data["localeCode"]
         enabled_languages[lang] = language_data
-        primary_data = language_data if !language_data["canDeleteLocale"]
+        primary_data = language_data unless language_data["canDeleteLocale"]
       end
 
       UI.user_error!("could not find primary language data for app '#{options[:app].name}'") unless primary_data


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

With `fastlane deliver upload_metadata`, I get the following error on a old iOS project that has never had languages added to it before:
    
    [⠇] Activating languages de-DE, en-US, es-ES, fr-FR, it, ja, ko, ms, pt-PT, ru, sv, zh-Hans... Potential server error received: 'Unexpected Error'. Retrying after 10 seconds (remaining: 5)...

Note that this error doesn't occur when I delete an existing language from ITC and then use `fastlane deliver` to recreate it.  The current code to activate languages works when a language has been previously used, but not on fresh projects.

I tested my changes on a project in ITC that only had an en-US language (primary). The current version of fastlane (2.75.1) failed with the error above. The changed code successfully added the languages.
There doesn't appear to be any existing spec tests for the deliver metadata code.

### Description

The changed code uses the edit details client instead of the edit version client to add languages. 
