### PR TITLE
Allow to use lane name contains `:'

### DIFF
--- a/fastlane/lib/fastlane/command_line_handler.rb
+++ b/fastlane/lib/fastlane/command_line_handler.rb
@@ -5,7 +5,13 @@ module Fastlane
     # @param [Array] args A hash of all options (e.g. --env NAME)
     def self.handle(args, options)
       lane_parameters = {} # the parameters we'll pass to the lane
-      platform_lane_info = [] # the part that's responsible for the lane/platform definition
+      platform_lane_info = args.slice!(0, 1) # the part that's responsible for the lane/platform definition
+      platform_or_lane = platform_lane_info[0]
+      if platform_or_lane && SupportedPlatforms.all.include?(platform_or_lane.to_sym)
+        # keep the lane name if platform name was given
+        platform_lane_info << args.shift
+      end
+
       args.each do |current|
         if current.include?(":") # that's a key/value which we want to pass to the lane
           key, value = current.split(":", 2)

--- a/fastlane/spec/command_line_handler_spec.rb
+++ b/fastlane/spec/command_line_handler_spec.rb
@@ -18,5 +18,12 @@ describe Fastlane do
                                                                   nil)
       Fastlane::CommandLineHandler.handle(["ios", "deploy", "key:true", "key2:false"], {})
     end
+
+    it "allows lane name contains `:'" do
+      expect(Fastlane::LaneManager).to receive(:cruise_lane).with("ios", "update:version:major",
+                                                                  { key: true },
+                                                                  nil)
+      Fastlane::CommandLineHandler.handle(["ios", "update:version:major", "key:true"], {})
+    end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I'd like to have a namespace by using `:` in lane name in `Fastfile` like `Rakefile`.

### Description

This patch will allow to use `:` in lane name like a following:

```
fastlane_version "2.55.0"

default_platform :ios

platform :ios do
  lane :"update:version:minor" do
    puts "** Update minor version"
  end

  lane :"update:version:patch" do
    puts "** Update patch version"
  end
end
```
