### PR TITLE
Added option to set path to lint using swiftlint action

### DIFF
--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -80,7 +80,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :path,
                                        description: "Specify path to lint",
                                        is_string: true,
-                                       optional: true),
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Couldn't find path '#{File.expand_path(value)}'") unless File.exist?(value)
+                                       end),
           FastlaneCore::ConfigItem.new(key: :output_file,
                                        description: 'Path to output SwiftLint result',
                                        optional: true),

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -13,6 +13,7 @@ module Fastlane
 
         command = (params[:executable] || "swiftlint").dup
         command << " #{params[:mode]}"
+        command << " --path #{params[:path].shellescape}" if params[:path]
         command << supported_option_switch(params, :strict, "0.9.2", true)
         command << " --config #{params[:config_file].shellescape}" if params[:config_file]
         command << " --reporter #{params[:reporter]}" if params[:reporter]
@@ -76,6 +77,10 @@ module Fastlane
                                        is_string: false,
                                        default_value: :lint,
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       description: "Specify path to lint",
+                                       is_string: true,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :output_file,
                                        description: 'Path to output SwiftLint result',
                                        optional: true),
@@ -131,6 +136,7 @@ module Fastlane
         [
           'swiftlint(
             mode: :lint,                          # SwiftLint mode: :lint (default) or :autocorrect
+            path: "/path/to/lint"                 # Specify path to lint (optional)
             output_file: "swiftlint.result.json", # The path of the output file (optional)
             config_file: ".swiftlint-ci.yml",     # The path of the configuration file (optional)
             files: [                              # List of files to process (optional)

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -122,7 +122,7 @@ describe Fastlane do
                 path: '#{path}'
               )
             end").runner.execute(:test)
-          end.to raise_error(%r{Couldn't find path '.*#{path}'})
+          end.to raise_error(/Couldn't find path '.*#{path}'/)
         end
       end
 

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -103,7 +103,7 @@ describe Fastlane do
 
       context "when specify path options" do
         it "adds path option" do
-          path = "spec/fixtures"
+          path = "./spec/fixtures"
           result = Fastlane::FastFile.new.parse("
             lane :test do
               swiftlint(
@@ -115,14 +115,14 @@ describe Fastlane do
         end
 
         it "adds invalid path option" do
-          path = "/path/to/lint"
+          path = "./non/existent/path"
           expect do
             Fastlane::FastFile.new.parse("lane :test do
               swiftlint(
                 path: '#{path}'
               )
             end").runner.execute(:test)
-          end.to raise_error("Couldn't find path '#{path}'")
+          end.to raise_error(%r{Couldn't find path '.*#{path}'})
         end
       end
 

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -4,6 +4,7 @@ describe Fastlane do
       let(:swiftlint_gem_version) { Gem::Version.new('0.9.2') }
       let(:output_file) { "swiftlint.result.json" }
       let(:config_file) { ".swiftlint-ci.yml" }
+      let(:path) { "/path/to/lint" }
 
       before :each do
         allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(swiftlint_gem_version)
@@ -98,6 +99,18 @@ describe Fastlane do
           end").runner.execute(:test)
 
           expect(result).to eq("swiftlint lint --strict --config #{config_file} > #{output_file}")
+        end
+      end
+
+      context "when specify path options" do
+        it "adds path option" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              path: '#{path}'
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint --path #{path}")
         end
       end
 

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -4,7 +4,6 @@ describe Fastlane do
       let(:swiftlint_gem_version) { Gem::Version.new('0.9.2') }
       let(:output_file) { "swiftlint.result.json" }
       let(:config_file) { ".swiftlint-ci.yml" }
-      let(:path) { "/path/to/lint" }
 
       before :each do
         allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(swiftlint_gem_version)
@@ -104,13 +103,26 @@ describe Fastlane do
 
       context "when specify path options" do
         it "adds path option" do
-          result = Fastlane::FastFile.new.parse("lane :test do
-            swiftlint(
-              path: '#{path}'
-            )
-          end").runner.execute(:test)
+          path = "spec/fixtures"
+          result = Fastlane::FastFile.new.parse("
+            lane :test do
+              swiftlint(
+                path: '#{path}'
+              )
+            end").runner.execute(:test)
 
           expect(result).to eq("swiftlint lint --path #{path}")
+        end
+
+        it "adds invalid path option" do
+          path = "/path/to/lint"
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              swiftlint(
+                path: '#{path}'
+              )
+            end").runner.execute(:test)
+          end.to raise_error("Couldn't find path '#{path}'")
         end
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Currently we can use `swiftlint` action to run in the current folder, but if you want to run `swiftlint` only in a specific subfolder or other path outside of the current path is not possible.

This PR adds the option `path` to `swiftlint` action, so now it's possible to specify the path you want to run following the default behaviour of `swiflint` treatment for this specific folder.

I didn't find any issue related.