### PR TITLE
app_store_build_number converts return to int if possible

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -8,6 +8,17 @@ module Fastlane
       def self.run(params)
         require 'spaceship'
 
+        build_nr = get_build_number(params)
+
+        # Convert build_nr to int (for legacy use) if no "." in string
+        if build_nr.kind_of?(String) && !build_nr.include?(".")
+          build_nr = build_nr.to_i
+        end
+
+        Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER] = build_nr
+      end
+
+      def self.get_build_number(params)
         UI.message("Login to iTunes Connect (#{params[:username]})")
         Spaceship::Tunes.login(params[:username])
         Spaceship::Tunes.select_team
@@ -53,7 +64,8 @@ module Fastlane
           end
         end
         UI.message("Latest upload for version #{version_number} is build: #{build_nr}")
-        Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER] = build_nr
+
+        build_nr
       end
 
       def self.order_versions(versions)

--- a/fastlane/spec/actions_specs/app_store_build_number_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_build_number_spec.rb
@@ -21,6 +21,26 @@ describe Fastlane do
 
         expect(result).to eq(['1', '2.3', '3', '5.6', '6.5.4', '9', '11.4.6'])
       end
+
+      it "returns value as string (with build number as version string)" do
+        allow(Fastlane::Actions::AppStoreBuildNumberAction).to receive(:get_build_number).and_return("1.2.3")
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          app_store_build_number(username: 'name@example.com', app_identifier: 'x.y.z')
+        end").runner.execute(:test)
+
+        expect(result).to eq("1.2.3")
+      end
+
+      it "returns value as integer (with build number as version number)" do
+        allow(Fastlane::Actions::AppStoreBuildNumberAction).to receive(:get_build_number).and_return("3")
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          app_store_build_number(username: 'name@example.com', app_identifier: 'x.y.z')
+        end").runner.execute(:test)
+
+        expect(result).to eq(3)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #12097

## Wut
A common use case of `app_store_build_number` was to get the return value and increment the number. However, `app_store_build_number` assumed that a build number was also integer (which isn't always the case) so last release there was a change to not assume that which resulted in build number correctly sorting to find "latest build number".

**BUT**, this introduced a regression where the return value was a string and therefor couldn't be incremented. This change will convert the return value to an integer if it does not contain a "." in it 