### PR TITLE
[spaceship] Raise a meaningful error if the device name is too long

### DIFF
--- a/spaceship/lib/spaceship/portal/device.rb
+++ b/spaceship/lib/spaceship/portal/device.rb
@@ -148,7 +148,7 @@ module Spaceship
             raise "You cannot create a device without a device_id (UDID) and name"
           end
 
-          raise "Device name must be 50 characters or less. \"#{name}\" has a #{name.length}-character length." if name.length > 50
+          raise "Device name must be 50 characters or less. \"#{name}\" has a #{name.length} character length." if name.length > 50
 
           # Find the device by UDID, raise an exception if it already exists
           existing = self.find_by_udid(udid, mac: mac)

--- a/spaceship/lib/spaceship/portal/device.rb
+++ b/spaceship/lib/spaceship/portal/device.rb
@@ -9,7 +9,7 @@ module Spaceship
       #   "XJXGVS46MW"
       attr_accessor :id
 
-      # @return (String) The name of the device
+      # @return (String) The name of the device, must be 50 characters or less.
       # @example
       #   "Felix Krause's iPhone 6"
       attr_accessor :name
@@ -147,6 +147,8 @@ module Spaceship
           unless udid && name
             raise "You cannot create a device without a device_id (UDID) and name"
           end
+
+          raise "Device name must be 50 characters or less. \"#{name}\" has a #{name.length}-character length." if name.length > 50
 
           # Find the device by UDID, raise an exception if it already exists
           existing = self.find_by_udid(udid, mac: mac)

--- a/spaceship/spec/portal/device_spec.rb
+++ b/spaceship/spec/portal/device_spec.rb
@@ -113,7 +113,7 @@ describe Spaceship::Device do
     it "should fail to create a device name longer than 50 characters" do
       expect do
         Spaceship::Device.create!(name: "Demo Device (Apple Watch Series 3 - 42mm GPS Black)", udid: "7f6c8dc83d77134b5a3a1c53f1202b395b04482b")
-      end.to raise_error("Device name must be 50 characters or less. \"Demo Device (Apple Watch Series 3 - 42mm GPS Black)\" has a 51-character length.")
+      end.to raise_error("Device name must be 50 characters or less. \"Demo Device (Apple Watch Series 3 - 42mm GPS Black)\" has a 51 character length.")
     end
 
     it "doesn't trigger an ITC call if the device ID is already registered" do

--- a/spaceship/spec/portal/device_spec.rb
+++ b/spaceship/spec/portal/device_spec.rb
@@ -110,6 +110,12 @@ describe Spaceship::Device do
       end.to raise_error("You cannot create a device without a device_id (UDID) and name")
     end
 
+    it "should fail to create a device name longer than 50 characters" do
+      expect do
+        Spaceship::Device.create!(name: "Demo Device (Apple Watch Series 3 - 42mm GPS Black)", udid: "7f6c8dc83d77134b5a3a1c53f1202b395b04482b")
+      end.to raise_error("Device name must be 50 characters or less. \"Demo Device (Apple Watch Series 3 - 42mm GPS Black)\" has a 51-character length.")
+    end
+
     it "doesn't trigger an ITC call if the device ID is already registered" do
       expect(client).to_not(receive(:create_device!))
       device = Spaceship::Device.create!(name: "Personal iPhone", udid: "e5814abb3b1d92087d48b64f375d8e7694932c39")


### PR DESCRIPTION
Apple Developer Portal does not allow to register a device with name
longer than 50 characters, but `spaceship` is currently returning an
unknown error if we try to do that.
