### PR TITLE
Reinitialize Spaceship::TestFlight.client if Spaceship::Tunes.client is auth with different team id

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -15,10 +15,6 @@ module Fastlane
         Spaceship::Tunes.select_team
         UI.message("Login successful")
 
-        # The TestFlight client's cookie and team ID can drift from the iTC
-        # client's cookie and team ID after logging in or switching teams
-        Spaceship::TestFlight::Base.invalidate_client
-
         # Get App
         app = Spaceship::Application.find(params[:app_identifier])
         unless app

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -15,6 +15,10 @@ module Fastlane
         Spaceship::Tunes.select_team
         UI.message("Login successful")
 
+        # The TestFlight client's cookie and team ID can drift from the iTC
+        # client's cookie and team ID after logging in or switching teams
+        Spaceship::TestFlight::Base.invalidate_client
+
         # Get App
         app = Spaceship::Application.find(params[:app_identifier])
         unless app

--- a/spaceship/docs/TestFlightTesting.md
+++ b/spaceship/docs/TestFlightTesting.md
@@ -35,7 +35,8 @@ At the top of your data model spec, set the client to be a `mock_client`:
 describe Spaceship::TestFlight::Tester do
   let(:mock_client) { double('MockClient') }
   before do
-    Spaceship::TestFlight::Base.client = mock_client
+    allow(Spaceship::TestFlight::Base).to receive(:client).and_return(mock_client)
+    allow(mock_client).to receive(:team_id).and_return('')
   end
 end
 ```

--- a/spaceship/lib/spaceship/test_flight/base.rb
+++ b/spaceship/lib/spaceship/test_flight/base.rb
@@ -5,10 +5,16 @@ module Spaceship
   module TestFlight
     class Base < Spaceship::Base
       def self.client
-        # Initialize new client if none or team changed
-        if Spaceship::Tunes.client && (@client.nil? || @client.team_id != Spaceship::Tunes.client.team_id)
-          @client = Client.client_with_authorization_from(Spaceship::Tunes.client)
+        # Verify there is a client that can be used
+        if Spaceship::Tunes.client
+          # Initialize new client if new or if team changed
+          if @client.nil? || @client.team_id != Spaceship::Tunes.client.team_id
+            @client = Client.client_with_authorization_from(Spaceship::Tunes.client)
+          end
         end
+
+        # Need to handle not having a client but this shouldn't ever happen
+        raise "Please login using `Spaceship::Tunes.login('user', 'password')`" unless @client
 
         @client
       end

--- a/spaceship/lib/spaceship/test_flight/base.rb
+++ b/spaceship/lib/spaceship/test_flight/base.rb
@@ -8,6 +8,10 @@ module Spaceship
         @client ||= Client.client_with_authorization_from(Spaceship::Tunes.client)
       end
 
+      def self.invalidate_client
+        @client = nil
+      end
+
       ##
       # Have subclasses inherit the client from their superclass
       #

--- a/spaceship/lib/spaceship/test_flight/base.rb
+++ b/spaceship/lib/spaceship/test_flight/base.rb
@@ -6,10 +6,10 @@ module Spaceship
     class Base < Spaceship::Base
       def self.client
         # Initialize new client if none or team changed
-        if @client.nil? || @client.team_id != Spaceship::Tunes.client.team_id
+        if Spaceship::Tunes.client && (@client.nil? || @client.team_id != Spaceship::Tunes.client.team_id)
           @client = Client.client_with_authorization_from(Spaceship::Tunes.client)
         end
-      
+
         @client
       end
 

--- a/spaceship/lib/spaceship/test_flight/base.rb
+++ b/spaceship/lib/spaceship/test_flight/base.rb
@@ -5,11 +5,12 @@ module Spaceship
   module TestFlight
     class Base < Spaceship::Base
       def self.client
-        @client ||= Client.client_with_authorization_from(Spaceship::Tunes.client)
-      end
-
-      def self.invalidate_client
-        @client = nil
+        # Initialize new client if none or team changed
+        if @client.nil? || @client.team_id != Spaceship::Tunes.client.team_id
+          @client = Client.client_with_authorization_from(Spaceship::Tunes.client)
+        end
+      
+        @client
       end
 
       ##

--- a/spaceship/spec/test_flight/app_test_info_spec.rb
+++ b/spaceship/spec/test_flight/app_test_info_spec.rb
@@ -63,7 +63,8 @@ describe Spaceship::TestFlight::AppTestInfo do
 
   before do
     # Use a simple client for all data models
-    Spaceship::TestFlight::Base.client = mock_client
+    allow(Spaceship::TestFlight::Base).to receive(:client).and_return(mock_client)
+    allow(mock_client).to receive(:team_id).and_return('')
   end
 
   it 'gets the TestInfo' do

--- a/spaceship/spec/test_flight/build_spec.rb
+++ b/spaceship/spec/test_flight/build_spec.rb
@@ -6,7 +6,8 @@ describe Spaceship::TestFlight::Build do
 
   before do
     # Use a simple client for all data models
-    Spaceship::TestFlight::Base.client = mock_client
+    allow(Spaceship::TestFlight::Base).to receive(:client).and_return(mock_client)
+    allow(mock_client).to receive(:team_id).and_return('')
   end
 
   context '.find' do

--- a/spaceship/spec/test_flight/build_trains_spec.rb
+++ b/spaceship/spec/test_flight/build_trains_spec.rb
@@ -4,7 +4,8 @@ require_relative '../mock_servers'
 describe Spaceship::TestFlight::BuildTrains do
   let(:mock_client) { double('MockClient') }
   before do
-    Spaceship::TestFlight::Base.client = mock_client
+    allow(Spaceship::TestFlight::Base).to receive(:client).and_return(mock_client)
+    allow(mock_client).to receive(:team_id).and_return('')
     mock_client_response(:get_build_trains, with: { app_id: 'some-app-id', platform: 'ios' }) do
       ['1.0', '1.1']
     end

--- a/spaceship/spec/test_flight/group_spec.rb
+++ b/spaceship/spec/test_flight/group_spec.rb
@@ -4,7 +4,8 @@ describe Spaceship::TestFlight::Group do
   let(:mock_client) { double('MockClient') }
 
   before do
-    Spaceship::TestFlight::Base.client = mock_client
+    allow(Spaceship::TestFlight::Base).to receive(:client).and_return(mock_client)
+    allow(mock_client).to receive(:team_id).and_return('')
   end
 
   context 'attr_mapping' do

--- a/spaceship/spec/test_flight/test_info_spec.rb
+++ b/spaceship/spec/test_flight/test_info_spec.rb
@@ -28,7 +28,8 @@ describe Spaceship::TestFlight::TestInfo do
 
   before do
     # Use a simple client for all data models
-    Spaceship::TestFlight::Base.client = mock_client
+    allow(Spaceship::TestFlight::Base).to receive(:client).and_return(mock_client)
+    allow(mock_client).to receive(:team_id).and_return('')
   end
 
   it 'gets the value from the first locale' do

--- a/spaceship/spec/test_flight/tester_spec.rb
+++ b/spaceship/spec/test_flight/tester_spec.rb
@@ -4,7 +4,8 @@ describe Spaceship::TestFlight::Tester do
   let(:mock_client) { double('MockClient') }
 
   before do
-    Spaceship::TestFlight::Base.client = mock_client
+    allow(Spaceship::TestFlight::Base).to receive(:client).and_return(mock_client)
+    allow(mock_client).to receive(:team_id).and_return('')
   end
 
   context 'attr_mapping' do

--- a/spaceship/spec/tunes/application_spec.rb
+++ b/spaceship/spec/tunes/application_spec.rb
@@ -131,7 +131,6 @@ describe Spaceship::Application do
       require_relative '../mock_servers'
 
       before do
-        # HEY JOSH
         allow(Spaceship::TestFlight::Base).to receive(:client).and_return(mock_client)
         allow(mock_client).to receive(:team_id).and_return('')
         mock_client_response(:get_build_trains) do

--- a/spaceship/spec/tunes/application_spec.rb
+++ b/spaceship/spec/tunes/application_spec.rb
@@ -131,7 +131,9 @@ describe Spaceship::Application do
       require_relative '../mock_servers'
 
       before do
-        Spaceship::TestFlight::Base.client = mock_client
+        # HEY JOSH
+        allow(Spaceship::TestFlight::Base).to receive(:client).and_return(mock_client)
+        allow(mock_client).to receive(:team_id).and_return('')
         mock_client_response(:get_build_trains) do
           ['1.0', '1.1']
         end


### PR DESCRIPTION
🔑
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This change allows the download_dsyms action to be run with multiple team IDs in the same session.

<!-- If it fixes an open issue, please link to the issue here. -->
This addresses Github issue #11094  

<!-- Please describe in detail how you tested your changes. -->
First I tested the TestFlight client in `irb`:
```> require 'spaceship'
> Spaceship::Tunes.login
> ENV['FASTLANE_ITC_TEAM_ID'] = '12345'
> Spaceship::Tunes.select_team
> Spaceship::Application.all.first.all_build_train_numbers
> Spaceship::Tunes.login
> ENV['FASTLANE_ITC_TEAM_ID'] = '67890'
> Spaceship::Tunes.select_team
> Spaceship::TestFlight::Base.invalidate_client
> Spaceship::Application.all.first.all_build_train_numbers
```

After that started working properly, I pointed my iPhone project's Gemfile at my local fastlane clone and ran my dsym refresh lane:

```
  lane :refresh_dsyms do
    flavors = Flavors.flavors.values.reject { |flavor| flavor.nonprod? }
    flavors.each do |flavor|
      download_dsyms(username: flavor.team.tunes_username,
                     app_identifier: flavor.bundle_id,
                     team_id: flavor.team.tunes_id,
                     version: 'latest')
    end

    upload_symbols_to_crashlytics(api_token: CRASHLYTICS_API_TOKEN)
    clean_build_artifacts
  end
```

### Description
<!-- Describe your changes in detail -->
This PR adds a new method, `Spaceship::TestFlight::Base.invalidate_client`, which nils the client out. After that, the next call to `client` forces a fresh clone from the iTunes Connect client.

The download_dsyms action now invalidates the TestFlight client after logging in. The TestFlight client can get stuck with an outdated cookie if it's not invalidated.

Thanks for your time!