### PR TITLE
Option to upload symbols to Firebase Crashlytics via GoogleService-Info.plist

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -163,14 +163,14 @@ module Fastlane
                                          UI.user_error!("No API token for Crashlytics given, pass using `api_token: 'token'`") if value.to_s.length == 0
                                        end),
           FastlaneCore::ConfigItem.new(key: :gsp_path,
-                                      env_name: "GOOGLE_SERVICES_INFO_PLIST_PATH",
-                                      sensitive: true,
-                                      optional: true,
-                                      description: "Path to GoogleService-Info.plist",
-                                      verify_block: proc do |value|
-                                        UI.user_error!("Couldn't find file at path '#{File.expand_path(value)}'") unless File.exist?(value)
-                                        UI.user_error!("No Path to GoogleService-Info.plist for Firebase Crashlytics given, pass using `gsp_path: 'path'`") if value.to_s.length == 0
-                                      end),
+                                       env_name: "GOOGLE_SERVICES_INFO_PLIST_PATH",
+                                       code_gen_sensitive: true,
+                                       optional: true,
+                                       description: "Path to GoogleService-Info.plist",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Couldn't find file at path '#{File.expand_path(value)}'") unless File.exist?(value)
+                                         UI.user_error!("No Path to GoogleService-Info.plist for Firebase Crashlytics given, pass using `gsp_path: 'path'`") if value.to_s.length == 0
+                                       end),
           FastlaneCore::ConfigItem.new(key: :binary_path,
                                        env_name: "FL_UPLOAD_SYMBOLS_TO_CRASHLYTICS_BINARY_PATH",
                                        description: "The path to the upload-symbols file of the Fabric app",

--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -22,10 +22,12 @@ describe Fastlane do
       it "uploads dSYM files" do
         binary_path = './spec/fixtures/screenshots/screenshot1.png'
         dsym_path = './spec/fixtures/dSYM/Themoji.dSYM'
+        gsp_path = './spec/fixtures/plist/Info.plist'
 
         command = []
         command << File.expand_path(File.join("fastlane", binary_path)).shellescape
         command << "-a something123"
+        command << "-gsp #{File.expand_path(File.join('fastlane', gsp_path)).shellescape}"
         command << "-p ios"
         command << File.expand_path(File.join("fastlane", dsym_path)).shellescape
 
@@ -34,9 +36,23 @@ describe Fastlane do
         Fastlane::FastFile.new.parse("lane :test do
           upload_symbols_to_crashlytics(
             dsym_path: 'fastlane/#{dsym_path}',
+            gsp_path: 'fastlane/#{gsp_path}',
             api_token: 'something123',
             binary_path: 'fastlane/#{binary_path}')
         end").runner.execute(:test)
+      end
+
+      it "raises exception if no api access is given" do
+        binary_path = './spec/fixtures/screenshots/screenshot1.png'
+        dsym_path = './spec/fixtures/dSYM/Themoji.dSYM'
+
+        expect do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            upload_symbols_to_crashlytics(
+              dsym_path: 'fastlane/#{dsym_path}',
+              binary_path: 'fastlane/#{binary_path}')
+          end").runner.execute(:test)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError)
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The `upload_symbols_to_crashlytics` Action doesn't yet support passing the _GoogleService-Info.plist_ when wanting to upload to Firebase Crashlytics. This can now be done with the `-gsp` parameter like shown in the [Firebase Crashlytics documentation](https://firebase.google.com/docs/crashlytics/get-deobfuscated-reports).
This also addresses https://github.com/fastlane/fastlane/issues/9840#issuecomment-361908666.

### Description
The action has now a new option with the `:gsp_path` (env var name `GOOGLE_SERVICES_INFO_PLIST_PATH`). The action now only throws an error if neither one of Fabric API key or _GoogleService-Info.plist_ is given.