### PR TITLE
[supply] fixed rollout fraction to only be sent on track "rollout"

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -242,6 +242,11 @@ module Supply
 
       track_version_codes = apk_version_code.kind_of?(Array) ? apk_version_code : [apk_version_code]
 
+      # This change happend on 2018-04-24
+      # rollout cannot be sent on any other track besides "rollout"
+      # https://github.com/fastlane/fastlane/issues/12372
+      rollout = nil unless track == "rollout"
+
       track_body = Androidpublisher::Track.new({
         track: track,
         user_fraction: rollout,


### PR DESCRIPTION
Fixes #12372

## Wut
- Google Play API changed up some rules where `use_fraction` (rollout) cannot be sent up on the `internal`, `alpha`, `beta`, or `production` tracks - it can only be be sent up on the `rollout` track

![](https://media2.giphy.com/media/3ohzdYJK1wAdPWVk88/giphy.gif)