### PR TITLE
fix team_id handling in automatic_code_signing action

### DIFF
--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -35,6 +35,7 @@ module Fastlane
 
           if params[:team_id]
             sett["DevelopmentTeam"] = params[:team_id]
+            build_configuration_list.set_setting("DEVELOPMENT_TEAM", params[:team_id])
             UI.important("Set Team id to: #{params[:team_id]} for target: #{found_target[:name]}")
           end
           if params[:code_sign_identity]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ +] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ +] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ +] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ +] I've updated the documentation if necessary.

### Motivation and Context
Resolve switching from automatic to manual signing with xcode 8. Without this fix xcode is requesting development team.

### Description
added DEVELOPMENT_TEAM to project configuration
