### PR TITLE
Coerce plugin output key to a string

### DIFF
--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -146,7 +146,7 @@ module Fastlane
       puts(Terminal::Table.new(
              title: "#{name} Output Variables".green,
              headings: ['Key', 'Description'],
-             rows: FastlaneCore::PrintTable.transform_output(output.map { |key, desc| [key.yellow, desc] })
+             rows: FastlaneCore::PrintTable.transform_output(output.map { |key, desc| [key.to_s.yellow, desc] })
       ))
       puts("Access the output values using `lane_context[SharedValues::VARIABLE_NAME]`")
       puts("")


### PR DESCRIPTION
This line will fail when a plugin specifies its output as an array map of symbols to descriptions. What I usually see are plugins mapping string-to-strings, but since those are constants elsewhere, why not use them there too?

In other words, let the developer say

```ruby
module SharedValues
  SOME_VAR = :SOME_VAR
end

def self.output
  [
    [SharedValues::SOME_VAR, 'Some output variasble']
  ]
end
```

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I had a plugin, and it wouldn't work when I did a `bundle exec fastlane action my_action`, because of this:

```
https://github.com/fastlane/fastlane/issues/new
Run `fastlane env` to append the fastlane environment to your issue
bundler: failed to load command: fastlane (/Users/phil_busby/vendor/bundle/ruby/2.3.0/bin/fastlane)
NoMethodError: [!] undefined method `yellow' for :FOO:Symbol
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/fastlane-2.85.0/fastlane/lib/fastlane/documentation/actions_list.rb:149:in `block in print_output_variables'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/fastlane-2.85.0/fastlane/lib/fastlane/documentation/actions_list.rb:149:in `map'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/fastlane-2.85.0/fastlane/lib/fastlane/documentation/actions_list.rb:149:in `print_output_variables'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/fastlane-2.85.0/fastlane/lib/fastlane/documentation/actions_list.rb:61:in `show_details'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/fastlane-2.85.0/fastlane/lib/fastlane/documentation/actions_list.rb:6:in `run'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/fastlane-2.85.0/fastlane/lib/fastlane/commands_generator.rb:234:in `block (2 levels) in run'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/commander-fastlane-4.4.6/lib/commander/command.rb:178:in `call'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/commander-fastlane-4.4.6/lib/commander/command.rb:153:in `run'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/commander-fastlane-4.4.6/lib/commander/runner.rb:476:in `run_active_command'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/fastlane-2.85.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:75:in `run!'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/commander-fastlane-4.4.6/lib/commander/delegates.rb:15:in `run!'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/fastlane-2.85.0/fastlane/lib/fastlane/commands_generator.rb:333:in `run'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/fastlane-2.85.0/fastlane/lib/fastlane/commands_generator.rb:42:in `start'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/fastlane-2.85.0/fastlane/lib/fastlane/cli_tools_distributor.rb:98:in `take_off'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/gems/fastlane-2.85.0/bin/fastlane:20:in `<top (required)>'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/bin/fastlane:23:in `load'
  /Users/phil_busby/vendor/bundle/ruby/2.3.0/bin/fastlane:23:in `<top (required)>'
```

### Description
<!-- Describe your changes in detail -->
