### PR TITLE
[swift] fix fastlane swift for return type of hash with anything

### DIFF
--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -23,6 +23,7 @@ module Fastlane
       :string,
       :array_of_strings,
       :hash_of_strings,
+      :hash,
       :bool,
       :int
     ]

--- a/fastlane/lib/fastlane/actions/lane_context.rb
+++ b/fastlane/lib/fastlane/actions/lane_context.rb
@@ -29,7 +29,7 @@ module Fastlane
       end
 
       def self.return_type
-        :hash_of_strings
+        :hash
       end
 
       def self.authors

--- a/fastlane/lib/fastlane/server/json_return_value_processor.rb
+++ b/fastlane/lib/fastlane/server/json_return_value_processor.rb
@@ -17,6 +17,8 @@ module Fastlane
         return process_value_as_array_of_strings(return_value: return_value)
       when :hash_of_strings
         return process_value_as_hash_of_strings(return_value: return_value)
+      when :hash
+        return process_value_as_hash_of_strings(return_value: return_value)
       else
         UI.verbose("Unknown return type defined: #{return_value_type} for value: #{return_value}")
         return process_value_as_string(return_value: return_value)

--- a/fastlane/lib/fastlane/swift_fastlane_api_generator.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_api_generator.rb
@@ -169,6 +169,14 @@ module Fastlane
 }
 
 func parseDictionary(fromString: String, function: String = #function) -> [String : String] {
+    return parseDictionaryHelper(fromString: fromString, function: function) as! [String: String]
+}
+
+func parseDictionary(fromString: String, function: String = #function) -> [String : Any] {
+    return parseDictionaryHelper(fromString: fromString, function: function)
+}
+
+func parseDictionaryHelper(fromString: String, function: String = #function) -> [String : Any] {
   verbose(message: "parsing an Array from data: \(fromString), from function: \(function)")
   let potentialDictionary: String
   if fromString.count < 2 {
@@ -177,7 +185,7 @@ func parseDictionary(fromString: String, function: String = #function) -> [Strin
   } else {
       potentialDictionary = fromString
   }
-  let dictionary: [String : String] = try! JSONSerialization.jsonObject(with: potentialDictionary.data(using: .utf8)!, options: []) as! [String : String]
+  let dictionary: [String : Any] = try! JSONSerialization.jsonObject(with: potentialDictionary.data(using: .utf8)!, options: []) as! [String : Any]
   return dictionary
 }
 

--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -53,6 +53,8 @@ module Fastlane
         return "[String]"
       when :hash_of_strings
         return "[String : String]"
+      when :hash
+        return "[String : Any]"
       when :bool
         return "Bool"
       when :int
@@ -196,6 +198,8 @@ module Fastlane
       when :array_of_strings
         returned_object = "parseArray(fromString: #{returned_object})"
       when :hash_of_strings
+        returned_object = "parseDictionary(fromString: #{returned_object})"
+      when :hash
         returned_object = "parseDictionary(fromString: #{returned_object})"
       when :bool
         returned_object = "parseBool(fromString: #{returned_object})"


### PR DESCRIPTION
Fixes issues in comments of #12303 by @doruvil

## What was happening? 💣  
- `laneContext()` was going 💥 when a return value of a hash with objects in keys was being created
  - `hockeyApp` and `match` set lane context info in the form of a hash

## What was fixed? 🛠 
- Ruby
  - Introduced a new `hash` return type that is less strict than `hash_with_strings`
- Swift
  - Created a `parseDictionaryHelper` based off of `parseDictionary` that returns `[String: Any]`
  - Created two `parseDictionary` with one that just returns the `[String: Any]` and another that casts response to `[String: String]`

## Additional thoughts 💭 
- We _could_ maybe get rid of `hash_with_strings` if we wanted (if this is to messy) but this may require more workload on the user in `Fastfile.swift` to check/cast types

## Proof is in the pudding
```swift
let laneContextInfo = laneContext()
puts(message: "SIGH_PROFILE_TYPE: \(laneContextInfo["SIGH_PROFILE_TYPE"])")
puts(message: "laneContextInfo: \(laneContextInfo)")
```

```sh
[07:34:35]: --------------------
[07:34:35]: --- Step: hockey ---
[07:34:35]: --------------------
[07:34:35]: Starting with file(s) upload to HockeyApp... this could take some time.
[07:34:41]: Public Download URL: https://rink.hockeyapp.net/apps/498913a71a9045c8b66b1e528f344e08
[07:34:41]: Build successfully uploaded to HockeyApp!
[07:34:41]: SIGH_PROFILE_TYPE: Optional(ad-hoc)
[07:34:41]: laneContextInfo: ["SIGH_PROFILE_TYPE": ad-hoc, "MATCH_PROVISIONING_PROFILE_MAPPING": {
    "com.joshholtz.FastlaneTest" = "match AdHoc com.joshholtz.FastlaneTest";
}, "XCODEBUILD_ARCHIVE": /Users/josh/Library/Developer/Xcode/Archives/2018-04-23/TestSwift 2018-04-23 07.32.57.xcarchive, "HOCKEY_BUILD_INFORMATION": {
    "bundle_identifier" = "com.joshholtz.FastlaneTest";
    company = RokkinCat;
    "config_url" = "https://rink.hockeyapp.net/manage/apps/753256/app_versions/5";
    "created_at" = "2018-04-23T11:11:31Z";
    "custom_release_type" = "<null>";
    "device_family" = "iPhone/iPod/iPad";
    featured = 0;
    id = 753256;
    "minimum_os_version" = "11.2";
    owner = RokkinCat;
    "owner_token" = ce72a5bc3de8438e66d45f9f7fbf60da28c4a13c;
    platform = iOS;
    "public_identifier" = 498913a71a9045c8b66b1e528f344e08;
    "public_url" = "https://rink.hockeyapp.net/apps/498913a71a9045c8b66b1e528f344e08";
    "release_type" = 0;
    "retention_days" = unlimited;
    role = 0;
    status = 2;
    title = FastlaneTest;
    "updated_at" = "2018-04-23T12:34:41Z";
    visibility = private;
}, "HOCKEY_DOWNLOAD_LINK": https://rink.hockeyapp.net/apps/498913a71a9045c8b66b1e528f344e08, "IPA_OUTPUT_PATH": /Users/josh/Projects/fastlane/test-swift/TestSwift.ipa, "DSYM_OUTPUT_PATH": /Users/josh/Projects/fastlane/test-swift/TestSwift.app.dSYM.zip]
```