### PR TITLE
Updates documentation of `repo_update` option.

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -64,7 +64,7 @@ module Fastlane
                                        default_value: true),
           FastlaneCore::ConfigItem.new(key: :repo_update,
                                        env_name: "FL_COCOAPODS_REPO_UPDATE",
-                                       description: "Run `pod repo update` before install",
+                                       description: "Add `--repo-update` flag to `pod install` command",
                                        is_string: false,
                                        default_value: false,
                                        conflicting_options: [:try_repo_update_on_error]),


### PR DESCRIPTION

🔑 

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I clicked the "Edit on GitHub" link from the [docs](https://docs.fastlane.tools/actions/cocoapods/#cocoapods).

### Motivation and Context

Since [adding the options](https://github.com/fastlane/fastlane/commit/e1e8760819c7117f95d0e5b6409e8b3ed6512436) to the `cocoapods` command three years ago, the `repo_update` option has specified that:

> Run `pod repo update` before install

But [the implementation](https://github.com/fastlane/fastlane/blob/ab13e6c6156d9276e1c9fd4089184f2e54d1ce8f/fastlane/lib/fastlane/actions/cocoapods.rb#L22) doesn't do that. Instead, it adds the `--repo-update` option to the `pod install` invocation. This PR updates the documentation to reflect the implementation

### Description
I just changed the documentation, not code changes were made. I didn't run this PR through Rubocop or Rspec because I don't anticipate failures (I will run them through if CI does fail).