### PR TITLE
[match][spaceship] Fixed matchfile overriding fastfile team_id with bonus spaceship select_team additions

### DIFF
--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -68,10 +68,7 @@ module Match
                                      optional: true,
                                      code_gen_sensitive: true,
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:team_id),
-                                     default_value_dynamic: true,
-                                     verify_block: proc do |value|
-                                       ENV["FASTLANE_TEAM_ID"] = value.to_s
-                                     end),
+                                     default_value_dynamic: true),
         FastlaneCore::ConfigItem.new(key: :git_full_name,
                                      env_name: "MATCH_GIT_FULL_NAME",
                                      description: "git user full name to commit",
@@ -89,10 +86,7 @@ module Match
                                      optional: true,
                                      code_gen_sensitive: true,
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:team_name),
-                                     default_value_dynamic: true,
-                                     verify_block: proc do |value|
-                                       ENV["FASTLANE_TEAM_NAME"] = value.to_s
-                                     end),
+                                     default_value_dynamic: true),
         FastlaneCore::ConfigItem.new(key: :verbose,
                                      env_name: "MATCH_VERBOSE",
                                      description: "Print out extra information and all commands",

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -30,7 +30,7 @@ module Match
                                            clone_branch_directly: params[:clone_branch_directly])
 
       unless params[:readonly]
-        self.spaceship = SpaceshipEnsure.new(params[:username])
+        self.spaceship = SpaceshipEnsure.new(params[:username], params[:team_id], params[:team_name])
         if params[:type] == "enterprise" && !Spaceship.client.in_house?
           UI.user_error!("You defined the profile type 'enterprise', but your Apple account doesn't support In-House profiles")
         end

--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -4,7 +4,7 @@ require_relative 'module'
 module Match
   # Ensures the certificate and profiles are also available on iTunes Connect
   class SpaceshipEnsure
-    def initialize(user)
+    def initialize(user, team_id, team_name)
       # We'll try to manually fetch the password
       # to tell the user that a password is optional
       require 'credentials_manager/account_manager'
@@ -20,7 +20,7 @@ module Match
 
       UI.message("Verifying that the certificate and profile are still valid on the Dev Portal...")
       Spaceship.login(user)
-      Spaceship.select_team
+      Spaceship.select_team(team_id: team_id, team_name: team_name)
     end
 
     def bundle_identifier_exists(username: nil, app_identifier: nil)

--- a/spaceship/lib/spaceship/launcher.rb
+++ b/spaceship/lib/spaceship/launcher.rb
@@ -58,10 +58,13 @@ module Spaceship
     # so that the user can use the environment variable `FASTLANE_TEAM_ID`
     # for future user.
     #
+    # @param team_id (String) (optional): The ID of a Developer Portal team
+    # @param team_name (String) (optional): The name of a Developer Portal team
+    #
     # @return (String) The ID of the select team. You also get the value if
     #   the user is only in one team.
-    def select_team
-      @client.select_team
+    def select_team(team_id: team_id = nil, team_name: team_name = nil)
+      @client.select_team(team_id: team_id, team_name: team_name)
     end
 
     #####################################################

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -65,8 +65,11 @@ module Spaceship
 
     # Shows a team selection for the user in the terminal. This should not be
     # called on CI systems
-    def select_team
-      @current_team_id = self.UI.select_team
+    #
+    # @param team_id (String) (optional): The ID of a Developer Portal team
+    # @param team_name (String) (optional): The name of a Developer Portal team
+    def select_team(team_id: team_id = nil, team_name: team_name = nil)
+      @current_team_id = self.UI.select_team(team_id: team_id, team_name: team_name)
     end
 
     # Set a new team ID which will be used from now on

--- a/spaceship/lib/spaceship/portal/spaceship.rb
+++ b/spaceship/lib/spaceship/portal/spaceship.rb
@@ -34,10 +34,13 @@ module Spaceship
       # so that the user can use the environment variable `FASTLANE_TEAM_ID`
       # for future user.
       #
+      # @param team_id (String) (optional): The ID of a Developer Portal team
+      # @param team_name (String) (optional): The name of a Developer Portal team
+      #
       # @return (String) The ID of the select team. You also get the value if
       #   the user is only in one team.
-      def select_team
-        @client.select_team
+      def select_team(team_id: team_id = nil, team_name: team_name = nil)
+        @client.select_team(team_id: team_id, team_name: team_name)
       end
 
       # Helper methods for managing multiple instances of spaceship
@@ -95,8 +98,8 @@ module Spaceship
       Spaceship::Portal.login(user, password)
     end
 
-    def select_team
-      Spaceship::Portal.select_team
+    def select_team(team_id: team_id = nil, team_name: team_name = nil)
+      Spaceship::Portal.select_team(team_id: team_id, team_name: team_name)
     end
 
     def app

--- a/spaceship/lib/spaceship/portal/ui/select_team.rb
+++ b/spaceship/lib/spaceship/portal/ui/select_team.rb
@@ -47,7 +47,7 @@ module Spaceship
       end
       # rubocop:enable Require/MissingRequireStatement
 
-      def select_team
+      def select_team(team_id: team_id = nil, team_name: team_name = nil)
         teams = client.teams
 
         if teams.count == 0
@@ -57,8 +57,8 @@ module Spaceship
           raise "Your account is in no teams"
         end
 
-        team_id = (ENV['FASTLANE_TEAM_ID'] || '').strip
-        team_name = (ENV['FASTLANE_TEAM_NAME'] || '').strip
+        team_id = (team_id || ENV['FASTLANE_TEAM_ID'] || '').strip
+        team_name = (team_name || ENV['FASTLANE_TEAM_NAME'] || '').strip
 
         if team_id.length > 0
           # User provided a value, let's see if it's valid

--- a/spaceship/lib/spaceship/tunes/spaceship.rb
+++ b/spaceship/lib/spaceship/tunes/spaceship.rb
@@ -28,8 +28,11 @@ module Spaceship
       #
       # If the user is in multiple teams, a team selection is shown.
       # The user can then select a team by entering the number
-      def select_team
-        @client.select_team
+      #
+      # @param team_id (String) (optional): The ID of a iTunesConnect team
+      # @param team_name (String) (optional): The name of a iTunesConnect team
+      def select_team(team_id: team_id = nil, team_name: team_name = nil)
+        @client.select_team(team_id: team_id, team_name: team_name)
       end
     end
   end

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -56,9 +56,12 @@ module Spaceship
 
     # Shows a team selection for the user in the terminal. This should not be
     # called on CI systems
-    def select_team
-      t_id = (ENV['FASTLANE_ITC_TEAM_ID'] || '').strip
-      t_name = (ENV['FASTLANE_ITC_TEAM_NAME'] || '').strip
+    #
+    # @param team_id (String) (optional): The ID of a iTunesConnect team
+    # @param team_name (String) (optional): The name of a iTunesConnect team
+    def select_team(team_id: team_id = nil, team_name: team_name = nil)
+      t_id = (team_id || ENV['FASTLANE_ITC_TEAM_ID'] || '').strip
+      t_name = (team_name || ENV['FASTLANE_ITC_TEAM_NAME'] || '').strip
 
       if t_name.length > 0 && t_id.length.zero? # we prefer IDs over names, they are unique
         puts("Looking for iTunes Connect Team with name #{t_name}") if Spaceship::Globals.verbose?

--- a/spaceship/spec/UI/select_team_spec.rb
+++ b/spaceship/spec/UI/select_team_spec.rb
@@ -32,19 +32,31 @@ describe Spaceship::Client do
           expect(subject.select_team).to eq("XXXXXXXXXX") # a different team
         end
 
-        it "Uses the specific team (1/2)" do
+        it "Uses the specific team (1/2) using environment variables" do
           ENV["FASTLANE_TEAM_ID"] = "SecondTeam"
           expect(subject.select_team).to eq("SecondTeam") # a different team
         end
 
-        it "Uses the specific team (2/2)" do
+        it "Uses the specific team (2/2) using environment variables" do
           ENV["FASTLANE_TEAM_ID"] = "XXXXXXXXXX"
           expect(subject.select_team).to eq("XXXXXXXXXX") # a different team
         end
 
-        it "Let's the user specify the team name" do
+        it "Let's the user specify the team name using environment variables" do
           ENV["FASTLANE_TEAM_NAME"] = "SecondTeamProfiName"
           expect(subject.select_team).to eq("SecondTeam")
+        end
+
+        it "Uses the specific team (1/2) using method parameters" do
+          expect(subject.select_team(team_id: "SecondTeam")).to eq("SecondTeam") # a different team
+        end
+
+        it "Uses the specific team (2/2) using method parameters" do
+          expect(subject.select_team(team_id: "XXXXXXXXXX")).to eq("XXXXXXXXXX") # a different team
+        end
+
+        it "Let's the user specify the team name using method parameters" do
+          expect(subject.select_team(team_name: "SecondTeamProfiName")).to eq("SecondTeam")
         end
 
         it "Strips out spaces before and after the team name" do

--- a/spaceship/spec/launcher_spec.rb
+++ b/spaceship/spec/launcher_spec.rb
@@ -19,8 +19,13 @@ describe Spaceship do
     end
 
     it "may have different teams" do
+      allow_any_instance_of(Spaceship::PortalClient).to receive(:teams).and_return([
+                                                                                     { 'teamId' => 'XXXXXXXXXX', 'currentTeamMember' => { 'teamMemberId' => '' } },
+                                                                                     { 'teamId' => 'ABCDEF', 'currentTeamMember' => { 'teamMemberId' => '' } }
+                                                                                   ])
+
       team_id = "ABCDEF"
-      spaceship1.client.team_id = team_id
+      spaceship1.client.select_team(team_id: team_id)
 
       expect(spaceship1.client.team_id).to eq(team_id) # custom
       expect(spaceship2.client.team_id).to eq("XXXXXXXXXX") # default

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -35,8 +35,13 @@ describe Spaceship::Client do
       end
 
       it "set custom Team ID" do
+        allow_any_instance_of(Spaceship::PortalClient).to receive(:teams).and_return([
+                                                                                       { 'teamId' => 'XXXXXXXXXX', 'currentTeamMember' => { 'teamMemberId' => '' } },
+                                                                                       { 'teamId' => 'ABCDEF', 'currentTeamMember' => { 'teamMemberId' => '' } }
+                                                                                     ])
+
         team_id = "ABCDEF"
-        subject.team_id = team_id
+        subject.select_team(team_id: team_id)
         expect(subject.team_id).to eq(team_id)
       end
 


### PR DESCRIPTION
Fixes #12146
Starting implementation of #12234 (see this issue for more details and examples)

## Issue
Using action options `verify_block` can have some unintended side effects that will break the rules of [Priorities of parameters and options](https://docs.fastlane.tools/advanced/#priorities-of-parameters-and-options)
1. CLI parameter (e.g. gym --scheme Example) or Fastfile (e.g. gym(scheme: 'Example'))
1. Environment variable (e.g. GYM_SCHEME)
1. Tool specific config file (e.g. Gymfile containing scheme 'Example')
1. Default value (which might be taken from the Appfile, e.g. app_identifier from the Appfile)
1. If this value is required, you'll be asked for it (e.g. you have multiple schemes, you'll be asked for it)

### Example of how this happens
This is mainly a problem when `load_configuration_file` is called outside of standard action loading process - https://github.com/fastlane/fastlane/blob/055f325725ac58d006ba46f0d85c6bb74e98adbc/fastlane/lib/fastlane/actions/sync_code_signing.rb#L7-L16

In `match`'s case above, it will load...
1. Load the `Fastfile` parameter (this is correct)
2. Attempt to load the `Matchfile` parameter but doesn't because `Fastfile` parameter set
3. During `match`'s run, this extra `load_configuration_file` will attempt to load files from `Matchfile` again (and won't override the `Fastfile` value) **but** the `verify_block` method gets called and sets `ENV["FASTLANE_TEAM_ID"]` to a potentially different team id (if the `Matchfile` value is different than the `Fastfile` value) which will cause a different value to be shown in `match`'s summary than what actually get's used by `spaceship`

## Solution
1. `verify_block` should not be used to set environment variables `verify_block` can actually get called multiple times and should really only be used for verifying a value (not setting it)
2. We should stop setting environment variables for `FASTLANE_TEAM_ID`, `FASTLANE_TEAM_NAME`, `FASTLANE_ITC_TEAM_ID`, and `FASTLANE_ITC_TEAM_NAME` for to use with the `spaceship`'s `select_team` method
3. `select_team` should take a parameter for `team_id` and `team_name` when explicitly looking for a team instead of setting a global environment variable that may potentially get overridden
