### PR TITLE
Delete result_bundle_path for gym and update gym and scan result_bundle descriptions

### DIFF
--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -125,7 +125,11 @@ module Gym
 
       def result_bundle_path
         unless Gym.cache[:result_bundle_path]
-          Gym.cache[:result_bundle_path] = File.join(Gym.config[:output_directory], Gym.config[:output_name]) + ".result"
+          path = File.join(Gym.config[:output_directory], Gym.config[:output_name]) + ".result"
+          if File.directory?(path)
+            FileUtils.remove_dir(path)
+          end
+          Gym.cache[:result_bundle_path] = path
         end
         return Gym.cache[:result_bundle_path]
       end

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -159,6 +159,7 @@ module Gym
                                      env_name: "GYM_RESULT_BUNDLE",
                                      is_string: false,
                                      description: "Should an Xcode result bundle be generated in the output directory",
+                                     default_value: false,
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :buildlog_path,
                                      short_option: "-l",

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -158,7 +158,7 @@ module Gym
                                      short_option: "-u",
                                      env_name: "GYM_RESULT_BUNDLE",
                                      is_string: false,
-                                     description: "Location of the Xcode result bundle",
+                                     description: "Should an Xcode result bundle be generated in the output directory",
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :buildlog_path,
                                      short_option: "-l",

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -179,7 +179,7 @@ module Scan
                                      short_option: "-z",
                                      env_name: "SCAN_RESULT_BUNDLE",
                                      is_string: false,
-                                     description: "Location of the Xcode result bundle",
+                                     description: "Should an Xcode result bundle be generated in the output directory",
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :sdk,
                                      short_option: "-k",

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -180,6 +180,7 @@ module Scan
                                      env_name: "SCAN_RESULT_BUNDLE",
                                      is_string: false,
                                      description: "Should an Xcode result bundle be generated in the output directory",
+                                     default_value: false,
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :sdk,
                                      short_option: "-k",


### PR DESCRIPTION
Addition fixes on top of #12350

## Wut
- Update _gym_ and _scan_ `options.rb` description to better indicate these are booleans
- Set `default_value` to `false` to also indicate that these values are booleans
- _gym_ would fail when `result_bundle: true` was set on second run
```sh
[04:44:54]: $ set -o pipefail && xcodebuild -workspace ./Test.xcworkspace -scheme Test -destination 'generic/platform=iOS' -archivePath /Users/josh/Library/Developer/Xcode/Archives/2018-04-23/Some\ Test\ App\ 2018-04-23\ 04.44.54.xcarchive -resultBundlePath './Some Test App.result' archive | tee /Users/josh/Library/Logs/gym/Some\ Test\ App-Test.log | xcpretty
[04:44:54]: ▸ xcodebuild: error: Existing file at -resultBundlePath "/Users/josh/Projects/fastlane/test-ios/Some Test App.result"
xcodebuild: error: Existing file at -resultBundlePath "/Users/josh/Projects/fastlane/test-ios/Some Test App.result"
[04:44:55]: Exit status: 64
```