### PR TITLE
[supply] add aab (android app bundle) support

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -93,7 +93,7 @@ Gem::Specification.new do |spec|
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.
   # If you upgrade this gem, make sure to upgrade the users of it as well.
-  spec.add_dependency('google-api-client', '0.21.2') # Google API Client to access Play Publishing API
+  spec.add_dependency('google-api-client', '>= 0.21.2', '< 0.22.0') # Google API Client to access Play Publishing API
 
   spec.add_dependency('emoji_regex', '~> 0.1') # Used to scan for Emoji in the changelog
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -93,7 +93,7 @@ Gem::Specification.new do |spec|
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.
   # If you upgrade this gem, make sure to upgrade the users of it as well.
-  spec.add_dependency('google-api-client', '>= 0.13.1', '< 0.14.0') # Google API Client to access Play Publishing API
+  spec.add_dependency('google-api-client', '0.21.2') # Google API Client to access Play Publishing API
 
   spec.add_dependency('emoji_regex', '~> 0.1') # Used to scan for Emoji in the changelog
 

--- a/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
@@ -4,7 +4,7 @@
 
 ###### Command line tool for updating Android apps and their metadata on the Google Play Store
 
-_supply_ uploads app metadata, screenshots and binaries to Google Play. You can also select tracks for builds and promote builds to production.
+_supply_ uploads app metadata, screenshots, binaries, and app bundles to Google Play. You can also select tracks for builds and promote builds to production.
 
 -------
 
@@ -14,6 +14,7 @@ _supply_ uploads app metadata, screenshots and binaries to Google Play. You can 
     <a href="#quick-start">Quick Start</a> &bull;
     <a href="#available-commands">Commands</a> &bull;
     <a href="#uploading-an-apk">Uploading an APK</a> &bull;
+    <a href="#uploading-an-aab">Uploading an AAB</a> &bull;
     <a href="#images-and-screenshots">Images</a>
 </p>
 
@@ -21,7 +22,7 @@ _supply_ uploads app metadata, screenshots and binaries to Google Play. You can 
 
 ## Features
 - Update existing Android applications on Google Play via the command line
-- Upload new builds (APKs)
+- Upload new builds (APKs and AABs)
 - Retrieve and edit metadata, such as title and description, for multiple languages
 - Upload the app icon, promo graphics and screenshots for multiple languages
 - Have a local copy of the metadata in your git repository
@@ -94,6 +95,22 @@ Expansion files (obbs) found under the same directory as your APK will also be u
 
 - they are identified as type 'main' or 'patch' (by containing 'main' or 'patch' in their file name)
 - you have at most one of each type
+
+## Uploading an AAB
+
+To upload a new [Android application bundle](https://developer.android.com/guide/app-bundle/) to Google Play, simply run
+
+```no-highlight
+fastlane supply --aab path/to/app.aab
+```
+
+This will also upload app metadata if you previously ran `fastlane supply init`.
+
+To gradually roll out a new build use
+
+```no-highlight
+fastlane supply --aab path/app.aab --track rollout --rollout 0.5
+```
 
 ## Images and Screenshots
 

--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -6,6 +6,8 @@ module Fastlane
     module SharedValues
       GRADLE_APK_OUTPUT_PATH = :GRADLE_APK_OUTPUT_PATH
       GRADLE_ALL_APK_OUTPUT_PATHS = :GRADLE_ALL_APK_OUTPUT_PATHS
+      GRADLE_AAB_OUTPUT_PATH = :GRADLE_AAB_OUTPUT_PATH
+      GRADLE_ALL_AAB_OUTPUT_PATHS = :GRADLE_ALL_AAB_OUTPUT_PATHS
       GRADLE_FLAVOR = :GRADLE_FLAVOR
       GRADLE_BUILD_TYPE = :GRADLE_BUILD_TYPE
     end
@@ -53,24 +55,33 @@ module Fastlane
                                 print_command: params[:print_command],
                                 print_command_output: params[:print_command_output])
 
-        # If we didn't build, then we return now, as it makes no sense to search for apk's in a non-`assemble` scenario
-        return result unless task =~ /\b(assemble)/
+        # If we didn't build, then we return now, as it makes no sense to search for apk's in a non-`assemble` or non-`build` scenario
+        return result unless task =~ /\b(assemble)/ || task =~ /\b(bundle)/
 
         apk_search_path = File.join(project_dir, '**', 'build', 'outputs', 'apk', '**', '*.apk')
+        aab_search_path = File.join(project_dir, '**', 'build', 'outputs', 'bundle', '**', '*.aab')
 
-        # Our apk is now built, but there might actually be multiple ones that were built if a flavor was not specified in a multi-flavor project (e.g. `assembleRelease`), however we're not interested in unaligned apk's...
+        # Our apk/aab is now built, but there might actually be multiple ones that were built if a flavor was not specified in a multi-flavor project (e.g. `assembleRelease`)
+        # However, we're not interested in unaligned apk's...
         new_apks = Dir[apk_search_path].reject { |path| path =~ /^.*-unaligned.apk$/i }
         new_apks = new_apks.map { |path| File.expand_path(path) }
+        new_aabs = Dir[aab_search_path]
+        new_aabs = new_aabs.map { |path| File.expand_path(path) }
 
-        # We expose all of these new apk's
+        # We expose all of these new apks and aabs
         Actions.lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] = new_apks
+        Actions.lane_context[SharedValues::GRADLE_ALL_AAB_OUTPUT_PATHS] = new_aabs
 
-        # We also take the most recent apk to return as SharedValues::GRADLE_APK_OUTPUT_PATH, this is the one that will be relevant for most projects that just build a single build variant (flavor + build type combo). In multi build variants this value is undefined
+        # We also take the most recent apk and aab to return as SharedValues::GRADLE_APK_OUTPUT_PATH and SharedValues::GRADLE_AAB_OUTPUT_PATH
+        # This is the one that will be relevant for most projects that just build a single build variant (flavor + build type combo).
+        # In multi build variants this value is undefined
         last_apk_path = new_apks.sort_by(&File.method(:mtime)).last
+        last_aab_path = new_aabs.sort_by(&File.method(:mtime)).last
         Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH] = File.expand_path(last_apk_path) if last_apk_path
+        Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH] = File.expand_path(last_aab_path) if last_aab_path
 
-        # Give a helpful message in case there were no new apk's. Remember we're only running this code when assembling, in which case we certainly expect there to be an apk
-        UI.message('Couldn\'t find any new signed apk files...') if new_apks.empty?
+        # Give a helpful message in case there were no new apks or aabs. Remember we're only running this code when assembling, in which case we certainly expect there to be an apk or aab
+        UI.message('Couldn\'t find any new signed apk files...') if new_apks.empty? && new_aabs.empty?
 
         return result
       end

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -214,8 +214,7 @@ module Supply
         android_publisher.upload_apk(
           current_package_name,
           current_edit.id,
-          upload_source: path_to_apk,
-          content_type: 'application/octet-stream'
+          upload_source: path_to_apk
         )
       end
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -231,7 +231,8 @@ module Supply
           current_edit.id,
           apk_version_code,
           "proguard",
-          upload_source: path_to_mapping
+          upload_source: path_to_mapping,
+          content_type: "application/octet-stream"
         )
       end
     end

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -210,8 +210,6 @@ module Supply
     def upload_apk(path_to_apk)
       ensure_active_edit!
 
-      puts "path_to_apk: #{path_to_apk}"
-
       result_upload = call_google_api do
         android_publisher.upload_apk(
           current_package_name,
@@ -233,10 +231,24 @@ module Supply
           current_edit.id,
           apk_version_code,
           "proguard",
-          upload_source: path_to_mapping,
+          upload_source: path_to_mapping
+        )
+      end
+    end
+
+    def upload_bundle(path_to_aab)
+      ensure_active_edit!
+
+      result_upload = call_google_api do
+        android_publisher.upload_edit_bundle(
+          current_package_name,
+          self.current_edit.id,
+          upload_source: path_to_aab,
           content_type: "application/octet-stream"
         )
       end
+
+      return result_upload.version_code
     end
 
     # Updates the track for the provided version code(s)

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -210,11 +210,14 @@ module Supply
     def upload_apk(path_to_apk)
       ensure_active_edit!
 
+      puts "path_to_apk: #{path_to_apk}"
+
       result_upload = call_google_api do
         android_publisher.upload_apk(
           current_package_name,
           current_edit.id,
-          upload_source: path_to_apk
+          upload_source: path_to_apk,
+          content_type: 'application/octet-stream'
         )
       end
 

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -115,7 +115,7 @@ module Supply
                                      verify_block: proc do |value|
                                        UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
                                        value.each do |path|
-                                         UI.user_error!("Could not find apk file at pat-h '#{path}'") unless File.exist?(path)
+                                         UI.user_error!("Could not find apk file at path '#{path}'") unless File.exist?(path)
                                          UI.user_error!("file at path '#{path}' is not an apk") unless path.end_with?('.apk')
                                        end
                                      end),
@@ -136,6 +136,12 @@ module Supply
                                      env_name: "SUPPLY_SKIP_UPLOAD_APK",
                                      optional: true,
                                      description: "Whether to skip uploading APK",
+                                     is_string: false,
+                                     default_value: false),
+        FastlaneCore::ConfigItem.new(key: :skip_upload_aab,
+                                     env_name: "SUPPLY_SKIP_UPLOAD_AAB",
+                                     optional: true,
+                                     description: "Whether to skip uploading AAB",
                                      is_string: false,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :skip_upload_metadata,

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -96,7 +96,7 @@ module Supply
                                      env_name: "SUPPLY_APK",
                                      description: "Path to the APK file to upload",
                                      short_option: "-b",
-                                     conflicting_options: [:apk_paths],
+                                     conflicting_options: [:apk_paths, :aab],
                                      code_gen_sensitive: true,
                                      default_value: Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-Release.apk")].last,
                                      default_value_dynamic: true,
@@ -107,7 +107,7 @@ module Supply
                                      end),
         FastlaneCore::ConfigItem.new(key: :apk_paths,
                                      env_name: "SUPPLY_APK_PATHS",
-                                     conflicting_options: [:apk],
+                                     conflicting_options: [:apk, :aab],
                                      optional: true,
                                      type: Array,
                                      description: "An array of paths to APK files to upload",
@@ -115,9 +115,22 @@ module Supply
                                      verify_block: proc do |value|
                                        UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
                                        value.each do |path|
-                                         UI.user_error!("Could not find apk file at path '#{path}'") unless File.exist?(path)
+                                         UI.user_error!("Could not find apk file at pat-h '#{path}'") unless File.exist?(path)
                                          UI.user_error!("file at path '#{path}' is not an apk") unless path.end_with?('.apk')
                                        end
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :aab,
+                                     env_name: "SUPPLY_AAB",
+                                     description: "Path to the AAB file to upload",
+                                     short_option: "-f",
+                                     conflicting_options: [:apk_path, :apk_paths],
+                                     code_gen_sensitive: true,
+                                     default_value: Dir["*.aab"].last || Dir[File.join("app", "build", "outputs", "bundle", "release", "bundle.aab")].last,
+                                     default_value_dynamic: true,
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Could not find aab file at path '#{value}'") unless File.exist?(value)
+                                       UI.user_error!("aab file is not an aab") unless value.end_with?('.aab')
                                      end),
         FastlaneCore::ConfigItem.new(key: :skip_upload_apk,
                                      env_name: "SUPPLY_SKIP_UPLOAD_APK",

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -24,6 +24,7 @@ module Supply
       end
 
       upload_binaries unless Supply.config[:skip_upload_apk]
+      upload_bundles
 
       promote_track if Supply.config[:track_promote_to]
 
@@ -111,7 +112,7 @@ module Supply
     end
 
     def upload_binaries
-      apk_paths = [Supply.config[:apk] || Supply.config[:aab]] unless (apk_paths = Supply.config[:apk_paths])
+      apk_paths = [Supply.config[:apk]] unless (apk_paths = Supply.config[:apk_paths])
       apk_paths.compact!
 
       apk_version_codes = []
@@ -126,6 +127,17 @@ module Supply
           client.upload_mapping(mapping_path, version_code)
         end
       end
+
+      # Only update tracks if we have version codes
+      # Updating a track with empty version codes can completely clear out a track
+      update_track(apk_version_codes) unless apk_version_codes.empty?
+    end
+
+    def upload_bundles
+      aab_path = Supply.config[:aab]
+
+      apk_version_codes = []
+      apk_version_codes.push(client.upload_bundle(aab_path))
 
       # Only update tracks if we have version codes
       # Updating a track with empty version codes can completely clear out a track

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -39,8 +39,8 @@ module Supply
     end
 
     def verify_config!
-      unless metadata_path || Supply.config[:apk] || Supply.config[:apk_paths] || (Supply.config[:track] && Supply.config[:track_promote_to])
-        UI.user_error!("No local metadata, apks, or track to promote were found, make sure to run `fastlane supply init` to setup supply")
+      unless metadata_path || Supply.config[:apk] || Supply.config[:apk_paths] || Supply.config[:aab] || (Supply.config[:track] && Supply.config[:track_promote_to])
+        UI.user_error!("No local metadata, apks, aab, or track to promote were found, make sure to run `fastlane supply init` to setup supply")
       end
     end
 
@@ -111,7 +111,7 @@ module Supply
     end
 
     def upload_binaries
-      apk_paths = [Supply.config[:apk]] unless (apk_paths = Supply.config[:apk_paths])
+      apk_paths = [Supply.config[:apk] || Supply.config[:aab]] unless (apk_paths = Supply.config[:apk_paths])
       apk_paths.compact!
 
       apk_version_codes = []

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -24,7 +24,7 @@ module Supply
       end
 
       upload_binaries unless Supply.config[:skip_upload_apk]
-      upload_bundles
+      upload_bundles unless Supply.config[:skip_upload_aab]
 
       promote_track if Supply.config[:track_promote_to]
 

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -43,6 +43,12 @@ module Supply
       unless metadata_path || Supply.config[:apk] || Supply.config[:apk_paths] || Supply.config[:aab] || (Supply.config[:track] && Supply.config[:track_promote_to])
         UI.user_error!("No local metadata, apks, aab, or track to promote were found, make sure to run `fastlane supply init` to setup supply")
       end
+
+      apk_paths = [Supply.config[:apk], Supply.config[:apk_paths]].flatten.compact
+      aab_path = Supply.config[:aab]
+      if !apk_paths.empty? && aab_path
+        UI.user_error!("Cannot provide both apk(s) and aab - please make sure to remove any existing .apk or .aab files that are no longer needed")
+      end
     end
 
     def promote_track
@@ -135,6 +141,7 @@ module Supply
 
     def upload_bundles
       aab_path = Supply.config[:aab]
+      return unless aab_path
 
       apk_version_codes = []
       apk_version_codes.push(client.upload_bundle(aab_path))

--- a/supply/spec/client_spec.rb
+++ b/supply/spec/client_spec.rb
@@ -19,6 +19,7 @@ describe Supply do
         expect(subject.class.method_defined?(:update_listing)).to eq(true)
         expect(subject.class.method_defined?(:update_track)).to eq(true)
         expect(subject.class.method_defined?(:upload_apk)).to eq(true)
+        expect(subject.class.method_defined?(:upload_edit_bundle)).to eq(true)
         expect(subject.class.method_defined?(:upload_edit_deobfuscationfile)).to eq(true)
         expect(subject.class.method_defined?(:upload_expansion_file)).to eq(true)
         expect(subject.class.method_defined?(:upload_image)).to eq(true)

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -9,7 +9,7 @@ describe Supply do
         Supply.config = {}
         expect do
           subject.verify_config!
-        end.to raise_error("No local metadata, apks, or track to promote were found, make sure to run `fastlane supply init` to setup supply")
+        end.to raise_error("No local metadata, apks, aab, or track to promote were found, make sure to run `fastlane supply init` to setup supply")
       end
 
       it "raises error if only track" do
@@ -18,7 +18,7 @@ describe Supply do
         }
         expect do
           subject.verify_config!
-        end.to raise_error("No local metadata, apks, or track to promote were found, make sure to run `fastlane supply init` to setup supply")
+        end.to raise_error("No local metadata, apks, aab, or track to promote were found, make sure to run `fastlane supply init` to setup supply")
       end
 
       it "raises error if only track_promote_to" do
@@ -27,7 +27,7 @@ describe Supply do
         }
         expect do
           subject.verify_config!
-        end.to raise_error("No local metadata, apks, or track to promote were found, make sure to run `fastlane supply init` to setup supply")
+        end.to raise_error("No local metadata, apks, aab, or track to promote were found, make sure to run `fastlane supply init` to setup supply")
       end
 
       it "does not raise error if only metadata" do
@@ -47,6 +47,13 @@ describe Supply do
       it "does not raise error if only apk_paths" do
         Supply.config = {
           apk_paths: ['some/path/app1.apk', 'some/path/app2.apk']
+        }
+        subject.verify_config!
+      end
+
+      it "does not raise error if only aab" do
+        Supply.config = {
+          aab: 'some/path/app1.aab'
         }
         subject.verify_config!
       end


### PR DESCRIPTION
Fixes #12478 


- Updated `fastlane.gemspec` to lock in at google ruby api client `0.21.2`
- Added support for `upload_bundle` in _supply_
  - Updated the doc
- `gradle` action has two new `Actions::SharedValues`
  - `GRADLE_AAB_OUTPUT_PATH`
  - `GRADLE_ALL_AAB_OUTPUT_PATHS`

## Example
```rb
lane :aab do
  gradle(
    task: 'bundle',
    build_type: 'Release'
  )

  puts "AABs: #{Actions.lane_context[SharedValues::GRADLE_ALL_AAB_OUTPUT_PATHS]}"
  puts "AAB: #{Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]}"

  supply
end
```

## Tested
- [x] `client.listings` 
- [x] `client.listing_for_language` 
- [x] `client.apks_version_codes` 
- [x] `client.apk_listings` 
- [x] `client.update_listing_for_language` 
- [x] `client.upload_apk` 
- [x] `client.upload_mapping` 
- [x] `client.upload_bundle` 
- [x] `client.update_track` 
- [x] `client.track_version_codes` 
- [x] `client.update_apk_listing_for_language` 
- [x] `client.fetch_images` 
- [x] `client.upload_image` 
- [x] `client.clear_screenshots` 
- [x] `client.upload_obb` 