### PR TITLE
[snapshot] initialize directories on retry and clear collected_errors on retry

### DIFF
--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
@@ -152,6 +152,12 @@ module Snapshot
     def retry_tests(retries, command, language, locale, launch_args, devices)
       UI.important("Retrying on devices: #{devices.join(', ')}")
       UI.important("Number of retries remaining: #{launcher_config.number_of_retries - retries - 1}")
+
+      # Make sure all needed directories exist for next retry
+      # `copy_screenshots` in `cleanup_after_failure` can delete some needed directories
+      # https://github.com/fastlane/fastlane/issues/10786
+      prepare_directories_for_launch(language: language, locale: locale, launch_arguments: launch_args)
+
       execute(retries + 1, command: command, language: language, locale: locale, launch_args: launch_args, devices: devices)
     end
 

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
@@ -158,6 +158,9 @@ module Snapshot
       # https://github.com/fastlane/fastlane/issues/10786
       prepare_directories_for_launch(language: language, locale: locale, launch_arguments: launch_args)
 
+      # Clear errors so a successful retry isn't reported as an over failure
+      self.collected_errors = []
+
       execute(retries + 1, command: command, language: language, locale: locale, launch_args: launch_args, devices: devices)
     end
 

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -27,6 +27,11 @@ module Snapshot
     end
 
     def prepare_for_launch(device_types, language, locale, launch_arguments)
+      prepare_directories_for_launch(language: language, locale: locale, launch_arguments: launch_arguments)
+      prepare_simulators_for_launch(device_types, language: language, locale: locale)
+    end
+
+    def prepare_directories_for_launch(language: nil, locale: nil, launch_arguments: nil)
       screenshots_path = TestCommandGenerator.derived_data_path
       FileUtils.rm_rf(File.join(screenshots_path, "Logs"))
       FileUtils.rm_rf(screenshots_path) if launcher_config.clean
@@ -38,8 +43,6 @@ module Snapshot
       File.write(File.join(CACHE_DIR, "language.txt"), language)
       File.write(File.join(CACHE_DIR, "locale.txt"), locale || "")
       File.write(File.join(CACHE_DIR, "snapshot-launch_arguments.txt"), launch_arguments.last)
-
-      prepare_simulators_for_launch(device_types, language: language, locale: locale)
     end
 
     def prepare_simulators_for_launch(device_types, language: nil, locale: nil)


### PR DESCRIPTION
Fixes #10786

## Wut
1. In a failure `copy_screenshots` would delete the cache directory but not recreate it for following retry runs
  - A retry new recreate the cache directories
2. A successful retry would always result in an overall failure since `collected_errors` was never getting cleared before a retry
  - This is now also fixed