### PR TITLE
Apply FASTLANE_DISABLE_COLORS globally (with bonus earlier dotenv loading)

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -56,6 +56,15 @@ module Fastlane
 
         FastlaneCore::UpdateChecker.start_looking_for_update('fastlane')
 
+        # Loading any .env files before any lanes are called since
+        # variables like FASTLANE_HIDE_CHANGELOG and FASTLANE_DISABLE_COLORS
+        # need to be set early on in execution
+        require 'fastlane/helper/dotenv_helper'
+        Fastlane::Helper::DotenvHelper.load_dot_env(nil)
+
+        # Disabling colors if environment variable set
+        require 'fastlane_core/ui/disable_colors' if FastlaneCore::Helper.colors_disabled?
+
         ARGV.unshift("spaceship") if ARGV.first == "spaceauth"
         tool_name = ARGV.first ? ARGV.first.downcase : nil
 

--- a/fastlane/lib/fastlane/helper/dotenv_helper.rb
+++ b/fastlane/lib/fastlane/helper/dotenv_helper.rb
@@ -1,0 +1,50 @@
+module Fastlane
+  module Helper
+    class DotenvHelper
+      # @param env_cl_param [String] an optional list of dotenv environment names separated by commas, without space
+      def self.load_dot_env(env_cl_param)
+        base_path = find_dotenv_directory
+
+        return unless base_path
+
+        load_dot_envs_from(env_cl_param, base_path)
+      end
+
+      # finds the first directory of [fastlane, its parent] containing dotenv files
+      def self.find_dotenv_directory
+        path = FastlaneCore::FastlaneFolder.path
+        search_paths = [path]
+        search_paths << path + "/.." unless path.nil?
+        search_paths.compact!
+        search_paths.find do |dir|
+          Dir.glob(File.join(dir, '*.env*'), File::FNM_DOTMATCH).count > 0
+        end
+      end
+
+      # loads the dotenvs. First the .env and .env.default and
+      # then override with all speficied extra environments
+      def self.load_dot_envs_from(env_cl_param, base_path)
+        require 'dotenv'
+
+        # Making sure the default '.env' and '.env.default' get loaded
+        env_file = File.join(base_path, '.env')
+        env_default_file = File.join(base_path, '.env.default')
+        Dotenv.load(env_file, env_default_file)
+
+        return unless env_cl_param
+
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ENVIRONMENT] = env_cl_param
+
+        # multiple envs?
+        envs = env_cl_param.split(",")
+
+        # Loads .env file for the environment(s) passed in through options
+        envs.each do |env|
+          env_file = File.join(base_path, ".env.#{env}")
+          UI.success("Loading from '#{env_file}'")
+          Dotenv.overload(env_file)
+        end
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -49,7 +49,7 @@ module Fastlane
       # Setting this environment variable causes xcodeproj to work around the problem
       ENV["FORK_XCODE_WRITING"] = "true" unless platform == 'android'
 
-      load_dot_env(env)
+      Fastlane::Helper::DotenvHelper.load_dot_env(env)
 
       started = Time.now
       e = nil

--- a/fastlane/lib/fastlane/lane_manager_base.rb
+++ b/fastlane/lib/fastlane/lane_manager_base.rb
@@ -55,51 +55,6 @@ module Fastlane
       puts("")
     end
 
-    # @param env_cl_param [String] an optional list of dotenv environment names separated by commas, without space
-    def self.load_dot_env(env_cl_param)
-      base_path = find_dotenv_directory
-
-      return unless base_path
-
-      load_dot_envs_from(env_cl_param, base_path)
-    end
-
-    # finds the first directory of [fastlane, its parent] containing dotenv files
-    def self.find_dotenv_directory
-      path = FastlaneCore::FastlaneFolder.path
-      search_paths = [path]
-      search_paths << path + "/.." unless path.nil?
-      search_paths.compact!
-      search_paths.find do |dir|
-        Dir.glob(File.join(dir, '*.env*'), File::FNM_DOTMATCH).count > 0
-      end
-    end
-
-    # loads the dotenvs. First the .env and .env.default and
-    # then override with all speficied extra environments
-    def self.load_dot_envs_from(env_cl_param, base_path)
-      require 'dotenv'
-
-      # Making sure the default '.env' and '.env.default' get loaded
-      env_file = File.join(base_path, '.env')
-      env_default_file = File.join(base_path, '.env.default')
-      Dotenv.load(env_file, env_default_file)
-
-      return unless env_cl_param
-
-      Actions.lane_context[Actions::SharedValues::ENVIRONMENT] = env_cl_param
-
-      # multiple envs?
-      envs = env_cl_param.split(",")
-
-      # Loads .env file for the environment(s) passed in through options
-      envs.each do |env|
-        env_file = File.join(base_path, ".env.#{env}")
-        UI.success("Loading from '#{env_file}'")
-        Dotenv.overload(env_file)
-      end
-    end
-
     def self.print_lane_context
       return if Actions.lane_context.empty?
 

--- a/fastlane/lib/fastlane/swift_lane_manager.rb
+++ b/fastlane/lib/fastlane/swift_lane_manager.rb
@@ -18,7 +18,7 @@ module Fastlane
       # https://github.com/fastlane/fastlane/issues/11913
       # FastlaneCore.session.is_fastfile = true
 
-      load_dot_env(env)
+      Fastlane::Helper::DotenvHelper.load_dot_env(env)
 
       started = Time.now
       e = nil

--- a/fastlane/spec/lane_manager_spec.rb
+++ b/fastlane/spec/lane_manager_spec.rb
@@ -59,7 +59,7 @@ describe Fastlane do
               ENV.delete(k.to_s)
             end
             Dir.chdir(dir) do
-              ff = Fastlane::LaneManager.load_dot_env(envs)
+              ff = Fastlane::Helper::DotenvHelper.load_dot_env(envs)
               expected_values.each do |k, v|
                 expect(ENV[k.to_s]).to eq(v)
               end

--- a/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
+++ b/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
@@ -26,8 +26,6 @@ module FastlaneCore
         "#{format_string(datetime, severity)}#{msg}\n"
       end
 
-      require 'fastlane_core/ui/disable_colors' if FastlaneCore::Helper.colors_disabled?
-
       @log
     end
 


### PR DESCRIPTION
Fixes #10498

## The Tale of the Unset Environment Variable
Written by: @joshdholtz

**fastlane community:** What is happening here?
**josh:** You see, `FASTLANE_DISABLE_COLORS` is supposed to disable all colors in the output but was only disabling the colors when `log` was being called for the first time.
**fastlane community:** Interesting
**josh:** Indeed! Now disable colors will get triggered as soon as the fastlane process starts so everything will be colorless.
**fastlane community:** But what does this have to do with `dotenv`? Why do you always have to bring `dotenv` into everything you do, Josh?
**josh:** That's a funny question, fastlane community. You see, I was working on an issue before this for `FASTLANE_HIDE_CHANGELOG` by running `fastlane lanes`. I was setting this environment variable in my `.env` file but it wasn't being loaded for some reason. I thought I was just being a dingus this morning.
**fastlane community:** ...
**josh:** Well, it turns out that `FASTLANE_HIDE_CHANGELOG` wasn't ever being loaded because 'fastlane lanes` never ran a lane which means my `.env. never got loaded. This was confusing to me as I was expecting my `.env` file to be applied.
**fastlane community:** ...
**josh:** Exactly! fastlane should load environment variables everywhere exactly like it does with lanes. And now it does!
**fastlane community:** 💃 🕺 🎊 
