### PR TITLE
Fix RuboCop warnings caused by renamed namespaces

### DIFF
--- a/spaceship/lib/spaceship/portal/ui/select_team.rb
+++ b/spaceship/lib/spaceship/portal/ui/select_team.rb
@@ -31,7 +31,7 @@ module Spaceship
       #     {...}
       #   ]
 
-      # rubocop:disable Lint/MissingRequireStatement
+      # rubocop:disable Require/MissingRequireStatement
       def self.ci?
         if Object.const_defined?("FastlaneCore") && FastlaneCore.const_defined?("Helper")
           return FastlaneCore::Helper.ci?
@@ -45,7 +45,7 @@ module Spaceship
         end
         return true
       end
-      # rubocop:enable Lint/MissingRequireStatement
+      # rubocop:enable Require/MissingRequireStatement
 
       def select_team
         teams = client.teams

--- a/spaceship/lib/spaceship/ui.rb
+++ b/spaceship/lib/spaceship/ui.rb
@@ -18,10 +18,10 @@ module Spaceship
     end
 
     # Public getter for all UI related code
-    # rubocop:disable Naming/MethodName
+    # rubocop:disable Style/MethodName
     def UI
       UserInterface.new(self)
     end
-    # rubocop:enable Naming/MethodName
+    # rubocop:enable Style/MethodName
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->
