### PR TITLE
[gym] Fix analyze_build_time setting interfering with xcpretty log generation

### DIFF
--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -9,8 +9,8 @@ module Gym
         parts = prefix
         parts << "xcodebuild"
         parts += options
-        parts += actions
-        parts += suffix
+        parts += buildactions
+        parts += setting
         parts += pipe
 
         parts
@@ -46,26 +46,25 @@ module Gym
         options
       end
 
-      def actions
+      def buildactions
         config = Gym.config
 
-        actions = []
-        actions << :clean if config[:clean]
-        actions << :archive unless config[:skip_archive]
+        buildactions = []
+        buildactions << :clean if config[:clean]
+        buildactions << :archive unless config[:skip_archive]
 
-        actions
+        buildactions
       end
 
-      def suffix
-        suffix = []
-        suffix << "CODE_SIGN_IDENTITY=#{Gym.config[:codesigning_identity].shellescape}" if Gym.config[:codesigning_identity]
-        suffix
+      def setting
+        setting = []
+        setting << "CODE_SIGN_IDENTITY=#{Gym.config[:codesigning_identity].shellescape}" if Gym.config[:codesigning_identity]
+        setting
       end
 
       def pipe
         pipe = []
         pipe << "| tee #{xcodebuild_log_path.shellescape}"
-        pipe << "| grep .[0-9]ms | grep -v ^0.[0-9]ms | sort -nr > culprits.txt" if Gym.config[:analyze_build_time]
         unless Gym.config[:disable_xcpretty]
           formatter = Gym.config[:xcpretty_formatter]
           pipe << "| xcpretty"
@@ -89,8 +88,13 @@ module Gym
           end
         end
         pipe << "> /dev/null" if Gym.config[:suppress_xcode_output]
-
         pipe
+      end
+
+      def post_build
+        commands = []
+        commands << %{grep -E '^[0-9.]+ms' #{xcodebuild_log_path.shellescape} | grep -vE '^0\.[0-9]' | sort -nr > culprits.txt} if Gym.config[:analyze_build_time]
+        commands
       end
 
       def xcodebuild_log_path

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -107,7 +107,7 @@ module Gym
     # Post-processing of build_app
     def post_build_app
       command = BuildCommandGenerator.post_build
-      
+
       return if command.empty?
 
       print_command(command, "Generated Post-Build Command") if FastlaneCore::Globals.verbose?

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -100,6 +100,20 @@ module Gym
       mark_archive_as_built_by_gym(BuildCommandGenerator.archive_path)
       UI.success("Successfully stored the archive. You can find it in the Xcode Organizer.") unless Gym.config[:archive_path].nil?
       UI.verbose("Stored the archive in: " + BuildCommandGenerator.archive_path)
+
+      post_build_app
+    end
+
+    # Post-processing of build_app
+    def post_build_app
+      command = BuildCommandGenerator.post_build
+      print_command(command, "Generated Post-Build Command") if FastlaneCore::Globals.verbose?
+      FastlaneCore::CommandExecutor.execute(command: command,
+                                          print_all: true,
+                                      print_command: !Gym.config[:silent],
+                                              error: proc do |output|
+                                                ErrorHandler.handle_build_error(output)
+                                              end)
     end
 
     # Makes sure the archive is there and valid

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -107,6 +107,9 @@ module Gym
     # Post-processing of build_app
     def post_build_app
       command = BuildCommandGenerator.post_build
+      
+      return if command.empty?
+
       print_command(command, "Generated Post-Build Command") if FastlaneCore::Globals.verbose?
       FastlaneCore::CommandExecutor.execute(command: command,
                                           print_all: true,

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -243,7 +243,7 @@ describe Gym do
                              ])
 
         result = Gym::BuildCommandGenerator.post_build
-        expect(result).to eq([])
+        expect(result).to be_empty
       end
     end
   end

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -197,9 +197,11 @@ describe Gym do
     end
 
     describe "Analyze Build Time Example" do
-      it "uses the correct build command with the example project", requires_xcodebuild: true do
-        log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
+      before do
+        @log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
+      end
 
+      it "uses the correct build command with the example project when option is enabled", requires_xcodebuild: true do
         options = { project: "./gym/examples/standard/Example.xcodeproj", analyze_build_time: true, scheme: 'Example' }
         Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 
@@ -213,10 +215,35 @@ describe Gym do
                                "-archivePath #{Gym::BuildCommandGenerator.archive_path.shellescape}",
                                "OTHER_SWIFT_FLAGS=\"-Xfrontend -debug-time-function-bodies\"",
                                :archive,
-                               "| tee #{log_path.shellescape}",
-                               "| grep .[0-9]ms | grep -v ^0.[0-9]ms | sort -nr > culprits.txt",
+                               "| tee #{@log_path.shellescape}",
                                "| xcpretty"
                              ])
+
+        result = Gym::BuildCommandGenerator.post_build
+        expect(result).to eq([
+                               "grep -E '^[0-9.]+ms' #{@log_path.shellescape} | grep -vE '^0\.[0-9]' | sort -nr > culprits.txt"
+                             ])
+      end
+
+      it "uses the correct build command with the example project when option is disabled", requires_xcodebuild: true do
+        options = { project: "./gym/examples/standard/Example.xcodeproj", analyze_build_time: false, scheme: 'Example' }
+        Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+        result = Gym::BuildCommandGenerator.generate
+        expect(result).to eq([
+                               "set -o pipefail &&",
+                               "xcodebuild",
+                               "-scheme Example",
+                               "-project ./gym/examples/standard/Example.xcodeproj",
+                               "-destination 'generic/platform=iOS'",
+                               "-archivePath #{Gym::BuildCommandGenerator.archive_path.shellescape}",
+                               :archive,
+                               "| tee #{@log_path.shellescape}",
+                               "| xcpretty"
+                             ])
+
+        result = Gym::BuildCommandGenerator.post_build
+        expect(result).to eq([])
       end
     end
   end


### PR DESCRIPTION
Fixes #10187

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

`gym`'s `analyze_build_time` option interferes with its own `xcpretty` output, since the analysis steps are incorrectly inserted between the `xcodebuild` and `xcpretty` pipelines and it improperly consumes output that should be piped to `xcpretty`. Processes that depend on `xcpretty` will thus fail (e.g. the json-compilation-database isn't generated when `analyze_build_time` is on).

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description

I moved the `analyze_build_time` steps to a `post_build` step that waits until the main `xcodebuild ... | xcpretty` command has finished. It seems more fitting that any build analysis should happen _after_ building has completed, not during the build process.