### PR TITLE
[spaceship] remove duplicate names in select_team to work with ruby 2.0

### DIFF
--- a/spaceship/lib/spaceship/launcher.rb
+++ b/spaceship/lib/spaceship/launcher.rb
@@ -63,7 +63,7 @@ module Spaceship
     #
     # @return (String) The ID of the select team. You also get the value if
     #   the user is only in one team.
-    def select_team(team_id: team_id = nil, team_name: team_name = nil)
+    def select_team(team_id: nil, team_name: nil)
       @client.select_team(team_id: team_id, team_name: team_name)
     end
 

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -68,7 +68,7 @@ module Spaceship
     #
     # @param team_id (String) (optional): The ID of a Developer Portal team
     # @param team_name (String) (optional): The name of a Developer Portal team
-    def select_team(team_id: team_id = nil, team_name: team_name = nil)
+    def select_team(team_id: nil, team_name: nil)
       @current_team_id = self.UI.select_team(team_id: team_id, team_name: team_name)
     end
 

--- a/spaceship/lib/spaceship/portal/spaceship.rb
+++ b/spaceship/lib/spaceship/portal/spaceship.rb
@@ -39,7 +39,7 @@ module Spaceship
       #
       # @return (String) The ID of the select team. You also get the value if
       #   the user is only in one team.
-      def select_team(team_id: team_id = nil, team_name: team_name = nil)
+      def select_team(team_id: nil, team_name: nil)
         @client.select_team(team_id: team_id, team_name: team_name)
       end
 
@@ -98,7 +98,7 @@ module Spaceship
       Spaceship::Portal.login(user, password)
     end
 
-    def select_team(team_id: team_id = nil, team_name: team_name = nil)
+    def select_team(team_id: nil, team_name: nil)
       Spaceship::Portal.select_team(team_id: team_id, team_name: team_name)
     end
 

--- a/spaceship/lib/spaceship/portal/ui/select_team.rb
+++ b/spaceship/lib/spaceship/portal/ui/select_team.rb
@@ -47,7 +47,7 @@ module Spaceship
       end
       # rubocop:enable Require/MissingRequireStatement
 
-      def select_team(team_id: team_id = nil, team_name: team_name = nil)
+      def select_team(team_id: nil, team_name: nil)
         teams = client.teams
 
         if teams.count == 0

--- a/spaceship/lib/spaceship/tunes/spaceship.rb
+++ b/spaceship/lib/spaceship/tunes/spaceship.rb
@@ -31,7 +31,7 @@ module Spaceship
       #
       # @param team_id (String) (optional): The ID of a iTunesConnect team
       # @param team_name (String) (optional): The name of a iTunesConnect team
-      def select_team(team_id: team_id = nil, team_name: team_name = nil)
+      def select_team(team_id: nil, team_name: nil)
         @client.select_team(team_id: team_id, team_name: team_name)
       end
     end

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -59,7 +59,7 @@ module Spaceship
     #
     # @param team_id (String) (optional): The ID of a iTunesConnect team
     # @param team_name (String) (optional): The name of a iTunesConnect team
-    def select_team(team_id: team_id = nil, team_name: team_name = nil)
+    def select_team(team_id: nil, team_name: nil)
       t_id = (team_id || ENV['FASTLANE_ITC_TEAM_ID'] || '').strip
       t_name = (team_name || ENV['FASTLANE_ITC_TEAM_NAME'] || '').strip
 


### PR DESCRIPTION
Fixes #12322

- Remove duplicate param name to support back to Ruby 2.0