### PR TITLE
Update docs on gym's :export_options action parameter

### DIFF
--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -111,7 +111,7 @@ module Gym
                                      end),
         FastlaneCore::ConfigItem.new(key: :export_options,
                                      env_name: "GYM_EXPORT_OPTIONS",
-                                     description: "Path to an export options plist or a hash with export options. Use 'xcodebuild -help' to print the full set of available options.",
+                                     description: "Path to an export options plist or a hash with export options. Use 'xcodebuild -help' to print the full set of available options",
                                      is_string: false,
                                      optional: true,
                                      type: Hash,

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -111,7 +111,7 @@ module Gym
                                      end),
         FastlaneCore::ConfigItem.new(key: :export_options,
                                      env_name: "GYM_EXPORT_OPTIONS",
-                                     description: "A path to an export options plist when running gym from the command line; a hash with export options when using gym as a Fastlane action. Use 'xcodebuild -help' to print the full set of available options.",
+                                     description: "Path to an export options plist or a hash with export options. Use 'xcodebuild -help' to print the full set of available options.",
                                      is_string: false,
                                      optional: true,
                                      type: Hash,

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -111,7 +111,7 @@ module Gym
                                      end),
         FastlaneCore::ConfigItem.new(key: :export_options,
                                      env_name: "GYM_EXPORT_OPTIONS",
-                                     description: "Specifies path to export options plist. Use 'xcodebuild -help' to print the full set of available options",
+                                     description: "A path to an export options plist when running gym from the command line; a hash with export options when using gym as a Fastlane action. Use 'xcodebuild -help' to print the full set of available options.",
                                      is_string: false,
                                      optional: true,
                                      type: Hash,


### PR DESCRIPTION
The :export_options cannot be a path to a plist anymore when running gym as a Fastlane action.
It was OK before when this config item was consumed only to prepare a file for xcodebuild
where it would be read from disk in case it was not a hash. However now it is used in
DetectValues.set_additional_default_values which does not expect it to be a non-hash.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->
