### PR TITLE
Add possibility to use a specific proxy

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -222,6 +222,9 @@ module Spaceship
           # This enables tracking of networking requests using Charles Web Proxy
           c.proxy("https://127.0.0.1:8888")
           c.ssl[:verify_mode] = OpenSSL::SSL::VERIFY_NONE
+        elsif ENV["SPACESHIP_PROXY"]
+          c.proxy(ENV["SPACESHIP_PROXY"])
+          c.ssl[:verify_mode] = OpenSSL::SSL::VERIFY_NONE if ENV["SPACESHIP_PROXY_SSL_VERIFY_NONE"]
         end
 
         if ENV["DEBUG"]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
Hello guys.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
On the machine a use I need to use a specific proxy defined by our sysadmin.

<!-- If it fixes an open issue, please link to the issue here. -->
Partially fixes #2061

<!-- Please describe in detail how you tested your changes. -->
I tested it by setting up a http proxy with mitmproxy and using it.

### Description
<!-- Describe your changes in detail -->
I've had the ability to specify an http proxy using the environment variable SPACESHIP_PROXY and to disable SSL_VERIFY using SPACESHIP_PROXY_SSL_VERIFY_NONE
