### PR TITLE
[xcodebuild] escape $(inherited) values in build settings

### DIFF
--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -332,7 +332,10 @@ module Fastlane
             value = (v != true && v.to_s.length > 0 ? "\"#{v}\"" : "")
             "#{arg} #{value}".strip
           elsif k == :build_settings
-            v.map {|setting, val| "#{setting}=\"#{val}\""}.join(' ')
+            v.map do |setting, val|
+              val = clean_build_setting_value(val)
+              "#{setting}=\"#{val}\""
+            end.join(' ')
           elsif k == :destination
             [*v].collect { |dst| "-destination \"#{dst}\"" }.join(' ')
           elsif k == :keychain && v.to_s.length > 0
@@ -343,6 +346,13 @@ module Fastlane
             "#{v}"
           end
         end.compact
+      end
+
+      # Cleans values for build settings
+      # Only escaping `$(inherit)` types of values since "sh"
+      # interprets these as sub-commands instead of passing value into xcodebuild
+      def self.clean_build_setting_value(value)
+        value.to_s.gsub('$(', '\\$(')
       end
 
       def self.detect_workspace

--- a/fastlane/spec/actions_specs/xcodebuild_spec.rb
+++ b/fastlane/spec/actions_specs/xcodebuild_spec.rb
@@ -99,14 +99,27 @@ describe Fastlane do
           build_settings: {
             'CODE_SIGN_IDENTITY' => 'iPhone Developer: Josh',
             'JOBS' => 16,
-            'PROVISIONING_PROFILE' => 'JoshIsCoolProfile'
+            'PROVISIONING_PROFILE' => 'JoshIsCoolProfile',
+            'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) NDEBUG=1'
           }
         )
       end").runner.execute(:test)
 
-        expect(result).to include('CODE_SIGN_IDENTITY="iPhone Developer: Josh"')
-        expect(result).to include('JOBS="16"')
-        expect(result).to include('PROVISIONING_PROFILE="JoshIsCoolProfile"')
+        expect(result).to eq(
+          "set -o pipefail && " \
+          + "xcodebuild " \
+          + "CODE_SIGN_IDENTITY=\"iPhone Developer: Josh\" " \
+          + "JOBS=\"16\" " \
+          + "PROVISIONING_PROFILE=\"JoshIsCoolProfile\" " \
+          + "GCC_PREPROCESSOR_DEFINITIONS=\"\\$(inherited) NDEBUG=1\" " \
+          + "-scheme \"MyApp\" " \
+          + "-workspace \"MyApp.xcworkspace\" " \
+          + "| tee '#{build_log_path}' | xcpretty --color --simple"
+        )
+
+        # expect(result).to include('CODE_SIGN_IDENTITY="iPhone Developer: Josh"')
+        # expect(result).to include('JOBS="16"')
+        # expect(result).to include('PROVISIONING_PROFILE="JoshIsCoolProfile"')
       end
 
       it "works with export_options_plist as hash" do


### PR DESCRIPTION
Fixes #12418

## Wut
- `$(inherited)` was getting interpreted as a subcommand by `sh`
  - Escaping now so that it doesn't
  - Attempted to use `.shellescape` but didn't feel right since it feel like it was doing things too strongly