### PR TITLE
Update devices in SnapfileTemplate

### DIFF
--- a/snapshot/lib/assets/SnapfileTemplate
+++ b/snapshot/lib/assets/SnapfileTemplate
@@ -2,9 +2,10 @@
 
 # A list of devices you want to take the screenshots from
 # devices([
-#   "iPhone 6",
-#   "iPhone 6 Plus",
-#   "iPhone 5",
+#   "iPhone 8",
+#   "iPhone 8 Plus",
+#   "iPhone SE",
+#   "iPhone X",
 #   "iPad Pro (12.9-inch)",
 #   "iPad Pro (9.7-inch)",
 #   "Apple TV 1080p"


### PR DESCRIPTION
🔑
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass.

I noticed one test fails, but it seems unrelated to this change:
```
  1) Gym Project with multiple Schemes and Gymfile #schemes returns all available schemes
     Failure/Error: expect(@project.schemes).to eq(["Example", "ExampleTests"])
     
       expected: ["Example", "ExampleTests"]
            got: ["ExampleTests", "Example"]
     
       (compared using ==)
     # ./gym/spec/gymfile_spec.rb:12:in `block (3 levels) in <top (required)>'
```

- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The devices list in Snapshot's Snapfile template is outdated at the moment. More specifically, the iPhone 5 does not even support iOS 11. So any apps that require iOS 11 will cause an error while running Snapshot if the iPhone 5 is listed. 

### Description
I've replaced the iPhone 5 with the iPhone SE. I've also added iPhone X to the list, since I'm guessing lots of apps forget to generate screenshots for it at the moment. Also changed the iPhone 6 generation to iPhone 8.
