### PR TITLE
[snapshot] add 'xcrun simctl addmedia' and fallback to addphoto/addvideo

### DIFF
--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -77,7 +77,16 @@ module Snapshot
 
         paths.each do |path|
           UI.message("Adding '#{path}'")
-          Helper.backticks("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape} &> /dev/null")
+
+          # Attempting addmedia since addphoto and addvideo are deprecated
+          output = Helper.backticks("xcrun simctl addmedia #{device_udid} #{path.shellescape} &> /dev/null")
+
+          # Run legacy addphoto and addvideo if addmedia isn't found
+          # Output will be empty strin gif it was a success
+          # Output will contain "usage: simctl" if command not found
+          if output.include?('usage: simctl')
+            Helper.backticks("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape} &> /dev/null")
+          end
         end
       end
     end

--- a/snapshot/spec/simulator_launcher_base_spec.rb
+++ b/snapshot/spec/simulator_launcher_base_spec.rb
@@ -1,0 +1,43 @@
+describe Snapshot do
+  describe Snapshot::SimulatorLauncherBase do
+    let(:device_udid) { "123456789" }
+    let(:paths) { ['./logo.png'] }
+
+    describe '#add_media' do
+      it "should call simctl addmedia" do
+        allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
+
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("xcrun instruments -w #{device_udid} &> /dev/null")
+          .and_return("").exactly(1).times
+
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')} &> /dev/null")
+          .and_return("").exactly(1).times
+
+        # Verify that backticks isn't called for the fallback to addphoto/addvideo
+        expect(Fastlane::Helper).to receive(:backticks).with(anything).and_return(anything).exactly(0).times
+
+        launcher = Snapshot::SimulatorLauncherBase.new
+        launcher.add_media(['phone'], 'photo', paths)
+      end
+
+      it "should call simctl addmedia and fallback to addphoto" do
+        allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
+
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("xcrun instruments -w #{device_udid} &> /dev/null")
+          .and_return("").exactly(1).times
+
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')} &> /dev/null")
+          .and_return("usage: simctl [--noxpc] [--set <path>] [--profiles <path>] <subcommand> ...\n").exactly(1).times
+
+        expect(Fastlane::Helper).to receive(:backticks).with(anything).and_return(anything).exactly(1).times
+
+        launcher = Snapshot::SimulatorLauncherBase.new
+        launcher.add_media(['phone'], 'photo', paths)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #12289

## Wut
- `xcrun simctl addphoto` and `xcrun simctl addvideo` are deprecated and say to use `addmedia`
- If `xcrun simctl addmedia` returns out that contains `usage: simctl`, it means `addmedia` wasn't found and we will fallback to `addphoto` and `addvideo`
  - `simctl` has zero documentation so its hard to know what versions `addmedia` was added
  - This `usage: simctl` was found out by running `xcrun simctl addpizza` to see what would happen with an unknown command
- Test have been added for both succesful `addmedia` and fallback to `addphoto` and `addvideo`