### PR TITLE
testflight - added method to find internal users

### DIFF
--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -171,7 +171,7 @@ module Spaceship
         url = "providers/#{team_id}/apps/#{app_id}/internalUsers"
         r = request(:get, url)
 
-        internal_users = parse_response(r, 'data')
+        parse_response(r, 'data')
       end
 
       ##

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -164,6 +164,20 @@ module Spaceship
         testers
       end
 
+      #####################################################
+      # @!Internal Testers
+      #####################################################
+      def internal_users(app_id)
+        url = "providers/#{team_id}/apps/#{app_id}/internalUsers"
+        r = request(:get, url)
+
+        require 'pry'
+        # binding.pry
+        # puts r
+        internal_users = parse_response(r, 'data')
+        # puts "a"
+      end
+
       ##
       # @!group Testers API
       ##

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -171,11 +171,7 @@ module Spaceship
         url = "providers/#{team_id}/apps/#{app_id}/internalUsers"
         r = request(:get, url)
 
-        require 'pry'
-        # binding.pry
-        # puts r
         internal_users = parse_response(r, 'data')
-        # puts "a"
       end
 
       ##

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -167,7 +167,8 @@ module Spaceship
       #####################################################
       # @!Internal Testers
       #####################################################
-      def internal_users(app_id)
+      def internal_users(app_id: nil)
+        assert_required_params(__method__, binding)
         url = "providers/#{team_id}/apps/#{app_id}/internalUsers"
         r = request(:get, url)
 

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -158,6 +158,18 @@ describe Spaceship::TestFlight::Client do
   end
 
   ##
+  # @!Internal Testers
+  ##
+
+  context '#internal_users_for_app' do
+    it 'executes the request' do
+      MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/internalUsers') {}
+      subject.internal_users(app_id: app_id)
+      expect(WebMock).to have_requested(:get, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/internalUsers')
+    end
+  end
+
+  ##
   # @!group Testers API
   ##
 

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -163,7 +163,7 @@ describe Spaceship::TestFlight::Client do
 
   context '#internal_users_for_app' do
     it 'executes the request' do
-      MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/internalUsers') {}
+      MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/internalUsers') { '{"data" : ""}' }
       subject.internal_users(app_id: app_id)
       expect(WebMock).to have_requested(:get, 'https://itunesconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/internalUsers')
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
This is followup pull request after discussing with @joshdholtz. Fixes issue https://github.com/fastlane/fastlane/issues/12750.

Added new method `internal_users` to get the internal users from App Store Connect.