### PR TITLE
Update example code to match real code.

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -147,7 +147,7 @@ module Fastlane
                                                           # Don\'t add this key, or pass nil, if you want all the default payloads. The available default payloads are: `lane`, `test_result`, `git_branch`, `git_author`, `last_git_commit_message`, `last_git_commit_hash`.
             attachment_properties: { # Optional, lets you specify any other properties available for attachments in the slack API (see https://api.slack.com/docs/attachments).
                                      # This hash is deep merged with the existing properties set using the other properties above. This allows your own fields properties to be appended to the existing fields that were created using the `payload` property for instance.
-              thumb_url: "http://example.com/path/to/thumb.png",
+              icon_url: "http://example.com/path/to/icon.png",
               fields: [{
                 title: "My Field",
                 value: "My Value",

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -64,7 +64,7 @@ describe Fastlane do
           channel: channel,
           default_payloads: [:lane],
           attachment_properties: {
-            thumb_url: 'https://example.com/path/to/thumb.png',
+            icon_url: 'https://example.com/path/to/icon.png',
             fields: [{
               title: 'My Field',
               value: 'My Value',
@@ -84,7 +84,7 @@ describe Fastlane do
         expect(fields[1][:value]).to eq('My Value')
         expect(fields[1][:short]).to eq(true)
 
-        expect(attachments[:thumb_url]).to eq('https://example.com/path/to/thumb.png')
+        expect(attachments[:icon_url]).to eq('https://example.com/path/to/icon.png')
       end
 
       it "parses default_payloads from a comma delimited string" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I noticed this discrepancy in the docs at https://docs.fastlane.tools/actions/slack/. The sample code references a `thumb_url`, but it looks like this key has changed to `icon_url` and the sample code wasn't updated.

### Description
I changed `thumb_url` to `icon_url` to make the sample code match the real code.