### PR TITLE
Fix duplicate loading of Gymfile. Was loaded twice when current dir == project root.

### DIFF
--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -19,8 +19,11 @@ module Gym
       Gym.project = FastlaneCore::Project.new(config)
 
       # Go into the project's folder, as there might be a Gymfile there
-      Dir.chdir(File.expand_path("..", Gym.project.path)) do
-        config.load_configuration_file(Gym.gymfile_name)
+      project_path = File.expand_path("..", Gym.project.path)
+      unless File.expand_path(".") == project_path
+        Dir.chdir(project_path) do
+          config.load_configuration_file(Gym.gymfile_name)
+        end
       end
 
       detect_scheme


### PR DESCRIPTION
`load_configuration_file` is already trying to look for Gymfile in `fastlane`, `.fastlane` and the project folders.

https://github.com/fastlane/fastlane/blob/0c23d5e64f3c193ac013e9383551149ac6e8d88c/fastlane_core/lib/fastlane_core/configuration/configuration.rb#L163-L168

https://github.com/fastlane/fastlane/blob/0c23d5e64f3c193ac013e9383551149ac6e8d88c/fastlane_core/lib/fastlane_core/configuration/configuration.rb#L196-L204