### PR TITLE
[match] Correct how match handles enterprise adhoc

### DIFF
--- a/match/lib/match/module.rb
+++ b/match/lib/match/module.rb
@@ -15,7 +15,7 @@ module Match
   end
 
   def self.cert_type_sym(type)
-    return :enterprise if type == "enterprise"
+    return :enterprise if type == "enterprise" || (type == "adhoc" && Spaceship.client.in_house?)
     return :development if type == "development"
     return :distribution if ["adhoc", "appstore", "distribution"].include?(type)
     raise "Unknown cert type: '#{type}'"

--- a/match/lib/match/module.rb
+++ b/match/lib/match/module.rb
@@ -1,3 +1,4 @@
+require 'spaceship'
 require 'fastlane_core/helper'
 
 module Match

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -176,7 +176,7 @@ module Sigh
           certificates = Spaceship.certificate.development.all
         elsif profile_type == Spaceship.provisioning_profile.InHouse
           certificates = Spaceship.certificate.in_house.all
-        elsif profile_type == Spaceship.provisioning_profile.AdHoc && Spaceship.client.in_house?  
+        elsif profile_type == Spaceship.provisioning_profile.AdHoc && Spaceship.client.in_house?
           certificates = Spaceship.certificate.in_house.all
         else
           certificates = Spaceship.certificate.production.all # Ad hoc or App Store

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -176,6 +176,8 @@ module Sigh
           certificates = Spaceship.certificate.development.all
         elsif profile_type == Spaceship.provisioning_profile.InHouse
           certificates = Spaceship.certificate.in_house.all
+        elsif profile_type == Spaceship.provisioning_profile.AdHoc && Spaceship.client.in_house?  
+          certificates = Spaceship.certificate.in_house.all
         else
           certificates = Spaceship.certificate.production.all # Ad hoc or App Store
         end


### PR DESCRIPTION
Fixes #11139
Fixes #12133

## Da motivation
I have experience this issue while (as well as others) where `match` doesn't treat `adhoc` profiles for `enterprise` accounts the way it is expected.

### ❌ Before
- `match` would place certificates for enterprise `adhoc` accounts under `distribution`
  - This meant that `match` wouldn't reuse the same cert used for `inhouse` which was placed under `enterprise`
- `sigh` would also look for enterprise `adhoc` files in `Spaceship.certificate.production.all` when actually in `Spaceship.certificate.in_house.all`

### ✅ After
- `match` looks for both enterprise `adhoc` and `inhouse` certs under the `enterprise` directory
  - Which now means the one certificate can be shared for all enterprise distribution builds
- `sigh` now properly returns certificates for enterprise `adhoc` profiles

### ⚠️ Warning
- This **may** introduce some backwards compatibility issues 🤔
  - `match` will now look for the adhoc cert in the `enterprise` directory instead of `distribution`
  - This shouldn't "break" anything but will make the other certificate just useless