### PR TITLE
[supply] allow for custom closed track names

### DIFF
--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -3,9 +3,8 @@ require 'credentials_manager/appfile_config'
 
 module Supply
   class Options
-    # rubocop:disable Metrics/PerceivedComplexity
     def self.available_options
-      valid_tracks = %w(production beta alpha internal rollout)
+      default_tracks = %w(production beta alpha internal rollout)
       @options ||= [
         FastlaneCore::ConfigItem.new(key: :package_name,
                                      env_name: "SUPPLY_PACKAGE_NAME",
@@ -17,12 +16,8 @@ module Supply
         FastlaneCore::ConfigItem.new(key: :track,
                                      short_option: "-a",
                                      env_name: "SUPPLY_TRACK",
-                                     description: "The track of the application to use: #{valid_tracks.join(', ')}",
-                                     default_value: 'production',
-                                     verify_block: proc do |value|
-                                       available = valid_tracks
-                                       UI.user_error!("Invalid value '#{value}', must be #{available.join(', ')}") unless available.include?(value)
-                                     end),
+                                     description: "The track of the application to use. The default available tracks are: #{default_tracks.join(', ')}",
+                                     default_value: 'production'),
         FastlaneCore::ConfigItem.new(key: :rollout,
                                      short_option: "-r",
                                      description: "The percentage of the user fraction when uploading to the rollout track",
@@ -146,11 +141,7 @@ module Supply
         FastlaneCore::ConfigItem.new(key: :track_promote_to,
                                      env_name: "SUPPLY_TRACK_PROMOTE_TO",
                                      optional: true,
-                                     description: "The track to promote to: #{valid_tracks.join(', ')}",
-                                     verify_block: proc do |value|
-                                       available = valid_tracks
-                                       UI.user_error!("Invalid value '#{value}', must be #{available.join(', ')}") unless available.include?(value)
-                                     end),
+                                     description: "The track to promote to. The default available tracks are: #{default_tracks.join(', ')}"),
         FastlaneCore::ConfigItem.new(key: :validate_only,
                                      env_name: "SUPPLY_VALIDATE_ONLY",
                                      optional: true,
@@ -195,6 +186,5 @@ module Supply
 
       ]
     end
-    # rubocop:enable Metrics/PerceivedComplexity
   end
 end

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -184,6 +184,11 @@ module Supply
       tracks = ["production", "rollout", "beta", "alpha", "internal"]
       config_track_index = tracks.index(Supply.config[:track])
 
+      # Custom "closed" tracks are now allowed (https://support.google.com/googleplay/android-developer/answer/3131213)
+      # Custom tracks have an equal level with alpha (alpha is considered a closed track as well)
+      # If a track index is not found, we will assume is a custom track so an alpha index is given
+      config_track_index = tracks.index("alpha") unless config_track_index
+
       tracks.each_index do |track_index|
         track = tracks[track_index]
         track_version_codes = client.track_version_codes(track).sort

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -241,6 +241,54 @@ describe Supply do
         }
         Supply::Uploader.new.check_superseded_tracks([105])
       end
+
+      it 'combined case with custom track as alpha' do
+        allow(client).to receive(:track_version_codes) do |track|
+          next [103] if track.eql?('production')
+          next [102] if track.eql?('rollout')
+          next [105] if track.eql?('alpha')
+          next [104] if track.eql?('custom')
+          next [101] if track.eql?('internal')
+          []
+        end
+
+        allow(client).to receive(:update_track) do |track, rollout, apk_version_code|
+          expect(track).to eq('rollout').or(eq('alpha')).or(eq('custom')).or(eq('internal'))
+          expect(rollout).to eq(1.0)
+          expect(apk_version_code).to be_empty
+        end
+
+        expect(client).to receive(:update_track).exactly(2).times
+
+        Supply.config = {
+          track: 'alpha'
+        }
+        Supply::Uploader.new.check_superseded_tracks([106])
+      end
+
+      it 'combined case with custom track as custom' do
+        allow(client).to receive(:track_version_codes) do |track|
+          next [103] if track.eql?('production')
+          next [102] if track.eql?('rollout')
+          next [105] if track.eql?('alpha')
+          next [104] if track.eql?('custom')
+          next [101] if track.eql?('internal')
+          []
+        end
+
+        allow(client).to receive(:update_track) do |track, rollout, apk_version_code|
+          expect(track).to eq('rollout').or(eq('alpha')).or(eq('custom')).or(eq('internal'))
+          expect(rollout).to eq(1.0)
+          expect(apk_version_code).to be_empty
+        end
+
+        expect(client).to receive(:update_track).exactly(2).times
+
+        Supply.config = {
+          track: 'custom'
+        }
+        Supply::Uploader.new.check_superseded_tracks([106])
+      end
     end
   end
 end


### PR DESCRIPTION
## Wut
- Discovered that Google Play now offers ability to allow for adding of custom closed tracks 
  - https://support.google.com/googleplay/android-developer/answer/3131213
- `:track` and `: track_promote_to` don't validate track names anymore
  - Descriptions have been changed to show default available tracks