### PR TITLE
[match] Add digest as parameter to match

### DIFF
--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -17,12 +17,13 @@ module Match
                                   branch: params[:git_branch],
                                   git_full_name: params[:git_full_name],
                                   git_user_email: params[:git_user_email],
-                                  clone_branch_directly: params[:clone_branch_directly])
+                                  clone_branch_directly: params[:clone_branch_directly],
+                                  digest: params[:digest])
       Encrypt.new.clear_password(params[:git_url])
       Encrypt.new.store_password(params[:git_url], to)
 
       message = "[fastlane] Changed passphrase"
-      GitHelper.commit_changes(workspace, message, params[:git_url], params[:git_branch])
+      GitHelper.commit_changes(workspace, message, params[:git_url], params[:git_branch], digest: params[:digest])
     end
 
     def self.ask_password(message: "Passphrase for Git Repo: ", confirm: true)

--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -112,7 +112,8 @@ module Match
           decrypted_repo = Match::GitHelper.clone(params[:git_url],
                                                   params[:shallow_clone],
                                                   branch: params[:git_branch],
-                                                  clone_branch_directly: params[:clone_branch_directly])
+                                                  clone_branch_directly: params[:clone_branch_directly],
+                                                  digest: params[:digest])
           UI.success "Repo is at: '#{decrypted_repo}'"
         end
       end

--- a/match/lib/match/encrypt.rb
+++ b/match/lib/match/encrypt.rb
@@ -44,27 +44,29 @@ module Match
       Security::InternetPassword.delete(server: server_name(git_url))
     end
 
-    def encrypt_repo(path: nil, git_url: nil)
+    def encrypt_repo(path: nil, git_url: nil, digest: nil)
       iterate(path) do |current|
         crypt(path: current,
           password: password(git_url),
-           encrypt: true)
+           encrypt: true,
+           digest: digest)
         UI.success "🔒  Encrypted '#{File.basename(current)}'" if FastlaneCore::Globals.verbose?
       end
       UI.success "🔒  Successfully encrypted certificates repo"
     end
 
-    def decrypt_repo(path: nil, git_url: nil, manual_password: nil)
+    def decrypt_repo(path: nil, git_url: nil, manual_password: nil, digest: nil)
       iterate(path) do |current|
         begin
           crypt(path: current,
             password: manual_password || password(git_url),
-             encrypt: false)
+             encrypt: false,
+              digest: digest)
         rescue
           UI.error "Couldn't decrypt the repo, please make sure you enter the right password!"
           UI.user_error!("Invalid password passed via 'MATCH_PASSWORD'") if ENV["MATCH_PASSWORD"]
           clear_password(git_url)
-          decrypt_repo(path: path, git_url: git_url)
+          decrypt_repo(path: path, git_url: git_url, digest: digest)
           return
         end
         UI.success "🔓  Decrypted '#{File.basename(current)}'" if FastlaneCore::Globals.verbose?
@@ -81,7 +83,7 @@ module Match
       end
     end
 
-    def crypt(path: nil, password: nil, encrypt: true)
+    def crypt(path: nil, password: nil, encrypt: true, digest: 'md5')
       if password.to_s.strip.length == 0 && encrypt
         UI.user_error!("No password supplied")
       end
@@ -89,6 +91,7 @@ module Match
       tmpfile = File.join(Dir.mktmpdir, "temporary")
       command = ["openssl aes-256-cbc"]
       command << "-k #{password.shellescape}"
+      command << "-md #{digest}"
       command << "-in #{path.shellescape}"
       command << "-out #{tmpfile.shellescape}"
       command << "-a"

--- a/match/lib/match/git_helper.rb
+++ b/match/lib/match/git_helper.rb
@@ -14,7 +14,8 @@ module Match
                    branch: "master",
                    git_full_name: nil,
                    git_user_email: nil,
-                   clone_branch_directly: false)
+                   clone_branch_directly: false,
+                   digest: nil)
       # Note: if you modify the parameters above, don't forget to also update the method call in
       # - runner.rb
       # - nuke.rb
@@ -69,7 +70,7 @@ module Match
         return self.clone(git_url, shallow_clone)
       end
 
-      Encrypt.new.decrypt_repo(path: @dir, git_url: git_url, manual_password: manual_password)
+      Encrypt.new.decrypt_repo(path: @dir, git_url: git_url, manual_password: manual_password, digest: digest)
 
       return @dir
     end
@@ -92,12 +93,12 @@ module Match
       end
     end
 
-    def self.commit_changes(path, message, git_url, branch = "master", files_to_commmit = nil)
+    def self.commit_changes(path, message, git_url, branch = "master", files_to_commmit = nil, digest: nil)
       files_to_commmit ||= []
       Dir.chdir(path) do
         return if `git status`.include?("nothing to commit")
 
-        Encrypt.new.encrypt_repo(path: path, git_url: git_url)
+        Encrypt.new.encrypt_repo(path: path, git_url: git_url, digest: digest)
         commands = []
 
         if files_to_commmit.count > 0 # e.g. for nuke this is treated differently

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -29,6 +29,13 @@ module Match
                                          UI.user_error!("Unsupported environment #{value}, must be in #{Match.environments.join(', ')}")
                                        end
                                      end),
+        FastlaneCore::ConfigItem.new(key: :digest,
+                                       short_option: "-m",
+                                       env_name: "MATCH_DIGEST",
+                                       description: "Specify the Message Digest to use for crypt routines",
+                                       is_string: true,
+                                       default_value: "md5"),
+
         FastlaneCore::ConfigItem.new(key: :app_identifier,
                                      short_option: "-a",
                                      env_name: "MATCH_APP_IDENTIFIER",

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -27,7 +27,8 @@ module Match
                                            branch: params[:git_branch],
                                            git_full_name: params[:git_full_name],
                                            git_user_email: params[:git_user_email],
-                                           clone_branch_directly: params[:clone_branch_directly])
+                                           clone_branch_directly: params[:clone_branch_directly],
+                                           digest: params[:digest])
 
       unless params[:readonly]
         self.spaceship = SpaceshipEnsure.new(params[:username])
@@ -69,7 +70,7 @@ module Match
       # Done
       if self.files_to_commmit.count > 0 and !params[:readonly]
         message = GitHelper.generate_commit_message(params)
-        GitHelper.commit_changes(params[:workspace], message, params[:git_url], params[:git_branch], self.files_to_commmit)
+        GitHelper.commit_changes(params[:workspace], message, params[:git_url], params[:git_branch], self.files_to_commmit, digest: params[:digest])
       end
 
       # Print a summary table for each app_identifier

--- a/match/spec/commands_generator_spec.rb
+++ b/match/spec/commands_generator_spec.rb
@@ -79,7 +79,7 @@ describe Match::CommandsGenerator do
     it "can use the git_url short flag from tool options" do
       stub_commander_runner_args(['decrypt', '-r', 'git@github.com:you/your_repo.git'])
 
-      expect_githelper_clone_with('git@github.com:you/your_repo.git', false, { branch: 'master', clone_branch_directly: false })
+      expect_githelper_clone_with('git@github.com:you/your_repo.git', false, { branch: 'master', clone_branch_directly: false, digest: 'md5' })
 
       Match::CommandsGenerator.start
     end
@@ -87,7 +87,7 @@ describe Match::CommandsGenerator do
     it "can use the shallow_clone flag from tool options" do
       stub_commander_runner_args(['decrypt', '-r', 'git@github.com:you/your_repo.git', '--shallow_clone', 'true'])
 
-      expect_githelper_clone_with('git@github.com:you/your_repo.git', true, { branch: 'master', clone_branch_directly: false })
+      expect_githelper_clone_with('git@github.com:you/your_repo.git', true, { branch: 'master', clone_branch_directly: false, digest: "md5" })
 
       Match::CommandsGenerator.start
     end

--- a/match/spec/encrypt_spec.rb
+++ b/match/spec/encrypt_spec.rb
@@ -8,33 +8,34 @@ describe Match do
       @git_url = "https://github.com/fastlane/fastlane/tree/master/so_random"
       allow(Dir).to receive(:mktmpdir).and_return(@directory)
       ENV["MATCH_PASSWORD"] = '2"QAHg@v(Qp{=*n^'
+      @digest = 'md5'
 
       @e = Match::Encrypt.new
     end
 
     it "encrypt" do
       @e = Match::Encrypt.new
-      @e.encrypt_repo(path: @directory, git_url: @git_url)
+      @e.encrypt_repo(path: @directory, git_url: @git_url, digest: @digest)
       expect(File.read(@full_path)).to_not eq(@content)
 
-      @e.decrypt_repo(path: @directory, git_url: @git_url)
+      @e.decrypt_repo(path: @directory, git_url: @git_url, digest: @digest)
       expect(File.read(@full_path)).to eq(@content)
     end
 
     it "raises an exception if invalid password is passed" do
-      @e.encrypt_repo(path: @directory, git_url: @git_url)
+      @e.encrypt_repo(path: @directory, git_url: @git_url, digest: @digest)
       expect(File.read(@full_path)).to_not eq(@content)
 
       ENV["MATCH_PASSWORD"] = "invalid"
       expect do
-        @e.decrypt_repo(path: @directory, git_url: @git_url)
+        @e.decrypt_repo(path: @directory, git_url: @git_url, digest: @digest)
       end.to raise_error("Invalid password passed via 'MATCH_PASSWORD'")
     end
 
     it "raises an exception if no password is supplied" do
       ENV["MATCH_PASSWORD"] = ""
       expect do
-        @e.encrypt_repo(path: @directory, git_url: @git_url)
+        @e.encrypt_repo(path: @directory, git_url: @git_url, digest: @digest)
       end.to raise_error("No password supplied")
     end
   end

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -23,7 +23,7 @@ describe Match do
       profile_path = "./match/spec/fixtures/test.mobileprovision"
       destination = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision")
 
-      expect(Match::GitHelper).to receive(:clone).with(git_url, true, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil, clone_branch_directly: false).and_return(repo_dir)
+      expect(Match::GitHelper).to receive(:clone).with(git_url, true, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil, clone_branch_directly: false, digest: "md5").and_return(repo_dir)
       expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution).and_return(cert_path)
       expect(Match::Generator).to receive(:generate_provisioning_profile).with(params: config,
                                                                             prov_type: :appstore,
@@ -39,7 +39,7 @@ describe Match do
           File.join(repo_dir, "something.cer"),
           File.join(repo_dir, "something.p12"), # this is important, as a cert consists out of 2 files
           "./match/spec/fixtures/test.mobileprovision"
-        ]
+        ], digest: "md5"
       )
 
       spaceship = "spaceship"
@@ -74,7 +74,7 @@ describe Match do
       cert_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.cer"
       key_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.p12"
 
-      expect(Match::GitHelper).to receive(:clone).with(git_url, false, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil, clone_branch_directly: false).and_return(repo_dir)
+      expect(Match::GitHelper).to receive(:clone).with(git_url, false, skip_docs: false, branch: "master", git_full_name: nil, git_user_email: nil, clone_branch_directly: false, digest: "md5").and_return(repo_dir)
       expect(Match::Utils).to receive(:import).with(key_path, keychain, password: nil).and_return(nil)
       expect(Match::GitHelper).to_not receive(:commit_changes)
 


### PR DESCRIPTION
port of https://github.com/hjanuschka/fastlane-plugin-cryptex/pull/10 to match.
to not break BC - default to md5

@nickgsc explained it very well:

Quote (https://github.com/hjanuschka/fastlane-plugin-cryptex/pull/10#issuecomment-384307855):


OpenSSL 1.1.0f (on Debian Jessie):
```
Message Digest commands (see the `dgst' command for more details)
blake2b512        blake2s256        gost              md4
md5               rmd160            sha1              sha224
sha256            sha384            sha512
```

LibreSSL 2.2.7 (MacOS High Sierra):
```
Message Digest commands (see the `dgst' command for more details)
gost-mac          md4               md5               md_gost94
ripemd160         sha               sha1              sha224
sha256            sha384            sha512            streebog256
streebog512       whirlpool
```

OpenSSL 1.0.2o (MacOS via Brew):
```
Message Digest commands (see the `dgst' command for more details)
md4               md5               mdc2              rmd160
sha               sha1
```

