### PR TITLE
Bugfix: scan with result_bundle cannot be run twice

### DIFF
--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -141,7 +141,7 @@ module Scan
     def result_bundle_path
       unless Scan.cache[:result_bundle_path]
         path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ".test_result"
-        if FileUtils.directory?(path)
+        if File.directory?(path)
           FileUtils.remove_dir(path)
         end
         Scan.cache[:result_bundle_path] = path

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -140,7 +140,11 @@ module Scan
 
     def result_bundle_path
       unless Scan.cache[:result_bundle_path]
-        Scan.cache[:result_bundle_path] = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ".test_result"
+        path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ".test_result"
+        if FileUtils.directory?(path)
+          FileUtils.remove_dir(path)
+        end
+        Scan.cache[:result_bundle_path] = path
       end
       return Scan.cache[:result_bundle_path]
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes: https://github.com/fastlane/fastlane/issues/12349

When running scan with `result_bundle` (which by the way is strangely a boolean, not a path) you cannot run it twice, because xcodebuild complains that the resultBundlePath already exists.

```
 [16:20:29]: ------------------
[16:20:29]: --- Step: scan ---
[16:20:29]: ------------------
[16:20:29]: $ xcodebuild -showBuildSettings -scheme BonMot-OSX -project ./BonMot.xcodeproj
[16:20:30]: $ xcodebuild -showBuildSettings -scheme BonMot-OSX -project ./BonMot.xcodeproj

+------------------------+-------------------------+
|             Summary for scan 2.92.1              |
+------------------------+-------------------------+
| output_types           | junit,html              |
| scheme                 | BonMot-OSX              |
| output_directory       | ./build/BonMot-OSX/scan |
| code_coverage          | true                    |
| derived_data_path      | ./build/derived_data    |
| result_bundle          | true                    |
| project                | ./BonMot.xcodeproj      |
| clean                  | false                   |
| skip_build             | false                   |
| buildlog_path          | ~/Library/Logs/scan     |
| include_simulator_logs | false                   |
| open_report            | false                   |
| skip_slack             | false                   |
| slack_only_on_failure  | false                   |
| use_clang_report_name  | false                   |
| fail_build             | true                    |
| xcode_path             | /Applications/Xcode.app |
+------------------------+-------------------------+

[16:20:31]: $ set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme BonMot-OSX -project ./BonMot.xcodeproj -destination 'platform=macOS' -derivedDataPath './build/derived_data' -resultBundlePath './build/BonMot-OSX/scan/BonMot-OSX.test_result' -enableCodeCoverage YES build test | tee '/Users/chrisbal/Library/Logs/scan/BonMot-BonMot-OSX.log' | xcpretty  --report junit --output '/Users/chrisbal/Documents/Beach/BonMot/build/BonMot-OSX/scan/report.junit' --report html --output '/Users/chrisbal/Documents/Beach/BonMot/build/BonMot-OSX/scan/report.html' --report junit --output '/var/folders/xc/l_vyn82x0hn7d7x6b055lnz40000gn/T/junit_report20180420-12062-8xm9q1'
[16:20:31]: ▸ Loading...
[16:20:31]: ▸ xcodebuild: error: Existing file at -resultBundlePath "/Users/chrisbal/Documents/Beach/BonMot/build/BonMot-OSX/scan/BonMot-OSX.test_result"
xcodebuild: error: Existing file at -resultBundlePath "/Users/chrisbal/Documents/Beach/BonMot/build/BonMot-OSX/scan/BonMot-OSX.test_result"
[16:20:31]: Exit status: 64
```

### Description
<!-- Describe your changes in detail -->

This patch simply checks if the `result_bundle_path` directory exists, and removes it if it does.