### PR TITLE
Version bump to 2.76.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,30 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <table>
 <tr>
 <td>
+<img src='https://github.com/jdee.png?size=200' width=140>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td>
+<img src='https://github.com/snatchev.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+<td>
+<img src='https://github.com/nafu.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+<td>
 <img src='https://github.com/KrauseFx.png?size=200' width=140>
 <h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td>
+<img src='https://github.com/giginet.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+</tr>
+<tr>
+<td>
+<img src='https://github.com/milch.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
 <td>
 <img src='https://github.com/janpio.png?size=200' width=140>
@@ -43,23 +65,15 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
 <td>
-<img src='https://github.com/matthewellis.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+<img src='https://github.com/hjanuschka.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
 <td>
-<img src='https://github.com/giginet.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<img src='https://github.com/revolter.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
 </tr>
 <tr>
-<td>
-<img src='https://github.com/lmirosevic.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-<td>
-<img src='https://github.com/milch.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
 <td>
 <img src='https://github.com/lacostej.png?size=200' width=140>
 <h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
@@ -69,44 +83,30 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
 <td>
-<img src='https://github.com/nafu.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-</tr>
-<tr>
-<td>
-<img src='https://github.com/revolter.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td>
-<img src='https://github.com/jdee.png?size=200' width=140>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td>
-<img src='https://github.com/hjanuschka.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td>
-<img src='https://github.com/snatchev.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td>
-<img src='https://github.com/DanToml.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
-</td>
-</tr>
-<tr>
-<td>
 <img src='https://github.com/mgrebenets.png?size=200' width=140>
 <h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+<td>
+<img src='https://github.com/lmirosevic.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
 <td>
 <img src='https://github.com/AliSoftware.png?size=200' width=140>
 <h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
 </td>
+</tr>
+<tr>
+<td>
+<img src='https://github.com/DanToml.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+</td>
 <td>
 <img src='https://github.com/taquitos.png?size=200' width=140>
 <h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td>
+<img src='https://github.com/matthewellis.png?size=200' width=140>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -29,38 +29,25 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 ## _fastlane_ team
 
 <table id='team'>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
+<tr>
 <td id='felix-krause'>
 <a href='https://github.com/KrauseFx'>
 <img src='https://github.com/KrauseFx.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
-</tr>
-<tr>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
 <td id='iulian-onofrei'>
 <a href='https://github.com/revolter'>
 <img src='https://github.com/revolter.png?size=140'>
@@ -73,17 +60,13 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/DanToml'>
-<img src='https://github.com/DanToml.png?size=140'>
+</tr>
+<tr>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 <td id='stefan-natchev'>
 <a href='https://github.com/snatchev'>
@@ -91,19 +74,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
-</tr>
-<tr>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
 <td id='matthew-ellis'>
 <a href='https://github.com/matthewellis'>
@@ -111,9 +86,63 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-<td>
-<img src='https://github.com/matthewellis.png?size=200' width=140>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+</tr>
+<tr>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/DanToml'>
+<img src='https://github.com/DanToml.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+</td>
+</tr>
+<tr>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -14,7 +14,7 @@ File.write("#{lib}/fastlane/plugins/template/.rubocop.yml", YAML.dump(config))
 Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
-  spec.authors       = ["Joshua Liebowitz", "Aaron Brager", "Luka Mirosevic", "Jérôme Lacoste", "Matthew Ellis", "Helmut Januschka", "Jan Piotrowski", "Olivier Halligon", "Iulian Onofrei", "Danielle Tomlinson", "Jimmy Dee", "Josh Holtz", "Stefan Natchev", "Kohki Miki", "Manu Wallner", "Fumiya Nakamura", "Felix Krause", "Maksym Grebenets"]
+  spec.authors       = ["Jan Piotrowski", "Felix Krause", "Matthew Ellis", "Luka Mirosevic", "Jérôme Lacoste", "Jimmy Dee", "Aaron Brager", "Manu Wallner", "Joshua Liebowitz", "Iulian Onofrei", "Josh Holtz", "Stefan Natchev", "Kohki Miki", "Helmut Januschka", "Olivier Halligon", "Danielle Tomlinson", "Maksym Grebenets", "Fumiya Nakamura"]
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION
   spec.description   = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.75.1'.freeze
+  VERSION = '2.76.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.75.1':**

* Update tty-spinner dependency (#11558) via Felix Krause
* Adding my twitter handle to team.json (#11549) via AliSoftware
* We're all one team ❤ (#11491) via Felix Krause
* register_devices: replace unsafe external link (#11542) via Jan Piotrowski
* Enable Swift FastlaneRunner to be updated automatically 🎉 (#11512) via Joshua Liebowitz
* Enable nuking of Enterprise account and warn the user beforehand (#11522) via Vedran Burojević
* Rename several internal frameit variables (#11532) via funnel20
* Remove double whitespace around operators (#11529) via Jon
* [frameit] Fix: Empty `keyword` breaks positioning and size of `title` (#11518) via funnel20
* Bump slack-notifier Gem Dependency (#11465) via Joe Masilotti
* Improve "Testing" part of YourFirstPR.md (#11517) via Jan Piotrowski
* Add missing require statements for legacy spaceship (PRECHECK) (#11510) via Bruno Barbieri
* Be more specific with gem cache key (#11504) via Manu Wallner
* Finish tool migration for docs (#11505) via Felix Krause
* Fix style of sample command in scan docs (#11480) via Felix Krause
* Add custom rubocop to check fork usage (#11502) via Manu Wallner
* Replace `fork` usage with cross-platform alternative (#11418) via Jan Piotrowski
* Use correct syntax for caches (#11501) via Danielle Tomlinson
* Hide loading indicator for CI systems (#11500) via Felix Krause
