### PR TITLE
Make enable_automatic_code_signing more robust to xcodeproj conf

### DIFF
--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -40,9 +40,12 @@ module Fastlane
           end
           if params[:code_sign_identity]
             build_configuration_list.set_setting("CODE_SIGN_IDENTITY", params[:code_sign_identity])
-            build_configuration_list.set_setting("CODE_SIGN_IDENTITY[sdk=*]", params[:code_sign_identity])
-            build_configuration_list.set_setting("CODE_SIGN_IDENTITY[sdk=iphoneos*]", params[:code_sign_identity])
-            build_configuration_list.set_setting("CODE_SIGN_IDENTITY[sdk=appletvos*]", params[:code_sign_identity])
+
+            # We also need to update the value if it was overriden for a specific SDK
+            build_configuration_list.build_configurations.each do |build_configuration|
+              codesign_build_settings_keys = build_configuration.build_settings.keys.select { |key| key.to_s.match(/CODE_SIGN_IDENTITY.*/) }
+              codesign_build_settings_keys.map { |key| build_configuration_list.set_setting(key, params[:code_sign_identity]) }
+            end
             UI.important("Set Code Sign identity to: #{params[:code_sign_identity]} for target: #{found_target[:name]}")
           end
           if params[:profile_name]

--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -40,6 +40,9 @@ module Fastlane
           end
           if params[:code_sign_identity]
             build_configuration_list.set_setting("CODE_SIGN_IDENTITY", params[:code_sign_identity])
+            build_configuration_list.set_setting("CODE_SIGN_IDENTITY[sdk=*]", params[:code_sign_identity])
+            build_configuration_list.set_setting("CODE_SIGN_IDENTITY[sdk=iphoneos*]", params[:code_sign_identity])
+            build_configuration_list.set_setting("CODE_SIGN_IDENTITY[sdk=appletvos*]", params[:code_sign_identity])
             UI.important("Set Code Sign identity to: #{params[:code_sign_identity]} for target: #{found_target[:name]}")
           end
           if params[:profile_name]

--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -44,7 +44,9 @@ module Fastlane
             # We also need to update the value if it was overriden for a specific SDK
             build_configuration_list.build_configurations.each do |build_configuration|
               codesign_build_settings_keys = build_configuration.build_settings.keys.select { |key| key.to_s.match(/CODE_SIGN_IDENTITY.*/) }
-              codesign_build_settings_keys.map { |key| build_configuration_list.set_setting(key, params[:code_sign_identity]) }
+              codesign_build_settings_keys.each do |setting|
+                build_configuration_list.set_setting(setting, params[:code_sign_identity])
+              end
             end
             UI.important("Set Code Sign identity to: #{params[:code_sign_identity]} for target: #{found_target[:name]}")
           end

--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -128,6 +128,15 @@ describe Fastlane do
         target.build_configuration_list.get_setting("CODE_SIGN_IDENTITY").map do |build_config, value|
           expect(value).to eq("iPhone Distribution")
         end
+        target.build_configuration_list.get_setting("CODE_SIGN_IDENTITY[sdk=*]").map do |build_config, value|
+          expect(value).to eq("iPhone Distribution")
+        end
+        target.build_configuration_list.get_setting("CODE_SIGN_IDENTITY[sdk=iphoneos*]").map do |build_config, value|
+          expect(value).to eq("iPhone Distribution")
+        end
+        target.build_configuration_list.get_setting("CODE_SIGN_IDENTITY[sdk=appletvos*]").map do |build_config, value|
+          expect(value).to eq("iPhone Distribution")
+        end
       end
     end
 

--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -128,13 +128,8 @@ describe Fastlane do
         target.build_configuration_list.get_setting("CODE_SIGN_IDENTITY").map do |build_config, value|
           expect(value).to eq("iPhone Distribution")
         end
-        target.build_configuration_list.get_setting("CODE_SIGN_IDENTITY[sdk=*]").map do |build_config, value|
-          expect(value).to eq("iPhone Distribution")
-        end
+        next unless target.name == 'demo'
         target.build_configuration_list.get_setting("CODE_SIGN_IDENTITY[sdk=iphoneos*]").map do |build_config, value|
-          expect(value).to eq("iPhone Distribution")
-        end
-        target.build_configuration_list.get_setting("CODE_SIGN_IDENTITY[sdk=appletvos*]").map do |build_config, value|
           expect(value).to eq("iPhone Distribution")
         end
       end

--- a/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
@@ -393,6 +393,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;


### PR DESCRIPTION
### Motivation and Context
In some cases, and it happens when automatic codesign was enabled, disabled and the reenabled the xcodeproj specifies the code_sign_identity for specific SDK. (tested on a clean project)

<img width="678" alt="screen shot 2018-03-27 at 22 54 31" src="https://user-images.githubusercontent.com/1089363/37994443-db1006fe-3211-11e8-89a2-b1b499c85821.png">

In that case the `disable_automatic_code_signing(code_sign_identity: 'iPhone Distribution')` (which is usually what you need) will not work since it will set the Distribution value for the high level paramter but not for the specific SDK

### Description
The PR enforce the requested code_sign_identity for any supported SDK (except macOS and simulators) to make it more robust toward xcodeproj configurations