### PR TITLE
Remove default value for initial_build_number

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -69,7 +69,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :initial_build_number,
                                        env_name: "INITIAL_BUILD_NUMBER",
                                        description: "sets the build number to given value if no build is in current train",
-                                       default_value: 1,
                                        is_string: false),
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        short_option: "-a",


### PR DESCRIPTION
- If there is an error, latest_testflight_build_number can return 1
- This is bad if ITC is down.
- Instead, rely on people setting it by allowing the error message
  "Could not find a build on iTC - and 'initial_build_number' option is not set"
  to be displayed
- fixes #11711
