### PR TITLE
[pilot] stubbed PILOT_APP_IDENTIFIER in tests (pilot was depending on fastlane_core tests to pass)

### DIFF
--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -139,7 +139,7 @@ describe FastlaneCore do
       end
 
       it "contains p_hash event and uses the bundle identifier and hashes the value if available" do
-        ENV["PILOT_APP_IDENTIFIER"] = "com.krausefx.app"
+        stub_const('ENV', { 'PILOT_APP_IDENTIFIER' => 'com.krausefx.app' })
         p_hashed_id = hash_of(ENV["PILOT_APP_IDENTIFIER"])
 
         expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|

--- a/pilot/spec/commands_generator_spec.rb
+++ b/pilot/spec/commands_generator_spec.rb
@@ -51,6 +51,7 @@ describe Pilot::CommandsGenerator do
 
   describe ":list option handling" do
     it "can use the username short flag from tool options" do
+      stub_const('ENV', { 'PILOT_APP_IDENTIFIER' => 'your.awesome.App' })
       stub_commander_runner_args(['list', '-u', 'me@it.com'])
 
       expected_options = FastlaneCore::Configuration.create(available_options, { username: 'me@it.com' })


### PR DESCRIPTION
Fixes #12402 

## Wut
- `rspec` ran perfectly fine 💯 
- `rspec pilot` would 💣 halfway through

## Fix
- Stub out `ENV['PILOT_APP_IDENTIFIER']
  - One in `pilot` (that was failing when running alone)
  - One in `fastlane_core` (that was causing pilot to pass when running everything)