### PR TITLE
Raise error when submission fails on export compliance

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -1019,11 +1019,14 @@ module Spaceship
       handle_itc_response(r.body)
 
       # iTunes Connect still returns a success status code even the submission
-      # was failed because of Ad ID info. This checks for any section error
-      # keys in returned adIdInfo and prints them out.
+      # was failed because of Ad ID Info / Export Complicance. This checks for any section error
+      # keys in returned adIdInfo / exportCompliance and prints them out.
       ad_id_error_keys = r.body.fetch('data').fetch('adIdInfo').fetch('sectionErrorKeys')
+      export_error_keys = r.body.fetch('data').fetch('exportCompliance').fetch('sectionErrorKeys')
       if ad_id_error_keys.any?
         raise "Something wrong with your Ad ID information: #{ad_id_error_keys}."
+      elsif export_error_keys.any?
+        raise "Something wrong with your Export Complicance: #{export_error_keys}"
       elsif r.body.fetch('messages').fetch('info').last == "Successful POST"
         # success
       else


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
When I submit an app for the first time with spaceship, it returns success but store status is still "prepare for submission". After debugging into fastlane I found that there was in fact an error in exportCompliance, though ignored.

### Description
Make the client also check the `exportCompliance` section for error keys so it will raise error when submit fails.
