### PR TITLE
Add ability to retrieve builds for a given TestFlight group

### DIFF
--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -261,6 +261,14 @@ module Spaceship
         handle_response(response)
       end
 
+      def builds_for_group(app_id: nil, group_id: nil)
+        assert_required_params(__method__, binding)
+
+        url = "providers/#{team_id}/apps/#{app_id}/groups/#{group_id}/builds"
+        response = request(:get, url)
+        handle_response(response)
+      end
+
       ##
       # @!group AppTestInfo
       ##

--- a/spaceship/lib/spaceship/test_flight/group.rb
+++ b/spaceship/lib/spaceship/test_flight/group.rb
@@ -1,4 +1,5 @@
 require_relative 'base'
+require_relative 'build'
 
 module Spaceship::TestFlight
   class Group < Base
@@ -102,6 +103,11 @@ module Spaceship::TestFlight
 
     def active?
       is_active
+    end
+
+    def builds
+      builds = client.builds_for_group(app_id: self.app_id, group_id: self.id)
+      builds.map { |b| Spaceship::TestFlight::Build.new(b) }
     end
 
     def self.perform_for_groups_in_app(app: nil, groups: nil, &block)

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -216,6 +216,14 @@ describe Spaceship::TestFlight::Client do
     end
   end
 
+  context '#builds_for_group' do
+    it 'executes the request' do
+      MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/groups/fake-group-id/builds') {}
+      subject.builds_for_group(app_id: app_id, group_id: 'fake-group-id')
+      expect(WebMock).to have_requested(:get, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/groups/fake-group-id/builds')
+    end
+  end
+
   ##
   # @!group AppTestInfo
   ##

--- a/spaceship/spec/test_flight/group_spec.rb
+++ b/spaceship/spec/test_flight/group_spec.rb
@@ -145,5 +145,27 @@ describe Spaceship::TestFlight::Group do
         expect(group.default_external_group?).to be(true)
       end
     end
+
+    context '#builds' do
+      before do
+        mock_client_response(:builds_for_group, with: { app_id: 1, group_id: 2 }) do
+          [
+            {
+              id: 1,
+              appAdamId: 10,
+              trainVersion: '1.0',
+              uploadDate: '2017-01-01T12:00:00.000+0000',
+              externalState: 'testflight.build.state.export.compliance.missing'
+            }
+          ]
+        end
+      end
+
+      it 'gets the builds for this group via client' do
+        expect(mock_client).to receive(:builds_for_group).with(app_id: 1, group_id: 2)
+        builds = group.builds
+        expect(builds.size).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I needed a way to determine if testing is active for a given TestFlight group (eg, the group has a build associated with it)

### Description
Added a new method to the TestFlight `group` object to retrieve the builds. This is a new endpoint that retrieves an already defined object (`TestFlight::Build`).