### PR TITLE
Support checking remote git tags existence

### DIFF
--- a/fastlane/lib/fastlane/actions/git_tag_exists.rb
+++ b/fastlane/lib/fastlane/actions/git_tag_exists.rb
@@ -34,12 +34,14 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :tag,
                                        description: "The tag name that should be checked"),
           FastlaneCore::ConfigItem.new(key: :remote,
-                                       description: "Defaults to `false`",
+                                       description: "Whether to check remote. Defaults to `false`",
                                        type: Boolean,
-                                       default_value: false),
+                                       default_value: false,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :remote_name,
                                        description: "The remote to check. Defaults to `origin`",
-                                       default_value: 'origin')
+                                       default_value: 'origin',
+                                       optional: true)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/git_tag_exists.rb
+++ b/fastlane/lib/fastlane/actions/git_tag_exists.rb
@@ -2,8 +2,21 @@ module Fastlane
   module Actions
     class GitTagExistsAction < Action
       def self.run(params)
-        result = Actions.sh("git rev-parse -q --verify refs/tags/#{params[:tag].shellescape} || true", log: FastlaneCore::Globals.verbose?).chomp
-        !result.empty?
+        tag_ref = "refs/tags/#{params[:tag].shellescape}"
+        if params[:remote]
+          command = "git ls-remote -q --exit-code #{params[:remote_name].shellescape} #{tag_ref}"
+        else
+          command = "git rev-parse -q --verify #{tag_ref}"
+        end
+        exists = true
+        Actions.sh(
+          command,
+          log: FastlaneCore::Globals.verbose?,
+          error_callback: lambda { |result|
+            exists = false
+          }
+        )
+        exists
       end
 
       #####################################################
@@ -21,7 +34,14 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :tag,
-                                       description: "The tag name that should be checked")
+                                       description: "The tag name that should be checked"),
+          FastlaneCore::ConfigItem.new(key: :remote,
+                                       description: "Defaults to `false`",
+                                       type: Boolean,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :remote_name,
+                                       description: "The remote to check. Defaults to `origin`",
+                                       default_value: 'origin'),
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/git_tag_exists.rb
+++ b/fastlane/lib/fastlane/actions/git_tag_exists.rb
@@ -12,9 +12,7 @@ module Fastlane
         Actions.sh(
           command,
           log: FastlaneCore::Globals.verbose?,
-          error_callback: lambda { |result|
-            exists = false
-          }
+          error_callback: lambda { |result| exists = false }
         )
         exists
       end

--- a/fastlane/lib/fastlane/actions/git_tag_exists.rb
+++ b/fastlane/lib/fastlane/actions/git_tag_exists.rb
@@ -12,7 +12,7 @@ module Fastlane
         Actions.sh(
           command,
           log: FastlaneCore::Globals.verbose?,
-          error_callback: lambda { |result| exists = false }
+          error_callback: ->(result) { exists = false }
         )
         exists
       end
@@ -39,7 +39,7 @@ module Fastlane
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :remote_name,
                                        description: "The remote to check. Defaults to `origin`",
-                                       default_value: 'origin'),
+                                       default_value: 'origin')
         ]
       end
 

--- a/fastlane/spec/actions_specs/git_tag_exists_spec.rb
+++ b/fastlane/spec/actions_specs/git_tag_exists_spec.rb
@@ -4,9 +4,25 @@ describe Fastlane do
       it "executes the correct git command" do
         allow(Fastlane::Actions).to receive(:sh)
           .with("git rev-parse -q --verify refs/tags/1.2.0", anything)
-          .and_return("")
+          .and_return("12345")
         result = Fastlane::FastFile.new.parse("lane :test do
           git_tag_exists(tag: '1.2.0')
+        end").runner.execute(:test)
+      end
+
+      it "executes the correct git command remote" do
+        allow(Fastlane::Actions).to receive(:sh)
+          .with("git ls-remote -q --exit-code origin refs/tags/1.2.0", anything)
+          .and_return("12345")
+        result = Fastlane::FastFile.new.parse("lane :test do
+          git_tag_exists(tag: '1.2.0', remote: true)
+        end").runner.execute(:test)
+
+        allow(Fastlane::Actions).to receive(:sh)
+          .with("git ls-remote -q --exit-code huga refs/tags/1.2.0", anything)
+          .and_return("12345")
+        result = Fastlane::FastFile.new.parse("lane :test do
+          git_tag_exists(tag: '1.2.0', remote: true, remote_name: 'huga')
         end").runner.execute(:test)
       end
 

--- a/fastlane/spec/actions_specs/git_tag_exists_spec.rb
+++ b/fastlane/spec/actions_specs/git_tag_exists_spec.rb
@@ -2,7 +2,9 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "git_tag_exists" do
       it "executes the correct git command" do
-        allow(Fastlane::Actions).to receive(:sh).with("git rev-parse -q --verify refs/tags/1.2.0 || true", anything).and_return("")
+        allow(Fastlane::Actions).to receive(:sh)
+          .with("git rev-parse -q --verify refs/tags/1.2.0", anything)
+          .and_return("")
         result = Fastlane::FastFile.new.parse("lane :test do
           git_tag_exists(tag: '1.2.0')
         end").runner.execute(:test)
@@ -10,7 +12,9 @@ describe Fastlane do
 
       it "logs the command if verbose" do
         with_verbose(true) do
-          allow(Fastlane::Actions).to receive(:sh).with(anything, { log: true }).and_return("")
+          allow(Fastlane::Actions).to receive(:sh)
+            .with(anything, hash_including(:log => true))
+            .and_return("")
           result = Fastlane::FastFile.new.parse("lane :test do
             git_tag_exists(tag: '1.2.0')
           end").runner.execute(:test)
@@ -19,7 +23,9 @@ describe Fastlane do
 
       context("when the tag exists") do
         before do
-          allow(Fastlane::Actions).to receive(:sh).with("git rev-parse -q --verify refs/tags/1.2.0 || true", { log: nil }).and_return("41215512353215321")
+          allow(Fastlane::Actions).to receive(:sh)
+            .with("git rev-parse -q --verify refs/tags/1.2.0", hash_including(:log => nil))
+            .and_return("41215512353215321")
         end
 
         it "returns true" do
@@ -33,7 +39,11 @@ describe Fastlane do
 
       context("when the tag doesn't exist") do
         before do
-          allow(Fastlane::Actions).to receive(:sh).with("git rev-parse -q --verify refs/tags/1.2.0 || true", { log: nil }).and_return("")
+          allow(Fastlane::Actions).to receive(:sh) { |command, params|
+            expect(command).to eq('git rev-parse -q --verify refs/tags/1.2.0')
+            expect(params[:log]).to be_nil
+            params[:error_callback].call('error')
+          }
         end
 
         it "returns true" do

--- a/fastlane/spec/actions_specs/git_tag_exists_spec.rb
+++ b/fastlane/spec/actions_specs/git_tag_exists_spec.rb
@@ -29,7 +29,7 @@ describe Fastlane do
       it "logs the command if verbose" do
         with_verbose(true) do
           allow(Fastlane::Actions).to receive(:sh)
-            .with(anything, hash_including(:log => true))
+            .with(anything, hash_including(log: true))
             .and_return("")
           result = Fastlane::FastFile.new.parse("lane :test do
             git_tag_exists(tag: '1.2.0')
@@ -40,7 +40,7 @@ describe Fastlane do
       context("when the tag exists") do
         before do
           allow(Fastlane::Actions).to receive(:sh)
-            .with("git rev-parse -q --verify refs/tags/1.2.0", hash_including(:log => nil))
+            .with("git rev-parse -q --verify refs/tags/1.2.0", hash_including(log: nil))
             .and_return("41215512353215321")
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR enables to check remote tag existence with `git_tag_exists` action.

### Description

Also switch to use `error_callback` to check existence since `git` commands outputs std logs in some cases like warnings and I thought it's more robust to check using status code.