### PR TITLE
Generate more idomatic screenshots.html file when using screengrab.

### DIFF
--- a/screengrab/lib/screengrab/page.html.erb
+++ b/screengrab/lib/screengrab/page.html.erb
@@ -64,117 +64,99 @@
       }
     </style>
   </head>
-  <body>
-    <% divide_size_by = 5.0 %>
-    <% max_width = 180 %>
-    <% image_counter = 0 %>
+  <body><% image_counter = 0 %><% @data.each do |language, content| %>
+    <h1 class="language"><%= language %></h1>
+    <hr>
+    <table><% content.each do |device_name, screens| %>
+      <tr>
+        <th colspan="<%= screens.count %>">
+          <span class="deviceName"><%= device_name %></span>
+        </th>
+      </tr>
+      <tr><% screens.each do |screen_path| %><% next if screen_path.include?"_framed.png" %>
+        <td><% image_counter += 1 %>
+          <a href="<%= screen_path %>" target="_blank" class="screenshotLink">
+            <img class="screenshot" src="<%= screen_path %>" style="width: 100%;" alt="<%= language %> <%= device_name %>" data-counter="<%= image_counter %>">
+          </a>
+        </td><% end %>
+      </tr><% end %>
+    </table><% end %>
+    <div id="overlay">
+      <img id="imageDisplay" src="" alt="" />
+      <div id="imageInfo"></div>
+    </div>
+    <script type="text/javascript">
+      var overlay        = document.getElementById('overlay');
+      var imageDisplay   = document.getElementById('imageDisplay');
+      var imageInfo      = document.getElementById('imageInfo');
+      var screenshotLink = document.getElementsByClassName('screenshotLink');
 
-
-    <% @data.each do |language, content| %>
-      <h1 class="language"><%= language %></h1>
-      <hr>
-      <table>
-        <% content.each do |device_name, screens| %>
-          <tr>
-            <th colspan="<%= screens.count %>">
-              <span class="deviceName"><%= device_name %></span>
-            </th>
-          </tr>
-          <tr>
-            <% screens.each do |screen_path| %>
-              <% next if screen_path.include?"_framed.png" %>
-              <td>
-                <% style = "width: 100%;" %>
-                <% image_counter += 1 %>
-                <a href="<%= screen_path %>" target="_blank" class="screenshotLink">
-                  <img class="screenshot"
-                         src="<%= screen_path %>"
-                       style="<%= style %>"
-                         alt="<%= language %> <%= device_name %>"
-                data-counter="<%= image_counter %>" />
-                </a>
-              </td>
-            <% end %>
-          </tr>
-        <% end %>
-      </table>
-    <% end %>
-      <div id="overlay">
-        <img id="imageDisplay" src="" alt="" />
-        <div id="imageInfo"></div>
-      </div>
-      <script type="text/javascript">
-        var overlay        = document.getElementById('overlay');
-        var imageDisplay   = document.getElementById('imageDisplay');
-        var imageInfo      = document.getElementById('imageInfo');
-        var screenshotLink = document.getElementsByClassName('screenshotLink');
-
-        function doClick(el) {
-          if (document.createEvent) {
-            var evObj = document.createEvent('MouseEvents', true);
-            evObj.initMouseEvent("click", false, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-            el.dispatchEvent(evObj);
-          } else if (document.createEventObject) { //IE
-            var evObj = document.createEventObject();
-            el.fireEvent('onclick', evObj);
-          }
+      function doClick(el) {
+        if (document.createEvent) {
+          var evObj = document.createEvent('MouseEvents', true);
+          evObj.initMouseEvent("click", false, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+          el.dispatchEvent(evObj);
+        } else if (document.createEventObject) { //IE
+          var evObj = document.createEventObject();
+          el.fireEvent('onclick', evObj);
         }
+      }
 
-        for (index = 0; index < screenshotLink.length; ++index) {
-          screenshotLink[index].addEventListener('click', function(e) {
-            e.preventDefault();
+      for (index = 0; index < screenshotLink.length; ++index) {
+        screenshotLink[index].addEventListener('click', function(e) {
+          e.preventDefault();
 
-            var img = e.target;
-            if (e.target.tagName == 'A') {
-              img = e.target.children[0];
-            }
-
-            // beautify
-            var tmpImg = new Image();
-            tmpImg.src = img.src;
-            imageDisplay.style.height     = 'auto';
-            imageDisplay.style.width     = 'auto';
-            if (window.innerHeight < tmpImg.height) {
-              imageDisplay.style.height = document.documentElement.clientHeight+'px';
-            } else if (window.innerWidth < tmpImg.width) {
-              imageDisplay.style.width = document.documentElement.clientWidth;+'px';
-            } else {
-              imageDisplay.style.paddingTop = parseInt((window.innerHeight - tmpImg.height) / 2)+'px';
-            }
-
-            imageDisplay.src             = img.src;
-            imageDisplay.alt             = img.alt;
-            imageDisplay.dataset.counter = img.dataset.counter;
-
-            imageInfo.innerHTML          = '<h3>'+img.alt+'</h3>';
-            imageInfo.innerHTML         += img.src.split("/").pop();
-            imageInfo.innerHTML         += '<br />'+tmpImg.height+'&times;'+tmpImg.width+'px';
-
-            overlay.style.display        = "block";
-          });
-        }
-
-        imageDisplay.addEventListener('click', function(e) {
-          e.stopPropagation(); // !
-
-          overlay.style.display = "none";
-
-          img_counter = parseInt(e.target.dataset.counter) + 1;
-          try {
-            link = document.body.querySelector('img[data-counter="'+img_counter+'"]').parentNode;
-          } catch (e) {
-            try {
-              link = document.body.querySelector('img[data-counter="0"]').parentNode;
-            } catch (e) {
-              return false;
-            }
+          var img = e.target;
+          if (e.target.tagName == 'A') {
+            img = e.target.children[0];
           }
-          doClick(link);
+
+          // beautify
+          var tmpImg = new Image();
+          tmpImg.src = img.src;
+          imageDisplay.style.height     = 'auto';
+          imageDisplay.style.width     = 'auto';
+          if (window.innerHeight < tmpImg.height) {
+            imageDisplay.style.height = document.documentElement.clientHeight+'px';
+          } else if (window.innerWidth < tmpImg.width) {
+            imageDisplay.style.width = document.documentElement.clientWidth;+'px';
+          } else {
+            imageDisplay.style.paddingTop = parseInt((window.innerHeight - tmpImg.height) / 2)+'px';
+          }
+
+          imageDisplay.src             = img.src;
+          imageDisplay.alt             = img.alt;
+          imageDisplay.dataset.counter = img.dataset.counter;
+
+          imageInfo.innerHTML          = '<h3>'+img.alt+'</h3>';
+          imageInfo.innerHTML         += decodeURI(img.src.split("/").pop());
+          imageInfo.innerHTML         += '<br />'+tmpImg.height+'&times;'+tmpImg.width+'px';
+
+          overlay.style.display        = "block";
         });
+      }
 
-        overlay.addEventListener('click', function(e) {
-          overlay.style.display = "none";
-        })
+      imageDisplay.addEventListener('click', function(e) {
+        e.stopPropagation(); // !
+
+        overlay.style.display = "none";
+
+        img_counter = parseInt(e.target.dataset.counter) + 1;
+        try {
+          link = document.body.querySelector('img[data-counter="'+img_counter+'"]').parentNode;
+        } catch (e) {
+          try {
+            link = document.body.querySelector('img[data-counter="0"]').parentNode;
+          } catch (e) {
+            return false;
+          }
+        }
+        doClick(link);
+      });
+
+      overlay.addEventListener('click', function(e) {
+        overlay.style.display = "none";
+      })
 
       function keyPressed(e) {
         e = e || window.event;
@@ -201,6 +183,6 @@
          }
       };
       document.body.addEventListener('keydown', keyPressed);
-      </script>
+    </script>
   </body>
 </html>

--- a/snapshot/lib/snapshot/page.html.erb
+++ b/snapshot/lib/snapshot/page.html.erb
@@ -64,118 +64,100 @@
       }
     </style>
   </head>
-  <body>
-    <% divide_size_by = 5.0 %>
-    <% max_width = 180 %>
-    <% image_counter = 0 %>
+  <body><% image_counter = 0 %><% @data.each do |language, content| %>
+    <h1 class="language"><%= language %></h1>
+    <hr>
+    <table><% content.each do |device_name, screens| %>
+      <tr>
+        <th colspan="<%= screens.count %>">
+          <span class="deviceName"><%= device_name %></span>
+        </th>
+      </tr>
+      <tr><% screens.each do |screen_path| %><% next if screen_path.include?"_framed.png" %>
+        <td><% image_counter += 1 %>
+          <a href="<%= screen_path %>" target="_blank" class="screenshotLink">
+            <img class="screenshot" src="<%= screen_path %>" style="width: 100%;" alt="<%= language %> <%= device_name %>" data-counter="<%= image_counter %>">
+          </a>
+        </td><% end %>
+      </tr><% end %>
+    </table><% end %>
+    <div id="overlay">
+      <img id="imageDisplay" src="" alt="" />
+      <div id="imageInfo"></div>
+    </div>
+    <script type="text/javascript">
+      var overlay        = document.getElementById('overlay');
+      var imageDisplay   = document.getElementById('imageDisplay');
+      var imageInfo      = document.getElementById('imageInfo');
+      var screenshotLink = document.getElementsByClassName('screenshotLink');
 
-
-    <% @data.each do |language, content| %>
-      <h1 class="language"><%= language %></h1>
-      <hr>
-      <table>
-        <% content.each do |device_name, screens| %>
-          <tr>
-            <th colspan="<%= screens.count %>">
-              <span class="deviceName"><%= device_name %></span>
-            </th>
-          </tr>
-          <tr>
-            <% screens.each do |screen_path| %>
-              <% next if screen_path.include?"_framed.png" %>
-              <td>
-                <% style = "width: 100%;" %>
-                <% image_counter += 1 %>
-                <a href="<%= screen_path %>" target="_blank" class="screenshotLink">
-                  <img class="screenshot"
-                         src="<%= screen_path %>"
-                       style="<%= style %>"
-                         alt="<%= language %> <%= device_name %>"
-                data-counter="<%= image_counter %>" />
-                </a>
-              </td>
-            <% end %>
-          </tr>
-        <% end %>
-      </table>
-    <% end %>
-      <div id="overlay">
-        <img id="imageDisplay" src="" alt="" />
-        <div id="imageInfo"></div>
-      </div>
-      <script type="text/javascript">
-        var overlay        = document.getElementById('overlay');
-        var imageDisplay   = document.getElementById('imageDisplay');
-        var imageInfo      = document.getElementById('imageInfo');
-        var screenshotLink = document.getElementsByClassName('screenshotLink');
-
-        function doClick(el) {
-          if (document.createEvent) {
-            var evObj = document.createEvent('MouseEvents', true);
-            evObj.initMouseEvent("click", false, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-            el.dispatchEvent(evObj);
-          } else if (document.createEventObject) { //IE
-            var evObj = document.createEventObject();
-            el.fireEvent('onclick', evObj);
-          }
+      function doClick(el) {
+        if (document.createEvent) {
+          var evObj = document.createEvent('MouseEvents', true);
+          evObj.initMouseEvent("click", false, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+          el.dispatchEvent(evObj);
+        } else if (document.createEventObject) { //IE
+          var evObj = document.createEventObject();
+          el.fireEvent('onclick', evObj);
         }
+      }
 
-        for (index = 0; index < screenshotLink.length; ++index) {
-          screenshotLink[index].addEventListener('click', function(e) {
-            e.preventDefault();
-            
-            var img = e.target;
-            if (e.target.tagName == 'A') {
-              img = e.target.children[0];
-            }
-            
-            // beautify
-            var tmpImg = new Image();
-            tmpImg.src = img.src;
-            imageDisplay.style.height     = 'auto';
-            imageDisplay.style.width     = 'auto';
-            if (window.innerHeight < tmpImg.height) {
-              imageDisplay.style.height = document.documentElement.clientHeight+'px';
-            } else if (window.innerWidth < tmpImg.width) {
-              imageDisplay.style.width = document.documentElement.clientWidth;+'px';
-            } else {
-              imageDisplay.style.paddingTop = parseInt((window.innerHeight - tmpImg.height) / 2)+'px';
-            }
+      for (index = 0; index < screenshotLink.length; ++index) {
+        screenshotLink[index].addEventListener('click', function(e) {
+          e.preventDefault();
 
-            imageDisplay.src             = img.src;
-            imageDisplay.alt             = img.alt;
-            imageDisplay.dataset.counter = img.dataset.counter;
-            
-            imageInfo.innerHTML          = '<h3>'+img.alt+'</h3>';
-            imageInfo.innerHTML         += decodeURI(img.src.split("/").pop());
-            imageInfo.innerHTML         += '<br />'+tmpImg.height+'&times;'+tmpImg.width+'px';
-                    
-            overlay.style.display        = "block";
-          });
-        }
-        
-        imageDisplay.addEventListener('click', function(e) {
-          e.stopPropagation(); // !
-          
-          overlay.style.display = "none";
-          
-          img_counter = parseInt(e.target.dataset.counter) + 1;
-          try {
-            link = document.body.querySelector('img[data-counter="'+img_counter+'"]').parentNode;
-          } catch (e) {
-            try {
-              link = document.body.querySelector('img[data-counter="0"]').parentNode;
-            } catch (e) {
-              return false;
-            }
+          var img = e.target;
+          if (e.target.tagName == 'A') {
+            img = e.target.children[0];
           }
-          doClick(link);
+
+          // beautify
+          var tmpImg = new Image();
+          tmpImg.src = img.src;
+          imageDisplay.style.height     = 'auto';
+          imageDisplay.style.width     = 'auto';
+          if (window.innerHeight < tmpImg.height) {
+            imageDisplay.style.height = document.documentElement.clientHeight+'px';
+          } else if (window.innerWidth < tmpImg.width) {
+            imageDisplay.style.width = document.documentElement.clientWidth;+'px';
+          } else {
+            imageDisplay.style.paddingTop = parseInt((window.innerHeight - tmpImg.height) / 2)+'px';
+          }
+
+          imageDisplay.src             = img.src;
+          imageDisplay.alt             = img.alt;
+          imageDisplay.dataset.counter = img.dataset.counter;
+
+          imageInfo.innerHTML          = '<h3>'+img.alt+'</h3>';
+          imageInfo.innerHTML         += decodeURI(img.src.split("/").pop());
+          imageInfo.innerHTML         += '<br />'+tmpImg.height+'&times;'+tmpImg.width+'px';
+
+          overlay.style.display        = "block";
         });
+      }
 
-        overlay.addEventListener('click', function(e) {
-          overlay.style.display = "none";
-        })
-        
+      imageDisplay.addEventListener('click', function(e) {
+        e.stopPropagation(); // !
+
+        overlay.style.display = "none";
+
+        img_counter = parseInt(e.target.dataset.counter) + 1;
+        try {
+          link = document.body.querySelector('img[data-counter="'+img_counter+'"]').parentNode;
+        } catch (e) {
+          try {
+            link = document.body.querySelector('img[data-counter="0"]').parentNode;
+          } catch (e) {
+            return false;
+          }
+        }
+        doClick(link);
+      });
+
+      overlay.addEventListener('click', function(e) {
+        overlay.style.display = "none";
+      })
+
       function keyPressed(e) {
         e = e || window.event;
         var charCode = e.keyCode || e.which;
@@ -201,6 +183,6 @@
          }
       };
       document.body.addEventListener('keydown', keyPressed);
-      </script>
+    </script>
   </body>
 </html>


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid (this actually threw some exceptions already before)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Fixing #10878

### Description

I've made some changes to the template to fix the above issue.

The generated output for the html site looks like actual code now that you'd write too and is also correctly indented.

**Before**

<img width="1680" alt="screen shot 2018-02-09 at 14 14 34" src="https://user-images.githubusercontent.com/5759366/36029466-99333b1c-0da3-11e8-969d-5cf19b8a06c0.png">


**After**

<img width="1680" alt="screen shot 2018-02-09 at 14 13 39" src="https://user-images.githubusercontent.com/5759366/36029438-80b5e8f0-0da3-11e8-8ff6-64bdbf13c013.png">

This allows the file to be correctly checked in into the repository and then having a minimal diff when adding or changing some more languages or device types.

I've updated both the templating for iOS & Android. I'll write a few more things in code that I changed.

I'd advise to review this PR by disabling whitespace changes (adding `?w=1` to the url).