### PR TITLE
Add filename option for cert

### DIFF
--- a/cert/lib/cert/options.rb
+++ b/cert/lib/cert/options.rb
@@ -48,6 +48,12 @@ module Cert
                                      verify_block: proc do |value|
                                        ENV["FASTLANE_TEAM_NAME"] = value.to_s
                                      end),
+        FastlaneCore::ConfigItem.new(key: :filename,
+                                     short_option: "-q",
+                                     env_name: "CERT_FILE_NAME",
+                                     optional: true,
+                                     description: "The filename of certificate to store",
+                                     is_string: true),
         FastlaneCore::ConfigItem.new(key: :output_path,
                                      short_option: "-o",
                                      env_name: "CERT_OUTPUT_PATH",

--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -89,7 +89,7 @@ module Cert
           next
         end
 
-        path = store_certificate(certificate)
+        path = store_certificate(certificate, Cert.config[:filename])
         private_key_path = File.expand_path(File.join(Cert.config[:output_path], "#{certificate.id}.p12"))
 
         if FastlaneCore::CertChecker.installed?(path)
@@ -170,7 +170,7 @@ module Cert
       private_key_path = File.expand_path(File.join(Cert.config[:output_path], "#{certificate.id}.p12"))
       File.write(private_key_path, pkey)
 
-      cert_path = store_certificate(certificate)
+      cert_path = store_certificate(certificate, Cert.config[:filename])
 
       # Import all the things into the Keychain
       keychain = File.expand_path(Cert.config[:keychain_path])
@@ -187,8 +187,10 @@ module Cert
       return cert_path
     end
 
-    def store_certificate(certificate)
-      path = File.expand_path(File.join(Cert.config[:output_path], "#{certificate.id}.cer"))
+    def store_certificate(certificate, filename = nil)
+      cert_name = filename ? filename : certificate.id
+      cert_name = "#{cert_name}.cer" unless File.extname(cert_name) == ".cer"
+      path = File.expand_path(File.join(Cert.config[:output_path], cert_name))
       raw_data = certificate.download_raw
       File.write(path, raw_data)
       return path

--- a/cert/spec/commands_generator_spec.rb
+++ b/cert/spec/commands_generator_spec.rb
@@ -60,4 +60,17 @@ describe Cert::CommandsGenerator do
       expect(Cert.config[:output_path]).to eq('output/path')
     end
   end
+
+  describe ":filename option handling" do
+    it "can use the filename flag from tool options" do
+      stub_commander_runner_args(['-q', 'cert_name'])
+
+      # launch takes no params, but we want to expect the call and prevent
+      # actual execution of the method
+      expect(runner).to receive(:launch)
+
+      Cert::CommandsGenerator.start
+      expect(Cert.config[:filename]).to eq('cert_name')
+    end
+  end
 end

--- a/cert/spec/runner_spec.rb
+++ b/cert/spec/runner_spec.rb
@@ -1,3 +1,5 @@
+require 'tmpdir'
+
 describe Cert do
   describe Cert::Runner do
     before do
@@ -72,6 +74,59 @@ describe Cert do
 
       Cert.config = FastlaneCore::Configuration.create(Cert::Options.available_options, keychain_path: ".")
       Cert::Runner.new.revoke_expired_certs!
+    end
+
+    describe ":filename option handling" do
+      filename = ""
+      let(:temp) { Dir.tmpdir }
+      let(:certificate) { stub_certificate }
+      let(:filepath) do
+        filename_ext = File.extname(filename) == ".cer" ? filename : "#{filename}.cer"
+        File.extname(filename) == ".cer" ? "#{temp}/#{filename}" : "#{temp}/#{filename}.cer"
+      end
+
+      before do
+        allow(Spaceship).to receive(:login).and_return(nil)
+        allow(Spaceship).to receive(:client).and_return("client")
+        allow(Spaceship).to receive(:select_team).and_return(nil)
+        allow(Spaceship.client).to receive(:in_house?).and_return(false)
+        allow(Spaceship.certificate.production).to receive(:all).and_return([certificate])
+        allow(FastlaneCore::CertChecker).to receive(:installed?).and_return(true)
+      end
+
+      let(:generate) do
+        options = { output_path: temp, filename: filename }
+        Cert.config = FastlaneCore::Configuration.create(Cert::Options.available_options, options)
+        Cert::Runner.new.launch
+      end
+
+      context 'with filename flag' do
+        it "can forget the file extension" do
+          filename = "cert_name"
+          expect(File.exist?(filepath)).to be false
+          generate
+          expect(File.exist?(filepath)).to be true
+          File.delete(filepath)
+        end
+
+        it "can use the file extension" do
+          filename = "cert_name.cer"
+          expect(File.exist?(filepath)).to be false
+          generate
+          expect(File.exist?(filepath)).to be true
+          File.delete(filepath)
+        end
+      end
+
+      context 'without filename flag' do
+        it "can generate certificate" do
+          filename = "cert_name.cer"
+          expect(File.exist?(filepath)).to be false
+          generate
+          expect(File.exist?(filepath)).to be true
+          File.delete(filepath)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] ~I've updated the documentation if necessary~ (not necessary?)

### Motivation and Context

As described in issue https://github.com/fastlane/fastlane/issues/8499, there is no option for adding a custom filename to generated certificate.

Based on `filename` option in `sigh`, I have added the same option in `cert`.

I test on my own : 
- [x] running `cert` with an env var named `CERT_FILE_NAME``
- [x] running `cert` in Fastfile **with** `filename` option
- [x] running `cert` in Fastfile **without** `filename` option
- [x] running `cert` in Fastfile with an incorrect `filename` option (without `.cer`)

### Description

Just add an option `filename` for cert command in the same way `sigh` action does.
