### PR TITLE
Adding support for b2b vpp

### DIFF
--- a/spaceship/lib/spaceship/tunes/availability.rb
+++ b/spaceship/lib/spaceship/tunes/availability.rb
@@ -36,11 +36,10 @@ module Spaceship
       )
 
       # Create a new object based on a set of territories.
+      # This will override any values already set for cleared_for_preorder, app_available_date, b2b_unavailable,
+      # b2b_app_enabled, and educational_discount
       # @param territories (Array of String or Spaceship::Tunes::Territory objects): A list of the territories
       # @param params (Hash): Optional parameters (include_future_territories (Bool, default: true) Are future territories included?)
-      # This method has serious implications on vpp + educational discount but i don't want to break
-      # existing support. please be very careful when using this and provide appropriate params.
-      # In future, we should create availability from territories as an instance method not as a class method.
       def self.from_territories(territories = [], params = {})
         # Initializes the DataHash with our preOrder structure so values
         # that are being modified will be saved

--- a/spaceship/lib/spaceship/tunes/availability.rb
+++ b/spaceship/lib/spaceship/tunes/availability.rb
@@ -22,6 +22,8 @@ module Spaceship
       # @return (Bool) b2b available for distribution
       attr_accessor :b2b_unavailable
 
+      # @return (Array of Spaceship::Tunes::B2bUser objects) A list of users set by user - if not
+      # then the b2b user list that is currently set
       attr_accessor :b2b_users
 
       attr_mapping(
@@ -82,21 +84,18 @@ module Spaceship
       # Sets the b2b flag. If you call Save on app_details without adding any b2b users
       # it will result in an error.
       def enable_b2b_app!
-        print("b2b : " + b2b_unavailable.to_s)
         raise "Not possible to enable b2b on this app" if b2b_unavailable
         @b2b_app_enabled = true
-        return self
+        self
       end
 
-      # just adds to the availability, You will still have to call update_availabilty
+      # just adds users to the availability, You will still have to call update_availabilty
       def add_b2b_users(user_list = [])
         raise "Cannot add b2b users if b2b is not enabled" unless b2b_app_enabled
-        b2b_user_array = []
-        user_list.each do |user|
-          b2b_user_array.push(B2bUser.from_username(user))
+        @b2b_users = user_list.map do |user|
+          B2bUser.from_username(user)
         end
-        @b2b_users = b2b_user_array
-        return self
+        self
       end
     end
   end

--- a/spaceship/lib/spaceship/tunes/availability.rb
+++ b/spaceship/lib/spaceship/tunes/availability.rb
@@ -1,6 +1,5 @@
 require_relative 'territory'
 require_relative 'b2b_user'
-
 module Spaceship
   module Tunes
     class Availability < TunesBase
@@ -19,6 +18,9 @@ module Spaceship
       # @return (Bool) app enabled for b2b users
       attr_accessor :b2b_app_enabled
 
+      # @return (Bool) app enabled for educational discount
+      attr_accessor :educational_discount
+
       # @return (Bool) b2b available for distribution
       attr_accessor :b2b_unavailable
 
@@ -30,13 +32,15 @@ module Spaceship
         'theWorld' => :include_future_territories,
         'preOrder.clearedForPreOrder.value' => :cleared_for_preorder,
         'preOrder.appAvailableDate.value' => :app_available_date,
-        'b2bAppEnabled' => :b2b_app_enabled,
         'b2BAppFlagDisabled' => :b2b_unavailable
       )
 
       # Create a new object based on a set of territories.
       # @param territories (Array of String or Spaceship::Tunes::Territory objects): A list of the territories
       # @param params (Hash): Optional parameters (include_future_territories (Bool, default: true) Are future territories included?)
+      # This method has serious implications on vpp + educational discount but i don't want to break
+      # existing support. please be very careful when using this and provide appropriate params.
+      # In future, we should create availability from territories as an instance method not as a class method.
       def self.from_territories(territories = [], params = {})
         # Initializes the DataHash with our preOrder structure so values
         # that are being modified will be saved
@@ -66,6 +70,7 @@ module Spaceship
         obj.app_available_date = params.fetch(:app_available_date, nil)
         obj.b2b_unavailable =  params.fetch(:b2b_unavailable, false)
         obj.b2b_app_enabled =  params.fetch(:b2b_app_enabled, false)
+        obj.educational_discount = params.fetch(:educational_discount, true)
         return obj
       end
 
@@ -77,6 +82,14 @@ module Spaceship
         @b2b_users ||= raw_data['b2bUsers'].map { |user| B2bUser.new(user) }
       end
 
+      def b2b_app_enabled
+        @b2b_app_enabled.nil? ? raw_data['b2bAppEnabled'] : @b2b_app_enabled
+      end
+
+      def educational_discount
+        @educational_discount.nil? ? raw_data['educationalDiscount'] : @educational_discount
+      end
+
       def cleared_for_preorder
         super || false
       end
@@ -86,6 +99,8 @@ module Spaceship
       def enable_b2b_app!
         raise "Not possible to enable b2b on this app" if b2b_unavailable
         @b2b_app_enabled = true
+        # need to set the educational discount to false
+        @educational_discount = false
         self
       end
 

--- a/spaceship/lib/spaceship/tunes/availability.rb
+++ b/spaceship/lib/spaceship/tunes/availability.rb
@@ -1,4 +1,5 @@
 require_relative 'territory'
+require_relative 'b2b_user'
 
 module Spaceship
   module Tunes
@@ -15,10 +16,20 @@ module Spaceship
       # @return (String) App available date in format of "YYYY-MM-DD"
       attr_accessor :app_available_date
 
+      # @return (Bool) app enabled for b2b users
+      attr_accessor :b2b_app_enabled
+
+      # @return (Bool) b2b available for distribution
+      attr_accessor :b2b_unavailable
+
+      attr_accessor :b2b_users
+
       attr_mapping(
         'theWorld' => :include_future_territories,
         'preOrder.clearedForPreOrder.value' => :cleared_for_preorder,
-        'preOrder.appAvailableDate.value' => :app_available_date
+        'preOrder.appAvailableDate.value' => :app_available_date,
+        'b2bAppEnabled' => :b2b_app_enabled,
+        'b2BAppFlagDisabled' => :b2b_unavailable
       )
 
       # Create a new object based on a set of territories.
@@ -51,6 +62,8 @@ module Spaceship
         obj.include_future_territories = params.fetch(:include_future_territories, true)
         obj.cleared_for_preorder = params.fetch(:cleared_for_preorder, false)
         obj.app_available_date = params.fetch(:app_available_date, nil)
+        obj.b2b_unavailable =  params.fetch(:b2b_unavailable, false)
+        obj.b2b_app_enabled =  params.fetch(:b2b_app_enabled, false)
         return obj
       end
 
@@ -58,8 +71,32 @@ module Spaceship
         @territories ||= raw_data['countries'].map { |info| Territory.new(info) }
       end
 
+      def b2b_users
+        @b2b_users ||= raw_data['b2bUsers'].map { |user| B2bUser.new(user) }
+      end
+
       def cleared_for_preorder
         super || false
+      end
+
+      # Sets the b2b flag. If you call Save on app_details without adding any b2b users
+      # it will result in an error.
+      def enable_b2b_app!
+        print("b2b : " + b2b_unavailable.to_s)
+        raise "Not possible to enable b2b on this app" if b2b_unavailable
+        @b2b_app_enabled = true
+        return self
+      end
+
+      # just adds to the availability, You will still have to call update_availabilty
+      def add_b2b_users(user_list = [])
+        raise "Cannot add b2b users if b2b is not enabled" unless b2b_app_enabled
+        b2b_user_array = []
+        user_list.each do |user|
+          b2b_user_array.push(B2bUser.from_username(user))
+        end
+        @b2b_users = b2b_user_array
+        return self
       end
     end
   end

--- a/spaceship/lib/spaceship/tunes/availability.rb
+++ b/spaceship/lib/spaceship/tunes/availability.rb
@@ -93,8 +93,8 @@ module Spaceship
         super || false
       end
 
-      # Sets the b2b flag. If you call Save on app_details without adding any b2b users
-      # it will result in an error.
+      # Sets `b2b_app_enabled` to true and `educational_discount` to false
+      # Requires users to be added with `add_b2b_users` otherwise `update_availability` will error
       def enable_b2b_app!
         raise "Not possible to enable b2b on this app" if b2b_unavailable
         @b2b_app_enabled = true
@@ -103,7 +103,7 @@ module Spaceship
         self
       end
 
-      # just adds users to the availability, You will still have to call update_availabilty
+      # Adds users for b2b enabled apps
       def add_b2b_users(user_list = [])
         raise "Cannot add b2b users if b2b is not enabled" unless b2b_app_enabled
         @b2b_users = user_list.map do |user|

--- a/spaceship/lib/spaceship/tunes/b2b_user.rb
+++ b/spaceship/lib/spaceship/tunes/b2b_user.rb
@@ -1,0 +1,25 @@
+require_relative 'tunes_base'
+module Spaceship
+  module Tunes
+    class B2bUser < TunesBase
+      # @return (Bool) add the user to b2b list
+      attr_accessor :add
+
+      # @return (Bool) delete the user to b2b list
+      attr_accessor :delete
+
+      # @return (String) b2b username
+      attr_accessor :ds_username
+
+      attr_mapping(
+        'value.add' => :add,
+        'value.delete' => :delete,
+        'value.dsUsername' => :ds_username
+      )
+
+      def self.from_username(username)
+        self.new({ 'value' => { 'add' => true, 'delete' => false, 'dsUsername' => username } })
+      end
+    end
+  end
+end

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -1,5 +1,4 @@
 require "securerandom"
-
 require_relative '../client'
 require_relative '../du/du_client'
 require_relative '../du/upload_file'
@@ -11,7 +10,6 @@ require_relative 'iap_subscription_pricing_tier'
 require_relative 'pricing_tier'
 require_relative 'territory'
 require_relative 'user_detail'
-
 module Spaceship
   # rubocop:disable Metrics/ClassLength
   class TunesClient < Spaceship::Client
@@ -613,8 +611,10 @@ module Spaceship
       # API will error out if cleared_for_preorder is false and app_available_date has a date
       cleared_for_preorder = availability.cleared_for_preorder
       app_available_date = cleared_for_preorder ? availability.app_available_date : nil
+      data["b2bAppEnabled"] = availability.b2b_app_enabled
       data["preOrder"]["clearedForPreOrder"] = { "value" => cleared_for_preorder, "isEditable" => true, "isRequired" => true, "errorKeys" => nil }
       data["preOrder"]["appAvailableDate"] = { "value" => app_available_date, "isEditable" => true, "isRequired" => true, "errorKeys" => nil }
+      data["b2bUsers"] = availability.b2b_app_enabled ? availability.b2b_users.map { |user| { "value" => { "add" => user.add, "delete" => user.delete, "dsUsername" => user.ds_username } } } : []
 
       # send the changes back to Apple
       r = request(:post) do |req|

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -612,6 +612,7 @@ module Spaceship
       cleared_for_preorder = availability.cleared_for_preorder
       app_available_date = cleared_for_preorder ? availability.app_available_date : nil
       data["b2bAppEnabled"] = availability.b2b_app_enabled
+      data["educationalDiscount"] = availability.educational_discount
       data["preOrder"]["clearedForPreOrder"] = { "value" => cleared_for_preorder, "isEditable" => true, "isRequired" => true, "errorKeys" => nil }
       data["preOrder"]["appAvailableDate"] = { "value" => app_available_date, "isEditable" => true, "isRequired" => true, "errorKeys" => nil }
       data["b2bUsers"] = availability.b2b_app_enabled ? availability.b2b_users.map { |user| { "value" => { "add" => user.add, "delete" => user.delete, "dsUsername" => user.ds_username } } } : []

--- a/spaceship/spec/tunes/availability_spec.rb
+++ b/spaceship/spec/tunes/availability_spec.rb
@@ -18,6 +18,18 @@ describe Spaceship::Tunes::Availability do
       expect(availability.include_future_territories).to be_truthy
     end
 
+    it "correctly parses b2b app enabled" do
+      availability = client.availability(app.apple_id)
+
+      expect(availability.b2b_app_enabled).to be(false)
+    end
+
+    it "correctly parses b2b app flag enabled" do
+      availability = client.availability(app.apple_id)
+
+      expect(availability.b2b_unavailable).to be(false)
+    end
+
     it "correctly parses the territories" do
       availability = client.availability(app.apple_id)
 
@@ -30,6 +42,15 @@ describe Spaceship::Tunes::Availability do
       expect(territory_0.name).to eq('United Kingdom')
       expect(territory_0.region).to eq('Europe')
       expect(territory_0.region_locale_key).to eq('ITC.region.EUR')
+    end
+
+    it "correctly parses b2b users" do
+      TunesStubbing.itc_stub_app_pricing_intervals_vpp
+      availability = client.availability(app.apple_id)
+      expect(availability.b2b_users.length).to eq(2)
+      b2b_user_0 = availability.b2b_users[0]
+      expect(b2b_user_0).not_to(be_nil)
+      expect(b2b_user_0.ds_username).to eq('b2b1@abc.com')
     end
   end
 
@@ -134,6 +155,30 @@ describe Spaceship::Tunes::Availability do
       availability = client.update_availability!(app.apple_id, availability)
 
       expect(availability.include_future_territories).to be_falsey
+    end
+
+    describe "enable_b2b_app!" do
+      it "throws exception if b2b cannot be enabled" do
+        TunesStubbing.itc_stub_app_pricing_intervals_b2b_disabled
+        availability = client.availability(app.apple_id)
+        expect { availability.enable_b2b_app! }.to raise_error("Not possible to enable b2b on this app")
+      end
+    end
+
+    describe "add_b2b_users" do
+      it "throws exception if b2b app not enabled" do
+        availability = client.availability(app.apple_id)
+        expect { availability.add_b2b_users(["abc@def.com"]) }.to raise_error("Cannot add b2b users if b2b is not enabled")
+      end
+
+      it "works correctly" do
+        TunesStubbing.itc_stub_app_pricing_intervals_vpp
+        availability = client.availability(app.apple_id)
+        new_availability = availability.add_b2b_users(["abc@def.com"])
+        expect(new_availability).to be_an_instance_of(Spaceship::Tunes::Availability)
+        expect(new_availability.b2b_users.length).to eq(1)
+        expect(new_availability.b2b_users.first.ds_username).to eq("abc@def.com")
+      end
     end
   end
 end

--- a/spaceship/spec/tunes/availability_spec.rb
+++ b/spaceship/spec/tunes/availability_spec.rb
@@ -163,6 +163,13 @@ describe Spaceship::Tunes::Availability do
         availability = client.availability(app.apple_id)
         expect { availability.enable_b2b_app! }.to raise_error("Not possible to enable b2b on this app")
       end
+
+      it "works correctly" do
+        availability = client.availability(app.apple_id)
+        new_availability = availability.enable_b2b_app!
+        expect(new_availability.b2b_app_enabled).to eq(true)
+        expect(new_availability.educational_discount).to eq(false)
+      end
     end
 
     describe "add_b2b_users" do

--- a/spaceship/spec/tunes/b2b_user_spec.rb
+++ b/spaceship/spec/tunes/b2b_user_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+class B2bUserSpec
+  describe Spaceship::Tunes::B2bUser do
+    before { Spaceship::Tunes.login }
+    before { TunesStubbing.itc_stub_app_pricing_intervals }
+
+    let(:client) { Spaceship::AppVersion.client }
+    let(:app) { Spaceship::Application.all.first }
+    let(:mock_client) { double('MockClient') }
+    let(:b2b_user) do
+      Spaceship::Tunes::B2bUser.new(
+        'value' => {
+            'dsUsername' => "b2b1@abc.com",
+            'delete' => false,
+            'add' => false,
+            'company' => 'b2b1'
+        },
+        "isEditable" => true,
+        "isRequired" => false
+      )
+    end
+    before do
+      allow(Spaceship::Tunes::TunesBase).to receive(:client).and_return(mock_client)
+      allow(mock_client).to receive(:team_id).and_return('')
+    end
+
+    describe 'b2b_user' do
+      it 'parses the data correctly' do
+        expect(b2b_user).to be_instance_of(Spaceship::Tunes::B2bUser)
+        !expect(b2b_user.add)
+        !expect(b2b_user.delete)
+        expect(b2b_user.ds_username).to eq('b2b1@abc.com')
+      end
+    end
+
+    describe 'from_username' do
+      it 'creates correct object to add' do
+        b2b_user_created = Spaceship::Tunes::B2bUser.from_username("b2b2@def.com")
+        expect(b2b_user_created.add)
+        !expect(b2b_user_created.delete)
+        expect(b2b_user_created.ds_username).to eq('b2b2@def.com')
+      end
+    end
+  end
+end

--- a/spaceship/spec/tunes/fixtures/app_pricing_intervals_b2b_flag_disabled.json
+++ b/spaceship/spec/tunes/fixtures/app_pricing_intervals_b2b_flag_disabled.json
@@ -1,0 +1,83 @@
+{
+  "data": {
+    "sectionErrorKeys": [
+
+    ],
+    "sectionInfoKeys": [
+
+    ],
+    "sectionWarningKeys": [
+
+    ],
+    "countriesChanged": false,
+    "countries": [
+      {
+        "code": "GB",
+        "name": "United Kingdom",
+        "region": "Europe",
+        "regionLocaleKey": "ITC.region.EUR",
+        "currencyCodeISO3A": "GBP"
+      },
+      {
+        "code": "US",
+        "name": "United States",
+        "region": "The United States and Canada",
+        "regionLocaleKey": "ITC.region.NAM",
+        "currencyCodeISO3A": "USD"
+      }
+    ],
+    "b2BAppFlagDisabled": true,
+    "educationDiscountDisabledFlag": false,
+    "hotFudgeFeatureEnabled": true,
+    "coldFudgeFeatureEnabled": false,
+    "bitcodeAutoRecompileDisAllowed": false,
+    "b2bAppEnabled": false,
+    "educationalDiscount": true,
+    "theWorld": true,
+    "pricingIntervalsFieldTO": {
+      "value": [
+        {
+          "priceTierEffectiveDate": null,
+          "priceTierEndDate": null,
+          "tierStem": "0"
+        }
+      ],
+      "isEditable": true,
+      "isRequired": false,
+      "errorKeys": null
+    },
+    "availableDate": 1476687600000,
+    "unavailableDate": -2,
+    "creatingApp": false,
+    "hasApprovedVersion": false,
+    "preOrder":{  
+      "clearedForPreOrder":{  
+        "value":false,
+        "isEditable":true,
+        "isRequired":true,
+        "errorKeys":null
+      },
+      "appAvailableDate":{  
+        "value":null,
+        "isEditable":true,
+        "isRequired":true,
+        "errorKeys":null
+      },
+      "preOrderAvailableDate":null
+    },
+    "appVersionsForOTAByPlatforms": {
+      "iOS": [
+
+      ]
+    },
+    "b2bUsers": [
+
+    ]
+  },
+  "messages": {
+    "warn": null,
+    "info": null,
+    "error": null
+  },
+  "statusCode": "SUCCESS"
+}

--- a/spaceship/spec/tunes/fixtures/app_pricing_intervals_b2b_included.json
+++ b/spaceship/spec/tunes/fixtures/app_pricing_intervals_b2b_included.json
@@ -1,0 +1,102 @@
+{
+  "data": {
+    "sectionErrorKeys": [
+
+    ],
+    "sectionInfoKeys": [
+
+    ],
+    "sectionWarningKeys": [
+
+    ],
+    "countriesChanged": false,
+    "countries": [
+      {
+        "code": "GB",
+        "name": "United Kingdom",
+        "region": "Europe",
+        "regionLocaleKey": "ITC.region.EUR",
+        "currencyCodeISO3A": "GBP"
+      },
+      {
+        "code": "US",
+        "name": "United States",
+        "region": "The United States and Canada",
+        "regionLocaleKey": "ITC.region.NAM",
+        "currencyCodeISO3A": "USD"
+      }
+    ],
+    "b2BAppFlagDisabled": false,
+    "educationDiscountDisabledFlag": false,
+    "hotFudgeFeatureEnabled": true,
+    "coldFudgeFeatureEnabled": false,
+    "bitcodeAutoRecompileDisAllowed": false,
+    "b2bAppEnabled": true,
+    "educationalDiscount": true,
+    "theWorld": true,
+    "pricingIntervalsFieldTO": {
+      "value": [
+        {
+          "priceTierEffectiveDate": null,
+          "priceTierEndDate": null,
+          "tierStem": "0"
+        }
+      ],
+      "isEditable": true,
+      "isRequired": false,
+      "errorKeys": null
+    },
+    "availableDate": 1476687600000,
+    "unavailableDate": -2,
+    "creatingApp": false,
+    "hasApprovedVersion": false,
+    "preOrder":{  
+      "clearedForPreOrder":{  
+        "value":false,
+        "isEditable":true,
+        "isRequired":true,
+        "errorKeys":null
+      },
+      "appAvailableDate":{  
+        "value":null,
+        "isEditable":true,
+        "isRequired":true,
+        "errorKeys":null
+      },
+      "preOrderAvailableDate":null
+    },
+    "appVersionsForOTAByPlatforms": {
+      "iOS": [
+
+      ]
+    },
+    "b2bUsers": [
+      {
+        "value": {
+          "dsUsername":"b2b1@abc.com",
+          "delete":false,"add":false,
+          "company":"b2b1"
+        },
+        "isEditable":true,
+        "isRequired":false,
+        "errorKeys":null
+      },
+      {
+        "value": {
+          "dsUsername":"b2b2@def.com",
+          "delete":false,"add":false,
+          "company":"b2b2"
+        },
+        "isEditable":true,
+        "isRequired":false,
+        "errorKeys":null
+      }
+    ]
+  },
+  "messages": {
+    "warn": null,
+    "info": null,
+    "error": null
+  },
+  "statusCode": "SUCCESS"
+}

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -452,6 +452,18 @@ class TunesStubbing
                   headers: { 'Content-Type' => 'application/json' })
     end
 
+    def itc_stub_app_pricing_intervals_vpp
+      stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/pricing/intervals").
+        to_return(status: 200, body: itc_read_fixture_file(File.join('app_pricing_intervals_b2b_included.json')),
+                    headers: { 'Content-Type' => 'application/json' })
+    end
+
+    def itc_stub_app_pricing_intervals_b2b_disabled
+      stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/pricing/intervals").
+        to_return(status: 200, body: itc_read_fixture_file(File.join('app_pricing_intervals_b2b_flag_disabled.json')),
+                    headers: { 'Content-Type' => 'application/json' })
+    end
+
     def itc_stub_members
       # resend notification
       stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/users/itc/helmut@januschka.com/resendInvitation").


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I wished to provide the support to enable vpp and add the vpp email addresses. I have deliberately not provided a way to remove them or disable vpp because i do not want to introduce changes that may mess up the system.

I have tested adding b2b users when existing users present. also enabled b2b distribution when it was disabled. I have also ensured it by making sure existing spec tests are working - which is a good test in this case since the specs for availability were quite extensive.

### Description
Created a class `b2b_user` for parsing the user details
Provided parsing for `b2bAppEnabled`, `b2bAppFlagDisabled` and `b2bUsers`
Updated `TunesClient`, `AvailabilitySpec`, `TunesStubbing` for this change and added a couple of fixtures for tests.
