### PR TITLE
[swift] find swift lane names with option parameters

### DIFF
--- a/fastlane/lib/fastlane/lane_list.rb
+++ b/fastlane/lib/fastlane/lane_list.rb
@@ -52,7 +52,6 @@ module Fastlane
 
     def self.lane_name_from_swift_line(potential_lane_line: nil)
       function_name_match = SWIFT_FUNCTION_REGEX.match(potential_lane_line)
-
       unless function_name_match
         return nil
       end

--- a/fastlane/lib/fastlane/lane_list.rb
+++ b/fastlane/lib/fastlane/lane_list.rb
@@ -1,7 +1,7 @@
 module Fastlane
   class LaneList
     # Print out the result of `generate`
-    SWIFT_FUNCTION_REGEX = /\s*func\s*(\w*)\s*\(\s*\)\s*/
+    SWIFT_FUNCTION_REGEX = /\s*func\s*(\w*)\s*\((.*)\)\s*/
     SWIFT_DESC_REGEX = /\s*desc\s*\(\s*"(.*)"\s*\)\s*/
     def self.output(path)
       puts(generate(path))
@@ -20,8 +20,7 @@ module Fastlane
 
       lane_content.split("\n").reject(&:empty?).each do |line|
         line.strip!
-        if line.start_with?("func")
-          current_lane_name = self.lane_name_from_swift_line(potential_lane_line: line)
+        if line.start_with?("func") && (current_lane_name = self.lane_name_from_swift_line(potential_lane_line: line))
           lanes_by_name[current_lane_name] = Fastlane::Lane.new(platform: nil, name: current_lane_name.to_sym, description: [])
         elsif line.start_with?("desc")
           lane_description = self.desc_entry_for_swift_lane(named: current_lane_name, potential_desc_line: line)
@@ -53,6 +52,7 @@ module Fastlane
 
     def self.lane_name_from_swift_line(potential_lane_line: nil)
       function_name_match = SWIFT_FUNCTION_REGEX.match(potential_lane_line)
+
       unless function_name_match
         return nil
       end

--- a/fastlane/spec/lane_list_spec.rb
+++ b/fastlane/spec/lane_list_spec.rb
@@ -36,5 +36,32 @@ describe Fastlane do
       result = Fastlane::LaneList.generate_json(nil)
       expect(result).to eq({})
     end
+
+    describe "#lane_name_from_swift_line" do
+      let(:testLane) { "func testLane() {" }
+      let(:testLaneWithOptions) { "func testLane(withOptions: [String: String]?) {" }
+      let(:testNoLane) { "func test() {" }
+      let(:testNoLaneWithOptions) { "func test(withOptions: [String: String]?) {" }
+
+      it "finds lane name without options" do
+        name = Fastlane::LaneList.lane_name_from_swift_line(potential_lane_line: testLane)
+        expect(name).to eq("testLane")
+      end
+
+      it "finds lane name with options" do
+        name = Fastlane::LaneList.lane_name_from_swift_line(potential_lane_line: testLaneWithOptions)
+        expect(name).to eq("testLane")
+      end
+
+      it "doesn't find lane name without options" do
+        name = Fastlane::LaneList.lane_name_from_swift_line(potential_lane_line: testNoLane)
+        expect(name).to eq(nil)
+      end
+
+      it "doesn't find lane name with options" do
+        name = Fastlane::LaneList.lane_name_from_swift_line(potential_lane_line: testNoLaneWithOptions)
+        expect(name).to eq(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Motivation
Be able to run a lane with options and use the options in swift
```sh
$: fastlane test some_option:"I want to see this in swift"
```

## Issue
- fastlane swift technically supports `func testLane(withOptions options: [String: String]?)` but fastlane ruby wasn't able to find this as a lane due to regex being too strict
- `Fastlane::LaneList` regex for a finding a lane name swift function wasn't allowing for a line like `func testLane(withOptions options: [String: String]?)`
  - The regex was looking only for `\s*` between the parentheses but really needed `(.*)`

## Fix
- Switched `\s*` for `(.*)` in the swift function regex 
- Added tests for `lane_name_from_swift_line`
- Also added extra check to **not set** not try to add a lane name if `lane_name_from_swift_line` returns `nil`

## Result 🎈 

```sh
$: fastlane test some_option:"I want to see this in swift"
```

```swift
func testLane(withOptions options:[String: String]?) {
	puts(message: "options: \(options)")
}
```

```sh
➜  test-swift git:(master) ✗ fl test some_option:'hey'
[✔] 🚀
[07:32:16]: loading manifest: /Users/josh/Projects/fastlane/fastlane/fastlane/swift/upgrade_manifest.json
[07:32:16]: FastlaneSwiftRunner project is up-to-date
[07:32:16]: $ ./fastlane/FastlaneRunner lane test some_option hey > /dev/null
[07:32:16]: options: Optional(["some_option": "hey"])
```