### PR TITLE
abort on interrupt to set exit code to 1

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -90,7 +90,7 @@ module Commander
           raise e
         else
           action_completed(@program[:name], status: FastlaneCore::ActionCompletionStatus::INTERRUPTED, exception: e)
-          puts("\nCancelled... use --verbose to show the stack trace")
+          abort("\nCancelled... use --verbose to show the stack trace")
         end
       rescue \
         OptionParser::InvalidOption,


### PR DESCRIPTION
Fixes #12629

## Wut
- The interrupt error caught was capturing the error which causing the exit code to be `0` (which is shouldn't be)
- The `puts` that was giving nice message to the user is not an `abort` (an exit code of `1` that displays same message)