### PR TITLE
snapshot - get actual sim device types instead of inferring by name

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 require:
-#  - rubocop/require_tools
+  - rubocop/require_tools
   - ./rubocop/fork_usage.rb
 
 Style/MultipleComparison:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 require:
   - rubocop/require_tools
   - ./rubocop/fork_usage.rb
+  Exclude:
+    - '**/simctl/xcode/path.rb'
 
 Style/MultipleComparison:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,6 @@
 require:
-  - rubocop/require_tools
+#  - rubocop/require_tools
   - ./rubocop/fork_usage.rb
-  Exclude:
-    - '**/simctl/xcode/path.rb'
 
 Style/MultipleComparison:
   Enabled: false

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -89,6 +89,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('bundler', '>= 1.12.0', '< 2.0.0') # Used for fastlane plugins
   spec.add_dependency('faraday', '~> 0.9') # Used for deploygate, hockey and testfairy actions
   spec.add_dependency('faraday_middleware', '~> 0.9') # same as faraday
+  spec.add_dependency('simctl', '~> 1.6') # Used for querying and interacting with iOS simulators
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.
   # If you upgrade this gem, make sure to upgrade the users of it as well.

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -89,10 +89,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('bundler', '>= 1.12.0', '< 2.0.0') # Used for fastlane plugins
   spec.add_dependency('faraday', '~> 0.9') # Used for deploygate, hockey and testfairy actions
   spec.add_dependency('faraday_middleware', '~> 0.9') # same as faraday
-
-  # rubocop:disable Require/MissingRequireStatement
   spec.add_dependency('simctl', '~> 1.6') # Used for querying and interacting with iOS simulators
-  # rubocop:enable Require/MissingRequireStatement
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.
   # If you upgrade this gem, make sure to upgrade the users of it as well.

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -89,7 +89,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency('bundler', '>= 1.12.0', '< 2.0.0') # Used for fastlane plugins
   spec.add_dependency('faraday', '~> 0.9') # Used for deploygate, hockey and testfairy actions
   spec.add_dependency('faraday_middleware', '~> 0.9') # same as faraday
+
+  # rubocop:disable Require/MissingRequireStatement
   spec.add_dependency('simctl', '~> 1.6') # Used for querying and interacting with iOS simulators
+  # rubocop:enable Require/MissingRequireStatement
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.
   # If you upgrade this gem, make sure to upgrade the users of it as well.

--- a/gym/spec/gymfile_spec.rb
+++ b/gym/spec/gymfile_spec.rb
@@ -9,7 +9,7 @@ describe Gym do
     before(:each) { Gym.config = @config }
 
     it "#schemes returns all available schemes" do
-      expect(@project.schemes).to eq(["Example", "ExampleTests"])
+      expect(@project.schemes).to contain_exactly("Example", "ExampleTests")
     end
 
     it "executing `gym` will not ask for the scheme" do

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -81,7 +81,7 @@ module Snapshot
       private
 
       # Creates an alias for require to prevent `rubocop/require_tools`
-      # from failing. This eventually change it when `simctl` doesn't 
+      # from failing. This eventually change it when `simctl` doesn't
       # execute shell commands at the top-level anymore
       alias silence_the_horrible_require_checker require
 

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -29,7 +29,6 @@ module Snapshot
       end
 
       def destination(devices)
-        puts("devices: #{devices.inspect}")
         unless verify_devices_share_os(devices)
           UI.user_error!('All devices provided to snapshot should run the same operating system')
         end
@@ -79,13 +78,22 @@ module Snapshot
         return devices.count == 1
       end
 
+      private
+
+      # Creates an alias for require to prevent `rubocop/require_tools`
+      # from failing. This eventually change it when `simctl` doesn't 
+      # execute shell commands at the top-level anymore
+      alias silence_the_horrible_require_checker require
+
       def get_device_type_with_simctl(device_names)
         return device_names if Helper.test?
 
+        silence_the_horrible_require_checker("simctl")
+
         # Gets actual simctl device type from device name
-        require 'simctl'
         return device_names.map do |device_name|
-          device = SimCtl.device(name: device_name)
+          # Disable checking due to alias-ed require above
+          device = SimCtl.device(name: device_name) # rubocop:disable Require/MissingRequireStatement
           if device
             device.devicetype.name
           end

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -29,7 +29,7 @@ module Snapshot
       end
 
       def destination(devices)
-        puts "devices: #{devices.inspect}"
+        puts("devices: #{devices.inspect}")
         unless verify_devices_share_os(devices)
           UI.user_error!('All devices provided to snapshot should run the same operating system')
         end

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -83,6 +83,8 @@ module Snapshot
       # Creates an alias for require to prevent `rubocop/require_tools`
       # from failing. This eventually change it when `simctl` doesn't
       # execute shell commands at the top-level anymore
+      #
+      # Issue: https://github.com/fastlane/fastlane/issues/12071
       alias silence_the_horrible_require_checker require
 
       def get_device_type_with_simctl(device_names)

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -79,6 +79,7 @@ module Snapshot
         return devices.count == 1
       end
 
+      # rubocop:disable Require/MissingRequireStatement
       def get_device_type_with_simctl(device_names)
         return device_names if Helper.test?
 
@@ -91,6 +92,7 @@ module Snapshot
           end
         end.compact
       end
+      # rubocop:enable Require/MissingRequireStatement
     end
   end
 end

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -29,6 +29,7 @@ module Snapshot
       end
 
       def destination(devices)
+        puts "devices: #{devices.inspect}"
         unless verify_devices_share_os(devices)
           UI.user_error!('All devices provided to snapshot should run the same operating system')
         end
@@ -52,7 +53,10 @@ module Snapshot
         return [destinations.join(' ')]
       end
 
-      def verify_devices_share_os(devices)
+      def verify_devices_share_os(device_names)
+        # Get device types based off of device name
+        devices = get_device_type_with_simctl(device_names)
+
         # Check each device to see if it is an iOS device
         all_ios = devices.map do |device|
           device = device.downcase
@@ -73,6 +77,19 @@ module Snapshot
         # device in the array, and they are not all iOS or tvOS
         # as checked above, that would imply that this is a mixed bag
         return devices.count == 1
+      end
+
+      def get_device_type_with_simctl(device_names)
+        return device_names if Helper.test?
+
+        # Gets actual simctl device type from device name
+        require 'simctl'
+        return device_names.map do |device_name|
+          device = SimCtl.device(name: device_name)
+          if device
+            device.devicetype.name
+          end
+        end.compact
       end
     end
   end

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -79,7 +79,6 @@ module Snapshot
         return devices.count == 1
       end
 
-      # rubocop:disable Require/MissingRequireStatement
       def get_device_type_with_simctl(device_names)
         return device_names if Helper.test?
 
@@ -92,7 +91,6 @@ module Snapshot
           end
         end.compact
       end
-      # rubocop:enable Require/MissingRequireStatement
     end
   end
 end


### PR DESCRIPTION
Fixes #11563

### ❌  Issue
Simulator names for `snapshot` required the device type to be in the name ("iphone", "ipad, "apple tv") which wasn't always the case for all users and made the error rather confusing

### ✅  Solution 
- Added in the `simctl` gem (which looks to be actively maintained) which can query a device type for for a device name (and udid if we need it later on).
- Added a new method which maps the "device name" array to a "device type" array using `simctl` which is actually what was trying to be checked

### ⚠️ Possible Issues With This  
- Another gem that needs to be added as dependency
- Hard to write nice tests for since it actually queries installed simulators

#### Why this gem?
- Querying a device type from a simulator isn't built into the `xcrun simctl` tool
- Steps that the `simctl` gem does:
  - Queries sims with `xcrun simctl` for match name to get udid
  - Queries available sim device types with  `xcrun simctl` 
  - Finds plist in/at installed sim and parses to get device type
  - Matches/maps all these things together
- We could do this logic ourselves but its not "trivial" and its already been done