### PR TITLE
Fix getting certificate info in match/utils.rb

### DIFF
--- a/match/lib/match/utils.rb
+++ b/match/lib/match/utils.rb
@@ -51,8 +51,8 @@ module Match
       return out_array.map { |x| x.split(/=+/) if x.include?("=") }
                       .compact
                       .map { |k, v| [openssl_keys_to_readable_keys.fetch(k, k), v] }
-                      .append([openssl_keys_to_readable_keys.fetch("notBefore"), cert.not_before])
-                      .append([openssl_keys_to_readable_keys.fetch("notAfter"), cert.not_after])
+                      .push([openssl_keys_to_readable_keys.fetch("notBefore"), cert.not_before])
+                      .push([openssl_keys_to_readable_keys.fetch("notAfter"), cert.not_after])
     rescue => ex
       UI.error(ex)
       return {}


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
After the latest update `match` fails with ```undefined method `append' for #<Array:0x007f8cbf8fee88>```.
### Description
<!-- Describe your changes in detail -->
This PR fixes the issue by replacing `append`, which is not a valid array method, with `push`.
I tested the changes on my local setup to make sure the issue with match is gone.