### PR TITLE
fixes doc on how to use export_options in Gymfile

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/build_ios_app.md
+++ b/fastlane/lib/fastlane/actions/docs/build_ios_app.md
@@ -134,7 +134,7 @@ export_options("./ExportOptions.plist")
 or you can provide hash of values directly in the `Gymfile`:
 
 ```ruby-skip-tests
-export_options: {
+export_options = {
   method: "ad-hoc",
   manifest: {
     appURL: "https://example.com/My App.ipa",


### PR DESCRIPTION
Fixes #12691

## Description
`=` not `:` 🙃 