### PR TITLE
added `team_name` to spaceship client

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -209,8 +209,6 @@ module Spaceship
           team_name: (team["contentProvider"] || {})["name"]
         }
       end
-      require 'pry'
-      binding.pry
 
       result = available_teams.find do |available_team|
         team_name.to_s == available_team[:team_name].to_s

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -211,7 +211,7 @@ module Spaceship
       end
       require 'pry'
       binding.pry
-      
+
       result = available_teams.find do |available_team|
         team_name.to_s == available_team[:team_name].to_s
       end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -186,6 +186,56 @@ module Spaceship
       @current_team_id = team_id
     end
 
+    # @return (String) The currently selected Team Name
+    def team_name
+      return @current_team_name if @current_team_name
+
+      if teams.count > 1
+        puts("The current user is in #{teams.count} teams. Pass a team Name or call `select_team` to choose a team. Using the first one for now.")
+      end
+      @current_team_name ||= teams[0]['contentProvider']['name']
+    end
+
+    # Set a new team Name which will be used from now on
+    def team_name=(team_name)
+      # First, we verify the team actually exists, because otherwise iTC would return the
+      # following confusing error message
+      #
+      #     invalid content provider name
+      #
+      available_teams = teams.collect do |team|
+        {
+          team_id: (team["contentProvider"] || {})["contentProviderId"],
+          team_name: (team["contentProvider"] || {})["name"]
+        }
+      end
+      require 'pry'
+      binding.pry
+      
+      result = available_teams.find do |available_team|
+        team_name.to_s == available_team[:team_name].to_s
+      end
+
+      unless result
+        error_string = "Could not set team Name to '#{team_name}', only found the following available teams:\n\n#{available_teams.map { |team| "- #{team[:team_id]} (#{team[:team_name]})" }.join("\n")}\n"
+        raise Tunes::Error.new, error_string
+      end
+
+      # TODO: Commented because this call is returning error. Discuss with joshdholtz to see what endpoint should be called here.
+      # response = request(:post) do |req|
+      #   req.url("ra/v1/session/webSession")
+      #   req.body = {
+      #     name: team_name,
+      #     dsId: user_detail_data.ds_id # https://github.com/fastlane/fastlane/issues/6711
+      #   }.to_json
+      #   req.headers['Content-Type'] = 'application/json'
+      # end
+
+      # handle_itc_response(response.body)
+
+      @current_team_name = team_name
+    end
+
     # @return (Hash) Fetches all information of the currently used team
     def team_information
       teams.find do |t|

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -188,21 +188,6 @@ module Spaceship
 
     # @return (String) The currently selected Team Name
     def team_name
-      return @current_team_name if @current_team_name
-
-      if teams.count > 1
-        puts("The current user is in #{teams.count} teams. Pass a team Name or call `select_team` to choose a team. Using the first one for now.")
-      end
-      @current_team_name ||= teams[0]['contentProvider']['name']
-    end
-
-    # Set a new team Name which will be used from now on
-    def team_name=(team_name)
-      # First, we verify the team actually exists, because otherwise iTC would return the
-      # following confusing error message
-      #
-      #     invalid content provider name
-      #
       available_teams = teams.collect do |team|
         {
           team_id: (team["contentProvider"] || {})["contentProviderId"],
@@ -211,27 +196,10 @@ module Spaceship
       end
 
       result = available_teams.find do |available_team|
-        team_name.to_s == available_team[:team_name].to_s
+        team_id.to_s == available_team[:team_id].to_s
       end
 
-      unless result
-        error_string = "Could not set team Name to '#{team_name}', only found the following available teams:\n\n#{available_teams.map { |team| "- #{team[:team_id]} (#{team[:team_name]})" }.join("\n")}\n"
-        raise Tunes::Error.new, error_string
-      end
-
-      # TODO: Commented because this call is returning error. Discuss with joshdholtz to see what endpoint should be called here.
-      # response = request(:post) do |req|
-      #   req.url("ra/v1/session/webSession")
-      #   req.body = {
-      #     name: team_name,
-      #     dsId: user_detail_data.ds_id # https://github.com/fastlane/fastlane/issues/6711
-      #   }.to_json
-      #   req.headers['Content-Type'] = 'application/json'
-      # end
-
-      # handle_itc_response(response.body)
-
-      @current_team_name = team_name
+      result[:team_name]
     end
 
     # @return (Hash) Fetches all information of the currently used team

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -186,27 +186,16 @@ module Spaceship
       @current_team_id = team_id
     end
 
-    # @return (String) The currently selected Team Name
-    def team_name
-      available_teams = teams.collect do |team|
-        {
-          team_id: (team["contentProvider"] || {})["contentProviderId"],
-          team_name: (team["contentProvider"] || {})["name"]
-        }
-      end
-
-      result = available_teams.find do |available_team|
-        team_id.to_s == available_team[:team_id].to_s
-      end
-
-      result[:team_name]
-    end
-
     # @return (Hash) Fetches all information of the currently used team
     def team_information
       teams.find do |t|
         t['teamId'] == team_id
       end
+    end
+
+    # @return (String) Fetches name from currently used team
+    def team_name
+      (team_information || {})['name']
     end
 
     # Instantiates a client but with a cookie derived from another client.

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -51,6 +51,29 @@ describe Spaceship::Client do
       end
     end
 
+    describe '#team_name' do
+      it 'returns the default team_name' do
+        puts subject.team_name
+        expect(subject.team_name).to eq('SpaceShip')
+      end
+
+      it "set custom Team Name" do
+        allow_any_instance_of(Spaceship::PortalClient).to receive(:teams).and_return([
+                                                                                       { 'teamId' => 'XXXXXXXXXX', 'currentTeamMember' => { 'teamMemberId' => '' } },
+                                                                                       { 'teamId' => 'ABCDEF', 'currentTeamMember' => { 'teamMemberId' => '' } }
+                                                                                     ])
+
+        team_name = "ABCDEF"
+        subject.select_team(team_name: team_name)
+        expect(subject.team_name).to eq(team_name)
+      end
+
+      it "shows a warning when user is in multiple teams and didn't call select_team" do
+        PortalStubbing.adp_stub_multiple_teams
+        expect(subject.team_name).to eq("SecondTeam")
+      end
+    end
+
     describe "csrf_tokens" do
       it "uses the stored token for all upcoming requests" do
         # Temporary stub a request to require the csrf_tokens

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -53,24 +53,24 @@ describe Spaceship::Client do
 
     describe '#team_name' do
       it 'returns the default team_name' do
-        puts subject.team_name
         expect(subject.team_name).to eq('SpaceShip')
       end
 
-      it "set custom Team Name" do
+      it "returns team_name from selected team_id" do
         allow_any_instance_of(Spaceship::PortalClient).to receive(:teams).and_return([
-                                                                                       { 'teamId' => 'XXXXXXXXXX', 'currentTeamMember' => { 'teamMemberId' => '' } },
-                                                                                       { 'teamId' => 'ABCDEF', 'currentTeamMember' => { 'teamMemberId' => '' } }
+                                                                                       { 'teamId' => 'XXXXXXXXXX', 'name' => 'SpaceShip', 'currentTeamMember' => { 'teamMemberId' => '' } },
+                                                                                       { 'teamId' => 'ABCDEF', 'name' => 'PirateShip', 'currentTeamMember' => { 'teamMemberId' => '' } }
                                                                                      ])
 
-        team_name = "ABCDEF"
-        subject.select_team(team_name: team_name)
-        expect(subject.team_name).to eq(team_name)
+        team_id = "ABCDEF"
+        subject.select_team(team_id: team_id)
+        expect(subject.team_id).to eq(team_id)
+        expect(subject.team_name).to eq('PirateShip')
       end
 
-      it "shows a warning when user is in multiple teams and didn't call select_team" do
-        PortalStubbing.adp_stub_multiple_teams
-        expect(subject.team_name).to eq("SecondTeam")
+      it "return nil if no teams" do
+        allow_any_instance_of(Spaceship::PortalClient).to receive(:teams).and_return([])
+        expect(subject.team_name).to eq(nil)
       end
     end
 


### PR DESCRIPTION
Currently the spaceship client doesn't contain a function to set the `team_name` from iTC. There is a `select_team` function. However I think it would be better if there is a `team_name` function similar to `team_id` to set the name. 