### PR TITLE
Improve build watcher message

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -53,7 +53,7 @@ module FastlaneCore
         # As this method is very often used to wait for a build, and then do something
         # with it, we have to be sure that the build actually is ready
         if build.nil?
-          UI.message("Build doesn't show up in the build list anymore, waiting for it to appear again")
+          UI.message("Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)")
         elsif build.active?
           UI.success("Build #{build.train_version} - #{build.build_version} is already being tested")
         elsif build.ready_to_submit? || build.export_compliance_missing? || build.review_rejected?

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -155,7 +155,7 @@ describe FastlaneCore::BuildWatcher do
       expect(Spaceship::TestFlight::Build).to receive(:builds_for_train).and_return([], [ready_build])
       expect(FastlaneCore::BuildWatcher).to receive(:sleep)
 
-      expect(UI).to receive(:message).with("Build doesn't show up in the build list anymore, waiting for it to appear again")
+      expect(UI).to receive(:message).with("Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)")
       expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.train_version} - #{ready_build.build_version}")
       found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1')
 


### PR DESCRIPTION
Fixes #11999

Sometimes builds don't show in iTC because of an error in the IPA (like missing swift something or missing permissions or invalid architecture) so it may help users who don't know about that or forgot about that when its trying to find the build for forever 💪 