### PR TITLE
[supply] set google client send_timeout

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -70,6 +70,7 @@ module Supply
       Google::Apis::ClientOptions.default.application_version = Fastlane::VERSION
       Google::Apis::ClientOptions.default.read_timeout_sec = 300
       Google::Apis::ClientOptions.default.open_timeout_sec = 300
+      Google::Apis::ClientOptions.default.send_timeout_sec = 300
       Google::Apis::RequestOptions.default.retries = 5
 
       self.android_publisher = Androidpublisher::AndroidPublisherService.new


### PR DESCRIPTION
Fixes #12173

## Description
`read_timeout_sec` and `open_timeout_sec` were set to `300` but `send_timeout_sec` was not