### PR TITLE
Version bump to 2.96.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,23 +32,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 
 <table id='team'>
 <tr>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+<h4 align='center'>Jimmy Dee</h4>
 </td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
 <td id='olivier-halligon'>
 <a href='https://github.com/AliSoftware'>
@@ -56,51 +50,25 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
 </td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
 </tr>
 <tr>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
 <td id='aaron-brager'>
 <a href='https://github.com/getaaron'>
 <img src='https://github.com/getaaron.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/DanToml'>
-<img src='https://github.com/DanToml.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
-</td>
-</tr>
-<tr>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
 <td id='josh-holtz'>
 <a href='https://github.com/joshdholtz'>
@@ -114,11 +82,43 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/DanToml'>
+<img src='https://github.com/DanToml.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+</td>
+</tr>
+<tr>
+<td id='andrew-mcburney'>
+<a href='https://github.com/AndrewMcBurney'>
+<img src='https://github.com/AndrewMcBurney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
 <td id='jorge-revuelta-h'>
 <a href='https://github.com/minuscorp'>
@@ -128,35 +128,35 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/AndrewMcBurney'>
-<img src='https://github.com/AndrewMcBurney.png?size=140'>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
 </tr>
 </table>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -14,26 +14,26 @@ File.write("#{lib}/fastlane/plugins/template/.rubocop.yml", YAML.dump(config))
 Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
-  spec.authors       = ["Stefan Natchev",
-                        "Fumiya Nakamura",
-                        "Joshua Liebowitz",
-                        "Iulian Onofrei",
+  spec.authors       = ["Maksym Grebenets",
                         "Manu Wallner",
-                        "Jorge Revuelta H",
+                        "Fumiya Nakamura",
+                        "Aaron Brager",
                         "Olivier Halligon",
-                        "Luka Mirosevic",
+                        "Felix Krause",
+                        "Jérôme Lacoste",
                         "Jimmy Dee",
                         "Helmut Januschka",
-                        "Jan Piotrowski",
-                        "Kohki Miki",
-                        "Andrew McBurney",
-                        "Aaron Brager",
                         "Matthew Ellis",
-                        "Felix Krause",
-                        "Maksym Grebenets",
-                        "Jérôme Lacoste",
+                        "Luka Mirosevic",
+                        "Joshua Liebowitz",
+                        "Andrew McBurney",
+                        "Danielle Tomlinson",
+                        "Iulian Onofrei",
+                        "Kohki Miki",
                         "Josh Holtz",
-                        "Danielle Tomlinson"]
+                        "Jorge Revuelta H",
+                        "Stefan Natchev",
+                        "Jan Piotrowski"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.95.0'.freeze
+  VERSION = '2.96.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.95.0
+// Generated with fastlane 2.96.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1373,7 +1373,7 @@ func ensureNoDebugCode(text: String,
                                                                                                       RubyCommand.Argument(name: "exclude_dirs", value: excludeDirs)])
   _ = runner.executeCommand(command)
 }
-func ensureXcodeVersion(version: String) {
+func ensureXcodeVersion(version: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "ensure_xcode_version", className: nil, args: [RubyCommand.Argument(name: "version", value: version)])
   _ = runner.executeCommand(command)
 }
@@ -3237,7 +3237,9 @@ func supply(packageName: String,
             jsonKeyData: String? = nil,
             apk: String? = nil,
             apkPaths: [String]? = nil,
+            aab: String? = nil,
             skipUploadApk: Bool = false,
+            skipUploadAab: Bool = false,
             skipUploadMetadata: Bool = false,
             skipUploadImages: Bool = false,
             skipUploadScreenshots: Bool = false,
@@ -3257,7 +3259,9 @@ func supply(packageName: String,
                                                                                         RubyCommand.Argument(name: "json_key_data", value: jsonKeyData),
                                                                                         RubyCommand.Argument(name: "apk", value: apk),
                                                                                         RubyCommand.Argument(name: "apk_paths", value: apkPaths),
+                                                                                        RubyCommand.Argument(name: "aab", value: aab),
                                                                                         RubyCommand.Argument(name: "skip_upload_apk", value: skipUploadApk),
+                                                                                        RubyCommand.Argument(name: "skip_upload_aab", value: skipUploadAab),
                                                                                         RubyCommand.Argument(name: "skip_upload_metadata", value: skipUploadMetadata),
                                                                                         RubyCommand.Argument(name: "skip_upload_images", value: skipUploadImages),
                                                                                         RubyCommand.Argument(name: "skip_upload_screenshots", value: skipUploadScreenshots),
@@ -3510,7 +3514,7 @@ func updatePlist(plistPath: String? = nil,
   _ = runner.executeCommand(command)
 }
 func updateProjectCodeSigning(path: String,
-                              udid: String,
+                              udid: String? = nil,
                               uuid: String) {
   let command = RubyCommand(commandID: "", methodName: "update_project_code_signing", className: nil, args: [RubyCommand.Argument(name: "path", value: path),
                                                                                                              RubyCommand.Argument(name: "udid", value: udid),
@@ -3522,13 +3526,15 @@ func updateProjectProvisioning(xcodeproj: String? = nil,
                                targetFilter: String? = nil,
                                buildConfigurationFilter: String? = nil,
                                buildConfiguration: String? = nil,
-                               certificate: String = "/tmp/AppleIncRootCertificate.cer") {
+                               certificate: String = "/tmp/AppleIncRootCertificate.cer",
+                               codeSigningIdentity: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "update_project_provisioning", className: nil, args: [RubyCommand.Argument(name: "xcodeproj", value: xcodeproj),
                                                                                                              RubyCommand.Argument(name: "profile", value: profile),
                                                                                                              RubyCommand.Argument(name: "target_filter", value: targetFilter),
                                                                                                              RubyCommand.Argument(name: "build_configuration_filter", value: buildConfigurationFilter),
                                                                                                              RubyCommand.Argument(name: "build_configuration", value: buildConfiguration),
-                                                                                                             RubyCommand.Argument(name: "certificate", value: certificate)])
+                                                                                                             RubyCommand.Argument(name: "certificate", value: certificate),
+                                                                                                             RubyCommand.Argument(name: "code_signing_identity", value: codeSigningIdentity)])
   _ = runner.executeCommand(command)
 }
 func updateProjectTeam(path: String,
@@ -3713,7 +3719,9 @@ func uploadToPlayStore(packageName: String,
                        jsonKeyData: String? = nil,
                        apk: String? = nil,
                        apkPaths: [String]? = nil,
+                       aab: String? = nil,
                        skipUploadApk: Bool = false,
+                       skipUploadAab: Bool = false,
                        skipUploadMetadata: Bool = false,
                        skipUploadImages: Bool = false,
                        skipUploadScreenshots: Bool = false,
@@ -3733,7 +3741,9 @@ func uploadToPlayStore(packageName: String,
                                                                                                       RubyCommand.Argument(name: "json_key_data", value: jsonKeyData),
                                                                                                       RubyCommand.Argument(name: "apk", value: apk),
                                                                                                       RubyCommand.Argument(name: "apk_paths", value: apkPaths),
+                                                                                                      RubyCommand.Argument(name: "aab", value: aab),
                                                                                                       RubyCommand.Argument(name: "skip_upload_apk", value: skipUploadApk),
+                                                                                                      RubyCommand.Argument(name: "skip_upload_aab", value: skipUploadAab),
                                                                                                       RubyCommand.Argument(name: "skip_upload_metadata", value: skipUploadMetadata),
                                                                                                       RubyCommand.Argument(name: "skip_upload_images", value: skipUploadImages),
                                                                                                       RubyCommand.Argument(name: "skip_upload_screenshots", value: skipUploadScreenshots),
@@ -4023,4 +4033,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.17]
+// FastlaneRunnerAPIVersion [0.9.18]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.95.0
+// Generated with fastlane 2.96.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.95.0
+// Generated with fastlane 2.96.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.95.0
+// Generated with fastlane 2.96.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.95.0
+// Generated with fastlane 2.96.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.95.0
+// Generated with fastlane 2.96.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.95.0
+// Generated with fastlane 2.96.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.95.0':**

* Updates documentation of `repo_update` option. (#12559) via Ash Furrow
* added `team_name` to spaceship client (#12457) via Rishabh Tayal
* Fix formatting for create_app_online action documentation (#12553) via Iulian Onofrei
* Update docs on gym's :export_options action parameter (#12545) via Aleh Dzenisiuk
* Fix broken parameters' table (#12561) via Iulian Onofrei
* Improve formatting in sync_code_signing's docs (#12562) via Iulian Onofrei
* [supply] add aab (android app bundle) support (#12568) via Josh Holtz
* Add parameter code_signing_identity for CODE_SIGN_IDENTITY setting (#12326) via Harris
* [gym] Fix analyze_build_time setting interfering with xcpretty log generation (#12527) via Allen Wu
* Adding support for b2b vpp (#12420) via heartofagoof
* fixes crash when url param is given (#12544) via Rishabh Tayal
* added support for appcenter is_ci? (#12512) via Rishabh Tayal
* changelog_from_git_commits fix from command line (#12477) via Rishabh Tayal
* Fix actions' options and example code (#12483) via Iulian Onofrei
* added loading indicator for frameit (#12518) via Rishabh Tayal
* Update FEATURE_REQUEST.md (#12514) via Najdan Tomić
* Add attr_reader for :prefix in AccountManager (#12524) via Felix Krause
* Make sure the user is logged in RubyGems when releasing a new version (#12513) via Iulian Onofrei
* disables color in xcpretty if env var is set (#12519) via Rishabh Tayal
* Fix slack crash in case of exception (#12494) via Dan Cohn
* Fix pilot 504ing on build submission for review on testflight (#12426) via Thibaud Robelain
* Fix nil path crash in changelog_from_git_commits action (#12505) via Rishabh Tayal
* Add support for xcode-version file (#12479) via Felix Krause
* [supply] allow for custom closed track names (#12487) via Josh Holtz
