### PR TITLE
[spaceship] Corrected spelling of team_select interactive messages when running in CI

### DIFF
--- a/spaceship/lib/spaceship/portal/ui/select_team.rb
+++ b/spaceship/lib/spaceship/portal/ui/select_team.rb
@@ -87,7 +87,7 @@ module Spaceship
           teams.each_with_index do |team, i|
             puts("#{i + 1}) #{team['teamId']} \"#{team['name']}\" (#{team['type']})")
           end
-          raise "Multiple Teams found; unable to choose, terminal not ineractive!"
+          raise "Multiple Teams found; unable to choose, terminal not interactive!"
         end
 
         # User Selection

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -105,7 +105,7 @@ module Spaceship
         unless Spaceship::Client::UserInterface.interactive?
           puts("Multiple teams found on iTunes Connect, Your Terminal is running in non-interactive mode! Cannot continue from here.")
           puts("Please check that you set FASTLANE_ITC_TEAM_ID or FASTLANE_ITC_TEAM_NAME to the right value.")
-          raise "Multiple iTunes Connect Teams found; unable to choose, terminal not ineractive!"
+          raise "Multiple iTunes Connect Teams found; unable to choose, terminal not interactive!"
         end
 
         selected = ($stdin.gets || '').strip.to_i - 1

--- a/spaceship/spec/UI/select_team_spec.rb
+++ b/spaceship/spec/UI/select_team_spec.rb
@@ -82,7 +82,7 @@ describe Spaceship::Client do
           expect(Spaceship::Client::UserInterface).to receive(:interactive?).and_return(false)
           expect do
             subject.select_team
-          end.to raise_error("Multiple Teams found; unable to choose, terminal not ineractive!")
+          end.to raise_error("Multiple Teams found; unable to choose, terminal not interactive!")
         end
 
         after do

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -111,7 +111,7 @@ describe Spaceship::TunesClient do
       expect(FastlaneCore::Helper).to receive(:ci?).and_return(true)
       provider = { 'contentProvider' => { 'name' => 'Tom', 'contentProviderId' => 1234 } }
       allow(subject).to receive(:teams).and_return([provider, provider]) # pass it twice, to call the team selection
-      expect { subject.select_team }.to raise_error("Multiple iTunes Connect Teams found; unable to choose, terminal not ineractive!")
+      expect { subject.select_team }.to raise_error("Multiple iTunes Connect Teams found; unable to choose, terminal not interactive!")
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When leveraging Fastlane in CI and a user doesn't yet belong to a team, the code would error out showing an error message. Typos happen and spelling is hard.

### Description
<!-- Describe your changes in detail -->
