### PR TITLE
fixed match do not recreate invalid provisioning

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -172,14 +172,20 @@ module Match
         self.files_to_commmit << profile
       end
 
-      installed_profile = FastlaneCore::ProvisioningProfile.install(profile, keychain_path)
       parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
       uuid = parsed["UUID"]
 
-      if spaceship && !spaceship.profile_exists(username: params[:username], uuid: uuid)
-        # This profile is invalid, let's remove the local file and generate a new one
-        File.delete(profile)
-        # This method will be called again, no need to modify `files_to_commmit`
+      if spaceship
+        if spaceship.profile_exists(username: params[:username], uuid: uuid)
+          # This profile is valid, so install
+          installed_profile = FastlaneCore::ProvisioningProfile.install(profile, keychain_path)
+        else
+          # This profile is invalid, let's remove the local file and generate a new one
+          File.delete(profile)
+          # This method will be called again, no need to modify `files_to_commmit`
+          return nil
+        end
+      else
         return nil
       end
 

--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -63,17 +63,22 @@ module Match
         UI.error("for the user #{username}")
         UI.error("Make sure to use the same user and team every time you run 'match' for this")
         UI.error("Git repository. This might be caused by deleting the provisioning profile on the Dev Portal")
-        UI.user_error!("To reset the provisioning profiles of your Apple account, you can use the `fastlane match nuke` feature, more information on https://docs.fastlane.tools/actions/match/")
+        # Do not throw exceptions now
+        # UI.user_error!("To reset the provisioning profiles of your Apple account, you can use the `fastlane match nuke` feature, more information on https://docs.fastlane.tools/actions/match/")
       end
 
-      if found.valid?
-        return found
+      if found
+        if found.valid?
+          return found
+        else
+          UI.important("'#{found.name}' is available on the Developer Portal, however it's 'Invalid', fixing this now for you 🔨")
+          # it's easier to just create a new one, than to repair an existing profile
+          # it has the same effects anyway, including a new UUID of the provisioning profile
+          found.delete!
+          # return nil to re-download the new profile in runner.rb
+          return nil
+        end
       else
-        UI.important("'#{found.name}' is available on the Developer Portal, however it's 'Invalid', fixing this now for you 🔨")
-        # it's easier to just create a new one, than to repair an existing profile
-        # it has the same effects anyway, including a new UUID of the provisioning profile
-        found.delete!
-        # return nil to re-download the new profile in runner.rb
         return nil
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
 -  Why is this change required? What problem does it solve?

    fastlane match do not recreate provisioning when i set readonly is false , meanwhile, it do not  recreate provisioning when the provisioning file is invalid.

 -  If it fixes an open issue, please link to the issue here. 

    Not found.

-  Please describe in detail how you tested your changes. 

   I delete adhoc provisioning file in apple developer website, then i run **fastlane match adhoc**,
   It work!

### Description

  If  the provisioning file is invalid , it should not raise a exception right now. May be we need recreate the   the provisioning file.

