### PR TITLE
match: Fixing Adhoc Certificate Generation for Enterprise Accounts

### DIFF
--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -177,7 +177,7 @@ module Sigh
         elsif profile_type == Spaceship.provisioning_profile.InHouse
           certificates = Spaceship.certificate.in_house.all
         else
-          certificates = Spaceship.certificate.production.all # Ad hoc or App Store
+          certificates = Spaceship.certificate.production.all | Spaceship.certificate.in_house.all # Ad hoc or App Store
         end
 
       when 'macos'


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixing an error that prevent match from generating adhoc certificates for enterprise accounts. Fixes #11139

### Description
Modified the runner file in order to implement the changes described in the issue #11139. 
