### PR TITLE
Version bump to 2.84.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,49 +30,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 
 <table id='team'>
 <tr>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
 </a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-</tr>
-<tr>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
 <td id='danielle-tomlinson'>
 <a href='https://github.com/DanToml'>
@@ -80,25 +42,43 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
 </td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/AndrewMcBurney'>
+<img src='https://github.com/AndrewMcBurney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
 <td id='iulian-onofrei'>
 <a href='https://github.com/revolter'>
 <img src='https://github.com/revolter.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
 </tr>
 <tr>
-<td id='andrew-mcburney'>
-<a href='https://github.com/AndrewMcBurney'>
-<img src='https://github.com/AndrewMcBurney.png?size=140'>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
 <td id='luka-mirosevic'>
 <a href='https://github.com/lmirosevic'>
@@ -106,23 +86,43 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+</tr>
+<tr>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
 <td id='jorge-revuelta-h'>
 <a href='https://github.com/minuscorp'>
 <img src='https://github.com/minuscorp.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
 </tr>
 <tr>
@@ -132,29 +132,29 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
 </tr>
 </table>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -14,26 +14,26 @@ File.write("#{lib}/fastlane/plugins/template/.rubocop.yml", YAML.dump(config))
 Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
-  spec.authors       = ["Felix Krause",
+  spec.authors       = ["Manu Wallner",
+                        "Olivier Halligon",
+                        "Jimmy Dee",
+                        "Luka Mirosevic",
+                        "Matthew Ellis",
+                        "Felix Krause",
+                        "Fumiya Nakamura",
+                        "Aaron Brager",
+                        "Andrew McBurney",
+                        "Maksym Grebenets",
                         "Danielle Tomlinson",
                         "Jérôme Lacoste",
-                        "Jimmy Dee",
-                        "Helmut Januschka",
-                        "Matthew Ellis",
-                        "Stefan Natchev",
-                        "Manu Wallner",
-                        "Luka Mirosevic",
-                        "Andrew McBurney",
                         "Jan Piotrowski",
-                        "Fumiya Nakamura",
-                        "Maksym Grebenets",
                         "Josh Holtz",
-                        "Joshua Liebowitz",
-                        "Aaron Brager",
-                        "Olivier Halligon",
-                        "Jorge Revuelta H",
+                        "Helmut Januschka",
                         "Iulian Onofrei",
-                        "Kohki Miki"]
+                        "Stefan Natchev",
+                        "Kohki Miki",
+                        "Jorge Revuelta H",
+                        "Joshua Liebowitz"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.83.0'.freeze
+  VERSION = '2.84.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.83.0
+// Generated with fastlane 2.84.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -2215,6 +2215,7 @@ func pilot(username: String,
            updateBuildInfoOnUpload: Bool = false,
            appleId: String? = nil,
            distributeExternal: Bool = false,
+           notifyExternalTesters: Bool = true,
            demoAccountRequired: Bool = false,
            firstName: String? = nil,
            lastName: String? = nil,
@@ -2239,6 +2240,7 @@ func pilot(username: String,
                                                                                        RubyCommand.Argument(name: "update_build_info_on_upload", value: updateBuildInfoOnUpload),
                                                                                        RubyCommand.Argument(name: "apple_id", value: appleId),
                                                                                        RubyCommand.Argument(name: "distribute_external", value: distributeExternal),
+                                                                                       RubyCommand.Argument(name: "notify_external_testers", value: notifyExternalTesters),
                                                                                        RubyCommand.Argument(name: "demo_account_required", value: demoAccountRequired),
                                                                                        RubyCommand.Argument(name: "first_name", value: firstName),
                                                                                        RubyCommand.Argument(name: "last_name", value: lastName),
@@ -2254,9 +2256,11 @@ func pilot(username: String,
   _ = runner.executeCommand(command)
 }
 func pluginScores(outputPath: String,
-                  templatePath: String) {
+                  templatePath: String,
+                  cachePath: String) {
   let command = RubyCommand(commandID: "", methodName: "plugin_scores", className: nil, args: [RubyCommand.Argument(name: "output_path", value: outputPath),
-                                                                                               RubyCommand.Argument(name: "template_path", value: templatePath)])
+                                                                                               RubyCommand.Argument(name: "template_path", value: templatePath),
+                                                                                               RubyCommand.Argument(name: "cache_path", value: cachePath)])
   _ = runner.executeCommand(command)
 }
 func podLibLint(useBundleExec: Bool = true,
@@ -3255,6 +3259,7 @@ func testflight(username: String,
                 updateBuildInfoOnUpload: Bool = false,
                 appleId: String? = nil,
                 distributeExternal: Bool = false,
+                notifyExternalTesters: Bool = true,
                 demoAccountRequired: Bool = false,
                 firstName: String? = nil,
                 lastName: String? = nil,
@@ -3279,6 +3284,7 @@ func testflight(username: String,
                                                                                             RubyCommand.Argument(name: "update_build_info_on_upload", value: updateBuildInfoOnUpload),
                                                                                             RubyCommand.Argument(name: "apple_id", value: appleId),
                                                                                             RubyCommand.Argument(name: "distribute_external", value: distributeExternal),
+                                                                                            RubyCommand.Argument(name: "notify_external_testers", value: notifyExternalTesters),
                                                                                             RubyCommand.Argument(name: "demo_account_required", value: demoAccountRequired),
                                                                                             RubyCommand.Argument(name: "first_name", value: firstName),
                                                                                             RubyCommand.Argument(name: "last_name", value: lastName),
@@ -3621,6 +3627,7 @@ func uploadToTestflight(username: String,
                         updateBuildInfoOnUpload: Bool = false,
                         appleId: String? = nil,
                         distributeExternal: Bool = false,
+                        notifyExternalTesters: Bool = true,
                         demoAccountRequired: Bool = false,
                         firstName: String? = nil,
                         lastName: String? = nil,
@@ -3645,6 +3652,7 @@ func uploadToTestflight(username: String,
                                                                                                       RubyCommand.Argument(name: "update_build_info_on_upload", value: updateBuildInfoOnUpload),
                                                                                                       RubyCommand.Argument(name: "apple_id", value: appleId),
                                                                                                       RubyCommand.Argument(name: "distribute_external", value: distributeExternal),
+                                                                                                      RubyCommand.Argument(name: "notify_external_testers", value: notifyExternalTesters),
                                                                                                       RubyCommand.Argument(name: "demo_account_required", value: demoAccountRequired),
                                                                                                       RubyCommand.Argument(name: "first_name", value: firstName),
                                                                                                       RubyCommand.Argument(name: "last_name", value: lastName),
@@ -3809,4 +3817,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.6]
+// FastlaneRunnerAPIVersion [0.9.7]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.83.0
+// Generated with fastlane 2.84.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.83.0
+// Generated with fastlane 2.84.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.83.0
+// Generated with fastlane 2.84.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.83.0
+// Generated with fastlane 2.84.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.83.0
+// Generated with fastlane 2.84.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.83.0
+// Generated with fastlane 2.84.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.83.0':**

* Shellscape java_home ENV var in Crashlytics helper (#11964) via Joshua Liebowitz
* Move plugin scores cache file to the docs repo (#11927) via Iulian Onofrei
* match/sigh/sync_code_signing: Improving documentation on profile templates. (#11548) via Luke Wakeford
* Some actions failed if true is passed as one of their params (#11935) via Sergii Ovcharenko
* Update remaining tests after merge (#11941) via Felix Krause
* Add possibility to use a specific proxy (#11938) via José Rodrigues
* Update fastlane UI handler to support FastlaneCI rendering (#11857) via Felix Krause
