### PR TITLE
[nexus_upload] Add support for Nexus 3

### DIFF
--- a/fastlane/spec/actions_specs/nexus_upload_spec.rb
+++ b/fastlane/spec/actions_specs/nexus_upload_spec.rb
@@ -1,26 +1,133 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Nexus Upload integration" do
-      it "verbosity is set correctly" do
+      it "sets verbosity correctly" do
         expect(Fastlane::Actions::NexusUploadAction.verbose(verbose: true)).to eq("--verbose")
         expect(Fastlane::Actions::NexusUploadAction.verbose(verbose: false)).to eq("--silent")
       end
 
-      it "upload url is set correctly" do
+      it "sets upload url correctly for Nexus 2" do
         expect(Fastlane::Actions::NexusUploadAction.upload_url(endpoint: "http://localhost:8081",
-          mount_path: "/nexus")).to eq("http://localhost:8081/nexus/service/local/artifact/maven/content")
+          mount_path: "/nexus", nexus_version: 2)).to eq("http://localhost:8081/nexus/service/local/artifact/maven/content")
         expect(Fastlane::Actions::NexusUploadAction.upload_url(endpoint: "http://localhost:8081",
-          mount_path: "/custom-nexus")).to eq("http://localhost:8081/custom-nexus/service/local/artifact/maven/content")
+          mount_path: "/custom-nexus", nexus_version: 2)).to eq("http://localhost:8081/custom-nexus/service/local/artifact/maven/content")
         expect(Fastlane::Actions::NexusUploadAction.upload_url(endpoint: "http://localhost:8081",
-          mount_path: "")).to eq("http://localhost:8081/service/local/artifact/maven/content")
+          mount_path: "", nexus_version: 2)).to eq("http://localhost:8081/service/local/artifact/maven/content")
       end
 
-      it "ssl option is set correctly" do
+      it "sets upload url correctly for Nexus 3 with all required parameters" do
+        tmp_path = Dir.mktmpdir
+        file_path = "#{tmp_path}/file.ipa"
+        FileUtils.touch(file_path)
+
+        expect(Fastlane::Actions::NexusUploadAction.upload_url(
+                 endpoint: 'http://localhost:8081',
+                   mount_path: '/nexus',
+                   nexus_version: 3,
+                 repo_id: 'artefacts',
+                 repo_group_id: 'com.fastlane',
+                 repo_project_name: 'myproject',
+                 repo_project_version: '1.12',
+                   file: file_path.to_s
+        )).to eq("http://localhost:8081/nexus/repository/artefacts/com/fastlane/myproject/1.12/myproject-1.12.ipa")
+      end
+
+      it "sets upload url correctly for Nexus 3 with repo classifier" do
+        tmp_path = Dir.mktmpdir
+        file_path = "#{tmp_path}/file.ipa"
+        FileUtils.touch(file_path)
+
+        expect(Fastlane::Actions::NexusUploadAction.upload_url(
+                 endpoint: 'http://localhost:8081',
+                   mount_path: '/nexus',
+                   nexus_version: 3,
+                 repo_id: 'artefacts',
+                 repo_group_id: 'com.fastlane',
+                 repo_project_name: 'myproject',
+                 repo_project_version: '1.12',
+                   file: file_path.to_s,
+                   repo_classifier: 'ipa'
+        )).to eq("http://localhost:8081/nexus/repository/artefacts/com/fastlane/myproject/1.12/myproject-1.12-ipa.ipa")
+      end
+
+      it "sets upload options correctly for Nexus 2 with all required parameters" do
+        tmp_path = Dir.mktmpdir
+        file_path = "#{tmp_path}/file.ipa"
+        FileUtils.touch(file_path)
+
+        result = Fastlane::Actions::NexusUploadAction.upload_options(
+          nexus_version: 2,
+        repo_id: 'artefacts',
+        repo_group_id: 'com.fastlane',
+        repo_project_name: 'myproject',
+        repo_project_version: '1.12',
+          file: file_path.to_s,
+                        username: 'admin',
+                        password: 'admin123'
+        )
+
+        expect(result).to include('-F p=zip')
+        expect(result).to include('-F hasPom=false')
+        expect(result).to include('-F r=artefacts')
+        expect(result).to include('-F g=com.fastlane')
+        expect(result).to include('-F a=myproject')
+        expect(result).to include('-F v=1.12')
+        expect(result).to include('-F e=ipa')
+        expect(result).to include("-F file=@#{file_path}")
+        expect(result).to include('-u admin:admin123')
+      end
+
+      it "sets upload options correctly for Nexus 2 with repo classifier" do
+        tmp_path = Dir.mktmpdir
+        file_path = "#{tmp_path}/file.ipa"
+        FileUtils.touch(file_path)
+
+        result = Fastlane::Actions::NexusUploadAction.upload_options(
+          nexus_version: 2,
+        repo_id: 'artefacts',
+        repo_group_id: 'com.fastlane',
+        repo_project_name: 'myproject',
+        repo_project_version: '1.12',
+          file: file_path.to_s,
+                        username: 'admin',
+                        password: 'admin123',
+                        repo_classifier: 'dSYM'
+        )
+
+        expect(result).to include('-F p=zip')
+        expect(result).to include('-F hasPom=false')
+        expect(result).to include('-F r=artefacts')
+        expect(result).to include('-F g=com.fastlane')
+        expect(result).to include('-F a=myproject')
+        expect(result).to include('-F v=1.12')
+        expect(result).to include('-F c=dSYM')
+        expect(result).to include('-F e=ipa')
+        expect(result).to include("-F file=@#{file_path}")
+        expect(result).to include('-u admin:admin123')
+      end
+
+      it "sets upload options correctly for Nexus 3 with all required parameters" do
+        tmp_path = Dir.mktmpdir
+        file_path = "#{tmp_path}/file.ipa"
+        FileUtils.touch(file_path)
+
+        result = Fastlane::Actions::NexusUploadAction.upload_options(
+          nexus_version: 3,
+          file: file_path.to_s,
+                        username: 'admin',
+                        password: 'admin123'
+        )
+
+        expect(result).to include("--upload-file #{file_path}")
+        expect(result).to include('-u admin:admin123')
+      end
+
+      it "sets ssl option correctly" do
         expect(Fastlane::Actions::NexusUploadAction.ssl_options(ssl_verify: false)).to eq(["--insecure"])
         expect(Fastlane::Actions::NexusUploadAction.ssl_options(ssl_verify: true)).to eq([])
       end
 
-      it "proxy options are set correctly" do
+      it "sets proxy options correctly" do
         expect(Fastlane::Actions::NexusUploadAction.proxy_options(proxy_address: "",
           proxy_port: nil, proxy_username: nil, proxy_password: nil)).to eq([])
         expect(Fastlane::Actions::NexusUploadAction.proxy_options(proxy_address: nil,
@@ -54,7 +161,7 @@ describe Fastlane do
         end.to raise_exception("Couldn't find file at path '#{file_path}'")
       end
 
-      it "mandatory options are used correctly" do
+      it "uses mandatory options correctly" do
         tmp_path = Dir.mktmpdir
         file_path = "#{tmp_path}/file.ipa"
         FileUtils.touch(file_path)
@@ -91,7 +198,7 @@ describe Fastlane do
         expect(result).to include('--insecure')
       end
 
-      it "optional options are used correctly" do
+      it "uses optional options correctly" do
         tmp_path = Dir.mktmpdir
         file_path = "#{tmp_path}/file.ipa"
         FileUtils.touch(file_path)
@@ -123,6 +230,37 @@ describe Fastlane do
         expect(result).to include('http://localhost:8081/my-nexus/service/local/artifact/maven/content')
         expect(result).not_to(include('-x '))
         expect(result).not_to(include('--proxy-user'))
+      end
+
+      it "runs the correct command for Nexus 3" do
+        tmp_path = Dir.mktmpdir
+        file_path = "#{tmp_path}/file.ipa"
+        FileUtils.touch(file_path)
+        result = Fastlane::FastFile.new.parse("lane :test do
+          nexus_upload(file: '#{file_path}',
+          nexus_version: 3,
+                      repo_id: 'artefacts',
+                      repo_group_id: 'com.fastlane',
+                      repo_project_name: 'myproject',
+                      repo_project_version: '1.12',
+                      endpoint: 'http://localhost:8081',
+                      username: 'admin',
+                      password: 'admin123',
+                      verbose: true,
+                      ssl_verify: false,
+                      proxy_address: 'http://server',
+                      proxy_port: '30',
+                      proxy_username: 'admin',
+                      proxy_password: 'admin')
+        end").runner.execute(:test)
+
+        expect(result).to include("--upload-file #{tmp_path}")
+        expect(result).to include('-u admin:admin123')
+        expect(result).to include('--verbose')
+        expect(result).to include('http://localhost:8081/nexus/repository/artefacts/com/fastlane/myproject/1.12/myproject-1.12.ipa')
+        expect(result).to include('-x http://server:30')
+        expect(result).to include('--proxy-user admin:admin')
+        expect(result).to include('--insecure')
       end
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This adds support for uploading artifacts to Nexus 3 and fixes #12336.

I successfully ran the changes against our in house hosted Nexus 3 OSS repository.

### Description
As the endpoint used for Nexus 2 [has been removed in Nexus 3](https://issues.sonatype.org/browse/NEXUS-7763) I had to switch to a different one which expects the parameters in the URL.
Since I don't have a Nexus 2 repository at hand to test, I didn't feel confident enough to move the Nexus 2 code to that endpoint.
