### PR TITLE
Disable pager explicitly for  'git branch --list' command

### DIFF
--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -181,7 +181,7 @@ module Match
       return unless @dir
 
       result = Dir.chdir(@dir) do
-        FastlaneCore::CommandExecutor.execute(command: "git branch --list origin/#{branch.shellescape} --no-color -r",
+        FastlaneCore::CommandExecutor.execute(command: "git --no-pager branch --list origin/#{branch.shellescape} --no-color -r",
                                               print_all: FastlaneCore::Globals.verbose?,
                                               print_command: FastlaneCore::Globals.verbose?)
       end

--- a/match/spec/git_helper_spec.rb
+++ b/match/spec/git_helper_spec.rb
@@ -97,7 +97,7 @@ describe Match do
           with(to_params).
           and_return(nil)
 
-        command = "git branch --list origin/#{git_branch} --no-color -r"
+        command = "git --no-pager branch --list origin/#{git_branch} --no-color -r"
         to_params = {
           command: command,
           print_all: nil,


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Starting with v2.16.0, git by default runs the output of `git branch --list` through its pager. (https://github.com/git/git/commit/0ae19de74f6f5d6c6f9c80899e1ecd611c5b9827)
This causes FastlaneCore::CommandExecutor.execute() to return a string of invisible control characters in Match::GitHelper.branch_exists?(), where previously it would return an empty string. This in turn causes match to not create a branch when needed.

### Description
Fixed the issue by passing "--no-pager" option to git. I tested this option with some older versions of git as well, including v2.5, which is over 2 years old, and it doesn't seem to cause any problems.
