### PR TITLE
[WIP] Fixes latest_testflight_build_number to get correct build number

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -40,7 +40,7 @@ module Fastlane
           UI.message("Fetching the latest build number for version #{version_number}")
 
           # Fetches build history to get list of latest build trains
-          data = Spaceship::Tunes.client.all_build_history(app_id: app.apple_id, platform: platform)
+          data = Spaceship::Tunes.client.all_build_trains(app_id: app.apple_id, platform: platform)
           trains = data["trains"]
 
           # Parse data to get build number

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -840,7 +840,7 @@ module Spaceship
     end
 
     # All build trains, even if there is no TestFlight
-    def all_build_trains(app_id: nil, platform: 'ios')
+    def all_build_history(app_id: nil, platform: 'ios')
       platform = 'ios' if platform.nil?
       r = request(:get, "ra/apps/#{app_id}/buildHistory?platform=#{platform}")
       handle_itc_response(r.body)

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -840,7 +840,7 @@ module Spaceship
     end
 
     # All build trains, even if there is no TestFlight
-    def all_build_history(app_id: nil, platform: 'ios')
+    def all_build_trains(app_id: nil, platform: 'ios')
       platform = 'ios' if platform.nil?
       r = request(:get, "ra/apps/#{app_id}/buildHistory?platform=#{platform}")
       handle_itc_response(r.body)


### PR DESCRIPTION
…dHistory API

Fixes #10462

⚠️ Still working on trying to find an API to show the latest build number of a build that failed processing

## Tasks
- [ ] Fix when build processing failed
- [x] Fix when build manually expired

## What happened???
| Description | Image |
|---|---|
| `app.all_builds_for_train` | ![screen shot 2018-03-13 at 8 09 17 pm](https://user-images.githubusercontent.com/401294/37377884-94df45cc-26fa-11e8-8c82-436da9963458.png) |
| `Spaceship::Tunes.client.all_build_trains` | ![screen shot 2018-03-13 at 8 09 25 pm](https://user-images.githubusercontent.com/401294/37377890-9fbdadbc-26fa-11e8-9834-3e8238399bde.png) |

## What's the fix?
- `app.all_builds_for_train` only shows active builds 
  - Like if a build was manually expired
- `Spaceship::Tunes.client.all_build_trains` get all build that show up in "activity" tab on iTC