### PR TITLE
Use Android environment to find adb (don't just rely on it being in PATH)

### DIFF
--- a/screengrab/lib/screengrab/options.rb
+++ b/screengrab/lib/screengrab/options.rb
@@ -16,7 +16,7 @@ module Screengrab
                                      short_option: "-n",
                                      optional: true,
                                      code_gen_sensitive: true,
-                                     default_value: ENV['ANDROID_HOME'] || ENV['ANDROID_SDK'],
+                                     default_value: ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK'],
                                      default_value_dynamic: true,
                                      description: "Path to the root of your Android SDK installation, e.g. ~/tools/android-sdk-macosx"),
         FastlaneCore::ConfigItem.new(key: :build_tools_version,

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -348,7 +348,8 @@ module Screengrab
     end
 
     def run_adb_command(command, print_all: false, print_command: false)
-      output = @executor.execute(command: command,
+      adb_path = @android_env.adb_path.chomp("adb")
+      output = @executor.execute(command: adb_path + command,
                                  print_all: print_all,
                                  print_command: print_command) || ''
       output.lines.reject do |line|

--- a/screengrab/spec/runner_spec.rb
+++ b/screengrab/spec/runner_spec.rb
@@ -24,6 +24,10 @@ describe Screengrab::Runner do
     let(:test_classes_to_use) { nil }
     let(:test_packages_to_use) { nil }
 
+    before do
+      expect(mock_android_environment).to receive(:adb_path).and_return("adb")
+    end
+
     context "when launch arguments are specified" do
       before do
         config[:launch_arguments] = ["username hjanuschka", "build_type x500"]
@@ -101,6 +105,10 @@ describe Screengrab::Runner do
   describe :select_device do
     let(:adb_list_devices_command) { 'adb devices -l' }
 
+    before do
+      expect(mock_android_environment).to receive(:adb_path).and_return("adb")
+    end
+
     context 'no devices' do
       it 'does not find any active devices' do
         adb_response = strip_heredoc(<<-ADB_OUTPUT)
@@ -176,6 +184,10 @@ describe Screengrab::Runner do
   end
 
   describe :run_adb_command do
+    before do
+      expect(mock_android_environment).to receive(:adb_path).and_return("adb")
+    end
+
     it 'filters out lines which are ADB warnings' do
       adb_response = strip_heredoc(<<-ADB_OUTPUT)
             adb: /home/me/rubystack-2.3.1-4/common/lib/libcrypto.so.1.0.0: no version information available (required by adb)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

screengrab currently builds up (and verifies) an android environment and then ignores it when calling adb -- assuming that adb is on the path (and failing when it isn't!).

This patch uses the android environment that has already been verified to run adb.

### Description
<!-- Describe your changes in detail -->

1. Pick up the standard Android SDK environment variable. According to https://developer.android.com/studio/command-line/variables.html the environment variable should be ANDROID_SDK_ROOT, not ANDROID_SDK.

2. Use AndroidEnvironment when calling adb: Previously adb had to be on the PATH to work, even if android_home had been configured properly and adb had been found earlier on.