### PR TITLE
[spaceship] delete preOrder from update_price_tier request body

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -520,6 +520,10 @@ module Spaceship
       r = request(:get, "ra/apps/#{app_id}/pricing/intervals")
       data = parse_response(r, 'data')
 
+      # preOrder isn't needed for for the request and has some
+      # values that can cause a failure (invalid dates) so we are removing it
+      data.delete('preOrder')
+
       first_price = (data["pricingIntervalsFieldTO"]["value"] || []).count == 0 # first price
       data["pricingIntervalsFieldTO"]["value"] ||= []
       data["pricingIntervalsFieldTO"]["value"] << {} if data["pricingIntervalsFieldTO"]["value"].count == 0

--- a/spaceship/spec/tunes/application_spec.rb
+++ b/spaceship/spec/tunes/application_spec.rb
@@ -339,5 +339,18 @@ describe Spaceship::Application do
         expect(availability.inspect).to include("Tunes::Availability")
       end
     end
+
+    describe "#update_price_tier" do
+      let(:app) { Spaceship::Application.all.first }
+      let(:effective_date) { 1_525_488_436 }
+      before { TunesStubbing.itc_stub_app_pricing_intervals }
+
+      it "inspect works" do
+        allow_any_instance_of(Time).to receive(:to_i).and_return(effective_date)
+        TunesStubbing.itc_stub_update_price_tier
+
+        app.update_price_tier!(3)
+      end
+    end
   end
 end

--- a/spaceship/spec/tunes/fixtures/update_price_tier/update_price_tier_request.json
+++ b/spaceship/spec/tunes/fixtures/update_price_tier/update_price_tier_request.json
@@ -1,0 +1,60 @@
+{
+  "sectionErrorKeys": [
+
+  ],
+  "sectionInfoKeys": [
+
+  ],
+  "sectionWarningKeys": [
+
+  ],
+  "countriesChanged": false,
+  "countries": [
+    {
+      "code": "GB",
+      "name": "United Kingdom",
+      "region": "Europe",
+      "regionLocaleKey": "ITC.region.EUR",
+      "currencyCodeISO3A": "GBP"
+    },
+    {
+      "code": "US",
+      "name": "United States",
+      "region": "The United States and Canada",
+      "regionLocaleKey": "ITC.region.NAM",
+      "currencyCodeISO3A": "USD"
+    }
+  ],
+  "b2BAppFlagDisabled": false,
+  "educationDiscountDisabledFlag": false,
+  "hotFudgeFeatureEnabled": true,
+  "coldFudgeFeatureEnabled": false,
+  "bitcodeAutoRecompileDisAllowed": false,
+  "b2bAppEnabled": false,
+  "educationalDiscount": true,
+  "theWorld": true,
+  "pricingIntervalsFieldTO": {
+    "value": [
+      {
+        "priceTierEffectiveDate": 1525488436000,
+        "priceTierEndDate": null,
+        "tierStem": "3"
+      }
+    ],
+    "isEditable": true,
+    "isRequired": false,
+    "errorKeys": null
+  },
+  "availableDate": 1476687600000,
+  "unavailableDate": -2,
+  "creatingApp": false,
+  "hasApprovedVersion": false,
+  "appVersionsForOTAByPlatforms": {
+    "iOS": [
+
+    ]
+  },
+  "b2bUsers": [
+
+  ]
+}

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -438,6 +438,13 @@ class TunesStubbing
                   headers: { 'Content-Type' => 'application/json' })
     end
 
+    def itc_stub_update_price_tier
+      stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/pricing/intervals").
+        with(body: JSON.parse(itc_read_fixture_file(File.join('update_price_tier', 'update_price_tier_request.json'))).to_json).
+        to_return(status: 200, body: itc_read_fixture_file(File.join('app_pricing_intervals.json')),
+                  headers: { 'Content-Type' => 'application/json' })
+    end
+
     def itc_stub_set_preorder_cleared
       stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/pricing/intervals").
         with(body: JSON.parse(itc_read_fixture_file(File.join('availability', 'set_preorder_cleared_request.json'))).to_json).


### PR DESCRIPTION
Fixes #12444

## Wut 
- `preOrder` from `update_price_tier` request body has values (based off of `/pricing/intervals` response) that cause  the `POST` request to sometimes in valid
  - Similar to a fix in `update_availability` in #12311

## Fix
- Delete `preOrder` from `update_price_tier` request body (based off of `/pricing/intervals` response)
- Added tests

## To Test This Change
Add the following to your Gemfile and then run `bundle install`
```rb
gem 'fastlane', :git => 'https://github.com/fastlane/fastlane.git', :branch => 'joshdholtz-spaceship-delete-preOrder-update-price-tier'
```