### PR TITLE
[action] added custom api_url option to testfairy

### DIFF
--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -5,13 +5,13 @@ module Fastlane
     end
 
     class TestfairyAction < Action
-      def self.upload_build(api_url, ipa, options)
+      def self.upload_build(upload_url, ipa, options)
         require 'faraday'
         require 'faraday_middleware'
 
-        UI.success("Uploading to #{api_url}...")
+        UI.success("Uploading to #{upload_url}...")
 
-        connection = Faraday.new(url: api_url) do |builder|
+        connection = Faraday.new(url: upload_url) do |builder|
           builder.request(:multipart)
           builder.request(:url_encoded)
           builder.request(:retry, max: 3, interval: 5)
@@ -66,9 +66,9 @@ module Fastlane
           end
         end
 
-        # Rejecting key `api_url` as we don't need it in options
+        # Rejecting key `upload_url` as we don't need it in options
         client_options = Hash[params.values.reject do |key, value|
-          key == :api_url
+          key == :upload_url
         end.map do |key, value|
           case key
           when :api_key
@@ -96,7 +96,7 @@ module Fastlane
 
         return params[:ipa] if Helper.test?
 
-        response = self.upload_build(params[:api_url], params[:ipa], client_options)
+        response = self.upload_build(params[:upload_url], params[:ipa], client_options)
         if parse_response(response)
           UI.success("Build URL: #{Actions.lane_context[SharedValues::TESTFAIRY_BUILD_URL]}")
           UI.success("Build successfully uploaded to TestFairy.")
@@ -160,8 +160,8 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find dSYM file at path '#{value}'") unless File.exist?(value)
                                        end),
-          FastlaneCore::ConfigItem.new(key: :api_url,
-                                       env_name: "FL_TESTFAIRY_API_URL", # The name of the environment variable
+          FastlaneCore::ConfigItem.new(key: :upload_url,
+                                       env_name: "FL_TESTFAIRY_UPLOAD_URL", # The name of the environment variable
                                        description: "API URL for TestFairy", # a short description of this parameter
                                        default_value: "https://upload.testfairy.com",
                                        is_string: true,

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -5,11 +5,13 @@ module Fastlane
     end
 
     class TestfairyAction < Action
-      def self.upload_build(ipa, options)
+      def self.upload_build(api_url, ipa, options)
         require 'faraday'
         require 'faraday_middleware'
 
-        connection = Faraday.new(url: "https://upload.testfairy.com") do |builder|
+        UI.success("Uploading to #{api_url}...")
+
+        connection = Faraday.new(url: api_url) do |builder|
           builder.request(:multipart)
           builder.request(:url_encoded)
           builder.request(:retry, max: 3, interval: 5)
@@ -64,7 +66,10 @@ module Fastlane
           end
         end
 
-        client_options = Hash[params.values.map do |key, value|
+        # Rejecting key `api_url` as we don't need it in options
+        client_options = Hash[params.values.reject do |key, value|
+          key == :api_url
+        end.map do |key, value|
           case key
           when :api_key
             [key, value]
@@ -91,7 +96,7 @@ module Fastlane
 
         return params[:ipa] if Helper.test?
 
-        response = self.upload_build(params[:ipa], client_options)
+        response = self.upload_build(params[:api_url], params[:ipa], client_options)
         if parse_response(response)
           UI.success("Build URL: #{Actions.lane_context[SharedValues::TESTFAIRY_BUILD_URL]}")
           UI.success("Build successfully uploaded to TestFairy.")
@@ -155,6 +160,12 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find dSYM file at path '#{value}'") unless File.exist?(value)
                                        end),
+          FastlaneCore::ConfigItem.new(key: :api_url,
+                                       env_name: "FL_TESTFAIRY_API_URL", # The name of the environment variable
+                                       description: "API URL for TestFairy", # a short description of this parameter
+                                       default_value: "https://upload.testfairy.com",
+                                       is_string: true,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :testers_groups,
                                        optional: true,
                                        type: Array,

--- a/fastlane/spec/actions_specs/testfairy_spec.rb
+++ b/fastlane/spec/actions_specs/testfairy_spec.rb
@@ -61,6 +61,7 @@ describe Fastlane do
             testfairy({
               ipa: './fastlane/spec/fixtures/fastfiles/Fastfile1',
               api_key: 'thisistest',
+              api_url: 'https://your-subdomain.testfairy.com',
               comment: 'Test Comment!',
               testers_groups: ['group1', 'group2']
             })

--- a/fastlane/spec/actions_specs/testfairy_spec.rb
+++ b/fastlane/spec/actions_specs/testfairy_spec.rb
@@ -61,7 +61,7 @@ describe Fastlane do
             testfairy({
               ipa: './fastlane/spec/fixtures/fastfiles/Fastfile1',
               api_key: 'thisistest',
-              api_url: 'https://your-subdomain.testfairy.com',
+              upload_url: 'https://your-subdomain.testfairy.com',
               comment: 'Test Comment!',
               testers_groups: ['group1', 'group2']
             })


### PR DESCRIPTION
Fixes #11057

## Wut
- Adds a new `api_url` option for private secure cloud
- Defaults to `https://upload.testfairy.com`

## Proof
<img width="622" alt="screen shot 2018-03-23 at 4 02 32 pm" src="https://user-images.githubusercontent.com/401294/37853563-46887750-2eb5-11e8-87e0-7af6add3947b.png">

![screen shot 2018-03-23 at 4 14 17 pm](https://user-images.githubusercontent.com/401294/37853576-4fa226f6-2eb5-11e8-9fb3-a29c88927299.png)

