### PR TITLE
[swift] give lane_context return_type of hash_with_strings

### DIFF
--- a/fastlane/lib/fastlane/actions/lane_context.rb
+++ b/fastlane/lib/fastlane/actions/lane_context.rb
@@ -28,6 +28,10 @@ module Fastlane
         []
       end
 
+      def self.return_type
+        :hash_of_strings
+      end
+
       def self.authors
         ["KrauseFx"]
       end


### PR DESCRIPTION
Fixes #12303

## Wut
- No return type so Swift returned nothing when `laneContext` was called 😊 

```swift
class Fastfile: LaneFile {
	func testLane() {

		let changelog = changelogFromGitCommits(commitsCount: 1)
		puts(message: "changelog: \(changelog)")

		let dict = laneContext()
		puts(message: "dict: \(dict["FL_CHANGELOG"])")
	}
}
```
But now we can do something like this ^