### PR TITLE
Allow CFPropertyList==3.0.0

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('terminal-notifier', '>= 1.6.2', '< 2.0.0') # macOS notifications
   spec.add_dependency('terminal-table', '>= 1.4.5', '< 2.0.0') # Actions documentation
   spec.add_dependency('plist', '>= 3.1.0', '< 4.0.0') # Needed for set_build_number_repository and get_info_plist_value actions
-  spec.add_dependency('CFPropertyList', '>= 2.3', '< 3.0.0') # Needed to be able to read binary plist format
+  spec.add_dependency('CFPropertyList', '>= 2.3', '< 4.0.0') # Needed to be able to read binary plist format
   spec.add_dependency('addressable', '>= 2.3', '< 3.0.0') # Support for URI templates
   spec.add_dependency('multipart-post', '~> 2.0.0') # Needed for uploading builds to appetize
   spec.add_dependency('word_wrap', '~> 1.0.0') # to add line breaks for tables with long strings


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

We use Spaceship not as a development tool, but on a server running JRuby. Unfortunately all versions in the allowed version range for CFPropertyList are breaking Enumerable under JRuby so fundamentally that even unrelated code crashes. The reason is a monkeypatch in CFPropertyList that enables support for MRI 1.8.

CFPropertyList 3.0.0 removed that monkeypatch, which means it drops support for MRI 1.8 while restoring compatibility with JRuby: https://github.com/ckruse/CFPropertyList/issues/52

### Description

This patch allows not only 2.x, but also 3.x versions of CFPropertyList to be used with fastlane. Either ombination works fine with MRI 2.4 in our tests, the combination with CFPropertyList 3.0.0 additionally works fine with JRuby.

Note that this patch technically still doesn't prevent people from using fastlane with MRI 1.8, because users who need the support can simply pin CFPropertyList to an older 2.x version.