### PR TITLE
Trying fallback legacy issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,35 @@
+---
+name: 🐛 Bug Report
+about: If something isn't working as expected 🤔
+
+---
+
+<!-- Thanks for helping _fastlane_! Before you submit your issue, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
+
+### New Issue Checklist
+
+- [ ] Updated fastlane to the latest version
+- [ ] I read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
+- [ ] I read [docs.fastlane.tools](https://docs.fastlane.tools)
+- [ ] I searched for [existing GitHub issues](https://github.com/fastlane/fastlane/issues)
+
+### Issue Description
+<!-- Please include what's happening, expected behavior, and any relevant code samples -->
+
+##### Complete output when running fastlane, including the stack trace and command used
+<!-- You can use: `--capture_output` as the last commandline argument to get that collected for you -->
+
+<!-- The output of `--capture_output` could contain sensitive data such as application ids, certificate ids, or email addreses, Please make sure you double check the output and replace anything sensitive you don't wish to submit in the issue -->
+
+<details>
+  <pre>[INSERT OUTPUT HERE]</pre>
+</details>
+
+### Environment
+
+<!-- Please run `fastlane env` and copy the output below. This will help us help you :+1:
+If you used `--capture_output` option, please remove this block as it is already included there. -->
+
+<details>
+  <pre>[INSERT OUTPUT HERE]</pre>
+</details>

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,3 @@
----
-name: 🐛 Bug Report
-about: If something isn't working as expected 🤔
-
----
-
 <!-- Thanks for helping _fastlane_! Before you submit your issue, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
 
 ### New Issue Checklist


### PR DESCRIPTION
There is an option to "Open regular issues" that doesn't use any template at all so going to see if the legacy ISSUE_TEMPLATE gets used by that.