### PR TITLE
Added whitespace after URL in error message

### DIFF
--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -237,7 +237,7 @@ module Sigh
         filters << "Certificate ID: '#{Sigh.config[:cert_id]}' " if Sigh.config[:cert_id]
         UI.important("No certificates for filter: #{filters}") if filters.length > 0
         message = "Could not find a matching code signing identity for type '#{profile_type.to_s.split(':').last}'. "
-        message += "It is recommended to use match to manage code signing for you, more information on https://codesigning.guide."
+        message += "It is recommended to use match to manage code signing for you, more information on https://codesigning.guide. "
         message += "If you don't want to do so, you can also use cert to generate a new one: https://fastlane.tools/cert"
         UI.user_error!(message)
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Added whitespace after URL, so people can ctrl+click on the link without `.If` being appended.

![fastlane-typo](https://user-images.githubusercontent.com/2340997/36374760-ceea9766-156c-11e8-840d-b6da610792d5.png)

### Description
See above.
