### PR TITLE
Add link to badge plugin

### DIFF
--- a/fastlane/lib/fastlane/actions/badge.rb
+++ b/fastlane/lib/fastlane/actions/badge.rb
@@ -38,6 +38,7 @@ module Fastlane
 
       def self.details
         [
+          "[Please use the badge fastlane plugin instead: https://github.com/HazAT/fastlane-plugin-badge]",
           "This action will add a light/dark badge onto your app icon.",
           "You can also provide your custom badge/overlay or add an shield for more customization more info:",
           "https://github.com/HazAT/badge",


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/11562
Makes it appear on https://docs.fastlane.tools/actions/badge/ also 👍
cc @janpio