### PR TITLE
Added update block to update_url_schemes action

### DIFF
--- a/fastlane/lib/fastlane/actions/update_url_schemes.rb
+++ b/fastlane/lib/fastlane/actions/update_url_schemes.rb
@@ -6,10 +6,42 @@ module Fastlane
       def self.run(params)
         path = params[:path]
         url_schemes = params[:url_schemes]
+        update_url_schemes = params[:update_url_schemes]
 
         hash = Plist.parse_xml(path)
-        hash['CFBundleURLTypes'].first['CFBundleURLSchemes'] = url_schemes
+
+        # Create CFBundleURLTypes array with empty scheme if none exist
+        unless hash['CFBundleURLTypes']
+          hash['CFBundleURLTypes'] = [{
+            'CFBundleTypeRole': 'Editor',
+            'CFBundleURLSchemes': []
+          }]
+        end
+
+        # Updates schemes with update block if exists
+        # Otherwise updates with array of strings
+        if update_url_schemes
+          new_schemes = update_url_schemes.call(hash['CFBundleURLTypes'].first['CFBundleURLSchemes'])
+
+          # Verify array of strings
+          string = "The URL schemes must be an array of strings, got '#{new_schemes}'."
+          verify_schemes!(new_schemes, string)
+          
+          hash['CFBundleURLTypes'].first['CFBundleURLSchemes'] = new_schemes
+        elsif url_schemes
+          hash['CFBundleURLTypes'].first['CFBundleURLSchemes'] = url_schemes
+        else
+          UI.user_error!("No `url_schemes` or `update_url_schemes` provided")
+        end
         File.write(path, Plist::Emit.dump(hash))
+      end
+
+      def self.verify_schemes!(url_schemes, error_message)
+        UI.user_error!(error_message) unless url_schemes.kind_of?(Array)
+
+        url_schemes.each do |url_scheme|
+          UI.user_error!(error_message) unless url_scheme.kind_of?(String)
+        end
       end
 
       def self.description
@@ -34,15 +66,17 @@ module Fastlane
             env_name: "FL_UPDATE_URL_SCHEMES_SCHEMES",
             description: 'The new URL schemes',
             is_string: false,
-            optional: false,
+            optional: true,
             verify_block: proc do |url_schemes|
               string = "The URL schemes must be an array of strings, got '#{url_schemes}'."
-              UI.user_error!(string) unless url_schemes.kind_of?(Array)
-
-              url_schemes.each do |url_scheme|
-                UI.user_error!(string) unless url_scheme.kind_of?(String)
-              end
+              verify_schemes!(url_schemes, string)
             end
+          ),
+
+          FastlaneCore::ConfigItem.new(key: :update_url_schemes,
+            description: "Block that is called to update schemes with current schemes passed in as parameter",
+            optional: true,
+            is_string: false
           )
         ]
       end
@@ -72,7 +106,13 @@ module Fastlane
           'update_url_schemes(
             path: "path/to/Info.plist",
             url_schemes: ["com.myapp"]
-          )'
+          )',
+          'update_url_schemes(
+            path: "path/to/Info.plist",
+            update_url_schemes: proc do |schemes|
+              schemes + ["anotherscheme"]
+            end
+          )',
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/update_url_schemes.rb
+++ b/fastlane/lib/fastlane/actions/update_url_schemes.rb
@@ -13,20 +13,21 @@ module Fastlane
         # Create CFBundleURLTypes array with empty scheme if none exist
         unless hash['CFBundleURLTypes']
           hash['CFBundleURLTypes'] = [{
-            'CFBundleTypeRole': 'Editor',
-            'CFBundleURLSchemes': []
+            'CFBundleTypeRole' => 'Editor',
+            'CFBundleURLSchemes' => []
           }]
         end
 
         # Updates schemes with update block if exists
-        # Otherwise updates with array of strings
+        # Else updates with array of strings if exist
+        # Otherwise shows error to user
         if update_url_schemes
           new_schemes = update_url_schemes.call(hash['CFBundleURLTypes'].first['CFBundleURLSchemes'])
 
           # Verify array of strings
           string = "The URL schemes must be an array of strings, got '#{new_schemes}'."
           verify_schemes!(new_schemes, string)
-          
+
           hash['CFBundleURLTypes'].first['CFBundleURLSchemes'] = new_schemes
         elsif url_schemes
           hash['CFBundleURLTypes'].first['CFBundleURLSchemes'] = url_schemes
@@ -76,8 +77,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :update_url_schemes,
             description: "Block that is called to update schemes with current schemes passed in as parameter",
             optional: true,
-            is_string: false
-          )
+            is_string: false)
         ]
       end
 
@@ -112,7 +112,7 @@ module Fastlane
             update_url_schemes: proc do |schemes|
               schemes + ["anotherscheme"]
             end
-          )',
+          )'
         ]
       end
 


### PR DESCRIPTION
Fixes #12012

 `update_url_schemes` only allowed users to override existing schemes (without seeing what was being overridden. Now there is a `update_url_schemes` block that can be passed in (instead of `url_schemes`) which passes in the existing schemes

### Option 1: With block (new way)
```rb
update_url_schemes(
  update_url_schemes: proc do |schemes|
    puts "existing schemes: #{schemes}"
    schemes + ["yooooo"]
  end
)
```

### Option 2: With string array (old way)
```rb
update_url_schemes(
  url_schemes: ["heyyyy", "hoooo", "heeeeee"],
)
```