### PR TITLE
Example code for latest_tesflight_build_number was incorrect.

### DIFF
--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -121,7 +121,7 @@ module Fastlane
 
       def self.example_code
         [
-          'latest_testflight_build_number(version: "1.3")',
+          'latest_testflight_build_number(version: "1.3").to_i',
           'increment_build_number({
             build_number: latest_testflight_build_number + 1
           })'


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->
This action used to return an integer, and now it returns a string. Currently the documentation does not reflect this change. I have updated the example code.