### PR TITLE
Add output variables to match with profiles names and UUIDs

### DIFF
--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -2,6 +2,8 @@ module Fastlane
   module Actions
     module SharedValues
       MATCH_PROVISIONING_PROFILE_MAPPING = :MATCH_PROVISIONING_PROFILE_MAPPING
+      MATCH_PROFILES_UUIDS = :MATCH_PROFILES_UUIDS
+      MATCH_PROFILES_NAMES = :MATCH_PROFILES_NAMES
     end
 
     class SyncCodeSigningAction < Action
@@ -13,6 +15,7 @@ module Fastlane
 
         define_profile_type(params)
         define_provisioning_profile_mapping(params)
+        define_shared_values(params)
       end
 
       def self.define_profile_type(params)
@@ -50,6 +53,25 @@ module Fastlane
         Actions.lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING] = mapping
       end
 
+      def self.define_shared_values(params)
+        profiles_uuids = []
+        profiles_names = []
+
+        Array(params[:app_identifier]).each do |app_identifier|
+          env_variable_name = Match::Utils.environment_variable_name(app_identifier: app_identifier,
+                                                                               type: Match.profile_type_sym(params[:type]),
+                                                                           platform: params[:platform])
+          environment_variable_name_profile_name = Match::Utils.environment_variable_name_profile_name(app_identifier: app_identifier,
+                                                                                                                 type: Match.profile_type_sym(params[:type]),
+                                                                                                             platform: params[:platform])
+          profiles_uuids << ENV[env_variable_name]
+          profiles_names << ENV[environment_variable_name_profile_name]
+        end
+
+        Actions.lane_context[SharedValues::MATCH_PROFILES_UUIDS] = profiles_uuids
+        Actions.lane_context[SharedValues::MATCH_PROFILES_NAMES] = profiles_names
+      end
+
       #####################################################
       # @!group Documentation
       #####################################################
@@ -69,8 +91,8 @@ module Fastlane
 
       def self.output
         [
-          ['MATCH_PROFILES_UUID', 'Collection: The UUIDs of the profiles returned by match for each app_identifier'],
-          ['MATCH_PROFILES_NAME', 'Collection: The names of the profiles returned by match for each app_identifier']
+          ['MATCH_PROFILES_UUIDS', 'Collection: The UUIDs of the profiles returned by match for each app_identifier'],
+          ['MATCH_PROFILES_NAMES', 'Collection: The names of the profiles returned by match for each app_identifier']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -68,7 +68,10 @@ module Fastlane
       end
 
       def self.output
-        []
+        [
+          ['MATCH_PROFILES_UUID', 'Collection: The UUIDs of the profiles returned by match for each app_identifier'],
+          ['MATCH_PROFILES_NAME', 'Collection: The names of the profiles returned by match for each app_identifier']
+        ]
       end
 
       def self.return_value

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -2,7 +2,6 @@ require 'fastlane_core/cert_checker'
 require 'fastlane_core/provisioning_profile'
 require 'fastlane_core/print_table'
 require 'spaceship/client'
-require 'fastlane/actions/lane_context'
 require_relative 'generator'
 require_relative 'git_helper'
 require_relative 'module'
@@ -172,8 +171,6 @@ module Match
       installed_profile = FastlaneCore::ProvisioningProfile.install(profile, keychain_path)
       parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
       uuid = parsed["UUID"]
-      Fastlane::Actions.lane_context[:MATCH_PROFILES_UUID] = Fastlane::Actions.lane_context[:MATCH_PROFILES_UUID].to_a << uuid
-      Fastlane::Actions.lane_context[:MATCH_PROFILES_NAME] = Fastlane::Actions.lane_context[:MATCH_PROFILES_NAME].to_a << parsed["Name"]
 
       if spaceship && !spaceship.profile_exists(username: params[:username], uuid: uuid)
         # This profile is invalid, let's remove the local file and generate a new one

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -2,6 +2,7 @@ require 'fastlane_core/cert_checker'
 require 'fastlane_core/provisioning_profile'
 require 'fastlane_core/print_table'
 require 'spaceship/client'
+require 'fastlane/actions/lane_context'
 require_relative 'generator'
 require_relative 'git_helper'
 require_relative 'module'
@@ -171,6 +172,8 @@ module Match
       installed_profile = FastlaneCore::ProvisioningProfile.install(profile, keychain_path)
       parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
       uuid = parsed["UUID"]
+      Fastlane::Actions.lane_context[:MATCH_PROFILES_UUID] = Fastlane::Actions.lane_context[:MATCH_PROFILES_UUID].to_a << uuid
+      Fastlane::Actions.lane_context[:MATCH_PROFILES_NAME] = Fastlane::Actions.lane_context[:MATCH_PROFILES_NAME].to_a << parsed["Name"]
 
       if spaceship && !spaceship.profile_exists(username: params[:username], uuid: uuid)
         # This profile is invalid, let's remove the local file and generate a new one


### PR DESCRIPTION
### Motivation and Context
On some boilerplate projects the bundle id of the apps and extensions might be changed dynamically.
For this reason it is not possible to hardcode the value avec the profile specifier using this technique https://docs.fastlane.tools/codesigning/xcode-project/#xcode-7-and-lower so we use a generic evar like `$PROFILE_UUID `and setup it's value to `ENV['SIGH_NAME']`.

Since this evar is note set up when `match` uses a local profile, we currently have to force a `sigh` run (using the `force` option of `match`).

### Description
This PR simply adds output variables to `match`: collections with the UUID / name for each profile generated (since match can generate multiple profiles at once).

### Side notes
I first intented to use evar since the lane_context was not available in the `match` action but since there might be multiple values an array seemed better than a coma-separated string.

Sigh sets both
https://github.com/fastlane/fastlane/blob/055f325725ac58d006ba46f0d85c6bb74e98adbc/fastlane/lib/fastlane/actions/get_provisioning_profile.rb#L25
Is there any good practice here? 

### Test

`bundle exec fastlane test` fails on my laptop but it also does on master so I suspect I might have a local issue
