### PR TITLE
Allow the usage of a postfix for the add_git_tag action

### DIFF
--- a/fastlane/lib/fastlane/actions/add_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/add_git_tag.rb
@@ -6,7 +6,7 @@ module Fastlane
         # lane name in lane_context could be nil because you can just call $fastlane add_git_tag which has no context
         lane_name = Actions.lane_context[Actions::SharedValues::LANE_NAME].to_s.delete(' ') # no spaces allowed
 
-        tag = options[:tag] || "#{options[:grouping]}/#{lane_name}/#{options[:prefix]}#{options[:build_number]}"
+        tag = options[:tag] || "#{options[:grouping]}/#{lane_name}/#{options[:prefix]}#{options[:build_number]}#{options[:postfix]}"
         message = options[:message] || "#{tag} (fastlane)"
 
         cmd = ['git tag']
@@ -31,6 +31,7 @@ module Fastlane
           "- `grouping` is just to keep your tags organised under one 'folder', defaults to 'builds'",
           "- `lane` is the name of the current fastlane lane",
           "- `prefix` is anything you want to stick in front of the version number, e.g. 'v'",
+          "- `postfix` is anything you want to stick at the end of the version number, e.g. '-RC1'",
           "- `build_number` is the build number, which defaults to the value emitted by the `increment_build_number` action",
           "",
           "For example for build 1234 in the 'appstore' lane it will tag the commit with `builds/appstore/1234`"
@@ -50,6 +51,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :prefix,
                                        env_name: "FL_GIT_TAG_PREFIX",
                                        description: "Anything you want to put in front of the version number (e.g. 'v')",
+                                       default_value: ''),
+          FastlaneCore::ConfigItem.new(key: :postfix,
+                                       env_name: "FL_GIT_TAG_POSTFIX",
+                                       description: "Anything you want to put at the end of the version number (e.g. '-RC1')",
                                        default_value: ''),
           FastlaneCore::ConfigItem.new(key: :build_number,
                                        env_name: "FL_GIT_TAG_BUILD_NUMBER",
@@ -85,6 +90,7 @@ module Fastlane
           'add_git_tag(
             grouping: "fastlane-builds",
             prefix: "v",
+            postfix: "-RC1",
             build_number: 123
           )',
           '# Alternatively, you can specify your own tag. Note that if you do specify a tag, all other arguments are ignored.

--- a/fastlane/spec/actions_specs/add_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/add_git_tag_spec.rb
@@ -42,7 +42,7 @@ describe Fastlane do
 
         expect(result).to eq("git tag -am builds/test/#{prefix}#{build_number}\\ \\(fastlane\\) \'builds/test/#{prefix}#{build_number}\'")
       end
-      
+
       it "allows you to specify a postfix" do
         postfix = '-RC1'
 

--- a/fastlane/spec/actions_specs/add_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/add_git_tag_spec.rb
@@ -42,6 +42,18 @@ describe Fastlane do
 
         expect(result).to eq("git tag -am builds/test/#{prefix}#{build_number}\\ \\(fastlane\\) \'builds/test/#{prefix}#{build_number}\'")
       end
+      
+      it "allows you to specify a postfix" do
+        postfix = '-RC1'
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          add_git_tag ({
+            postfix: '#{postfix}',
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("git tag -am builds/test/#{build_number}#{postfix}\\ \\(fastlane\\) \'builds/test/#{build_number}#{postfix}\'")
+      end
 
       it "allows you to specify your own tag" do
         tag = '2.0.0'


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
For a project of mine we tag builds with `v10.5-RC1` where RC number gets appended with the Jenkins build number. Therefore I would like to be able to append a postfix to the build number.

### Description
I added an `:postfix` option to the `add_git_tag` action.
