### PR TITLE
#10187 Fix xcodebuild inherited command not found

### DIFF
--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -42,7 +42,7 @@ module Gym
         options << "-derivedDataPath '#{config[:derived_data_path]}'" if config[:derived_data_path]
         options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
         options << config[:xcargs] if config[:xcargs]
-        options << "OTHER_SWIFT_FLAGS=\"\$(inherited) -Xfrontend -debug-time-function-bodies\"" if config[:analyze_build_time]
+        options << "OTHER_SWIFT_FLAGS=\"-Xfrontend -debug-time-function-bodies\"" if config[:analyze_build_time]
 
         options
       end

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -211,7 +211,7 @@ describe Gym do
                                "-project ./gym/examples/standard/Example.xcodeproj",
                                "-destination 'generic/platform=iOS'",
                                "-archivePath #{Gym::BuildCommandGenerator.archive_path.shellescape}",
-                               "OTHER_SWIFT_FLAGS=\"$(inherited) -Xfrontend -debug-time-function-bodies\"",
+                               "OTHER_SWIFT_FLAGS=\"-Xfrontend -debug-time-function-bodies\"",
                                :archive,
                                "| tee #{log_path.shellescape}",
                                "| grep .[0-9]ms | grep -v ^0.[0-9]ms | sort -nr > culprits.txt",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
There is actually a bug when executing gym with **analyze_build_time** parameter
Link to open issue: https://github.com/fastlane/fastlane/issues/10187
I updated the test spec according to changes.
All test passed.
Tested from command line.

### Description
When passing "analyze_build_time" parameter to "build_ios_app" aka gym, wrong xcodebuild flag "$(inherited)" is generated.
$(inherited) is an xcode environment variable where xcode checks the same variable value from the project level and replace it before executing the build step.
This is not intended to be used from command line.
