### PR TITLE
Removing original IPA basename from copied IPA for ITC upload for sta…

### DIFF
--- a/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -36,8 +36,7 @@ module FastlaneCore
     end
 
     def unique_ipa_path(ipa_path)
-      basename = File.basename(ipa_path, '.ipa').gsub(' ', '_')
-      "#{basename}_#{Digest::SHA256.file(ipa_path).hexdigest}.ipa"
+      "#{Digest::SHA256.file(ipa_path).hexdigest}.ipa"
     end
 
     private


### PR DESCRIPTION
…bility

Fixes #12302

- `File.basename(ipa_path, '.ipa')` was returning some weird values that was causing iTunesTransporting to 💥  at just using the nice SHA ✨ 