### PR TITLE
Handle 412 response with authType = non-sa

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -468,7 +468,7 @@ module Spaceship
           # User Credentials are wrong
           raise InvalidUserCredentialsError.new, "Invalid username and password combination. Used '#{user}' as the username."
         elsif response.status == 412 &&
-              (response.body["authType"] == "sa" || response.body["authType"] == "hsa")
+              (response.body["authType"] == "non-sa" || response.body["authType"] == "sa" || response.body["authType"] == "hsa")
           # Need to acknowledge Apple ID and Privacy statement - https://github.com/fastlane/fastlane/issues/12577
           raise AppleIDAndPrivacyAcknowledgementNeeded.new, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://itunesconnect.apple.com) to acknowledge the statement."
         elsif (response['Set-Cookie'] || "").include?("itctx")

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -47,6 +47,19 @@ describe Spaceship::TunesClient do
         Spaceship::Tunes.login(username, password)
       end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://itunesconnect.apple.com) to acknowledge the statement.")
     end
+
+    it 'has authType is non-sa' do
+      response = double
+      allow(response).to receive(:status).and_return(412)
+      allow(response).to receive(:body).and_return({ "authType" => "non-sa" })
+
+      allow_any_instance_of(Spaceship::Client).to receive(:request)
+        .and_return(response)
+
+      expect do
+        Spaceship::Tunes.login(username, password)
+      end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://itunesconnect.apple.com) to acknowledge the statement.")
+    end
   end
 
   describe "Logged in" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context

This change supports handling 412 response with HTTP body `{"authType"=>"non-sa"}` while logging in to the portal. That means I need to set additional security information like birthday or security questions.


```sh
$  bundle exec fastlane match
```

```
/Users/ngs/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/fastlane-2.96.0/spaceship/lib/spaceship/client.rb:479:in `send_shared_login_request': [!] The request could not be completed because: (Spaceship::Tunes::Error)
        {"authType"=>"non-sa"}
aa=XXX; Domain=idmsa.apple.com; Path=/; Secure; HttpOnly, dslang=US-EN; Domain=apple.com; Path=/; Secure; HttpOnly, site=USA; Domain=apple.com; Path=/; Secure; HttpOnly, acn01=XXX; Max-Age=31536000; Expires=Wed, 22-May-2019 04:32:26 GMT; Domain=apple.com; Path=/; Secure; HttpOnly
```