### PR TITLE
[WIP] Screengrab: Add option to clear app data between test runs.

### DIFF
--- a/screengrab/lib/screengrab/options.rb
+++ b/screengrab/lib/screengrab/options.rb
@@ -128,6 +128,11 @@ module Screengrab
                                      env_name: 'SCREENGRAB_REINSTALL_APP',
                                      description: "Enabling this option will automatically uninstall the application before running it",
                                      default_value: false,
+                                     is_string: false),
+        FastlaneCore::ConfigItem.new(key: :clear_app_data,
+                                     env_name: 'SCREENGRAB_CLEAR_APP_DATA',
+                                     description: "Enabling this option will automatically clear the application data before running it",
+                                     default_value: false,
                                      is_string: false)
       ]
     end

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -240,6 +240,13 @@ module Screengrab
     end
 
     def run_tests_for_locale(locale, device_serial, test_classes_to_use, test_packages_to_use, launch_arguments)
+      if @config[:clear_app_data]
+        UI.message("Clearing application data")
+        run_adb_command("adb -s #{device_serial} shell pm clear #{@config[:app_package_name]}",
+                        print_all: true,
+                        print_command: true)
+      end
+
       UI.message("Running tests for locale: #{locale}")
 
       instrument_command = ["adb -s #{device_serial} shell am instrument --no-window-animation -w",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Reinstalling the app is expensive. Especially when having 17 locales. A quicker solution would be to clear the app data between running the tests.

This PR aims to provide such functionality.

Unfortunately there's a problem with taking screenshots after enabling this behavior:

```
[12:49:00]: ▸ com.vanniktech.chessclock.screenshots.ScreenshotsTest:
[12:49:00]: ▸ Error in takeScreenShots(com.vanniktech.chessclock.screenshots.ScreenshotsTest):
[12:49:00]: ▸ java.lang.RuntimeException: Unable to capture screenshot.
[12:49:00]: ▸ at tools.fastlane.screengrab.FileWritingScreenshotCallback.screenshotCaptured(FileWritingScreenshotCallback.java:56)
[12:49:00]: ▸ at tools.fastlane.screengrab.UiAutomatorScreenshotStrategy.takeScreenshot(UiAutomatorScreenshotStrategy.java:39)
[12:49:00]: ▸ at tools.fastlane.screengrab.Screengrab.screenshot(Screengrab.java:94)
[12:49:00]: ▸ at com.vanniktech.chessclock.screenshots.ScreenshotsTest.screenshot(ScreenshotsTest.kt:141)
[12:49:00]: ▸ at com.vanniktech.chessclock.screenshots.ScreenshotsTest.takeScreenShots(ScreenshotsTest.kt:63)
[12:49:00]: ▸ at java.lang.reflect.Method.invoke(Native Method)
[12:49:00]: ▸ at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
[12:49:00]: ▸ at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
[12:49:00]: ▸ at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
[12:49:00]: ▸ at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
[12:49:00]: ▸ at android.support.test.internal.runner.junit4.statement.RunBefores.evaluate(RunBefores.java:80)
[12:49:00]: ▸ at android.support.test.internal.runner.junit4.statement.RunAfters.evaluate(RunAfters.java:61)
[12:49:00]: ▸ at android.support.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:527)
[12:49:00]: ▸ at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
[12:49:00]: ▸ at org.junit.rules.RunRules.evaluate(RunRules.java:20)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
[12:49:00]: ▸ at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
[12:49:00]: ▸ at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
[12:49:00]: ▸ at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
[12:49:00]: ▸ at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
[12:49:00]: ▸ at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
[12:49:00]: ▸ at tools.fastlane.screengrab.locale.LocaleTestRule$1.evaluate(LocaleTestRule.java:32)
[12:49:00]: ▸ at org.junit.rules.RunRules.evaluate(RunRules.java:20)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
[12:49:00]: ▸ at android.support.test.runner.AndroidJUnit4.run(AndroidJUnit4.java:101)
[12:49:00]: ▸ at org.junit.runners.Suite.runChild(Suite.java:128)
[12:49:00]: ▸ at org.junit.runners.Suite.runChild(Suite.java:27)
[12:49:00]: ▸ at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
[12:49:00]: ▸ at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
[12:49:00]: ▸ at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
[12:49:00]: ▸ at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
[12:49:00]: ▸ at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
[12:49:00]: ▸ at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:56)
[12:49:00]: ▸ at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:384)
[12:49:00]: ▸ at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2075)
[12:49:00]: ▸ Caused by: java.io.IOException: Unable to get a screenshot storage directory
[12:49:00]: ▸ at tools.fastlane.screengrab.FileWritingScreenshotCallback.getFilesDirectory(FileWritingScreenshotCallback.java:81)
[12:49:00]: ▸ at tools.fastlane.screengrab.FileWritingScreenshotCallback.screenshotCaptured(FileWritingScreenshotCallback.java:39)
[12:49:00]: ▸ ... 39 more
[12:49:00]: ▸ Time: 15.42
[12:49:00]: ▸ There was 1 failure:
[12:49:00]: ▸ 1) takeScreenShots(com.vanniktech.chessclock.screenshots.ScreenshotsTest)
[12:49:00]: ▸ java.lang.RuntimeException: Unable to capture screenshot.
[12:49:00]: ▸ at tools.fastlane.screengrab.FileWritingScreenshotCallback.screenshotCaptured(FileWritingScreenshotCallback.java:56)
[12:49:00]: ▸ at tools.fastlane.screengrab.UiAutomatorScreenshotStrategy.takeScreenshot(UiAutomatorScreenshotStrategy.java:39)
[12:49:00]: ▸ at tools.fastlane.screengrab.Screengrab.screenshot(Screengrab.java:94)
[12:49:00]: ▸ at com.vanniktech.chessclock.screenshots.ScreenshotsTest.screenshot(ScreenshotsTest.kt:141)
[12:49:00]: ▸ at com.vanniktech.chessclock.screenshots.ScreenshotsTest.takeScreenShots(ScreenshotsTest.kt:63)
[12:49:00]: ▸ at java.lang.reflect.Method.invoke(Native Method)
[12:49:00]: ▸ at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
[12:49:00]: ▸ at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
[12:49:00]: ▸ at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
[12:49:00]: ▸ at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
[12:49:00]: ▸ at android.support.test.internal.runner.junit4.statement.RunBefores.evaluate(RunBefores.java:80)
[12:49:00]: ▸ at android.support.test.internal.runner.junit4.statement.RunAfters.evaluate(RunAfters.java:61)
[12:49:00]: ▸ at android.support.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:527)
[12:49:00]: ▸ at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
[12:49:00]: ▸ at org.junit.rules.RunRules.evaluate(RunRules.java:20)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
[12:49:00]: ▸ at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
[12:49:00]: ▸ at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
[12:49:00]: ▸ at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
[12:49:00]: ▸ at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
[12:49:00]: ▸ at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
[12:49:00]: ▸ at tools.fastlane.screengrab.locale.LocaleTestRule$1.evaluate(LocaleTestRule.java:32)
[12:49:00]: ▸ at org.junit.rules.RunRules.evaluate(RunRules.java:20)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
[12:49:00]: ▸ at android.support.test.runner.AndroidJUnit4.run(AndroidJUnit4.java:101)
[12:49:00]: ▸ at org.junit.runners.Suite.runChild(Suite.java:128)
[12:49:00]: ▸ at org.junit.runners.Suite.runChild(Suite.java:27)
[12:49:00]: ▸ at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
[12:49:00]: ▸ at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
[12:49:00]: ▸ at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
[12:49:00]: ▸ at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
[12:49:00]: ▸ at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
[12:49:00]: ▸ at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
[12:49:00]: ▸ at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:56)
[12:49:00]: ▸ at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:384)
[12:49:00]: ▸ at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2075)
[12:49:00]: ▸ Caused by: java.io.IOException: Unable to get a screenshot storage directory
[12:49:00]: ▸ at tools.fastlane.screengrab.FileWritingScreenshotCallback.getFilesDirectory(FileWritingScreenshotCallback.java:81)
[12:49:00]: ▸ at tools.fastlane.screengrab.FileWritingScreenshotCallback.screenshotCaptured(FileWritingScreenshotCallback.java:39)
[12:49:01]: ▸ ... 39 more
[12:49:01]: ▸ FAILURES!!!
[12:49:01]: ▸ Tests run: 1,  Failures: 1
```

I've tried to reason where it's coming from but I could not find anything.

Can anyone else have a second look?
