### PR TITLE
Set FASTLANE_SHOW_TIMEZONE env var to show timestamp in logs

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
+++ b/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
@@ -31,11 +31,11 @@ module FastlaneCore
 
     def format_string(datetime = Time.now, severity = "")
       if FastlaneCore::Globals.verbose?
-        return "#{severity} [#{datetime.strftime('%Y-%m-%d %H:%M:%S.%2N')}]: "
+        return "#{severity} [#{datetime.strftime('%Y-%m-%d %H:%M:%S.%2N %z')}]: "
       elsif FastlaneCore::Env.truthy?("FASTLANE_HIDE_TIMESTAMP")
         return ""
       else
-        return "[#{datetime.strftime('%H:%M:%S')}]: "
+        return "[#{datetime.strftime('%H:%M:%S %z')}]: "
       end
     end
 

--- a/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
+++ b/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
@@ -30,12 +30,13 @@ module FastlaneCore
     end
 
     def format_string(datetime = Time.now, severity = "")
+      timezone_string = !ENV.key?('FASTLANE_SHOW_TIMEZONE') ? '' : ' %z'
       if FastlaneCore::Globals.verbose?
-        return "#{severity} [#{datetime.strftime('%Y-%m-%d %H:%M:%S.%2N %z')}]: "
+        return "#{severity} [#{datetime.strftime('%Y-%m-%d %H:%M:%S.%2N' + timezone_string)}]: "
       elsif FastlaneCore::Env.truthy?("FASTLANE_HIDE_TIMESTAMP")
         return ""
       else
-        return "[#{datetime.strftime('%H:%M:%S %z')}]: "
+        return "[#{datetime.strftime('%H:%M:%S' + timezone_string)}]: "
       end
     end
 

--- a/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
+++ b/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
@@ -30,7 +30,7 @@ module FastlaneCore
     end
 
     def format_string(datetime = Time.now, severity = "")
-      timezone_string = !ENV.key?('FASTLANE_SHOW_TIMEZONE') ? '' : ' %z'
+      timezone_string = !FastlaneCore::Env.truthy?('FASTLANE_SHOW_TIMEZONE') ? '' : ' %z'
       if FastlaneCore::Globals.verbose?
         return "#{severity} [#{datetime.strftime('%Y-%m-%d %H:%M:%S.%2N' + timezone_string)}]: "
       elsif FastlaneCore::Env.truthy?("FASTLANE_HIDE_TIMESTAMP")


### PR DESCRIPTION
Adding timezones to the timestamps. This makes logging indexers like Splunk happy. Otherwise, they may misinterpret the  true time of the timestamp depending on the time zone settings of the system and running process.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This makes logging indexers like Splunk happy. Otherwise, they may misinterpret the  true time of the timestamp depending on the time zone settings of the system and running process.
<!-- If it fixes an open issue, please link to the issue here. -->
No issue open, as of yet.
<!-- Please describe in detail how you tested your changes. -->
Ran fastlane. The timestamps now have the time zone added.

### Description
<!-- Describe your changes in detail -->
Adding timezones to the timestamps.