### PR TITLE
Resolve more (strange) Windows test failures

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,12 +47,11 @@ lane(:execute_tests) do
   version = local_version # has to be outside of the `Dir.chdir`
 
   # Verifying the --help command
-  unless Helper.windows?
-    Dir.chdir("..") do
-      content = sh("PAGER=cat bin/fastlane --help")
-      ["--version", "https://fastlane.tools", "fastlane"].each do |current|
-        UI.user_error!("--help missing information: '#{current}'") unless content.include?(current)
-      end
+  Dir.chdir("..") do
+    cmd = (Helper.windows?) ? "cd bin && fastlane --help" : "PAGER=cat bin/fastlane --help"
+    content = sh(cmd)
+    ["--version", "https://fastlane.tools", "fastlane"].each do |current|
+      UI.user_error!("--help missing information: '#{current}'") unless content.include?(current)
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,11 +47,12 @@ lane(:execute_tests) do
   version = local_version # has to be outside of the `Dir.chdir`
 
   # Verifying the --help command
-  #
-  Dir.chdir("..") do
-    content = sh("PAGER=cat bin/fastlane --help")
-    ["--version", "https://fastlane.tools", "fastlane"].each do |current|
-      UI.user_error!("--help missing information: '#{current}'") unless content.include?(current)
+  unless Helper.windows?
+    Dir.chdir("..") do
+      content = sh("PAGER=cat bin/fastlane --help")
+      ["--version", "https://fastlane.tools", "fastlane"].each do |current|
+        UI.user_error!("--help missing information: '#{current}'") unless content.include?(current)
+      end
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,7 +48,7 @@ lane(:execute_tests) do
 
   # Verifying the --help command
   Dir.chdir("..") do
-    cmd = (Helper.windows?) ? "cd bin && fastlane --help" : "PAGER=cat bin/fastlane --help"
+    cmd = Helper.windows? ? "cd bin && fastlane --help" : "PAGER=cat bin/fastlane --help"
     content = sh(cmd)
     ["--version", "https://fastlane.tools", "fastlane"].each do |current|
       UI.user_error!("--help missing information: '#{current}'") unless content.include?(current)

--- a/fastlane/spec/actions_specs/nexus_upload_spec.rb
+++ b/fastlane/spec/actions_specs/nexus_upload_spec.rb
@@ -121,7 +121,7 @@ describe Fastlane do
         expect(result).to include('-u admin:admin123')
         expect(result).to include('--verbose')
         expect(result).to include('http://localhost:8081/my-nexus/service/local/artifact/maven/content')
-        expect(result).not_to(include('-x'))
+        expect(result).not_to(include('-x '))
         expect(result).not_to(include('--proxy-user'))
       end
     end

--- a/fastlane/spec/actions_specs/splunkmint_spec.rb
+++ b/fastlane/spec/actions_specs/splunkmint_spec.rb
@@ -154,7 +154,7 @@ describe Fastlane do
         expect(result).to include('--verbose')
         expect(result).to include("--header 'X-Splunk-Mint-Auth-Token: e05ba40754c4869fb7e0b61'")
         expect(result).to include("--header 'X-Splunk-Mint-apikey: 33823d3a'")
-        expect(result).not_to(include('-x'))
+        expect(result).not_to(include('-x '))
         expect(result).not_to(include('--proxy-user'))
       end
 
@@ -180,7 +180,7 @@ describe Fastlane do
         expect(result).to include("--header 'X-Splunk-Mint-Auth-Token: e05ba40754c4869fb7e0b61'")
         expect(result).to include("--header 'X-Splunk-Mint-apikey: 33823d3a'")
         expect(result).to include('--progress-bar -o /dev/null --no-buffer')
-        expect(result).not_to(include('-x'))
+        expect(result).not_to(include('-x '))
         expect(result).not_to(include('--proxy-user'))
       end
     end

--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -15,8 +15,8 @@ module FastlaneCore
       def which(cmd)
         # PATHEXT contains the list of file extensions that Windows considers executable, semicolon separated.
         # e.g. ".COM;.EXE;.BAT;.CMD"
-        exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
-        exts << ''
+        exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : [] 
+        exts << '' # Always have an empty string (= no file extension)
 
         ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
           exts.each do |ext|

--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -15,7 +15,7 @@ module FastlaneCore
       def which(cmd)
         # PATHEXT contains the list of file extensions that Windows considers executable, semicolon separated.
         # e.g. ".COM;.EXE;.BAT;.CMD"
-        exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : [] 
+        exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : []
         exts << '' # Always have an empty string (= no file extension)
 
         ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|

--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -16,6 +16,7 @@ module FastlaneCore
         # PATHEXT contains the list of file extensions that Windows considers executable, semicolon separated.
         # e.g. ".COM;.EXE;.BAT;.CMD"
         exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+        exts << ''
 
         ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
           exts.each do |ext|

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -419,7 +419,7 @@ describe FastlaneCore do
       end
 
       it "runs simple commands" do
-        cmd = 'echo "HO"'
+        cmd = 'echo HO'
         expect(FastlaneCore::Project.run_command(cmd)).to eq("HO\n")
       end
 

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -419,7 +419,7 @@ describe FastlaneCore do
       end
 
       it "runs simple commands" do
-        cmd = 'echo HO'
+        cmd = 'echo HO' # note: this command is deliberately not using `"` around `HO` as `echo` would echo those back on Windows
         expect(FastlaneCore::Project.run_command(cmd)).to eq("HO\n")
       end
 

--- a/frameit/lib/frameit/strings_parser.rb
+++ b/frameit/lib/frameit/strings_parser.rb
@@ -10,7 +10,7 @@ module Frameit
       result = {}
 
       # A .strings file is UTF-16 encoded. We only want to deal with UTF-8
-      content = `iconv -f UTF-16 -t UTF-8 '#{path}' 2>&1`
+      content = `iconv -f UTF-16 -t UTF-8 "#{path}" 2>&1`
 
       content.split("\n").each_with_index do |line, index|
         begin

--- a/frameit/lib/frameit/strings_parser.rb
+++ b/frameit/lib/frameit/strings_parser.rb
@@ -10,7 +10,7 @@ module Frameit
       result = {}
 
       # A .strings file is UTF-16 encoded. We only want to deal with UTF-8
-      content = `iconv -f UTF-16 -t UTF-8 "#{path}" 2>&1`
+      content = `iconv -f UTF-16 -t UTF-8 "#{path}" 2>&1` # note: double quotes around path so command also works on Windows
 
       content.split("\n").each_with_index do |line, index|
         begin

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -95,7 +95,7 @@ module Match
       command << "-d" unless encrypt
       # to show an error message if something goes wrong
       unless FastlaneCore::Globals.verbose?
-        if !Helper.is_windows?
+        if !Helper.windows?
           command << "&> /dev/null"
         else
           command << "2> nul"

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -97,16 +97,17 @@ module Match
       _out, err, st = Open3.capture3(command.join(' '))
       success = st.success?
 
-      # Ubuntu `openssl` does not fail on failure
-      # but at least outputs an error message
       unless err.to_s.empty?
-        success = false
-      end
+        # to show an error message if something goes wrong
+        if FastlaneCore::Globals.verbose?
+          UI.error("`openssl` failed with an error:")
+          UI.error(err)
+        end
 
-      # to show an error message if something goes wrong
-      if FastlaneCore::Globals.verbose?
-        UI.error("`openssl` failed with an error:")
-        UI.error(err)
+        # Ubuntu `openssl` does not fail on failure
+        # but at least outputs an error message -
+        # so we use that as indication of failure
+        success = false
       end
 
       UI.crash!("Error decrypting '#{path}'") unless success

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -94,9 +94,9 @@ module Match
       command << "-a"
       command << "-d" unless encrypt
       # to show an error message if something goes wrong
-      unless FastlaneCore::Globals.verbose? 
-        unless Helper.is_windows?
-          command << "&> /dev/null" 
+      unless FastlaneCore::Globals.verbose?
+        if !Helper.is_windows?
+          command << "&> /dev/null"
         else
           command << "2> nul"
         end

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -93,14 +93,6 @@ module Match
       command << "-out #{tmpfile.shellescape}"
       command << "-a"
       command << "-d" unless encrypt
-      # to show an error message if something goes wrong
-      unless FastlaneCore::Globals.verbose?
-        if !Helper.windows?
-          command << "&> /dev/null"
-        else
-          command << "2> nul"
-        end
-      end
 
       _out, err, st = Open3.capture3(command.join(' '))
       success = st.success?
@@ -109,6 +101,12 @@ module Match
       # but at least outputs an error message
       unless err.to_s.empty?
         success = false
+      end
+
+      # to show an error message if something goes wrong
+      if FastlaneCore::Globals.verbose?
+        UI.error("`openssl` failed with an error:")
+        UI.error(err)
       end
 
       UI.crash!("Error decrypting '#{path}'") unless success

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -93,7 +93,9 @@ module Match
       command << "-out #{tmpfile.shellescape}"
       command << "-a"
       command << "-d" unless encrypt
-      command << "&> /dev/null" unless FastlaneCore::Globals.verbose? # to show an error message if something goes wrong
+      unless Helper.is_windows?
+        command << "&> /dev/null" unless FastlaneCore::Globals.verbose? # to show an error message if something goes wrong
+      end
 
       _out, err, st = Open3.capture3(command.join(' '))
       success = st.success?

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -93,8 +93,13 @@ module Match
       command << "-out #{tmpfile.shellescape}"
       command << "-a"
       command << "-d" unless encrypt
-      unless Helper.is_windows?
-        command << "&> /dev/null" unless FastlaneCore::Globals.verbose? # to show an error message if something goes wrong
+      # to show an error message if something goes wrong
+      unless FastlaneCore::Globals.verbose? 
+        unless Helper.is_windows?
+          command << "&> /dev/null" 
+        else
+          command << "2> nul"
+        end
       end
 
       _out, err, st = Open3.capture3(command.join(' '))


### PR DESCRIPTION
These commits are fixing more surprising and some even pretty strange things that made the tests on Windows fail:

- Tests were checking for the presence of `-x` in calculated commands that also include temp paths. These temp paths now can include `-x` in strings, so the matchers were suffixed with a space ` ` that to `-x ` which is actually the param that should (not) be present on these commands so the test is now actually better.
- "Verifying the --help command" didn't work on Windows as setting an env variable via `PAGER=cat cmd` doesn't work and results in an `No such file or directory - PAGER=cat bin/fastlane --help` error. So I now set the command depending on the platform and use one for Windows that works there and does the job.
- `which` was checking for executable files on Windows only by using the preset `ENV['PATHEXT']` list, but especially for the tests it also has to look at files with no file extension - so this was manually added to the list
- `echo "HO"` actually echos `"HO"` on Windows instead of only `HO` on Linux and macOS - so the command was changed to `echo HO` which matches the expectation of the test - which is only checking if commands can run (and not the implementation details of `echo`)
- A backtick command needs `"` in Windows instead of `'` which is also valid on macOS/Linux - so this was replaced
- In `encrypt.rb` the implementation of some error output if `verbose` is true was actually broken after previous changes (when `system` was replaced by `Open3.capture3`) - so I repaired that and made it cross platform at the same time.