### PR TITLE
Add parameter code_signing_identity for CODE_SIGN_IDENTITY setting

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -65,12 +65,10 @@ module Fastlane
             end
 
             unless codesigning_identity.nil?
-              if build_configuration.build_settings["CODE_SIGN_IDENTITY[sdk=iphoneos*]"] != nil
-                build_configuration.build_settings["CODE_SIGN_IDENTITY"] = codesigning_identity
+              unless build_configuration.build_settings["CODE_SIGN_IDENTITY[sdk=iphoneos*]"].nil?
                 build_configuration.build_settings["CODE_SIGN_IDENTITY[sdk=iphoneos*]"] = codesigning_identity
-              else
-                build_configuration.build_settings["CODE_SIGN_IDENTITY"] = codesigning_identity
               end
+              build_configuration.build_settings["CODE_SIGN_IDENTITY"] = codesigning_identity
             end
 
             build_configuration.build_settings["PROVISIONING_PROFILE"] = data["UUID"]

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -64,9 +64,11 @@ module Fastlane
               next
             end
 
-            codesign_build_settings_keys = build_configuration.build_settings.keys.select { |key| key.to_s.match(/CODE_SIGN_IDENTITY.*/) }
-            codesign_build_settings_keys.each do |setting|
-              build_configuration.build_settings[setting] = code_signing_identity
+            if code_signing_identity
+              codesign_build_settings_keys = build_configuration.build_settings.keys.select { |key| key.to_s.match(/CODE_SIGN_IDENTITY.*/) }
+              codesign_build_settings_keys.each do |setting|
+                build_configuration.build_settings[setting] = code_signing_identity
+              end
             end
 
             build_configuration.build_settings["PROVISIONING_PROFILE"] = data["UUID"]

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -65,7 +65,7 @@ module Fastlane
             end
 
             unless codesigning_identity.nil?
-              unless build_configuration.build_settings["CODE_SIGN_IDENTITY[sdk=iphoneos*]"].nil?
+              if build_configuration.build_settings["CODE_SIGN_IDENTITY[sdk=iphoneos*]"] != nil
                 build_configuration.build_settings["CODE_SIGN_IDENTITY"] = codesigning_identity
                 build_configuration.build_settings["CODE_SIGN_IDENTITY[sdk=iphoneos*]"] = codesigning_identity
               else

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -40,6 +40,7 @@ module Fastlane
 
         target_filter = params[:target_filter] || params[:build_configuration_filter]
         configuration = params[:build_configuration]
+        codesigning_identity = params[:codesigning_identity]
 
         # manipulate project file
         UI.success("Going to update project '#{folder}' with UUID")
@@ -61,6 +62,15 @@ module Fastlane
             else
               UI.important("Skipping configuration #{config_name} as it doesn't match the filter '#{configuration}'")
               next
+            end
+
+            unless codesigning_identity.nil?
+              unless build_configuration.build_settings["CODE_SIGN_IDENTITY[sdk=iphoneos*]"].nil?
+                build_configuration.build_settings["CODE_SIGN_IDENTITY"] = codesigning_identity
+                build_configuration.build_settings["CODE_SIGN_IDENTITY[sdk=iphoneos*]"] = codesigning_identity
+              else
+                build_configuration.build_settings["CODE_SIGN_IDENTITY"] = codesigning_identity
+              end
             end
 
             build_configuration.build_settings["PROVISIONING_PROFILE"] = data["UUID"]
@@ -130,7 +140,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :certificate,
                                        env_name: "FL_PROJECT_PROVISIONING_CERTIFICATE_PATH",
                                        description: "Path to apple root certificate",
-                                       default_value: "/tmp/AppleIncRootCertificate.cer")
+                                       default_value: "/tmp/AppleIncRootCertificate.cer"),
+          FastlaneCore::ConfigItem.new(key: :codesigning_identity,
+                                       env_name: "FL_PROJECT_PROVISIONING_CODE_SIGN_IDENTITY",
+                                       description: "Code sign identity for build configuration",
+                                       optional: true)
         ]
       end
 
@@ -148,7 +162,8 @@ module Fastlane
             xcodeproj: "Project.xcodeproj",
             profile: "./watch_app_store.mobileprovision", # optional if you use sigh
             target_filter: ".*WatchKit Extension.*", # matches name or type of a target
-            build_configuration: "Release"
+            build_configuration: "Release",
+            codesigning_identity: "iPhone Development" #specified the codesigning identity
           )'
         ]
       end

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -40,7 +40,7 @@ module Fastlane
 
         target_filter = params[:target_filter] || params[:build_configuration_filter]
         configuration = params[:build_configuration]
-        codesigning_identity = params[:codesigning_identity]
+        code_signing_identity = params[:code_signing_identity]
 
         # manipulate project file
         UI.success("Going to update project '#{folder}' with UUID")
@@ -64,11 +64,9 @@ module Fastlane
               next
             end
 
-            unless codesigning_identity.nil?
-              unless build_configuration.build_settings["CODE_SIGN_IDENTITY[sdk=iphoneos*]"].nil?
-                build_configuration.build_settings["CODE_SIGN_IDENTITY[sdk=iphoneos*]"] = codesigning_identity
-              end
-              build_configuration.build_settings["CODE_SIGN_IDENTITY"] = codesigning_identity
+            codesign_build_settings_keys = build_configuration.build_settings.keys.select { |key| key.to_s.match(/CODE_SIGN_IDENTITY.*/) }
+            codesign_build_settings_keys.each do |setting|
+              build_configuration.build_settings[setting] = code_signing_identity
             end
 
             build_configuration.build_settings["PROVISIONING_PROFILE"] = data["UUID"]
@@ -139,7 +137,7 @@ module Fastlane
                                        env_name: "FL_PROJECT_PROVISIONING_CERTIFICATE_PATH",
                                        description: "Path to apple root certificate",
                                        default_value: "/tmp/AppleIncRootCertificate.cer"),
-          FastlaneCore::ConfigItem.new(key: :codesigning_identity,
+          FastlaneCore::ConfigItem.new(key: :code_signing_identity,
                                        env_name: "FL_PROJECT_PROVISIONING_CODE_SIGN_IDENTITY",
                                        description: "Code sign identity for build configuration",
                                        optional: true)
@@ -161,7 +159,7 @@ module Fastlane
             profile: "./watch_app_store.mobileprovision", # optional if you use sigh
             target_filter: ".*WatchKit Extension.*", # matches name or type of a target
             build_configuration: "Release",
-            codesigning_identity: "iPhone Development" #specified the codesigning identity
+            code_signing_identity: "iPhone Development" # optionally specify the codesigning identity
           )'
         ]
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
```ruby
update_project_provisioning(
                xcodeproj: "iOSArchive.xcodeproj",
                profile: "./#{profilename}", # optional if you use sigh
                target_filter: "iOSArchive", # matches name or type of a target
                build_configuration: "Release",
              )
```

When Release Archive a project with the `development` export method
The Release XCBuildConfiguration's `CODE_SIGN_IDENTITY[sdk=iphoneos*]` defualt value is `"iPhone Distribution"`

This will cause the profile doesn't include distribution signing certificate
![image](https://user-images.githubusercontent.com/15394437/38804448-03293758-41a5-11e8-90c5-a48fc3ee8919.png)

![image](https://user-images.githubusercontent.com/15394437/38804516-3ef4d0c6-41a5-11e8-89ea-4d733be28cd1.png)

The same as the Debug Archive with `ad-hoc` export method for Debug XCBuildConfiguration's                 `CODE_SIGN_IDENTITY` defualt value is `iPhone Developer`

So I add a parameter for `update_project_provisioning` to change the` CODE_SIGN_IDENTITY` in `XCBuildConfiguration` so that the certificate will be find
```ruby
update_project_provisioning(
                xcodeproj: "iOSArchive.xcodeproj",
                profile: "./#{profilename}", # optional if you use sigh
                target_filter: "iOSArchive", # matches name or type of a target
                build_configuration: "Release",
                code_signing_identity: "iPhone Developer" # optionally specify the codesigning identity
              )

  gym
```
![image](https://user-images.githubusercontent.com/15394437/38852341-0ce090b4-424c-11e8-9b4c-cf7b0eb625c6.png)
![image](https://user-images.githubusercontent.com/15394437/38852367-2d16ef72-424c-11e8-94ea-041b8bb61fd8.png)


I use the changed `update_project_provisioning` action in my local project It worked well

### Description
Add parameter `codesigning_identity` for action `update_project_provisioning` which you can set to `iPhone Developer` or `iPhone Distribution` according to the demand