### PR TITLE
Default skip_build to true in Scanfile template

### DIFF
--- a/scan/lib/assets/ScanfileTemplate
+++ b/scan/lib/assets/ScanfileTemplate
@@ -11,3 +11,6 @@
 # open_report(true)
 
 # clean(true)
+
+# Enable skip_build to skip debug builds for faster test performance
+skip_build(true)


### PR DESCRIPTION
As @kballard notes, _scan_ should not run the 'build' action by default because its output is typically unused.

We don't want to change the default option to avoid breaking existing setups, but we can at least opt new users into skipping the unnecessary build by setting the appropriate option in the default `Scanfile`. Fixes #12050.