### PR TITLE
Fix nil path crash in changelog_from_git_commits action

### DIFF
--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -28,6 +28,10 @@ module Fastlane
         if params[:include_merges] == false
           merge_commit_filtering = :exclude_merges
         end
+        
+        if params[:path] == nil
+          params[:path] = './'
+        end
 
         Dir.chdir(params[:path]) do
           if params[:commits_count]

--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -28,10 +28,8 @@ module Fastlane
         if params[:include_merges] == false
           merge_commit_filtering = :exclude_merges
         end
-        
-        if params[:path] == nil
-          params[:path] = './'
-        end
+
+        params[:path] = './' unless params[:path]
 
         Dir.chdir(params[:path]) do
           if params[:commits_count]


### PR DESCRIPTION
fixes: https://github.com/fastlane/fastlane/issues/12497.

**Note:**
I don't think the solution implemented in this PR is right. However it solves the crash issue. 

The `path` param should not be `nil` in the first place because we are setting the `default_value` for the param. Need to figure out why it is setting `nil` value for `path`.