### PR TITLE
added loading indicator for frameit

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -59,6 +59,7 @@ module Frameit
       output_path = screenshot.path.gsub('.png', '_framed.png').gsub('.PNG', '_framed.png')
       image.format("png")
       image.write(output_path)
+      Helper.hide_loading_indicator
       UI.success("Added frame: '#{File.expand_path(output_path)}'")
     end
 

--- a/frameit/lib/frameit/runner.rb
+++ b/frameit/lib/frameit/runner.rb
@@ -35,8 +35,7 @@ module Frameit
             next # we don't care about watches right now
           end
 
-          UI.message("Framing screenshot '#{full_path}'")
-          Helper.show_loading_indicator('')
+          Helper.show_loading_indicator("Framing screenshot '#{full_path}'")
 
           begin
             screenshot = Screenshot.new(full_path, color)
@@ -45,7 +44,6 @@ module Frameit
             UI.error(ex.to_s)
             UI.error("Backtrace:\n\t#{ex.backtrace.join("\n\t")}") if FastlaneCore::Globals.verbose?
           end
-          Helper.hide_loading_indicator
         end
       else
         UI.error("Could not find screenshots in current directory: '#{File.expand_path(path)}'")

--- a/frameit/lib/frameit/runner.rb
+++ b/frameit/lib/frameit/runner.rb
@@ -36,6 +36,7 @@ module Frameit
           end
 
           UI.message("Framing screenshot '#{full_path}'")
+          Helper.show_loading_indicator('')
 
           begin
             screenshot = Screenshot.new(full_path, color)
@@ -44,6 +45,7 @@ module Frameit
             UI.error(ex.to_s)
             UI.error("Backtrace:\n\t#{ex.backtrace.join("\n\t")}") if FastlaneCore::Globals.verbose?
           end
+          Helper.hide_loading_indicator
         end
       else
         UI.error("Could not find screenshots in current directory: '#{File.expand_path(path)}'")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
Currently, the action `frameit` takes some time to complete. There is no loading indicator when the screenshots are being framed. It would be nice to show indicator while the action is doing its magic.

### Description
<!-- Describe your changes in detail -->
Before:
![kcnq6ozwea](https://user-images.githubusercontent.com/2100166/40006801-e9bf961e-5760-11e8-9eef-1a3a44ddd6d2.gif)

After:
![dhwrdxylri](https://user-images.githubusercontent.com/2100166/40070181-fbdf7cd8-5832-11e8-9b32-f5f83430b11b.gif)
