### PR TITLE
Add parentheses for calls in generated Appfile

### DIFF
--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -323,7 +323,7 @@ module Fastlane
         if self.is_swift_fastfile
           self.append_team("var itcTeam: String? { return \"#{self.itc_team_id}\" } // iTunes Connect Team ID")
         else
-          self.append_team("itc_team_id \"#{self.itc_team_id}\" # iTunes Connect Team ID")
+          self.append_team("itc_team_id(\"#{self.itc_team_id}\") # iTunes Connect Team ID")
         end
       end
 
@@ -334,7 +334,7 @@ module Fastlane
         if self.is_swift_fastfile
           self.append_team("var teamID: String { return \"#{self.adp_team_id}\" } // Apple Developer Portal Team ID")
         else
-          self.append_team("team_id \"#{self.adp_team_id}\" # Developer Portal Team ID")
+          self.append_team("team_id(\"#{self.adp_team_id}\") # Developer Portal Team ID")
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

The generated `Appfile` contained 2 calls with parentheses and 2 calls without (that were changed by this), and it most probably was creating confusion for people new to the ruby syntax.

<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->
