### PR TITLE
[match] using ruby openssl instead of terminal one

### DIFF
--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -99,7 +99,6 @@ module Match
     end
 
     def decrypt(path: nil, password: nil)
-      stored_data = ""
       stored_data = Base64.decode64(File.read(path))
       salt = stored_data[8..15]
       data_to_decrypt = stored_data[16..-1]

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -93,6 +93,8 @@ module Match
       encrypted_data = "Salted__" + salt + cipher.update(data_to_encrypt) + cipher.final
 
       File.write(path, Base64.encode64(encrypted_data))
+    rescue FastlaneCore::Interface::FastlaneError => user_error
+      raise
     rescue => error
       UI.error(error.to_s)
       UI.crash!("Error encrypting '#{path}'")

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -81,6 +81,12 @@ module Match
       end
     end
 
+    # We encrypt with MD5 because that was the most common default value in older fastlane versions which used the local OpenSSL installation
+    # A more secure key and IV generation is needed in the future
+    # IV should be randomly generated and provided unencrypted
+    # salt should be randomly generated and provided unencrypted (like in the current implementation)
+    # key should be generated with OpenSSL::KDF::pbkdf2_hmac with properly chosen parameters
+    # Short explanation about salt and IV: https://stackoverflow.com/a/1950674/6324550
     def encrypt(path: nil, password: nil)
       UI.user_error!("No password supplied") if password.to_s.strip.length == 0
 
@@ -100,6 +106,8 @@ module Match
       UI.crash!("Error encrypting '#{path}'")
     end
 
+    # The encryption parameters in this implementations reflect the old behaviour which depended on the users' local OpenSSL version
+    # 1.0.x OpenSSL and earlier versions use MD5, 1.1.0c and newer uses SHA256, we try both before giving an error
     def decrypt(path: nil, password: nil, hash_algorithm: "MD5")
       stored_data = Base64.decode64(File.read(path))
       salt = stored_data[8..15]

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -93,7 +93,7 @@ module Match
       encrypted_data = "Salted__" + salt + cipher.update(data_to_encrypt) + cipher.final
 
       File.write(path, Base64.encode64(encrypted_data))
-    rescue FastlaneCore::Interface::FastlaneError => user_error
+    rescue FastlaneCore::Interface::FastlaneError
       raise
     rescue => error
       UI.error(error.to_s)

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -3,9 +3,11 @@ require_relative 'change_password'
 
 module Match
   class Encrypt
+    require 'base64'
+    require 'openssl'
+    require 'securerandom'
     require 'security'
     require 'shellwords'
-    require 'open3'
 
     def server_name(git_url)
       ["match", git_url].join("_")
@@ -46,9 +48,8 @@ module Match
 
     def encrypt_repo(path: nil, git_url: nil)
       iterate(path) do |current|
-        crypt(path: current,
-          password: password(git_url),
-           encrypt: true)
+        encrypt(path: current,
+          password: password(git_url))
         UI.success("🔒  Encrypted '#{File.basename(current)}'") if FastlaneCore::Globals.verbose?
       end
       UI.success("🔒  Successfully encrypted certificates repo")
@@ -57,9 +58,8 @@ module Match
     def decrypt_repo(path: nil, git_url: nil, manual_password: nil)
       iterate(path) do |current|
         begin
-          crypt(path: current,
-            password: manual_password || password(git_url),
-             encrypt: false)
+          decrypt(path: current,
+            password: manual_password || password(git_url))
         rescue
           UI.error("Couldn't decrypt the repo, please make sure you enter the right password!")
           UI.user_error!("Invalid password passed via 'MATCH_PASSWORD'") if ENV["MATCH_PASSWORD"]
@@ -81,43 +81,39 @@ module Match
       end
     end
 
-    def crypt(path: nil, password: nil, encrypt: true)
-      if password.to_s.strip.length == 0 && encrypt
-        UI.user_error!("No password supplied")
-      end
+    def encrypt(path: nil, password: nil)
+      UI.user_error!("No password supplied") if password.to_s.strip.length == 0
 
-      tmpfile = File.join(Dir.mktmpdir, "temporary")
-      command = ["openssl aes-256-cbc"]
-      command << "-k #{password.shellescape}"
-      command << "-in #{path.shellescape}"
-      command << "-out #{tmpfile.shellescape}"
-      command << "-a"
-      command << "-d" unless encrypt
-      command << "&> /dev/null" unless FastlaneCore::Globals.verbose? # to show an error message if something goes wrong
+      data_to_encrypt = File.read(path)
+      salt = SecureRandom.random_bytes(8)
 
-      _out, err, st = Open3.capture3(command.join(' '))
-      success = st.success?
+      cipher = OpenSSL::Cipher.new('AES-256-CBC')
+      cipher.encrypt
+      cipher.pkcs5_keyivgen(password, salt, 1, "MD5")
+      encrypted_data = "Salted__" + salt + cipher.update(data_to_encrypt) + cipher.final
 
-      # Ubuntu `openssl` does not fail on failure
-      # but at least outputs an error message
-      unless err.to_s.empty?
-        success = false
-      end
+      File.write(path, Base64.encode64(encrypted_data))
+    rescue => error
+      UI.error(error.to_s)
+      UI.crash!("Error encrypting '#{path}'")
+    end
 
-      UI.crash!("Error decrypting '#{path}'") unless success
+    def decrypt(path: nil, password: nil)
+      stored_data = ""
+      stored_data = Base64.decode64(File.read(path))
+      salt = stored_data[8..15]
+      data_to_decrypt = stored_data[16..-1]
 
-      # On non-Mac systems (more specific Ubuntu Linux) it might take some time for the file to actually be there (see #11182).
-      # To try to circumvent this flakyness (in tests), we wait a bit until the file appears (max 2s) (usually only 0.1 is actually waited)
-      unless FastlaneCore::Helper.mac?
-        count = 0
-        # sleep until file exists or 20*0.1s (=2s) passed
-        until File.exist?(tmpfile) || count == 20
-          sleep(0.1)
-          count += 1
-        end
-      end
+      decipher = OpenSSL::Cipher.new('AES-256-CBC')
+      decipher.decrypt
+      decipher.pkcs5_keyivgen(password, salt, 1, "MD5")
 
-      FileUtils.mv(tmpfile, path)
+      decrypted_data = decipher.update(data_to_decrypt) + decipher.final
+
+      File.write(path, decrypted_data)
+    rescue => error
+      UI.error(error.to_s)
+      UI.crash!("Error decrypting '#{path}'")
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
https://github.com/fastlane/fastlane/issues/10306
https://github.com/fastlane/fastlane/issues/9542

My current solution does exactly the same as the master on macOS 10.12.6

We should also change any other terminal based openssl usage to the ruby version to avoid these kind of conflicts.

We should also deprecate the current encryption of certificates to be more safer:
-randomly generate an IV instead of calculating it from the password and provide it in the certs repo unencrypted
-use higher iteration count for generating the key
https://crypto.stackexchange.com/questions/2280/why-is-the-iv-passed-in-the-clear-when-it-can-be-easily-encrypted
https://stackoverflow.com/questions/1949640/does-iv-work-like-salt
https://ruby.github.io/openssl/OpenSSL/Cipher.html

### Description
Changed terminal openssl to ruby openssl in fastlane match