### PR TITLE
Version bump to 2.94.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 
 <table id='team'>
 <tr>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
 <td id='joshua-liebowitz'>
 <a href='https://github.com/taquitos'>
 <img src='https://github.com/taquitos.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
 <td id='aaron-brager'>
 <a href='https://github.com/getaaron'>
@@ -50,37 +50,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
 <td id='manu-wallner'>
 <a href='https://github.com/milch'>
 <img src='https://github.com/milch.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-</tr>
-<tr>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/DanToml'>
-<img src='https://github.com/DanToml.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
 </td>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
@@ -88,25 +62,13 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
 </tr>
 <tr>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
 <td id='andrew-mcburney'>
 <a href='https://github.com/AndrewMcBurney'>
@@ -114,11 +76,43 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
 <td id='olivier-halligon'>
 <a href='https://github.com/AliSoftware'>
 <img src='https://github.com/AliSoftware.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+</tr>
+<tr>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/DanToml'>
+<img src='https://github.com/DanToml.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+</td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
 <td id='luka-mirosevic'>
 <a href='https://github.com/lmirosevic'>
@@ -126,37 +120,43 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
 </tr>
 <tr>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
 <td id='felix-krause'>
 <a href='https://github.com/KrauseFx'>
 <img src='https://github.com/KrauseFx.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
 </tr>
 </table>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -14,26 +14,26 @@ File.write("#{lib}/fastlane/plugins/template/.rubocop.yml", YAML.dump(config))
 Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
-  spec.authors       = ["Felix Krause",
-                        "Luka Mirosevic",
-                        "Maksym Grebenets",
-                        "Josh Holtz",
-                        "Kohki Miki",
-                        "Aaron Brager",
-                        "Jan Piotrowski",
+  spec.authors       = ["Stefan Natchev",
                         "Jorge Revuelta H",
-                        "Fumiya Nakamura",
-                        "Stefan Natchev",
-                        "Joshua Liebowitz",
-                        "Manu Wallner",
-                        "Jimmy Dee",
-                        "Helmut Januschka",
                         "Andrew McBurney",
+                        "Maksym Grebenets",
+                        "Felix Krause",
                         "Danielle Tomlinson",
-                        "Olivier Halligon",
-                        "Matthew Ellis",
+                        "Jan Piotrowski",
+                        "Josh Holtz",
+                        "Iulian Onofrei",
+                        "Kohki Miki",
                         "Jérôme Lacoste",
-                        "Iulian Onofrei"]
+                        "Olivier Halligon",
+                        "Fumiya Nakamura",
+                        "Helmut Januschka",
+                        "Joshua Liebowitz",
+                        "Jimmy Dee",
+                        "Manu Wallner",
+                        "Aaron Brager",
+                        "Matthew Ellis",
+                        "Luka Mirosevic"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.93.1'.freeze
+  VERSION = '2.94.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.93.1
+// Generated with fastlane 2.94.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -2440,10 +2440,12 @@ func produce(username: String,
 @discardableResult func prompt(text: String = "Please enter some text: ",
                                ciInput: String = "",
                                boolean: Bool = false,
+                               secureText: Bool = false,
                                multiLineEndKeyword: String? = nil) -> String {
   let command = RubyCommand(commandID: "", methodName: "prompt", className: nil, args: [RubyCommand.Argument(name: "text", value: text),
                                                                                         RubyCommand.Argument(name: "ci_input", value: ciInput),
                                                                                         RubyCommand.Argument(name: "boolean", value: boolean),
+                                                                                        RubyCommand.Argument(name: "secure_text", value: secureText),
                                                                                         RubyCommand.Argument(name: "multi_line_end_keyword", value: multiLineEndKeyword)])
   return runner.executeCommand(command)
 }
@@ -2591,10 +2593,13 @@ func runTests(workspace: String? = nil,
               buildlogPath: String = "~/Library/Logs/scan",
               includeSimulatorLogs: Bool = false,
               formatter: String? = nil,
+              maxConcurrentSimulators: Int? = nil,
+              disableConcurrentTesting: Bool = false,
               testWithoutBuilding: Bool? = nil,
               buildForTesting: Bool? = nil,
               xctestrun: String? = nil,
               derivedDataPath: String? = nil,
+              shouldZipBuildProducts: Bool = false,
               resultBundle: Bool = false,
               sdk: String? = nil,
               openReport: Bool = false,
@@ -2630,10 +2635,13 @@ func runTests(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "buildlog_path", value: buildlogPath),
                                                                                            RubyCommand.Argument(name: "include_simulator_logs", value: includeSimulatorLogs),
                                                                                            RubyCommand.Argument(name: "formatter", value: formatter),
+                                                                                           RubyCommand.Argument(name: "max_concurrent_simulators", value: maxConcurrentSimulators),
+                                                                                           RubyCommand.Argument(name: "disable_concurrent_testing", value: disableConcurrentTesting),
                                                                                            RubyCommand.Argument(name: "test_without_building", value: testWithoutBuilding),
                                                                                            RubyCommand.Argument(name: "build_for_testing", value: buildForTesting),
                                                                                            RubyCommand.Argument(name: "xctestrun", value: xctestrun),
                                                                                            RubyCommand.Argument(name: "derived_data_path", value: derivedDataPath),
+                                                                                           RubyCommand.Argument(name: "should_zip_build_products", value: shouldZipBuildProducts),
                                                                                            RubyCommand.Argument(name: "result_bundle", value: resultBundle),
                                                                                            RubyCommand.Argument(name: "sdk", value: sdk),
                                                                                            RubyCommand.Argument(name: "open_report", value: openReport),
@@ -2709,10 +2717,13 @@ func scan(workspace: String? = scanfile.workspace,
           buildlogPath: String = scanfile.buildlogPath,
           includeSimulatorLogs: Bool = scanfile.includeSimulatorLogs,
           formatter: String? = scanfile.formatter,
+          maxConcurrentSimulators: Int? = scanfile.maxConcurrentSimulators,
+          disableConcurrentTesting: Bool = scanfile.disableConcurrentTesting,
           testWithoutBuilding: Bool? = scanfile.testWithoutBuilding,
           buildForTesting: Bool? = scanfile.buildForTesting,
           xctestrun: String? = scanfile.xctestrun,
           derivedDataPath: String? = scanfile.derivedDataPath,
+          shouldZipBuildProducts: Bool = scanfile.shouldZipBuildProducts,
           resultBundle: Bool = scanfile.resultBundle,
           sdk: String? = scanfile.sdk,
           openReport: Bool = scanfile.openReport,
@@ -2748,10 +2759,13 @@ func scan(workspace: String? = scanfile.workspace,
                                                                                       RubyCommand.Argument(name: "buildlog_path", value: buildlogPath),
                                                                                       RubyCommand.Argument(name: "include_simulator_logs", value: includeSimulatorLogs),
                                                                                       RubyCommand.Argument(name: "formatter", value: formatter),
+                                                                                      RubyCommand.Argument(name: "max_concurrent_simulators", value: maxConcurrentSimulators),
+                                                                                      RubyCommand.Argument(name: "disable_concurrent_testing", value: disableConcurrentTesting),
                                                                                       RubyCommand.Argument(name: "test_without_building", value: testWithoutBuilding),
                                                                                       RubyCommand.Argument(name: "build_for_testing", value: buildForTesting),
                                                                                       RubyCommand.Argument(name: "xctestrun", value: xctestrun),
                                                                                       RubyCommand.Argument(name: "derived_data_path", value: derivedDataPath),
+                                                                                      RubyCommand.Argument(name: "should_zip_build_products", value: shouldZipBuildProducts),
                                                                                       RubyCommand.Argument(name: "result_bundle", value: resultBundle),
                                                                                       RubyCommand.Argument(name: "sdk", value: sdk),
                                                                                       RubyCommand.Argument(name: "open_report", value: openReport),
@@ -2985,7 +2999,8 @@ func slack(message: String? = nil,
            defaultPayloads: [String]? = nil,
            attachmentProperties: [String : Any] = [:],
            success: Bool = true,
-           failOnError: Bool = true) {
+           failOnError: Bool = true,
+           linkNames: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "slack", className: nil, args: [RubyCommand.Argument(name: "message", value: message),
                                                                                        RubyCommand.Argument(name: "channel", value: channel),
                                                                                        RubyCommand.Argument(name: "use_webhook_configured_username_and_icon", value: useWebhookConfiguredUsernameAndIcon),
@@ -2996,7 +3011,8 @@ func slack(message: String? = nil,
                                                                                        RubyCommand.Argument(name: "default_payloads", value: defaultPayloads),
                                                                                        RubyCommand.Argument(name: "attachment_properties", value: attachmentProperties),
                                                                                        RubyCommand.Argument(name: "success", value: success),
-                                                                                       RubyCommand.Argument(name: "fail_on_error", value: failOnError)])
+                                                                                       RubyCommand.Argument(name: "fail_on_error", value: failOnError),
+                                                                                       RubyCommand.Argument(name: "link_names", value: linkNames)])
   _ = runner.executeCommand(command)
 }
 func slackTrain() {
@@ -3783,14 +3799,16 @@ func verifyBuild(provisioningType: String? = nil,
                  teamName: String? = nil,
                  appName: String? = nil,
                  bundleIdentifier: String? = nil,
-                 ipaPath: String? = nil) {
+                 ipaPath: String? = nil,
+                 buildPath: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "verify_build", className: nil, args: [RubyCommand.Argument(name: "provisioning_type", value: provisioningType),
                                                                                               RubyCommand.Argument(name: "provisioning_uuid", value: provisioningUuid),
                                                                                               RubyCommand.Argument(name: "team_identifier", value: teamIdentifier),
                                                                                               RubyCommand.Argument(name: "team_name", value: teamName),
                                                                                               RubyCommand.Argument(name: "app_name", value: appName),
                                                                                               RubyCommand.Argument(name: "bundle_identifier", value: bundleIdentifier),
-                                                                                              RubyCommand.Argument(name: "ipa_path", value: ipaPath)])
+                                                                                              RubyCommand.Argument(name: "ipa_path", value: ipaPath),
+                                                                                              RubyCommand.Argument(name: "build_path", value: buildPath)])
   _ = runner.executeCommand(command)
 }
 func verifyPodKeys() {
@@ -3869,8 +3887,62 @@ func xcodebuild() {
   let command = RubyCommand(commandID: "", methodName: "xcodebuild", className: nil, args: [])
   _ = runner.executeCommand(command)
 }
-func xcov() {
-  let command = RubyCommand(commandID: "", methodName: "xcov", className: nil, args: [])
+func xcov(workspace: String? = nil,
+          project: String? = nil,
+          scheme: String? = nil,
+          configuration: String? = nil,
+          sourceDirectory: String? = nil,
+          derivedDataPath: String? = nil,
+          outputDirectory: String = "./xcov_report",
+          htmlReport: Bool = true,
+          markdownReport: Bool = false,
+          jsonReport: Bool = false,
+          minimumCoveragePercentage: Int = 0,
+          slackUrl: String? = nil,
+          slackChannel: String? = nil,
+          skipSlack: Bool = false,
+          slackUsername: String = "xcov",
+          slackMessage: String = "Your *xcov* coverage report",
+          ignoreFilePath: String = "./.xcovignore",
+          includeTestTargets: Bool = false,
+          excludeTargets: String? = nil,
+          includeTargets: String? = nil,
+          onlyProjectTargets: Bool = false,
+          disableCoveralls: Bool = false,
+          coverallsServiceName: String? = nil,
+          coverallsServiceJobId: String? = nil,
+          coverallsRepoToken: String? = nil,
+          xcconfig: String? = nil,
+          ideFoundationPath: String = "/Applications/Xcode92/Xcode.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
+          legacySupport: Bool = false) {
+  let command = RubyCommand(commandID: "", methodName: "xcov", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
+                                                                                      RubyCommand.Argument(name: "project", value: project),
+                                                                                      RubyCommand.Argument(name: "scheme", value: scheme),
+                                                                                      RubyCommand.Argument(name: "configuration", value: configuration),
+                                                                                      RubyCommand.Argument(name: "source_directory", value: sourceDirectory),
+                                                                                      RubyCommand.Argument(name: "derived_data_path", value: derivedDataPath),
+                                                                                      RubyCommand.Argument(name: "output_directory", value: outputDirectory),
+                                                                                      RubyCommand.Argument(name: "html_report", value: htmlReport),
+                                                                                      RubyCommand.Argument(name: "markdown_report", value: markdownReport),
+                                                                                      RubyCommand.Argument(name: "json_report", value: jsonReport),
+                                                                                      RubyCommand.Argument(name: "minimum_coverage_percentage", value: minimumCoveragePercentage),
+                                                                                      RubyCommand.Argument(name: "slack_url", value: slackUrl),
+                                                                                      RubyCommand.Argument(name: "slack_channel", value: slackChannel),
+                                                                                      RubyCommand.Argument(name: "skip_slack", value: skipSlack),
+                                                                                      RubyCommand.Argument(name: "slack_username", value: slackUsername),
+                                                                                      RubyCommand.Argument(name: "slack_message", value: slackMessage),
+                                                                                      RubyCommand.Argument(name: "ignore_file_path", value: ignoreFilePath),
+                                                                                      RubyCommand.Argument(name: "include_test_targets", value: includeTestTargets),
+                                                                                      RubyCommand.Argument(name: "exclude_targets", value: excludeTargets),
+                                                                                      RubyCommand.Argument(name: "include_targets", value: includeTargets),
+                                                                                      RubyCommand.Argument(name: "only_project_targets", value: onlyProjectTargets),
+                                                                                      RubyCommand.Argument(name: "disable_coveralls", value: disableCoveralls),
+                                                                                      RubyCommand.Argument(name: "coveralls_service_name", value: coverallsServiceName),
+                                                                                      RubyCommand.Argument(name: "coveralls_service_job_id", value: coverallsServiceJobId),
+                                                                                      RubyCommand.Argument(name: "coveralls_repo_token", value: coverallsRepoToken),
+                                                                                      RubyCommand.Argument(name: "xcconfig", value: xcconfig),
+                                                                                      RubyCommand.Argument(name: "ideFoundationPath", value: ideFoundationPath),
+                                                                                      RubyCommand.Argument(name: "legacy_support", value: legacySupport)])
   _ = runner.executeCommand(command)
 }
 func xctest() {
@@ -3947,4 +4019,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.15]
+// FastlaneRunnerAPIVersion [0.9.16]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.93.1
+// Generated with fastlane 2.94.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.93.1
+// Generated with fastlane 2.94.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.93.1
+// Generated with fastlane 2.94.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.93.1
+// Generated with fastlane 2.94.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -17,10 +17,13 @@ protocol ScanfileProtocol: class {
   var buildlogPath: String { get }
   var includeSimulatorLogs: Bool { get }
   var formatter: String? { get }
+  var maxConcurrentSimulators: Int? { get }
+  var disableConcurrentTesting: Bool { get }
   var testWithoutBuilding: Bool? { get }
   var buildForTesting: Bool? { get }
   var xctestrun: String? { get }
   var derivedDataPath: String? { get }
+  var shouldZipBuildProducts: Bool { get }
   var resultBundle: Bool { get }
   var sdk: String? { get }
   var openReport: Bool { get }
@@ -59,10 +62,13 @@ extension ScanfileProtocol {
   var buildlogPath: String { return "~/Library/Logs/scan" }
   var includeSimulatorLogs: Bool { return false }
   var formatter: String? { return nil }
+  var maxConcurrentSimulators: Int? { return nil }
+  var disableConcurrentTesting: Bool { return false }
   var testWithoutBuilding: Bool? { return nil }
   var buildForTesting: Bool? { return nil }
   var xctestrun: String? { return nil }
   var derivedDataPath: String? { return nil }
+  var shouldZipBuildProducts: Bool { return false }
   var resultBundle: Bool { return false }
   var sdk: String? { return nil }
   var openReport: Bool { return false }
@@ -84,4 +90,4 @@ extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.2]
+// FastlaneRunnerAPIVersion [0.9.3]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.93.1
+// Generated with fastlane 2.94.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.93.1
+// Generated with fastlane 2.94.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.93.1':**

* Make sure xcov action's parameters are generated in the docs (#12416) via Iulian Onofrei
* [verify_build] Add support for xcarchive files (#12394) via Maksym Grebenets
* added secure text input option (#12409) via Rishabh Tayal
* Scan: Add option to limit max concurrent simulators (#12377) via Chris Ballinger
* [frameit] accepts utf8 and utf16 .strings files (#12414) via Josh Holtz
* Fix formatting for the frame_screenshots action (#12407) via Iulian Onofrei
* Fix incorrect formatting in Migration Guide (#12406) via Iulian Onofrei
* [match] only check if cert is installed on specified keychain (#12413) via Josh Holtz
* [scan] add option for zipping build productions (#12378) via Josh Holtz
* Fix old documentation for ConfigItem (#12399) via Iulian Onofrei
* [slack] add link names arg (#12389) via Sujith Vadakkepat
* Screengrab + Snapshot: Generate ids onto languages headers and device name sections. (#12383) via Niklas Baudy
* Add skip_bundle_update option to the update_docs lane (#12387) via Iulian Onofrei
* [verify_build] App build path support (#12370) via Maksym Grebenets
* Removed unused Fastfile in pem folder (#12385) via Felix Krause
* [swift] find swift lane names with option parameters (#12382) via Josh Holtz
* Fix broken markdown in actions' details (#12348) via Iulian Onofrei
