### PR TITLE
Adding TestFlight group deletion functionality

### DIFF
--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -115,6 +115,13 @@ module Spaceship
         handle_response(response)
       end
 
+      def delete_group_for_app(app_id: nil, group_id: nil)
+        assert_required_params(__method__, binding)
+        url = "providers/#{team_id}/apps/#{app_id}/groups/#{group_id}"
+        response = request(:delete, url)
+        handle_response(response)
+      end
+
       def add_group_to_build(app_id: nil, group_id: nil, build_id: nil)
         assert_required_params(__method__, binding)
 

--- a/spaceship/lib/spaceship/test_flight/group.rb
+++ b/spaceship/lib/spaceship/test_flight/group.rb
@@ -30,6 +30,11 @@ module Spaceship::TestFlight
       self.new(data)
     end
 
+    def self.delete!(app_id: nil, group_name: nil)
+      group = self.find(app_id: app_id, group_name: group_name)
+      client.delete_group_for_app(app_id: app_id, group_id: group.id)
+    end
+
     def self.all(app_id: nil)
       groups = client.get_groups(app_id: app_id)
       groups.map { |g| self.new(g) }

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -135,9 +135,9 @@ describe Spaceship::TestFlight::Client do
 
   context '#delete_group_for_app' do
     it 'executes the request' do
-      MockAPI::TestFlightServer.post('/testflight/v2/providers/fake-team-id/apps/some-app-id/groups/fake-group-id') {}
+      MockAPI::TestFlightServer.delete('/testflight/v2/providers/fake-team-id/apps/some-app-id/groups/fake-group-id') {}
       subject.delete_group_for_app(app_id: app_id, group_id: 'fake-group-id')
-      expect(WebMock).to have_requested(:delete, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/groups/group-test-id')
+      expect(WebMock).to have_requested(:delete, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/groups/fake-group-id')
     end
   end
 

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -133,6 +133,14 @@ describe Spaceship::TestFlight::Client do
     end
   end
 
+  context '#delete_group_for_app' do
+    it 'executes the request' do
+      MockAPI::TestFlightServer.post('/testflight/v2/providers/fake-team-id/apps/some-app-id/groups/fake-group-id') {}
+      subject.delete_group_for_app(app_id: app_id, group_id: 'fake-group-id')
+      expect(WebMock).to have_requested(:delete, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/groups/group-test-id')
+    end
+  end
+
   context '#get_groups' do
     it 'executes the request' do
       MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/groups') {}


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently we can create testflight groups via spaceship. But the functionality to delete the testflight groups via spaceship doesn't exist. This would PR will allow users to cleanup their testflight groups and reduce the error prone nature of using the iTunes connect UI.

This PR provides a fix for this Github Issue:
https://github.com/fastlane/fastlane/issues/12094

We have tried running this through the rspec tests and also performed a test on a live testflight app that we have on iTunes Connect. The testflight group was successfully deleted and we were able to validate this by looking at the iTunes Connect UI.

### Description
We added the group.delete and client.delete_group_for_app methods. This would send a delete request to the itunes connect URL containing the team_id, app_id and group_id. The associated client_spec.rb has also been updated.
