### PR TITLE
Missing variable fix for socket_server

### DIFF
--- a/fastlane/lib/fastlane/server/socket_server.rb
+++ b/fastlane/lib/fastlane/server/socket_server.rb
@@ -208,7 +208,7 @@ module Fastlane
 
       while e.respond_to?("cause") && (e = e.cause)
         exception_array << "cause: #{e.class}"
-        exception_array << backtrace
+        exception_array << e.backtrace
       end
       return "{\"payload\":{\"status\":\"failure\",\"failure_information\":#{exception_array.flatten}}}"
     end


### PR DESCRIPTION
fixes #11614

If your exception has a `cause` then when we're examining it, we accidentally call `backtrace` instead of `e.backtrace`. `backtrace` isn't a thing.
