### PR TITLE
[match] only check if cert is installed on specified keychain

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -6,10 +6,10 @@ require_relative 'helper'
 module FastlaneCore
   # This class checks if a specific certificate is installed on the current mac
   class CertChecker
-    def self.installed?(path)
+    def self.installed?(path, in_keychain: nil)
       UI.user_error!("Could not find file '#{path}'") unless File.exist?(path)
 
-      ids = installed_identies
+      ids = installed_identies(in_keychain: in_keychain)
       finger_print = sha1_fingerprint(path)
 
       return ids.include?(finger_print)
@@ -20,7 +20,7 @@ module FastlaneCore
       installed?(path)
     end
 
-    def self.installed_identies
+    def self.installed_identies(in_keychain: nil)
       install_wwdr_certificate unless wwdr_certificate_installed?
 
       available = list_available_identities
@@ -47,8 +47,10 @@ module FastlaneCore
       return ids
     end
 
-    def self.list_available_identities
-      `security find-identity -v -p codesigning`
+    def self.list_available_identities(in_keychain: nil)
+      commands = ['security find-identity -v -p codesigning']
+      commands << in_keychain if in_keychain
+      `#{commands.join(' ')}`
     end
 
     def self.wwdr_certificate_installed?

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -106,7 +106,11 @@ module Match
         cert_path = certs.last
         UI.message("Installing certificate...")
 
-        if FastlaneCore::CertChecker.installed?(cert_path)
+        # Only looking for cert in "custom" (non login.keychain) keychain
+        # Doing this for backwards compatability
+        keychain_name = params[:keychain_name] == "login.keychain" ? nil : params[:keychain_name]
+
+        if FastlaneCore::CertChecker.installed?(cert_path, in_keychain: keychain_name)
           UI.verbose("Certificate '#{File.basename(cert_path)}' is already installed on this machine")
         else
           Utils.import(cert_path, params[:keychain_name], password: params[:keychain_password])

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -80,7 +80,7 @@ describe Match do
       expect(Match::GitHelper).to_not(receive(:commit_changes))
 
       # To also install the certificate, fake that
-      expect(FastlaneCore::CertChecker).to receive(:installed?).with(cert_path).and_return(false)
+      expect(FastlaneCore::CertChecker).to receive(:installed?).with(cert_path, in_keychain: nil).and_return(false)
       expect(Match::Utils).to receive(:import).with(cert_path, keychain, password: nil).and_return(nil)
 
       spaceship = "spaceship"


### PR DESCRIPTION
Fixes #11659

## Wut
- _match_ should only check if cert is installed on a specific keychain of a specific keychain is given
  - _match_ will still look in list of **all** keychains if `keychain` not explicitly set because backwards compatibility (even though it could be argued it should just look in `login.keychain`)

## To Test This Change
Add the following to your Gemfile and then run `bundle install`
```rb
gem 'fastlane', :git => 'https://github.com/fastlane/fastlane.git', :branch => 'joshdholtz-match-only-check-cert-installed-in-given-keychain'
```