### PR TITLE
fixed match does not recreate provisioning profile

### DIFF
--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -71,6 +71,21 @@ module FastlaneCore
         destination
       end
 
+      # Installs a provisioning profile for Xcode to use
+      def uninstall(path, keychain_path = nil)
+        UI.message("Delete provisioning profile...")
+        unless path.nil?
+          profile_filename = uuid(path, keychain_path) + ".mobileprovision"
+          destination = File.join(profiles_path, profile_filename)
+          if File.exist?(destination)
+            File.delete(destination)
+          end
+          if File.exist?(path)
+            File.delete(path)
+          end
+        end
+      end
+
       private
 
       def decode(path, keychain_path = nil)

--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -63,7 +63,10 @@ module Match
         UI.error("for the user #{username}")
         UI.error("Make sure to use the same user and team every time you run 'match' for this")
         UI.error("Git repository. This might be caused by deleting the provisioning profile on the Dev Portal")
-        UI.user_error!("To reset the provisioning profiles of your Apple account, you can use the `fastlane match nuke` feature, more information on https://docs.fastlane.tools/actions/match/")
+      end
+
+      if found.nil?
+        return nil
       end
 
       if found.valid?


### PR DESCRIPTION
bundle exec rspec<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
 -  Why is this change required? What problem does it solve?

 	When the provisioning profile is invalid, it might be caused by deleting the provisioning profile on the Dev Portal.
 	fastlane does not work! fastlane match do not recreate provisioning when i set readonly is false , meanwhile, it do not  recreate provisioning when the provisioning file is invalid.

 -  If it fixes an open issue, please link to the issue here. 

    Not found.

-  Please describe in detail how you tested your changes. 

   I delete adhoc provisioning file in apple developer website, then i run **fastlane match adhoc**,
   It work!

### Description

  If  the provisioning file is invalid , it should not raise a exception right now. May be we need recreate the   the provisioning file.

