### PR TITLE
Fix plugin scores updating crash

### DIFF
--- a/fastlane/helper/plugin_scores_helper.rb
+++ b/fastlane/helper/plugin_scores_helper.rb
@@ -220,7 +220,7 @@ module Fastlane
                 FastlaneActionFileParser.new.parse_file(action_file)
               end
               # Result of the above is an array of arrays, this merges all of them into data[:actions]
-              self.data[:actions].concat(*actions)
+              self.data[:actions] = actions.flatten
 
               cache_data = self.cache[self.name]
 


### PR DESCRIPTION
I don't know exactly how to reproduce it, but sometimes it crashed with
"wrong number of arguments (given X, expected 1)". Using flatten seems
to fix it and looks safer and cleaner.