### PR TITLE
spaceship: allow to remove tester(s) from testflight

### DIFF
--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -202,6 +202,17 @@ module Spaceship
         handle_response(response)
       end
 
+      def remove_testers_from_testflight(app_id: nil, tester_ids: nil)
+        assert_required_params(__method__, binding)
+        url = "providers/#{team_id}/apps/#{app_id}/deleteTesters"
+        response = request(:post) do |req|
+          req.url(url)
+          req.body = tester_ids.map { |i| { "id" => i } }.to_json
+          req.headers['Content-Type'] = 'application/json'
+        end
+        handle_response(response)
+      end
+
       def search_for_tester_in_app(app_id: nil, text: nil)
         assert_required_params(__method__, binding)
         text = CGI.escape(text)

--- a/spaceship/lib/spaceship/test_flight/tester.rb
+++ b/spaceship/lib/spaceship/test_flight/tester.rb
@@ -109,6 +109,10 @@ module Spaceship
         return testers_matching_text
       end
 
+      def self.remove_testers_from_testflight(app_id: nil, tester_ids: nil)
+        client.remove_testers_from_testflight(app_id: app_id, tester_ids: tester_ids)
+      end
+
       def self.create_app_level_tester(app_id: nil, first_name: nil, last_name: nil, email: nil)
         client.create_app_level_tester(app_id: app_id,
                                        first_name: first_name,
@@ -118,6 +122,10 @@ module Spaceship
 
       def remove_from_app!(app_id: nil)
         client.delete_tester_from_app(app_id: app_id, tester_id: self.tester_id)
+      end
+
+      def remove_from_testflight!(app_id: nil)
+        client.remove_testers_from_testflight(app_id: app_id, tester_ids: [self.tester_id])
       end
 
       def resend_invite(app_id: nil)

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -194,6 +194,14 @@ describe Spaceship::TestFlight::Client do
     end
   end
 
+  context '#remove_testers_from_testflight' do
+    it 'executes the request' do
+      MockAPI::TestFlightServer.post('/testflight/v2/providers/fake-team-id/apps/some-app-id/deleteTesters') {}
+      subject.remove_testers_from_testflight(app_id: app_id, tester_ids: [1, 2])
+      expect(WebMock).to have_requested(:post, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/deleteTesters')
+    end
+  end
+
   context '#post_tester_to_group' do
     it 'executes the request' do
       MockAPI::TestFlightServer.post('/testflight/v2/providers/fake-team-id/apps/some-app-id/groups/fake-group-id/testers') {}

--- a/spaceship/spec/test_flight/tester_spec.rb
+++ b/spaceship/spec/test_flight/tester_spec.rb
@@ -137,6 +137,13 @@ describe Spaceship::TestFlight::Tester do
         tester.remove_from_app!(app_id: 'app-id')
       end
     end
+
+    context '.remove_from_testflight!' do
+      it 'removes a tester from TestFlight' do
+        expect(mock_client).to receive(:remove_testers_from_testflight).with(app_id: 'app-id', tester_ids: [2])
+        tester.remove_from_testflight!(app_id: 'app-id')
+      end
+    end
   end
 
   context 'invites' do


### PR DESCRIPTION
When you import the wrong list of testers, you have to clean up your mess.