### PR TITLE
Add debug option to the update_docs lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -334,11 +334,12 @@ end
 
 desc "Update the actions.md on https://docs.fastlane.tools"
 desc "This will also automatically submit a pull request to fastlane/docs"
-lane :update_docs do
+lane :update_docs do |options|
+  debug = options[:debug]
   verify_env_variables
 
   template_path = File.expand_path("./assets/render_plugin.md.erb")
-  clone_docs do
+  clone_docs(debug: debug) do
     plugin_scores_cache_path = File.expand_path("./plugin_scores_cache.yml")
     docs_path = generate_markdown_docs(target_path: ".")
     yml_path = File.expand_path("./mkdocs.yml")
@@ -364,11 +365,13 @@ lane :update_docs do
       UI.success("No changes in the actions.md ✅")
     else
       # Create a new branch
-      sh("git checkout -b 'update-actions-md-#{Time.now.to_i}'")
+      sh("git checkout -b 'update-actions-md-#{Time.now.to_i}'") unless debug
       plugins_path = "docs/plugins/available-plugins.md"
       plugin_scores(template_path: template_path,
                       output_path: plugins_path,
                        cache_path: plugin_scores_cache_path)
+
+      next if debug
 
       Dir.chdir("fastlane") do # this is an assumption of fastlane, that we have to .. when shelling out
         # Commit the changes
@@ -392,15 +395,23 @@ lane :update_docs do
   end
 end
 
-def clone_docs
-  require 'tmpdir'
-  git_url = ENV['FASTLANE_DOCS_GIT_URL'] || "https://github.com/fastlane/docs"
+def clone_docs(debug: false)
+  if debug
+    clone_url = ENV['FASTLANE_DOCS_CLONE_URL'] || "../../docs"
 
-  Dir.mktmpdir("fl_clone") do |tmp_dir|
-    Dir.chdir(tmp_dir) do
-      sh("git clone #{git_url} --depth=1")
-      Dir.chdir("docs") do
-        yield
+    Dir.chdir(clone_url) do
+      yield
+    end
+  else
+    require 'tmpdir'
+    git_url = ENV['FASTLANE_DOCS_GIT_URL'] || "https://github.com/fastlane/docs"
+
+    Dir.mktmpdir("fl_clone") do |tmp_dir|
+      Dir.chdir(tmp_dir) do
+        sh("git clone #{git_url} --depth=1")
+        Dir.chdir("docs") do
+          yield
+        end
       end
     end
   end


### PR DESCRIPTION
Passing `debug:true` to this lane does these:
- Clones the docs in a non-temporary location. By default, a
  directory named `docs` that's a sibling of the root directory.
  Can be changed by defining the `FASTLANE_DOCS_CLONE_URL`
  environment variable.
- Skips the branch, commit, push and PR creation

This way, you can `cd` into the `docs` folder and `mkdocs serve` it to make sure everything is alright instead of actually deploying it to docs.fastlane.tools to check it.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->
