### PR TITLE
[Swift] Fix parsing of method signature to lane name when lane has parameters

### DIFF
--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -111,16 +111,16 @@ public class LaneFile: NSObject, LaneFileProtocol {
         let lowerCasedLaneRequested = named.lowercased()
 
         guard let laneMethod = currentLanes[lowerCasedLaneRequested] else {
-			let laneNames = self.laneFunctionNames.compactMap { functionName in
-				let laneFunctionName = functionName.lowercased()
-				if laneFunctionName.hasSuffix("lane") {
-					return trimLaneFromName(laneName: laneFunctionName)
-				} else if laneFunctionName.hasSuffix("lanewithoptions:") {
-					return trimLaneWithoutOptionsFromName(laneName: laneFunctionName)
-				} else  {
-					return nil
-				}
-			}.joined(separator: ", ")
+            let laneNames = self.laneFunctionNames.compactMap { functionName in
+                let laneFunctionName = functionName.lowercased()
+                if laneFunctionName.hasSuffix("lane") {
+                    return trimLaneFromName(laneName: laneFunctionName)
+                } else if laneFunctionName.hasSuffix("lanewithoptions:") {
+                    return trimLaneWithoutOptionsFromName(laneName: laneFunctionName)
+                } else {
+                    return nil
+                }
+            }.joined(separator: ", ")
 
             let message = "[!] Could not find lane '\(named)'. Available lanes: \(laneNames)"
             log(message: message)

--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -50,9 +50,9 @@ public class LaneFile: NSObject, LaneFileProtocol {
         return String(laneName.prefix(laneName.count - 12))
     }
 
-	private static func trimLaneWithoutOptionsFromName(laneName: String) -> String {
-		return String(laneName.prefix(laneName.count - 16))
-	}
+    private static func trimLaneWithoutOptionsFromName(laneName: String) -> String {
+        return String(laneName.prefix(laneName.count - 16))
+    }
 
     private static var laneFunctionNames: [String] {
         var lanes: [String] = []

--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -50,6 +50,10 @@ public class LaneFile: NSObject, LaneFileProtocol {
         return String(laneName.prefix(laneName.count - 12))
     }
 
+	private static func trimLaneWithoutOptionsFromName(laneName: String) -> String {
+		return String(laneName.prefix(laneName.count - 16))
+	}
+
     private static var laneFunctionNames: [String] {
         var lanes: [String] = []
         var methodCount: UInt32 = 0
@@ -107,13 +111,16 @@ public class LaneFile: NSObject, LaneFileProtocol {
         let lowerCasedLaneRequested = named.lowercased()
 
         guard let laneMethod = currentLanes[lowerCasedLaneRequested] else {
-            let laneNames = self.laneFunctionNames.map { laneFuctionName in
-                if laneFuctionName.hasSuffix("lanewithoptions:") {
-                    return trimLaneWithOptionsFromName(laneName: laneFuctionName)
-                } else {
-                    return trimLaneFromName(laneName: laneFuctionName)
-                }
-            }.joined(separator: ", ")
+			let laneNames = self.laneFunctionNames.compactMap { functionName in
+				let laneFunctionName = functionName.lowercased()
+				if laneFunctionName.hasSuffix("lane") {
+					return trimLaneFromName(laneName: laneFunctionName)
+				} else if laneFunctionName.hasSuffix("lanewithoptions:") {
+					return trimLaneWithoutOptionsFromName(laneName: laneFunctionName)
+				} else  {
+					return nil
+				}
+			}.joined(separator: ", ")
 
             let message = "[!] Could not find lane '\(named)'. Available lanes: \(laneNames)"
             log(message: message)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change is required in order to fix:
Wrong parsing in case the lane (method) is having parameters.

closes #12277

For having the following methods (lanes) declared:

```swift
func firstLane() {
		
	}
	
	func secondLane(_ options:[String: String]?) {
		
	}
	
	func thirdLane(withOptions options:[String: String]?) {

	}
	
	func fourthLaneWithOptions(_ options:[String: String]?) {
		
	}
	
	func fifthLaneWithOptions(withOptions options:[String: String]?) {
		
	}
	
	func hockeyAppLane(withOptions options:[String: String]?) {
		
	}
```

I was  getting the following output:
![list of available lanes before my changes](https://user-images.githubusercontent.com/4958872/39125692-258c0bee-4700-11e8-9488-c24e16371591.png)

I have detailed the problem here:
https://medium.com/@doruvil/fatlane-continous-integration-swift-version-b8851f1f38b6

After my changes, the output is:
<img width="605" alt="list of available lanes after my changes" src="https://user-images.githubusercontent.com/4958872/39125683-1737bdd6-4700-11e8-8f7e-81a043e47ac4.png">


### Description
Added additional parsing for lane (methods) which have parameters.

I have detailed my tests here:
https://medium.com/@doruvil/fatlane-continous-integration-swift-version-b8851f1f38b6
