### PR TITLE
Make sure xcov action's parameters are generated in the docs

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -114,4 +114,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rest-client', '>= 1.8.0')
   spec.add_development_dependency('fakefs', '~> 0.8.1')
   spec.add_development_dependency('sinatra', '~> 1.4.8')
+  spec.add_development_dependency('xcov', '~> 1.4.1')
 end

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -114,5 +114,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rest-client', '>= 1.8.0')
   spec.add_development_dependency('fakefs', '~> 0.8.1')
   spec.add_development_dependency('sinatra', '~> 1.4.8')
-  spec.add_development_dependency('xcov', '~> 1.4.1')
+  spec.add_development_dependency('xcov', '~> 1.4.1') # Used for xcov's parameters generation: https://github.com/fastlane/fastlane/pull/12416
 end

--- a/fastlane/lib/fastlane/actions/xcov.rb
+++ b/fastlane/lib/fastlane/actions/xcov.rb
@@ -24,6 +24,8 @@ module Fastlane
       end
 
       def self.available_options
+        return [] unless Helper.mac?
+
         # We call Gem::Specification.find_by_name in many more places than this, but for right now
         # this is the only place we're having trouble. If there are other reports about RubyGems
         # 2.6.2 causing problems, we may need to move this code and require it someplace better,

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -62,6 +62,7 @@ describe Fastlane do
           puts
           println
           echo
+          xcov
         )
       end
 


### PR DESCRIPTION
Having `xcov` added as a development dependency ensures that the computer on which the `update_docs` lane is run has `xcov` installed so the `available_options` can be returned from:

https://github.com/fastlane/fastlane/blob/d56f70d416ae63c60172b84d4763be97f837779e/fastlane/lib/fastlane/actions/xcov.rb#L34

Before:

![screen shot 2018-05-01 at 01 17 09](https://user-images.githubusercontent.com/5748627/39453124-68796b58-4cdd-11e8-9c9c-c7b32662ea9f.png)

After:

![screen shot 2018-05-01 at 01 17 15](https://user-images.githubusercontent.com/5748627/39453126-6b02d436-4cdd-11e8-8d9f-e240bd661f40.png)
