### PR TITLE
Fastlane.swift: Fix default type for Integer parameters

### DIFF
--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -108,6 +108,8 @@ module Fastlane
         type = "[String]"
       elsif default_value.kind_of?(Hash)
         type = "[String : Any]"
+      elsif default_value.kind_of?(Integer)
+        type = "Int"
       end
       return "#{type}#{optional_specifier}"
     end


### PR DESCRIPTION
This fixes #11790.
