### PR TITLE
[Swift] Fixes string return value and shows all lanes (even without description)

### DIFF
--- a/fastlane/lib/fastlane/lane_list.rb
+++ b/fastlane/lib/fastlane/lane_list.rb
@@ -22,13 +22,14 @@ module Fastlane
         line.strip!
         if line.start_with?("func")
           current_lane_name = self.lane_name_from_swift_line(potential_lane_line: line)
+          lanes_by_name[current_lane_name] = Fastlane::Lane.new(platform: nil, name: current_lane_name.to_sym, description: [])
         elsif line.start_with?("desc")
           lane_description = self.desc_entry_for_swift_lane(named: current_lane_name, potential_desc_line: line)
           unless lane_description
             next
           end
 
-          lanes_by_name[current_lane_name] = Fastlane::Lane.new(platform: nil, name: current_lane_name.to_sym, description: [lane_description])
+          lanes_by_name[current_lane_name].description = [lane_description]
           current_lane_name = nil
         end
       end

--- a/fastlane/lib/fastlane/server/json_return_value_processor.rb
+++ b/fastlane/lib/fastlane/server/json_return_value_processor.rb
@@ -28,8 +28,7 @@ module Fastlane
         return_value = ""
       end
 
-      # quirks_mode because sometimes the built-in library is used for some folks and that needs quirks_mode: true
-      return JSON.generate(return_value.to_s, quirks_mode: true)
+      return_value
     end
 
     def process_value_as_array_of_strings(return_value: nil)


### PR DESCRIPTION
Fixes #12167
Fixes #12170

## Wut
- When generating string return type, Ruby was trying to JSONify the string value 
  - Now it doesn't 🙃 
  - This was a side effect of https://github.com/fastlane/fastlane/pull/12065
- `fastlane lanes` wasn't returning lanes without a description
  - This was a little confusing to new users (since `desc` is optional in Ruby)

## Proof is in the pudding

### lanes before
`numberLane` has no description and it didn't show
```sh
➜  test-swift git:(master) ✗ fl lanes
[✔] 🚀

--------- general---------
----- fastlane testLane
Description of what the lane does

----- fastlane ughLane
Ugh

Execute using `fastlane [lane_name]`
```

### lanes after
`numberLane` has no description and now it shows
```sh
➜  test-swift git:(master) ✗ fl lanes
[✔] 🚀

--------- general---------
----- fastlane testLane
Description of what the lane does

----- fastlane ughLane
Ugh

----- fastlane numberLane

Execute using `fastlane [lane_name]`
```