### PR TITLE
Disable more tests on Windows (temporarily)

### DIFF
--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane do
       allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
     end
 
-    it "enable_automatic_code_signing" do
+    it "enable_automatic_code_signing", requires_xcodeproj: true do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Automatic'")
       result = Fastlane::FastFile.new.parse("lane :test do
@@ -30,7 +30,7 @@ describe Fastlane do
       end
     end
 
-    it "disable_automatic_code_signing for specific target" do
+    it "disable_automatic_code_signing for specific target", requires_xcodeproj: true do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
       expect(UI).to receive(:success).with("\t * today")
@@ -52,7 +52,7 @@ describe Fastlane do
       end
     end
 
-    it "disable_automatic_code_signing" do
+    it "disable_automatic_code_signing", requires_xcodeproj: true do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
       result = Fastlane::FastFile.new.parse("lane :test do
@@ -72,7 +72,7 @@ describe Fastlane do
       end
     end
 
-    it "sets team id" do
+    it "sets team id", requires_xcodeproj: true do
       # G3KGXDXQL9
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
@@ -99,7 +99,7 @@ describe Fastlane do
       end
     end
 
-    it "sets code sign identity" do
+    it "sets code sign identity", requires_xcodeproj: true do
       # G3KGXDXQL9
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
@@ -131,7 +131,7 @@ describe Fastlane do
       end
     end
 
-    it "sets profile name" do
+    it "sets profile name", requires_xcodeproj: true do
       # G3KGXDXQL9
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
@@ -163,7 +163,7 @@ describe Fastlane do
       end
     end
 
-    it "sets profile uuid" do
+    it "sets profile uuid", requires_xcodeproj: true do
       # G3KGXDXQL9
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
@@ -195,7 +195,7 @@ describe Fastlane do
       end
     end
 
-    it "sets bundle identifier" do
+    it "sets bundle identifier", requires_xcodeproj: true do
       # G3KGXDXQL9
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
@@ -227,7 +227,7 @@ describe Fastlane do
       end
     end
 
-    it "targets not found notice" do
+    it "targets not found notice", requires_xcodeproj: true do
       allow(UI).to receive(:important)
       expect(UI).to receive(:important).with("None of the specified targets has been modified")
       result = Fastlane::FastFile.new.parse("lane :test do
@@ -236,7 +236,7 @@ describe Fastlane do
       expect(result).to eq(false)
     end
 
-    it "raises exception on old projects" do
+    it "raises exception on old projects", requires_xcodeproj: true do
       expect(UI).to receive(:user_error!).with("Seems to be a very old project file format - please open your project file in a more recent version of Xcode")
       result = Fastlane::FastFile.new.parse("lane :test do
         disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic-code-signing-old.xcodeproj')

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -90,7 +90,7 @@ RSpec.configure do |config|
       meta[:skip] = "Skipped: Requires `security` to be installed (which is not possible on this platform and no workaround has been implemented)"
     end
     config.define_derived_metadata(:requires_xcodeproj) do |meta|
-      meta[:skip] = "Skipped: Requires `xcodeproj` which is unfortunately broken on Windows right now: https://github.com/CocoaPods/Xcodeproj/issues/549"
+      meta[:skip] = "Skipped: Requires `xcodeproj` which is unfortunately currently broken on Windows: https://github.com/CocoaPods/Xcodeproj/issues/549"
     end
 
     # also skip `before()` for test groups that are skipped because of their tags.

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -89,6 +89,9 @@ RSpec.configure do |config|
     config.define_derived_metadata(:requires_security) do |meta|
       meta[:skip] = "Skipped: Requires `security` to be installed (which is not possible on this platform and no workaround has been implemented)"
     end
+    config.define_derived_metadata(:requires_xcodeproj) do |meta|
+      meta[:skip] = "Skipped: Requires `xcodeproj` which is unfortunately broken on Windows right now: https://github.com/CocoaPods/Xcodeproj/issues/549"
+    end
 
     # also skip `before()` for test groups that are skipped because of their tags
     # only works for `describe` groups (that are parents of the `before`, not if the tag is set on `it`

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -93,9 +93,9 @@ RSpec.configure do |config|
       meta[:skip] = "Skipped: Requires `xcodeproj` which is unfortunately broken on Windows right now: https://github.com/CocoaPods/Xcodeproj/issues/549"
     end
 
-    # also skip `before()` for test groups that are skipped because of their tags
-    # only works for `describe` groups (that are parents of the `before`, not if the tag is set on `it`
-    # caution! has unexpected side effect on usage of `skip: false` for individual examples
+    # also skip `before()` for test groups that are skipped because of their tags.
+    # only works for `describe` groups (that are parents of the `before`, not if the tag is set on `it`.
+    # caution: has unexpected side effect on usage of `skip: false` for individual examples,
     # see https://groups.google.com/d/msg/rspec/5qeKQr_7G7k/Pb3ss2hOAAAJ
     module HookOverrides
       def before(*args)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
A gem being used in the action `automatic_code_signing` and its tests is broken on Windows right now:
https://github.com/CocoaPods/Xcodeproj/issues/549
This is blocking enabling AppVeyor/Windows CI tests on the repo.

### Description
Disable 10 more tests on Windows until the bug is fixed.
