### PR TITLE
Prevent automatic_code_signing spec from changing test fixture

### DIFF
--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -100,6 +100,10 @@ describe Fastlane do
     end
 
     it "sets code sign identity", requires_xcodeproj: true do
+
+      temp_dir = Dir.tmpdir()
+      FileUtils.copy_entry('./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', temp_dir)
+
       # G3KGXDXQL9
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
@@ -108,11 +112,11 @@ describe Fastlane do
       expect(UI).to receive(:important).with("Set Code Sign identity to: iPhone Distribution for target: demo")
       expect(UI).to receive(:important).with("Set Code Sign identity to: iPhone Distribution for target: today")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9', code_sign_identity: 'iPhone Distribution')
+        disable_automatic_code_signing(path: '#{temp_dir}', team_id: 'G3KGXDXQL9', code_sign_identity: 'iPhone Distribution')
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open("#{temp_dir}")
       root_attrs = project.root_object.attributes["TargetAttributes"]
 
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")

--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -100,8 +100,7 @@ describe Fastlane do
     end
 
     it "sets code sign identity", requires_xcodeproj: true do
-
-      temp_dir = Dir.tmpdir()
+      temp_dir = Dir.tmpdir
       FileUtils.copy_entry('./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', temp_dir)
 
       # G3KGXDXQL9
@@ -116,7 +115,7 @@ describe Fastlane do
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("#{temp_dir}")
+      project = Xcodeproj::Project.open(temp_dir.to_s)
       root_attrs = project.root_object.attributes["TargetAttributes"]
 
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")


### PR DESCRIPTION
Spec for `automatic_code_signing` was leaving some changes to a test fixture which sometimes could easily get accidentally committed 🙃 

So this fixes that 😉 