### PR TITLE
Automatic creation + updating of Gemfile on `fastlane init`

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -12,6 +12,10 @@ module Fastlane
         ARGV.include?('-h') || ARGV.include?('--help')
       end
 
+      def running_init_command?
+        ARGV.include?("init")
+      end
+
       def take_off
         before_import_time = Time.now
 
@@ -37,7 +41,7 @@ module Fastlane
           require "fastlane"
         end
         # We want to avoid printing output other than the version number if we are running `fastlane -v`
-        unless running_version_command?
+        unless running_version_command? || running_init_command?
           print_bundle_exec_warning(is_slow: (Time.now - before_import_time > 3))
         end
 

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -42,7 +42,7 @@ module Fastlane
         UI.message("")
 
         setup_ios = self.new
-        setup_ios.ensure_gemfile_valid!(update_gemfile_if_needed: false)
+        setup_ios.add_or_update_gemfile(update_gemfile_if_needed: false)
         setup_ios.suggest_next_steps
         return
       end
@@ -173,7 +173,7 @@ module Fastlane
 
       File.write(appfile_path, self.appfile_content)
 
-      gemfile_path = add_or_update_gemfile
+      add_or_update_gemfile(update_gemfile_if_needed: true)
 
       UI.header("✅  Successfully generated fastlane configuration")
       UI.message("Generated Fastfile at path `#{fastfile_path}`")
@@ -184,7 +184,6 @@ module Fastlane
       UI.message("This way everyone in your team can benefit from your fastlane setup")
       continue_with_enter
     end
-
 
     def gemfile_path
       gemfile_path = "Gemfile" # TODO: use bundler class
@@ -244,11 +243,13 @@ module Fastlane
     # This method is responsible for ensuring there is a working
     # Gemfile, and that `fastlane` is defined as a dependency
     # while also having `rubygems` as a gem source
-    def add_or_update_gemfile
+    def add_or_update_gemfile(update_gemfile_if_needed: false)
       if gemfile_exists?
-        ensure_gemfile_valid!(update_gemfile_if_needed: true)
+        ensure_gemfile_valid!(update_gemfile_if_needed: update_gemfile_if_needed)
       else
-        setup_gemfile!
+        if update_gemfile_if_needed || UI.confirm("It is recommended to run fastlane with a Gemfile set up, do you want fastlane to create one for you?")
+          setup_gemfile!
+        end
       end
       return gemfile_path
     end

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -186,7 +186,7 @@ module Fastlane
     end
 
     def gemfile_path
-      gemfile_path = "Gemfile" # TODO: use bundler class
+      gemfile_path = "Gemfile"
     end
 
     # Gemfile related code:

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -186,7 +186,7 @@ module Fastlane
     end
 
     def gemfile_path
-      gemfile_path = "Gemfile"
+      "Gemfile"
     end
 
     # Gemfile related code:

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -40,7 +40,10 @@ module Fastlane
         UI.important("------------------")
         UI.important("fastlane is already set up at path `#{FastlaneCore::FastlaneFolder.path}`, see the available lanes above")
         UI.message("")
-        self.new.suggest_next_steps
+
+        setup_ios = self.new
+        setup_ios.ensure_gemfile_valid!(update_gemfile_if_needed: false)
+        setup_ios.suggest_next_steps
         return
       end
 
@@ -201,6 +204,7 @@ module Fastlane
       gemfile_content << ""
       File.write(gemfile_path, gemfile_content.join("\n"))
 
+      UI.message("Installing dependencies for you...")
       FastlaneCore::CommandExecutor.execute(
         command: "bundle update",
         print_all: FastlaneCore::Globals.verbose?,
@@ -218,7 +222,10 @@ module Fastlane
       unless gemfile_content.include?("https://rubygems.org")
         UI.error("You have a local Gemfile, but RubyGems isn't defined as source")
         UI.error("Please update your Gemfile at path `#{gemfile_path}` to include")
+        UI.important("")
         UI.important("source \"https://rubygems.org\"")
+        UI.important("")
+        UI.error("Update your Gemfile, and run `bundle update` afterwards")
       end
 
       unless gemfile_content.include?("fastlane")


### PR DESCRIPTION
Fixes #11546

**Done**
- If fastlane already set up, but no Gemfile, offer to create one
- More testing

**Follow-up PR**
- We have code that mentions `To get started with a Gemfile, run`, we should unify this, and make it all as part of `fastlane init`

Related docs https://github.com/fastlane/fastlane/issues/11586

<img width="686" alt="screen shot 2018-01-16 at 2 52 19 pm" src="https://user-images.githubusercontent.com/869950/35009208-dfdbe09e-facc-11e7-97ad-607be038a60e.png">
