### PR TITLE
Replace parentheses in export_options parameter

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/build_ios_app.md
+++ b/fastlane/lib/fastlane/actions/docs/build_ios_app.md
@@ -134,25 +134,25 @@ export_options("./ExportOptions.plist")
 or you can provide hash of values directly in the `Gymfile`:
 
 ```ruby-skip-tests
-export_options(
+export_options: {
   method: "ad-hoc",
   manifest: {
     appURL: "https://example.com/My App.ipa",
   },
   thinning: "<thin-for-all-variants>"
-)
+}
 ```
 
 Optional: If _gym_ can't automatically detect the provisioning profiles to use, you can pass a mapping of bundle identifiers to provisioning profiles:
 
 ```ruby-skip-tests
-export_options(
+export_options: {
   method: "app-store",
   provisioningProfiles: { 
     "com.example.bundleid" => "Provisioning Profile Name",
     "com.example.bundleid2" => "Provisioning Profile Name 2"
   }
-)
+}
 ```
 
 **Note**: If you use [_fastlane_](https://fastlane.tools) with [_match_](https://fastlane.tools/match) you don't need to provide those values manually.


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Could not be able to build with `gym` because a syntax error in gym's documentation. That's why I updated the docs. This PR Closes #10510 

### Description
Fix a syntax issue with gym's `export_options`
