### PR TITLE
[Regression] Fix usage of FastlanePty.spawn()

### DIFF
--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -47,9 +47,9 @@ module FastlaneCore
         end
 
         begin
-          FastlaneCore::FastlanePty.spawn(command) do |stdin, stdout, pid|
+          FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
             begin
-              stdin.each do |l|
+              command_stdout.each do |l|
                 line = l.strip # strip so that \n gets removed
                 output << line
 

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -3,18 +3,18 @@
 # https://github.com/DragonBox/u3d/blob/59e471ad78ac00cb629f479dbe386c5ad2dc5075/lib/u3d_core/command_runner.rb#L88-L96
 module FastlaneCore
   class FastlanePty
-    def self.spawn(*command, &block)
+    def self.spawn(command, &block)
       require 'pty'
-      PTY.spawn(command) do |stdout, stdin, pid|
-        block.call(stdin, stdout, pid)
+      PTY.spawn(command) do |command_stdout, command_stdin, pid|
+        block.call(command_stdout, command_stdin, pid)
       end
     rescue LoadError
       require 'open3'
-      Open3.popen2e(command) do |r, w, p|
-        yield(w, r, p.value.pid) # note the inversion
+      Open3.popen2e(command) do |command_stdin, command_stdout, p| # note the inversion
+        yield(command_stdout, command_stdin, p.value.pid)
 
-        r.close
-        w.close
+        command_stdin.close
+        command_stdout.close
         p.value.exitstatus
       end
     end

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -44,9 +44,9 @@ module FastlaneCore
       end
 
       begin
-        FastlaneCore::FastlanePty.spawn(command) do |stdin, stdout, pid|
+        FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
           begin
-            stdin.each do |line|
+            command_stdout.each do |line|
               @all_lines << line
               parse_line(line, hide_output) # this is where the parsing happens
             end

--- a/snapshot/lib/snapshot/screenshot_rotate.rb
+++ b/snapshot/lib/snapshot/screenshot_rotate.rb
@@ -28,9 +28,9 @@ module Snapshot
         next unless command
 
         # Only rotate if we need to
-        FastlaneCore::FastlanePty.spawn(command) do |r, w, pid|
-          r.sync
-          r.each do |line|
+        FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
+          command_stdout.sync
+          command_stdout.each do |line|
             # We need to read this otherwise things hang
           end
           ::Process.wait(pid)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

99e486a6987b84bcd64db8670cf68c2c9fb644ab introduced FastlanePty.spawn() to provide a `PTY` for Windows. In caused several regressions that don't seem to be covered by tests.
1) It replaced PTY.spawn() which takes a string as its first parameter. FastlanePty.spawn() converts all parameters into an array for Open3.popen2e() but doesn't convert it back to string for PTY.spawn().
2) The old PTY.spawn() call sites had swapped stdout and stdin, even going to far as read from "stdin" (actually stdout). This was then carried forward, but because PTY.spawn() and Open3.popen2e() provide these sockets in a different order, calls to FastlanePty.spawn() don't work as intended on Mac OS.

### Description

This PR fixed these issues and also clears up the incorrect labelling at all call sites.
