### PR TITLE
Version bump to 2.89.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,38 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 
 <table id='team'>
 <tr>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
 <td id='stefan-natchev'>
 <a href='https://github.com/snatchev'>
 <img src='https://github.com/snatchev.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+</tr>
+<tr>
 <td id='josh-holtz'>
 <a href='https://github.com/joshdholtz'>
 <img src='https://github.com/joshdholtz.png?size=140'>
@@ -50,11 +76,49 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/AndrewMcBurney'>
+<img src='https://github.com/AndrewMcBurney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+</tr>
+<tr>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
 <img src='https://github.com/hjanuschka.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
 <td id='danielle-tomlinson'>
 <a href='https://github.com/DanToml'>
@@ -64,43 +128,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
 <td id='felix-krause'>
 <a href='https://github.com/KrauseFx'>
 <img src='https://github.com/KrauseFx.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-</tr>
-<tr>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
 <td id='olivier-halligon'>
 <a href='https://github.com/AliSoftware'>
@@ -108,49 +140,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
 </td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/AndrewMcBurney'>
-<img src='https://github.com/AndrewMcBurney.png?size=140'>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-</tr>
-<tr>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+<h4 align='center'>Jimmy Dee</h4>
 </td>
 <td id='maksym-grebenets'>
 <a href='https://github.com/mgrebenets'>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -14,26 +14,26 @@ File.write("#{lib}/fastlane/plugins/template/.rubocop.yml", YAML.dump(config))
 Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
-  spec.authors       = ["Kohki Miki",
-                        "Helmut Januschka",
-                        "Joshua Liebowitz",
-                        "Jan Piotrowski",
+  spec.authors       = ["Manu Wallner",
                         "Jorge Revuelta H",
-                        "Maksym Grebenets",
-                        "Danielle Tomlinson",
                         "Olivier Halligon",
-                        "Fumiya Nakamura",
-                        "Felix Krause",
-                        "Manu Wallner",
-                        "Andrew McBurney",
                         "Matthew Ellis",
-                        "Jimmy Dee",
-                        "Iulian Onofrei",
-                        "Stefan Natchev",
                         "Jérôme Lacoste",
+                        "Danielle Tomlinson",
+                        "Helmut Januschka",
+                        "Felix Krause",
+                        "Joshua Liebowitz",
                         "Josh Holtz",
+                        "Iulian Onofrei",
+                        "Jan Piotrowski",
+                        "Aaron Brager",
+                        "Jimmy Dee",
                         "Luka Mirosevic",
-                        "Aaron Brager"]
+                        "Kohki Miki",
+                        "Stefan Natchev",
+                        "Maksym Grebenets",
+                        "Fumiya Nakamura",
+                        "Andrew McBurney"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.88.0'.freeze
+  VERSION = '2.89.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.88.0
+// Generated with fastlane 2.89.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -2487,12 +2487,14 @@ func registerDevices(devices: [String : Any]? = nil,
                      devicesFile: String? = nil,
                      teamId: String? = nil,
                      teamName: String? = nil,
-                     username: String) {
+                     username: String,
+                     platform: String = "ios") {
   let command = RubyCommand(commandID: "", methodName: "register_devices", className: nil, args: [RubyCommand.Argument(name: "devices", value: devices),
                                                                                                   RubyCommand.Argument(name: "devices_file", value: devicesFile),
                                                                                                   RubyCommand.Argument(name: "team_id", value: teamId),
                                                                                                   RubyCommand.Argument(name: "team_name", value: teamName),
-                                                                                                  RubyCommand.Argument(name: "username", value: username)])
+                                                                                                  RubyCommand.Argument(name: "username", value: username),
+                                                                                                  RubyCommand.Argument(name: "platform", value: platform)])
   _ = runner.executeCommand(command)
 }
 func resetGitRepo(files: String? = nil,
@@ -3314,6 +3316,7 @@ func teamName() {
 func testfairy(apiKey: String,
                ipa: String,
                symbolsFile: String? = nil,
+               uploadUrl: String = "https://upload.testfairy.com",
                testersGroups: [String] = [],
                metrics: [String] = [],
                comment: String = "No comment provided",
@@ -3323,6 +3326,7 @@ func testfairy(apiKey: String,
   let command = RubyCommand(commandID: "", methodName: "testfairy", className: nil, args: [RubyCommand.Argument(name: "api_key", value: apiKey),
                                                                                            RubyCommand.Argument(name: "ipa", value: ipa),
                                                                                            RubyCommand.Argument(name: "symbols_file", value: symbolsFile),
+                                                                                           RubyCommand.Argument(name: "upload_url", value: uploadUrl),
                                                                                            RubyCommand.Argument(name: "testers_groups", value: testersGroups),
                                                                                            RubyCommand.Argument(name: "metrics", value: metrics),
                                                                                            RubyCommand.Argument(name: "comment", value: comment),
@@ -3917,4 +3921,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.11]
+// FastlaneRunnerAPIVersion [0.9.12]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.88.0
+// Generated with fastlane 2.89.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.88.0
+// Generated with fastlane 2.89.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.88.0
+// Generated with fastlane 2.89.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.88.0
+// Generated with fastlane 2.89.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.88.0
+// Generated with fastlane 2.89.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.88.0
+// Generated with fastlane 2.89.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.88.0':**

* [action] Make sure get_version_number targets respond to test_target_type? (#12212) via Josh Holtz
* Make enable_automatic_code_signing more robust to xcodeproj conf (#12187) via Nicolas Braun
* Remove rubocop errors from simctl dependency (#12196) via Josh Holtz
* Use correct spelling of icloud service in product/service.rb (#12134) via Jakub Knejzlík
* Add Support for Registering Mac Devices on Apple Developer Portal (#11978) via Baumchen
* Spaceship delete testflight groups (#12111) via Kenneth Wong
* Enable set 'NFC Tag Reading' at 'fastlane produce' cli. (#12179) (#12201) via Kazuhide Takahashi
* Update docs with links to ProvisionQL Quick Look plugin (#11891) via Evgeny Aleksandrov
* frameit documentation should describe all parameters from the Framefile (#11662) via funnel20
* Clarify difference between SUPPLY_JSON_KEY and SUPPLY_JSON_KEY_DATA via Aaron Brager
* [action] added custom api_url option to testfairy (#12153) via Josh Holtz
