### PR TITLE
Auto-generate deliver doc content (metadata folder options and langua…

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -46,10 +46,10 @@ module Deliver
     }
 
     # Localized app details values, that are editable in live state
-    LOCALISED_LIVE_VALUES = [:description, :release_notes, :support_url, :marketing_url, :promotional_text]
+    LOCALISED_LIVE_VALUES = [:description, :release_notes, :support_url, :marketing_url, :promotional_text, :privacy_url]
 
     # Non localized app details values, that are editable in live state
-    NON_LOCALISED_LIVE_VALUES = [:privacy_url]
+    NON_LOCALISED_LIVE_VALUES = [:copyright]
 
     # Directory name it contains trade representative contact information
     TRADE_REPRESENTATIVE_CONTACT_INFORMATION_DIR = "trade_representative_contact_information"

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -453,25 +453,6 @@ Key | Editable While Live | Directory | Filename
   `<%= value %>` | Yes | `<metadata_path>/<%= Deliver::UploadMetadata::REVIEW_INFORMATION_DIR %>` | `<%= value %>.txt`
 <%- end %>
 
-
-
-### Review Information Metadata
-
-<details>
-<summary>View all</summary>
-
-Key | Editable While Live | Directory | Filename
-----|--------|--------|--------
-  `first_name` | Yes | `<metadata_path>/review_information` | `first_name.txt`
-  `last_name` | Yes | `<metadata_path>/review_information` | `last_name.txt`
-  `phone_number` | Yes | `<metadata_path>/review_information` | `phone_number.txt`
-  `email_address` | Yes | `<metadata_path>/review_information` | `email_address.txt`
-  `demo_user` | Yes | `<metadata_path>/review_information` | `demo_user.txt`
-  `demo_password` | Yes | `<metadata_path>/review_information` | `demo_password.txt`
-  `notes` | Yes | `<metadata_path>/review_information` | `notes.txt`
-
-</details>
-
 ## Reference
 
 <details>

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -131,6 +131,7 @@ The bundle identifier (e.g. "com.krausefx.app")
 Your Apple ID email address
 
 ##### ipa
+
 A path to a signed ipa file, which will be uploaded. If you don't provide this value, only app metadata will be uploaded. If you want to submit the app for review make sure to either use `fastlane deliver --submit_for_review` or add `submit_for_review true` to your `Deliverfile`
 
 ```ruby-skip-tests
@@ -411,8 +412,65 @@ _deliver_ uses the following techniques under the hood:
 
 ## Available language codes
 ```no-highlight
-no, en-US, en-CA, fi, ru, zh-Hans, nl-NL, zh-Hant, en-AU, id, de-DE, sv, ko, ms, pt-BR, el, es-ES, it, fr-CA, es-MX, pt-PT, vi, th, ja, fr-FR, da, tr, en-GB
+<%= FastlaneCore::Languages::ALL_LANGUAGES.join(', ') %>
 ```
+
+## Available Metadata Folder Options
+
+_deliver_ allows for metadata to be set through `.txt` files in the metadata folder. This metadata folder location is defaulted to `./fastlane/metadata` but can be overridden through the `metadata_path` parameter. Below are all allowed metadata options.
+
+<%- require 'deliver' -%>
+
+### Non-Localized Metadata
+
+Key | Editable While Live | Directory | Filename
+----|--------|--------|--------
+<%- (Deliver::UploadMetadata::NON_LOCALISED_VERSION_VALUES + Deliver::UploadMetadata::NON_LOCALISED_APP_VALUES).each do |value| -%>
+  `<%= value %>` | <%= Deliver::UploadMetadata::NON_LOCALISED_LIVE_VALUES.include?(value) ? 'Yes' : 'No' %> | `<metadata_path>` | `<%= value %>.txt`
+<%- end %>
+
+### Localized Metadata
+
+Key | Editable While Live | Directory | Filename
+----|--------|--------|--------
+<%- (Deliver::UploadMetadata::LOCALISED_APP_VALUES + Deliver::UploadMetadata::LOCALISED_VERSION_VALUES).each do |value| -%>
+  `<%= value %>` | <%= Deliver::UploadMetadata::LOCALISED_LIVE_VALUES.include?(value) ? 'Yes' : 'No' %> | `<metadata_path>/<lang>/` | `<%= value %>.txt`
+<%- end %>
+
+### Trade Representative Contact Information Metadata
+
+Key | Editable While Live | Directory | Filename
+----|--------|--------|--------
+<%- Deliver::UploadMetadata::TRADE_REPRESENTATIVE_CONTACT_INFORMATION_VALUES.each do |key, value| -%>
+  `<%= value %>` | Yes | `<metadata_path>/<%= Deliver::UploadMetadata::TRADE_REPRESENTATIVE_CONTACT_INFORMATION_DIR %>` | `<%= value %>.txt`
+<%- end %>
+
+### Review Information Metadata
+
+Key | Editable While Live | Directory | Filename
+----|--------|--------|--------
+<%- Deliver::UploadMetadata::REVIEW_INFORMATION_VALUES.each do |key, value| -%>
+  `<%= value %>` | Yes | `<metadata_path>/<%= Deliver::UploadMetadata::REVIEW_INFORMATION_DIR %>` | `<%= value %>.txt`
+<%- end %>
+
+
+
+### Review Information Metadata
+
+<details>
+<summary>View all</summary>
+
+Key | Editable While Live | Directory | Filename
+----|--------|--------|--------
+  `first_name` | Yes | `<metadata_path>/review_information` | `first_name.txt`
+  `last_name` | Yes | `<metadata_path>/review_information` | `last_name.txt`
+  `phone_number` | Yes | `<metadata_path>/review_information` | `phone_number.txt`
+  `email_address` | Yes | `<metadata_path>/review_information` | `email_address.txt`
+  `demo_user` | Yes | `<metadata_path>/review_information` | `demo_user.txt`
+  `demo_password` | Yes | `<metadata_path>/review_information` | `demo_password.txt`
+  `notes` | Yes | `<metadata_path>/review_information` | `notes.txt`
+
+</details>
 
 ## Reference
 

--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -58,7 +58,7 @@ module Fastlane
     end
 
     def load_custom_action_md_erb(action)
-      # check if there is a custom detail view in markdown available in the fastlane code base
+      # check if there is a custom detail view as markdown ERB available in the fastlane code base
       custom_file_location = File.join(Fastlane::ROOT, custom_action_docs_path, "#{action.action_name}.md.erb")
       if File.exist?(custom_file_location)
         UI.verbose("Using custom md.erb file for action #{action.action_name}")

--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -54,6 +54,19 @@ module Fastlane
         UI.verbose("Using custom md file for action #{action.action_name}")
         return File.read(custom_file_location)
       end
+      return load_custom_action_md_erb(action)
+    end
+
+    def load_custom_action_md_erb(action)
+      # check if there is a custom detail view in markdown available in the fastlane code base
+      custom_file_location = File.join(Fastlane::ROOT, custom_action_docs_path, "#{action.action_name}.md.erb")
+      if File.exist?(custom_file_location)
+        UI.verbose("Using custom md.erb file for action #{action.action_name}")
+
+        result = ERB.new(File.read(custom_file_location), 0, '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
+
+        return result
+      end
       return nil
     end
 
@@ -71,6 +84,8 @@ module Fastlane
       all_actions_ref_yml = []
       FileUtils.mkdir_p(File.join(docs_dir, "actions"))
       ActionsList.all_actions do |action|
+        @action = action # to provide a reference in the .html.erb template
+
         # Make sure to always assign `@custom_content`, as we're in a loop and `@` is needed for the `erb`
         @custom_content = load_custom_action_md(action)
 
@@ -83,7 +98,6 @@ module Fastlane
         end
 
         template = File.join(Fastlane::ROOT, "lib/assets/ActionDetails.md.erb")
-        @action = action # to provide a reference in the .html.erb template
         result = ERB.new(File.read(template), 0, '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
 
         file_name = File.join("actions", "#{action.action_name}.md")


### PR DESCRIPTION
Fixes #11988 

- `markdown_docs_generator.rb` can now render action docs as `.md` and also `.md.erb`
- `upload_to_app_store.md.erb` has new auto-generated content
  - Available language codes
  - Non-localized Metadata
  - Localized Metadata
  - Trade Representative Contact Information Metadata
  - Review Information Metadata
- Also fixed a bonus bug with live values
  - `privacy_url` was in `NON_LOCALISED_LIVE_VALUES` and is now in `LOCALISED_LIVE_VALUES `
  - `copyright` wasn't anywhere but is now in `NON_LOCALISED_LIVE_VALUES `

## Screenshots
![screen shot 2018-03-05 at 11 10 18 am](https://user-images.githubusercontent.com/401294/36988945-db2dcd5a-2065-11e8-9746-a326ae776063.png)
![screen shot 2018-03-05 at 11 10 27 am](https://user-images.githubusercontent.com/401294/36988946-db4d2588-2065-11e8-8ef2-9c34644e19d9.png)
