### PR TITLE
Improve SnapshotHelper.swift to support snapshotting for multiple apps.

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -133,7 +133,7 @@ open class Snapshot: NSObject {
         sleep(1) // Waiting for the animation to be finished (kind of)
 
         #if os(OSX)
-            XCUIApplication().typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
+            Snapshot.app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
         #else
             let screenshot = app.windows.firstMatch.screenshot()
             guard let simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
@@ -152,7 +152,7 @@ open class Snapshot: NSObject {
             return
         #endif
 
-        let networkLoadingIndicator = XCUIApplication().otherElements.deviceStatusBars.networkLoadingIndicators.element
+        let networkLoadingIndicator = Snapshot.app.otherElements.deviceStatusBars.networkLoadingIndicators.element
         let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
         _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
     }
@@ -223,7 +223,7 @@ private extension XCUIElementQuery {
     }
 
     var deviceStatusBars: XCUIElementQuery {
-        let deviceWidth = XCUIApplication().frame.width
+        let deviceWidth = Snapshot.app.frame.width
 
         let isStatusBar = NSPredicate { (evaluatedObject, _) in
             guard let element = evaluatedObject as? XCUIElementAttributes else { return false }


### PR DESCRIPTION
Support multiple apps testing flows with native XCUIApplication(bundleIdentifier:).

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)

### Motivation and Context
Subsequent call to XCUIApplication() would rise an exception if UITest was previously setup with XCUIApplication(bundleIdentifier:).
Replacing XCUIApplication() with Snapshot.app is safe because 'app' variable was previous initialized via setupSnapshot() function invocation.
Reusing an existing 'Snapshot.app' variable will enable multiple apps testing by leveraging  XCUIApplication(bundleIdentifier:) initialization.

### Description
Support multiple apps testing flows with native XCUIApplication(bundleIdentifier:).