### PR TITLE
Do not show step text for environment_variable action.

### DIFF
--- a/fastlane/lib/fastlane/actions/environment_variable.rb
+++ b/fastlane/lib/fastlane/actions/environment_variable.rb
@@ -57,6 +57,10 @@ module Fastlane
         "Sets/gets env vars for Fastlane.swift. Don't use in ruby, use `ENV[key] = val`"
       end
 
+      def self.step_text
+        nil
+      end
+
       def self.category
         :misc
       end


### PR DESCRIPTION
When running in Fastlane.swift, this action prints out lots of
unnecessary step text for each environment variable being set.