### PR TITLE
[pem] "No such file or directory" fix

### DIFF
--- a/pem/lib/pem/manager.rb
+++ b/pem/lib/pem/manager.rb
@@ -62,8 +62,8 @@ module PEM
         filename_base = PEM.config[:pem_name] || "#{certificate_type}_#{PEM.config[:app_identifier]}"
         filename_base = File.basename(filename_base, ".pem") # strip off the .pem if it was provided.
 
-        output_path = PEM.config[:output_path]
-        FileUtils.mkdir_p(File.expand_path(output_path))
+        output_path = File.expand_path(PEM.config[:output_path])
+        FileUtils.mkdir_p(output_path)
 
         if PEM.config[:save_private_key]
           private_key_path = File.join(output_path, "#{filename_base}.pkey")


### PR DESCRIPTION
This should fix "No such file or directory" error when using related output_path (for example "~/Documents/pems/")

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
I was trying to 
```pem(app_identifier: "identifier", save_private_key: true, output_path: "~/Documents/ProdPem/")```
 and got "No such file or directory" even though it exists.

### Description
My fix forces converted absolute path usage for next write operations.
