### PR TITLE
Fix fastlane crashing when running a lane

### DIFF
--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -102,6 +102,8 @@ module Fastlane
       end
 
       rows << [0, "cancel", "No selection, exit fastlane!"]
+      
+      require 'terminal-table'
 
       table = Terminal::Table.new(
         title: "Available lanes to run",

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -102,7 +102,7 @@ module Fastlane
       end
 
       rows << [0, "cancel", "No selection, exit fastlane!"]
-      
+
       require 'terminal-table'
 
       table = Terminal::Table.new(


### PR DESCRIPTION
Fixes #12293

I tested this and seems to work, though I don't think that `require` was ever there.

So we've got to figure out what happened and fix it properly. And also why didn't RuboCop missing requires cop didn't catch it.

We could also checkout `2.90.0` and write some failing tests that catch this.