### PR TITLE
Fix pilot 504ing on build submission for review on testflight

### DIFF
--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -83,10 +83,17 @@ describe "Build Manager" do
       allow(mock_base_client).to receive(:add_group_to_build)
       allow(Spaceship::TestFlight::Group).to receive(:default_external_group).and_return(mock_default_external_group)
       # used to return the approved build if we recover from the 504
-      allow(Spaceship::TestFlight::Build).to receive(:find).and_return(approved_mock_build)
     end
-    it "recovers if there is a 504" do
+    it "doesnt recover if there is a 504 and the build is not approved" do
       allow(mock_base_client).to receive(:post_for_testflight_review).and_raise(Spaceship::Client::InternalServerError, "Server error got 504")
+      allow(Spaceship::TestFlight::Build).to receive(:find).and_return(ready_to_submit_mock_build)
+      expect(FastlaneCore::UI).to receive(:message).with('Distributing new build to testers:  - ')
+      expect(FastlaneCore::UI).to receive(:message).with('Submitting the build for review timed out, trying to recover.')
+      expect { fake_build_manager.distribute(distribute_options, build: ready_to_submit_mock_build) }.to raise_error(Spaceship::Client::InternalServerError, "Server error got 504")
+    end
+    it "recovers if there is a 504 and the build is approved" do
+      allow(mock_base_client).to receive(:post_for_testflight_review).and_raise(Spaceship::Client::InternalServerError, "Server error got 504")
+      allow(Spaceship::TestFlight::Build).to receive(:find).and_return(approved_mock_build)
       expect(FastlaneCore::UI).to receive(:message).with('Distributing new build to testers:  - ')
       expect(FastlaneCore::UI).to receive(:message).with('Submitting the build for review timed out, trying to recover.')
       fake_build_manager.distribute(distribute_options, build: ready_to_submit_mock_build)

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -24,4 +24,81 @@ describe "Build Manager" do
       expect(changelog).to eq(File.read("./pilot/spec/fixtures/build_manager/changelog_long_truncated"))
     end
   end
+  describe "distribute submits the build for review" do
+    let(:mock_base_client) { "fake testflight base client" }
+    let(:fake_build_manager) { Pilot::BuildManager.new }
+    let(:ready_to_submit_mock_build) do
+      Spaceship::TestFlight::Build.new(
+        'bundleId' => 1,
+        'appAdamId' => 1,
+        'externalState' => Spaceship::TestFlight::Build::BUILD_STATES[:ready_to_submit],
+        'exportCompliance' => {
+          'usesEncryption' => true,
+          'encryptionUpdated' => false
+        },
+        'betaReviewInfo' => {
+          'contactFirstName' => 'First',
+          'contactLastName' => 'Last'
+        }
+      )
+    end
+    let(:approved_mock_build) do
+      Spaceship::TestFlight::Build.new(
+        'bundleId' => 1,
+        'appAdamId' => 1,
+        'externalState' => Spaceship::TestFlight::Build::BUILD_STATES[:approved],
+        'exportCompliance' => {
+          'usesEncryption' => true,
+          'encryptionUpdated' => false
+        },
+        'betaReviewInfo' => {
+          'contactFirstName' => 'First',
+          'contactLastName' => 'Last'
+        }
+      )
+    end
+    let(:distribute_options) do
+      {
+        apple_id: 'mock_apple_id',
+        app_identifier: 'mock_app_id',
+        distribute_external: true,
+        skip_submission: false
+      }
+    end
+    let(:mock_default_external_group) do
+      Spaceship::TestFlight::Group.new({
+        'id' => 1,
+        'name' => 'Group 1',
+        'appAdamId' => 123,
+        'isDefaultExternalGroup' => false
+      })
+    end
+
+    before(:each) do
+      # default client mocks setup
+      allow(fake_build_manager).to receive(:login)
+      allow(Spaceship::TestFlight::Base).to receive(:client).and_return(mock_base_client)
+      allow(mock_base_client).to receive(:team_id).and_return('')
+      allow(mock_base_client).to receive(:get_build).and_return(ready_to_submit_mock_build)
+      allow(mock_base_client).to receive(:add_group_to_build)
+      allow(Spaceship::TestFlight::Group).to receive(:default_external_group).and_return(mock_default_external_group)
+      # used to return the approved build if we recover from the 504
+      allow(Spaceship::TestFlight::Build).to receive(:find).and_return(approved_mock_build)
+    end
+    it "recovers if there is a 504" do
+      allow(mock_base_client).to receive(:post_for_testflight_review).and_raise(Spaceship::Client::InternalServerError, "Server error got 504")
+      expect(FastlaneCore::UI).to receive(:message).with('Distributing new build to testers:  - ')
+      expect(FastlaneCore::UI).to receive(:message).with('Submitting the build for review timed out, trying to recover.')
+      fake_build_manager.distribute(distribute_options, build: ready_to_submit_mock_build)
+    end
+    it "throws if there is a different error than 504" do
+      allow(mock_base_client).to receive(:post_for_testflight_review).and_raise(Spaceship::Client::InternalServerError, "Server error got 500")
+      expect { fake_build_manager.distribute(distribute_options, build: ready_to_submit_mock_build) }.to raise_error(Spaceship::Client::InternalServerError, "Server error got 500")
+    end
+    it "doesnt try to recover if no 504" do
+      allow(mock_base_client).to receive(:post_for_testflight_review) # pretend it worked.
+      expect(FastlaneCore::UI).not_to(receive(:message).with('Submitting the build for review timed out, trying to recover.'))
+      fake_build_manager.distribute(distribute_options, build: ready_to_submit_mock_build)
+    end
+  end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
We're running into a 504 error that seems related in some way to #11828 when trying to upload and submit a build to our nightly testers group. When the build is submitted for review, the call times out with a 504 but the build manages to get in an approved state. However, because an error is thrown, execution is stopped and pilot never tries to add groups to the build, requiring manual input from a team member to make it happen.

Additional context:
Changing the version and submitting a new build for review seems to work fine, only subsequent builds for the same version are hitting the 504.
The 504 doesn't always happen, but it's unpredictable.

### Description
<!-- Describe your changes in detail -->
This change is a workaround around the iTunesConnect issue until it gets resolved. I just wanted to put this up for review so that we could discuss if that's a fix that could be made available widely within Fastlane, or to see if we should instead rely on other means such as:

- Checking our CI logs for such 504 and then triggering lanes meant to only distribute the build to a group (instead of restarting the whole upload process)
- Using that fork internally until the timeout gets fixed and regularly rebasing on the tip of fastlane's master.

"Clean" options on this issue seem somewhat limited so if you have other ideas I'd love to hear them.

If this change seems reasonable, I can add test coverage!