### PR TITLE
Screengrab + Snapshot: Generate ids onto languages headers and device name sections.

### DIFF
--- a/screengrab/lib/screengrab/page.html.erb
+++ b/screengrab/lib/screengrab/page.html.erb
@@ -65,12 +65,12 @@
     </style>
   </head>
   <body><% image_counter = 0 %><% @data.each do |language, content| %>
-    <h1 class="language"><%= language %></h1>
+    <h1 id="<%= language %>" class="language"><%= language %></h1>
     <hr>
     <table><% content.each do |device_name, screens| %>
       <tr>
         <th colspan="<%= screens.count %>">
-          <span class="deviceName"><%= device_name %></span>
+          <span id="<%= language %>-<%= device_name %>" class="deviceName"><%= device_name %></span>
         </th>
       </tr>
       <tr><% screens.each do |screen_path| %><% next if screen_path.include?"_framed.png" %>

--- a/screengrab/lib/screengrab/page.html.erb
+++ b/screengrab/lib/screengrab/page.html.erb
@@ -70,7 +70,7 @@
     <table><% content.each do |device_name, screens| %>
       <tr>
         <th colspan="<%= screens.count %>">
-          <span id="<%= language %>-<%= device_name %>" class="deviceName"><%= device_name %></span>
+          <a id="<%= language %>-<%= device_name %>" class="deviceName" href="#<%= language %>-<%= device_name %>"><%= device_name %></a>
         </th>
       </tr>
       <tr><% screens.each do |screen_path| %><% next if screen_path.include?"_framed.png" %>

--- a/snapshot/lib/snapshot/page.html.erb
+++ b/snapshot/lib/snapshot/page.html.erb
@@ -65,12 +65,12 @@
     </style>
   </head>
   <body><% image_counter = 0 %><% @data.each do |language, content| %>
-    <h1 class="language"><%= language %></h1>
+    <h1 id="<%= language %>" class="language"><%= language %></h1>
     <hr>
     <table><% content.each do |device_name, screens| %>
       <tr>
         <th colspan="<%= screens.count %>">
-          <span class="deviceName"><%= device_name %></span>
+          <span id="<%= language %>-<%= device_name %>" class="deviceName"><%= device_name %></span>
         </th>
       </tr>
       <tr><% screens.each do |screen_path| %><% next if screen_path.include?"_framed.png" %>

--- a/snapshot/lib/snapshot/page.html.erb
+++ b/snapshot/lib/snapshot/page.html.erb
@@ -70,7 +70,7 @@
     <table><% content.each do |device_name, screens| %>
       <tr>
         <th colspan="<%= screens.count %>">
-          <span id="<%= language %>-<%= device_name %>" class="deviceName"><%= device_name %></span>
+          <a id="<%= language %>-<%= device_name %>" class="deviceName" href="#<%= language %>-<%= device_name %>"><%= device_name %></a>
         </th>
       </tr>
       <tr><% screens.each do |screen_path| %><% next if screen_path.include?"_framed.png" %>


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I want to have some links that I can open quickly and jump to the correct language / language device name. I've got 17 different languages and this feature makes it easier to navigate and handle them.

### Description

Added the ids. Here's the diff:

```diff
-<h1 class="language">en-US</h1>
+<h1 id="en-US" class="language">en-US</h1>
<hr>
<table>
  <tr>
    <th colspan="36">
-      <span class="deviceName">phoneScreenshots</span>
+      <span id="en-US-phoneScreenshots" class="deviceName">phoneScreenshots</span>
    </th>
  </tr>
```