### PR TITLE
Sort candidate_builds by upload_date in Spaceship::Tunes::AppVersion

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -328,7 +328,7 @@ module Spaceship
           build_version
         else
           if candidate_builds.length > 0
-            candidate_builds.first.build_version
+            candidate_builds.sort_by(&:upload_date).last.build_version
           end
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #11420.

### Description
Unlike https://github.com/fastlane/fastlane/blob/master/spaceship/spec/tunes/fixtures/candiate_builds.json which are time-sorted iTunes Connect doesn't necessarily returns the candidate builds in a time-sorted order, thus sorting by upload_date is required to retrieve the latest version. 