### PR TITLE
YES/NO auto convert fix

### DIFF
--- a/fastlane/spec/actions_specs/zip_spec.rb
+++ b/fastlane/spec/actions_specs/zip_spec.rb
@@ -20,7 +20,7 @@ describe Fastlane do
         expect(Fastlane::Actions).to receive(:sh).with("zip -rq #{File.expand_path(@path)}.zip archive.rb")
 
         result = Fastlane::FastFile.new.parse("lane :test do
-          zip(path: '#{@path}', verbose: 'false')
+          zip(path: '#{@path}', verbose: false)
         end").runner.execute(:test)
       end
 

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -240,7 +240,7 @@ module FastlaneCore
       elsif allow_shell_conversion
         return Shellwords.join(value) if value.kind_of?(Array)
         return value.map { |k, v| "#{k.to_s.shellescape}=#{v.shellescape}" }.join(' ') if value.kind_of?(Hash)
-      else
+      elsif data_type != String
         # Special treatment if the user specified true, false or YES, NO
         # There is no boolean type, so we just do it here
         if %w(YES yes true TRUE).include?(value)

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -322,6 +322,27 @@ describe FastlaneCore do
           expect(config[:false_value2]).to eq(false)
         end
 
+        it "doesn't auto convert booleans as strings to booleans if type is explicitly set to String" do
+          c = [
+            FastlaneCore::ConfigItem.new(key: :true_value, type: String),
+            FastlaneCore::ConfigItem.new(key: :true_value2, type: String),
+            FastlaneCore::ConfigItem.new(key: :false_value, type: String),
+            FastlaneCore::ConfigItem.new(key: :false_value2, type: String)
+          ]
+
+          config = FastlaneCore::Configuration.create(c, {
+            true_value: "true",
+            true_value2: "YES",
+            false_value: "false",
+            false_value2: "NO"
+          })
+
+          expect(config[:true_value]).to eq("true")
+          expect(config[:true_value2]).to eq("YES")
+          expect(config[:false_value]).to eq("false")
+          expect(config[:false_value2]).to eq("NO")
+        end
+
         it "auto converts strings to integers" do
           c = [
             FastlaneCore::ConfigItem.new(key: :int_value,


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I'm developing a plugin that updates xcconfig files and noticed that `'YES'/'NO'` or `'true'/'false'` strings passed as action's config gets automatically converted to `true/false` (boolean) despite config's type is explicitly set to `String`. This is causing issues to me as my code is unable to get the initial value that was set by the user - was it `YES` or `true`?

### Description
I've updated the code that auto converts `YES/NO/true/false` strings into booleans so that it check config's type before performing conversion. If type was explicitly set to `String` auto conversion will not happen.

Hope that makes sense.
