### PR TITLE
[snapshot] Make sure matched window has a non-empty frame

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -278,4 +278,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.9]
+// SnapshotHelperVersion [1.10]

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -161,7 +161,12 @@ open class Snapshot: NSObject {
                 return
             }
             
-            let screenshot = app.windows.firstMatch.screenshot()
+            guard let window = app.windows.allElementsBoundByIndex.first(where: { $0.frame.isEmpty == false }) else {
+                print("Couldn't find an element window in XCUIApplication with a non-empty frame.")
+                return
+            }
+
+            let screenshot = window.screenshot()
             guard let simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
             let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
             do {

--- a/snapshot/spec/runner_spec.rb
+++ b/snapshot/spec/runner_spec.rb
@@ -8,7 +8,7 @@ describe Snapshot do
         allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("9.0").and_return(true)
 
         helper_version = runner.version_of_bundled_helper
-        expect(helper_version).to match(/^SnapshotHelperVersion \[\d+.\d+\]$$/)
+        expect(helper_version).to match(/^SnapshotHelperVersion \[\d+.\d+\]$/)
       end
     end
     describe 'Parses embedded SnapshotHelperXcode8.swift' do

--- a/snapshot/spec/runner_spec.rb
+++ b/snapshot/spec/runner_spec.rb
@@ -8,7 +8,7 @@ describe Snapshot do
         allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("9.0").and_return(true)
 
         helper_version = runner.version_of_bundled_helper
-        expect(helper_version).to match(/^SnapshotHelperVersion \[\d.\d\]$/)
+        expect(helper_version).to match(/^SnapshotHelperVersion \[\d+.\d+\]$$/)
       end
     end
     describe 'Parses embedded SnapshotHelperXcode8.swift' do
@@ -16,7 +16,7 @@ describe Snapshot do
         allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("9.0").and_return(false)
 
         helper_version = runner.version_of_bundled_helper
-        expect(helper_version).to match(/^SnapshotHelperXcode8Version \[\d.\d\]$/)
+        expect(helper_version).to match(/^SnapshotHelperXcode8Version \[\d+.\d+\]$/)
       end
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
When finding a window to call `screenshot()` on, the provided code in `SnapshotHelper.swift` doesn't ensure that said window has a non-empty frame. This results in the call to `screenshot()` raising the following error: `Element Window cannot request screenshot data because it has an empty frame SnapshotHelper.swift:164`

<!-- If it fixes an open issue, please link to the issue here. -->
This change solves https://github.com/fastlane/fastlane/issues/12140.

<!-- Please describe in detail how you tested your changes. -->
`SnapshotHelper.swift` does not appear to be tested at all. My apologies if this is the case and I just missed it.

### Description
<!-- Describe your changes in detail -->
Rather than using `firstMatch` on `app.windows`, we make sure that the selected window has a non-empty frame by using `allElementsBoundByIndex.first(where: { $0.frame.isEmpty == false })`.