### PR TITLE
[action] app_store_build_number now nicely alerts user when no live version

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -29,6 +29,7 @@ module Fastlane
         app = Spaceship::Tunes::Application.find(params[:app_identifier])
         if params[:live]
           UI.message("Fetching the latest build number for live-version")
+          UI.user_error!("Could not find a live-version of #{params[:app_identifier]} on iTC") unless app.live_version
           build_nr = app.live_version.current_build_number
         else
           version_number = params[:version]


### PR DESCRIPTION
Fixes #12714

## My Test Output
```sh
[06:59:04]: Driving the lane 'ios latest_app_store' 🚀
[06:59:04]: ------------------------------------
[06:59:04]: --- Step: app_store_build_number ---
[06:59:04]: ------------------------------------
[06:59:04]: Login to iTunes Connect (email@email.com)
[06:59:09]: Login successful
[06:59:11]: Fetching the latest build number for live-version
[06:59:15]: Latest upload for version  is build: 2.0.0
[06:59:15]: good night car version: 2.0.0
[06:59:15]: ------------------------------------
[06:59:15]: --- Step: app_store_build_number ---
[06:59:15]: ------------------------------------
[06:59:15]: Login to iTunes Connect (email@email.com)
[06:59:19]: Login successful
[06:59:20]: Fetching the latest build number for live-version
+---------------------+----------------------+
|                Lane Context                |
+---------------------+----------------------+
| PLATFORM_NAME       | ios                  |
| LANE_NAME           | ios latest_app_store |
| LATEST_BUILD_NUMBER | 2.0.0                |
+---------------------+----------------------+
[06:59:21]: Could not find a live-version of com.joshholtz.FastlaneTest on iTC

+------+------------------------+-------------+
|              fastlane summary               |
+------+------------------------+-------------+
| Step | Action                 | Time (in s) |
+------+------------------------+-------------+
| 1    | app_store_build_number | 11          |
| 💥   | app_store_build_number | 5           |
+------+------------------------+-------------+

[06:59:21]: fastlane finished with errors

[!] Could not find a live-version of com.joshholtz.FastlaneTest on iTC
```