### PR TITLE
Add use_bundle_exec option to pod_push action

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_push.rb
+++ b/fastlane/lib/fastlane/actions/pod_push.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class PodPushAction < Action
       def self.run(params)
-        command = ''
+        command = []
 
         command << "bundle exec" if params[:use_bundle_exec] && shell_out_should_use_bundle_exec?
 
@@ -14,32 +14,32 @@ module Fastlane
         end
 
         if params[:path]
-          command << " '#{params[:path]}'"
+          command << "'#{params[:path]}'"
         end
 
         if params[:sources]
           sources = params[:sources].join(",")
-          command << " --sources='#{sources}'"
+          command << "--sources='#{sources}'"
         end
 
         if params[:swift_version]
           swift_version = params[:swift_version]
-          command << " --swift-version=#{swift_version}"
+          command << "--swift-version=#{swift_version}"
         end
 
         if params[:allow_warnings]
-          command << " --allow-warnings"
+          command << "--allow-warnings"
         end
 
         if params[:use_libraries]
-          command << " --use-libraries"
+          command << "--use-libraries"
         end
 
         if params[:verbose]
-          command << " --verbose"
+          command << "--verbose"
         end
 
-        result = Actions.sh(command.to_s)
+        result = Actions.sh(command.join(' '))
         UI.success("Successfully pushed Podspec ⬆️ ")
         return result
       end

--- a/fastlane/lib/fastlane/actions/pod_push.rb
+++ b/fastlane/lib/fastlane/actions/pod_push.rb
@@ -2,11 +2,15 @@ module Fastlane
   module Actions
     class PodPushAction < Action
       def self.run(params)
+        command = ''
+
+        command << "bundle exec" if params[:use_bundle_exec] && shell_out_should_use_bundle_exec?
+
         if params[:repo]
           repo = params[:repo]
-          command = "pod repo push #{repo}"
+          command << "pod repo push #{repo}"
         else
-          command = 'pod trunk push'
+          command << 'pod trunk push'
         end
 
         if params[:path]
@@ -54,6 +58,10 @@ module Fastlane
 
       def self.available_options
         [
+          FastlaneCore::ConfigItem.new(key: :use_bundle_exec,
+                                         description: "Use bundle exec when there is a Gemfile presented",
+                                         is_string: false,
+                                         default_value: false),
           FastlaneCore::ConfigItem.new(key: :path,
                                        description: "The Podspec you want to push",
                                        optional: true,

--- a/fastlane/spec/actions_specs/pod_push_spec.rb
+++ b/fastlane/spec/actions_specs/pod_push_spec.rb
@@ -76,7 +76,7 @@ describe Fastlane do
         context "false" do
           it "does not appends bundle exec at the beginning of the command" do
             result = Fastlane::FastFile.new.parse("lane :test do
-              pod_push(use_bundle_exec: true)
+              pod_push(use_bundle_exec: false)
             end").runner.execute(:test)
 
             expect(result).to eq("pod trunk push")

--- a/fastlane/spec/actions_specs/pod_push_spec.rb
+++ b/fastlane/spec/actions_specs/pod_push_spec.rb
@@ -62,6 +62,27 @@ describe Fastlane do
           ff.runner.execute(:test)
         end.to raise_error("File must be a `.podspec` or `.podspec.json`")
       end
+
+      context "with use_bundle_exec flag" do
+        context "true" do
+          it "appends bundle exec at the beginning of the command" do
+            result = Fastlane::FastFile.new.parse("lane :test do
+              pod_push(use_bundle_exec: true)
+            end").runner.execute(:test)
+
+            expect(result).to eq("bundle exec pod trunk push")
+          end
+        end
+        context "false" do
+          it "does not appends bundle exec at the beginning of the command" do
+            result = Fastlane::FastFile.new.parse("lane :test do
+              pod_push(use_bundle_exec: true)
+            end").runner.execute(:test)
+
+            expect(result).to eq("pod trunk push")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation and Context

The `pod_lib_lint` action offer an action to use (or not) the local Gemfile
https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/pod_lib_lint.rb#L7

The `pod_push` does not which can cause sometimes the lib lint to pass and then  the push to fail

### Description
Added the same option to the `pod_push` action

I choose to default this to false, for backward compatibility but it could be defaulted to true for consistency with `pod_lib_lint` (and it seems to be the legit expectation if the project has a Gemfile)