### PR TITLE
Add support for hidding Ruby backtraces

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -269,7 +269,8 @@ module Commander
     end
 
     def reraise_formatted!(e, message)
-      raise e, "[!] #{message}".red, e.backtrace
+      backtrace = FastlaneCore::Env.truthy?("FASTLANE_HIDE_BACKTRACE") ? [] : e.backtrace
+      raise e, "[!] #{message}".red, backtrace
     end
 
     def show_github_issues(message_or_error)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This is probably going to be a bit controversial, but for teams where not everyone is a Ruby developer, the Ruby backtrace has very little value and makes reading the output and intimidating task. I'd like to hide the Ruby backtrace from CI output, so developers can feel less intimidated by Ruby while focusing on the problems with their iOS projects.

### Description
Setting FASTLANE_HIDE_BACKTRACE environment variable will hide all Ruby exceptions backtraces.