### PR TITLE
Stabilize tests by setting all android sdk path environment variables

### DIFF
--- a/fastlane/spec/actions_specs/adb_spec.rb
+++ b/fastlane/spec/actions_specs/adb_spec.rb
@@ -1,6 +1,12 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "adb" do
+      before(:each) do
+        ENV['ANDROID_HOME'] = nil
+        ENV['ANDROID_SDK_ROOT'] = nil
+        ENV['ANDROID_SDK'] = nil
+      end
+
       it "generates a valid command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           adb(command: 'test', adb_path: './fastlane/README.md')
@@ -12,8 +18,6 @@ describe Fastlane do
       it "picks up path from ANDROID_HOME environment variable" do
         result = Fastlane::FastFile.new.parse("lane :test do
           ENV['ANDROID_HOME'] = '/usr/local/android-sdk'
-          ENV['ANDROID_SDK_ROOT'] = nil
-          ENV['ANDROID_SDK'] = nil
           adb(command: 'test')
         end").runner.execute(:test)
 
@@ -22,9 +26,7 @@ describe Fastlane do
 
       it "picks up path from ANDROID_SDK_ROOT environment variable" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          ENV['ANDROID_HOME'] = nil
           ENV['ANDROID_SDK_ROOT'] = '/usr/local/android-sdk'
-          ENV['ANDROID_SDK'] = nil
           adb(command: 'test')
         end").runner.execute(:test)
 
@@ -33,8 +35,6 @@ describe Fastlane do
 
       it "picks up path from ANDROID_SDK environment variable" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          ENV['ANDROID_HOME'] = nil
-          ENV['ANDROID_SDK_ROOT'] = nil
           ENV['ANDROID_SDK'] = '/usr/local/android-sdk'
           adb(command: 'test')
         end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/adb_spec.rb
+++ b/fastlane/spec/actions_specs/adb_spec.rb
@@ -9,9 +9,33 @@ describe Fastlane do
         expect(result).to eq(" ./fastlane/README.md test")
       end
 
+      it "picks up path from ANDROID_HOME environment variable" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ENV['ANDROID_HOME'] = '/usr/local/android-sdk'
+          ENV['ANDROID_SDK_ROOT'] = nil
+          ENV['ANDROID_SDK'] = nil
+          adb(command: 'test')
+        end").runner.execute(:test)
+
+        expect(result).to eq(" /usr/local/android-sdk/platform-tools/adb test")
+      end
+
       it "picks up path from ANDROID_SDK_ROOT environment variable" do
         result = Fastlane::FastFile.new.parse("lane :test do
+          ENV['ANDROID_HOME'] = nil
           ENV['ANDROID_SDK_ROOT'] = '/usr/local/android-sdk'
+          ENV['ANDROID_SDK'] = nil
+          adb(command: 'test')
+        end").runner.execute(:test)
+
+        expect(result).to eq(" /usr/local/android-sdk/platform-tools/adb test")
+      end
+
+      it "picks up path from ANDROID_SDK environment variable" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ENV['ANDROID_HOME'] = nil
+          ENV['ANDROID_SDK_ROOT'] = nil
+          ENV['ANDROID_SDK'] = '/usr/local/android-sdk'
           adb(command: 'test')
         end").runner.execute(:test)
 


### PR DESCRIPTION
Fixes #12300

- Tests would fail if ANDROID_HOME or ANDROID_SDK were also set
- Tests now make sure to set, clear, and test all of the possible values (ANDROID_HOME, ANDROID_SDK_ROOT, ANDROID_SDK)