### PR TITLE
[mailgun] Add ability to pass custom placeholders

### DIFF
--- a/fastlane/lib/fastlane/actions/mailgun.rb
+++ b/fastlane/lib/fastlane/actions/mailgun.rb
@@ -91,8 +91,14 @@ module Fastlane
                                       env_name: "MAILGUN_ATTACHMENT",
                                       description: "Mail Attachment filenames, either an array or just one string",
                                       optional: true,
-                                      is_string: false)
-
+                                      is_string: false),
+          FastlaneCore::ConfigItem.new(key: :custom_placeholders,
+                                       short_option: "-p",
+                                       env_name: "MAILGUN_CUSTOM_PLACEHOLDERS",
+                                       description: "Placeholders for template given as a hash",
+                                       default_value: {},
+                                       is_string: false,
+                                       type: Hash)
         ]
       end
 
@@ -139,6 +145,9 @@ module Fastlane
         }
         hash[:success] = options[:success]
         hash[:ci_build_link] = options[:ci_build_link]
+
+        # concatenate with custom placeholders passed by user
+        hash = hash.merge(options[:custom_placeholders])
 
         # grabs module
         eth = Fastlane::ErbTemplateHelper

--- a/fastlane/lib/fastlane/actions/mailgun.rb
+++ b/fastlane/lib/fastlane/actions/mailgun.rb
@@ -180,6 +180,10 @@ module Fastlane
             app_link: "http://www.myapplink.com",
             ci_build_link: "http://www.mycibuildlink.com",
             template_path: "HTML_TEMPLATE_PATH",
+            custom_placeholders: {
+              :var1 => 123,
+              :var2 => "string"
+            },
             attachment: "dirname/filename.ext"
           )'
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Presently the mailgun action uses an erb template to send as message body. Placeholders in this erb template cannot be extended; they are based on parameters such as **:message**, **:app_link**, **git author of the last commit**, etc. Mailgun put them in an internal **Hash** to use them (see [mailgun.rb:134](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/mailgun.rb#L134))
I would like to be able to add other placeholders in my erb template and have mailgun action populate them.

<!-- Please describe in detail how you tested your changes. -->
I have tested this locally and was able to completely modify the erb template and populating it properly.
I also tried to use the mailgun action without specifying this new parameter and everything worked fine thanks to the default empty Hash value.

### Description
I have added a new Hash parameter, **custom_placeholders** with an empty Hash default value.
This parameter is then merged with the internal hash used by the mailgun action before rendering the final html file.
I have looked at the **erb** action and took [this parameter](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/erb.rb#L42) as an example
