### PR TITLE
Account for adhoc certificates under enterprise accounts

### DIFF
--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -179,7 +179,7 @@ module Sigh
         # handles case where the desired certificate type is adhoc but the account is an enterprise account
         # the apple dev portal api has a weird quirk in it where if you query for distribution certificates
         # for enterprise accounts, you get nothing back even if they exist.
-        elsif profile_type == Spaceship.provisioning_profile.AdHoc && Spaceship.client.in_house?
+        elsif profile_type == Spaceship.provisioning_profile.AdHoc && Spaceship.client && Spaceship.client.in_house?
           certificates = Spaceship.certificate.in_house.all
         else
           certificates = Spaceship.certificate.production.all # Ad hoc or App Store

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -176,6 +176,9 @@ module Sigh
           certificates = Spaceship.certificate.development.all
         elsif profile_type == Spaceship.provisioning_profile.InHouse
           certificates = Spaceship.certificate.in_house.all
+        # handles case where the desired certificate type is adhoc but the account is an enterprise account
+        # the apple dev portal api has a weird quirk in it where if you query for distribution certificates
+        # for enterprise accounts, you get nothing back even if they exist.
         elsif profile_type == Spaceship.provisioning_profile.AdHoc && Spaceship.client.in_house?
           certificates = Spaceship.certificate.in_house.all
         else

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -176,6 +176,8 @@ module Sigh
           certificates = Spaceship.certificate.development.all
         elsif profile_type == Spaceship.provisioning_profile.InHouse
           certificates = Spaceship.certificate.in_house.all
+        elsif profile_type == Spaceship.provisioning_profile.AdHoc && Spaceship.client.in_house?
+          certificates = Spaceship.certificate.in_house.all
         else
           certificates = Spaceship.certificate.production.all # Ad hoc or App Store
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes issue highlighted in trailing comments of #11139. TL;DR the apple dev portal API doesn't return adhoc certificates when you query `https://developer.apple.com/services-account/PLATFORM_ID/account/ios/certificate/listCertRequests.action` for adhoc certs when the account is an enterprise account.

### Description
<!-- Describe your changes in detail -->

Pretty simple, just added an extra case to `sigh`'s method `:

```ruby
def certificates_for_profile_and_platform
      case Sigh.config[:platform].to_s
      when 'ios', 'tvos'
        if profile_type == Spaceship.provisioning_profile.Development
          certificates = Spaceship.certificate.development.all
        elsif profile_type == Spaceship.provisioning_profile.InHouse
          certificates = Spaceship.certificate.in_house.all
        # handles case where the desired certificate type is adhoc but the account is an enterprise account
        # the apple dev portal api has a weird quirk in it where if you query for distribution certificates
        # for enterprise accounts, you get nothing back even if they exist.
        elsif profile_type == Spaceship.provisioning_profile.AdHoc && Spaceship.client.in_house?
          certificates = Spaceship.certificate.in_house.all
        else
          certificates = Spaceship.certificate.production.all # Ad hoc or App Store
        end

      when 'macos'
        if profile_type == Spaceship.provisioning_profile.Development
          certificates = Spaceship.certificate.mac_development.all
        elsif profile_type == Spaceship.provisioning_profile.AppStore
          certificates = Spaceship.certificate.mac_app_distribution.all
        elsif profile_type == Spaceship.provisioning_profile.Direct
          certificates = Spaceship.certificate.developer_id_application.all
        else
          certificates = Spaceship.certificate.mac_app_distribution.all
        end
      end

      certificates
    end
```
