### PR TITLE
Fastlane.swift: Fix getPushCertificate type

### DIFF
--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1515,7 +1515,7 @@ func getProvisioningProfile(adhoc: Bool = false,
 }
 func getPushCertificate(development: Bool = false,
                         generateP12: Bool = true,
-                        activeDaysLimit: String = "30",
+                        activeDaysLimit: Int = 30,
                         force: Bool = false,
                         savePrivateKey: Bool = true,
                         appIdentifier: String,


### PR DESCRIPTION
Changing type of activeDaysLimit to Int to creathe pushcertificates

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change fixes a bug in the Swift getPushCertificate wrapper. The type for the activedaysLimit needs to be an Int
This solves issue #11790

I tested it locally and it works
