### PR TITLE
Version bump to 2.93.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,23 +32,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 
 <table id='team'>
 <tr>
-<td id='andrew-mcburney'>
-<a href='https://github.com/AndrewMcBurney'>
-<img src='https://github.com/AndrewMcBurney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
 <td id='stefan-natchev'>
 <a href='https://github.com/snatchev'>
 <img src='https://github.com/snatchev.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
 <td id='jorge-revuelta-h'>
 <a href='https://github.com/minuscorp'>
@@ -56,69 +44,49 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
 </td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
 </td>
 </tr>
 <tr>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
 <td id='iulian-onofrei'>
 <a href='https://github.com/revolter'>
 <img src='https://github.com/revolter.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
-</tr>
-<tr>
 <td id='kohki-miki'>
 <a href='https://github.com/giginet'>
 <img src='https://github.com/giginet.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/DanToml'>
-<img src='https://github.com/DanToml.png?size=140'>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
-</td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 <td id='aaron-brager'>
 <a href='https://github.com/getaaron'>
@@ -128,23 +96,43 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/DanToml'>
+<img src='https://github.com/DanToml.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
 </td>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/AndrewMcBurney'>
+<img src='https://github.com/AndrewMcBurney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+</tr>
+<tr>
 <td id='jan-piotrowski'>
 <a href='https://github.com/janpio'>
 <img src='https://github.com/janpio.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
 <td id='jérôme-lacoste'>
 <a href='https://github.com/lacostej'>
@@ -152,11 +140,23 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
 </tr>
 </table>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -14,26 +14,26 @@ File.write("#{lib}/fastlane/plugins/template/.rubocop.yml", YAML.dump(config))
 Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
-  spec.authors       = ["Jorge Revuelta H",
-                        "Luka Mirosevic",
+  spec.authors       = ["Stefan Natchev",
+                        "Jimmy Dee",
+                        "Felix Krause",
+                        "Matthew Ellis",
                         "Kohki Miki",
                         "Maksym Grebenets",
-                        "Josh Holtz",
                         "Aaron Brager",
-                        "Joshua Liebowitz",
-                        "Helmut Januschka",
-                        "Felix Krause",
-                        "Andrew McBurney",
-                        "Danielle Tomlinson",
-                        "Fumiya Nakamura",
-                        "Matthew Ellis",
-                        "Manu Wallner",
-                        "Iulian Onofrei",
-                        "Jimmy Dee",
                         "Jérôme Lacoste",
-                        "Stefan Natchev",
+                        "Danielle Tomlinson",
+                        "Jorge Revuelta H",
+                        "Luka Mirosevic",
                         "Jan Piotrowski",
-                        "Olivier Halligon"]
+                        "Iulian Onofrei",
+                        "Helmut Januschka",
+                        "Josh Holtz",
+                        "Manu Wallner",
+                        "Andrew McBurney",
+                        "Olivier Halligon",
+                        "Joshua Liebowitz",
+                        "Fumiya Nakamura"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.92.1'.freeze
+  VERSION = '2.93.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.92.1
+// Generated with fastlane 2.93.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -481,7 +481,7 @@ func buildApp(workspace: String? = nil,
               buildPath: String? = nil,
               archivePath: String? = nil,
               derivedDataPath: String? = nil,
-              resultBundle: String? = nil,
+              resultBundle: Bool = false,
               buildlogPath: String = "~/Library/Logs/gym",
               sdk: String? = nil,
               toolchain: String? = nil,
@@ -559,7 +559,7 @@ func buildIosApp(workspace: String? = nil,
                  buildPath: String? = nil,
                  archivePath: String? = nil,
                  derivedDataPath: String? = nil,
-                 resultBundle: String? = nil,
+                 resultBundle: Bool = false,
                  buildlogPath: String = "~/Library/Logs/gym",
                  sdk: String? = nil,
                  toolchain: String? = nil,
@@ -1695,7 +1695,7 @@ func gym(workspace: String? = gymfile.workspace,
          buildPath: String? = gymfile.buildPath,
          archivePath: String? = gymfile.archivePath,
          derivedDataPath: String? = gymfile.derivedDataPath,
-         resultBundle: String? = gymfile.resultBundle,
+         resultBundle: Bool = gymfile.resultBundle,
          buildlogPath: String = gymfile.buildlogPath,
          sdk: String? = gymfile.sdk,
          toolchain: String? = gymfile.toolchain,
@@ -1975,7 +1975,7 @@ func jira(url: String,
                                                                                       RubyCommand.Argument(name: "comment_text", value: commentText)])
   _ = runner.executeCommand(command)
 }
-@discardableResult func laneContext() -> [String : String] {
+@discardableResult func laneContext() -> [String : Any] {
   let command = RubyCommand(commandID: "", methodName: "lane_context", className: nil, args: [])
   return parseDictionary(fromString: runner.executeCommand(command))
 }
@@ -2595,7 +2595,7 @@ func runTests(workspace: String? = nil,
               buildForTesting: Bool? = nil,
               xctestrun: String? = nil,
               derivedDataPath: String? = nil,
-              resultBundle: String? = nil,
+              resultBundle: Bool = false,
               sdk: String? = nil,
               openReport: Bool = false,
               configuration: String? = nil,
@@ -2713,7 +2713,7 @@ func scan(workspace: String? = scanfile.workspace,
           buildForTesting: Bool? = scanfile.buildForTesting,
           xctestrun: String? = scanfile.xctestrun,
           derivedDataPath: String? = scanfile.derivedDataPath,
-          resultBundle: String? = scanfile.resultBundle,
+          resultBundle: Bool = scanfile.resultBundle,
           sdk: String? = scanfile.sdk,
           openReport: Bool = scanfile.openReport,
           configuration: String? = scanfile.configuration,
@@ -3483,6 +3483,12 @@ func updateInfoPlist(xcodeproj: String? = nil,
                                                                                                    RubyCommand.Argument(name: "block", value: block)])
   _ = runner.executeCommand(command)
 }
+func updatePlist(plistPath: String? = nil,
+                 block: String) {
+  let command = RubyCommand(commandID: "", methodName: "update_plist", className: nil, args: [RubyCommand.Argument(name: "plist_path", value: plistPath),
+                                                                                              RubyCommand.Argument(name: "block", value: block)])
+  _ = runner.executeCommand(command)
+}
 func updateProjectCodeSigning(path: String,
                               udid: String,
                               uuid: String) {
@@ -3902,6 +3908,14 @@ func parseArray(fromString: String, function: String = #function) -> [String] {
 }
 
 func parseDictionary(fromString: String, function: String = #function) -> [String : String] {
+    return parseDictionaryHelper(fromString: fromString, function: function) as! [String: String]
+}
+
+func parseDictionary(fromString: String, function: String = #function) -> [String : Any] {
+    return parseDictionaryHelper(fromString: fromString, function: function)
+}
+
+func parseDictionaryHelper(fromString: String, function: String = #function) -> [String : Any] {
   verbose(message: "parsing an Array from data: \(fromString), from function: \(function)")
   let potentialDictionary: String
   if fromString.count < 2 {
@@ -3910,7 +3924,7 @@ func parseDictionary(fromString: String, function: String = #function) -> [Strin
   } else {
       potentialDictionary = fromString
   }
-  let dictionary: [String : String] = try! JSONSerialization.jsonObject(with: potentialDictionary.data(using: .utf8)!, options: []) as! [String : String]
+  let dictionary: [String : Any] = try! JSONSerialization.jsonObject(with: potentialDictionary.data(using: .utf8)!, options: []) as! [String : Any]
   return dictionary
 }
 
@@ -3933,4 +3947,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.14]
+// FastlaneRunnerAPIVersion [0.9.15]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.92.1
+// Generated with fastlane 2.93.0

--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -19,7 +19,7 @@ protocol GymfileProtocol: class {
   var buildPath: String? { get }
   var archivePath: String? { get }
   var derivedDataPath: String? { get }
-  var resultBundle: String? { get }
+  var resultBundle: Bool { get }
   var buildlogPath: String { get }
   var sdk: String? { get }
   var toolchain: String? { get }
@@ -60,7 +60,7 @@ extension GymfileProtocol {
   var buildPath: String? { return nil }
   var archivePath: String? { return nil }
   var derivedDataPath: String? { return nil }
-  var resultBundle: String? { return nil }
+  var resultBundle: Bool { return false }
   var buildlogPath: String { return "~/Library/Logs/gym" }
   var sdk: String? { return nil }
   var toolchain: String? { return nil }
@@ -82,4 +82,4 @@ extension GymfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.1]
+// FastlaneRunnerAPIVersion [0.9.2]

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.92.1
+// Generated with fastlane 2.93.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.92.1
+// Generated with fastlane 2.93.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.92.1
+// Generated with fastlane 2.93.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -21,7 +21,7 @@ protocol ScanfileProtocol: class {
   var buildForTesting: Bool? { get }
   var xctestrun: String? { get }
   var derivedDataPath: String? { get }
-  var resultBundle: String? { get }
+  var resultBundle: Bool { get }
   var sdk: String? { get }
   var openReport: Bool { get }
   var configuration: String? { get }
@@ -63,7 +63,7 @@ extension ScanfileProtocol {
   var buildForTesting: Bool? { return nil }
   var xctestrun: String? { return nil }
   var derivedDataPath: String? { return nil }
-  var resultBundle: String? { return nil }
+  var resultBundle: Bool { return false }
   var sdk: String? { return nil }
   var openReport: Bool { return false }
   var configuration: String? { return nil }
@@ -82,7 +82,6 @@ extension ScanfileProtocol {
   var failBuild: Bool { return true }
 }
 
-
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.1]
+// FastlaneRunnerAPIVersion [0.9.2]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.92.1
+// Generated with fastlane 2.93.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.92.1
+// Generated with fastlane 2.93.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.92.1':**

* [swift] fix fastlane swift for return type of hash with anything (#12360) via Josh Holtz
* new action update_plist (#12190) via Rishabh Tayal
* Delete result_bundle_path for gym and update gym and scan result_bundle descriptions (#12357) via Josh Holtz
* Bugfix: scan with result_bundle cannot be run twice (#12350) via Chris Ballinger
* Move FastlaneCore::UpdateChecker to after dot_env load (#12338) via Josh Holtz
* [snapshot] add 'xcrun simctl addmedia' and fallback to addphoto/addvideo (#12347) via Josh Holtz
* Add available plugins link to Fastfile template (#12341) via Iulian Onofrei
* Removing original IPA basename from copied IPA for ITC upload for stability (#12334) via Josh Holtz
* [spaceship] remove duplicate names in select_team to work with ruby 2.0 (#12333) via Josh Holtz
