### PR TITLE
Use correct spelling of icloud service

### DIFF
--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -95,10 +95,10 @@ module Produce
         elsif k.to_sym == :icloud
           case v
           when SERVICE_LEGACY
-            enabled_clean_options[app_service.icloud.on.service_id] = app_service.icloud.on
+            enabled_clean_options[app_service.cloud.on.service_id] = app_service.cloud.on
             enabled_clean_options[app_service.cloud_kit.xcode5_compatible.service_id] = app_service.cloud_kit.xcode5_compatible
           when SERVICE_CLOUDKIT
-            enabled_clean_options[app_service.icloud.on.service_id] = app_service.icloud.on
+            enabled_clean_options[app_service.i_cloud.on.service_id] = app_service.i_cloud.on
             enabled_clean_options[app_service.cloud_kit.cloud_kit.service_id] = app_service.cloud_kit.cloud_kit
           end
         else


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This fixes https://github.com/fastlane/fastlane/issues/11860.

### Description

Use the correct method `Spaceship::Portal::AppService.cloud` because the constant is named `Cloud` instead of `iCloud`. The latter would cause that the Ruby-style method would be named `i_cloud`. That doesn't look better either.