### PR TITLE
Use correct spelling of icloud service in product/service.rb

### DIFF
--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -98,7 +98,7 @@ module Produce
             enabled_clean_options[app_service.cloud.on.service_id] = app_service.cloud.on
             enabled_clean_options[app_service.cloud_kit.xcode5_compatible.service_id] = app_service.cloud_kit.xcode5_compatible
           when SERVICE_CLOUDKIT
-            enabled_clean_options[app_service.i_cloud.on.service_id] = app_service.i_cloud.on
+            enabled_clean_options[app_service.cloud.on.service_id] = app_service.cloud.on
             enabled_clean_options[app_service.cloud_kit.cloud_kit.service_id] = app_service.cloud_kit.cloud_kit
           end
         else

--- a/produce/lib/produce/service.rb
+++ b/produce/lib/produce/service.rb
@@ -141,10 +141,10 @@ module Produce
         if on
           case options.icloud
           when "legacy"
-            app.update_service(Spaceship.app_service.icloud.on)
+            app.update_service(Spaceship.app_service.cloud.on)
             app.update_service(Spaceship.app_service.cloud_kit.xcode5_compatible)
           when "cloudkit"
-            app.update_service(Spaceship.app_service.icloud.on)
+            app.update_service(Spaceship.app_service.i_cloud.on)
             app.update_service(Spaceship.app_service.cloud_kit.cloud_kit)
           else
             UI.user_error!("Unknown service '#{options.icloud}'. Valid values: 'legacy', 'cloudkit'")

--- a/produce/lib/produce/service.rb
+++ b/produce/lib/produce/service.rb
@@ -144,13 +144,13 @@ module Produce
             app.update_service(Spaceship.app_service.cloud.on)
             app.update_service(Spaceship.app_service.cloud_kit.xcode5_compatible)
           when "cloudkit"
-            app.update_service(Spaceship.app_service.i_cloud.on)
+            app.update_service(Spaceship.app_service.cloud.on)
             app.update_service(Spaceship.app_service.cloud_kit.cloud_kit)
           else
             UI.user_error!("Unknown service '#{options.icloud}'. Valid values: 'legacy', 'cloudkit'")
           end
         else
-          app.update_service(Spaceship.app_service.icloud.off)
+          app.update_service(Spaceship.app_service.cloud.off)
         end
       end
 


### PR DESCRIPTION
These changes are already done in produce/developer_center.rb

https://github.com/fastlane/fastlane/pull/11861

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This extends this fix #11861 

### Description
Use the correct method Spaceship::Portal::AppService.cloud because the constant is named Cloud instead of iCloud. The latter would cause that the Ruby-style method would be named i_cloud. That doesn't look better either.
