### PR TITLE
Ignore "be" test method for MethodCallWithArgsParentheses cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -307,6 +307,7 @@ Style/MethodCallWithArgsParentheses:
     - 'to'
     - 'describe'
     - 'it'
+    - 'be'
     - 'context'
     - 'before'
     - 'after'


### PR DESCRIPTION
The actual reason for this is that the same config file is used for new plugins, and I needed for `be` to be (pun intended) ignored.

If it doesn't make sense, or there are many more test methods that I don't know of and we don't want to add them all, feel free to close this.