### PR TITLE
Prompt user  instead of not setting the export_method when codesign env = developmen

### DIFF
--- a/fastlane/lib/fastlane/actions/build_ios_app.rb
+++ b/fastlane/lib/fastlane/actions/build_ios_app.rb
@@ -9,9 +9,12 @@ module Fastlane
       def self.run(values)
         require 'gym'
 
-        unless Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE].to_s == "development"
-          values[:export_method] ||= Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE]
+        if Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE].to_s == "development" && UI.interactive?
+          confirm = UI.confirm("development was defined as export_method which almost never makes sense. Proceed?")
+          return unless confirm
         end
+
+        values[:export_method] ||= Actions.lane_context[SharedValues::SIGH_PROFILE_TYPE]
 
         if Actions.lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING]
           # Since Xcode 9 you need to explicitly provide the provisioning profile per app target


### PR DESCRIPTION
### Motivation and Context

Currently fastlane code does not set export_method when codesign = development
https://github.com/fastlane/fastlane/blob/f4e516c3a6f4a17088bcd099feb02ffa1a6fe9c7/fastlane/lib/fastlane/actions/build_ios_app.rb#L12

It comes from an old commit from @KrauseFx https://github.com/fastlane/fastlane/pull/9742 that assumes exporting using gym in development is usually not a legit usecase.

Currently when using match(type: development), gym tries to exports as app-store and fails.
Actually this use case is legit. For example when testing recurring In App Purchases. 

### Description

The export_method is correctly set and if the UI is interactive we prompt the user for confirmation since it might be a configuration error.

PS: Not even sure that prompt is legit