### PR TITLE
Take xcconfig option into account when generating showBuildSettings command

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -309,6 +309,7 @@ module FastlaneCore
       proj << "-scheme #{options[:scheme].shellescape}" if options[:scheme]
       proj << "-project #{options[:project].shellescape}" if options[:project]
       proj << "-configuration #{options[:configuration].shellescape}" if options[:configuration]
+      proj << "-xcconfig #{options[:xcconfig].shellescape}" if options[:xcconfig]
 
       return proj
     end

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -462,6 +462,23 @@ describe FastlaneCore do
       end
     end
 
+    describe 'xcodebuild_xcconfig option', requires_xcode: true do
+      it 'generates an xcodebuild -showBuildSettings command without xcconfig by default' do
+        project = FastlaneCore::Project.new({ project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" })
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+        expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
+      end
+
+      it 'generates an xcodebuild -showBuildSettings command that includes xcconfig if provided in options', requires_xcode: true do
+        project = FastlaneCore::Project.new({
+          project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
+          xcconfig: "/path/to/some.xcconfig"
+        })
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -xcconfig /path/to/some.xcconfig"
+        expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
+      end
+    end
+
     describe "#project_paths" do
       it "works with basic projects" do
         project = FastlaneCore::Project.new({

--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -37,7 +37,6 @@ module Gym
         options << "-sdk '#{config[:sdk]}'" if config[:sdk]
         options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]
         options << "-destination '#{config[:destination]}'" if config[:destination]
-        options << "-xcconfig '#{config[:xcconfig]}'" if config[:xcconfig]
         options << "-archivePath #{archive_path.shellescape}" unless config[:skip_archive]
         options << "-derivedDataPath '#{config[:derived_data_path]}'" if config[:derived_data_path]
         options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -40,7 +40,6 @@ module Scan
       options << "-enableCodeCoverage #{config[:code_coverage] ? 'YES' : 'NO'}" unless config[:code_coverage].nil?
       options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
       options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?
-      options << "-xcconfig '#{config[:xcconfig]}'" if config[:xcconfig]
       options << "-xctestrun '#{config[:xctestrun]}'" if config[:xctestrun]
       options << config[:xcargs] if config[:xcargs]
 

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -37,6 +37,14 @@ module Snapshot
                                      description: "Pass additional arguments to xcodebuild for the test phase. Be sure to quote the setting names and values e.g. OTHER_LDFLAGS=\"-ObjC -lstdc++\"",
                                      optional: true,
                                      type: :shell_string),
+        FastlaneCore::ConfigItem.new(key: :xcconfig,
+                                     short_option: "-y",
+                                     env_name: "SNAPSHOT_XCCONFIG",
+                                     description: "Use an extra XCCONFIG file to build your app",
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       UI.user_error!("File not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
+                                     end),
         FastlaneCore::ConfigItem.new(key: :devices,
                                      description: "A list of devices you want to take the screenshots from",
                                      short_option: "-d",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

As described in #10424 `gym` takes the xcconfig option into account when generating the main `xcodebuild` command, but it doesn't take it into account when generating the preliminary `xcodebuild -showBuildSettings` command, which causes various problems later.

I verified this fix in my own project (tested the fix against `scan` and `gym` specifically).  Also ran all the automated tests.

### Description

I started by finding that `build_xcodebuild_showbuildsettings_command` uses the shared `xcodebuild_parameters` function, and that function didn't previously take `xcconfig` into account, so I added it there.

Then I grep'd and found that a few other commands (`scan`, `gym`, and `snapshot`) were using `xcodebuild_parameters` as well.  `scan` and `gym` were previously manually handling the `xcconfig` option, so now that I added that to `xcodebuild_parameters` I could remove that per-action handling.

`snapshot` on the other hand previously didn't list `xcconfig` as a supported option, so the tests actually failed.  I see no reason why `xcconfig` shouldn't be supported for `snapshot` as it is for the other commands, so I added it as a newly supported option, and now all the tests are passing.

I also added a simple unit test to verify that the correct `showBuildSettings` command is generated when `xcconfig` is included in the options.