### PR TITLE
Include contents of BCSymbolMaps directory in dSYM.zip file.

### DIFF
--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -132,7 +132,7 @@ module Gym
       UI.message("Compressing #{available_dsyms.count} dSYM(s)") unless Gym.config[:silent]
 
       output_path = File.expand_path(File.join(Gym.config[:output_directory], Gym.config[:output_name] + ".app.dSYM.zip"))
-      command = "cd '#{containing_directory}' && zip -r '#{output_path}' *.dSYM"
+      command = "cd '#{containing_directory}/..' && zip -r '#{output_path}' dSYMs/*.dSYM BCSymbolMaps/*"
       Helper.backticks(command, print: !Gym.config[:silent])
 
       puts("") # new line

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -127,14 +127,20 @@ module Gym
 
       # Compress and move the dsym file
       containing_directory = File.expand_path("..", PackageCommandGenerator.dsym_path)
+      bcsymbolmaps_directory = File.expand_path("../../BCSymbolMaps", PackageCommandGenerator.dsym_path)
 
       available_dsyms = Dir.glob("#{containing_directory}/*.dSYM")
       UI.message("Compressing #{available_dsyms.count} dSYM(s)") unless Gym.config[:silent]
 
       output_path = File.expand_path(File.join(Gym.config[:output_directory], Gym.config[:output_name] + ".app.dSYM.zip"))
-      command = "cd '#{containing_directory}/..' && zip -r '#{output_path}' dSYMs/*.dSYM BCSymbolMaps/*"
+      command = "cd '#{containing_directory}' && zip -r '#{output_path}' *.dSYM"
       Helper.backticks(command, print: !Gym.config[:silent])
-
+      if Dir.exist?(bcsymbolmaps_directory)
+        available_bcsymbolmaps = Dir.glob("#{bcsymbolmaps_directory}/*.bcsymbolmap")
+        UI.message("Compressing #{available_bcsymbolmaps.count} bcsymbolmap(s)") unless Gym.config[:silent]
+        command = "cd '#{bcsymbolmaps_directory}' && zip -rg '#{output_path}' *.bcsymbolmap"
+        Helper.backticks(command, print: !Gym.config[:silent])
+      end
       puts("") # new line
 
       UI.success("Successfully exported and compressed dSYM file")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
DWARF files used for symbolicating Apple crash reports often times hide the actual symbols, replacing them with e.g. `__hiddden#34_`. In order to do a full symbolication .bcsymbolmap files are needed to translate these hidden symbols in to the original.

Related issues: https://github.com/fastlane/fastlane/issues/6574, https://github.com/fastlane/fastlane/issues/10902


### Description
Added the contents of BCSymbolMaps to the .dSYM.zip file.