### PR TITLE
Fix for Travis CI not installing WWDRC how we expect it

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -65,13 +65,17 @@ module FastlaneCore
       keychain = "-k #{keychain.shellescape}" unless keychain.empty?
 
       require 'open3'
-      stdout, stderr, status = Open3.capture3("curl -f -o #{filename} #{url} && security import #{filename} #{keychain}")
+
+      import_command = "curl -f -o #{filename} #{url} && security import #{filename} #{keychain}"
+      UI.verbose("Installing WWDR Cert: #{import_command}")
+
+      stdout, stderr, _status = Open3.capture3(import_command)
       if FastlaneCore::Globals.verbose?
         UI.command_output(stdout)
         UI.command_output(stderr)
       end
 
-      unless status.success?
+      unless $?.success?
         UI.verbose("Failed to install WWDR Certificate, checking output to see why")
         # Check the command output, WWDR might already exist
         unless /The specified item already exists in the keychain./ =~ stderr
@@ -79,6 +83,7 @@ module FastlaneCore
         end
         UI.verbose("WWDR Certificate was already installed")
       end
+      return true
     end
 
     def self.wwdr_keychain

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -35,12 +35,12 @@ describe FastlaneCore do
         `ls`
 
         cmd = %r{curl -f -o (/.+?) https://developer\.apple\.com/certificationauthority/AppleWWDRCA.cer && security import \1 -k keychain\\ with\\ spaces\.keychain}
+        require "open3"
 
-        expect(FastlaneCore::Helper).to receive(:backticks).with(cmd, { print: nil }).and_return("")
+        expect(Open3).to receive(:capture3).with(cmd).and_return("")
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
-        expect($?).to receive(:success?).and_return(true)
 
-        FastlaneCore::CertChecker.install_wwdr_certificate
+        expect(FastlaneCore::CertChecker.install_wwdr_certificate).to be(true)
       end
     end
   end


### PR DESCRIPTION
- Travic CI doesn't seem to install the WWDRC cert how we expect
 so attempt to install it, and if we get a failure during install
 check the reason. If it's because the cert exists, then skip.

This is a workaround for #10059
