### PR TITLE
Checking for a build_id before trying to download_dsym

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -65,14 +65,18 @@ module Fastlane
               next
             end
 
-            begin
-              # need to call reload here or dsym_url is nil
-              UI.verbose("Build_version: #{build.build_version} matches #{build_number}, grabbing dsym_url")
-              build.reload
-              download_url = build.dsym_url
-              UI.verbose("dsym_url: #{download_url}")
-            rescue Spaceship::TunesClient::ITunesConnectError => ex
-              UI.error("Error accessing dSYM file for build\n\n#{build}\n\nException: #{ex}")
+            # Need to check for a build_id
+            # No build_id means dsym is not ready
+            if build.build_id
+              begin
+                # need to call reload here or dsym_url is nil
+                UI.verbose("Build_version: #{build.build_version} matches #{build_number}, grabbing dsym_url")
+                build.reload
+                download_url = build.dsym_url
+                UI.verbose("dsym_url: #{download_url}")
+              rescue Spaceship::TunesClient::ITunesConnectError => ex
+                UI.error("Error accessing dSYM file for build\n\n#{build}\n\nException: #{ex}")
+              end
             end
 
             if download_url

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -65,9 +65,9 @@ module Fastlane
               next
             end
 
-            # Need to check for a build_id
-            # No build_id means dsym is not ready
-            if build.build_id
+            # Need to check for a build.id
+            # No build.id means dsym is not ready
+            if build.id
               begin
                 # need to call reload here or dsym_url is nil
                 UI.verbose("Build_version: #{build.build_version} matches #{build_number}, grabbing dsym_url")


### PR DESCRIPTION
Fixes #11435

# Wuuuutttttt
- Now checking for a `build.id` before trying to download dsyms

## Before fix - waiting for build crash 
<img width="479" alt="screen shot 2018-03-15 at 10 18 25 pm" src="https://user-images.githubusercontent.com/401294/37502009-d7e5bbc6-289e-11e8-9c35-18be2184748f.png">

## After fix - waiting for build
<img width="784" alt="screen shot 2018-03-15 at 10 18 14 pm" src="https://user-images.githubusercontent.com/401294/37502014-dbc1a21e-289e-11e8-806e-46f2e7750ba0.png">

## After fix - build ready
<img width="814" alt="screen shot 2018-03-15 at 10 26 26 pm" src="https://user-images.githubusercontent.com/401294/37502257-f5926b00-289f-11e8-9ee7-ca5d9b4375ac.png">
