### PR TITLE
Version bump to 2.87.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,87 +32,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 
 <table id='team'>
 <tr>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-</tr>
-<tr>
-<td id='andrew-mcburney'>
-<a href='https://github.com/AndrewMcBurney'>
-<img src='https://github.com/AndrewMcBurney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
 <td id='luka-mirosevic'>
 <a href='https://github.com/lmirosevic'>
 <img src='https://github.com/lmirosevic.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
 </a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-</tr>
-<tr>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/DanToml'>
-<img src='https://github.com/DanToml.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 <td id='fumiya-nakamura'>
 <a href='https://github.com/nafu'>
@@ -120,25 +50,63 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-</tr>
-<tr>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
 <img src='https://github.com/hjanuschka.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
+<td id='andrew-mcburney'>
+<a href='https://github.com/AndrewMcBurney'>
+<img src='https://github.com/AndrewMcBurney.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+</tr>
+<tr>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+</tr>
+<tr>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
 <td id='joshua-liebowitz'>
 <a href='https://github.com/taquitos'>
@@ -146,17 +114,49 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+</tr>
+<tr>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/DanToml'>
+<img src='https://github.com/DanToml.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+</td>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 </tr>
 </table>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -14,26 +14,26 @@ File.write("#{lib}/fastlane/plugins/template/.rubocop.yml", YAML.dump(config))
 Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
-  spec.authors       = ["Maksym Grebenets",
+  spec.authors       = ["Olivier Halligon",
+                        "Joshua Liebowitz",
+                        "Maksym Grebenets",
+                        "Stefan Natchev",
+                        "Jérôme Lacoste",
+                        "Jorge Revuelta H",
                         "Andrew McBurney",
+                        "Iulian Onofrei",
+                        "Fumiya Nakamura",
+                        "Jan Piotrowski",
                         "Aaron Brager",
                         "Jimmy Dee",
-                        "Iulian Onofrei",
-                        "Jorge Revuelta H",
-                        "Fumiya Nakamura",
-                        "Matthew Ellis",
-                        "Helmut Januschka",
-                        "Kohki Miki",
-                        "Joshua Liebowitz",
-                        "Josh Holtz",
-                        "Stefan Natchev",
-                        "Olivier Halligon",
-                        "Danielle Tomlinson",
-                        "Felix Krause",
-                        "Jérôme Lacoste",
-                        "Jan Piotrowski",
                         "Manu Wallner",
-                        "Luka Mirosevic"]
+                        "Felix Krause",
+                        "Kohki Miki",
+                        "Helmut Januschka",
+                        "Luka Mirosevic",
+                        "Danielle Tomlinson",
+                        "Josh Holtz",
+                        "Matthew Ellis"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.86.2'.freeze
+  VERSION = '2.87.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.86.2
+// Generated with fastlane 2.87.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -2333,14 +2333,16 @@ func podLibLint(useBundleExec: Bool = true,
                                                                                               RubyCommand.Argument(name: "quick", value: quick)])
   _ = runner.executeCommand(command)
 }
-func podPush(path: String? = nil,
+func podPush(useBundleExec: Bool = false,
+             path: String? = nil,
              repo: String? = nil,
              allowWarnings: String? = nil,
              useLibraries: String? = nil,
              sources: String? = nil,
              swiftVersion: String? = nil,
              verbose: Bool = false) {
-  let command = RubyCommand(commandID: "", methodName: "pod_push", className: nil, args: [RubyCommand.Argument(name: "path", value: path),
+  let command = RubyCommand(commandID: "", methodName: "pod_push", className: nil, args: [RubyCommand.Argument(name: "use_bundle_exec", value: useBundleExec),
+                                                                                          RubyCommand.Argument(name: "path", value: path),
                                                                                           RubyCommand.Argument(name: "repo", value: repo),
                                                                                           RubyCommand.Argument(name: "allow_warnings", value: allowWarnings),
                                                                                           RubyCommand.Argument(name: "use_libraries", value: useLibraries),
@@ -3911,4 +3913,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.9]
+// FastlaneRunnerAPIVersion [0.9.10]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.86.2
+// Generated with fastlane 2.87.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.86.2
+// Generated with fastlane 2.87.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.86.2
+// Generated with fastlane 2.87.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.86.2
+// Generated with fastlane 2.87.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.86.2
+// Generated with fastlane 2.87.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.86.2
+// Generated with fastlane 2.87.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.86.2':**

* Revise README for yardoc (#12150) via Fumiya Nakamura
* [supply] Added internal track (#12128) via Josh Holtz
* Add simple yardopts to generate yardoc indexes (#12145) via Fumiya Nakamura
* get_latest_version handles $(SRCROOT) and tries to get target that isn't test (#12138) via Josh Holtz
* app_store_build_number converts return to int if possible (#12148) via Josh Holtz
* Call Workspace.load_schemes() to load workspace contained schemes (#12147) via Lou Franco
* Ignore *.xcodeproj & *.xcworkspace in gem paths for detecting ios projects (#12142) via Hiroyuki Morita
* Add use_bundle_exec option to pod_push action (#11947) via Nicolas Braun
* Write Match encrypted files in binary mode to avoid UndefinedConversion error (#12112) via Michael Smith
* Fixed typo in setup UI message (#12136) via Michiel De Mey
* [Action] Fix a bug that upload_symbols_to_crashlytics fails in specific cases (#12098) via Takeru Chuganji
* Improve ActionDetails.md.erb look at actual file names (#12125) via Josh Holtz
* Replace parentheses in export_options parameter (#12078) via Juan Pablo Garcia Dalolla
