### PR TITLE
Fix *_path is not affected on deliver-init

### DIFF
--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -24,12 +24,13 @@ module Deliver
     def setup_deliver(file_path, data, deliver_path, options)
       File.write(file_path, data)
 
+      screenshots_path = options[:screenshots_path] || File.join(deliver_path, 'screenshots')
       unless options[:skip_screenshots]
-        download_screenshots(deliver_path, options)
+        download_screenshots(screenshots_path, options)
 
         # Add a README to the screenshots folder
-        FileUtils.mkdir_p(File.join(deliver_path, 'screenshots')) # just in case the fetching didn't work
-        File.write(File.join(deliver_path, 'screenshots', 'README.txt'), File.read("#{Deliver::ROOT}/lib/assets/ScreenshotsHelp"))
+        FileUtils.mkdir_p(screenshots_path) # just in case the fetching didn't work
+        File.write(File.join(screenshots_path, 'README.txt'), File.read("#{Deliver::ROOT}/lib/assets/ScreenshotsHelp"))
       end
 
       UI.success("Successfully created new Deliverfile at path '#{file_path}'")
@@ -39,7 +40,8 @@ module Deliver
     # and screenshots folders
     def generate_deliver_file(deliver_path, options)
       v = options[:app].latest_version
-      generate_metadata_files(v, File.join(deliver_path, 'metadata'))
+      metadata_path = options[:metadata_path] || File.join(deliver_path, 'metadata')
+      generate_metadata_files(v, metadata_path)
 
       # Generate the final Deliverfile here
       return File.read(deliverfile_path)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I host multiple application in a mono repo.
I tried `fastlane deliver init` with `--screenshots_path` and `metadata_path` options.
They are not affected when executing `deliver init`.

```sh
$ fastlane deliver init -a com.example.myapp --screenshots_path fastlane/screenshots/myapp --metadata_path fastlane/metadata/myapp
```

### Description

When passing these options, screenshots and metadata are initialized on there.