### PR TITLE
Adds an option android_gcm_sender_id to onesignal action as optional

### DIFF
--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -16,7 +16,7 @@ module Fastlane
         app_name = params[:app_name]
         apns_p12_password = params[:apns_p12_password]
         android_token = params[:android_token]
-        android_sender_id = params[:android_sender_id]
+        android_gcm_sender_id = params[:android_gcm_sender_id]
 
         payload = {}
         payload['name'] = app_name
@@ -31,7 +31,7 @@ module Fastlane
         end
 
         payload["gcm_key"] = android_token unless android_token.nil?
-        payload["android_gcm_sender_id"] = android_sender_id unless android_sender_id.nil?
+        payload["android_gcm_sender_id"] = android_gcm_sender_id unless android_gcm_sender_id.nil?
 
         # here's the actual lifting - POST to OneSignal
 
@@ -94,9 +94,9 @@ module Fastlane
                                        sensitive: true,
                                        optional: true),
 
-          FastlaneCore::ConfigItem.new(key: :android_sender_id,
-                                       env_name: "ANDROID_SENDER_ID",
-                                       description: "ANDROID SENDER ID",
+          FastlaneCore::ConfigItem.new(key: :android_gcm_sender_id,
+                                       env_name: "android_gcm_sender_id",
+                                       description: "GCM SENDER ID",
                                        sensitive: true,
                                        optional: true),
 
@@ -140,7 +140,7 @@ module Fastlane
             auth_token: "Your OneSignal Auth Token",
             app_name: "Name for OneSignal App",
             android_token: "Your Android GCM key (optional)",
-            android_sender_id: "Your Google Project/Sender ID number (optional)",
+            android_gcm_sender_id: "Your Android GCM Sender ID (optional)",
             apns_p12: "Path to Apple .p12 file (optional)",
             apns_p12_password: "Password for .p12 file (optional)",
             apns_env: "production/sandbox (defaults to production)"

--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -16,6 +16,7 @@ module Fastlane
         app_name = params[:app_name]
         apns_p12_password = params[:apns_p12_password]
         android_token = params[:android_token]
+        android_sender_id = params[:android_sender_id]
 
         payload = {}
         payload['name'] = app_name
@@ -30,6 +31,7 @@ module Fastlane
         end
 
         payload["gcm_key"] = android_token unless android_token.nil?
+        payload["android_gcm_sender_id"] = android_sender_id unless android_sender_id.nil?
 
         # here's the actual lifting - POST to OneSignal
 
@@ -92,6 +94,12 @@ module Fastlane
                                        sensitive: true,
                                        optional: true),
 
+          FastlaneCore::ConfigItem.new(key: :android_sender_id,
+                                       env_name: "ANDROID_SENDER_ID",
+                                       description: "ANDROID SENDER ID",
+                                       sensitive: true,
+                                       optional: true),
+
           FastlaneCore::ConfigItem.new(key: :apns_p12,
                                        env_name: "APNS_P12",
                                        description: "APNS P12 File (in .p12 format)",
@@ -132,6 +140,7 @@ module Fastlane
             auth_token: "Your OneSignal Auth Token",
             app_name: "Name for OneSignal App",
             android_token: "Your Android GCM key (optional)",
+            android_sender_id: "Your Google Project/Sender ID number (optional)",
             apns_p12: "Path to Apple .p12 file (optional)",
             apns_p12_password: "Password for .p12 file (optional)",
             apns_env: "production/sandbox (defaults to production)"

--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -131,7 +131,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :android].include?(platform)
       end
 
       def self.example_code

--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -95,7 +95,7 @@ module Fastlane
                                        optional: true),
 
           FastlaneCore::ConfigItem.new(key: :android_gcm_sender_id,
-                                       env_name: "android_gcm_sender_id",
+                                       env_name: "ANDROID_GCM_SENDER_ID",
                                        description: "GCM SENDER ID",
                                        sensitive: true,
                                        optional: true),


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
Fix #12243 

### Description
<!-- Describe your changes in detail -->
I added an option to configure a sender_id from firebase to onesignal through the action and therefore, configures it on a new app at onesignal.