### PR TITLE
Scan formatter backticks patch

### DIFF
--- a/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
@@ -393,7 +393,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;
@@ -410,6 +410,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;

--- a/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj/project.pbxproj
@@ -393,7 +393,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;
@@ -410,7 +410,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
 				INFOPLIST_FILE = demo/Info.plist;

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -1,4 +1,4 @@
-require_relative "xcpretty_reporter_options_generator"
+require_relative 'xcpretty_reporter_options_generator'
 
 module Scan
   # Responsible for building the fully working xcodebuild command
@@ -39,9 +39,9 @@ module Scan
       options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
       options << "-maximum-concurrent-test-simulator-destinations #{config[:max_concurrent_simulators]}" if config[:max_concurrent_simulators]
       options << "-disable-concurrent-testing" if config[:disable_concurrent_testing]
-      options << "-enableCodeCoverage #{config[:code_coverage] ? "YES" : "NO"}" unless config[:code_coverage].nil?
-      options << "-enableAddressSanitizer #{config[:address_sanitizer] ? "YES" : "NO"}" unless config[:address_sanitizer].nil?
-      options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? "YES" : "NO"}" unless config[:thread_sanitizer].nil?
+      options << "-enableCodeCoverage #{config[:code_coverage] ? 'YES' : 'NO'}" unless config[:code_coverage].nil?
+      options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
+      options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?
       options << "-xctestrun '#{config[:xctestrun]}'" if config[:xctestrun]
       options << config[:xcargs] if config[:xcargs]
 
@@ -79,7 +79,7 @@ module Scan
     def pipe
       pipe = ["| tee '#{xcodebuild_log_path}'"]
 
-      if Scan.config[:output_style] == "raw"
+      if Scan.config[:output_style] == 'raw'
         return pipe
       end
 
@@ -99,11 +99,11 @@ module Scan
         formatter << "--no-color"
       end
 
-      if Scan.config[:output_style] == "basic"
+      if Scan.config[:output_style] == 'basic'
         formatter << "--no-utf"
       end
 
-      if Scan.config[:output_style] == "rspec"
+      if Scan.config[:output_style] == 'rspec'
         formatter << "--test"
       end
 
@@ -113,7 +113,7 @@ module Scan
                                                                          Scan.config[:output_directory],
                                                                          Scan.config[:use_clang_report_name])
       reporter_options = @reporter_options_generator.generate_reporter_options
-      return pipe << "| xcpretty #{formatter.join(" ")} #{reporter_options.join(" ")}"
+      return pipe << "| xcpretty #{formatter.join(' ')} #{reporter_options.join(' ')}"
     end
 
     # Store the raw file
@@ -128,7 +128,7 @@ module Scan
     # Generate destination parameters
     def destination
       unless Scan.cache[:destination]
-        Scan.cache[:destination] = [*Scan.config[:destination]].map { |dst| "-destination '#{dst}'" }.join(" ")
+        Scan.cache[:destination] = [*Scan.config[:destination]].map { |dst| "-destination '#{dst}'" }.join(' ')
       end
       Scan.cache[:destination]
     end

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -1,4 +1,4 @@
-require_relative 'xcpretty_reporter_options_generator'
+require_relative "xcpretty_reporter_options_generator"
 
 module Scan
   # Responsible for building the fully working xcodebuild command
@@ -39,9 +39,9 @@ module Scan
       options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
       options << "-maximum-concurrent-test-simulator-destinations #{config[:max_concurrent_simulators]}" if config[:max_concurrent_simulators]
       options << "-disable-concurrent-testing" if config[:disable_concurrent_testing]
-      options << "-enableCodeCoverage #{config[:code_coverage] ? 'YES' : 'NO'}" unless config[:code_coverage].nil?
-      options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
-      options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?
+      options << "-enableCodeCoverage #{config[:code_coverage] ? "YES" : "NO"}" unless config[:code_coverage].nil?
+      options << "-enableAddressSanitizer #{config[:address_sanitizer] ? "YES" : "NO"}" unless config[:address_sanitizer].nil?
+      options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? "YES" : "NO"}" unless config[:thread_sanitizer].nil?
       options << "-xctestrun '#{config[:xctestrun]}'" if config[:xctestrun]
       options << config[:xcargs] if config[:xcargs]
 
@@ -79,15 +79,19 @@ module Scan
     def pipe
       pipe = ["| tee '#{xcodebuild_log_path}'"]
 
-      if Scan.config[:output_style] == 'raw'
+      if Scan.config[:output_style] == "raw"
         return pipe
       end
 
       formatter = []
-      if Scan.config[:formatter]
-        formatter << "-f '#{Scan.config[:formatter]}'"
+      if (custom_formatter = Scan.config[:formatter])
+        if custom_formatter.end_with? ".rb"
+          formatter << "-f '#{custom_formatter}'"
+        else
+          formatter << "-f `#{custom_formatter}`"
+        end
       elsif FastlaneCore::Env.truthy?("TRAVIS")
-        formatter << "-f 'xcpretty-travis-formatter'"
+        formatter << "-f `xcpretty-travis-formatter`"
         UI.success("Automatically switched to Travis formatter")
       end
 
@@ -95,11 +99,11 @@ module Scan
         formatter << "--no-color"
       end
 
-      if Scan.config[:output_style] == 'basic'
+      if Scan.config[:output_style] == "basic"
         formatter << "--no-utf"
       end
 
-      if Scan.config[:output_style] == 'rspec'
+      if Scan.config[:output_style] == "rspec"
         formatter << "--test"
       end
 
@@ -109,7 +113,7 @@ module Scan
                                                                          Scan.config[:output_directory],
                                                                          Scan.config[:use_clang_report_name])
       reporter_options = @reporter_options_generator.generate_reporter_options
-      return pipe << "| xcpretty #{formatter.join(' ')} #{reporter_options.join(' ')}"
+      return pipe << "| xcpretty #{formatter.join(" ")} #{reporter_options.join(" ")}"
     end
 
     # Store the raw file
@@ -124,7 +128,7 @@ module Scan
     # Generate destination parameters
     def destination
       unless Scan.cache[:destination]
-        Scan.cache[:destination] = [*Scan.config[:destination]].map { |dst| "-destination '#{dst}'" }.join(' ')
+        Scan.cache[:destination] = [*Scan.config[:destination]].map { |dst| "-destination '#{dst}'" }.join(" ")
       end
       Scan.cache[:destination]
     end

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -85,9 +85,9 @@ module Scan
 
       formatter = []
       if Scan.config[:formatter]
-        formatter << "-f \"#{Scan.config[:formatter]}\""
+        formatter << "-f '#{Scan.config[:formatter]}'"
       elsif FastlaneCore::Env.truthy?("TRAVIS")
-        formatter << "-f \"xcpretty-travis-formatter\""
+        formatter << "-f 'xcpretty-travis-formatter'"
         UI.success("Automatically switched to Travis formatter")
       end
 

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -85,9 +85,9 @@ module Scan
 
       formatter = []
       if Scan.config[:formatter]
-        formatter << "-f `#{Scan.config[:formatter]}`"
+        formatter << "-f \"#{Scan.config[:formatter]}\""
       elsif FastlaneCore::Env.truthy?("TRAVIS")
-        formatter << "-f `xcpretty-travis-formatter`"
+        formatter << "-f \"xcpretty-travis-formatter\""
         UI.success("Automatically switched to Travis formatter")
       end
 

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -147,7 +147,7 @@ describe Scan do
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
       result = @test_command_generator.generate
-      expect(result.last).to include("| xcpretty -f `custom-formatter`")
+      expect(result.last).to include("| xcpretty -f 'custom-formatter'")
     end
 
     describe "Standard Example" do

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -1,6 +1,6 @@
 describe Scan do
   before(:all) do
-    options = {project: "./scan/examples/standard/app.xcodeproj"}
+    options = { project: "./scan/examples/standard/app.xcodeproj" }
     config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
     @project = FastlaneCore::Project.new(config)
   end
@@ -67,7 +67,7 @@ describe Scan do
     allow(rt_response).to receive(:read).and_return("no\n")
     allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, rt_response, nil, nil)
 
-    allow(FastlaneCore::CommandExecutor).to receive(:execute).with(command: "sw_vers -productVersion", print_all: false, print_command: false).and_return("10.12.1")
+    allow(FastlaneCore::CommandExecutor).to receive(:execute).with(command: "sw_vers -productVersion", print_all: false, print_command: false).and_return('10.12.1')
 
     allow(Scan).to receive(:project).and_return(@project)
   end
@@ -81,7 +81,7 @@ describe Scan do
       tmp_path = Dir.mktmpdir
       path = "#{tmp_path}/notExistent"
       expect do
-        options = {project: path}
+        options = { project: path }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end.to raise_error("Project file not found at path '#{path}'")
     end
@@ -101,7 +101,7 @@ describe Scan do
       end
 
       it "passes the toolchain option to xcodebuild", requires_xcodebuild: true do
-        options = {project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0", toolchain: "com.apple.dt.toolchain.Swift_2_3"}
+        options = { project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0", toolchain: "com.apple.dt.toolchain.Swift_2_3" }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -115,7 +115,7 @@ describe Scan do
                                        "-toolchain 'com.apple.dt.toolchain.Swift_2_3'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
-                                       :test,
+                                       :test
                                      ])
       end
     end
@@ -123,8 +123,8 @@ describe Scan do
     it "supports additional parameters", requires_xcodebuild: true do
       log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-      xcargs = {DEBUG: "1", BUNDLE_NAME: "Example App"}
-      options = {project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0", xcargs: xcargs}
+      xcargs = { DEBUG: "1", BUNDLE_NAME: "Example App" }
+      options = { project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0", xcargs: xcargs }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
       result = @test_command_generator.generate
@@ -138,12 +138,12 @@ describe Scan do
                                      "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                      "DEBUG=1 BUNDLE_NAME=Example\\ App",
                                      :build,
-                                     :test,
+                                     :test
                                    ])
     end
 
     it "supports custom xcpretty formatter as a gem name", requires_xcodebuild: true do
-      options = {formatter: "custom-formatter", project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0"}
+      options = { formatter: "custom-formatter", project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
       result = @test_command_generator.generate
@@ -151,7 +151,7 @@ describe Scan do
     end
 
     it "supports custom xcpretty formatter as a path to a ruby file", requires_xcodebuild: true do
-      options = {formatter: "custom-formatter.rb", project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0"}
+      options = { formatter: "custom-formatter.rb", project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
       result = @test_command_generator.generate
@@ -160,7 +160,7 @@ describe Scan do
 
     describe "Standard Example" do
       before do
-        options = {project: "./scan/examples/standard/app.xcodeproj"}
+        options = { project: "./scan/examples/standard/app.xcodeproj" }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
@@ -176,7 +176,7 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
-                                       :test,
+                                       :test
                                      ])
       end
 
@@ -192,7 +192,7 @@ describe Scan do
       end
 
       it "#buildlog_path is used when provided", requires_xcodebuild: true do
-        options = {project: "./scan/examples/standard/app.xcodeproj", buildlog_path: "/tmp/my/path"}
+        options = { project: "./scan/examples/standard/app.xcodeproj", buildlog_path: "/tmp/my/path" }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
         result = @test_command_generator.xcodebuild_log_path
         expect(result).to include("/tmp/my/path")
@@ -206,7 +206,7 @@ describe Scan do
 
     describe "Derived Data Example" do
       before do
-        options = {project: "./scan/examples/standard/app.xcodeproj", derived_data_path: "/tmp/my/derived_data"}
+        options = { project: "./scan/examples/standard/app.xcodeproj", derived_data_path: "/tmp/my/derived_data" }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
@@ -222,14 +222,14 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '/tmp/my/derived_data'",
                                        :build,
-                                       :test,
+                                       :test
                                      ])
       end
     end
 
     describe "Test Max Concurrent Simulators" do
       before do
-        options = {project: "./scan/examples/standard/app.xcodeproj", max_concurrent_simulators: 3}
+        options = { project: "./scan/examples/standard/app.xcodeproj", max_concurrent_simulators: 3 }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
@@ -243,7 +243,7 @@ describe Scan do
 
     describe "Test Disable Concurrent Simulators" do
       before do
-        options = {project: "./scan/examples/standard/app.xcodeproj", disable_concurrent_testing: true}
+        options = { project: "./scan/examples/standard/app.xcodeproj", disable_concurrent_testing: true }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
@@ -259,24 +259,24 @@ describe Scan do
       context "extract system.logarchive" do
         it "copies all device logs to the output directory", requires_xcodebuild: true do
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
-            output_directory: "/tmp/scan_results",
+            output_directory: '/tmp/scan_results',
             include_simulator_logs: true,
             devices: ["iPhone 6s", "iPad Air"],
-            project: "./scan/examples/standard/app.xcodeproj",
+            project: './scan/examples/standard/app.xcodeproj'
           })
-          Scan.cache[:temp_junit_report] = "./scan/spec/fixtures/boring.log"
+          Scan.cache[:temp_junit_report] = './scan/spec/fixtures/boring.log'
 
           expect(FastlaneCore::CommandExecutor).
             to receive(:execute).
-              with(command: "xcrun simctl spawn 021A465B-A294-4D9E-AD07-6BDC8E186343 log collect --output /tmp/scan_results/system_logs-iPhone\\ 6s_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
+            with(command: "xcrun simctl spawn 021A465B-A294-4D9E-AD07-6BDC8E186343 log collect --output /tmp/scan_results/system_logs-iPhone\\ 6s_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
 
           expect(FastlaneCore::CommandExecutor).
             to receive(:execute).
-              with(command: "xcrun simctl spawn 2ABEAF08-E480-4617-894F-6BAB587E7963 log collect --output /tmp/scan_results/system_logs-iPad\\ Air_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
+            with(command: "xcrun simctl spawn 2ABEAF08-E480-4617-894F-6BAB587E7963 log collect --output /tmp/scan_results/system_logs-iPad\\ Air_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
 
           mock_test_result_parser = Object.new
           allow(Scan::TestResultParser).to receive(:new).and_return(mock_test_result_parser)
-          allow(mock_test_result_parser).to receive(:parse_result).and_return({tests: 100, failures: 0})
+          allow(mock_test_result_parser).to receive(:parse_result).and_return({ tests: 100, failures: 0 })
 
           mock_slack_poster = Object.new
           allow(Scan::SlackPoster).to receive(:new).and_return(mock_slack_poster)
@@ -284,7 +284,7 @@ describe Scan do
 
           mock_test_command_generator = Object.new
           allow(Scan::TestCommandGenerator).to receive(:new).and_return(mock_test_command_generator)
-          allow(mock_test_command_generator).to receive(:xcodebuild_log_path).and_return("./scan/spec/fixtures/boring.log")
+          allow(mock_test_command_generator).to receive(:xcodebuild_log_path).and_return('./scan/spec/fixtures/boring.log')
 
           Scan::Runner.new.handle_results(0)
         end
@@ -295,7 +295,7 @@ describe Scan do
       it "uses the correct build command with the example project", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-        options = {project: "./scan/examples/standard/app.xcodeproj", result_bundle: true, scheme: "app"}
+        options = { project: "./scan/examples/standard/app.xcodeproj", result_bundle: true, scheme: 'app' }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -308,7 +308,7 @@ describe Scan do
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        "-resultBundlePath './fastlane/test_output/app.test_result'",
                                        :build,
-                                       :test,
+                                       :test
                                      ])
       end
     end
@@ -317,8 +317,8 @@ describe Scan do
       it "only tests the test bundle/suite/cases specified in only_testing when the input is an array", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-        options = {project: "./scan/examples/standard/app.xcodeproj", scheme: "app",
-                   only_testing: %w(TestBundleA/TestSuiteB TestBundleC)}
+        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
+                    only_testing: %w(TestBundleA/TestSuiteB TestBundleC) }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -330,18 +330,18 @@ describe Scan do
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                       "-only-testing:TestBundleA/TestSuiteB",
-                                       "-only-testing:TestBundleC",
+                                       '-only-testing:TestBundleA/TestSuiteB',
+                                       '-only-testing:TestBundleC',
                                        :build,
-                                       :test,
+                                       :test
                                      ])
       end
 
       it "only tests the test bundle/suite/cases specified in only_testing when the input is a string", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-        options = {project: "./scan/examples/standard/app.xcodeproj", scheme: "app",
-                   only_testing: "TestBundleA/TestSuiteB"}
+        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
+                    only_testing: 'TestBundleA/TestSuiteB' }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -353,17 +353,17 @@ describe Scan do
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                       "-only-testing:TestBundleA/TestSuiteB",
+                                       '-only-testing:TestBundleA/TestSuiteB',
                                        :build,
-                                       :test,
+                                       :test
                                      ])
       end
 
       it "does not the test bundle/suite/cases specified in skip_testing when the input is an array", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-        options = {project: "./scan/examples/standard/app.xcodeproj", scheme: "app",
-                   skip_testing: %w(TestBundleA/TestSuiteB TestBundleC)}
+        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
+                    skip_testing: %w(TestBundleA/TestSuiteB TestBundleC) }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -375,18 +375,18 @@ describe Scan do
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                       "-skip-testing:TestBundleA/TestSuiteB",
-                                       "-skip-testing:TestBundleC",
+                                       '-skip-testing:TestBundleA/TestSuiteB',
+                                       '-skip-testing:TestBundleC',
                                        :build,
-                                       :test,
+                                       :test
                                      ])
       end
 
       it "does not the test bundle/suite/cases specified in skip_testing when the input is a string", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-        options = {project: "./scan/examples/standard/app.xcodeproj", scheme: "app",
-                   skip_testing: "TestBundleA/TestSuiteB"}
+        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
+                    skip_testing: 'TestBundleA/TestSuiteB' }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -398,15 +398,15 @@ describe Scan do
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                       "-skip-testing:TestBundleA/TestSuiteB",
+                                       '-skip-testing:TestBundleA/TestSuiteB',
                                        :build,
-                                       :test,
+                                       :test
                                      ])
       end
     end
 
     it "uses a device without version specifier", requires_xcodebuild: true do
-      options = {project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 6s"}
+      options = { project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 6s" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
       result = @test_command_generator.generate
@@ -419,12 +419,12 @@ describe Scan do
                                      "-destination 'platform=iOS Simulator,id=021A465B-A294-4D9E-AD07-6BDC8E186343'",
                                      "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                      :build,
-                                     :test,
+                                     :test
                                    ])
     end
 
     it "rejects devices with versions below deployment target", requires_xcodebuild: true do
-      options = {project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 5 (8.4)"}
+      options = { project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 5 (8.4)" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
       result = @test_command_generator.generate
@@ -433,10 +433,10 @@ describe Scan do
 
     describe "test-without-building and build-for-testing" do
       before do
-        options = {project: "./scan/examples/standard/app.xcodeproj", destination: [
+        options = { project: "./scan/examples/standard/app.xcodeproj", destination: [
           "platform=iOS Simulator,name=iPhone 6s,OS=9.3",
-          "platform=iOS Simulator,name=iPad Air 2,OS=9.2",
-        ]}
+          "platform=iOS Simulator,name=iPad Air 2,OS=9.2"
+        ] }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
@@ -451,7 +451,7 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                       "build-for-testing",
+                                       "build-for-testing"
                                      ])
       end
       it "should test-without-building", requires_xcodebuild: true do
@@ -465,7 +465,7 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                       "test-without-building",
+                                       "test-without-building"
                                      ])
       end
       it "should raise an exception if two build_modes are set", requires_xcodebuild: true do
@@ -491,17 +491,17 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        "-xctestrun '/folder/mytests.xctestrun'",
-                                       "test-without-building",
+                                       "test-without-building"
                                      ])
       end
     end
 
     describe "Multiple devices example" do
       it "uses multiple destinations", requires_xcodebuild: true do
-        options = {project: "./scan/examples/standard/app.xcodeproj", destination: [
+        options = { project: "./scan/examples/standard/app.xcodeproj", destination: [
           "platform=iOS Simulator,name=iPhone 6s,OS=9.3",
-          "platform=iOS Simulator,name=iPad Air 2,OS=9.2",
-        ]}
+          "platform=iOS Simulator,name=iPad Air 2,OS=9.2"
+        ] }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -514,15 +514,15 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
-                                       :test,
+                                       :test
                                      ])
       end
 
       it "uses multiple devices", requires_xcodebuild: true do
-        options = {project: "./scan/examples/standard/app.xcodeproj", devices: [
+        options = { project: "./scan/examples/standard/app.xcodeproj", devices: [
           "iPhone 6s (9.3)",
-          "iPad Air (9.3)",
-        ]}
+          "iPad Air (9.3)"
+        ] }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -535,15 +535,15 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,id=DD134998-177F-47DA-99FA-D549D9305476'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
-                                       :test,
+                                       :test
                                      ])
       end
 
       it "de-duplicates devices matching same simulator", requires_xcodebuild: true do
-        options = {project: "./scan/examples/standard/app.xcodeproj", devices: [
+        options = { project: "./scan/examples/standard/app.xcodeproj", devices: [
           "iPhone 5 (9.0)",
-          "iPhone 5 (9.0.0)",
-        ]}
+          "iPhone 5 (9.0.0)"
+        ] }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -555,16 +555,16 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,id=9905A018-9DC9-4DD8-BA14-B0B000CC8622'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
-                                       :test,
+                                       :test
                                      ])
       end
 
       it "raises an error if multiple devices are specified for `device`" do
         expect do
-          options = {project: "./scan/examples/standard/app.xcodeproj", device: [
+          options = { project: "./scan/examples/standard/app.xcodeproj", device: [
             "iPhone 6s (9.3)",
-            "iPad Air (9.3)",
-          ]}
+            "iPad Air (9.3)"
+          ] }
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
         end.to raise_error("'device' value must be a String! Found Array instead.")
       end
@@ -574,7 +574,7 @@ describe Scan do
           options = {
             project: "./scan/examples/standard/app.xcodeproj",
             device: ["iPhone 6s (9.3)"],
-            devices: ["iPhone 6"],
+            devices: ["iPhone 6"]
           }
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
         end.to raise_error("'device' value must be a String! Found Array instead.")

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -1,6 +1,6 @@
 describe Scan do
   before(:all) do
-    options = { project: "./scan/examples/standard/app.xcodeproj" }
+    options = {project: "./scan/examples/standard/app.xcodeproj"}
     config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
     @project = FastlaneCore::Project.new(config)
   end
@@ -67,7 +67,7 @@ describe Scan do
     allow(rt_response).to receive(:read).and_return("no\n")
     allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, rt_response, nil, nil)
 
-    allow(FastlaneCore::CommandExecutor).to receive(:execute).with(command: "sw_vers -productVersion", print_all: false, print_command: false).and_return('10.12.1')
+    allow(FastlaneCore::CommandExecutor).to receive(:execute).with(command: "sw_vers -productVersion", print_all: false, print_command: false).and_return("10.12.1")
 
     allow(Scan).to receive(:project).and_return(@project)
   end
@@ -81,7 +81,7 @@ describe Scan do
       tmp_path = Dir.mktmpdir
       path = "#{tmp_path}/notExistent"
       expect do
-        options = { project: path }
+        options = {project: path}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end.to raise_error("Project file not found at path '#{path}'")
     end
@@ -101,7 +101,7 @@ describe Scan do
       end
 
       it "passes the toolchain option to xcodebuild", requires_xcodebuild: true do
-        options = { project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0", toolchain: "com.apple.dt.toolchain.Swift_2_3" }
+        options = {project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0", toolchain: "com.apple.dt.toolchain.Swift_2_3"}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -115,7 +115,7 @@ describe Scan do
                                        "-toolchain 'com.apple.dt.toolchain.Swift_2_3'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
-                                       :test
+                                       :test,
                                      ])
       end
     end
@@ -123,8 +123,8 @@ describe Scan do
     it "supports additional parameters", requires_xcodebuild: true do
       log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-      xcargs = { DEBUG: "1", BUNDLE_NAME: "Example App" }
-      options = { project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0", xcargs: xcargs }
+      xcargs = {DEBUG: "1", BUNDLE_NAME: "Example App"}
+      options = {project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0", xcargs: xcargs}
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
       result = @test_command_generator.generate
@@ -138,21 +138,29 @@ describe Scan do
                                      "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                      "DEBUG=1 BUNDLE_NAME=Example\\ App",
                                      :build,
-                                     :test
+                                     :test,
                                    ])
     end
 
-    it "supports custom xcpretty formatter", requires_xcodebuild: true do
-      options = { formatter: "custom-formatter", project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0" }
+    it "supports custom xcpretty formatter as a gem name", requires_xcodebuild: true do
+      options = {formatter: "custom-formatter", project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0"}
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
       result = @test_command_generator.generate
-      expect(result.last).to include("| xcpretty -f 'custom-formatter'")
+      expect(result.last).to include("| xcpretty -f `custom-formatter`")
+    end
+
+    it "supports custom xcpretty formatter as a path to a ruby file", requires_xcodebuild: true do
+      options = {formatter: "custom-formatter.rb", project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0"}
+      Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+      result = @test_command_generator.generate
+      expect(result.last).to include("| xcpretty -f 'custom-formatter.rb'")
     end
 
     describe "Standard Example" do
       before do
-        options = { project: "./scan/examples/standard/app.xcodeproj" }
+        options = {project: "./scan/examples/standard/app.xcodeproj"}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
@@ -168,7 +176,7 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
-                                       :test
+                                       :test,
                                      ])
       end
 
@@ -184,7 +192,7 @@ describe Scan do
       end
 
       it "#buildlog_path is used when provided", requires_xcodebuild: true do
-        options = { project: "./scan/examples/standard/app.xcodeproj", buildlog_path: "/tmp/my/path" }
+        options = {project: "./scan/examples/standard/app.xcodeproj", buildlog_path: "/tmp/my/path"}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
         result = @test_command_generator.xcodebuild_log_path
         expect(result).to include("/tmp/my/path")
@@ -198,7 +206,7 @@ describe Scan do
 
     describe "Derived Data Example" do
       before do
-        options = { project: "./scan/examples/standard/app.xcodeproj", derived_data_path: "/tmp/my/derived_data" }
+        options = {project: "./scan/examples/standard/app.xcodeproj", derived_data_path: "/tmp/my/derived_data"}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
@@ -214,14 +222,14 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '/tmp/my/derived_data'",
                                        :build,
-                                       :test
+                                       :test,
                                      ])
       end
     end
 
     describe "Test Max Concurrent Simulators" do
       before do
-        options = { project: "./scan/examples/standard/app.xcodeproj", max_concurrent_simulators: 3 }
+        options = {project: "./scan/examples/standard/app.xcodeproj", max_concurrent_simulators: 3}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
@@ -235,7 +243,7 @@ describe Scan do
 
     describe "Test Disable Concurrent Simulators" do
       before do
-        options = { project: "./scan/examples/standard/app.xcodeproj", disable_concurrent_testing: true }
+        options = {project: "./scan/examples/standard/app.xcodeproj", disable_concurrent_testing: true}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
@@ -251,24 +259,24 @@ describe Scan do
       context "extract system.logarchive" do
         it "copies all device logs to the output directory", requires_xcodebuild: true do
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
-            output_directory: '/tmp/scan_results',
+            output_directory: "/tmp/scan_results",
             include_simulator_logs: true,
             devices: ["iPhone 6s", "iPad Air"],
-            project: './scan/examples/standard/app.xcodeproj'
+            project: "./scan/examples/standard/app.xcodeproj",
           })
-          Scan.cache[:temp_junit_report] = './scan/spec/fixtures/boring.log'
+          Scan.cache[:temp_junit_report] = "./scan/spec/fixtures/boring.log"
 
           expect(FastlaneCore::CommandExecutor).
             to receive(:execute).
-            with(command: "xcrun simctl spawn 021A465B-A294-4D9E-AD07-6BDC8E186343 log collect --output /tmp/scan_results/system_logs-iPhone\\ 6s_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
+              with(command: "xcrun simctl spawn 021A465B-A294-4D9E-AD07-6BDC8E186343 log collect --output /tmp/scan_results/system_logs-iPhone\\ 6s_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
 
           expect(FastlaneCore::CommandExecutor).
             to receive(:execute).
-            with(command: "xcrun simctl spawn 2ABEAF08-E480-4617-894F-6BAB587E7963 log collect --output /tmp/scan_results/system_logs-iPad\\ Air_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
+              with(command: "xcrun simctl spawn 2ABEAF08-E480-4617-894F-6BAB587E7963 log collect --output /tmp/scan_results/system_logs-iPad\\ Air_iOS_10.0.logarchive 2>/dev/null", print_all: false, print_command: true)
 
           mock_test_result_parser = Object.new
           allow(Scan::TestResultParser).to receive(:new).and_return(mock_test_result_parser)
-          allow(mock_test_result_parser).to receive(:parse_result).and_return({ tests: 100, failures: 0 })
+          allow(mock_test_result_parser).to receive(:parse_result).and_return({tests: 100, failures: 0})
 
           mock_slack_poster = Object.new
           allow(Scan::SlackPoster).to receive(:new).and_return(mock_slack_poster)
@@ -276,7 +284,7 @@ describe Scan do
 
           mock_test_command_generator = Object.new
           allow(Scan::TestCommandGenerator).to receive(:new).and_return(mock_test_command_generator)
-          allow(mock_test_command_generator).to receive(:xcodebuild_log_path).and_return('./scan/spec/fixtures/boring.log')
+          allow(mock_test_command_generator).to receive(:xcodebuild_log_path).and_return("./scan/spec/fixtures/boring.log")
 
           Scan::Runner.new.handle_results(0)
         end
@@ -287,7 +295,7 @@ describe Scan do
       it "uses the correct build command with the example project", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-        options = { project: "./scan/examples/standard/app.xcodeproj", result_bundle: true, scheme: 'app' }
+        options = {project: "./scan/examples/standard/app.xcodeproj", result_bundle: true, scheme: "app"}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -300,7 +308,7 @@ describe Scan do
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        "-resultBundlePath './fastlane/test_output/app.test_result'",
                                        :build,
-                                       :test
+                                       :test,
                                      ])
       end
     end
@@ -309,8 +317,8 @@ describe Scan do
       it "only tests the test bundle/suite/cases specified in only_testing when the input is an array", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
-                    only_testing: %w(TestBundleA/TestSuiteB TestBundleC) }
+        options = {project: "./scan/examples/standard/app.xcodeproj", scheme: "app",
+                   only_testing: %w(TestBundleA/TestSuiteB TestBundleC)}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -322,18 +330,18 @@ describe Scan do
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                       '-only-testing:TestBundleA/TestSuiteB',
-                                       '-only-testing:TestBundleC',
+                                       "-only-testing:TestBundleA/TestSuiteB",
+                                       "-only-testing:TestBundleC",
                                        :build,
-                                       :test
+                                       :test,
                                      ])
       end
 
       it "only tests the test bundle/suite/cases specified in only_testing when the input is a string", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
-                    only_testing: 'TestBundleA/TestSuiteB' }
+        options = {project: "./scan/examples/standard/app.xcodeproj", scheme: "app",
+                   only_testing: "TestBundleA/TestSuiteB"}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -345,17 +353,17 @@ describe Scan do
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                       '-only-testing:TestBundleA/TestSuiteB',
+                                       "-only-testing:TestBundleA/TestSuiteB",
                                        :build,
-                                       :test
+                                       :test,
                                      ])
       end
 
       it "does not the test bundle/suite/cases specified in skip_testing when the input is an array", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
-                    skip_testing: %w(TestBundleA/TestSuiteB TestBundleC) }
+        options = {project: "./scan/examples/standard/app.xcodeproj", scheme: "app",
+                   skip_testing: %w(TestBundleA/TestSuiteB TestBundleC)}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -367,18 +375,18 @@ describe Scan do
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                       '-skip-testing:TestBundleA/TestSuiteB',
-                                       '-skip-testing:TestBundleC',
+                                       "-skip-testing:TestBundleA/TestSuiteB",
+                                       "-skip-testing:TestBundleC",
                                        :build,
-                                       :test
+                                       :test,
                                      ])
       end
 
       it "does not the test bundle/suite/cases specified in skip_testing when the input is a string", requires_xcodebuild: true do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-        options = { project: "./scan/examples/standard/app.xcodeproj", scheme: 'app',
-                    skip_testing: 'TestBundleA/TestSuiteB' }
+        options = {project: "./scan/examples/standard/app.xcodeproj", scheme: "app",
+                   skip_testing: "TestBundleA/TestSuiteB"}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -390,15 +398,15 @@ describe Scan do
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                       '-skip-testing:TestBundleA/TestSuiteB',
+                                       "-skip-testing:TestBundleA/TestSuiteB",
                                        :build,
-                                       :test
+                                       :test,
                                      ])
       end
     end
 
     it "uses a device without version specifier", requires_xcodebuild: true do
-      options = { project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 6s" }
+      options = {project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 6s"}
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
       result = @test_command_generator.generate
@@ -411,12 +419,12 @@ describe Scan do
                                      "-destination 'platform=iOS Simulator,id=021A465B-A294-4D9E-AD07-6BDC8E186343'",
                                      "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                      :build,
-                                     :test
+                                     :test,
                                    ])
     end
 
     it "rejects devices with versions below deployment target", requires_xcodebuild: true do
-      options = { project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 5 (8.4)" }
+      options = {project: "./scan/examples/standard/app.xcodeproj", device: "iPhone 5 (8.4)"}
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
       result = @test_command_generator.generate
@@ -425,10 +433,10 @@ describe Scan do
 
     describe "test-without-building and build-for-testing" do
       before do
-        options = { project: "./scan/examples/standard/app.xcodeproj", destination: [
+        options = {project: "./scan/examples/standard/app.xcodeproj", destination: [
           "platform=iOS Simulator,name=iPhone 6s,OS=9.3",
-          "platform=iOS Simulator,name=iPad Air 2,OS=9.2"
-        ] }
+          "platform=iOS Simulator,name=iPad Air 2,OS=9.2",
+        ]}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 
@@ -443,7 +451,7 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                       "build-for-testing"
+                                       "build-for-testing",
                                      ])
       end
       it "should test-without-building", requires_xcodebuild: true do
@@ -457,7 +465,7 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
-                                       "test-without-building"
+                                       "test-without-building",
                                      ])
       end
       it "should raise an exception if two build_modes are set", requires_xcodebuild: true do
@@ -483,17 +491,17 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        "-xctestrun '/folder/mytests.xctestrun'",
-                                       "test-without-building"
+                                       "test-without-building",
                                      ])
       end
     end
 
     describe "Multiple devices example" do
       it "uses multiple destinations", requires_xcodebuild: true do
-        options = { project: "./scan/examples/standard/app.xcodeproj", destination: [
+        options = {project: "./scan/examples/standard/app.xcodeproj", destination: [
           "platform=iOS Simulator,name=iPhone 6s,OS=9.3",
-          "platform=iOS Simulator,name=iPad Air 2,OS=9.2"
-        ] }
+          "platform=iOS Simulator,name=iPad Air 2,OS=9.2",
+        ]}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -506,15 +514,15 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
-                                       :test
+                                       :test,
                                      ])
       end
 
       it "uses multiple devices", requires_xcodebuild: true do
-        options = { project: "./scan/examples/standard/app.xcodeproj", devices: [
+        options = {project: "./scan/examples/standard/app.xcodeproj", devices: [
           "iPhone 6s (9.3)",
-          "iPad Air (9.3)"
-        ] }
+          "iPad Air (9.3)",
+        ]}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -527,15 +535,15 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,id=DD134998-177F-47DA-99FA-D549D9305476'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
-                                       :test
+                                       :test,
                                      ])
       end
 
       it "de-duplicates devices matching same simulator", requires_xcodebuild: true do
-        options = { project: "./scan/examples/standard/app.xcodeproj", devices: [
+        options = {project: "./scan/examples/standard/app.xcodeproj", devices: [
           "iPhone 5 (9.0)",
-          "iPhone 5 (9.0.0)"
-        ] }
+          "iPhone 5 (9.0.0)",
+        ]}
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = @test_command_generator.generate
@@ -547,16 +555,16 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,id=9905A018-9DC9-4DD8-BA14-B0B000CC8622'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        :build,
-                                       :test
+                                       :test,
                                      ])
       end
 
       it "raises an error if multiple devices are specified for `device`" do
         expect do
-          options = { project: "./scan/examples/standard/app.xcodeproj", device: [
+          options = {project: "./scan/examples/standard/app.xcodeproj", device: [
             "iPhone 6s (9.3)",
-            "iPad Air (9.3)"
-          ] }
+            "iPad Air (9.3)",
+          ]}
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
         end.to raise_error("'device' value must be a String! Found Array instead.")
       end
@@ -566,7 +574,7 @@ describe Scan do
           options = {
             project: "./scan/examples/standard/app.xcodeproj",
             device: ["iPhone 6s (9.3)"],
-            devices: ["iPhone 6"]
+            devices: ["iPhone 6"],
           }
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
         end.to raise_error("'device' value must be a String! Found Array instead.")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->

Fixed the 'formatter' argument for scan using backticks to quote the value. Couldn't run scan with a custom formatter.