### PR TITLE
Version bump to 2.88.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,23 +32,23 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 
 <table id='team'>
 <tr>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
 <td id='stefan-natchev'>
 <a href='https://github.com/snatchev'>
 <img src='https://github.com/snatchev.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
@@ -56,14 +56,84 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/DanToml'>
+<img src='https://github.com/DanToml.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+</td>
+</tr>
+<tr>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+</tr>
+<tr>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
 <td id='andrew-mcburney'>
 <a href='https://github.com/AndrewMcBurney'>
 <img src='https://github.com/AndrewMcBurney.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
 </tr>
 <tr>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
 <td id='jorge-revuelta-h'>
 <a href='https://github.com/minuscorp'>
 <img src='https://github.com/minuscorp.png?size=140'>
@@ -76,81 +146,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-</tr>
-<tr>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
 <td id='joshua-liebowitz'>
 <a href='https://github.com/taquitos'>
 <img src='https://github.com/taquitos.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-</tr>
-<tr>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/DanToml'>
-<img src='https://github.com/DanToml.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
 </td>
 <td id='maksym-grebenets'>
 <a href='https://github.com/mgrebenets'>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -14,26 +14,26 @@ File.write("#{lib}/fastlane/plugins/template/.rubocop.yml", YAML.dump(config))
 Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
-  spec.authors       = ["Olivier Halligon",
+  spec.authors       = ["Kohki Miki",
+                        "Helmut Januschka",
                         "Joshua Liebowitz",
+                        "Jan Piotrowski",
+                        "Jorge Revuelta H",
                         "Maksym Grebenets",
+                        "Danielle Tomlinson",
+                        "Olivier Halligon",
+                        "Fumiya Nakamura",
+                        "Felix Krause",
+                        "Manu Wallner",
+                        "Andrew McBurney",
+                        "Matthew Ellis",
+                        "Jimmy Dee",
+                        "Iulian Onofrei",
                         "Stefan Natchev",
                         "Jérôme Lacoste",
-                        "Jorge Revuelta H",
-                        "Andrew McBurney",
-                        "Iulian Onofrei",
-                        "Fumiya Nakamura",
-                        "Jan Piotrowski",
-                        "Aaron Brager",
-                        "Jimmy Dee",
-                        "Manu Wallner",
-                        "Felix Krause",
-                        "Kohki Miki",
-                        "Helmut Januschka",
-                        "Luka Mirosevic",
-                        "Danielle Tomlinson",
                         "Josh Holtz",
-                        "Matthew Ellis"]
+                        "Luka Mirosevic",
+                        "Aaron Brager"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.87.0'.freeze
+  VERSION = '2.88.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.87.0
+// Generated with fastlane 2.88.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1599,8 +1599,12 @@ func gitSubmoduleUpdate(recursive: Bool = false,
                                                                                                       RubyCommand.Argument(name: "init", value: `init`)])
   _ = runner.executeCommand(command)
 }
-func gitTagExists(tag: String) {
-  let command = RubyCommand(commandID: "", methodName: "git_tag_exists", className: nil, args: [RubyCommand.Argument(name: "tag", value: tag)])
+func gitTagExists(tag: String,
+                  remote: Bool = false,
+                  remoteName: String = "origin") {
+  let command = RubyCommand(commandID: "", methodName: "git_tag_exists", className: nil, args: [RubyCommand.Argument(name: "tag", value: tag),
+                                                                                                RubyCommand.Argument(name: "remote", value: remote),
+                                                                                                RubyCommand.Argument(name: "remote_name", value: remoteName)])
   _ = runner.executeCommand(command)
 }
 func githubApi(serverUrl: String = "https://api.github.com",
@@ -3913,4 +3917,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.10]
+// FastlaneRunnerAPIVersion [0.9.11]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.87.0
+// Generated with fastlane 2.88.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.87.0
+// Generated with fastlane 2.88.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.87.0
+// Generated with fastlane 2.88.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.87.0
+// Generated with fastlane 2.88.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.87.0
+// Generated with fastlane 2.88.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.87.0
+// Generated with fastlane 2.88.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.87.0':**

* Fix crashlytics to not autoload gsp_path if api_token is set (#12176) via Josh Holtz
* Improve error message when specified scheme is not found (#12182) via Cédric Luthi
* Support checking remote git tags existence (#11675) via Takeru Chuganji
* Add new rspecs for verify_build action (#12157) via Maksym Grebenets
* Use Android environment to find adb (don't just rely on it being in PATH) (#12168) via Adam Cohen-Rose
* [snapshot] Make sure matched window has a non-empty frame (#12174) via François Pradel
* [Swift] Fixes string return value and shows all lanes (even without description) (#12171) via Josh Holtz
* Default skip_build to true in Scanfile template (#12162) via Aaron Brager
* Include .yardopts in fastlane gem (#12156) via Fumiya Nakamura
