### PR TITLE
increment_build_number informs user what to do when detecting SRCROOT

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -30,11 +30,8 @@ module Fastlane
         # https://developer.apple.com/library/ios/qa/qa1827/_index.html
         # Attention: This is NOT the version number - but the build number
 
-        # We do not want to run agvtool under tests to avoid output about not having a project available
-        unless Helper.test?
-          agv_enabled = system([command_prefix, 'agvtool what-version', command_suffix].join(' '))
-          raise "Apple Generic Versioning is not enabled." unless agv_enabled
-        end
+        agv_enabled = system([command_prefix, 'agvtool what-version', command_suffix].join(' '))
+        raise "Apple Generic Versioning is not enabled." unless agv_enabled
 
         command = [
           command_prefix,
@@ -43,16 +40,16 @@ module Fastlane
           command_suffix
         ].join(' ')
 
-        if Helper.test?
-          return Actions.lane_context[SharedValues::BUILD_NUMBER] = command
-        else
-          Actions.sh(command)
-
-          # Store the new number in the shared hash
-          build_number = `#{command_prefix} agvtool what-version`.split("\n").last.strip
-
-          return Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number
+        output = Actions.sh(command)
+        if output.include?('$(SRCROOT)')
+          UI.error('Cannot set build number with plist path containing $(SRCROOT)')
+          UI.error('Please remove $(SRCROOT) in your Xcode target build settings')
         end
+
+        # Store the new number in the shared hash
+        build_number = Actions.sh("#{command_prefix} agvtool what-version", log: false).split("\n").last.strip
+
+        return Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number
       rescue
         UI.user_error!("Apple Generic Versioning is not enabled in this project.\nBefore being able to increment and read the version number from your Xcode project, you first need to setup your project properly. Please follow the guide at https://developer.apple.com/library/content/qa/qa1827/_index.html")
       end

--- a/fastlane/spec/actions_specs/increment_build_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_build_number_action_spec.rb
@@ -3,36 +3,106 @@ describe Fastlane do
     describe "Increment Build Number Integration" do
       require 'shellwords'
 
-      it "increments the build number of the Xcode project" do
-        Fastlane::FastFile.new.parse("lane :test do
-          increment_build_number(xcodeproj: '.xcproject')
-        end").runner.execute(:test)
+      describe "With agv enabled" do
+        before(:each) do
+          allow(Fastlane::Actions::IncrementBuildNumberAction).to receive(:system).with(/agvtool/).and_return(true)
+        end
 
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool next-version -all/)
-      end
+        it "increments the build number of the Xcode project" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool next[-]version [-]all && cd [-]/)
+            .once
+            .and_return("")
 
-      it "pass a custom build number to the tool" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          increment_build_number(build_number: 24, xcodeproj: '.xcproject')
-        end").runner.execute(:test)
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool what[-]version/, log: false)
+            .once
+            .and_return("Current version of project Test is:\n40")
 
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool new-version -all 24/)
-      end
-
-      it "raises an exception when use passes workspace" do
-        expect do
           Fastlane::FastFile.new.parse("lane :test do
-            increment_build_number(xcodeproj: 'project.xcworkspace')
+            increment_build_number(xcodeproj: '.xcproject')
           end").runner.execute(:test)
-        end.to raise_error("Please pass the path to the project, not the workspace")
+
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq('40')
+        end
+
+        it "pass a custom build number to the tool" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool new[-]version [-]all 24 && cd [-]/)
+            .once
+            .and_return("")
+
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool what[-]version/, log: false)
+            .once
+            .and_return("Current version of project Test is:\n24")
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            increment_build_number(build_number: 24, xcodeproj: '.xcproject')
+          end").runner.execute(:test)
+
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq('24')
+        end
+
+        it "displays error when $(SRCROOT) detected" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool new[-]version [-]all 24 && cd [-]/)
+            .and_return("Something\n$(SRCROOT)/Test/Info.plist")
+
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool what[-]version/, log: false)
+            .once
+            .and_return("Current version of project Test is:\n24")
+
+          expect(UI).to receive(:error).with('Cannot set build number with plist path containing $(SRCROOT)')
+          expect(UI).to receive(:error).with('Please remove $(SRCROOT) in your Xcode target build settings')
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            increment_build_number(build_number: 24, xcodeproj: '.xcproject')
+          end").runner.execute(:test)
+
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq('24')
+        end
+
+        it "raises an exception when user passes workspace" do
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              increment_build_number(xcodeproj: 'project.xcworkspace')
+            end").runner.execute(:test)
+          end.to raise_error("Please pass the path to the project, not the workspace")
+        end
+
+        it "properly removes new lines of the build number" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool new[-]version [-]all 24 && cd [-]/)
+            .once
+            .and_return("")
+
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool what[-]version/, log: false)
+            .once
+            .and_return("Current version of project Test is:\n24")
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            increment_build_number(build_number: '24\n', xcodeproj: '.xcproject')
+          end").runner.execute(:test)
+
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq('24')
+        end
       end
 
-      it "properly removes new lines of the build number" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          increment_build_number(build_number: '24\n', xcodeproj: '.xcproject')
-        end").runner.execute(:test)
+      describe "With agv not enabled" do
+        before(:each) do
+          allow(Fastlane::Actions::IncrementBuildNumberAction).to receive(:system).and_return(nil)
+        end
 
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool new-version -all 24 \&\& cd \-/)
+        it "raises an exception when agv not enabled" do
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              increment_build_number(xcodeproj: '.xcproject')
+            end").runner.execute(:test)
+          end.to raise_error(/Apple Generic Versioning is not enabled./)
+        end
       end
     end
   end

--- a/fastlane/spec/actions_specs/set_build_number_repository_spec.rb
+++ b/fastlane/spec/actions_specs/set_build_number_repository_spec.rb
@@ -2,35 +2,60 @@ describe Fastlane do
   describe Fastlane::FastFile do
     context "set build number repository" do
       before do
+        allow(Fastlane::Actions::IncrementBuildNumberAction).to receive(:system).with(/agvtool/).and_return(true)
         expect(Fastlane::Actions::GetBuildNumberRepositoryAction).to receive(:run).and_return("asd123")
       end
 
       it "set build number without xcodeproj" do
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool new[-]version [-]all asd123 && cd [-]/)
+          .and_return("")
+
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool what[-]version/, log: false)
+          .and_return("Current version of project Test is:\nasd123")
+
         result = Fastlane::FastFile.new.parse("lane :test do
             set_build_number_repository
         end").runner.execute(:test)
 
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool new-version -all asd123/)
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq('asd123')
       end
 
       it "set build number with use_hg_revision_number" do
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool new[-]version [-]all asd123 && cd [-]/)
+          .and_return("")
+
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool what[-]version/, log: false)
+          .and_return("Current version of project Test is:\nasd123")
+
         result = Fastlane::FastFile.new.parse("lane :test do
             set_build_number_repository(
               use_hg_revision_number: true
             )
         end").runner.execute(:test)
 
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool new-version -all asd123/)
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq('asd123')
       end
 
       it "set build number with explicit xcodeproj" do
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool new[-]version [-]all asd123 && cd [-]/)
+          .and_return("")
+
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool what[-]version/, log: false)
+          .and_return("Current version of project Test is:\nasd123")
+
         result = Fastlane::FastFile.new.parse("lane :test do
             set_build_number_repository(
               xcodeproj: 'asd123/project.xcodeproj'
             )
         end").runner.execute(:test)
 
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to match(/cd .* && agvtool new-version -all asd123/)
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq('asd123')
       end
     end
   end


### PR DESCRIPTION
Fixes #12536

## Wut
- plist paths containing `$(SRCROOT)` can be updated by `agvtool` and not straight forward to user why
- this change informs the user to remove `$(SRCROOT)` in the target build settings

## Bonus
- this change also removes all the `Helper.test?` for more thorough testing
- adds test for when `agvtool` isn't enabled in project