### PR TITLE
[spaceship] display apple id and privacy statement instructions to hsa2 accounts

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -23,6 +23,7 @@ module Spaceship
   class Client
     PROTOCOL_VERSION = "QH65B2"
     USER_AGENT = "Spaceship #{Fastlane::VERSION}"
+    AUTH_TYPES = ["sa", "hsa", "non-sa", "hsa2"]
 
     attr_reader :client
 
@@ -467,9 +468,9 @@ module Spaceship
         if (response.body || "").include?('invalid="true"')
           # User Credentials are wrong
           raise InvalidUserCredentialsError.new, "Invalid username and password combination. Used '#{user}' as the username."
-        elsif response.status == 412 &&
-              (response.body["authType"] == "sa" || response.body["authType"] == "hsa" || response.body["authType"] == "non-sa")
+        elsif response.status == 412 && AUTH_TYPES.include?(response.body["authType"])
           # Need to acknowledge Apple ID and Privacy statement - https://github.com/fastlane/fastlane/issues/12577
+          # Looking for status of 412 might be enough but might be safer to keep looking only at what is being reported
           raise AppleIDAndPrivacyAcknowledgementNeeded.new, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://itunesconnect.apple.com) to acknowledge the statement."
         elsif (response['Set-Cookie'] || "").include?("itctx")
           raise "Looks like your Apple ID is not enabled for iTunes Connect, make sure to be able to login online"

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -54,6 +54,17 @@ describe Spaceship::TunesClient do
         Spaceship::Tunes.login(username, password)
       end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://itunesconnect.apple.com) to acknowledge the statement.")
     end
+
+    it 'has authType of hsa2' do
+      response = double
+      allow(response).to receive(:status).and_return(412)
+      allow(response).to receive(:body).and_return({ "authType" => "hsa2" })
+      allow_any_instance_of(Spaceship::Client).to receive(:request).and_return(response)
+
+      expect do
+        Spaceship::Tunes.login(username, password)
+      end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://itunesconnect.apple.com) to acknowledge the statement.")
+    end
   end
 
   describe "Logged in" do


### PR DESCRIPTION
Follow up on #12578 
Fixes https://github.com/fastlane/fastlane/issues/12577#issuecomment-391001489

🤔 Maybe we just look at status 412? But unsure if that's too generic