### PR TITLE
added support for appcenter is_ci?

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -72,7 +72,7 @@ module FastlaneCore
     # @return [boolean] true if building in a known CI environment
     def self.ci?
       # Check for Jenkins, Travis CI, ... environment variables
-      ['JENKINS_HOME', 'JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI', 'XCS'].each do |current|
+      ['JENKINS_HOME', 'JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'APPCENTER_OUTPUT_DIRECTORY', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI', 'XCS'].each do |current|
         return true if ENV.key?(current)
       end
       return false

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -72,7 +72,7 @@ module FastlaneCore
     # @return [boolean] true if building in a known CI environment
     def self.ci?
       # Check for Jenkins, Travis CI, ... environment variables
-      ['JENKINS_HOME', 'JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'APPCENTER_OUTPUT_DIRECTORY', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI', 'XCS'].each do |current|
+      ['JENKINS_HOME', 'JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'APPCENTER_BUILD_ID', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI', 'XCS'].each do |current|
         return true if ENV.key?(current)
       end
       return false

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -53,7 +53,7 @@ describe FastlaneCore do
       end
 
       it "returns true when building in AppCenter" do
-        stub_const('ENV', { 'APPCENTER_OUTPUT_DIRECTORY' => '/Users/vsts/agent/2.133.3/work/1/a/build'})
+        stub_const('ENV', { 'APPCENTER_OUTPUT_DIRECTORY' => '/Users/vsts/agent/2.133.3/work/1/a/build' })
         expect(FastlaneCore::Helper.ci?).to be(true)
       end
 

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -53,7 +53,7 @@ describe FastlaneCore do
       end
 
       it "returns true when building in AppCenter" do
-        stub_const('ENV', { 'APPCENTER_OUTPUT_DIRECTORY' => '/path/to/a/build' })
+        stub_const('ENV', { 'APPCENTER_BUILD_ID' => '185' })
         expect(FastlaneCore::Helper.ci?).to be(true)
       end
 

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -52,6 +52,11 @@ describe FastlaneCore do
         expect(FastlaneCore::Helper.ci?).to be(true)
       end
 
+      it "returns true when building in AppCenter" do
+        stub_const('ENV', { 'APPCENTER_OUTPUT_DIRECTORY' => '/Users/vsts/agent/2.133.3/work/1/a/build'})
+        expect(FastlaneCore::Helper.ci?).to be(true)
+      end
+
       it "returns true when building in Xcode Server" do
         stub_const('ENV', { 'XCS' => true })
         expect(FastlaneCore::Helper.ci?).to be(true)

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -53,7 +53,7 @@ describe FastlaneCore do
       end
 
       it "returns true when building in AppCenter" do
-        stub_const('ENV', { 'APPCENTER_OUTPUT_DIRECTORY' => '/Users/vsts/agent/2.133.3/work/1/a/build' })
+        stub_const('ENV', { 'APPCENTER_OUTPUT_DIRECTORY' => '/path/to/a/build' })
         expect(FastlaneCore::Helper.ci?).to be(true)
       end
 


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->
Currently `is_ci` action doesn't support Microsoft [Appcenter](http://appcenter.ms) CI. This PR adds support for the same.

fixes: #12511 