### PR TITLE
Include .yardopts in fastlane gem

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.files = Dir.glob("*/lib/**/*", File::FNM_DOTMATCH) + Dir["fastlane/swift/**/*"] + Dir["bin/*"] + Dir["*/README.md"] + %w(README.md LICENSE) - Dir["fastlane/lib/fastlane/actions/device_grid/assets/*"] - Dir["fastlane/lib/fastlane/actions/docs/assets/*"]
+  spec.files = Dir.glob("*/lib/**/*", File::FNM_DOTMATCH) + Dir["fastlane/swift/**/*"] + Dir["bin/*"] + Dir["*/README.md"] + %w(README.md LICENSE .yardopts) - Dir["fastlane/lib/fastlane/actions/device_grid/assets/*"] - Dir["fastlane/lib/fastlane/actions/docs/assets/*"]
   spec.bindir = "bin"
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
One more action for https://github.com/fastlane/fastlane/issues/12139.
We've already supported `.yardopts` https://github.com/fastlane/fastlane/pull/12145 but the fastlane gem does not include `.yardopts`.
That is why [rubydoc.info](http://www.rubydoc.info/gems/fastlane/2.87.0/file/README.md) still does not recognize `.yardopts` and we don't have expected outputs.

### Description
<!-- Describe your changes in detail -->

Include `.yardopts` in fastlane gem to generate yardoc on rubydoc.info.

2.87.0 on rubydoc.info | Expected outputs on next releases
--- | ---
[![image](https://user-images.githubusercontent.com/932290/37858519-d96a0974-2f48-11e8-892d-affaf506177a.png)](http://www.rubydoc.info/gems/fastlane/2.87.0/file/README.md) | ![image](https://user-images.githubusercontent.com/932290/37841434-1ad36af4-2f03-11e8-8f24-8777dbbee99c.png)