### PR TITLE
require terminal-table in files that didn't

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_search.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_search.rb
@@ -1,5 +1,6 @@
 module Fastlane
   class PluginSearch
+    require 'terminal-table'
     require 'word_wrap'
 
     def self.print_plugins(search_query: nil)

--- a/fastlane/lib/fastlane/plugins/plugin_update_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_update_manager.rb
@@ -41,6 +41,7 @@ module Fastlane
         return
       end
 
+      require 'terminal-table'
       puts(Terminal::Table.new({
         rows: FastlaneCore::PrintTable.transform_output(rows),
         title: "Plugin updates available".yellow,


### PR DESCRIPTION
Fixes #12718

## Wut
Some setups have issues with terminal table not being required in time so made sure that every file using `Terminal::Table.new` has the proper `require`.