### PR TITLE
Fix for handling Apple's new Apple ID and Privacy statement

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -467,6 +467,10 @@ module Spaceship
         if (response.body || "").include?('invalid="true"')
           # User Credentials are wrong
           raise InvalidUserCredentialsError.new, "Invalid username and password combination. Used '#{user}' as the username."
+        elsif response.status == 412 &&
+              (response.body["authType"] == "sa" || response.body["authType"] == "hsa")
+          # Need to acknowledge Apple ID and Privacy statement - https://github.com/fastlane/fastlane/issues/12577
+          raise AppleIDAndPrivacyAcknowledgementNeeded.new, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://itunesconnect.apple.com) to acknowledge the statement."
         elsif (response['Set-Cookie'] || "").include?("itctx")
           raise "Looks like your Apple ID is not enabled for iTunes Connect, make sure to be able to login online"
         else

--- a/spaceship/lib/spaceship/errors.rb
+++ b/spaceship/lib/spaceship/errors.rb
@@ -22,6 +22,12 @@ module Spaceship
     end
   end
 
+  class AppleIDAndPrivacyAcknowledgementNeeded < BasicPreferredInfoError
+    def show_github_issues
+      false
+    end
+  end
+
   # User doesn't have enough permission for given action
   class InsufficientPermissions < BasicPreferredInfoError
     TITLE = 'Insufficient permissions for your Apple ID:'.freeze

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -17,6 +17,38 @@ describe Spaceship::TunesClient do
     end
   end
 
+  describe 'exception if Apple ID & Privacy not acknowledged' do
+    subject { Spaceship::Tunes.client }
+    let(:username) { 'spaceship@krausefx.com' }
+    let(:password) { 'so_secret' }
+
+    it 'has authType is sa' do
+      response = double
+      allow(response).to receive(:status).and_return(412)
+      allow(response).to receive(:body).and_return({ "authType" => "sa" })
+
+      allow_any_instance_of(Spaceship::Client).to receive(:request)
+        .and_return(response)
+
+      expect do
+        Spaceship::Tunes.login(username, password)
+      end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://itunesconnect.apple.com) to acknowledge the statement.")
+    end
+
+    it 'has authType of hsa' do
+      response = double
+      allow(response).to receive(:status).and_return(412)
+      allow(response).to receive(:body).and_return({ "authType" => "hsa" })
+
+      allow_any_instance_of(Spaceship::Client).to receive(:request)
+        .and_return(response)
+
+      expect do
+        Spaceship::Tunes.login(username, password)
+      end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://itunesconnect.apple.com) to acknowledge the statement.")
+    end
+  end
+
   describe "Logged in" do
     subject { Spaceship::Tunes.client }
     let(:username) { 'spaceship@krausefx.com' }


### PR DESCRIPTION
Fixes #12577

## Problem
- Handles status code `412` (precondition error) with body of `{"authType": "sa"}` and `{"authType": "hsa"}`