### PR TITLE
[slack] add pretext to show text above attachment block

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -71,6 +71,10 @@ module Fastlane
                                        env_name: "FL_SLACK_MESSAGE",
                                        description: "The message that should be displayed on Slack. This supports the standard Slack markup language",
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :pretext,
+                                       env_name: "FL_SLACK_PRETEXT",
+                                       description: "This is optional text that appears above the message attachment block. This supports the standard Slack markup language",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :channel,
                                        env_name: "FL_SLACK_CHANNEL",
                                        description: "#channel or @username",
@@ -185,6 +189,7 @@ module Fastlane
         slack_attachment = {
           fallback: options[:message],
           text: options[:message],
+          pretext: options[:pretext],
           color: color,
           mrkdwn_in: ["pretext", "text", "fields", "message"],
           fields: []

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -37,6 +37,7 @@ describe Fastlane do
 
         expect(attachments[:color]).to eq('danger')
         expect(attachments[:text]).to eq(message)
+        expect(attachments[:pretext]).to eq(nil)
 
         fields = attachments[:fields]
         expect(fields[1][:title]).to eq('Built by')
@@ -47,6 +48,33 @@ describe Fastlane do
 
         expect(fields[3][:title]).to eq('Result')
         expect(fields[3][:value]).to eq('Error')
+      end
+
+      it "works so perfect, like Slack does with pretext" do
+        channel = "#myChannel"
+        message = "Custom Message"
+        pretext = "This is pretext"
+        lane_name = "lane_name"
+
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
+
+        require 'fastlane/actions/slack'
+        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+          slack_url: 'https://127.0.0.1',
+          message: message,
+          pretext: pretext,
+          success: false,
+          channel: channel
+        })
+
+        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+
+        expect(notifier.config.defaults[:username]).to eq('fastlane')
+        expect(notifier.config.defaults[:channel]).to eq(channel)
+
+        expect(attachments[:color]).to eq('danger')
+        expect(attachments[:text]).to eq(message)
+        expect(attachments[:pretext]).to eq(pretext)
       end
 
       it "merges attachment_properties when specified" do


### PR DESCRIPTION
Fixes #12468

## Wut
- `:message` is put into the "attachments" text so no way to put text above (outside) attachment block

## Fix
- Added in `:pretext` option which puts text above (outside) of attachment block

## Screenshots

### With pretext
![screen shot 2018-05-08 at 7 29 04 am](https://user-images.githubusercontent.com/401294/39757760-6e67565e-5293-11e8-973b-5399c4e8ee4c.png)

### Wihout pretext
![screen shot 2018-05-08 at 7 43 11 am](https://user-images.githubusercontent.com/401294/39757769-7b0c1c5a-5293-11e8-8520-8dcaf52864d6.png)
