### PR TITLE
Add attr_reader for :prefix in AccountManager

### DIFF
--- a/credentials_manager/lib/credentials_manager/account_manager.rb
+++ b/credentials_manager/lib/credentials_manager/account_manager.rb
@@ -6,6 +6,10 @@ require_relative 'appfile_config'
 module CredentialsManager
   class AccountManager
     DEFAULT_PREFIX = "deliver"
+
+    # Is used for iTunes Transporter
+    attr_reader :prefix
+
     # @param prefix [String] Very optional, is used for the
     #   iTunes Transporter which uses application specific passwords
     # @param note [String] An optional note that will be shown next


### PR DESCRIPTION
Just to make it publicly accessible, we don't need it now, but might be needed for http://fastlane.ci in the future