### PR TITLE
[frameit] Corrects vertical padding and spacing between keyword and multi-line title when using the stacked title option

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -378,7 +378,7 @@ module Frameit
           top_vertical_trim_offset = trim_box.offset_y
         end
 
-        # Get the maximum bottom offset of the trimbox, this is the top offset + height:
+        # Get the maximum bottom offset of the trim box, this is the top offset + height:
         if (trim_box.offset_y + trim_box.height) > bottom_vertical_trim_offset
           bottom_vertical_trim_offset = trim_box.offset_y + trim_box.height
         end
@@ -392,7 +392,7 @@ module Frameit
         # Get matching trim box:
         trim_box = trim_boxes[key]
 
-        # For side-by-side text images (e.g. stack_title is false) adjust the trimbox based on top_vertical_trim_offset and bottom_vertical_trim_offset to maintain the text baseline:
+        # For side-by-side text images (e.g. stack_title is false) adjust the trim box based on top_vertical_trim_offset and bottom_vertical_trim_offset to maintain the text baseline:
         unless stack_title
           # Determine the trim area by maintaining the same vertical top offset based on the smallest value from all trim boxes (top_vertical_trim_offset).
           # When the vertical top offset is larger than the smallest vertical top offset, the trim box needs to be adjusted:


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
This is the solution for issue #11646.
Here is the before (left) and after (right) situation:

![iphone-se-01_remotetab_framed-sbs](https://user-images.githubusercontent.com/2139844/35276107-8168c722-0042-11e8-9d8f-d9addd299698.png)

### Description
<!-- Describe your changes in detail -->
**Code changes**
- Add `stack_title`  as 3rd input argument to method `build_text_images()`
- When `stack_title` is true, the trim box adjustment is omitted in the `words.each` loop to crop the image.
- Updated comments to reflect these changes.
- Corrected calculation of `spacing_between_title_and_keyword` by using `actual_font_size` instead of `title`. The idea is to have a spacing of half the text height, but the `title` height can become larger when using multi-line. Therefor it's replaced by `actual_font_size`.

**Verification**
Tests have been performed by using a multi-line keyword (which is a bit ridicule as "keyword" implies singular) and both multi and single line title, see: https://github.com/fastlane/fastlane/issues/11646#issuecomment-359779229.
Also test have been performed with `stack_title` disabled.