### PR TITLE
Mapping dSYM files with BCSymbolMaps

### DIFF
--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -128,19 +128,22 @@ module Gym
       # Compress and move the dsym file
       containing_directory = File.expand_path("..", PackageCommandGenerator.dsym_path)
       bcsymbolmaps_directory = File.expand_path("../../BCSymbolMaps", PackageCommandGenerator.dsym_path)
-
       available_dsyms = Dir.glob("#{containing_directory}/*.dSYM")
+      
+      UI.message("Mapping dSYM(s) using generated BCSymbolMaps") unless Gym.config[:silent]
+      available_dsyms.each do |dsym|
+      	command = []
+        command << "dsymutil"
+        command << "--symbol-map #{bcsymbolmaps_directory}"
+        command << dsym
+        Actions.sh(command.join(" "), log: false)
+      end
+      
       UI.message("Compressing #{available_dsyms.count} dSYM(s)") unless Gym.config[:silent]
 
       output_path = File.expand_path(File.join(Gym.config[:output_directory], Gym.config[:output_name] + ".app.dSYM.zip"))
       command = "cd '#{containing_directory}' && zip -r '#{output_path}' *.dSYM"
       Helper.backticks(command, print: !Gym.config[:silent])
-      if Dir.exist?(bcsymbolmaps_directory)
-        available_bcsymbolmaps = Dir.glob("#{bcsymbolmaps_directory}/*.bcsymbolmap")
-        UI.message("Compressing #{available_bcsymbolmaps.count} bcsymbolmap(s)") unless Gym.config[:silent]
-        command = "cd '#{bcsymbolmaps_directory}' && zip -rg '#{output_path}' *.bcsymbolmap"
-        Helper.backticks(command, print: !Gym.config[:silent])
-      end
       puts("") # new line
 
       UI.success("Successfully exported and compressed dSYM file")

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -130,13 +130,15 @@ module Gym
       bcsymbolmaps_directory = File.expand_path("../../BCSymbolMaps", PackageCommandGenerator.dsym_path)
       available_dsyms = Dir.glob("#{containing_directory}/*.dSYM")
 
-      UI.message("Mapping dSYM(s) using generated BCSymbolMaps") unless Gym.config[:silent]
-      available_dsyms.each do |dsym|
-        command = []
-        command << "dsymutil"
-        command << "--symbol-map #{bcsymbolmaps_directory.shellescape}"
-        command << dsym.shellescape
-        Helper.backticks(command.join(" "), print: !Gym.config[:silent])
+      if Dir.exist?(bcsymbolmaps_directory)
+        UI.message("Mapping dSYM(s) using generated BCSymbolMaps") unless Gym.config[:silent]
+        available_dsyms.each do |dsym|
+          command = []
+          command << "dsymutil"
+          command << "--symbol-map #{bcsymbolmaps_directory.shellescape}"
+          command << dsym.shellescape
+          Helper.backticks(command.join(" "), print: !Gym.config[:silent])
+        end
       end
 
       UI.message("Compressing #{available_dsyms.count} dSYM(s)") unless Gym.config[:silent]

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -134,8 +134,8 @@ module Gym
       available_dsyms.each do |dsym|
         command = []
         command << "dsymutil"
-        command << "--symbol-map #{bcsymbolmaps_directory}"
-        command << dsym
+        command << "--symbol-map #{bcsymbolmaps_directory.shellescape}"
+        command << dsym.shellescape
         Helper.backticks(command.join(" "), print: !Gym.config[:silent])
       end
 

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -129,16 +129,16 @@ module Gym
       containing_directory = File.expand_path("..", PackageCommandGenerator.dsym_path)
       bcsymbolmaps_directory = File.expand_path("../../BCSymbolMaps", PackageCommandGenerator.dsym_path)
       available_dsyms = Dir.glob("#{containing_directory}/*.dSYM")
-      
+
       UI.message("Mapping dSYM(s) using generated BCSymbolMaps") unless Gym.config[:silent]
       available_dsyms.each do |dsym|
-      	command = []
+        command = []
         command << "dsymutil"
         command << "--symbol-map #{bcsymbolmaps_directory}"
         command << dsym
         Helper.backticks(command.join(" "), print: !Gym.config[:silent])
       end
-      
+
       UI.message("Compressing #{available_dsyms.count} dSYM(s)") unless Gym.config[:silent]
 
       output_path = File.expand_path(File.join(Gym.config[:output_directory], Gym.config[:output_name] + ".app.dSYM.zip"))

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -136,7 +136,7 @@ module Gym
         command << "dsymutil"
         command << "--symbol-map #{bcsymbolmaps_directory}"
         command << dsym
-        Actions.sh(command.join(" "), log: false)
+        Helper.backticks(command.join(" "), print: !Gym.config[:silent])
       end
       
       UI.message("Compressing #{available_dsyms.count} dSYM(s)") unless Gym.config[:silent]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR solves the problem describe in #10902 and fix the PR #11771 by mapping symbols with bitcode support enabled.
Including BCSymbolMaps on dSYM zip file is not enough to Crashlytics identify the stack trace, at least for CI environment when `upload_symbols_to_crashlytics` use is necessary.

### Description
The code made by PR #11771 was removed and added a shell command to `dsymutil` to map a dSYM file using BCSymbolMaps.