### PR TITLE
Better cross platform tests and code

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,20 @@ init:
 install:
   - set PATH=C:\Ruby24-x64\bin;%PATH%
   - bundle install
+  - cinst gtk-runtime # includes iconv
 
 environment:
   LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
   FASTLANE_ITUNES_TRANSPORTER_PATH: C:/tmp
+
+before_test:
+  - ruby -v
+  - which ruby
+  - gem -v
+  - bundle -v
+  - which iconv
+  - which openssl
 
 build: off
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,7 +36,7 @@ lane(:lint_source) do
     # Verify shell code style
     if FastlaneCore::Helper.is_mac?
       sh('find -E . -regex ".*\.(sh|bash)" -not -name "Pods-*" -name ".bundle" -exec shellcheck {} +')
-    else
+    elsif !FastlaneCore::Helper.is_windows?
       sh('find . -regextype posix-egrep -regex ".*\.(sh|bash)" -not -name "Pods-*" -name ".bundle" -exec shellcheck {} +')
     end
   end

--- a/fastlane/spec/actions_specs/crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/crashlytics_spec.rb
@@ -24,12 +24,12 @@ describe Fastlane do
               )
             end').runner.execute(:test)
             ["java",
-             "-jar /",
+             "-jar",
              "-androidRes .",
              "-apiKey api_token",
              "-apiSecret build_secret",
-             "-uploadDist '/",
-             "-betaDistributionReleaseNotesFilePath '/",
+             "-uploadDist '",
+             "-betaDistributionReleaseNotesFilePath '",
              "-betaDistributionEmails 'email1@krausefx.com,email2@krausefx.com'",
              "-betaDistributionGroupAliases 'testgroup'",
              "-betaDistributionNotifications true"].each do |to_be|

--- a/fastlane/spec/actions_specs/delete_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/delete_keychain_spec.rb
@@ -49,8 +49,9 @@ describe Fastlane do
       end
 
       it "works with keychain name that contain spaces and `\"`" do
+        keychain = File.expand_path('" test ".keychain')
         allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
-        allow(File).to receive(:file?).with(File.expand_path('" test ".keychain')).and_return(true)
+        allow(File).to receive(:file?).with(keychain).and_return(true)
 
         result = Fastlane::FastFile.new.parse("lane :test do
           delete_keychain ({
@@ -58,8 +59,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        keychain = File.expand_path('\\"\\ test\\ \\".keychain')
-        expect(result).to eq(%(security delete-keychain #{keychain}))
+        expect(result).to eq(%(security delete-keychain #{keychain.shellescape}))
       end
 
       it "works with absolute keychain path" do

--- a/fastlane/spec/actions_specs/import_spec.rb
+++ b/fastlane/spec/actions_specs/import_spec.rb
@@ -39,7 +39,7 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             import('tmp/asdf')
           end").runner.execute(:test)
-        end.to raise_error(%r{Could not find Fastfile at path \'\/.*}) # /home (travis) # /Users (Mac)
+        end.to raise_error(%r{Could not find Fastfile at path \'([A-Z]\:)?\/.+}) # /home (travis) # /Users (Mac) # C:/path (Windows)
       end
     end
   end

--- a/fastlane/spec/env_spec.rb
+++ b/fastlane/spec/env_spec.rb
@@ -8,6 +8,13 @@ describe Fastlane do
         to_return(status: 200, body: '{"version": "0.16.2"}', headers: {})
     end
 
+    let(:fastlane_files) { Fastlane::EnvironmentPrinter.print_fastlane_files }
+    it "contains the key words" do
+      expect(fastlane_files).to include("fastlane files")
+      expect(fastlane_files).to include("Fastfile")
+      expect(fastlane_files).to include("Appfile")
+    end
+
     let(:env) { Fastlane::EnvironmentPrinter.get }
 
     it "contains the key words" do

--- a/fastlane/spec/fixtures/actions/example_action.rb
+++ b/fastlane/spec/fixtures/actions/example_action.rb
@@ -2,7 +2,9 @@ module Fastlane
   module Actions
     class ExampleActionAction < Action
       def self.run(params)
-        File.write("/tmp/example_action.txt", Time.now.to_i)
+        tmp = Dir.mktmpdir
+        tmp_path = File.join(tmp, "example_action.txt")
+        File.write(tmp_path, Time.now.to_i)
       end
 
       def self.is_supported?(platform)

--- a/fastlane_core/lib/fastlane_core/module.rb
+++ b/fastlane_core/lib/fastlane_core/module.rb
@@ -24,7 +24,7 @@ module FastlaneCore
   # Since we don't want to access FastlaneCore from spaceship
   # this method is duplicated in spaceship/client.rb
   def self.fastlane_user_dir
-    path = File.expand_path(File.join("~", ".fastlane"))
+    path = File.expand_path(File.join(Dir.home, ".fastlane"))
     FileUtils.mkdir_p(path) unless File.directory?(path)
     return path
   end

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -34,7 +34,7 @@ describe FastlaneCore do
         # We have to execute *something* using ` since otherwise we set expectations to `nil`, which is not healthy
         `ls`
 
-        cmd = %r{curl -f -o (/.+?) https://developer\.apple\.com/certificationauthority/AppleWWDRCA.cer && security import \1 -k keychain\\ with\\ spaces\.keychain}
+        cmd = %r{curl -f -o (([A-Z]\:)?\/.+) https://developer\.apple\.com/certificationauthority/AppleWWDRCA.cer && security import \1 -k keychain\\ with\\ spaces\.keychain}
         require "open3"
 
         expect(Open3).to receive(:capture3).with(cmd).and_return("")

--- a/fastlane_core/spec/pkg_file_analyser_spec.rb
+++ b/fastlane_core/spec/pkg_file_analyser_spec.rb
@@ -5,11 +5,11 @@ describe FastlaneCore do
     context "with a normal path" do
       let(:pkg) { 'MacAppOnly' }
 
-      describe '::fetch_app_identifier' do
+      describe '::fetch_app_identifier', requires_xar: true do
         subject { described_class.fetch_app_identifier(path) }
         it { is_expected.to eq('com.example.Sample') }
       end
-      describe '::fetch_app_version' do
+      describe '::fetch_app_version', requires_xar: true do
         subject { described_class.fetch_app_version(path) }
         it { is_expected.to eq('1.0') }
       end
@@ -18,11 +18,11 @@ describe FastlaneCore do
     context "with a path containing spaces" do
       let(:pkg) { 'Spaces in Path' }
 
-      describe '::fetch_app_identifier' do
+      describe '::fetch_app_identifier', requires_xar: true do
         subject { described_class.fetch_app_identifier(path) }
         it { is_expected.to eq('com.example.Sample') }
       end
-      describe '::fetch_app_version' do
+      describe '::fetch_app_version', requires_xar: true do
         subject { described_class.fetch_app_version(path) }
         it { is_expected.to eq('1.0') }
       end

--- a/fastlane_core/spec/spec_helper.rb
+++ b/fastlane_core/spec/spec_helper.rb
@@ -37,15 +37,8 @@ end
 # provided keys and values set as defined in hash. After the block
 # completes, restores the ENV to its previous state.
 def with_env_values(hash)
-  old_vals = ENV.select { |k, v| hash.include?(k) }
   hash.each do |k, v|
-    ENV[k] = hash[k]
-  end
-  yield
-ensure
-  hash.each do |k, v|
-    ENV.delete(k) unless old_vals.include?(k)
-    ENV[k] = old_vals[k]
+    stub_const('ENV', ENV.to_h.merge(k => v))
   end
 end
 

--- a/scan/spec/slack_poster_spec.rb
+++ b/scan/spec/slack_poster_spec.rb
@@ -90,10 +90,11 @@ describe Scan::SlackPoster do
 
     describe "with slack_url option set to a URL value" do
       it "does Slack posting", requires_xcodebuild: true do
-        expect_slack_posting
-
         # ensures that people's local environment variable doesn't interfere with this test
         with_env_values('SLACK_URL' => nil) do
+          expect(ENV['SLACK_URL']).to eq(nil)
+          expect_slack_posting
+
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
             project: './scan/examples/standard/app.xcodeproj',
             slack_url: 'https://slack/hook/url'
@@ -106,9 +107,10 @@ describe Scan::SlackPoster do
 
     describe "with SLACK_URL ENV var set to a URL value" do
       it "does Slack posting", requires_xcodebuild: true do
-        expect_slack_posting
-
         with_env_values('SLACK_URL' => 'https://slack/hook/url') do
+          expect(ENV['SLACK_URL']).to eq('https://slack/hook/url')
+          expect_slack_posting
+
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
             project: './scan/examples/standard/app.xcodeproj'
           })

--- a/spaceship/lib/spaceship/portal/certificate.rb
+++ b/spaceship/lib/spaceship/portal/certificate.rb
@@ -243,7 +243,7 @@ module Spaceship
           klass.new(attrs)
         end
 
-        # @param mac [Bool] Fetches Mac certificates if true. (Ignored if callsed from a subclass)
+        # @param mac [Bool] Fetches Mac certificates if true. (Ignored if called from a subclass)
         # @return (Array) Returns all certificates of this account.
         #  If this is called from a subclass of Certificate, this will
         #  only include certificates matching the current type.

--- a/spaceship/spec/du/du_stubbing.rb
+++ b/spaceship/spec/du/du_stubbing.rb
@@ -101,7 +101,7 @@ end
 def du_upload_geojson_success
   stub_request(:post, "https://du-itc.itunes.apple.com/upload/geo-json").
     with(body: du_upload_valid_geojson.bytes,
-           headers: { 'Accept' => 'application/json, text/plain, */*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Content-Length' => '224', 'Content-Type' => 'application/json', 'Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088',
+           headers: { 'Accept' => 'application/json, text/plain, */*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Content-Length' => du_upload_valid_geojson.file_size, 'Content-Type' => 'application/json', 'Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088',
                      'X-Apple-Jingle-Correlation-Key' => 'iOS App:AdamId=898536088:Version=0.9.13', 'X-Apple-Upload-Appleid' => '898536088', 'X-Apple-Upload-Contentproviderid' => '1234567', 'X-Apple-Upload-Itctoken' => 'sso token for image',
                      'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Original-Filename' => 'ftl_FAKEMD5_upload_valid.geojson' }).
     to_return(status: 201, body: du_read_upload_geojson_response_success, headers: { 'Content-Type' => 'application/json' })
@@ -110,7 +110,7 @@ end
 def du_upload_geojson_failure
   stub_request(:post, "https://du-itc.itunes.apple.com/upload/geo-json").
     with(body: du_upload_invalid_geojson.bytes,
-           headers: { 'Accept' => 'application/json, text/plain, */*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Content-Length' => '243', 'Content-Type' => 'application/json', 'Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088',
+           headers: { 'Accept' => 'application/json, text/plain, */*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Connection' => 'keep-alive', 'Content-Length' => du_upload_invalid_geojson.file_size, 'Content-Type' => 'application/json', 'Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088',
                      'X-Apple-Jingle-Correlation-Key' => 'iOS App:AdamId=898536088:Version=0.9.13', 'X-Apple-Upload-Appleid' => '898536088', 'X-Apple-Upload-Contentproviderid' => '1234567', 'X-Apple-Upload-Itctoken' => 'sso token for image',
                      'X-Apple-Upload-Referrer' => 'https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088', 'X-Original-Filename' => 'ftl_FAKEMD5_upload_invalid.GeoJSON' }).
     to_return(status: 400, body: du_read_upload_geojson_response_failed, headers: { 'Content-Type' => 'application/json' })

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -44,6 +44,7 @@ RSpec.configure do |config|
 
     ENV['FASTLANE_PLATFORM_NAME'] = nil
 
+    # execute `before_each_*` method from spec_helper for each tool
     tool_name = current_test.id.match(%r{\.\/(\w+)\/})[1]
     method_name = "before_each_#{tool_name}".to_sym
     begin
@@ -51,9 +52,13 @@ RSpec.configure do |config|
     rescue NoMethodError
       # no method implemented
     end
+
+    # Make sure PATH didnt get emptied during execution of previous (!) test
+    expect(ENV['PATH']).to be_truthy, "PATH is missing. (Previous test probably emptied it.)"
   end
 
   config.after(:each) do |current_test|
+    # execute `after_each_*` method from spec_helper for each tool
     tool_name = current_test.id.match(%r{\.\/(\w+)\/})[1]
     method_name = "after_each_#{tool_name}".to_sym
     begin
@@ -96,6 +101,13 @@ RSpec.configure do |config|
     end
     config.extend(HookOverrides)
 
+  end
+
+  # skip some more tests if run on on Windows
+  if FastlaneCore::Helper.is_windows?
+    config.define_derived_metadata(:requires_xar) do |meta|
+      meta[:skip] = "Skipped: Requires `xar` to be installed (which is not possible on Windows and no workaround has been implemented)"
+    end
   end
 end
 


### PR DESCRIPTION
This is a mixed bag of cross platform stuff in tests and code:

- chocolatey installs gtk-runtime on Appveyor for iconv
- test that makes sure ENV doesn't get emptied
- better method to temporarily overwrite ENV variables (that doesn't empty it on Windows after usage)
- tests using `xar` pending on Windows
- do not verify shell code style on Windows (as find has no regex support there)
- test for EnvironmentPrinter fastlane_files
- better construction of paths to compare
- better regex to also match Windows paths
- more Windows compatible /tmp and ~ paths
- dynamic stubs
