### PR TITLE
[spaceship] display apple id and privacy statement instructions to non-sa accounts

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -468,7 +468,7 @@ module Spaceship
           # User Credentials are wrong
           raise InvalidUserCredentialsError.new, "Invalid username and password combination. Used '#{user}' as the username."
         elsif response.status == 412 &&
-              (response.body["authType"] == "sa" || response.body["authType"] == "hsa")
+              (response.body["authType"] == "sa" || response.body["authType"] == "hsa" || response.body["authType"] == "non-sa")
           # Need to acknowledge Apple ID and Privacy statement - https://github.com/fastlane/fastlane/issues/12577
           raise AppleIDAndPrivacyAcknowledgementNeeded.new, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://itunesconnect.apple.com) to acknowledge the statement."
         elsif (response['Set-Cookie'] || "").include?("itctx")

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -26,9 +26,7 @@ describe Spaceship::TunesClient do
       response = double
       allow(response).to receive(:status).and_return(412)
       allow(response).to receive(:body).and_return({ "authType" => "sa" })
-
-      allow_any_instance_of(Spaceship::Client).to receive(:request)
-        .and_return(response)
+      allow_any_instance_of(Spaceship::Client).to receive(:request).and_return(response)
 
       expect do
         Spaceship::Tunes.login(username, password)
@@ -39,9 +37,18 @@ describe Spaceship::TunesClient do
       response = double
       allow(response).to receive(:status).and_return(412)
       allow(response).to receive(:body).and_return({ "authType" => "hsa" })
+      allow_any_instance_of(Spaceship::Client).to receive(:request).and_return(response)
 
-      allow_any_instance_of(Spaceship::Client).to receive(:request)
-        .and_return(response)
+      expect do
+        Spaceship::Tunes.login(username, password)
+      end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://itunesconnect.apple.com) to acknowledge the statement.")
+    end
+
+    it 'has authType of non-sa' do
+      response = double
+      allow(response).to receive(:status).and_return(412)
+      allow(response).to receive(:body).and_return({ "authType" => "non-sa" })
+      allow_any_instance_of(Spaceship::Client).to receive(:request).and_return(response)
 
       expect do
         Spaceship::Tunes.login(username, password)


### PR DESCRIPTION
Follow up on #12578 
Fixes https://github.com/fastlane/fastlane/issues/12577#issuecomment-390980837