### PR TITLE
[Action] Fix a bug that upload_symbols_to_crashlytics fails in specific cases

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -85,7 +85,7 @@ module Fastlane
         command = []
         command << File.expand_path(params[:binary_path]).shellescape
         command << "-a #{params[:api_token]}" if params[:api_token]
-        command << "-gsp #{params[:gsp_path]}" if params[:gsp_path]
+        command << "-gsp #{params[:gsp_path].shellescape}" if params[:gsp_path]
         command << "-p #{params[:platform] == 'appletvos' ? 'tvos' : params[:platform]}"
         command << File.expand_path(path).shellescape
         begin

--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -22,7 +22,7 @@ describe Fastlane do
       it "uploads dSYM files" do
         binary_path = './spec/fixtures/screenshots/screenshot1.png'
         dsym_path = './spec/fixtures/dSYM/Themoji.dSYM'
-        gsp_path = './spec/fixtures/plist/Info.plist'
+        gsp_path = './spec/fixtures/plist/With Space.plist'
 
         command = []
         command << File.expand_path(File.join("fastlane", binary_path)).shellescape
@@ -51,6 +51,17 @@ describe Fastlane do
             upload_symbols_to_crashlytics(
               dsym_path: 'fastlane/#{dsym_path}',
               binary_path: 'fastlane/#{binary_path}')
+          end").runner.execute(:test)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError)
+      end
+
+      it "raises exception if given gsp_path is not found" do
+        gsp_path = './spec/fixtures/plist/_Not Exist_.plist'
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            upload_symbols_to_crashlytics(
+              gsp_path: 'fastlane/#{gsp_path}',
+              api_token: 'something123')
           end").runner.execute(:test)
         end.to raise_error(FastlaneCore::Interface::FastlaneError)
       end

--- a/fastlane/spec/fixtures/plist/With Space.plist
+++ b/fastlane/spec/fixtures/plist/With Space.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>App Name</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIcons</key>
+	<dict/>
+	<key>CFBundleIcons~ipad</key>
+	<dict/>
+	<key>CFBundleIdentifier</key>
+	<string>com.krausefx.app</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>App Name</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.9.14</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>com.krausefx.app</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.krausefx.app</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>0.9.14</string>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>We show your location on the map.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleDefault</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

`upload_symbols_to_crashlytics` fails in specific cases.

### Description

For instance, if the path contains spaces it fails..