### PR TITLE
Fix crashlytics to not autoload gsp_path if api_token is set

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -110,6 +110,8 @@ module Fastlane
       end
 
       def self.find_gsp_path(params)
+        return if params[:api_token]
+
         if params[:gsp_path].to_s.length > 0
           params[:gsp_path] = File.expand_path(params[:gsp_path])
         else

--- a/fastlane/spec/actions_specs/set_info_plist_value_spec.rb
+++ b/fastlane/spec/actions_specs/set_info_plist_value_spec.rb
@@ -16,6 +16,10 @@ describe Fastlane do
           set_info_plist_value(path: '#{plist_path}', key: 'CFBundleIdentifier', value: '#{new_value}')
         end").runner.execute(:test)
 
+        Fastlane::FastFile.new.parse("lane :test do
+          set_info_plist_value(path: '#{plist_path}', key: 'CFBundleIdentifier', value: '#{new_value}')
+        end").runner.execute(:test)
+
         value = Fastlane::FastFile.new.parse("lane :test do
           get_info_plist_value(path: '#{plist_path}', key: 'CFBundleIdentifier')
         end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -19,7 +19,7 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
-      it "uploads dSYM files" do
+      it "uploads dSYM files with api_token" do
         binary_path = './spec/fixtures/screenshots/screenshot1.png'
         dsym_path = './spec/fixtures/dSYM/Themoji.dSYM'
         gsp_path = './spec/fixtures/plist/With Space.plist'
@@ -27,6 +27,26 @@ describe Fastlane do
         command = []
         command << File.expand_path(File.join("fastlane", binary_path)).shellescape
         command << "-a something123"
+        command << "-p ios"
+        command << File.expand_path(File.join("fastlane", dsym_path)).shellescape
+
+        expect(Fastlane::Actions).to receive(:sh).with(command.join(" "), log: false)
+
+        Fastlane::FastFile.new.parse("lane :test do
+          upload_symbols_to_crashlytics(
+            dsym_path: 'fastlane/#{dsym_path}',
+            api_token: 'something123',
+            binary_path: 'fastlane/#{binary_path}')
+        end").runner.execute(:test)
+      end
+
+      it "uploads dSYM files with gsp_path" do
+        binary_path = './spec/fixtures/screenshots/screenshot1.png'
+        dsym_path = './spec/fixtures/dSYM/Themoji.dSYM'
+        gsp_path = './spec/fixtures/plist/With Space.plist'
+
+        command = []
+        command << File.expand_path(File.join("fastlane", binary_path)).shellescape
         command << "-gsp #{File.expand_path(File.join('fastlane', gsp_path)).shellescape}"
         command << "-p ios"
         command << File.expand_path(File.join("fastlane", dsym_path)).shellescape
@@ -37,12 +57,33 @@ describe Fastlane do
           upload_symbols_to_crashlytics(
             dsym_path: 'fastlane/#{dsym_path}',
             gsp_path: 'fastlane/#{gsp_path}',
-            api_token: 'something123',
+            binary_path: 'fastlane/#{binary_path}')
+        end").runner.execute(:test)
+      end
+
+      it "uploads dSYM files with auto-finding gsp_path" do
+        binary_path = './spec/fixtures/screenshots/screenshot1.png'
+        dsym_path = './spec/fixtures/dSYM/Themoji.dSYM'
+        gsp_path = './spec/fixtures/plist/GoogleService-Info.plist'
+
+        command = []
+        command << File.expand_path(File.join("fastlane", binary_path)).shellescape
+        command << "-gsp #{File.expand_path(File.join('fastlane', gsp_path)).shellescape}"
+        command << "-p ios"
+        command << File.expand_path(File.join("fastlane", dsym_path)).shellescape
+
+        expect(Fastlane::Actions).to receive(:sh).with(command.join(" "), log: false)
+
+        Fastlane::FastFile.new.parse("lane :test do
+          upload_symbols_to_crashlytics(
+            dsym_path: 'fastlane/#{dsym_path}',
             binary_path: 'fastlane/#{binary_path}')
         end").runner.execute(:test)
       end
 
       it "raises exception if no api access is given" do
+        allow(Fastlane::Actions::UploadSymbolsToCrashlyticsAction).to receive(:find_gsp_path).and_return(nil)
+
         binary_path = './spec/fixtures/screenshots/screenshot1.png'
         dsym_path = './spec/fixtures/dSYM/Themoji.dSYM'
 

--- a/fastlane/spec/fixtures/plist/GoogleService-Info.plist
+++ b/fastlane/spec/fixtures/plist/GoogleService-Info.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>App Name</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIcons</key>
+	<dict/>
+	<key>CFBundleIcons~ipad</key>
+	<dict/>
+	<key>CFBundleIdentifier</key>
+	<string>com.krausefx.app</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>App Name</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.9.14</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>com.krausefx.app</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.krausefx.app</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>0.9.14</string>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>We show your location on the map.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleDefault</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes #12132 

## Wut
- `upload_symbols_to_crashlytics` would automatically use a `gsp_path` (by searching for it in project directory) even if an `api_token` was being used
  - only one of the setting needs to be used
  - should only auto look for `gsp_path` if no `api_token`
  - using the `gsp_path` is optional but would ALWAYS be used if a `GoogleServices-Info.plist` existed in the project (even if not wanted)