### PR TITLE
Add skip_plugin_scores option to the update_docs lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -367,9 +367,11 @@ lane :update_docs do |options|
       # Create a new branch
       sh("git checkout -b 'update-actions-md-#{Time.now.to_i}'") unless debug
       plugins_path = "docs/plugins/available-plugins.md"
-      plugin_scores(template_path: template_path,
-                      output_path: plugins_path,
-                       cache_path: plugin_scores_cache_path) unless options[:skip_plugin_scores]
+      unless options[:skip_plugin_scores]
+        plugin_scores(template_path: template_path,
+                        output_path: plugins_path,
+                         cache_path: plugin_scores_cache_path)
+      end
 
       next if debug
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -369,7 +369,7 @@ lane :update_docs do |options|
       plugins_path = "docs/plugins/available-plugins.md"
       plugin_scores(template_path: template_path,
                       output_path: plugins_path,
-                       cache_path: plugin_scores_cache_path)
+                       cache_path: plugin_scores_cache_path) unless options[:skip_plugin_scores]
 
       next if debug
 


### PR DESCRIPTION
Passing `skip_plugin_scores:true` to this lane skips running the
`plugin_scores` actions, that even with caching, still takes a bit of a
long time. This is useful for local development/debugging of the docs by
running:

```
bundle exec fastlane update_docs skip_plugin_scores:true debug:true
```