### PR TITLE
Proposal to remove and/or from conditionals with Mr. Rubocop 🚨

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -179,7 +179,8 @@ Style/IfUnlessModifier:
 
 # and and or is okay
 Style/AndOr:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: conditionals
 
 # Configuration parameters: CountComments.
 Metrics/ClassLength:

--- a/credentials_manager/lib/credentials_manager/appfile_config.rb
+++ b/credentials_manager/lib/credentials_manager/appfile_config.rb
@@ -29,7 +29,7 @@ module CredentialsManager
 
       path ||= self.class.default_path
 
-      if path and File.exist?(path) # it might not exist, we still want to use the default values
+      if path && File.exist?(path) # it might not exist, we still want to use the default values
         full_path = File.expand_path(path)
         Dir.chdir(File.expand_path('..', path)) do
           content = File.read(full_path, encoding: "utf-8")

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -232,7 +232,7 @@ module Deliver
     def self.calculate_screen_size(path)
       size = FastImage.size(path)
 
-      UI.user_error!("Could not find or parse file at path '#{path}'") if size.nil? or size.count == 0
+      UI.user_error!("Could not find or parse file at path '#{path}'") if size.nil? || size.count == 0
 
       # Walk up two directories and test if we need to handle a platform that doesn't support landscape
       path_component = Pathname.new(path).each_filename.to_a[-3]
@@ -246,12 +246,12 @@ module Deliver
       devices.each do |device_type, array|
         array.each do |resolution|
           if skip_landscape
-            if size[0] == resolution[0] and size[1] == resolution[1] # portrait
+            if size[0] == (resolution[0]) && size[1] == (resolution[1]) # portrait
               return device_type
             end
           else
-            if (size[0] == resolution[0] and size[1] == resolution[1]) or # portrait
-               (size[1] == resolution[0] and size[0] == resolution[1]) # landscape
+            if (size[0] == (resolution[0]) && size[1] == (resolution[1])) || # portrait
+               (size[1] == (resolution[0]) && size[0] == (resolution[1])) # landscape
               return device_type
             end
           end

--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -102,7 +102,7 @@ module Deliver
         FastlaneCore::CommanderGenerator.new.generate(deliverfile_options, command: c)
 
         c.action do |args, options|
-          if File.exist?("Deliverfile") or File.exist?("fastlane/Deliverfile")
+          if File.exist?("Deliverfile") || File.exist?("fastlane/Deliverfile")
             UI.important("You already have a running deliver setup in this directory")
             return 0
           end

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -33,7 +33,7 @@ module Deliver
       app = options[:app]
       v = app.edit_version
 
-      if options[:build_number] and options[:build_number] != "latest"
+      if options[:build_number] && options[:build_number] != "latest"
         UI.message("Selecting existing build-number: #{options[:build_number]}")
         build = v.candidate_builds.detect { |a| a.build_version == options[:build_number] }
         unless build

--- a/fastlane/lib/fastlane/actions/badge.rb
+++ b/fastlane/lib/fastlane/actions/badge.rb
@@ -74,7 +74,7 @@ module Fastlane
                                        description: "Add your custom overlay/badge image",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         UI.user_error!("custom should be a valid file path") unless value and File.exist?(value)
+                                         UI.user_error!("custom should be a valid file path") unless value && File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :no_badge,
                                        env_name: "FL_BADGE_NO_BADGE",

--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -64,7 +64,7 @@ module Fastlane
       def self.available_options
         platform = Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
 
-        if platform == :ios or platform.nil?
+        if platform == :ios || platform.nil?
           ipa_path_default = Dir["*.ipa"].sort_by { |x| File.mtime(x) }.last
         end
 

--- a/fastlane/lib/fastlane/actions/get_build_number.rb
+++ b/fastlane/lib/fastlane/actions/get_build_number.rb
@@ -61,7 +61,7 @@ module Fastlane
                              optional: true,
                              verify_block: proc do |value|
                                UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with?(".xcworkspace")
-                               UI.user_error!("Could not find Xcode project") if !File.exist?(value) and !Helper.test?
+                               UI.user_error!("Could not find Xcode project") if !File.exist?(value) && !Helper.test?
                              end),
           FastlaneCore::ConfigItem.new(key: :hide_error_when_versioning_disabled,
                              env_name: "FL_BUILD_NUMBER_HIDE_ERROR_WHEN_VERSIONING_DISABLED",

--- a/fastlane/lib/fastlane/actions/get_push_certificate.rb
+++ b/fastlane/lib/fastlane/actions/get_push_certificate.rb
@@ -16,7 +16,7 @@ module Fastlane
           profile_path = PEM::Manager.start
         end
 
-        if success_block and profile_path
+        if success_block && profile_path
           success_block.call(File.expand_path(profile_path)) if success_block
         end
       end

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -113,7 +113,7 @@ module Fastlane
                              optional: true,
                              verify_block: proc do |value|
                                UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with?(".xcworkspace")
-                               UI.user_error!("Could not find Xcode project at path '#{File.expand_path(value)}'") if !File.exist?(value) and !Helper.test?
+                               UI.user_error!("Could not find Xcode project at path '#{File.expand_path(value)}'") if !File.exist?(value) && !Helper.test?
                              end),
           FastlaneCore::ConfigItem.new(key: :scheme,
                              env_name: "FL_VERSION_NUMBER_SCHEME",

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -39,7 +39,7 @@ module Fastlane
       def self.upload_build(api_token, ipa, options)
         connection = self.connection(options)
 
-        options[:ipa] = Faraday::UploadIO.new(ipa, 'application/octet-stream') if ipa and File.exist?(ipa)
+        options[:ipa] = Faraday::UploadIO.new(ipa, 'application/octet-stream') if ipa && File.exist?(ipa)
 
         dsym_filename = options.delete(:dsym_filename)
         if dsym_filename
@@ -74,11 +74,11 @@ module Fastlane
         options.delete(:apk)
         app_id = options.delete(:public_identifier)
 
-        ipaio = Faraday::UploadIO.new(ipa, 'application/octet-stream') if ipa and File.exist?(ipa)
+        ipaio = Faraday::UploadIO.new(ipa, 'application/octet-stream') if ipa && File.exist?(ipa)
         dsym = options.delete(:dsym)
 
         if dsym
-          dsym_io = Faraday::UploadIO.new(dsym, 'application/octet-stream') if dsym and File.exist?(dsym)
+          dsym_io = Faraday::UploadIO.new(dsym, 'application/octet-stream') if dsym && File.exist?(dsym)
         end
 
         # https://support.hockeyapp.net/discussions/problems/83559
@@ -206,7 +206,7 @@ module Fastlane
                                        sensitive: true,
                                        description: "API Token for Hockey Access",
                                        verify_block: proc do |value|
-                                         UI.user_error!("No API token for Hockey given, pass using `api_token: 'token'`") unless value and !value.empty?
+                                         UI.user_error!("No API token for Hockey given, pass using `api_token: 'token'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :ipa,
                                        env_name: "FL_HOCKEY_IPA",

--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -74,7 +74,7 @@ module Fastlane
                                        optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with?(".xcworkspace")
-                                         UI.user_error!("Could not find Xcode project") if !File.exist?(value) and !Helper.test?
+                                         UI.user_error!("Could not find Xcode project") if !File.exist?(value) && !Helper.test?
                                        end)
         ]
       end

--- a/fastlane/lib/fastlane/actions/installr.rb
+++ b/fastlane/lib/fastlane/actions/installr.rb
@@ -70,7 +70,7 @@ module Fastlane
                                      sensitive: true,
                                      description: "API Token for Installr Access",
                                      verify_block: proc do |value|
-                                       UI.user_error!("No API token for Installr given, pass using `api_token: 'token'`") unless value and !value.empty?
+                                       UI.user_error!("No API token for Installr given, pass using `api_token: 'token'`") unless value && !value.empty?
                                      end),
           FastlaneCore::ConfigItem.new(key: :ipa,
                                      env_name: "INSTALLR_IPA_PATH",

--- a/fastlane/lib/fastlane/actions/oclint.rb
+++ b/fastlane/lib/fastlane/actions/oclint.rb
@@ -8,7 +8,7 @@ module Fastlane
       # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         oclint_path = params[:oclint_path]
-        if `which #{oclint_path}`.to_s.empty? and !Helper.test?
+        if `which #{oclint_path}`.to_s.empty? && !Helper.test?
           UI.user_error!("You have to install oclint or provide path to oclint binary. Fore more details: ") + "http://docs.oclint.org/en/stable/intro/installation.html".yellow
         end
 

--- a/fastlane/lib/fastlane/actions/set_changelog.rb
+++ b/fastlane/lib/fastlane/actions/set_changelog.rb
@@ -16,7 +16,7 @@ module Fastlane
         unless version_number
           # Automatically fetch the latest version
           UI.message("Fetching the latest version for this app")
-          if app.edit_version and app.edit_version.version
+          if app.edit_version && app.edit_version.version
             version_number = app.edit_version.version
           else
             UI.message("You have to specify a new version number: ")

--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -126,7 +126,7 @@ Slather is available at https://github.com/SlatherOrg/slather
                                        env_name: "FL_SLATHER_PROJ", # The name of the environment variable
                                        description: "The project file that slather looks at", # a short description of this parameter
                                        verify_block: proc do |value|
-                                         UI.user_error!("No project file specified, pass using `proj: 'Project.xcodeproj'`") unless value and !value.empty?
+                                         UI.user_error!("No project file specified, pass using `proj: 'Project.xcodeproj'`") unless value && !value.empty?
                                        end,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :workspace,

--- a/fastlane/lib/fastlane/actions/sonar.rb
+++ b/fastlane/lib/fastlane/actions/sonar.rb
@@ -56,7 +56,7 @@ module Fastlane
                                         description: "The path to your sonar project configuration file; defaults to `sonar-project.properties`", # default is enforced by sonar-scanner binary
                                         optional: true,
                                         verify_block: proc do |value|
-                                          UI.user_error!("Couldn't find file at path '#{value}'") unless value.nil? or File.exist?(value)
+                                          UI.user_error!("Couldn't find file at path '#{value}'") unless value.nil? || File.exist?(value)
                                         end),
           FastlaneCore::ConfigItem.new(key: :project_key,
                                        env_name: "FL_SONAR_RUNNER_PROJECT_KEY",

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -7,7 +7,7 @@ module Fastlane
         end
 
         version = swiftlint_version(executable: params[:executable])
-        if params[:mode] == :autocorrect and version < Gem::Version.new('0.5.0') and !Helper.test?
+        if params[:mode] == :autocorrect && version < Gem::Version.new('0.5.0') && !Helper.test?
           UI.user_error!("Your version of swiftlint (#{version}) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
         end
 

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -18,7 +18,7 @@ module Fastlane
           builder.adapter(:net_http)
         end
 
-        options[:file] = Faraday::UploadIO.new(ipa, 'application/octet-stream') if ipa and File.exist?(ipa)
+        options[:file] = Faraday::UploadIO.new(ipa, 'application/octet-stream') if ipa && File.exist?(ipa)
 
         symbols_file = options.delete(:symbols_file)
         if symbols_file

--- a/fastlane/lib/fastlane/actions/tryouts.rb
+++ b/fastlane/lib/fastlane/actions/tryouts.rb
@@ -71,14 +71,14 @@ module Fastlane
                                      env_name: "TRYOUTS_APP_ID",
                                      description: "Tryouts application hash",
                                      verify_block: proc do |value|
-                                       UI.user_error!("No application identifier for Tryouts given, pass using `app_id: 'application id'`") unless value and !value.empty?
+                                       UI.user_error!("No application identifier for Tryouts given, pass using `app_id: 'application id'`") unless value && !value.empty?
                                      end),
           FastlaneCore::ConfigItem.new(key: :api_token,
                                      env_name: "TRYOUTS_API_TOKEN",
                                      sensitive: true,
                                      description: "API Token for Tryouts Access",
                                      verify_block: proc do |value|
-                                       UI.user_error!("No API token for Tryouts given, pass using `api_token: 'token'`") unless value and !value.empty?
+                                       UI.user_error!("No API token for Tryouts given, pass using `api_token: 'token'`") unless value && !value.empty?
                                      end),
           FastlaneCore::ConfigItem.new(key: :build_file,
                                      env_name: "TRYOUTS_BUILD_FILE",

--- a/fastlane/lib/fastlane/actions/typetalk.rb
+++ b/fastlane/lib/fastlane/actions/typetalk.rb
@@ -18,7 +18,7 @@ module Fastlane
         message = "#{emoticon} #{options[:message]}"
 
         note_path = File.expand_path(options[:note_path]) if options[:note_path]
-        if note_path and File.exist?(note_path)
+        if note_path && File.exist?(note_path)
           contents = File.read(note_path)
           message += "\n\n```\n#{contents}\n```"
         end

--- a/fastlane/lib/fastlane/actions/update_app_group_identifiers.rb
+++ b/fastlane/lib/fastlane/actions/update_app_group_identifiers.rb
@@ -48,7 +48,7 @@ module Fastlane
                                        description: "The path to the entitlement file which contains the app group identifiers", # a short description of this parameter
                                        verify_block: proc do |value|
                                          UI.user_error!("Please pass a path to an entitlements file. ") unless value.include?(".entitlements")
-                                         UI.user_error!("Could not find entitlements file") if !File.exist?(value) and !Helper.test?
+                                         UI.user_error!("Could not find entitlements file") if !File.exist?(value) && !Helper.test?
                                        end),
           FastlaneCore::ConfigItem.new(key: :app_group_identifiers,
                                        env_name: "FL_UPDATE_APP_GROUP_IDENTIFIER_APP_GROUP_IDENTIFIERS",

--- a/fastlane/lib/fastlane/actions/update_icloud_container_identifiers.rb
+++ b/fastlane/lib/fastlane/actions/update_icloud_container_identifiers.rb
@@ -56,7 +56,7 @@ module Fastlane
                                        description: "The path to the entitlement file which contains the iCloud container identifiers",
                                        verify_block: proc do |value|
                                          UI.user_error!("Please pass a path to an entitlements file. ") unless value.include?(".entitlements")
-                                         UI.user_error!("Could not find entitlements file") if !File.exist?(value) and !Helper.test?
+                                         UI.user_error!("Could not find entitlements file") if !File.exist?(value) && !Helper.test?
                                        end),
           FastlaneCore::ConfigItem.new(key: :icloud_container_identifiers,
                                        env_name: "FL_UPDATE_ICLOUD_CONTAINER_IDENTIFIERS_IDENTIFIERS",

--- a/fastlane/lib/fastlane/actions/update_info_plist.rb
+++ b/fastlane/lib/fastlane/actions/update_info_plist.rb
@@ -8,8 +8,8 @@ module Fastlane
         require 'xcodeproj'
 
         # Check if parameters are set
-        if params[:app_identifier] or params[:display_name] or params[:block]
-          if (params[:app_identifier] or params[:display_name]) and params[:block]
+        if params[:app_identifier] || params[:display_name] || params[:block]
+          if (params[:app_identifier] || params[:display_name]) && params[:block]
             UI.important("block parameter can not be specified with app_identifier or display_name")
             return false
           end

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
@@ -100,13 +100,13 @@ module Fastlane
                                        env_name: "SENTRY_ORG_SLUG",
                                        description: "Organization slug for Sentry project",
                                        verify_block: proc do |value|
-                                         UI.user_error!("No organization slug for SentryAction given, pass using `org_slug: 'org'`") unless value and !value.empty?
+                                         UI.user_error!("No organization slug for SentryAction given, pass using `org_slug: 'org'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :project_slug,
                                        env_name: "SENTRY_PROJECT_SLUG",
                                        description: "Project slug for Sentry",
                                        verify_block: proc do |value|
-                                         UI.user_error!("No project slug for SentryAction given, pass using `project_slug: 'project'`") unless value and !value.empty?
+                                         UI.user_error!("No project slug for SentryAction given, pass using `project_slug: 'project'`") unless value && !value.empty?
                                        end),
           FastlaneCore::ConfigItem.new(key: :dsym_path,
                                        env_name: "SENTRY_DSYM_PATH",

--- a/fastlane/lib/fastlane/actions/verify_xcode.rb
+++ b/fastlane/lib/fastlane/actions/verify_xcode.rb
@@ -70,7 +70,7 @@ module Fastlane
 
         output = verify(command: command, must_includes: must_includes, params: params)
 
-        if output.include?("source=Mac App Store") or output.include?("source=Apple") or output.include?("source=Apple System")
+        if output.include?("source=Mac App Store") || output.include?("source=Apple") || output.include?("source=Apple System")
           UI.success("Successfully verified Xcode installation at path '#{params[:xcode_path]}' 🎧")
         else
           show_and_raise_error("Invalid Download Source of Xcode: #{output}", params[:xcode_path])

--- a/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
+++ b/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
@@ -186,7 +186,7 @@ module Fastlane
             'X-XCSAPIVersion' => 1 # XCS API version with this API, Xcode needs this otherwise it explodes in a 500 error fire. Currently Xcode 7 Beta 5 is on Version 5.
           }
 
-          if @username and @password
+          if @username && @password
             userpass = "#{@username}:#{@password}"
             headers['Authorization'] = "Basic #{Base64.strict_encode64(userpass)}"
           end

--- a/fastlane/lib/fastlane/configuration_helper.rb
+++ b/fastlane/lib/fastlane/configuration_helper.rb
@@ -3,7 +3,7 @@ module Fastlane
     def self.parse(action, params)
       first_element = (action.available_options || []).first
 
-      if first_element and first_element.kind_of?(FastlaneCore::ConfigItem)
+      if first_element && first_element.kind_of?(FastlaneCore::ConfigItem)
         # default use case
         return FastlaneCore::Configuration.create(action.available_options, params)
       elsif first_element

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -7,9 +7,9 @@ module Fastlane
     # @param parameters [Hash] The parameters passed from the command line to the lane
     # @param env Dot Env Information
     def self.cruise_lane(platform, lane, parameters = nil, env = nil)
-      UI.user_error!("lane must be a string") unless lane.kind_of?(String) or lane.nil?
-      UI.user_error!("platform must be a string") unless platform.kind_of?(String) or platform.nil?
-      UI.user_error!("parameters must be a hash") unless parameters.kind_of?(Hash) or parameters.nil?
+      UI.user_error!("lane must be a string") unless lane.kind_of?(String) || lane.nil?
+      UI.user_error!("platform must be a string") unless platform.kind_of?(String) || platform.nil?
+      UI.user_error!("parameters must be a hash") unless parameters.kind_of?(Hash) || parameters.nil?
 
       ff = Fastlane::FastFile.new(FastlaneCore::FastlaneFolder.fastfile_path)
 
@@ -29,7 +29,7 @@ module Fastlane
         end
       end
 
-      if !platform and lane
+      if !platform && lane
         # Either, the user runs a specific lane in root or want to auto complete the available lanes for a platform
         # e.g. `fastlane ios` should list all available iOS actions
         if ff.is_platform_block?(lane)

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -238,7 +238,7 @@ module Fastlane
             # Since we usually just need the passed hash, we'll just use the first object if there is only one
             if arguments.count == 0
               arguments = ConfigurationHelper.parse(class_ref, {}) # no parameters => empty hash
-            elsif arguments.count == 1 and arguments.first.kind_of?(Hash)
+            elsif arguments.count == 1 && arguments.first.kind_of?(Hash)
               arguments = ConfigurationHelper.parse(class_ref, arguments.first) # Correct configuration passed
             elsif !class_ref.available_options
               # This action does not use the new action format
@@ -309,7 +309,7 @@ module Fastlane
     def add_lane(lane, override = false)
       lanes[lane.platform] ||= {}
 
-      if !override and lanes[lane.platform][lane.name]
+      if !override && lanes[lane.platform][lane.name]
         UI.user_error!("Lane '#{lane.name}' was defined multiple times!")
       end
 

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -34,7 +34,7 @@ module Fastlane
     # Start the setup process
     # rubocop:disable Metrics/BlockNesting
     def self.start(user: nil, is_swift_fastfile: false)
-      if FastlaneCore::FastlaneFolder.setup? and !Helper.test?
+      if FastlaneCore::FastlaneFolder.setup? && !Helper.test?
         require 'fastlane/lane_list'
         Fastlane::LaneList.output(FastlaneCore::FastlaneFolder.fastfile_path)
         UI.important("------------------")

--- a/fastlane/lib/fastlane/swift_lane_manager.rb
+++ b/fastlane/lib/fastlane/swift_lane_manager.rb
@@ -7,8 +7,8 @@ module Fastlane
     # @param parameters [Hash] The parameters passed from the command line to the lane
     # @param env Dot Env Information
     def self.cruise_lane(lane, parameters = nil, env = nil, disable_runner_upgrades: false)
-      UI.user_error!("lane must be a string") unless lane.kind_of?(String) or lane.nil?
-      UI.user_error!("parameters must be a hash") unless parameters.kind_of?(Hash) or parameters.nil?
+      UI.user_error!("lane must be a string") unless lane.kind_of?(String) || lane.nil?
+      UI.user_error!("parameters must be a hash") unless parameters.kind_of?(Hash) || parameters.nil?
 
       # xcodeproj has a bug in certain versions that causes it to change directories
       # and not return to the original working directory

--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -43,7 +43,7 @@ module FastlaneCore
         command = command.join(" ") if command.kind_of?(Array)
         UI.command(command) if print_command
 
-        if print_all and loading # this is only used to show the "Loading text"...
+        if print_all && loading # this is only used to show the "Loading text"...
           UI.command_output(loading)
         end
 

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -216,9 +216,9 @@ module FastlaneCore
       option = verify_options_key!(key)
 
       # Same order as https://docs.fastlane.tools/advanced/#priorities-of-parameters-and-options
-      value = if @values.key?(key) and !@values[key].nil?
+      value = if @values.key?(key) && !@values[key].nil?
                 @values[key]
-              elsif option.env_name and !ENV[option.env_name].nil?
+              elsif option.env_name && !ENV[option.env_name].nil?
                 ENV[option.env_name].dup
               elsif self.config_file_options.key?(key)
                 self.config_file_options[key]
@@ -227,11 +227,11 @@ module FastlaneCore
               end
 
       value = option.auto_convert_value(value)
-      value = nil if value.nil? and !option.string? # by default boolean flags are false
-      return value unless value.nil? and !option.optional and ask
+      value = nil if value.nil? && !option.string? # by default boolean flags are false
+      return value unless value.nil? && !option.optional && ask
 
       # fallback to asking
-      if Helper.test? or !UI.interactive?
+      if Helper.test? || !UI.interactive?
         # Since we don't want to be asked on tests, we'll just call the verify block with no value
         # to raise the exception that is shown when the user passes an invalid value
         set(key, '')

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -342,7 +342,7 @@ module FastlaneCore
     def self.gem_path(gem_name)
       UI.deprecated('`Helper.gem_path` is deprecated. Use the `ROOT` constant from the appropriate tool module instead.')
 
-      if !Helper.test? and Gem::Specification.find_all_by_name(gem_name).any?
+      if !Helper.test? && Gem::Specification.find_all_by_name(gem_name).any?
         return Gem::Specification.find_by_name(gem_name).gem_dir
       else
         return './'

--- a/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
@@ -51,7 +51,7 @@ module FastlaneCore
           end
           result = CFPropertyList.native_types(CFPropertyList::List.new(file: tmp_path).value)
 
-          if result['CFBundleIdentifier'] or result['CFBundleVersion']
+          if result['CFBundleIdentifier'] || result['CFBundleVersion']
             return result
           end
         end

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -118,7 +118,7 @@ module FastlaneCore
         UI.error("[Transporter Error Output]: #{$1}")
 
         # Check if it's a login error
-        if $1.include?("Your Apple ID or password was entered incorrectly") or
+        if $1.include?("Your Apple ID or password was entered incorrectly") ||
            $1.include?("This Apple ID has been locked for security reasons")
 
           unless Helper.test?
@@ -148,7 +148,7 @@ module FastlaneCore
         end
       end
 
-      if !hide_output and line =~ OUTPUT_REGEX
+      if !hide_output && line =~ OUTPUT_REGEX
         # General logging for debug purposes
         unless output_done
           UI.verbose("[Transporter]: #{$1}")

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -7,7 +7,7 @@ module FastlaneCore
     class << self
       # Project discovery
       def detect_projects(config)
-        if config[:workspace].to_s.length > 0 and config[:project].to_s.length > 0
+        if config[:workspace].to_s.length > 0 && config[:project].to_s.length > 0
           UI.user_error!("You can only pass either a workspace or a project path, not both")
         end
 
@@ -25,7 +25,7 @@ module FastlaneCore
 
         return if config[:workspace].to_s.length > 0
 
-        if config[:workspace].to_s.length == 0 and config[:project].to_s.length == 0
+        if config[:workspace].to_s.length == 0 && config[:project].to_s.length == 0
           project = Dir["./*.xcodeproj"]
           if project.count > 1
             puts("Select Project: ")
@@ -35,7 +35,7 @@ module FastlaneCore
           end
         end
 
-        if config[:workspace].nil? and config[:project].nil?
+        if config[:workspace].nil? && config[:project].nil?
           select_project(config)
         end
       end
@@ -83,7 +83,7 @@ module FastlaneCore
       self.xcodebuild_list_silent = xcodebuild_list_silent
       self.xcodebuild_suppress_stderr = xcodebuild_suppress_stderr
 
-      if !path or !File.directory?(path)
+      if !path || !File.directory?(path)
         UI.user_error!("Could not find project at path '#{path}'")
       end
     end
@@ -144,7 +144,7 @@ module FastlaneCore
           preferred = schemes.find_all { |a| a.downcase.include?(preferred_to_include.downcase) }
         end
 
-        if preferred_to_include and preferred.count == 1
+        if preferred_to_include && preferred.count == 1
           options[:scheme] = preferred.last
         elsif automated_scheme_selection? && schemes.include?(project_name)
           UI.important("Using scheme matching project name (#{project_name}).")

--- a/fastlane_core/lib/fastlane_core/tool_collector.rb
+++ b/fastlane_core/lib/fastlane_core/tool_collector.rb
@@ -59,7 +59,7 @@ module FastlaneCore
     def did_finish
       return false if FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
 
-      if !did_show_message? and !Helper.ci?
+      if !did_show_message? && !Helper.ci?
         show_message
       end
 

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -86,7 +86,7 @@ module Frameit
 
       @offset_information = fetch_config['offset'] || Offsets.image_offset(screenshot).dup
 
-      if @offset_information and (@offset_information['offset'] or @offset_information['offset'])
+      if @offset_information && (@offset_information['offset'] || @offset_information['offset'])
         return @offset_information
       end
       UI.user_error!("Could not find offset_information for '#{screenshot}'")
@@ -450,7 +450,7 @@ module Frameit
       # No string files, fallback to Framefile config
       text = fetch_config[type.to_s]['text'] if fetch_config[type.to_s] && fetch_config[type.to_s]['text'] && fetch_config[type.to_s]['text'].length > 0 # Ignore empty string
 
-      if type == :title and !text
+      if type == :title && !text
         # title is mandatory
         UI.user_error!("Could not get title for screenshot #{screenshot.path}. Please provide one in your Framefile.json or title.strings")
       end

--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -59,7 +59,7 @@ module Match
 
       checkout_branch(branch) unless branch == "master"
 
-      if !Helper.test? and GitHelper.match_version(@dir).nil? and manual_password.nil? and File.exist?(File.join(@dir, "README.md"))
+      if !Helper.test? && GitHelper.match_version(@dir).nil? && manual_password.nil? && File.exist?(File.join(@dir, "README.md"))
         UI.important("Migrating to new match...")
         ChangePassword.update(params: { git_url: git_url,
                                     git_branch: branch,

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -125,7 +125,7 @@ module Match
                                      description: nil,
                                      verify_block: proc do |value|
                                        unless Helper.test?
-                                         if value.start_with?("/var/folders") or value.include?("tmp/") or value.include?("temp/")
+                                         if value.start_with?("/var/folders") || value.include?("tmp/") || value.include?("temp/")
                                            # that's fine
                                          else
                                            UI.user_error!("Specify the `git_url` instead of the `path`")

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -67,7 +67,7 @@ module Match
       end
 
       # Done
-      if self.files_to_commmit.count > 0 and !params[:readonly]
+      if self.files_to_commmit.count > 0 && !params[:readonly]
         message = GitHelper.generate_commit_message(params)
         GitHelper.commit_changes(params[:workspace], message, params[:git_url], params[:git_branch], self.files_to_commmit)
       end
@@ -94,7 +94,7 @@ module Match
       certs = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.cer")]
       keys = Dir[File.join(params[:workspace], "certs", cert_type.to_s, "*.p12")]
 
-      if certs.count == 0 or keys.count == 0
+      if certs.count == 0 || keys.count == 0
         UI.important("Couldn't find a valid code signing identity in the git repo for #{cert_type}... creating one for you now")
         UI.crash!("No code signing identity found and can not create a new one because you enabled `readonly`") if params[:readonly]
         cert_path = Generator.generate_certificate(params, cert_type)
@@ -151,7 +151,7 @@ module Match
         end
       end
 
-      if profile.nil? or params[:force]
+      if profile.nil? || params[:force]
         if params[:readonly]
           all_profiles = Dir.entries(base_dir).reject { |f| f.start_with?(".") }
           UI.error("No matching provisioning profiles found for '#{profile_name}'")

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -15,7 +15,7 @@ module Pilot
 
       UI.user_error!("No ipa file given") unless config[:ipa]
 
-      if options[:changelog].nil? and options[:distribute_external] == true
+      if options[:changelog].nil? && options[:distribute_external] == true
         if UI.interactive?
           options[:changelog] = UI.input("No changelog provided for new build. Please provide a changelog. You can also provide a changelog using the `changelog` option")
         else
@@ -62,7 +62,7 @@ module Pilot
 
     def distribute(options, build: nil)
       start(options)
-      if config[:apple_id].to_s.length == 0 and config[:app_identifier].to_s.length == 0
+      if config[:apple_id].to_s.length == 0 && config[:app_identifier].to_s.length == 0
         config[:app_identifier] = UI.input("App Identifier: ")
       end
 
@@ -102,7 +102,7 @@ module Pilot
 
     def list(options)
       start(options)
-      if config[:apple_id].to_s.length == 0 and config[:app_identifier].to_s.length == 0
+      if config[:apple_id].to_s.length == 0 && config[:app_identifier].to_s.length == 0
         config[:app_identifier] = UI.input("App Identifier: ")
       end
 

--- a/scan/lib/scan/slack_poster.rb
+++ b/scan/lib/scan/slack_poster.rb
@@ -41,7 +41,7 @@ module Scan
         }
       end
 
-      if results[:tests] and results[:failures]
+      if results[:tests] && results[:failures]
         attachments << {
           text: "Successful Tests: #{results[:tests] - results[:failures]}",
           color: "good",

--- a/scan/lib/scan/test_result_parser.rb
+++ b/scan/lib/scan/test_result_parser.rb
@@ -6,7 +6,7 @@ module Scan
       # e.g. ...<testsuites tests='2' failures='1'>...
       matched = output.scan(/<testsuites\b(?=[^<>]*\s+tests='(\d+)')(?=[^<>]*\s+failures='(\d+)')[^<>]+>/)
 
-      if matched and matched.length == 1 and matched[0].length == 2
+      if matched && matched.length == 1 && matched[0].length == 2
         tests = matched[0][0].to_i
         failures = matched[0][1].to_i
 

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -222,7 +222,7 @@ module Sigh
         end
       end
 
-      if certificates.count > 1 and !Sigh.config[:development]
+      if certificates.count > 1 && !Sigh.config[:development]
         UI.important("Found more than one code signing identity. Choosing the first one. Check out `fastlane sigh --help` to see all available options.")
         UI.important("Available Code Signing Identities for current filters:")
         certificates.each do |c|

--- a/snapshot/lib/snapshot/runner.rb
+++ b/snapshot/lib/snapshot/runner.rb
@@ -16,7 +16,7 @@ require_relative 'simulator_launchers/launcher_configuration'
 module Snapshot
   class Runner
     def work
-      if File.exist?("./fastlane/snapshot.js") or File.exist?("./snapshot.js")
+      if File.exist?("./fastlane/snapshot.js") || File.exist?("./snapshot.js")
         UI.error("Found old snapshot configuration file 'snapshot.js'")
         UI.error("You updated to snapshot 1.0 which now uses UI Automation")
         UI.error("Please follow the migration guide: https://github.com/fastlane/fastlane/blob/master/snapshot/MigrationGuide.md")

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -340,7 +340,7 @@ module Spaceship
     #
     # @return (Spaceship::Client) The client the login method was called for
     def login(user = nil, password = nil)
-      if user.to_s.empty? or password.to_s.empty?
+      if user.to_s.empty? || password.to_s.empty?
         require 'credentials_manager/account_manager'
 
         keychain_entry = CredentialsManager::AccountManager.new(user: user, password: password)
@@ -348,7 +348,7 @@ module Spaceship
         password = keychain_entry.password
       end
 
-      if user.to_s.strip.empty? or password.to_s.strip.empty?
+      if user.to_s.strip.empty? || password.to_s.strip.empty?
         raise NoUserCredentialsError.new, "No login data provided"
       end
 
@@ -657,9 +657,9 @@ module Spaceship
 
     # Is called from `parse_response` to store the latest csrf_token (if available)
     def store_csrf_tokens(response)
-      if response and response.headers
+      if response && response.headers
         tokens = response.headers.select { |k, v| %w(csrf csrf_ts).include?(k) }
-        if tokens and !tokens.empty?
+        if tokens && !tokens.empty?
           @csrf_tokens = tokens
         end
       end

--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -89,7 +89,7 @@ module Spaceship
         req.headers['Connection'] = "keep-alive"
       end
 
-      if r.status == 500 and r.body.include?("Server Error")
+      if r.status == 500 && r.body.include?("Server Error")
         return upload_file(app_version: app_version, upload_file: upload_file, path: path, content_provider_id: content_provider_id, sso_token: sso_token, du_validation_rule_set: du_validation_rule_set, app_id: app_id)
       end
 

--- a/spaceship/lib/spaceship/launcher.rb
+++ b/spaceship/lib/spaceship/launcher.rb
@@ -23,7 +23,7 @@ module Spaceship
     def initialize(user = nil, password = nil)
       @client = PortalClient.new
 
-      if user or password
+      if user || password
         @client.login(user, password)
       end
     end

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -262,7 +262,7 @@ module Spaceship
           app = Spaceship::Portal::App.find(bundle_id, mac: mac)
           raise "Could not find app with bundle id '#{bundle_id}'" unless app
 
-          raise "Invalid sub_platform #{sub_platform}, valid values are tvOS" if !sub_platform.nil? and sub_platform != 'tvOS'
+          raise "Invalid sub_platform #{sub_platform}, valid values are tvOS" if !sub_platform.nil? && sub_platform != 'tvOS'
 
           # Fill in sensible default values
           name ||= [bundle_id, self.pretty_type].join(' ')
@@ -278,8 +278,8 @@ module Spaceship
           # Fix https://github.com/KrauseFx/fastlane/issues/349
           certificate_parameter = certificate_parameter.first if certificate_parameter.count == 1
 
-          if devices.nil? or devices.count == 0
-            if self == Development or self == AdHoc
+          if devices.nil? || devices.count == 0
+            if self == Development || self == AdHoc
               # For Development and AdHoc we usually want all compatible devices by default
               if mac
                 devices = Spaceship::Portal::Device.all_macs
@@ -364,7 +364,7 @@ module Spaceship
         #   This may also contain invalid or expired profiles
         def find_by_bundle_id(bundle_id: nil, mac: false, sub_platform: nil)
           raise "Missing required parameter 'bundle_id'" if bundle_id.to_s.empty?
-          raise "Invalid sub_platform #{sub_platform}, valid values are tvOS" if !sub_platform.nil? and sub_platform != 'tvOS'
+          raise "Invalid sub_platform #{sub_platform}, valid values are tvOS" if !sub_platform.nil? && sub_platform != 'tvOS'
           find_tvos_profiles = sub_platform == 'tvOS'
           all(mac: mac).find_all do |profile|
             profile.app.bundle_id == bundle_id && profile.tvos? == find_tvos_profiles

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -182,7 +182,7 @@ module Spaceship
           hash.each do |key, value|
             errors += handle_response_hash.call(value, current_language)
 
-            next unless key == 'errorKeys' and value.kind_of?(Array) and value.count > 0
+            next unless key == 'errorKeys' && value.kind_of?(Array) && value.count > 0
             # Prepend the error with the language so it's easier to understand for the user
             errors += value.collect do |current_error_message|
               current_language ? "[#{current_language}]: #{current_error_message}" : current_error_message
@@ -215,11 +215,11 @@ module Spaceship
 
       if errors.count > 0 # they are separated by `.` by default
         # Sample `error` content: [["Forbidden"]]
-        if errors.count == 1 and errors.first == "You haven't made any changes."
+        if errors.count == 1 && errors.first == "You haven't made any changes."
           # This is a special error which we really don't care about
-        elsif errors.count == 1 and errors.first.include?("try again later")
+        elsif errors.count == 1 && errors.first.include?("try again later")
           raise ITunesConnectTemporaryError.new, errors.first
-        elsif errors.count == 1 and errors.first.include?("Forbidden")
+        elsif errors.count == 1 && errors.first.include?("Forbidden")
           raise_insuffient_permission_error!
         elsif flaky_api_call
           raise ITunesConnectPotentialServerError.new, errors.join(' ')


### PR DESCRIPTION
## Why
Ruby style guide explains how `&&`, `||`, `and`, and `or` should be used - https://github.com/bbatsov/ruby-style-guide#no-and-or-or

>The and and or keywords are banned. The minimal added readability is just not worth the high probability of introducing subtle bugs. For boolean expressions, always use && and || instead. For flow control, use if and unless; && and || are also acceptable but less clear. 

## What
`rubocop` changed about 160ish instances of `and` and `or` used for boolean expressions. This change **does** touch many places of the codebase but **shouldn't** have any side effects (unless there were side effects from `and` and `or` that we were somehow depending on)

