### PR TITLE
Limit AppVeyor builds to `master` and PRs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,21 @@
 
 version: "{build}"
 
+# branches to build
+branches:
+  # whitelist
+  only:
+    - master
+
+# Do not build on tags (GitHub and BitBucket)
+skip_tags: true
+
+# Do not build additional commits to feature branch with open Pull Requests
+skip_branch_with_pr: true
+
+# Rolling builds
+# can only be configured via UI: https://www.appveyor.com/docs/build-configuration/#rolling-builds
+
 init:
   - git config --global core.autocrlf true
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Right now Appveyor builds too much stuff.

### Description
<!-- Describe your changes in detail -->

This limits the builds to commits to the `master` branch and open PRs. 
It disables builds for all other branches (feature and release branches) and tags or releases. This way should always have only one AppVeyor check to wait for per commit or PR, matching the configuration on Circle.