### PR TITLE
Improve ActionDetails.md.erb look at actual file names

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -112,4 +112,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rest-client', '>= 1.8.0')
   spec.add_development_dependency('fakefs', '~> 0.8.1')
   spec.add_development_dependency('sinatra', '~> 1.4.8')
+  spec.add_development_dependency('where_is', '~> 0.2.0')
 end

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -112,5 +112,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rest-client', '>= 1.8.0')
   spec.add_development_dependency('fakefs', '~> 0.8.1')
   spec.add_development_dependency('sinatra', '~> 1.4.8')
-  spec.add_development_dependency('where_is', '~> 0.2.0')
 end

--- a/fastlane/lib/assets/ActionDetails.md.erb
+++ b/fastlane/lib/assets/ActionDetails.md.erb
@@ -1,6 +1,6 @@
 <!--
 This file is auto-generated and will be re-generated every time the docs are updated.
-To modify it, go to its source at https://github.com/fastlane/fastlane/blob/master/fastlane/lib/assets/ActionDetails.md.erb
+To modify it, go to its source at https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/<%= @action_filename %>
 -->
 
 # <%= @action.action_name %>

--- a/fastlane/lib/assets/ActionDetails.md.erb
+++ b/fastlane/lib/assets/ActionDetails.md.erb
@@ -55,7 +55,7 @@ To show the documentation in your terminal, run
 fastlane action <%= action.action_name %>
 ```
 
-<a href="https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/<%= action.action_name %>.rb" target="_blank">View source code</a>
+<a href="https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/<%= @action_filename %>" target="_blank">View source code</a>
 
 <hr />
 

--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -43,6 +43,22 @@ module Fastlane
       @_launches ||= JSON.parse(File.read(File.join(Fastlane::ROOT, "assets/action_ranking.json"))) # root because we're in a temporary directory here
     end
 
+    def actions_path
+      "lib/fastlane/actions/"
+    end
+
+    def filename_for_action(action)
+      require 'where_is'
+      filename = File.basename(Where.is(action)[0])
+
+      path = File.join(Fastlane::ROOT, actions_path, filename)
+      unless File.exist?(path)
+        UI.message("Cannot find action `#{action.action_name}` at #{path}")
+        return ""
+      end
+      filename
+    end
+
     def custom_action_docs_path
       "lib/fastlane/actions/docs/"
     end
@@ -85,7 +101,7 @@ module Fastlane
       FileUtils.mkdir_p(File.join(docs_dir, "actions"))
       ActionsList.all_actions do |action|
         @action = action # to provide a reference in the .html.erb template
-        @action_filename = "#{action.action_name}.rb"
+        @action_filename = filename_for_action(action)
 
         # Make sure to always assign `@custom_content`, as we're in a loop and `@` is needed for the `erb`
         @custom_content = load_custom_action_md(action)

--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -85,6 +85,7 @@ module Fastlane
       FileUtils.mkdir_p(File.join(docs_dir, "actions"))
       ActionsList.all_actions do |action|
         @action = action # to provide a reference in the .html.erb template
+        @action_filename = "#{action.action_name}.rb"
 
         # Make sure to always assign `@custom_content`, as we're in a loop and `@` is needed for the `erb`
         @custom_content = load_custom_action_md(action)


### PR DESCRIPTION
Fixes #12107

- comment links directly to file that action is in for editing (previously linked to ActionDetails.md.erb
- source link to actual file action is in (assume file name by action name)
- doesn’t generate actions that were actually plugins which fastlane uses for build/dev stuff

### Finds actual file where action is defined

#### Comment will now link to action file for changing
```
To modify it, go to its source at https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/s3.rb
```

#### Source file will now link to proper source location in GitHub 
https://docs.fastlane.tools/actions/xcbuild/
before: https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/xcbuild.rb
now: https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/xcodebuild.rb

### Was loading plugins that fastlane used for building 
- https://docs.fastlane.tools/actions/clubmate
- https://docs.fastlane.tools/actions/plugin_scores
- https://docs.fastlane.tools/actions/rspec
- https://docs.fastlane.tools/actions/rubocop
- https://docs.fastlane.tools/actions/slack_train_action
- https://docs.fastlane.tools/actions/slack_train_crash_action
- https://docs.fastlane.tools/actions/slack_train_start_action

and it now will skip these

```sh
ERROR [2018-03-21 09:09:43.73]: Action 'Fastlane::Actions::ClubmateAction' not found in root fastlane project... skipping
DEBUG [2018-03-21 09:09:43.73]: Action 'Fastlane::Actions::ClubmateAction' found at /Users/josh/Projects/fastlane/fastlane/fastlane/lib/fastlane/actions/clubmate_action.rb
ERROR [2018-03-21 09:09:44.72]: Action 'Fastlane::Actions::PluginScoresAction' not found in root fastlane project... skipping
DEBUG [2018-03-21 09:09:44.72]: Action 'Fastlane::Actions::PluginScoresAction' found at /Users/josh/Projects/fastlane/fastlane/fastlane/lib/fastlane/actions/plugin_scores.rb
ERROR [2018-03-21 09:09:44.81]: Action 'Fastlane::Actions::RspecAction' not found in root fastlane project... skipping
DEBUG [2018-03-21 09:09:44.81]: Action 'Fastlane::Actions::RspecAction' found at /Users/josh/Projects/fastlane/fastlane/fastlane/lib/fastlane/actions/rspec.rb
ERROR [2018-03-21 09:09:44.82]: Action 'Fastlane::Actions::RubocopAction' not found in root fastlane project... skipping
DEBUG [2018-03-21 09:09:44.82]: Action 'Fastlane::Actions::RubocopAction' found at /Users/josh/Projects/fastlane/fastlane/fastlane/lib/fastlane/actions/rubocop.rb
ERROR [2018-03-21 09:09:44.89]: Action 'Fastlane::Actions::SlackTrainAction' not found in root fastlane project... skipping
DEBUG [2018-03-21 09:09:44.89]: Action 'Fastlane::Actions::SlackTrainAction' found at /Users/josh/Projects/fastlane/fastlane/fastlane/lib/fastlane/actions/slack_train_action.rb
ERROR [2018-03-21 09:09:44.89]: Action 'Fastlane::Actions::SlackTrainCrashAction' not found in root fastlane project... skipping
DEBUG [2018-03-21 09:09:44.89]: Action 'Fastlane::Actions::SlackTrainCrashAction' found at /Users/josh/Projects/fastlane/fastlane/fastlane/lib/fastlane/actions/slack_train_crash_action.rb
ERROR [2018-03-21 09:09:44.90]: Action 'Fastlane::Actions::SlackTrainStartAction' not found in root fastlane project... skipping
DEBUG [2018-03-21 09:09:44.90]: Action 'Fastlane::Actions::SlackTrainStartAction' found at /Users/josh/Projects/fastlane/fastlane/fastlane/lib/fastlane/actions/slack_train_start_action.rb
```