### PR TITLE
Shellscape java_home ENV var in Crashlytics helper

### DIFF
--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 module Fastlane
   module Helper
     class CrashlyticsHelper
@@ -46,7 +48,7 @@ module Fastlane
           if ENV['JAVA_HOME'].nil?
             command = ["java"]
           else
-            command = ["#{ENV['JAVA_HOME']}/bin/java"]
+            command = [Shellwords.escape(File.join(ENV['JAVA_HOME'], "/bin/java"))]
           end
           command << "-jar #{File.expand_path(params[:crashlytics_path])}"
           command << "-androidRes ."


### PR DESCRIPTION
Fix for #11255

This fix makes it so people can use spaces in their `JAVA_HOME` path again. 