### PR TITLE
Lock xcpretty at 0.2.x to prevent auto 0.3.x updates

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('slack-notifier', '>= 2.0.0', '< 3.0.0') # Slack notifications
   spec.add_dependency('xcodeproj', '>= 1.5.7', '< 2.0.0') # Needed for commit_version_bump action and gym code_signing_mapping
-  spec.add_dependency('xcpretty', '>= 0.2.4', '< 1.0.0') # prettify xcodebuild output
+  spec.add_dependency('xcpretty', '~> 0.2.8') # prettify xcodebuild output
   spec.add_dependency('terminal-notifier', '>= 1.6.2', '< 2.0.0') # macOS notifications
   spec.add_dependency('terminal-table', '>= 1.4.5', '< 2.0.0') # Actions documentation
   spec.add_dependency('plist', '>= 3.1.0', '< 4.0.0') # Needed for set_build_number_repository and get_info_plist_value actions


### PR DESCRIPTION
`xcpretty` is prepping for a full rewrite that will be release in version `0.3.x` so going to lock this and future versions to `0.2.x` for now 🙃 