### PR TITLE
[match] Check OpenSSL version on attempt to decrypt certificates repo

### DIFF
--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -9,6 +9,10 @@ module Match
     require 'security'
     require 'shellwords'
 
+    def self.openssl_version
+      OpenSSL::OPENSSL_VERSION
+    end
+
     def server_name(git_url)
       ["match", git_url].join("_")
     end

--- a/match/spec/git_helper_spec.rb
+++ b/match/spec/git_helper_spec.rb
@@ -139,8 +139,161 @@ describe Match do
         expect(File.exist?(File.join(result, 'README.md'))).to eq(false) # because the README is being added when committing the changes now
       end
 
+      it "throws error if OpenSSL versions do not match" do
+        path = Dir.mktmpdir # to have access to the actual path
+        expect(Dir).to receive(:mktmpdir).and_return(path)
+        git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
+        shallow_clone = false
+        command = "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{path}'"
+        to_params = {
+          command: command,
+          print_all: nil,
+          print_command: nil
+        }
+
+        expect(FastlaneCore::CommandExecutor).
+          to receive(:execute).
+          with(to_params).
+          and_return(nil)
+
+        expect(File).
+          to receive(:exist?).
+          with(File.join(path, "openssl_version.txt")).
+          and_return(true)
+        expect(File).
+          to receive(:read).
+          with(File.join(path, "openssl_version.txt")).
+          and_return("TooOldSSL")
+        allow(Match::Encrypt).
+          to receive(:openssl_version).
+          and_return("OpenSSL 1.0.2k  26 Jan 2017")
+
+        expect(UI).
+          to receive(:user_error!).
+          with("Repository was encrypted using 'TooOldSSL' and currently used version is 'OpenSSL 1.0.2k  26 Jan 2017'")
+        Match::GitHelper.clone(git_url, shallow_clone)
+      end
+
       after(:each) do
         Match::GitHelper.clear_changes
+      end
+    end
+
+    describe "#commit_changes" do
+      before(:each) do
+        allow(Dir).
+          to receive(:chdir).
+          and_yield
+        allow_any_instance_of(Module).
+          to receive(:`).
+          and_return("Uncommited changes exist")
+        allow_any_instance_of(Match::Encrypt).to receive(:encrypt_repo)
+        allow(Match::Encrypt)
+          .to receive(:openssl_version)
+          .and_return("OpenSSL 1.0.2k  26 Jan 2017")
+        allow(File).
+          to receive(:read).
+          and_return("template")
+
+        allow(File).
+          to receive(:exist?).
+          with("match_version.txt").
+          and_return(true)
+        allow(File).
+          to receive(:read).
+          and_return(Fastlane::VERSION.to_s)
+
+        allow(File).
+          to receive(:exist?).
+          with("README.md").
+          and_return(true)
+
+        allow(FileUtils).to receive(:rm_rf)
+
+        to_params = {
+          command: "git add file1",
+          print_all: nil,
+          print_command: nil
+        }
+        expect(FastlaneCore::CommandExecutor).
+          to receive(:execute).
+          with(to_params)
+
+        to_params = {
+          command: "git commit -m message",
+          print_all: nil,
+          print_command: nil
+        }
+        expect(FastlaneCore::CommandExecutor).
+          to receive(:execute).
+          with(to_params)
+
+        to_params = {
+          command: "GIT_TERMINAL_PROMPT=0 git push origin master",
+          print_all: nil,
+          print_command: nil
+        }
+        expect(FastlaneCore::CommandExecutor).
+          to receive(:execute).
+          with(to_params)
+      end
+
+      it "creates openssl version file and commits it if it didn't exist" do
+        expect(File).
+          to receive(:exist?).
+          with("openssl_version.txt").
+          and_return(false)
+        expect(File).
+          to receive(:write).
+          with("openssl_version.txt", "OpenSSL 1.0.2k  26 Jan 2017")
+        to_params = {
+          command: "git add openssl_version.txt",
+          print_all: nil,
+          print_command: nil
+        }
+        expect(FastlaneCore::CommandExecutor).
+          to receive(:execute).
+          with(to_params).
+          and_return(nil)
+
+        Match::GitHelper.commit_changes("path", "message", "git_url", "master", ["file1"])
+      end
+
+      it "updates openssl version file and commits it if version has changed" do
+        expect(File).
+          to receive(:exist?).
+          with("openssl_version.txt").
+          and_return(true)
+        expect(File).
+          to receive(:read).
+          with("openssl_version.txt").
+          and_return("TooOldSSL 0.0.1")
+        expect(File).
+          to receive(:write).
+          with("openssl_version.txt", "OpenSSL 1.0.2k  26 Jan 2017")
+        to_params = {
+          command: "git add openssl_version.txt",
+          print_all: nil,
+          print_command: nil
+        }
+        expect(FastlaneCore::CommandExecutor).
+          to receive(:execute).
+          with(to_params).
+          and_return(nil)
+
+        Match::GitHelper.commit_changes("path", "message", "git_url", "master", ["file1"])
+      end
+
+      it "not updates openssl version file" do
+        expect(File).
+          to receive(:exist?).
+          with("openssl_version.txt").
+          and_return(true)
+        expect(File).
+          to receive(:read).
+          with("openssl_version.txt").
+          and_return("OpenSSL 1.0.2k  26 Jan 2017")
+        Match::GitHelper.commit_changes("path", "message", "git_url", "master", ["file1"])
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #12149.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
Checks if repo was encrypted with the currently used OpenSSL version if OpenSSL version file exists. Backwards compatible as missing file is ignored.
Introduces step to create the OpenSSL version file on commit+push action.

Written some unit tests, they're quite messy I guess as I don't have much experience working with ruby & RSpec. So any advice is more than welcomed!
In addition I've tested it in mocked environment, works fine.

Questionable:
* checks for exact OpenSSL version (e.g `OpenSSL 1.0.2k  26 Jan 2017`) instead of developer (?) (e.g `OpenSSL`)
* ignores missing OpenSSL version file making this backwards compatible
* raises OpenSSL mismatch issue instead of doing something clever
* unit tests have some hardcoded values 
<!-- Describe your changes in detail -->