### PR TITLE
Write Match encrypted files in binary mode to avoid UndefinedConversi…

### DIFF
--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -119,7 +119,7 @@ module Match
 
       decrypted_data = decipher.update(data_to_decrypt) + decipher.final
 
-      File.write(path, decrypted_data)
+      File.binwrite(path, decrypted_data)
     rescue => error
       fallback_hash_algorithm = "SHA256"
       if hash_algorithm != fallback_hash_algorithm


### PR DESCRIPTION
…on error

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Writing encrypted files from a Match git repo resulted in a conversion error when values could not be converted from ASCII-8BIT to UTF-8.

For example: 
```
Exception in decrypt Encoding::UndefinedConversionError "\x82" from ASCII-8BIT to UTF-8: 
...match/lib/match/encrypt.rb:123:in `write'
```

(Fastlane might want to consider Encoding.default_external = "ASCII-8BIT" to avoid the myriad changes from read/write to binread/binwrite.)

### Description
Open the file for write in binary mode to avoid the UTF-8 conversion.

This fixes at least some of the issues reported in #11858, but I'm not using Swift, so others will need to verify.

Specifically, I no longer get the following (misleading ;-) error:

```
ERROR [2018-03-06 16:31:52.48]: Couldn't decrypt the repo, please make sure you enter the right password!
ERROR [2018-03-06 16:31:52.94]: Invalid password passed via 'MATCH_PASSWORD'
```