### PR TITLE
[gym] Trim ApplicationIdentifierPrefix to get correct Bundle ID

### DIFF
--- a/fastlane/lib/fastlane/actions/build_ios_app.rb
+++ b/fastlane/lib/fastlane/actions/build_ios_app.rb
@@ -47,9 +47,8 @@ module Fastlane
             Actions.lane_context[SharedValues::SIGH_PROFILE_PATHS].each do |profile_path|
               begin
                 profile = FastlaneCore::ProvisioningProfile.parse(profile_path)
-                profile_team_id = profile["TeamIdentifier"].first
-                next if profile_team_id != values[:export_team_id] && !values[:export_team_id].nil?
-                bundle_id = profile["Entitlements"]["application-identifier"].gsub("#{profile_team_id}.", "")
+                app_id_prefix = profile["ApplicationIdentifierPrefix"].first
+                bundle_id = profile["Entitlements"]["application-identifier"].gsub("#{app_id_prefix}.", "")
                 values[:export_options][:provisioningProfiles][bundle_id] = profile["Name"]
               rescue => ex
                 UI.error("Couldn't load profile at path: #{profile_path}")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
#### Why is this change required? What problem does it solve?

When creating the provisioning profile on developer portal, you are free to choose any App Identifier Prefix, not being limited by the Team ID, so the 'provisioningProfiles' mapping in the exportOptions.plist would be wrong in case the prefix differs from the Team ID. 

#### Please describe in detail how you tested your changes.
I ran `gym` on a project that has an App ID Prefix different than the Team ID in Developer Portal. It successfully downloaded the provisioning, trimmed the correct prefix and finally generated a correct `exportOptions.plist` file.

### Description
This PR aims to trim 'AppIdentifierPrefix' key contained in the Provisioning Profile rather than the 'TeamIdentifier' key when detecting the provisioning profile to bundle IDs mapping.