### PR TITLE
disables color in xcpretty if env var is set

### DIFF
--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -25,7 +25,11 @@ module Snapshot
         tee_command = ['tee']
         tee_command << '-a' if log_path && File.exist?(log_path)
         tee_command << log_path.shellescape if log_path
-        return ["| #{tee_command.join(' ')} | xcpretty #{Snapshot.config[:xcpretty_args]}"]
+
+        xcpretty = "xcpretty #{Snapshot.config[:xcpretty_args]}"
+        xcpretty << "--no-color" if Helper.colors_disabled?
+
+        return ["| #{tee_command.join(' ')} | #{xcpretty}"]
       end
 
       def destination(devices)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
Currently `snapshot` doesn't disables color when `export FASTLANE_DISABLE_COLORS=1` is set. This PR will disable the color output.

### Description
<!-- Describe your changes in detail -->
Before:
![screenshot 2018-05-14 12 55 57](https://user-images.githubusercontent.com/2100166/40014484-53153b68-5776-11e8-90d0-69833239f856.png)

After:
![screenshot 2018-05-14 12 56 59](https://user-images.githubusercontent.com/2100166/40014493-57c39042-5776-11e8-9b21-a61539b76e1b.png)
