### PR TITLE
Fix incorrect backup_xcarchive example

### DIFF
--- a/fastlane/lib/fastlane/actions/backup_xcarchive.rb
+++ b/fastlane/lib/fastlane/actions/backup_xcarchive.rb
@@ -119,7 +119,8 @@ module Fastlane
         [
           'backup_xcarchive(
             xcarchive: "/path/to/file.xcarchive", # Optional if you use the `xcodebuild` action
-            destination: "/somewhere/else/file.xcarchive", # Where the backup should be created
+            destination: "/somewhere/else/", # Where the backup should be created
+            zip_filename: "file.xcarchive", # The name of the backup file
             zip: false, # Enable compression of the archive. Defaults to `true`.
             versioned: true # Create a versioned (date and app version) subfolder where to put the archive
           )'


### PR DESCRIPTION
Fixes https://github.com/fastlane/docs/issues/556

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->
