### PR TITLE
Getting Derived Data path value from Xcode preferences

### DIFF
--- a/fastlane/lib/fastlane/actions/clear_derived_data.rb
+++ b/fastlane/lib/fastlane/actions/clear_derived_data.rb
@@ -1,3 +1,5 @@
+require 'fastlane_core/core_ext/cfpropertylist'
+
 module Fastlane
   module Actions
     class ClearDerivedDataAction < Action
@@ -6,6 +8,15 @@ module Fastlane
         UI.message("Derived Data path located at: #{path}")
         FileUtils.rm_rf(path) if File.directory?(path)
         UI.success("Successfully cleared Derived Data ♻️")
+      end
+
+      # Helper Methods
+      def self.xcode_preferences
+        file = File.expand_path("~/Library/Preferences/com.apple.dt.Xcode.plist")
+        if File.exist?(file)
+          return CFPropertyList.native_types(CFPropertyList::List.new(file: file).value)
+        end
+        return ''
       end
 
       #####################################################
@@ -17,7 +28,7 @@ module Fastlane
       end
 
       def self.details
-        "Deletes the Derived Data from '~/Library/Developer/Xcode/DerivedData' or a supplied path"
+        "Deletes the Derived Data from path set on Xcode or a supplied path"
       end
 
       def self.available_options
@@ -25,7 +36,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :derived_data_path,
                                        env_name: "DERIVED_DATA_PATH",
                                        description: "Custom path for derivedData",
-                                       default_value: "~/Library/Developer/Xcode/DerivedData")
+                                       default_value: xcode_preferences['IDECustomDerivedDataLocation'] || "~/Library/Developer/Xcode/DerivedData")
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/clear_derived_data.rb
+++ b/fastlane/lib/fastlane/actions/clear_derived_data.rb
@@ -33,11 +33,7 @@ module Fastlane
       end
 
       def self.available_options
-        path = begin
-                 xcode_preferences['IDECustomDerivedDataLocation']
-               rescue
-                 nil
-               end
+        path = xcode_preferences ? xcode_preferences['IDECustomDerivedDataLocation'] : nil
         path ||= "~/Library/Developer/Xcode/DerivedData"
         [
           FastlaneCore::ConfigItem.new(key: :derived_data_path,

--- a/fastlane/lib/fastlane/actions/clear_derived_data.rb
+++ b/fastlane/lib/fastlane/actions/clear_derived_data.rb
@@ -14,9 +14,10 @@ module Fastlane
       def self.xcode_preferences
         file = File.expand_path("~/Library/Preferences/com.apple.dt.Xcode.plist")
         if File.exist?(file)
-          return CFPropertyList.native_types(CFPropertyList::List.new(file: file).value)
+          plist = CFPropertyList::List.new(file: file).value
+          return CFPropertyList.native_types(plist) unless plist.nil?
         end
-        return ''
+        return nil
       end
 
       #####################################################
@@ -32,11 +33,18 @@ module Fastlane
       end
 
       def self.available_options
+        path = begin
+                 xcode_preferences['IDECustomDerivedDataLocation']
+               rescue
+                 nil
+               end
+        path ||= "~/Library/Developer/Xcode/DerivedData"
         [
           FastlaneCore::ConfigItem.new(key: :derived_data_path,
                                        env_name: "DERIVED_DATA_PATH",
                                        description: "Custom path for derivedData",
-                                       default_value: xcode_preferences['IDECustomDerivedDataLocation'] || "~/Library/Developer/Xcode/DerivedData")
+                                       default_value_dynamic: true,
+                                       default_value: path)
         ]
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR fix #11951

### Description
Changed action to get value from Xcode preferences if exists, if not uses default value.