### PR TITLE
FastLane android init: clean before build/deploy

### DIFF
--- a/fastlane/lib/fastlane/setup/setup_android.rb
+++ b/fastlane/lib/fastlane/setup/setup_android.rb
@@ -28,7 +28,7 @@ module Fastlane
       self.append_lane([
                          "desc \"Submit a new Beta Build to Crashlytics Beta\"",
                          "lane :beta do",
-                         "  gradle(task: \"assembleRelease\")",
+                         "  gradle(task: \"clean assembleRelease\")",
                          "  crashlytics",
                          "",
                          "  # sh \"your_script.sh\"",
@@ -39,7 +39,7 @@ module Fastlane
       self.append_lane([
                          "desc \"Deploy a new version to the Google Play\"",
                          "lane :deploy do",
-                         "  gradle(task: \"assembleRelease\")",
+                         "  gradle(task: \"clean assembleRelease\")",
                          "  upload_to_play_store",
                          "end"
                        ])


### PR DESCRIPTION
As requested, this is an update of the original PR: https://github.com/fastlane/fastlane/pull/11086

Cleaning ensures that Supply won't try to upload debug build if both release/debug builds are present in output folder (https://github.com/fastlane/fastlane/issues/4675)