### PR TITLE
Scan: Add option to limit max concurrent simulators

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -151,6 +151,12 @@ module Scan
                                      env_name: "SCAN_MAX_CONCURRENT_SIMULATORS",
                                      description: "Constrain the number of simulator devices on which to test concurrently. Equivalent to -maximum-concurrent-test-simulator-destinations",
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :disable_concurrent_testing,
+                                     type: Boolean,
+                                     default_value: false,
+                                     env_name: "SCAN_DISABLE_CONCURRENT_TESTING",
+                                     description: "Do not run test bundles in parallel on the specified destinations. Testing will occur on each destination serially. Equivalent to -disable-concurrent-testing",
+                                     optional: true),
 
         FastlaneCore::ConfigItem.new(key: :test_without_building,
                                      short_option: "-T",

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -146,6 +146,10 @@ module Scan
                                      env_name: "SCAN_FORMATTER",
                                      description: "A custom xcpretty formatter to use",
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :max_concurrent_simulators,
+                                     env_name: "SCAN_MAX_CONCURRENT_SIMULATORS",
+                                     description: "Constrain the number of simulator devices on which to test concurrently. Equivalent to -maximum-concurrent-test-simulator-destinations",
+                                     optional: true),
 
         FastlaneCore::ConfigItem.new(key: :test_without_building,
                                      short_option: "-T",

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -147,6 +147,7 @@ module Scan
                                      description: "A custom xcpretty formatter to use",
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :max_concurrent_simulators,
+                                     type: Integer,
                                      env_name: "SCAN_MAX_CONCURRENT_SIMULATORS",
                                      description: "Constrain the number of simulator devices on which to test concurrently. Equivalent to -maximum-concurrent-test-simulator-destinations",
                                      optional: true),

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -38,6 +38,7 @@ module Scan
       options << "-derivedDataPath '#{config[:derived_data_path]}'" if config[:derived_data_path]
       options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
       options << "-maximum-concurrent-test-simulator-destinations #{config[:max_concurrent_simulators]}" if config[:max_concurrent_simulators]
+      options << "-disable-concurrent-testing" if config[:disable_concurrent_testing]
       options << "-enableCodeCoverage #{config[:code_coverage] ? 'YES' : 'NO'}" unless config[:code_coverage].nil?
       options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
       options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -37,6 +37,7 @@ module Scan
       options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]
       options << "-derivedDataPath '#{config[:derived_data_path]}'" if config[:derived_data_path]
       options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
+      options << "-maximum-concurrent-test-simulator-destinations '#{config[:max_concurrent_simulators]}'" if config[:max_concurrent_simulators]
       options << "-enableCodeCoverage #{config[:code_coverage] ? 'YES' : 'NO'}" unless config[:code_coverage].nil?
       options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
       options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -37,7 +37,7 @@ module Scan
       options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]
       options << "-derivedDataPath '#{config[:derived_data_path]}'" if config[:derived_data_path]
       options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
-      options << "-maximum-concurrent-test-simulator-destinations '#{config[:max_concurrent_simulators]}'" if config[:max_concurrent_simulators]
+      options << "-maximum-concurrent-test-simulator-destinations #{config[:max_concurrent_simulators]}" if config[:max_concurrent_simulators]
       options << "-enableCodeCoverage #{config[:code_coverage] ? 'YES' : 'NO'}" unless config[:code_coverage].nil?
       options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
       options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -219,7 +219,6 @@ describe Scan do
       end
     end
 
-
     describe "Test Max Concurrent Simulators" do
       before do
         options = { project: "./scan/examples/standard/app.xcodeproj", max_concurrent_simulators: 3 }

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -219,6 +219,35 @@ describe Scan do
       end
     end
 
+
+    describe "Test Max Concurrent Simulators" do
+      before do
+        options = { project: "./scan/examples/standard/app.xcodeproj", max_concurrent_simulators: 3 }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+      end
+
+      it "uses the correct number of concurrent simulators", requires_xcodebuild: true do
+        log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+        result = @test_command_generator.generate
+        expect(result).to include("-maximum-concurrent-test-simulator-destinations 3")
+      end
+    end
+
+    describe "Test Disable Concurrent Simulators" do
+      before do
+        options = { project: "./scan/examples/standard/app.xcodeproj", disable_concurrent_testing: true }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+      end
+
+      it "disables concurrent simulators", requires_xcodebuild: true do
+        log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+        result = @test_command_generator.generate
+        expect(result).to include("-disable-concurrent-testing")
+      end
+    end
+
     describe "with Scan option :include_simulator_logs" do
       context "extract system.logarchive" do
         it "copies all device logs to the output directory", requires_xcodebuild: true do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

From xcodebuild man page:

```
     -maximum-concurrent-test-simulator-destinations number
           Constrain the number of simulator devices on which to test  concur-
           rently.
```

When using parallel device testing with scan, it can be problematic to test large numbers of simulators on CI because of resource limits. Adding this option allows you to constrain your resource usage to avoid breaking your CI system.

For example on CircleCI this is what happens when you test too many simulators in parallel: https://circleci.com/gh/Raizlabs/BonMot/445

```
2018-04-23 16:22:55.164 xcodebuild[1212:12066] CoreSimulatorService connection interrupted.  Resubscribing to notifications.
✓ iPhone 7 Plus
✗ iPhone SE
2018-04-23 16:22:55.453 xcodebuild[1212:7434] Error Domain=IDETestOperationsObserverErrorDomain Code=6 "Early unexpected exit, operation never finished bootstrapping - no restart will be attempted" UserInfo={NSLocalizedDescription=Early unexpected exit, operation never finished bootstrapping - no restart will be attempted}
✗ iPhone 7
2018-04-23 16:22:55.459 xcodebuild[1212:7434] Error Domain=IDETestOperationsObserverErrorDomain Code=6 "Early unexpected exit, operation never finished bootstrapping - no restart will be attempted" UserInfo={NSLocalizedDescription=Early unexpected exit, operation never finished bootstrapping - no restart will be attempted}

Testing failed:
Test target BonMot-iOSTests encountered an error (Early unexpected exit, operation never finished bootstrapping - no restart will be attempted)
** TEST FAILED **
```
