### PR TITLE
Fix force output files on trade_representative_contact_information

### DIFF
--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -92,7 +92,6 @@ module Deliver
         base_dir = File.join(path, UploadMetadata::TRADE_REPRESENTATIVE_CONTACT_INFORMATION_DIR)
         FileUtils.mkdir_p(base_dir)
         resulting_path = File.join(base_dir, "#{option_name}.txt")
-        next if content.to_s.chomp.length == 0 # as many developers won't need trade information
         File.write(resulting_path, content)
         UI.message("Writing to '#{resulting_path}'")
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail -->
In my case, when creating a new application, iTC had my developer profile entered by default. However, because postal code was not registered in the item of trade_representative_contact_information, only postal_code.txt was not created in the process of deliver init and download_metadata.
If some information is missing like this, the generated file will also become fragmented, so I modified it.