### PR TITLE
Ignore *.xcodeproj & *.xcworkspace in gem paths for detecting ios projects

### DIFF
--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -54,6 +54,9 @@ module Fastlane
       spinner.auto_spin
 
       ios_projects = Dir["**/*.xcodeproj"] + Dir["**/*.xcworkspace"]
+      ios_projects.delete_if do |path|
+        Gem.path.any? { |gem_path| File.expand_path(__dir__, path).start_with?(gem_path) }
+      end
       ios_projects.delete_if { |path| path.match("fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj") }
       android_projects = Dir["**/*.gradle"]
 

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -55,7 +55,7 @@ module Fastlane
 
       ios_projects = Dir["**/*.xcodeproj"] + Dir["**/*.xcworkspace"]
       ios_projects.delete_if do |path|
-        Gem.path.any? { |gem_path| File.expand_path(__dir__, path).start_with?(gem_path) }
+        Gem.path.any? { |gem_path| File.expand_path(path).start_with?(gem_path) }
       end
       ios_projects.delete_if { |path| path.match("fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj") }
       android_projects = Dir["**/*.gradle"]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`fastlane init` always ios projects when install the fastlane by bundle with `--(project_dir)/vendor/bundle` option, because some gems(include fastlane)  has *.xcodeproj or *.xcworkspace inside.

This fix related with #12075

### Description

Ignore *.xcodeproj & *.xcworkspace files in Gem paths.