### PR TITLE
[adb] Pick up ANDROID_SDK_ROOT environment variable

### DIFF
--- a/fastlane/lib/fastlane/actions/adb.rb
+++ b/fastlane/lib/fastlane/actions/adb.rb
@@ -1,5 +1,3 @@
-require 'pathname'
-
 module Fastlane
   module Actions
     module SharedValues
@@ -7,11 +5,7 @@ module Fastlane
 
     class AdbAction < Action
       def self.run(params)
-        adb_path = params[:adb_path]
-        if adb_path == "adb" && params[:android_home]
-          adb_path = Pathname.new(params[:android_home]).join("platform-tools/adb").to_s
-        end
-        adb = Helper::AdbHelper.new(adb_path: adb_path)
+        adb = Helper::AdbHelper.new(adb_path: params[:adb_path])
         result = adb.trigger(command: params[:command], serial: params[:serial])
         return result
       end
@@ -42,15 +36,10 @@ module Fastlane
                                        description: "All commands you want to pass to the adb command, e.g. `kill-server`",
                                        optional: true,
                                        is_string: true),
-          FastlaneCore::ConfigItem.new(key: :android_home,
-                                       optional: true,
-                                       default_value: ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK'],
-                                       default_value_dynamic: true,
-                                       description: "Path to the root of your Android SDK installation, e.g. ~/tools/android-sdk-macosx"),
           FastlaneCore::ConfigItem.new(key: :adb_path,
                                        env_name: "FL_ADB_PATH",
                                        optional: true,
-                                       description: "The path to your `adb` binary",
+                                       description: "The path to your `adb` binary (can be left blank if the ANDROID_SDK_ROOT environment variable is set)",
                                        is_string: true,
                                        default_value: "adb")
         ]

--- a/fastlane/lib/fastlane/actions/adb.rb
+++ b/fastlane/lib/fastlane/actions/adb.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 module Fastlane
   module Actions
     module SharedValues
@@ -5,7 +7,11 @@ module Fastlane
 
     class AdbAction < Action
       def self.run(params)
-        adb = Helper::AdbHelper.new(adb_path: params[:adb_path])
+        adb_path = params[:adb_path]
+        if adb_path == "adb" && params[:android_home]
+          adb_path = Pathname.new(params[:android_home]).join("platform-tools/adb").to_s
+        end
+        adb = Helper::AdbHelper.new(adb_path: adb_path)
         result = adb.trigger(command: params[:command], serial: params[:serial])
         return result
       end
@@ -36,6 +42,11 @@ module Fastlane
                                        description: "All commands you want to pass to the adb command, e.g. `kill-server`",
                                        optional: true,
                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :android_home,
+                                       optional: true,
+                                       default_value: ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK'],
+                                       default_value_dynamic: true,
+                                       description: "Path to the root of your Android SDK installation, e.g. ~/tools/android-sdk-macosx"),
           FastlaneCore::ConfigItem.new(key: :adb_path,
                                        env_name: "FL_ADB_PATH",
                                        optional: true,

--- a/fastlane/lib/fastlane/actions/adb_devices.rb
+++ b/fastlane/lib/fastlane/actions/adb_devices.rb
@@ -5,11 +5,7 @@ module Fastlane
 
     class AdbDevicesAction < Action
       def self.run(params)
-        adb_path = params[:adb_path]
-        if adb_path == "adb" && params[:android_home]
-          adb_path = Pathname.new(params[:android_home]).join("platform-tools/adb").to_s
-        end
-        adb = Helper::AdbHelper.new(adb_path: adb_path)
+        adb = Helper::AdbHelper.new(adb_path: params[:adb_path])
         result = adb.load_all_devices
         return result
       end
@@ -30,14 +26,9 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :android_home,
-                                       optional: true,
-                                       default_value: ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK'],
-                                       default_value_dynamic: true,
-                                       description: "Path to the root of your Android SDK installation, e.g. ~/tools/android-sdk-macosx"),
           FastlaneCore::ConfigItem.new(key: :adb_path,
                                        env_name: "FL_ADB_PATH",
-                                       description: "The path to your `adb` binary",
+                                       description: "The path to your `adb` binary (can be left blank if the ANDROID_SDK_ROOT environment variable is set)",
                                        is_string: true,
                                        optional: true,
                                        default_value: "adb")

--- a/fastlane/lib/fastlane/actions/adb_devices.rb
+++ b/fastlane/lib/fastlane/actions/adb_devices.rb
@@ -5,7 +5,11 @@ module Fastlane
 
     class AdbDevicesAction < Action
       def self.run(params)
-        adb = Helper::AdbHelper.new(adb_path: params[:adb_path])
+        adb_path = params[:adb_path]
+        if adb_path == "adb" && params[:android_home]
+          adb_path = Pathname.new(params[:android_home]).join("platform-tools/adb").to_s
+        end
+        adb = Helper::AdbHelper.new(adb_path: adb_path)
         result = adb.load_all_devices
         return result
       end
@@ -26,6 +30,11 @@ module Fastlane
 
       def self.available_options
         [
+          FastlaneCore::ConfigItem.new(key: :android_home,
+                                       optional: true,
+                                       default_value: ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK'],
+                                       default_value_dynamic: true,
+                                       description: "Path to the root of your Android SDK installation, e.g. ~/tools/android-sdk-macosx"),
           FastlaneCore::ConfigItem.new(key: :adb_path,
                                        env_name: "FL_ADB_PATH",
                                        description: "The path to your `adb` binary",

--- a/fastlane/lib/fastlane/helper/adb_helper.rb
+++ b/fastlane/lib/fastlane/helper/adb_helper.rb
@@ -16,6 +16,10 @@ module Fastlane
       attr_accessor :devices
 
       def initialize(adb_path: nil)
+        android_home = ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK']
+        if (adb_path == nil || adb_path == "adb") && android_home
+          adb_path = Pathname.new(android_home).join("platform-tools/adb").to_s
+        end
         self.adb_path = adb_path
       end
 

--- a/fastlane/lib/fastlane/helper/adb_helper.rb
+++ b/fastlane/lib/fastlane/helper/adb_helper.rb
@@ -17,7 +17,7 @@ module Fastlane
 
       def initialize(adb_path: nil)
         android_home = ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK']
-        if (adb_path == nil || adb_path == "adb") && android_home
+        if (adb_path.nil? || adb_path == "adb") && android_home
           adb_path = Pathname.new(android_home).join("platform-tools/adb").to_s
         end
         self.adb_path = adb_path

--- a/fastlane/spec/actions_specs/adb_devices_spec.rb
+++ b/fastlane/spec/actions_specs/adb_devices_spec.rb
@@ -3,7 +3,15 @@ describe Fastlane do
     describe "adb_devices" do
       it "generates a valid command" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          adb_devices(adb_path: './fastlane/README.md')
+          adb_devices(adb_path: '/some/path/to/adb')
+        end").runner.execute(:test)
+
+        expect(result).to match_array([])
+      end
+
+      it "generates a valid command with android_home" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb_devices(android_home: '/usr/local/android-sdk')
         end").runner.execute(:test)
 
         expect(result).to match_array([])

--- a/fastlane/spec/actions_specs/adb_devices_spec.rb
+++ b/fastlane/spec/actions_specs/adb_devices_spec.rb
@@ -9,9 +9,10 @@ describe Fastlane do
         expect(result).to match_array([])
       end
 
-      it "generates a valid command with android_home" do
+      it "generates a valid command when ANDROID_SDK_ROOT is set" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          adb_devices(android_home: '/usr/local/android-sdk')
+          ENV['ANDROID_SDK_ROOT'] = '/usr/local/android-sdk'
+          adb_devices()
         end").runner.execute(:test)
 
         expect(result).to match_array([])

--- a/fastlane/spec/actions_specs/adb_spec.rb
+++ b/fastlane/spec/actions_specs/adb_spec.rb
@@ -9,9 +9,10 @@ describe Fastlane do
         expect(result).to eq(" ./fastlane/README.md test")
       end
 
-      it "picks up path from android_home" do
+      it "picks up path from ANDROID_SDK_ROOT environment variable" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          adb(command: 'test', android_home: '/usr/local/android-sdk')
+          ENV['ANDROID_SDK_ROOT'] = '/usr/local/android-sdk'
+          adb(command: 'test')
         end").runner.execute(:test)
 
         expect(result).to eq(" /usr/local/android-sdk/platform-tools/adb test")

--- a/fastlane/spec/actions_specs/adb_spec.rb
+++ b/fastlane/spec/actions_specs/adb_spec.rb
@@ -15,7 +15,6 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result).to eq(" /usr/local/android-sdk/platform-tools/adb test")
-
       end
     end
   end

--- a/fastlane/spec/actions_specs/adb_spec.rb
+++ b/fastlane/spec/actions_specs/adb_spec.rb
@@ -8,6 +8,15 @@ describe Fastlane do
 
         expect(result).to eq(" ./fastlane/README.md test")
       end
+
+      it "picks up path from android_home" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'test', android_home: '/usr/local/android-sdk')
+        end").runner.execute(:test)
+
+        expect(result).to eq(" /usr/local/android-sdk/platform-tools/adb test")
+
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
Pick up ANDROID_SDK_ROOT for adb and adb_devices actions so they don't need the path to the specific adb binary.

### Description
<!-- Describe your changes in detail -->
Add a new `android_home` parameter for the `adb` and `adb_devices` actions which default to the ANDROID_SDK_ROOT environment variable.