### PR TITLE
[Proposal] Run `Bundler.setup` for the user

### DIFF
--- a/bin/fastlane
+++ b/bin/fastlane
@@ -4,6 +4,17 @@ if RUBY_VERSION < '2.0.0'
   abort("fastlane requires Ruby 2.0.0 or higher")
 end
 
+# We recommend people use bundler together with a Gemfile
+# but we can't really force them. To make it easier for them
+# we don't want to tell every user to run every fastlane command
+# using `bundle exec`, so instead we'll try to load it for them
+require 'bundler'
+begin
+  Bundler.setup
+rescue => ex
+  # No Gemfile setup, no big deal
+end
+
 $LOAD_PATH.push(File.expand_path("../../lib", __FILE__))
 
 require "fastlane/cli_tools_distributor"


### PR DESCRIPTION
This worked on my local machine, but I probably didn't consider everything. Here are some thoughts:
1. Will this work with plugins?
1. Will this actually make it possible for people to use _fastlane_ without using `bundle exec` ever time? 
1. Does this change then actually resolve the issues we had with conflicting versions? 
1. Does this have any side effects?