### PR TITLE
Improve error message when specified scheme is not found

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -131,7 +131,7 @@ module FastlaneCore
       if options[:scheme].to_s.length > 0
         # Verify the scheme is available
         unless schemes.include?(options[:scheme].to_s)
-          UI.error("Couldn't find specified scheme '#{options[:scheme]}'.")
+          UI.error("Couldn't find specified scheme '#{options[:scheme]}'. Please make sure that the scheme is shared, see https://developer.apple.com/library/content/documentation/IDEs/Conceptual/xcode_guide-continuous_integration/ConfigureBots.html#//apple_ref/doc/uid/TP40013292-CH9-SW3")
           options[:scheme] = nil
         end
       end


### PR DESCRIPTION
Since #12027, schemes are read with Xcodeproj rather than parsed from `xcodebuild -list` output. Unlike `xcodebuild -list`, Xcodeproj reads only **shared** schemes (from [project](https://github.com/CocoaPods/Xcodeproj/blob/50e70d32d1176d14c57807c8b5adaa6f42ef38ac/lib/xcodeproj/project.rb#L780-L793)
and also from [workspace](https://github.com/CocoaPods/Xcodeproj/blob/50e70d32d1176d14c57807c8b5adaa6f42ef38ac/lib/xcodeproj/workspace.rb#L199-L204)).

As the specified scheme might exist on the user machine but not be shared, the error message is improved to suggest that the scheme must be shared with a link to Apple's documentation.