### PR TITLE
Support Other Gem Server on PluginManager

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -116,9 +116,10 @@ module Fastlane
       selection_git_url = "Git URL"
       selection_path = "Local Path"
       selection_rubygems = "RubyGems.org ('#{plugin_name}' seems to not be available there)"
+      selection_gem_server = "Other Gem Server"
       selection = UI.select(
         "Seems like the plugin is not available on RubyGems, what do you want to do?",
-        [selection_git_url, selection_path, selection_rubygems]
+        [selection_git_url, selection_path, selection_rubygems, selection_gem_server]
       )
 
       if selection == selection_git_url
@@ -129,6 +130,9 @@ module Fastlane
         return ", path: '#{path}'"
       elsif selection == selection_rubygems
         return ""
+      elsif selection == selection_gem_server
+        source_url = UI.input('Please enter the gem source URL which hosts the plugin you want to use, including the protocol (e.g. https:// or git://)')
+        return ", source: '#{source_url}'"
       else
         UI.user_error!("Unknown input #{selection}")
       end

--- a/fastlane/spec/plugins_specs/plugin_manager_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_manager_spec.rb
@@ -121,6 +121,12 @@ describe Fastlane do
           expect(FastlaneCore::UI.current).to receive(:select).and_return("RubyGems.org ('fastlane' seems to not be available there)")
           expect(plugin_manager.gem_dependency_suffix("fastlane")).to eq("")
         end
+
+        it "supports specifying a custom source" do
+          expect(FastlaneCore::UI.current).to receive(:select).and_return("Other Gem Server")
+          expect(FastlaneCore::UI.current).to receive(:input).and_return("https://gems.mycompany.com")
+          expect(plugin_manager.gem_dependency_suffix("fastlane")).to eq(", source: 'https://gems.mycompany.com'")
+        end
       end
     end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

We host in-house fastlane plugin on our [geminabox](https://github.com/geminabox/geminabox).

By default, fastlane searches the plugin from rubygems.org.
So I added the feature to specify gem source.

### Description

<img width="1099" alt="screen shot 2018-02-14 at 16 19 11" src="https://user-images.githubusercontent.com/147051/36191951-e4fbc728-11a2-11e8-89a3-aa66c6ed3747.png">

The following snippet is added to `Pluginfile`.

```ruby
gem "fastlane-plugin-myplugin", source: 'https://gems.mycompany.com'
```
