### PR TITLE
Fix formatting for the frame_screenshots action

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
@@ -203,7 +203,8 @@ To define the title and optionally the keyword, put two `.strings` files into th
 
 The `keyword.strings` and `title.strings` are standard `.strings` file you already use for your iOS apps, making it easy to use your existing translation service to get localized titles.
 
-**Notes** 
+**Notes**
+
 - These `.strings` files **MUST** be utf-16 encoded (UTF-16 BE with BOM). They also must begin with an empty line. If you are having trouble see [issue #1740](https://github.com/fastlane/fastlane/issues/1740)
 - You **MUST** provide a background if you want titles. _frameit_ will not add the tiles if a background is not specified.
 


### PR DESCRIPTION
Before:

![screen shot 2018-04-29 at 01 41 05](https://user-images.githubusercontent.com/5748627/39401494-e242c8fc-4b4e-11e8-9f2d-ced4ed363ba4.png)

After:

![screen shot 2018-04-29 at 01 41 12](https://user-images.githubusercontent.com/5748627/39401496-e4f60b18-4b4e-11e8-82c9-c867e19f5eb7.png)
