### PR TITLE
Specify source filename in pilot import docs

### DIFF
--- a/pilot/lib/pilot/commands_generator.rb
+++ b/pilot/lib/pilot/commands_generator.rb
@@ -151,7 +151,7 @@ module Pilot
 
       command :import do |c|
         c.syntax = "fastlane pilot import"
-        c.description = "Create external testers from a CSV file"
+        c.description = "Import external testers from a CSV file called testers.csv"
 
         FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options, command: c)
 


### PR DESCRIPTION
I ran into an issue where I incorrectly ran:

```bash
bundle exec fastlane import updated_testers.csv
```

I should've used the `-c` flag:

```bash
bundle exec fastlane import -c updated_testers.csv
```

Instead of either (1) importing the specified file, or (2) failing from invalid input, fastlane imported the `testers.csv` which was leftover from the last time I ran the `pilot export` command.

This PR attempts to clarify usage in the docs; a later PR will improve input validation.