### PR TITLE
Fix Gym skip_archive option

### DIFF
--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -17,7 +17,7 @@ module Gym
       unless Gym.config[:skip_build_archive]
         build_app
       end
-      verify_archive
+      verify_archive unless Gym.config[:skip_archive]
       FileUtils.mkdir_p(File.expand_path(Gym.config[:output_directory]))
 
       if Gym.project.ios? || Gym.project.tvos?


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The `skip_archive` option removes the archive action from the xcodebuild generated command, but Gym still tried to verify that an archive exists after this command runs

### Description
This PR should fix that.