### PR TITLE
Allow parameterize port

### DIFF
--- a/fastlane/lib/fastlane/command_line_handler.rb
+++ b/fastlane/lib/fastlane/command_line_handler.rb
@@ -6,7 +6,6 @@ module Fastlane
     def self.handle(args, options)
       lane_parameters = {} # the parameters we'll pass to the lane
       platform_lane_info = [] # the part that's responsible for the lane/platform definition
-      port = 2000
       args.each do |current|
         if current.include?(":") # that's a key/value which we want to pass to the lane
           key, value = current.split(":", 2)
@@ -14,9 +13,6 @@ module Fastlane
           value = convert_value(value)
           UI.verbose("Using #{key}: #{value}")
           lane_parameters[key.to_sym] = value
-          if key.include?("port")
-            port = value
-          end
         else
           platform_lane_info << current
         end
@@ -34,8 +30,8 @@ module Fastlane
 
       if FastlaneCore::FastlaneFolder.swift?
         disable_runner_upgrades = options.disable_runner_upgrades || false
-
-        Fastlane::SwiftLaneManager.cruise_lane(lane, port, lane_parameters, dot_env, disable_runner_upgrades: disable_runner_upgrades)
+        swift_server_port = options.swift_server_port || 2000
+        Fastlane::SwiftLaneManager.cruise_lane(lane, lane_parameters, dot_env, swift_server_port, disable_runner_upgrades: disable_runner_upgrades)
       else
         Fastlane::LaneManager.cruise_lane(platform, lane, lane_parameters, dot_env)
       end

--- a/fastlane/lib/fastlane/command_line_handler.rb
+++ b/fastlane/lib/fastlane/command_line_handler.rb
@@ -31,11 +31,7 @@ module Fastlane
       if FastlaneCore::FastlaneFolder.swift?
         disable_runner_upgrades = options.disable_runner_upgrades || false
         swift_server_port = options.swift_server_port
-        if swift_server_port
-          Fastlane::SwiftLaneManager.cruise_lane(lane, lane_parameters, dot_env, disable_runner_upgrades: disable_runner_upgrades, swift_server_port: swift_server_port)
-        else
-          Fastlane::SwiftLaneManager.cruise_lane(lane, lane_parameters, dot_env, disable_runner_upgrades: disable_runner_upgrades)
-        end
+        Fastlane::SwiftLaneManager.cruise_lane(lane, lane_parameters, dot_env, disable_runner_upgrades: disable_runner_upgrades, swift_server_port: swift_server_port)
       else
         Fastlane::LaneManager.cruise_lane(platform, lane, lane_parameters, dot_env)
       end

--- a/fastlane/lib/fastlane/command_line_handler.rb
+++ b/fastlane/lib/fastlane/command_line_handler.rb
@@ -30,8 +30,12 @@ module Fastlane
 
       if FastlaneCore::FastlaneFolder.swift?
         disable_runner_upgrades = options.disable_runner_upgrades || false
-        swift_server_port = options.swift_server_port || 2000
-        Fastlane::SwiftLaneManager.cruise_lane(lane, lane_parameters, dot_env, disable_runner_upgrades: disable_runner_upgrades, swift_server_port: swift_server_port)
+        swift_server_port = options.swift_server_port
+        if swift_server_port
+          Fastlane::SwiftLaneManager.cruise_lane(lane, lane_parameters, dot_env, disable_runner_upgrades: disable_runner_upgrades, swift_server_port: swift_server_port)
+        else
+          Fastlane::SwiftLaneManager.cruise_lane(lane, lane_parameters, dot_env, disable_runner_upgrades: disable_runner_upgrades)
+        end
       else
         Fastlane::LaneManager.cruise_lane(platform, lane, lane_parameters, dot_env)
       end

--- a/fastlane/lib/fastlane/command_line_handler.rb
+++ b/fastlane/lib/fastlane/command_line_handler.rb
@@ -6,6 +6,7 @@ module Fastlane
     def self.handle(args, options)
       lane_parameters = {} # the parameters we'll pass to the lane
       platform_lane_info = [] # the part that's responsible for the lane/platform definition
+      port = 2000
       args.each do |current|
         if current.include?(":") # that's a key/value which we want to pass to the lane
           key, value = current.split(":", 2)
@@ -13,6 +14,9 @@ module Fastlane
           value = convert_value(value)
           UI.verbose("Using #{key}: #{value}")
           lane_parameters[key.to_sym] = value
+          if key.include?("port")
+            port = value
+          end
         else
           platform_lane_info << current
         end
@@ -31,7 +35,7 @@ module Fastlane
       if FastlaneCore::FastlaneFolder.swift?
         disable_runner_upgrades = options.disable_runner_upgrades || false
 
-        Fastlane::SwiftLaneManager.cruise_lane(lane, lane_parameters, dot_env, disable_runner_upgrades: disable_runner_upgrades)
+        Fastlane::SwiftLaneManager.cruise_lane(lane, port, lane_parameters, dot_env, disable_runner_upgrades: disable_runner_upgrades)
       else
         Fastlane::LaneManager.cruise_lane(platform, lane, lane_parameters, dot_env)
       end

--- a/fastlane/lib/fastlane/command_line_handler.rb
+++ b/fastlane/lib/fastlane/command_line_handler.rb
@@ -31,7 +31,7 @@ module Fastlane
       if FastlaneCore::FastlaneFolder.swift?
         disable_runner_upgrades = options.disable_runner_upgrades || false
         swift_server_port = options.swift_server_port || 2000
-        Fastlane::SwiftLaneManager.cruise_lane(lane, lane_parameters, dot_env, swift_server_port, disable_runner_upgrades: disable_runner_upgrades)
+        Fastlane::SwiftLaneManager.cruise_lane(lane, lane_parameters, dot_env, disable_runner_upgrades: disable_runner_upgrades, swift_server_port: swift_server_port)
       else
         Fastlane::LaneManager.cruise_lane(platform, lane, lane_parameters, dot_env)
       end

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -101,6 +101,7 @@ module Fastlane
         c.description = 'Run a specific lane. Pass the lane name and optionally the platform first.'
         c.option('--env STRING[,STRING2]', String, 'Add environment(s) to use with `dotenv`')
         c.option('--disable_runner_upgrades', 'Prevents fastlane from attempting to update FastlaneRunner swift project')
+        c.option('--swift_server_port INT', 'Set specific port to communicate between fastlane and FastlaneRunner')
 
         c.action do |args, options|
           if ensure_fastfile

--- a/fastlane/lib/fastlane/server/socket_server.rb
+++ b/fastlane/lib/fastlane/server/socket_server.rb
@@ -7,19 +7,19 @@ require 'json'
 module Fastlane
   class SocketServer
     COMMAND_EXECUTION_STATE = {
-      ready: :ready,
-      already_shutdown: :already_shutdown,
-      error: :error
+    ready: :ready,
+    already_shutdown: :already_shutdown,
+    error: :error
     }
 
     attr_accessor :command_executor
     attr_accessor :return_value_processor
 
     def initialize(
-      command_executor: nil,
-      return_value_processor: nil,
-      connection_timeout: 5,
-      stay_alive: false
+                   command_executor: nil,
+                   return_value_processor: nil,
+                   connection_timeout: 5,
+                   stay_alive: false
     )
       if return_value_processor.nil?
         return_value_processor = JSONReturnValueProcessor.new
@@ -32,12 +32,12 @@ module Fastlane
     end
 
     # this is the public API, don't call anything else
-    def start
-      listen
+    def start(port: 2000)
+      listen(port: port)
 
       while @stay_alive
         UI.important("stay_alive is set to true, restarting server")
-        listen
+        listen(port: port)
       end
     end
 
@@ -134,8 +134,8 @@ module Fastlane
       return COMMAND_EXECUTION_STATE[:ready]
     end
 
-    def listen
-      @server = TCPServer.open('localhost', 2000) # Socket to listen on port 2000
+    def listen(port: 2000)
+      @server = TCPServer.open('localhost', port) # Socket to listen on port 2000
       UI.verbose("Waiting for #{@connection_timeout} seconds for a connection from FastlaneRunner")
 
       # set thread local to ready so we can check it
@@ -184,7 +184,7 @@ module Fastlane
 
       return_object = return_value_processor.prepare_object(
         return_value: return_object,
-        return_value_type: return_value_type
+          return_value_type: return_value_type
       )
 
       if closure_arg.nil?
@@ -192,19 +192,19 @@ module Fastlane
       else
         closure_arg = return_value_processor.prepare_object(
           return_value: closure_arg,
-          return_value_type: :string # always assume string for closure error_callback
+                                                            return_value_type: :string # always assume string for closure error_callback
         )
       end
 
       Thread.current[:exception] = nil
 
       payload = {
-        payload: {
-          status: "ready_for_next",
-          return_object: return_object,
-          closure_argument_value: closure_arg
+            payload: {
+                status: "ready_for_next",
+                return_object: return_object,
+                closure_argument_value: closure_arg
+            }
         }
-      }
       return JSON.generate(payload)
     rescue StandardError => e
       Thread.current[:exception] = e
@@ -219,10 +219,10 @@ module Fastlane
       end
 
       payload = {
-        payload: {
-          status: "failure",
-          failure_information: exception_array.flatten
-        }
+          payload: {
+              status: "failure",
+              failure_information: exception_array.flatten
+          }
       }
       return JSON.generate(payload)
     end

--- a/fastlane/lib/fastlane/server/socket_server.rb
+++ b/fastlane/lib/fastlane/server/socket_server.rb
@@ -19,7 +19,8 @@ module Fastlane
       command_executor: nil,
       return_value_processor: nil,
       connection_timeout: 5,
-      stay_alive: false
+      stay_alive: false,
+      port: 2000
     )
       if return_value_processor.nil?
         return_value_processor = JSONReturnValueProcessor.new
@@ -29,15 +30,16 @@ module Fastlane
       @return_value_processor = return_value_processor
       @connection_timeout = connection_timeout.to_i
       @stay_alive = stay_alive
+      @port = port.to_i
     end
 
     # this is the public API, don't call anything else
-    def start(port: 2000)
-      listen(port: port)
+    def start
+      listen(@port)
 
       while @stay_alive
         UI.important("stay_alive is set to true, restarting server")
-        listen(port: port)
+        listen(@port)
       end
     end
 
@@ -134,7 +136,7 @@ module Fastlane
       return COMMAND_EXECUTION_STATE[:ready]
     end
 
-    def listen(port: 2000)
+    def listen(port)
       @server = TCPServer.open('localhost', port) # Socket to listen on port 2000
       UI.verbose("Waiting for #{@connection_timeout} seconds for a connection from FastlaneRunner")
 

--- a/fastlane/lib/fastlane/server/socket_server.rb
+++ b/fastlane/lib/fastlane/server/socket_server.rb
@@ -7,19 +7,19 @@ require 'json'
 module Fastlane
   class SocketServer
     COMMAND_EXECUTION_STATE = {
-    ready: :ready,
-    already_shutdown: :already_shutdown,
-    error: :error
+      ready: :ready,
+      already_shutdown: :already_shutdown,
+      error: :error
     }
 
     attr_accessor :command_executor
     attr_accessor :return_value_processor
 
     def initialize(
-                   command_executor: nil,
-                   return_value_processor: nil,
-                   connection_timeout: 5,
-                   stay_alive: false
+      command_executor: nil,
+      return_value_processor: nil,
+      connection_timeout: 5,
+      stay_alive: false
     )
       if return_value_processor.nil?
         return_value_processor = JSONReturnValueProcessor.new
@@ -184,7 +184,7 @@ module Fastlane
 
       return_object = return_value_processor.prepare_object(
         return_value: return_object,
-          return_value_type: return_value_type
+        return_value_type: return_value_type
       )
 
       if closure_arg.nil?
@@ -192,19 +192,19 @@ module Fastlane
       else
         closure_arg = return_value_processor.prepare_object(
           return_value: closure_arg,
-                                                            return_value_type: :string # always assume string for closure error_callback
+          return_value_type: :string # always assume string for closure error_callback
         )
       end
 
       Thread.current[:exception] = nil
 
       payload = {
-            payload: {
-                status: "ready_for_next",
-                return_object: return_object,
-                closure_argument_value: closure_arg
-            }
+        payload: {
+          status: "ready_for_next",
+          return_object: return_object,
+          closure_argument_value: closure_arg
         }
+      }
       return JSON.generate(payload)
     rescue StandardError => e
       Thread.current[:exception] = e
@@ -219,10 +219,10 @@ module Fastlane
       end
 
       payload = {
-          payload: {
-              status: "failure",
-              failure_information: exception_array.flatten
-          }
+        payload: {
+          status: "failure",
+          failure_information: exception_array.flatten
+        }
       }
       return JSON.generate(payload)
     end

--- a/fastlane/lib/fastlane/server/socket_server.rb
+++ b/fastlane/lib/fastlane/server/socket_server.rb
@@ -35,11 +35,11 @@ module Fastlane
 
     # this is the public API, don't call anything else
     def start
-      listen(@port)
+      listen
 
       while @stay_alive
         UI.important("stay_alive is set to true, restarting server")
-        listen(@port)
+        listen
       end
     end
 
@@ -136,8 +136,8 @@ module Fastlane
       return COMMAND_EXECUTION_STATE[:ready]
     end
 
-    def listen(port)
-      @server = TCPServer.open('localhost', port) # Socket to listen on port 2000
+    def listen
+      @server = TCPServer.open('localhost', @port) # Socket to listen on port 2000
       UI.verbose("Waiting for #{@connection_timeout} seconds for a connection from FastlaneRunner")
 
       # set thread local to ready so we can check it

--- a/fastlane/lib/fastlane/swift_lane_manager.rb
+++ b/fastlane/lib/fastlane/swift_lane_manager.rb
@@ -225,7 +225,7 @@ module Fastlane
       return Thread.new do
         command_executor = SocketServerActionCommandExecutor.new
         server = Fastlane::SocketServer.new(command_executor: command_executor, port: port)
-        server.start()
+        server.start
       end
     end
 

--- a/fastlane/lib/fastlane/swift_lane_manager.rb
+++ b/fastlane/lib/fastlane/swift_lane_manager.rb
@@ -194,8 +194,8 @@ module Fastlane
       # Swap in all new user supplied configs into the project
       project_modified = swap_paths_in_target(
         target: runner_target,
-          file_refs_to_swap: target_file_refs,
-          expected_path_to_replacement_path_tuples: new_user_tool_file_paths
+        file_refs_to_swap: target_file_refs,
+        expected_path_to_replacement_path_tuples: new_user_tool_file_paths
       )
 
       # Swap out any configs the user has removed, inserting fastlane defaults

--- a/fastlane/lib/fastlane/swift_lane_manager.rb
+++ b/fastlane/lib/fastlane/swift_lane_manager.rb
@@ -6,7 +6,7 @@ module Fastlane
     # @param lane_name The name of the lane to execute
     # @param parameters [Hash] The parameters passed from the command line to the lane
     # @param env Dot Env Information
-    def self.cruise_lane(lane, parameters = nil, env = nil, disable_runner_upgrades: false, swift_server_port: 2000)
+    def self.cruise_lane(lane, parameters = nil, env = nil, disable_runner_upgrades: false, swift_server_port: nil)
       UI.user_error!("lane must be a string") unless lane.kind_of?(String) || lane.nil?
       UI.user_error!("parameters must be a hash") unless parameters.kind_of?(Hash) || parameters.nil?
 
@@ -33,6 +33,7 @@ module Fastlane
         end
 
         self.ensure_runner_built!
+        swift_server_port ||= 2000
         socket_thread = self.start_socket_thread(port: swift_server_port)
         sleep(0.250) while socket_thread[:ready].nil?
         # wait on socket_thread to be in ready state, then start the runner thread

--- a/fastlane/lib/fastlane/swift_lane_manager.rb
+++ b/fastlane/lib/fastlane/swift_lane_manager.rb
@@ -6,7 +6,7 @@ module Fastlane
     # @param lane_name The name of the lane to execute
     # @param parameters [Hash] The parameters passed from the command line to the lane
     # @param env Dot Env Information
-    def self.cruise_lane(lane, parameters = nil, env = nil, disable_runner_upgrades: false, swift_server_port: nil)
+    def self.cruise_lane(lane, parameters = nil, env = nil, disable_runner_upgrades: false, swift_server_port: 2000)
       UI.user_error!("lane must be a string") unless lane.kind_of?(String) || lane.nil?
       UI.user_error!("parameters must be a hash") unless parameters.kind_of?(Hash) || parameters.nil?
 

--- a/fastlane/lib/fastlane/swift_lane_manager.rb
+++ b/fastlane/lib/fastlane/swift_lane_manager.rb
@@ -6,7 +6,7 @@ module Fastlane
     # @param lane_name The name of the lane to execute
     # @param parameters [Hash] The parameters passed from the command line to the lane
     # @param env Dot Env Information
-    def self.cruise_lane(lane, parameters = nil, env = nil, swift_server_port, disable_runner_upgrades: false)
+    def self.cruise_lane(lane, parameters = nil, env = nil, disable_runner_upgrades: false, swift_server_port: nil)
       UI.user_error!("lane must be a string") unless lane.kind_of?(String) || lane.nil?
       UI.user_error!("parameters must be a hash") unless parameters.kind_of?(Hash) || parameters.nil?
 
@@ -218,14 +218,14 @@ module Fastlane
       return project_modified
     end
 
-    def self.start_socket_thread(port: 2000)
+    def self.start_socket_thread(port: nil)
       require 'fastlane/server/socket_server'
       require 'fastlane/server/socket_server_action_command_executor'
 
       return Thread.new do
         command_executor = SocketServerActionCommandExecutor.new
-        server = Fastlane::SocketServer.new(command_executor: command_executor)
-        server.start(port: port)
+        server = Fastlane::SocketServer.new(command_executor: command_executor, port: port)
+        server.start()
       end
     end
 

--- a/fastlane/swift/ArgumentProcessor.swift
+++ b/fastlane/swift/ArgumentProcessor.swift
@@ -19,6 +19,7 @@ struct ArgumentProcessor {
     let args: [RunnerArgument]
     let currentLane: String
     let commandTimeout: Int
+    let port: UInt32
     
     init(args: [String]) {        
         // Dump the first arg which is the program name
@@ -34,6 +35,8 @@ struct ArgumentProcessor {
         let potentialLogMode = fastlaneArgsMinusLanes.filter { arg in
             return arg.name.lowercased() == "logmode"
         }
+        
+        port = UInt32(fastlaneArgsMinusLanes.first(where: { $0.name == "swiftServerPort" })?.value ?? "") ?? 2000
         
         // Configure logMode since we might need to use it before we finish parsing
         if let logModeArg = potentialLogMode.first {

--- a/fastlane/swift/Runner.swift
+++ b/fastlane/swift/Runner.swift
@@ -34,7 +34,7 @@ class Runner {
     fileprivate var returnValue: String? // lol, so safe
     fileprivate var currentlyExecutingCommand: RubyCommandable? = nil
     fileprivate var shouldLeaveDispatchGroupDuringDisconnect = false
-
+    
     func executeCommand(_ command: RubyCommandable) -> String {
         self.dispatchGroup.enter()
         currentlyExecutingCommand = command
@@ -60,12 +60,12 @@ class Runner {
 
 // Handle threading stuff
 extension Runner {
-    func startSocketThread() {
+    func startSocketThread(port: UInt32 = 2000) {
         let secondsToWait = DispatchTimeInterval.seconds(SocketClient.connectTimeoutSeconds)
         
         self.dispatchGroup.enter()
         
-        self.socketClient = SocketClient(commandTimeoutSeconds:timeout, socketDelegate: self)
+        self.socketClient = SocketClient(port: port, commandTimeoutSeconds:timeout, socketDelegate: self)
         self.thread = Thread(target: self, selector: #selector(startSocketComs), object: nil)
         self.thread!.name = "socket thread"
         self.thread!.start()
@@ -94,7 +94,7 @@ extension Runner {
         guard let socketClient = self.socketClient else {
             return
         }
-
+        
         socketClient.connectAndOpenStreams()
         self.dispatchGroup.leave()
     }
@@ -125,11 +125,11 @@ extension Runner : SocketClientDelegateProtocol {
         case .clientInitiatedCancelAcknowledged:
             verbose(message: "server acknowledged a cancel request")
             self.dispatchGroup.leave()
-
+            
         case .alreadyClosedSockets, .connectionFailure, .malformedRequest, .malformedResponse, .serverError:
             log(message: "error encountered while executing command:\n\(serverResponse)")
             self.dispatchGroup.leave()
-
+            
         case .commandTimeout(let timeout):
             log(message: "Runner timed out after \(timeout) second(s)")
         }
@@ -198,3 +198,4 @@ func verbose(message: String) {
 // Please don't remove the lines below
 // They are used to detect outdated files
 // FastlaneRunnerAPIVersion [0.9.2]
+

--- a/fastlane/swift/Runner.swift
+++ b/fastlane/swift/Runner.swift
@@ -60,7 +60,7 @@ class Runner {
 
 // Handle threading stuff
 extension Runner {
-    func startSocketThread(port: UInt32 = 2000) {
+    func startSocketThread(port: UInt32) {
         let secondsToWait = DispatchTimeInterval.seconds(SocketClient.connectTimeoutSeconds)
         
         self.dispatchGroup.enter()

--- a/fastlane/swift/main.swift
+++ b/fastlane/swift/main.swift
@@ -23,11 +23,7 @@ class MainProcess {
     var thread: Thread!
     
     @objc func connectToFastlaneAndRunLane() {
-        var port: UInt32 = 2000
-        if let portString = argumentProcessor.laneParameters()["port"], let _port = UInt32(portString) {
-            port = _port
-        }
-        runner.startSocketThread(port: port)
+        runner.startSocketThread(port: argumentProcessor.port)
         
         let completedRun = Fastfile.runLane(named: argumentProcessor.currentLane, parameters: argumentProcessor.laneParameters())
         if completedRun {

--- a/fastlane/swift/main.swift
+++ b/fastlane/swift/main.swift
@@ -23,7 +23,11 @@ class MainProcess {
     var thread: Thread!
     
     @objc func connectToFastlaneAndRunLane() {
-        runner.startSocketThread()
+        var port: UInt32 = 2000
+        if let portString = argumentProcessor.laneParameters()["port"], let _port = UInt32(portString) {
+            port = _port
+        }
+        runner.startSocketThread(port: port)
         
         let completedRun = Fastfile.runLane(named: argumentProcessor.currentLane, parameters: argumentProcessor.laneParameters())
         if completedRun {
@@ -50,3 +54,4 @@ while (!process.doneRunningLane && (RunLoop.current.run(mode: RunLoopMode.defaul
 // Please don't remove the lines below
 // They are used to detect outdated files
 // FastlaneRunnerAPIVersion [0.9.2]
+


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
This change allows to run several instances of fastlane with FastlaneRunner. Until now, there were using always the port 2000 to communicate, so I was unable to run more that one instance in the same server because the port was in use. This PR allow to set the port which will be used. This param is optional and it could be sent only if you need it. The port could be set using same way than the other params: 
bundle exec fastlane myLane port:2001
If port is set, both codes use it instead of the default one (2000)

This fixes this issue: 
https://github.com/fastlane/fastlane/issues/12604



### Description
<!-- Describe your changes in detail -->
Both fastlane and FastlaneSwiftRunner checks if param port is set. If so, they use this port instead of default to communicate.  