### PR TITLE
Add missing action aliases

### DIFF
--- a/fastlane/lib/fastlane/actions/echo.rb
+++ b/fastlane/lib/fastlane/actions/echo.rb
@@ -1,0 +1,14 @@
+module Fastlane
+  module Actions
+    require 'fastlane/actions/puts'
+    class EchoAction < PutsAction
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Alias for the `puts` action"
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/println.rb
+++ b/fastlane/lib/fastlane/actions/println.rb
@@ -1,0 +1,14 @@
+module Fastlane
+  module Actions
+    require 'fastlane/actions/puts'
+    class PrintlnAction < PutsAction
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Alias for the `puts` action"
+      end
+    end
+  end
+end

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -193,7 +193,7 @@ describe Fastlane do
         expect(UI).to receive(:important).with("Setting '[:windows, :neogeo]' as extra SupportedPlatforms")
         ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileAddNewPlatform')
         expect(UI).to receive(:message).with("echo :windows")
-        ff.runner.execute(:echo, :windows)
+        ff.runner.execute(:echo_lane, :windows)
       end
 
       it "before_each and after_each are called every time" do

--- a/fastlane/spec/fixtures/fastfiles/FastfileAddNewPlatform
+++ b/fastlane/spec/fixtures/fastfiles/FastfileAddNewPlatform
@@ -4,7 +4,7 @@ platform :windows do
   lane :empty do
   end
 
-  lane :echo do
+  lane :echo_lane do
     UI.message "echo :windows"
   end
 end

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -59,6 +59,9 @@ describe Fastlane do
           upload_to_app_store
           upload_to_play_store
           upload_to_testflight
+          puts
+          println
+          echo
         )
       end
 


### PR DESCRIPTION
`fastlane/lib/fastlane/actions/puts.rb` lists `println` and `echo` as action aliases but these actions are missing.