### PR TITLE
Updated upload_to_play_store.md

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
@@ -115,6 +115,7 @@ And you can supply screenshots by creating directories with the following names,
 - `wearScreenshots/`
 
 Note that these will replace the current images and screenshots on the play store listing, not add to them.
+Note: The above screenshots directories should be inside the `images` directory.
 
 ## Changelogs (What's new)
 

--- a/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
@@ -106,7 +106,7 @@ Inside of a given locale directory is a folder called `images`. Here you can sup
 - `promoGraphic`
 - `tvBanner`
 
-And you can supply screenshots by creating directories with the following names, containing PNGs or JPEGs (image names are irrelevant):
+You can also supply screenshots by creating directories within the `images` directory with the following names, containing PNGs or JPEGs (image names are irrelevant):
 
 - `phoneScreenshots/`
 - `sevenInchScreenshots/` (7-inch tablets)
@@ -115,7 +115,6 @@ And you can supply screenshots by creating directories with the following names,
 - `wearScreenshots/`
 
 Note that these will replace the current images and screenshots on the play store listing, not add to them.
-Note: The above screenshots directories should be inside the `images` directory.
 
 ## Changelogs (What's new)
 


### PR DESCRIPTION
Added more clear verbiage to screenshots documentation in regards to screenshots directories.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
Makes directories needed for supply screenshots more clear.

### Description
<!-- Describe your changes in detail -->
It helps users understand the supply screenshots documentation more clearly.  Although minor change, it will help users upload screenshots correctly; unlike me, who has to do another Android deployment to see the updated screenshots because of incorrect directories the first time.
