### PR TITLE
Fixes app_store_build_number when finding latest version

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -24,7 +24,8 @@ module Fastlane
           unless version_number
             # Automatically fetch the latest version in testflight
             begin
-              testflight_version = app.all_build_train_numbers(platform: platform).sort_by { |v| Gem::Version.new(v) }.last
+              train_numbers = app.all_build_train_numbers(platform: platform)
+              testflight_version = self.order_versions(train_numbers).last
             rescue
               testflight_version = params[:version]
             end
@@ -40,7 +41,8 @@ module Fastlane
           UI.message("Fetching the latest build number for version #{version_number}")
 
           begin
-            build_nr = app.all_builds_for_train(train: version_number, platform: platform).map(&:build_version).map(&:to_i).sort.last
+            build_numbers = app.all_builds_for_train(train: version_number, platform: platform).map(&:build_version)
+            build_nr = self.order_versions(build_numbers).last
             if build_nr.nil? && params[:initial_build_number]
               UI.message("Could not find a build on iTC. Using supplied 'initial_build_number' option")
               build_nr = params[:initial_build_number]
@@ -52,6 +54,10 @@ module Fastlane
         end
         UI.message("Latest upload for version #{version_number} is build: #{build_nr}")
         Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER] = build_nr
+      end
+
+      def self.order_versions(versions)
+        versions.map(&:to_s).sort_by { |v| Gem::Version.new(v) }
       end
 
       #####################################################

--- a/fastlane/spec/actions_specs/app_store_build_number_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_build_number_spec.rb
@@ -2,24 +2,24 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "app_store_build_number" do
       it "orders versions array of integers" do
-        versions = [3,5,1,0,4]
+        versions = [3, 5, 1, 0, 4]
         result = Fastlane::Actions::AppStoreBuildNumberAction.order_versions(versions)
 
-        expect(result).to eq(['0','1','3','4','5'])
+        expect(result).to eq(['0', '1', '3', '4', '5'])
       end
 
       it "orders versions array of integers and string integers" do
-        versions = [3,5,'1',0,'4']
+        versions = [3, 5, '1', 0, '4']
         result = Fastlane::Actions::AppStoreBuildNumberAction.order_versions(versions)
 
-        expect(result).to eq(['0','1','3','4','5'])
+        expect(result).to eq(['0', '1', '3', '4', '5'])
       end
 
       it "orders versions array of integers, string integers, floats, and semantic versions string" do
-        versions = [3,'1','2.3',9,'6.5.4','11.4.6',5.6]
+        versions = [3, '1', '2.3', 9, '6.5.4', '11.4.6', 5.6]
         result = Fastlane::Actions::AppStoreBuildNumberAction.order_versions(versions)
 
-        expect(result).to eq(['1','2.3','3','5.6','6.5.4','9','11.4.6'])
+        expect(result).to eq(['1', '2.3', '3', '5.6', '6.5.4', '9', '11.4.6'])
       end
     end
   end

--- a/fastlane/spec/actions_specs/app_store_build_number_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_build_number_spec.rb
@@ -1,0 +1,26 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "app_store_build_number" do
+      it "orders versions array of integers" do
+        versions = [3,5,1,0,4]
+        result = Fastlane::Actions::AppStoreBuildNumberAction.order_versions(versions)
+
+        expect(result).to eq(['0','1','3','4','5'])
+      end
+
+      it "orders versions array of integers and string integers" do
+        versions = [3,5,'1',0,'4']
+        result = Fastlane::Actions::AppStoreBuildNumberAction.order_versions(versions)
+
+        expect(result).to eq(['0','1','3','4','5'])
+      end
+
+      it "orders versions array of integers, string integers, floats, and semantic versions string" do
+        versions = [3,'1','2.3',9,'6.5.4','11.4.6',5.6]
+        result = Fastlane::Actions::AppStoreBuildNumberAction.order_versions(versions)
+
+        expect(result).to eq(['1','2.3','3','5.6','6.5.4','9','11.4.6'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #11712

# Wuuuuttttt
- `app_store_build_number` assumed build version numbers were only integers and sorted by that
  - Build version number can actually be strings and should be semantic versioned
  - Now uses `Gem::Version` to order build numbers
  - This works for integers, floats, string, and semantic strings
  - Will properly order - `[3,'1','2.3',9,'6.5.4','11.4.6',5.6]`