### PR TITLE
[spaceship] Updated Tunes.client so select_team returns team_id when executed just like Portal.client does

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -65,7 +65,7 @@ module Spaceship
         puts("Looking for iTunes Connect Team with name #{t_name}") if Spaceship::Globals.verbose?
 
         teams.each do |t|
-          t_id = t['contentProvider']['contentProviderId'].to_s if t['contentProvider']['name'].casecmp(t_name.downcase).zero?
+          t_id = t['contentProvider']['contentProviderId'].to_s if t['contentProvider']['name'].casecmp(t_name).zero?
         end
 
         puts("Could not find team with name '#{t_name}', trying to fallback to default team") if t_id.length.zero?
@@ -78,7 +78,7 @@ module Spaceship
 
         # actually set the team id here
         self.team_id = t_id
-        return
+        return self.team_id
       end
 
       # user didn't specify a team... #thisiswhywecanthavenicethings
@@ -113,7 +113,7 @@ module Spaceship
 
         if team_to_use
           self.team_id = team_to_use['contentProvider']['contentProviderId'].to_s # actually set the team id here
-          break
+          return self.team_id
         end
       end
     end

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -119,14 +119,9 @@ describe Spaceship::TunesClient do
       end
 
       it "returns team_id from environment variable" do
-        ENV["FASTLANE_ITC_TEAM_NAME"] = "Harry"
+        stub_const('ENV', { 'FASTLANE_ITC_TEAM_NAME' => 'Harry' })
         allow(subject).to receive(:teams).and_return(associated_teams)
         expect(subject.select_team).to eq('5678')
-      end
-
-      after do
-        ENV.delete("FASTLANE_ITC_TEAM_ID")
-        ENV.delete("FASTLANE_ITC_TEAM_NAME")
       end
     end
   end

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -104,6 +104,31 @@ describe Spaceship::TunesClient do
         end.to raise_error(Spaceship::TunesClient::ITunesConnectTemporaryError, "We're temporarily unable to save your changes. Please try again later.")
       end
     end
+
+    describe "associated to multiple teams" do
+      let(:associated_teams) { [{ 'contentProvider' => { 'name' => 'Tom', 'contentProviderId' => '1234' } }, { 'contentProvider' => { 'name' => 'Harry', 'contentProviderId' => '5678' } }] }
+
+      it "#team_id picks the first team if select_team not called" do
+        allow(subject).to receive(:teams).and_return(associated_teams)
+        expect(subject.team_id).to eq('1234')
+      end
+
+      it "returns team_id from legitimate team_name parameter" do
+        allow(subject).to receive(:teams).and_return(associated_teams)
+        expect(subject.select_team(team_name: 'Harry')).to eq('5678')
+      end
+
+      it "returns team_id from environment variable" do
+        ENV["FASTLANE_ITC_TEAM_NAME"] = "Harry"
+        allow(subject).to receive(:teams).and_return(associated_teams)
+        expect(subject.select_team).to eq('5678')
+      end
+
+      after do
+        ENV.delete("FASTLANE_ITC_TEAM_ID")
+        ENV.delete("FASTLANE_ITC_TEAM_NAME")
+      end
+    end
   end
 
   describe "CI" do

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -35,6 +35,11 @@ class TunesStubbing
       stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin").
         with(body: { "accountName" => "bad-username", "password" => "bad-password", "rememberMe" => true }.to_json).
         to_return(status: 401, body: '{}', headers: { 'Set-Cookie' => 'session=invalid' })
+
+      stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/v1/session/webSession").
+        with(body: "{\"contentProviderId\":\"5678\",\"dsId\":null}",
+              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type' => 'application/json', 'User-Agent' => 'Spaceship 2.96.1' }).
+        to_return(status: 200, body: "", headers: {})
     end
 
     def itc_stub_applications


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When using Spaceship directly, and selecting a team based on the name, it was convenient to get the team_id back in Portal to use in any other calls. However, Tunes didn't work that way and just returned nil so you needed to make an extra call to Tunes.client.team_id to get the value.

### Description
<!-- Describe your changes in detail -->
