### PR TITLE
download_dysm will now find more trains and versions by switching to …

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -51,14 +51,13 @@ module Fastlane
         message << "(#{build_number})" if build_number
         UI.message(message.join(" "))
 
-        # Loop through all app versions and download their dSYM
-        app.all_build_train_numbers(platform: platform).each do |train_number|
-          UI.verbose("Found train: #{train_number}, comparing to supplied version: #{version}")
-          if version && version != train_number
+        app.tunes_all_build_trains(platform: platform).each do |train|
+          UI.verbose("Found train: #{train}, comparing to supplied version: #{version}")
+          if version && version != train.version_string
             UI.verbose("Version #{version} doesn't match: #{train_number}")
             next
           end
-          app.all_builds_for_train(train: train_number, platform: platform).each do |build|
+          app.tunes_all_builds_for_train(train: train.version_string, platform: platform).each do |build|
             UI.verbose("Found build version: #{build.build_version}, comparing to supplied build_number: #{build_number}")
             if build_number && build.build_version != build_number
               UI.verbose("build_version: #{build.build_version} doesn't match: #{build_number}")
@@ -68,23 +67,18 @@ module Fastlane
             begin
               # need to call reload here or dsym_url is nil
               UI.verbose("Build_version: #{build.build_version} matches #{build_number}, grabbing dsym_url")
-              build.reload
-              download_url = build.dsym_url
+              build_details = app.tunes_build_details(train: train.version_string, build_number: build.build_version, platform: platform)
+              download_url = build_details.dsym_url
               UI.verbose("dsym_url: #{download_url}")
             rescue Spaceship::TunesClient::ITunesConnectError => ex
               UI.error("Error accessing dSYM file for build\n\n#{build}\n\nException: #{ex}")
             end
 
             if download_url
-              result = self.download(download_url)
-              path   = write_dsym(result, app.bundle_id, train_number, build.build_version, output_directory)
-              UI.success("🔑  Successfully downloaded dSYM file for #{train_number} - #{build.build_version} to '#{path}'")
-
-              Actions.lane_context[SharedValues::DSYM_PATHS] ||= []
-              Actions.lane_context[SharedValues::DSYM_PATHS] << File.expand_path(path)
+              self.download(download_url, app.bundle_id, train.version_string, build.build_version, output_directory)
               break if build_number
             else
-              UI.message("No dSYM URL for #{build.build_version} (#{build.train_version})")
+              UI.message("No dSYM URL for #{build.build_version} (#{train.version_string})")
             end
           end
         end
@@ -95,6 +89,15 @@ module Fastlane
       end
       # rubocop:enable Metrics/PerceivedComplexity
 
+      def self.download(download_url, bundle_id, train_number, build_version, output_directory)
+        result = self.download_file(download_url)
+        path   = write_dsym(result, bundle_id, train_number, build_version, output_directory)
+        UI.success("🔑  Successfully downloaded dSYM file for #{train_number} - #{build_version} to '#{path}'")
+
+        Actions.lane_context[SharedValues::DSYM_PATHS] ||= []
+        Actions.lane_context[SharedValues::DSYM_PATHS] << File.expand_path(path)
+      end
+
       def self.write_dsym(data, bundle_id, train_number, build_number, output_directory)
         file_name = "#{bundle_id}-#{train_number}-#{build_number}.dSYM.zip"
         if output_directory
@@ -104,7 +107,7 @@ module Fastlane
         file_name
       end
 
-      def self.download(url)
+      def self.download_file(url)
         uri = URI.parse(url)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = (uri.scheme == "https")

--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -6,6 +6,7 @@ require_relative 'app_submission'
 require_relative 'app_version'
 require_relative 'app_version_generated_promocodes'
 require_relative 'app_version_history'
+require_relative 'build_train'
 require_relative 'iap'
 require_relative 'tunes_base'
 require_relative 'version_set'
@@ -294,6 +295,30 @@ module Spaceship
       #   this include pre-processing or standard processing
       def all_processing_builds(platform: nil)
         return TestFlight::Build.all_processing_builds(app_id: self.apple_id, platform: platform || self.platform)
+      end
+
+      def tunes_all_build_trains(app_id: nil, platform: nil)
+        resp = client.all_build_trains(app_id: apple_id, platform: platform)
+        trains = resp["trains"] or []
+        trains.map do |attrs|
+          attrs['application'] = self
+          Tunes::BuildTrain.factory(attrs)
+        end
+      end
+
+      def tunes_all_builds_for_train(train: nil, platform: nil)
+        resp = client.all_builds_for_train(app_id: apple_id, train: train, platform: platform)
+        items = resp["items"] or []
+        items.map do |attrs|
+          attrs['apple_id'] = apple_id
+          Tunes::Build.factory(attrs)
+        end
+      end
+
+      def tunes_build_details(train: nil, build_number: nil, platform: nil)
+        resp = client.build_details(app_id: apple_id, train: train, build_number: build_number, platform: platform)
+        resp['apple_id'] = apple_id
+        Tunes::BuildDetails.factory(resp)
       end
 
       # Get all builds that are already processed for all build trains

--- a/spaceship/lib/spaceship/tunes/build_train.rb
+++ b/spaceship/lib/spaceship/tunes/build_train.rb
@@ -38,6 +38,7 @@ module Spaceship
       attr_reader :invalid_builds
 
       attr_mapping(
+        'application' => 'application',
         'versionString' => :version_string,
         'platform' => :platform,
         'externalTesting.value' => :external_testing_enabled,


### PR DESCRIPTION
…tunes API

Fixes #11755

# Problem?
- `download_dsym` was not always finding the versions/builds numbers that it needed to find
- Specifying a `version` and `build_number` would not download a dSYM even though it could be manually downloaded through the iTC dashboard 
- `Spaceship::TestFlight` seems to only hold build info for 90ish days

# Solution?
- Switched over to `Spaceship::Tunes` (which is what the iTC dashboard uses)
- Added there "new" methods to `application`
  - `tunes_all_build_trains `
  - `tunes_all_builds_for_train `
  - `tunes_build_details `

⚠️ ^^^ I super hate that I prefixed these methods with "tunes" but there are methods already named these that use the `Spaceship::TestFlight` API 😕 

# Proof

### This screenshot does not specify a version/build number (and worked previously)
<img width="997" alt="screen shot 2018-03-16 at 12 39 20 am" src="https://user-images.githubusercontent.com/401294/37505680-0c3851d0-28b4-11e8-8a54-8b682a5df930.png">

### This screenshot does specify a version/build number (and worked previously)
<img width="962" alt="screen shot 2018-03-16 at 12 39 59 am" src="https://user-images.githubusercontent.com/401294/37505682-13cba528-28b4-11e8-8d7e-b6023838a747.png">

### This screenshot does specify a version/build number (BUT DID NOT WORK PREVIOUSLY)
<img width="993" alt="screen shot 2018-03-16 at 12 39 41 am" src="https://user-images.githubusercontent.com/401294/37505688-1991064c-28b4-11e8-8710-f3e51d541809.png">