### PR TITLE
Write dSYMs in binary mode to avoid UndefinedConversion error

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -94,9 +94,7 @@ module Fastlane
         if output_directory
           file_name = output_directory + file_name
         end
-        File.open(file_name, 'w', binmode: true) do |file|
-          file.write(data)
-        end
+        File.binwrite(file_name, data)
         file_name
       end
 

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -94,7 +94,9 @@ module Fastlane
         if output_directory
           file_name = output_directory + file_name
         end
-        File.write(file_name, data)
+        File.open(file_name, 'w', binmode: true) do |file|
+          file.write(data)
+        end
         file_name
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Downloading dsyms from iTunes Connect resulted in a conversion error when values could not be converted from ASCII-8BIT to UTF-8.  

Closes #11119 
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->
Open the file for write in binary mode to avoid the UTF-8 conversion.
