### PR TITLE
Add option to disable any kind of formatting on the output

### DIFF
--- a/fastlane_core/README.md
+++ b/fastlane_core/README.md
@@ -20,9 +20,10 @@ This gem contains all shared classes and code:
 
 You can hide the inline changelog by setting the `FASTLANE_HIDE_CHANGELOG` environment variable
 
-## Timestamps
+## Output environment variables
 
-To hide timestamps in each row, set the `FASTLANE_HIDE_TIMESTAMP` environment variable.
+- To hide timestamps in each row, set the `FASTLANE_HIDE_TIMESTAMP` environment variable to true.
+- To disable output formatting, set the `FASTLANE_DISABLE_OUTPUT_FORMAT` environment variable to true.
 
 ## Interacting with the user
 

--- a/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
+++ b/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
@@ -72,8 +72,12 @@ module FastlaneCore
     def command_output(message)
       actual = (message.split("\r").last || "") # as clearing the line will remove the `>` and the time stamp
       actual.split("\n").each do |msg|
-        prefix = msg.include?("▸") ? "" : "▸ "
-        log.info(prefix + "" + msg.magenta)
+        if FastlaneCore::Env.truthy?("FASTLANE_DISABLE_OUTPUT_FORMAT")
+          log.info(msg)
+        else
+          prefix = msg.include?("▸") ? "" : "▸ "
+          log.info(prefix + "" + msg.magenta)
+        end
       end
     end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The CI platform that we are using, Buildkite, supports grouping if the logs have the following format:

```bash
--- this is a group
# then something else is printed
# and another thing
--- and this is another group
# with some logs inside
```
However, when we use Fastlane, our groups lines get prefixed with the `▸` character and coloured with a magenta color. As a result, the grouping doesn't work.

### Description
I've added a new environment variables, `FASTLANE_DISABLE_OUTPUT_FORMAT` that disables any kind of formatting on the output.
