### PR TITLE
Make Carthage action support dependencies for bootstrap command

### DIFF
--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -11,7 +11,7 @@ module Fastlane
 
         if command_name == "archive" && params[:frameworks].count > 0
           cmd.concat(params[:frameworks])
-        elsif (command_name == "update" || command_name == "build") && params[:dependencies].count > 0
+        elsif ["update", "build", "bootstrap"].include?(command_name) && params[:dependencies].count > 0
           cmd.concat(params[:dependencies])
         end
 
@@ -71,7 +71,7 @@ module Fastlane
                                          UI.user_error!("Please pass a valid command. Use one of the following: #{available_commands.join(', ')}") unless available_commands.include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :dependencies,
-                                       description: "Carthage dependencies to update or build",
+                                       description: "Carthage dependencies to update, build or bootstrap",
                                        default_value: [],
                                        is_string: false,
                                        type: Array),
@@ -178,7 +178,7 @@ module Fastlane
             frameworks: ["MyFramework1", "MyFramework2"],   # Specify which frameworks to archive (only for the archive command)
             output: "MyFrameworkBundle.framework.zip",      # Specify the output archive name (only for the archive command)
             command: "bootstrap",                           # One of: build, bootstrap, update, archive. (default: bootstrap)
-            dependencies: ["Alamofire", "Notice"],          # Specify which dependencies to update or build (only for update and build commands)
+            dependencies: ["Alamofire", "Notice"],          # Specify which dependencies to update or build (only for update, build and bootstrap commands)
             use_ssh: false,                                 # Use SSH for downloading GitHub repositories.
             use_submodules: false,                          # Add dependencies as Git submodules.
             use_binaries: true,                             # Check out dependency repositories even when prebuilt frameworks exist

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -386,6 +386,30 @@ describe Fastlane do
           eq("carthage build TestDependency1 TestDependency2")
       end
 
+      it "bootstraps with a single dependency" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              command: 'bootstrap',
+              dependencies: ['TestDependency']
+            )
+          end").runner.execute(:test)
+
+        expect(result).to \
+          eq("carthage bootstrap TestDependency")
+      end
+
+      it "bootstraps with multiple dependencies" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              command: 'bootstrap',
+              dependencies: ['TestDependency1', 'TestDependency2']
+            )
+          end").runner.execute(:test)
+
+        expect(result).to \
+          eq("carthage bootstrap TestDependency1 TestDependency2")
+      end
+
       it "works with no parameters" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

With Carthage you can specify which dependencies should be built, e.g. you can run `carthage bootstrap Alamofire` to only build Alamofire and it's dependencies. Currently the Carthage action ignores the dependencies parameter when for the `bootstrap` command. This PR adds support for dependencies for this command.

I used the same tests as the update and build commands, and just changed it to use bootstrap instead of build/update.