### PR TITLE
Forcing ASCII for this ASCII encoded certificate

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -22,7 +22,7 @@ module Fastlane
         unless File.exist?(params[:certificate])
           UI.message("Downloading root certificate from (#{ROOT_CERTIFICATE_URL}) to path '#{params[:certificate]}'")
           require 'open-uri'
-          File.open(params[:certificate], "w") do |file|
+          File.open(params[:certificate], "w:ASCII-8BIT") do |file|
             file.write(open(ROOT_CERTIFICATE_URL, "rb").read)
           end
         end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change allows the Apple Root Certificate to be successfully downloaded when using update_project_provisioning. 

This fix was tested by running these changes against my local project. Without them I got the same issue as is detailed in https://github.com/fastlane/fastlane/issues/11752. After the fix, the certificate is downloaded successfully.

### Description

This file is ASCII, so here I am opening it for write and explicitly using the ASCII encoding. Otherwise, we encountered a crash when trying to convert it to UTF-8.