### PR TITLE
Update podspec CocoaPods version regex to work with new `swift_version` in CocoaPods 1.4.0

### DIFF
--- a/fastlane/lib/fastlane/helper/podspec_helper.rb
+++ b/fastlane/lib/fastlane/helper/podspec_helper.rb
@@ -9,7 +9,7 @@ module Fastlane
 
       def initialize(path = nil)
         version_var_name = 'version'
-        @version_regex = /^(?<begin>[^#]*#{version_var_name}\s*=\s*['"])(?<value>(?<major>[0-9]+)(\.(?<minor>[0-9]+))?(\.(?<patch>[0-9]+))?(?<appendix>(\.[0-9]+)*)?)(?<end>['"])/i
+        @version_regex = /^(?<begin>[^#]*\w\.#{version_var_name}\s*=\s*['"])(?<value>(?<major>[0-9]+)(\.(?<minor>[0-9]+))?(\.(?<patch>[0-9]+))?(?<appendix>(\.[0-9]+)*)?)(?<end>['"])/i
 
         return unless (path || '').length > 0
         UI.user_error!("Could not find podspec file at path '#{path}'") unless File.exist?(path)

--- a/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
+++ b/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
@@ -26,14 +26,21 @@ describe Fastlane do
 
       context "when semantic version" do
         it "returns the current version once parsed" do
-          test_content = 'version = "1.3.2"'
+          test_content = 'spec.version = "1.3.2"'
+          result = @version_podspec_file.parse(test_content)
+          expect(result).to eq('1.3.2')
+          expect(@version_podspec_file.version_value).to eq('1.3.2')
+        end
+
+        it "works with CocoaPods 1.4.0 with the new `swift_version` parameter" do
+          test_content = "spec.version = '1.3.2'\nspec.swift_version = '4.0'"
           result = @version_podspec_file.parse(test_content)
           expect(result).to eq('1.3.2')
           expect(@version_podspec_file.version_value).to eq('1.3.2')
         end
 
         it "bumps the patch version when passing 'patch'" do
-          test_content = 'version = "1.3.2"'
+          test_content = 'spec.version = "1.3.2"'
           @version_podspec_file.parse(test_content)
           result = @version_podspec_file.bump_version('patch')
           expect(result).to eq('1.3.3')
@@ -41,7 +48,7 @@ describe Fastlane do
         end
 
         it "bumps the minor version when passing 'minor'" do
-          test_content = 'version = "1.3.2"'
+          test_content = 'spec.version = "1.3.2"'
           @version_podspec_file.parse(test_content)
           result = @version_podspec_file.bump_version('minor')
           expect(result).to eq('1.4.0')
@@ -49,7 +56,7 @@ describe Fastlane do
         end
 
         it "bumps the major version when passing 'major'" do
-          test_content = 'version = "1.3.2"'
+          test_content = 'something.version = "1.3.2"'
           @version_podspec_file.parse(test_content)
           result = @version_podspec_file.bump_version('major')
           expect(result).to eq('2.0.0')

--- a/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
+++ b/fastlane/spec/actions_specs/version_bump_podspec_spec.rb
@@ -18,7 +18,7 @@ describe Fastlane do
       end
 
       it "raises an exception when the version is commented-out in podspec" do
-        test_content = '# version = "1.3.2"'
+        test_content = '# s.version = "1.3.2"'
         expect do
           Fastlane::Helper::PodspecHelper.new.parse(test_content)
         end.to raise_error("Could not find version in podspec content '#{test_content}'")
@@ -109,14 +109,14 @@ describe Fastlane do
 
       context "when not semantic version" do
         it "returns the current version once parsed" do
-          test_content = 'version = "1.3.2.5"'
+          test_content = 's.version = "1.3.2.5"'
           result = @version_podspec_file.parse(test_content)
           expect(result).to eq('1.3.2.5')
           expect(@version_podspec_file.version_value).to eq('1.3.2.5')
         end
 
         it "bumps the patch version when passing 'patch'" do
-          test_content = 'version = "1.3.2.5"'
+          test_content = 's.version = "1.3.2.5"'
           @version_podspec_file.parse(test_content)
           result = @version_podspec_file.bump_version('patch')
           expect(result).to eq('1.3.3')
@@ -124,7 +124,7 @@ describe Fastlane do
         end
 
         it "bumps the minor version when passing 'minor'" do
-          test_content = 'version = "1.3.2.1"'
+          test_content = 's.version = "1.3.2.1"'
           @version_podspec_file.parse(test_content)
           result = @version_podspec_file.bump_version('minor')
           expect(result).to eq('1.4.0')
@@ -132,7 +132,7 @@ describe Fastlane do
         end
 
         it "bumps the major version when passing 'major'" do
-          test_content = 'version = "1.3.2.3"'
+          test_content = 's.version = "1.3.2.3"'
           @version_podspec_file.parse(test_content)
           result = @version_podspec_file.bump_version('major')
           expect(result).to eq('2.0.0')

--- a/fastlane/spec/fixtures/podspecs/test.podspec
+++ b/fastlane/spec/fixtures/podspecs/test.podspec
@@ -2,6 +2,7 @@ Pod::Spec.new do |s|
   s.name         = "SpecName"
   s.header_dir   = "SuchHeader"
   s.version      = "1.5.1"
+  s.swift_version = "3.0.0"
   s.summary      = "With just a few lines of code, your app can add fastlane support."
 
   s.description  = <<-DESC


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/11700