### PR TITLE
[WIP] remove emoji from changelog

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -95,6 +95,8 @@ Gem::Specification.new do |spec|
   # If you upgrade this gem, make sure to upgrade the users of it as well.
   spec.add_dependency('google-api-client', '>= 0.13.1', '< 0.14.0') # Google API Client to access Play Publishing API
 
+  spec.add_dependency('emoji_regex', '~> 0.1') # Used to scan for Emoji in the changelog
+
   # Development only
   spec.add_development_dependency('rake', '< 12')
   spec.add_development_dependency('rspec', '~> 3.5.0')

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -131,13 +131,17 @@ module Pilot
       changelog
     end
 
-    def self.sanitize_changelog(changelog)
-      changelog = truncate_changelog(changelog)
+    def self.strip_emoji(changelog)
       if changelog && changelog =~ EmojiRegex::Regex
         changelog.gsub!(EmojiRegex::Regex, "")
         UI.important("Emoji symbols have been removed from the changelog, since they're not allowed by Apple.")
       end
       changelog
+    end
+
+    def self.sanitize_changelog(changelog)
+      changelog = strip_emoji(changelog)
+      truncate_changelog(changelog)
     end
 
     private

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -1,5 +1,6 @@
 require 'tmpdir'
 require 'terminal-table'
+require 'emoji_regex'
 
 require 'fastlane_core/itunes_transporter'
 require 'fastlane_core/build_watcher'
@@ -11,7 +12,7 @@ module Pilot
     def upload(options)
       start(options)
 
-      options[:changelog] = self.class.truncate_changelog(options[:changelog]) if options[:changelog]
+      options[:changelog] = self.class.sanitize_changelog(options[:changelog]) if options[:changelog]
 
       UI.user_error!("No ipa file given") unless config[:ipa]
 
@@ -127,7 +128,16 @@ module Pilot
         changelog = "#{changelog[0...max_changelog_length - bottom_message.length]}#{bottom_message}"
         UI.important("Changelog has been truncated since it exceeds Apple's #{max_changelog_length} character limit. It currently contains #{original_length} characters.")
       end
-      return changelog
+      changelog
+    end
+
+    def self.sanitize_changelog(changelog)
+      changelog = truncate_changelog(changelog)
+      if changelog && changelog =~ EmojiRegex::Regex
+        changelog.gsub!(EmojiRegex::Regex, "")
+        UI.important("Emoji symbols have been removed from the changelog, since they're not allowed by Apple.")
+      end
+      changelog
     end
 
     private

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -1,12 +1,27 @@
 describe "Build Manager" do
-  it "Truncates Changelog" do
-    changelog = File.read("./pilot/spec/fixtures/build_manager/changelog_long")
-    changelog = Pilot::BuildManager.truncate_changelog(changelog)
-    expect(changelog).to eq(File.read("./pilot/spec/fixtures/build_manager/changelog_long_truncated"))
+  describe ".truncate_changelog" do
+    it "Truncates Changelog" do
+      changelog = File.read("./pilot/spec/fixtures/build_manager/changelog_long")
+      changelog = Pilot::BuildManager.truncate_changelog(changelog)
+      expect(changelog).to eq(File.read("./pilot/spec/fixtures/build_manager/changelog_long_truncated"))
+    end
+    it "Keeps changelog if short enough" do
+      changelog = "1234"
+      changelog = Pilot::BuildManager.truncate_changelog(changelog)
+      expect(changelog).to eq("1234")
+    end
   end
-  it "Keeps changelog if short enough" do
-    changelog = "1234"
-    changelog = Pilot::BuildManager.truncate_changelog(changelog)
-    expect(changelog).to eq("1234")
+  describe ".sanitize_changelog" do
+    it "removes emoji" do
+      changelog = "I'm 🦇B🏧an!"
+      changelog = Pilot::BuildManager.sanitize_changelog(changelog)
+      expect(changelog).to eq("I'm Ban!")
+    end
+    it "removes emoji before truncating" do
+      changelog = File.read("./pilot/spec/fixtures/build_manager/changelog_long")
+      changelog = "🎉🎉🎉#{changelog}"
+      changelog = Pilot::BuildManager.sanitize_changelog(changelog)
+      expect(changelog).to eq(File.read("./pilot/spec/fixtures/build_manager/changelog_long_truncated"))
+    end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

When trying to submit a changelog containing emoji, the request fails with a response similar to:

```
ERROR-1: What to Test can't contain the following characters: ?.; ERROR-1: What to Test can't contain the following characters: ?.; ERROR-1: What to Test can't contain the following characters: ?.
```

### Description

Apple doesn't allow emoji to be used in the changelog value

WIP because the regex has to be updated to apply to a broader range of emoji, or maybe there's a gem that can do the heavy lifting for us.
