### PR TITLE
`update_app_identifier` resolves SRCROOT on build_settings

### DIFF
--- a/fastlane/lib/fastlane/actions/update_app_identifier.rb
+++ b/fastlane/lib/fastlane/actions/update_app_identifier.rb
@@ -23,7 +23,7 @@ module Fastlane
           configs = project.objects.select { |obj| obj.isa == 'XCBuildConfiguration' && !obj.build_settings[identifier_key].nil? }
           UI.user_error!("Info plist uses $(#{identifier_key}), but xcodeproj does not") unless configs.count > 0
 
-          configs = configs.select { |obj| obj.build_settings[info_plist_key] == params[:plist_path] }
+          configs = configs.select { |obj| resolve_path(obj.build_settings[info_plist_key], params[:xcodeproj]) == info_plist_path }
           UI.user_error!("Xcodeproj doesn't have configuration with info plist #{params[:plist_path]}.") unless configs.count > 0
 
           # For each of the build configurations, set app identifier

--- a/fastlane/lib/fastlane/actions/update_app_identifier.rb
+++ b/fastlane/lib/fastlane/actions/update_app_identifier.rb
@@ -48,6 +48,7 @@ module Fastlane
       end
 
       def self.resolve_path(path, xcodeproj_path)
+        return nil unless path
         project_dir = File.dirname(xcodeproj_path)
         # SRCROOT, SOURCE_ROOT and PROJECT_DIR are the same
         %w{SRCROOT SOURCE_ROOT PROJECT_DIR}.each do |variable_name|

--- a/fastlane/spec/actions_specs/update_app_identifier_spec.rb
+++ b/fastlane/spec/actions_specs/update_app_identifier_spec.rb
@@ -108,6 +108,36 @@ describe Fastlane do
           expect(stub_settings_2['PRODUCT_BUNDLE_IDENTIFIER']).to_not(eq('com.test.plist'))
         end
 
+        it "updates the xcode project when info plist path not contains $(SRCROOT)" do
+          stub_project = 'stub project'
+          stub_configuration_1 = 'stub config 1'
+          stub_configuration_2 = 'stub config 2'
+          stub_object = ['object']
+          stub_settings_1 = Hash['PRODUCT_BUNDLE_IDENTIFIER', 'com.something.else']
+          stub_settings_1['INFOPLIST_FILE'] = plist_path_with_srcroot
+          stub_settings_2 = Hash['PRODUCT_BUNDLE_IDENTIFIER', 'com.something.entirely.else']
+          stub_settings_2['INFOPLIST_FILE'] = "Other-Info.plist"
+
+          expect(Xcodeproj::Project).to receive(:open).with('/tmp/fastlane/tests/fastlane/bundle.xcodeproj').and_return(stub_project)
+          expect(stub_project).to receive(:objects).and_return(stub_object)
+          expect(stub_object).to receive(:select).and_return([stub_configuration_1, stub_configuration_2])
+          expect(stub_configuration_1).to receive(:build_settings).twice.and_return(stub_settings_1)
+          expect(stub_configuration_2).to receive(:build_settings).and_return(stub_settings_2)
+          expect(stub_project).to receive(:save)
+
+          create_plist_with_identifier("$(#{identifier_key})")
+          Fastlane::FastFile.new.parse("lane :test do
+            update_app_identifier({
+              xcodeproj: '#{xcodeproj}',
+              plist_path: '#{plist_path}',
+              app_identifier: '#{app_identifier}'
+            })
+          end").runner.execute(:test)
+
+          expect(stub_settings_1['PRODUCT_BUNDLE_IDENTIFIER']).to eq('com.test.plist')
+          expect(stub_settings_2['PRODUCT_BUNDLE_IDENTIFIER']).to_not(eq('com.test.plist'))
+        end
+
         it "should raise an exception when PRODUCT_BUNDLE_IDENTIFIER in info plist but project doesn't use this info plist" do
           stub_project = 'stub project'
           stub_configuration = 'stub config'


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

In `update_app_identifier` action, when targets build_settings contain `$SRCROOT` as `INFO_PLIST_PATH`, we also have to path `$SRCROOT` as `plist_path` parameter.

### Description

#### Before

```ruby
 update_app_identifier(
  plist_path: '$(SRCROOT)/Resources/Info.plist',
  app_identifier: "com.example.MyApp"
)
```

If remove `$SRCROOT`, then action raises `Xcodeproj doesn't have configuration with info plist Resources/Info.plist`.

#### After

```ruby
 update_app_identifier(
  plist_path: 'Resources/Info.plist',
  app_identifier: "com.example.MyApp"
)
```

This patch makes this action to resolve `$SRCROOT`.
In result, both parameters (contains `$SRCROOT` or not) are OK.
