### PR TITLE
For for get_version_number to auto-select target when its only one

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -34,6 +34,11 @@ module Fastlane
       def self.get_target!(project, target_name)
         targets = project.targets
 
+        # Returns if only one target
+        if targets.count == 1
+          return targets.first
+        end
+
         # Prompt targets if no name
         unless target_name
           options = targets.map(&:name)

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -34,13 +34,13 @@ module Fastlane
       def self.get_target!(project, target_name)
         targets = project.targets
 
-        # Returns if only one target
-        if targets.count == 1
-          return targets.first
-        end
-
         # Prompt targets if no name
         unless target_name
+          # Returns if only one target
+          if targets.count == 1
+            return targets.first
+          end
+
           options = targets.map(&:name)
           target_name = UI.select("What target would you like to use?", options)
         end

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -65,6 +65,18 @@ describe Fastlane do
         expect(result).to eq("4.3.2")
       end
 
+      it "raises if one target and specified wrong target name", requires_xcodeproj: true do
+        allow_any_instance_of(Xcodeproj::Project).to receive(:targets).and_wrap_original do |m, *args|
+          [m.call(*args).first]
+        end
+
+        expect do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            get_version_number(xcodeproj: '#{path}', target: 'ThisIsNotATarget')
+          end").runner.execute(:test)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, "Cannot find target named 'ThisIsNotATarget'")
+      end
+
       it "raises if in non-interactive mode with no target", requires_xcodeproj: true do
         expect do
           result = Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -54,6 +54,17 @@ describe Fastlane do
         expect(result).to eq("1.0")
       end
 
+      it "gets the correct version number with no target specified", requires_xcodeproj: true do
+        allow_any_instance_of(Xcodeproj::Project).to receive(:targets).and_wrap_original do |m, *args|
+          [m.call(*args).first]
+        end
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          get_version_number(xcodeproj: '#{path}')
+        end").runner.execute(:test)
+        expect(result).to eq("4.3.2")
+      end
+
       it "raises if in non-interactive mode with no target", requires_xcodeproj: true do
         expect do
           result = Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
Fixes #12119 
Fixes #12115
Fixes #12114

`get_version_number` now will auto-select target if there is only one