### PR TITLE
[pilot] Fix a bug that auto_notify_enabled always be true

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -92,11 +92,7 @@ module Pilot
         end
       end
 
-      if config[:notify_external_testers]
-        build.auto_notify_enabled = config[:notify_external_testers]
-      else
-        build.auto_notify_enabled = true
-      end
+      build.auto_notify_enabled = config[:notify_external_testers]
 
       return if config[:skip_submission]
       distribute_build(build, options)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.