### PR TITLE
Added alias for 'swift init' to map to 'init swift'

### DIFF
--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -125,7 +125,7 @@ module Fastlane
       end
 
       # Creating alias for mapping "swift init" to "init swift"
-      alias_command :'swift init', :'init', 'swift'
+      alias_command(:'swift init', :init, 'swift')
 
       command :new_action do |c|
         c.syntax = 'fastlane new_action'

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -119,15 +119,13 @@ module Fastlane
         # CrashlyticsBetaCommandLineHandler.apply_options(c)
 
         c.action do |args, options|
-          # if args[0] == 'beta'
-          #   beta_info = CrashlyticsBetaCommandLineHandler.info_from_options(options)
-          #   Fastlane::CrashlyticsBeta.new(beta_info, Fastlane::CrashlyticsBetaUi.new).run
-          # else
           is_swift_fastfile = args.include?("swift")
           Fastlane::Setup.start(user: options.user, is_swift_fastfile: is_swift_fastfile)
-          # end
         end
       end
+
+      # Creating alias for mapping "swift init" to "init swift"
+      alias_command :'swift init', :'init', 'swift'
 
       command :new_action do |c|
         c.syntax = 'fastlane new_action'


### PR DESCRIPTION
Fixes #11973 

- Aliases `fastlane swift init` to `fastlane init swift`
- I also removed some commented out code 🙃 