### PR TITLE
Replace usage of deprecated Helper methods

### DIFF
--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -22,7 +22,7 @@ module Deliver
     def self.language_folders(root, ignore_validation)
       folders = Dir.glob(File.join(root, '*'))
 
-      if Helper.is_test?
+      if Helper.test?
         available_languages = FastlaneCore::Languages::ALL_LANGUAGES
       else
         available_languages = Spaceship::Tunes.client.available_languages.sort

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,9 +34,9 @@ lane(:lint_source) do
 
   Dir.chdir("..") do
     # Verify shell code style
-    if FastlaneCore::Helper.is_mac?
+    if FastlaneCore::Helper.mac?
       sh('find -E . -regex ".*\.(sh|bash)" -not -name "Pods-*" -name ".bundle" -exec shellcheck {} +')
-    elsif !FastlaneCore::Helper.is_windows?
+    elsif !FastlaneCore::Helper.windows?
       sh('find . -regextype posix-egrep -regex ".*\.(sh|bash)" -not -name "Pods-*" -name ".bundle" -exec shellcheck {} +')
     end
   end

--- a/fastlane/lib/fastlane/actions/apteligent.rb
+++ b/fastlane/lib/fastlane/actions/apteligent.rb
@@ -11,7 +11,7 @@ module Fastlane
         # will reanable it when it is fixed
         # result = Fastlane::Actions.sh(command.join(' '), log: false)
         shell_command = command.join(' ')
-        return shell_command if Helper.is_test?
+        return shell_command if Helper.test?
         result = Actions.sh(shell_command)
         fail_on_error(result)
       end

--- a/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
+++ b/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
@@ -28,7 +28,7 @@ module Fastlane
           end
         end
 
-        return command if Helper.is_test?
+        return command if Helper.test?
 
         UI.important(command)
         results = `#{command}` # we don't use `sh` as the return code of grep is wrong for some reason

--- a/fastlane/lib/fastlane/actions/get_build_number.rb
+++ b/fastlane/lib/fastlane/actions/get_build_number.rb
@@ -61,7 +61,7 @@ module Fastlane
                              optional: true,
                              verify_block: proc do |value|
                                UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with?(".xcworkspace")
-                               UI.user_error!("Could not find Xcode project") if !File.exist?(value) and !Helper.is_test?
+                               UI.user_error!("Could not find Xcode project") if !File.exist?(value) and !Helper.test?
                              end),
           FastlaneCore::ConfigItem.new(key: :hide_error_when_versioning_disabled,
                              env_name: "FL_BUILD_NUMBER_HIDE_ERROR_WHEN_VERSIONING_DISABLED",

--- a/fastlane/lib/fastlane/actions/get_push_certificate.rb
+++ b/fastlane/lib/fastlane/actions/get_push_certificate.rb
@@ -10,7 +10,7 @@ module Fastlane
 
         PEM.config = params
 
-        if Helper.is_test?
+        if Helper.test?
           profile_path = './test.pem'
         else
           profile_path = PEM::Manager.start

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -113,7 +113,7 @@ module Fastlane
                              optional: true,
                              verify_block: proc do |value|
                                UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with?(".xcworkspace")
-                               UI.user_error!("Could not find Xcode project at path '#{File.expand_path(value)}'") if !File.exist?(value) and !Helper.is_test?
+                               UI.user_error!("Could not find Xcode project at path '#{File.expand_path(value)}'") if !File.exist?(value) and !Helper.test?
                              end),
           FastlaneCore::ConfigItem.new(key: :scheme,
                              env_name: "FL_VERSION_NUMBER_SCHEME",

--- a/fastlane/lib/fastlane/actions/hg_add_tag.rb
+++ b/fastlane/lib/fastlane/actions/hg_add_tag.rb
@@ -8,7 +8,7 @@ module Fastlane
         UI.message("Adding mercurial tag '#{tag}' 🎯.")
 
         command = "hg tag \"#{tag}\""
-        return command if Helper.is_test?
+        return command if Helper.test?
 
         Actions.sh(command)
       end

--- a/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
@@ -10,17 +10,17 @@ module Fastlane
 
         xcodeproj_path = params[:xcodeproj] ? File.expand_path(File.join('.', params[:xcodeproj])) : nil
 
-        if Helper.is_test?
+        if Helper.test?
           xcodeproj_path = "/tmp/Test.xcodeproj"
         end
 
         # get the repo root path
-        repo_path = Helper.is_test? ? '/tmp/repo' : Actions.sh('hg root').strip
+        repo_path = Helper.test? ? '/tmp/repo' : Actions.sh('hg root').strip
         repo_pathname = Pathname.new(repo_path)
 
         if xcodeproj_path
           # ensure that the xcodeproj passed in was OK
-          unless Helper.is_test?
+          unless Helper.test?
             UI.user_error!("Could not find the specified xcodeproj: #{xcodeproj_path}") unless File.directory?(xcodeproj_path)
           end
         else
@@ -42,7 +42,7 @@ module Fastlane
         end
 
         # find the pbxproj path, relative to hg directory
-        if Helper.is_test?
+        if Helper.test?
           hg_dirty_files = params[:test_dirty_files].split(",")
           expected_changed_files = params[:test_expected_files].split(",")
         else
@@ -94,7 +94,7 @@ module Fastlane
 
         # create a commit with a message
         command = "hg commit -m '#{params[:message]}'"
-        return command if Helper.is_test?
+        return command if Helper.test?
         begin
           Actions.sh(command)
 

--- a/fastlane/lib/fastlane/actions/hg_push.rb
+++ b/fastlane/lib/fastlane/actions/hg_push.rb
@@ -8,7 +8,7 @@ module Fastlane
         command << '--force' if params[:force]
         command << params[:destination] unless params[:destination].empty?
 
-        return command.join(' ') if Helper.is_test?
+        return command.join(' ') if Helper.test?
 
         Actions.sh(command.join(' '))
         UI.success('Successfully pushed changes to remote 🚀.')

--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -74,7 +74,7 @@ module Fastlane
                                        optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with?(".xcworkspace")
-                                         UI.user_error!("Could not find Xcode project") if !File.exist?(value) and !Helper.is_test?
+                                         UI.user_error!("Could not find Xcode project") if !File.exist?(value) and !Helper.test?
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/is_ci.rb
+++ b/fastlane/lib/fastlane/actions/is_ci.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class IsCiAction < Action
       def self.run(params)
-        Helper.is_ci?
+        Helper.ci?
       end
 
       #####################################################

--- a/fastlane/lib/fastlane/actions/make_changelog_from_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/make_changelog_from_jenkins.rb
@@ -7,7 +7,7 @@ module Fastlane
 
         changelog = ""
 
-        if Helper.is_ci? || Helper.is_test?
+        if Helper.ci? || Helper.test?
           # The "BUILD_URL" environment variable is set automatically by Jenkins in every build
           jenkins_api_url = URI(ENV["BUILD_URL"] + "api/json\?wrapper\=changes\&xpath\=//changeSet//comment")
           begin

--- a/fastlane/lib/fastlane/actions/push_to_git_remote.rb
+++ b/fastlane/lib/fastlane/actions/push_to_git_remote.rb
@@ -25,7 +25,7 @@ module Fastlane
 
         # execute our command
         Actions.sh('pwd')
-        return command.join(' ') if Helper.is_test?
+        return command.join(' ') if Helper.test?
 
         Actions.sh(command.join(' '))
         UI.message('Successfully pushed to remote.')

--- a/fastlane/lib/fastlane/actions/reset_git_repo.rb
+++ b/fastlane/lib/fastlane/actions/reset_git_repo.rb
@@ -8,7 +8,7 @@ module Fastlane
         if params[:force] || Actions.lane_context[SharedValues::GIT_REPO_WAS_CLEAN_ON_START]
           paths = params[:files]
 
-          return paths if Helper.is_test?
+          return paths if Helper.test?
 
           if paths.nil?
             Actions.sh('git reset --hard HEAD')

--- a/fastlane/lib/fastlane/actions/set_build_number_repository.rb
+++ b/fastlane/lib/fastlane/actions/set_build_number_repository.rb
@@ -50,7 +50,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          path = File.expand_path(value)
                                          UI.user_error!("Please pass the path to the project, not the workspace") if path.end_with?(".xcworkspace")
-                                         UI.user_error!("Could not find Xcode project at #{path}") unless Helper.is_test? || File.exist?(path)
+                                         UI.user_error!("Could not find Xcode project at #{path}") unless Helper.test? || File.exist?(path)
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/setup_circle_ci.rb
+++ b/fastlane/lib/fastlane/actions/setup_circle_ci.rb
@@ -49,7 +49,7 @@ module Fastlane
       end
 
       def self.should_run?(params)
-        Helper.is_ci? || params[:force]
+        Helper.ci? || params[:force]
       end
 
       #####################################################

--- a/fastlane/lib/fastlane/actions/setup_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/setup_jenkins.rb
@@ -19,7 +19,7 @@ module Fastlane
 
       def self.run(params)
         # Stop if not executed by CI
-        if !Helper.is_ci? && !params[:force]
+        if !Helper.ci? && !params[:force]
           UI.important("Not executed by Continuous Integration system.")
           return
         end

--- a/fastlane/lib/fastlane/actions/setup_travis.rb
+++ b/fastlane/lib/fastlane/actions/setup_travis.rb
@@ -3,7 +3,7 @@ module Fastlane
     class SetupTravisAction < Action
       def self.run(params)
         # Stop if not executed by CI
-        if !Helper.is_ci? && !params[:force]
+        if !Helper.ci? && !params[:force]
           UI.message("Currently not running on CI system, skipping travis setup")
           return
         end

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -37,7 +37,7 @@ module Fastlane
 
         slack_attachment = generate_slack_attachments(options)
 
-        return [notifier, slack_attachment] if Helper.is_test? # tests will verify the slack attachments and other properties
+        return [notifier, slack_attachment] if Helper.test? # tests will verify the slack attachments and other properties
 
         begin
           results = notifier.ping('', icon_url: icon_url, attachments: [slack_attachment])

--- a/fastlane/lib/fastlane/actions/splunkmint.rb
+++ b/fastlane/lib/fastlane/actions/splunkmint.rb
@@ -14,7 +14,7 @@ module Fastlane
         # will reanable it when it is fixed
         # result = Fastlane::Actions.sh(command.join(' '), log: false)
         shell_command = command.join(' ')
-        result = Helper.is_test? ? shell_command : `#{shell_command}`
+        result = Helper.test? ? shell_command : `#{shell_command}`
         fail_on_error(result)
 
         result

--- a/fastlane/lib/fastlane/actions/update_app_group_identifiers.rb
+++ b/fastlane/lib/fastlane/actions/update_app_group_identifiers.rb
@@ -48,7 +48,7 @@ module Fastlane
                                        description: "The path to the entitlement file which contains the app group identifiers", # a short description of this parameter
                                        verify_block: proc do |value|
                                          UI.user_error!("Please pass a path to an entitlements file. ") unless value.include?(".entitlements")
-                                         UI.user_error!("Could not find entitlements file") if !File.exist?(value) and !Helper.is_test?
+                                         UI.user_error!("Could not find entitlements file") if !File.exist?(value) and !Helper.test?
                                        end),
           FastlaneCore::ConfigItem.new(key: :app_group_identifiers,
                                        env_name: "FL_UPDATE_APP_GROUP_IDENTIFIER_APP_GROUP_IDENTIFIERS",

--- a/fastlane/lib/fastlane/actions/update_icloud_container_identifiers.rb
+++ b/fastlane/lib/fastlane/actions/update_icloud_container_identifiers.rb
@@ -56,7 +56,7 @@ module Fastlane
                                        description: "The path to the entitlement file which contains the iCloud container identifiers",
                                        verify_block: proc do |value|
                                          UI.user_error!("Please pass a path to an entitlements file. ") unless value.include?(".entitlements")
-                                         UI.user_error!("Could not find entitlements file") if !File.exist?(value) and !Helper.is_test?
+                                         UI.user_error!("Could not find entitlements file") if !File.exist?(value) and !Helper.test?
                                        end),
           FastlaneCore::ConfigItem.new(key: :icloud_container_identifiers,
                                        env_name: "FL_UPDATE_ICLOUD_CONTAINER_IDENTIFIERS_IDENTIFIERS",

--- a/fastlane/lib/fastlane/command_line_handler.rb
+++ b/fastlane/lib/fastlane/command_line_handler.rb
@@ -26,7 +26,7 @@ module Fastlane
         lane = platform_lane_info[0]
       end
 
-      dot_env = Helper.is_test? ? nil : options.env
+      dot_env = Helper.test? ? nil : options.env
 
       if FastlaneCore::FastlaneFolder.swift?
         disable_runner_upgrades = options.disable_runner_upgrades || false

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -56,7 +56,7 @@ module Fastlane
     end
 
     def self.confirm_troubleshoot
-      if Helper.is_ci?
+      if Helper.ci?
         UI.error("---")
         UI.error("You are trying to use '--troubleshoot' on CI")
         UI.error("this option is not usable in CI, as it is insecure")

--- a/fastlane/lib/fastlane/configuration_helper.rb
+++ b/fastlane/lib/fastlane/configuration_helper.rb
@@ -7,7 +7,7 @@ module Fastlane
         # default use case
         return FastlaneCore::Configuration.create(action.available_options, params)
       elsif first_element
-        UI.error("Old configuration format for action '#{action}'") if Helper.is_test?
+        UI.error("Old configuration format for action '#{action}'") if Helper.test?
         return params
       else
 

--- a/fastlane/lib/fastlane/helper/gem_helper.rb
+++ b/fastlane/lib/fastlane/helper/gem_helper.rb
@@ -18,7 +18,7 @@ module Fastlane
         UI.important("  gem '#{gem_name}'")
         UI.error("and run `bundle install`")
 
-        UI.user_error!("You have to install the `#{gem_name}` gem on this machine") unless Helper.is_test?
+        UI.user_error!("You have to install the `#{gem_name}` gem on this machine") unless Helper.test?
       end
       true
     end

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -34,7 +34,7 @@ module Fastlane
     # Start the setup process
     # rubocop:disable Metrics/BlockNesting
     def self.start(user: nil, is_swift_fastfile: false)
-      if FastlaneCore::FastlaneFolder.setup? and !Helper.is_test?
+      if FastlaneCore::FastlaneFolder.setup? and !Helper.test?
         require 'fastlane/lane_list'
         Fastlane::LaneList.output(FastlaneCore::FastlaneFolder.fastfile_path)
         UI.important("------------------")

--- a/fastlane/lib/fastlane/swift_lane_manager.rb
+++ b/fastlane/lib/fastlane/swift_lane_manager.rb
@@ -26,7 +26,7 @@ module Fastlane
         display_upgraded_message = false
         if disable_runner_upgrades
           UI.verbose("disable_runner_upgrades is true, not attempting to update the FastlaneRunner project".yellow)
-        elsif Helper.is_ci?
+        elsif Helper.ci?
           UI.verbose("Running in CI, not attempting to update the FastlaneRunner project".yellow)
         else
           display_upgraded_message = self.ensure_runner_up_to_date_fastlane!

--- a/fastlane/spec/actions_specs/clipboard_spec.rb
+++ b/fastlane/spec/actions_specs/clipboard_spec.rb
@@ -1,7 +1,7 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Clipboard Integration" do
-      if FastlaneCore::Helper.is_mac?
+      if FastlaneCore::Helper.mac?
         it "properly stores the value in the clipboard" do
           str = "Some value: #{Time.now.to_i}"
 

--- a/fastlane/spec/actions_specs/is_ci_spec.rb
+++ b/fastlane/spec/actions_specs/is_ci_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane do
           is_ci
         end").runner.execute(:test)
 
-        expect(result).to eq(FastlaneCore::Helper.is_ci?)
+        expect(result).to eq(FastlaneCore::Helper.ci?)
       end
 
       it "works with a ? in the end" do
@@ -14,7 +14,7 @@ describe Fastlane do
           is_ci?
         end").runner.execute(:test)
 
-        expect(result).to eq(FastlaneCore::Helper.is_ci?)
+        expect(result).to eq(FastlaneCore::Helper.ci?)
       end
     end
   end

--- a/fastlane/spec/actions_specs/setup_circle_ci_spec.rb
+++ b/fastlane/spec/actions_specs/setup_circle_ci_spec.rb
@@ -24,7 +24,7 @@ describe Fastlane do
     describe "#should_run" do
       context "when running on CI" do
         before do
-          expect(Fastlane::Helper).to receive(:is_ci?).and_return(true)
+          expect(Fastlane::Helper).to receive(:ci?).and_return(true)
         end
 
         it "returns true when :force is true" do
@@ -38,7 +38,7 @@ describe Fastlane do
 
       context "when not running on CI" do
         before do
-          expect(Fastlane::Helper).to receive(:is_ci?).and_return(false)
+          expect(Fastlane::Helper).to receive(:ci?).and_return(false)
         end
 
         it "returns false when :force is not set" do

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -190,7 +190,7 @@ module FastlaneCore
     end
 
     def ci?
-      return Helper.is_ci?
+      return Helper.ci?
     end
 
     def operating_system_version

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -198,7 +198,7 @@ module FastlaneCore
       paths += Dir["./fastlane/#{config_file_name}"]
       paths += Dir["./.fastlane/#{config_file_name}"]
       paths += Dir["./#{config_file_name}"]
-      paths += Dir["./fastlane_core/spec/fixtures/#{config_file_name}"] if Helper.is_test?
+      paths += Dir["./fastlane_core/spec/fixtures/#{config_file_name}"] if Helper.test?
       return nil if paths.count == 0
       return paths.first
     end
@@ -231,7 +231,7 @@ module FastlaneCore
       return value unless value.nil? and !option.optional and ask
 
       # fallback to asking
-      if Helper.is_test? or !UI.interactive?
+      if Helper.test? or !UI.interactive?
         # Since we don't want to be asked on tests, we'll just call the verify block with no value
         # to raise the exception that is shown when the user passes an invalid value
         set(key, '')

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -31,7 +31,7 @@ module FastlaneCore
     private_constant :ERROR_REGEX, :WARNING_REGEX, :OUTPUT_REGEX, :RETURN_VALUE_REGEX, :SKIP_ERRORS
 
     def execute(command, hide_output)
-      return command if Helper.is_test?
+      return command if Helper.test?
 
       @errors = []
       @warnings = []
@@ -113,7 +113,7 @@ module FastlaneCore
         if $1.include?("Your Apple ID or password was entered incorrectly") or
            $1.include?("This Apple ID has been locked for security reasons")
 
-          unless Helper.is_test?
+          unless Helper.test?
             CredentialsManager::AccountManager.new(user: @user).invalid_credentials
             UI.error("Please run this tool again to apply the new password")
           end
@@ -255,7 +255,7 @@ module FastlaneCore
     end
 
     def java_code_option
-      if Helper.is_mac? && Helper.xcode_at_least?(9)
+      if Helper.mac? && Helper.xcode_at_least?(9)
         return "-jar #{Helper.transporter_java_jar_path.shellescape}"
       else
         return "-classpath #{Helper.transporter_java_jar_path.shellescape} com.apple.transporter.Application"
@@ -337,7 +337,7 @@ module FastlaneCore
         return download(app_id, dir)
       end
 
-      return result if Helper.is_test?
+      return result if Helper.test?
 
       itmsp_path = File.join(dir, "#{app_id}.itmsp")
       successful = result && File.directory?(itmsp_path)
@@ -376,7 +376,7 @@ module FastlaneCore
       if result
         UI.header("Successfully uploaded package to iTunes Connect. It might take a few minutes until it's visible online.")
 
-        FileUtils.rm_rf(actual_dir) unless Helper.is_test? # we don't need the package any more, since the upload was successful
+        FileUtils.rm_rf(actual_dir) unless Helper.test? # we don't need the package any more, since the upload was successful
       else
         handle_error(@password)
       end

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -131,7 +131,7 @@ module FastlaneCore
         elsif automated_scheme_selection? && schemes.include?(project_name)
           UI.important("Using scheme matching project name (#{project_name}).")
           options[:scheme] = project_name
-        elsif Helper.is_ci?
+        elsif Helper.ci?
           UI.error("Multiple schemes found but you haven't specified one.")
           UI.error("Since this is a CI, please pass one using the `scheme` option")
           show_scheme_shared_information

--- a/fastlane_core/lib/fastlane_core/swag.rb
+++ b/fastlane_core/lib/fastlane_core/swag.rb
@@ -38,7 +38,7 @@ module FastlaneCore
 
     def self.should_be_shown?
       return false unless FastlaneCore::Env.truthy?("FL_ENABLE_LOGO_ANIMATION")
-      return false if Helper.is_ci?
+      return false if Helper.ci?
       return false unless UI.interactive?
       return true
     end

--- a/fastlane_core/lib/fastlane_core/tool_collector.rb
+++ b/fastlane_core/lib/fastlane_core/tool_collector.rb
@@ -59,7 +59,7 @@ module FastlaneCore
     def did_finish
       return false if FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
 
-      if !did_show_message? and !Helper.is_ci?
+      if !did_show_message? and !Helper.ci?
         show_message
       end
 

--- a/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
+++ b/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
@@ -15,7 +15,7 @@ module FastlaneCore
 
       $stdout.sync = true
 
-      if Helper.is_test? && !ENV.key?('DEBUG')
+      if Helper.test? && !ENV.key?('DEBUG')
         $stdout.puts("Logging disabled while running tests. Force them by setting the DEBUG environment variable")
         @log ||= Logger.new(nil) # don't show any logs when running tests
       else

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -10,7 +10,7 @@ module FastlaneCore
   # Verifies, the user runs the latest version of this gem
   class UpdateChecker
     def self.start_looking_for_update(gem_name)
-      return if Helper.is_test?
+      return if Helper.test?
       return if FastlaneCore::Env.truthy?("FASTLANE_SKIP_UPDATE_CHECK")
 
       @start_time = Time.now
@@ -124,7 +124,7 @@ module FastlaneCore
 
     def self.send_launch_analytic_events_for(gem_name)
       return if FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
-      ci = Helper.is_ci?.to_s
+      ci = Helper.ci?.to_s
       app_id_guesser = FastlaneCore::AppIdentifierGuesser.new(args: ARGV, gem_name: gem_name)
       project_hash = app_id_guesser.p_hash
       p_hash = project_hash if project_hash
@@ -198,7 +198,7 @@ module FastlaneCore
     def self.send_completion_events_for(gem_name)
       return if FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
 
-      ci = Helper.is_ci?.to_s
+      ci = Helper.ci?.to_s
       install_method = if Helper.rubygems?
                          'gem'
                        elsif Helper.bundler?

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -136,7 +136,7 @@ describe FastlaneCore do
 
       describe "#sensitive flag" do
         before(:each) do
-          allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
+          allow(FastlaneCore::Helper).to receive(:itest?).and_return(false)
           allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
           allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
         end
@@ -585,7 +585,7 @@ describe FastlaneCore do
           end
 
           it "auto converts the value after asking the user for one" do
-            allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
+            allow(FastlaneCore::Helper).to receive(:test?).and_return(false)
             allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
             allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
 
@@ -668,7 +668,7 @@ describe FastlaneCore do
           end
 
           it "asks if no other option" do
-            allow(FastlaneCore::Helper).to receive(:is_test?).and_return(false)
+            allow(FastlaneCore::Helper).to receive(:test?).and_return(false)
             allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
             allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
 

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -136,7 +136,7 @@ describe FastlaneCore do
 
       describe "#sensitive flag" do
         before(:each) do
-          allow(FastlaneCore::Helper).to receive(:itest?).and_return(false)
+          allow(FastlaneCore::Helper).to receive(:test?).and_return(false)
           allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
           allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
         end

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -26,35 +26,35 @@ describe FastlaneCore do
       end
     end
 
-    describe "#is_ci?" do
+    describe "#ci?" do
       it "returns false when not building in a known CI environment" do
         stub_const('ENV', {})
-        expect(FastlaneCore::Helper.is_ci?).to be(false)
+        expect(FastlaneCore::Helper.ci?).to be(false)
       end
 
       it "returns true when building in Jenkins" do
         stub_const('ENV', { 'JENKINS_URL' => 'http://fake.jenkins.url' })
-        expect(FastlaneCore::Helper.is_ci?).to be(true)
+        expect(FastlaneCore::Helper.ci?).to be(true)
       end
 
       it "returns true when building in Jenkins Slave" do
         stub_const('ENV', { 'JENKINS_HOME' => '/fake/jenkins/home' })
-        expect(FastlaneCore::Helper.is_ci?).to be(true)
+        expect(FastlaneCore::Helper.ci?).to be(true)
       end
 
       it "returns true when building in Travis CI" do
         stub_const('ENV', { 'TRAVIS' => true })
-        expect(FastlaneCore::Helper.is_ci?).to be(true)
+        expect(FastlaneCore::Helper.ci?).to be(true)
       end
 
       it "returns true when building in gitlab-ci" do
         stub_const('ENV', { 'GITLAB_CI' => true })
-        expect(FastlaneCore::Helper.is_ci?).to be(true)
+        expect(FastlaneCore::Helper.ci?).to be(true)
       end
 
       it "returns true when building in Xcode Server" do
         stub_const('ENV', { 'XCS' => true })
-        expect(FastlaneCore::Helper.is_ci?).to be(true)
+        expect(FastlaneCore::Helper.ci?).to be(true)
       end
     end
 

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -437,7 +437,7 @@ describe FastlaneCore do
         end.to raise_error(Timeout::Error)
 
         # on mac this before only partially works as expected
-        if FastlaneCore::Helper.is_mac?
+        if FastlaneCore::Helper.mac?
           # this shows the current implementation issue
           # Timeout doesn't kill the running process
           # i.e. see fastlane/fastlane_core#102

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -108,7 +108,7 @@ describe FastlaneCore do
     describe "#send_launch_analytic_events_for" do
       before do
         ENV.delete("FASTLANE_OPT_OUT_USAGE")
-        allow(FastlaneCore::Helper).to receive(:is_ci?).and_return(false)
+        allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
       end
 
       it "sends no events when opted out" do
@@ -128,7 +128,7 @@ describe FastlaneCore do
       end
 
       it "identifies CI correctly" do
-        allow(FastlaneCore::Helper).to receive(:is_ci?).and_return(true)
+        allow(FastlaneCore::Helper).to receive(:ci?).and_return(true)
 
         expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|
           expect(analytics.size).to eq(1)
@@ -155,7 +155,7 @@ describe FastlaneCore do
     describe "#send_completion_events_for" do
       before do
         ENV.delete("FASTLANE_OPT_OUT_USAGE")
-        allow(FastlaneCore::Helper).to receive(:is_ci?).and_return(false)
+        allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
       end
 
       it "sends no events when opted out" do

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -108,7 +108,7 @@ module Match
 
       # On non-Mac systems (more specific Ubuntu Linux) it might take some time for the file to actually be there (see #11182).
       # To try to circumvent this flakyness (in tests), we wait a bit until the file appears (max 2s) (usually only 0.1 is actually waited)
-      unless FastlaneCore::Helper.is_mac?
+      unless FastlaneCore::Helper.mac?
         count = 0
         # sleep until file exists or 20*0.1s (=2s) passed
         until File.exist?(tmpfile) || count == 20

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -87,7 +87,7 @@ module Scan
         UI.test_failure!("Test execution failed. Exit status: #{tests_exit_status}")
       end
 
-      if !Helper.is_ci? && Scan.cache[:open_html_report_path]
+      if !Helper.ci? && Scan.cache[:open_html_report_path]
         `open --hide '#{Scan.cache[:open_html_report_path]}'`
       end
     end

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -17,7 +17,7 @@ unless ENV["DEBUG"]
   $stdout = File.open(fastlane_tests_tmpdir, "w")
 end
 
-if FastlaneCore::Helper.is_mac?
+if FastlaneCore::Helper.mac?
   xcode_path = FastlaneCore::Helper.xcode_path
   unless xcode_path.include?("Contents/Developer")
     UI.error("Seems like you didn't set the developer tools path correctly")
@@ -71,7 +71,7 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = "#{Dir.tmpdir}/rspec_failed_tests.txt"
 
   # skip some tests if not running on mac
-  unless FastlaneCore::Helper.is_mac?
+  unless FastlaneCore::Helper.mac?
 
     # define metadata tags that also imply :skip
     config.define_derived_metadata(:requires_xcode) do |meta|
@@ -104,7 +104,7 @@ RSpec.configure do |config|
   end
 
   # skip some more tests if run on on Windows
-  if FastlaneCore::Helper.is_windows?
+  if FastlaneCore::Helper.windows?
     config.define_derived_metadata(:requires_xar) do |meta|
       meta[:skip] = "Skipped: Requires `xar` to be installed (which is not possible on Windows and no workaround has been implemented)"
     end


### PR DESCRIPTION
Several of the Helper methods are "deprecated" and should not be used any more internally. Replaced all usages of those methods with their current counterparts.