### PR TITLE
[action] add mute to say action (with rework)

### DIFF
--- a/fastlane/lib/fastlane/actions/say.rb
+++ b/fastlane/lib/fastlane/actions/say.rb
@@ -2,16 +2,36 @@ module Fastlane
   module Actions
     class SayAction < Action
       def self.run(params)
-        text = params.join(' ') if params.kind_of?(Array) # that's usually the case
-        text = params if params.kind_of?(String)
-        UI.user_error!("You can't call the `say` action as OneOff") unless text
+        text = params[:text]
+        text = text.join(' ') if text.kind_of?(Array)
         text = text.tr("'", '"')
 
-        Actions.sh("say '#{text}'")
+        if params[:mute]
+          UI.message(text)
+          return text
+        else
+          Actions.sh("say '#{text}'")
+        end
       end
 
       def self.description
-        "This action speaks out loud the given text"
+        "This action speaks the given text out loud"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :text,
+                                       description: 'Text to be spoken out loud (as string or array of strings)',
+                                       optional: false,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :mute,
+                                       env_name: "SAY_MUTE",
+                                       description: 'If say should be muted with text printed out',
+                                       optional: false,
+                                       is_string: false,
+                                       type: Boolean,
+                                       default_value: false)
+        ]
       end
 
       def self.is_supported?(platform)

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -307,12 +307,9 @@ module Fastlane
     def say(value)
       # Overwrite this, since there is already a 'say' method defined in the Ruby standard library
       value ||= yield
-      Actions.execute_action('say') do
-        action_launched('say')
-        return_value = Fastlane::Actions::SayAction.run([value])
-        action_completed('say', status: FastlaneCore::ActionCompletionStatus::SUCCESS)
-        return return_value
-      end
+
+      value = { text: value } if value.kind_of?(String) || value.kind_of?(Array)
+      self.runner.trigger_action_by_name(:say, nil, false, value)
     end
 
     def puts(value)

--- a/fastlane/spec/actions_specs/say_spec.rb
+++ b/fastlane/spec/actions_specs/say_spec.rb
@@ -1,12 +1,108 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Say Integration" do
-      it "works" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          say ['Hi Felix', 'Good Job']
-        end").runner.execute(:test)
+      describe "saying" do
+        it "works with array" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with('say \'Hi Felix Good Job\'')
+            .and_call_original
 
-        expect(result).to eq('say \'Hi Felix Good Job\'')
+          result = Fastlane::FastFile.new.parse("lane :test do
+            say(['Hi Felix', 'Good Job'])
+          end").runner.execute(:test)
+
+          expect(result).to eq('say \'Hi Felix Good Job\'')
+        end
+
+        it "works with string" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with('say \'Hi Josh Good Job\'')
+            .and_call_original
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            say('Hi Josh Good Job')
+          end").runner.execute(:test)
+
+          expect(result).to eq('say \'Hi Josh Good Job\'')
+        end
+
+        it "works with options array" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with('say \'Hi Felix Good Job\'')
+            .and_call_original
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            say(text: ['Hi Felix', 'Good Job'])
+          end").runner.execute(:test)
+
+          expect(result).to eq('say \'Hi Felix Good Job\'')
+        end
+
+        it "works with options string" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with('say \'Hi Josh Good Job\'')
+            .and_call_original
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            say(text: 'Hi Josh Good Job')
+          end").runner.execute(:test)
+
+          expect(result).to eq('say \'Hi Josh Good Job\'')
+        end
+      end
+
+      describe "muted" do
+        before do
+          stub_const('ENV', { 'SAY_MUTE' => 'true' })
+        end
+
+        it "works with array" do
+          expect(Fastlane::UI).to receive(:message)
+            .with('Hi Felix Good Job')
+            .and_call_original
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            say(['Hi Felix', 'Good Job'])
+          end").runner.execute(:test)
+
+          expect(result).to eq('Hi Felix Good Job')
+        end
+
+        it "works with string" do
+          expect(Fastlane::UI).to receive(:message)
+            .with('Hi Josh Good Job')
+            .and_call_original
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            say('Hi Josh Good Job')
+          end").runner.execute(:test)
+
+          expect(result).to eq('Hi Josh Good Job')
+        end
+
+        it "works with options array" do
+          expect(Fastlane::UI).to receive(:message)
+            .with('Hi Felix Good Job')
+            .and_call_original
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            say(text: ['Hi Felix', 'Good Job'])
+          end").runner.execute(:test)
+
+          expect(result).to eq('Hi Felix Good Job')
+        end
+
+        it "works with options string" do
+          expect(Fastlane::UI).to receive(:message)
+            .with('Hi Josh Good Job')
+            .and_call_original
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            say(text: 'Hi Josh Good Job')
+          end").runner.execute(:test)
+
+          expect(result).to eq('Hi Josh Good Job')
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #11750

## Wut
- Reworked how `say` method gets overridden
  - Gets called as an action now to allow `params` in `actions/say.rb` to actually be config items 
- Added option for `mute` which ends up just calling `UI.message`
  - `Fastfile` option, command line, environment variable
- Added more tests