### PR TITLE
Version bump to 2.98.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 
 <table id='team'>
 <tr>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+<h4 align='center'>Jimmy Dee</h4>
 </td>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
@@ -50,31 +44,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
 </td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-</tr>
-<tr>
 <td id='danielle-tomlinson'>
 <a href='https://github.com/DanToml'>
 <img src='https://github.com/DanToml.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
 </td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+</tr>
+<tr>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 <td id='matthew-ellis'>
 <a href='https://github.com/matthewellis'>
@@ -82,43 +76,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/AndrewMcBurney'>
-<img src='https://github.com/AndrewMcBurney.png?size=140'>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-</tr>
-<tr>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
 <td id='felix-krause'>
 <a href='https://github.com/KrauseFx'>
@@ -128,23 +96,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
 <td id='aaron-brager'>
 <a href='https://github.com/getaaron'>
@@ -157,6 +113,50 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <img src='https://github.com/giginet.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/AndrewMcBurney'>
+<img src='https://github.com/AndrewMcBurney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+</tr>
+<tr>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
 </tr>
 </table>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -14,26 +14,26 @@ File.write("#{lib}/fastlane/plugins/template/.rubocop.yml", YAML.dump(config))
 Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
-  spec.authors       = ["Danielle Tomlinson",
+  spec.authors       = ["Stefan Natchev",
+                        "Jimmy Dee",
+                        "Maksym Grebenets",
                         "Joshua Liebowitz",
-                        "Andrew McBurney",
-                        "Manu Wallner",
                         "Jérôme Lacoste",
-                        "Aaron Brager",
+                        "Helmut Januschka",
+                        "Matthew Ellis",
                         "Kohki Miki",
                         "Felix Krause",
-                        "Iulian Onofrei",
-                        "Fumiya Nakamura",
-                        "Maksym Grebenets",
                         "Josh Holtz",
-                        "Jorge Revuelta H",
-                        "Matthew Ellis",
-                        "Jimmy Dee",
-                        "Luka Mirosevic",
                         "Jan Piotrowski",
-                        "Stefan Natchev",
-                        "Helmut Januschka",
-                        "Olivier Halligon"]
+                        "Danielle Tomlinson",
+                        "Aaron Brager",
+                        "Manu Wallner",
+                        "Jorge Revuelta H",
+                        "Olivier Halligon",
+                        "Fumiya Nakamura",
+                        "Iulian Onofrei",
+                        "Luka Mirosevic",
+                        "Andrew McBurney"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.97.0'.freeze
+  VERSION = '2.98.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.97.0
+// Generated with fastlane 2.98.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -2033,7 +2033,8 @@ func mailgun(mailgunSandboxDomain: String? = nil,
              ciBuildLink: String? = nil,
              templatePath: String? = nil,
              replyTo: String? = nil,
-             attachment: String? = nil) {
+             attachment: String? = nil,
+             customPlaceholders: [String : Any] = [:]) {
   let command = RubyCommand(commandID: "", methodName: "mailgun", className: nil, args: [RubyCommand.Argument(name: "mailgun_sandbox_domain", value: mailgunSandboxDomain),
                                                                                          RubyCommand.Argument(name: "mailgun_sandbox_postmaster", value: mailgunSandboxPostmaster),
                                                                                          RubyCommand.Argument(name: "mailgun_apikey", value: mailgunApikey),
@@ -2048,7 +2049,8 @@ func mailgun(mailgunSandboxDomain: String? = nil,
                                                                                          RubyCommand.Argument(name: "ci_build_link", value: ciBuildLink),
                                                                                          RubyCommand.Argument(name: "template_path", value: templatePath),
                                                                                          RubyCommand.Argument(name: "reply_to", value: replyTo),
-                                                                                         RubyCommand.Argument(name: "attachment", value: attachment)])
+                                                                                         RubyCommand.Argument(name: "attachment", value: attachment),
+                                                                                         RubyCommand.Argument(name: "custom_placeholders", value: customPlaceholders)])
   _ = runner.executeCommand(command)
 }
 func makeChangelogFromJenkins(fallbackChangelog: String = "",
@@ -2130,6 +2132,7 @@ func nexusUpload(file: String,
                  username: String,
                  password: String,
                  sslVerify: Bool = true,
+                 nexusVersion: Int = 2,
                  verbose: Bool = false,
                  proxyUsername: String? = nil,
                  proxyPassword: String? = nil,
@@ -2146,6 +2149,7 @@ func nexusUpload(file: String,
                                                                                               RubyCommand.Argument(name: "username", value: username),
                                                                                               RubyCommand.Argument(name: "password", value: password),
                                                                                               RubyCommand.Argument(name: "ssl_verify", value: sslVerify),
+                                                                                              RubyCommand.Argument(name: "nexus_version", value: nexusVersion),
                                                                                               RubyCommand.Argument(name: "verbose", value: verbose),
                                                                                               RubyCommand.Argument(name: "proxy_username", value: proxyUsername),
                                                                                               RubyCommand.Argument(name: "proxy_password", value: proxyPassword),
@@ -2295,7 +2299,8 @@ func pilot(username: String,
            devPortalTeamId: String? = nil,
            itcProvider: String? = nil,
            groups: [String]? = nil,
-           waitForUploadedBuild: Bool = false) {
+           waitForUploadedBuild: Bool = false,
+           rejectBuildWaitingForReview: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "pilot", className: nil, args: [RubyCommand.Argument(name: "username", value: username),
                                                                                        RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                        RubyCommand.Argument(name: "app_platform", value: appPlatform),
@@ -2320,7 +2325,8 @@ func pilot(username: String,
                                                                                        RubyCommand.Argument(name: "dev_portal_team_id", value: devPortalTeamId),
                                                                                        RubyCommand.Argument(name: "itc_provider", value: itcProvider),
                                                                                        RubyCommand.Argument(name: "groups", value: groups),
-                                                                                       RubyCommand.Argument(name: "wait_for_uploaded_build", value: waitForUploadedBuild)])
+                                                                                       RubyCommand.Argument(name: "wait_for_uploaded_build", value: waitForUploadedBuild),
+                                                                                       RubyCommand.Argument(name: "reject_build_waiting_for_review", value: rejectBuildWaitingForReview)])
   _ = runner.executeCommand(command)
 }
 func pluginScores(outputPath: String,
@@ -3403,7 +3409,8 @@ func testflight(username: String,
                 devPortalTeamId: String? = nil,
                 itcProvider: String? = nil,
                 groups: [String]? = nil,
-                waitForUploadedBuild: Bool = false) {
+                waitForUploadedBuild: Bool = false,
+                rejectBuildWaitingForReview: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "testflight", className: nil, args: [RubyCommand.Argument(name: "username", value: username),
                                                                                             RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                             RubyCommand.Argument(name: "app_platform", value: appPlatform),
@@ -3428,7 +3435,8 @@ func testflight(username: String,
                                                                                             RubyCommand.Argument(name: "dev_portal_team_id", value: devPortalTeamId),
                                                                                             RubyCommand.Argument(name: "itc_provider", value: itcProvider),
                                                                                             RubyCommand.Argument(name: "groups", value: groups),
-                                                                                            RubyCommand.Argument(name: "wait_for_uploaded_build", value: waitForUploadedBuild)])
+                                                                                            RubyCommand.Argument(name: "wait_for_uploaded_build", value: waitForUploadedBuild),
+                                                                                            RubyCommand.Argument(name: "reject_build_waiting_for_review", value: rejectBuildWaitingForReview)])
   _ = runner.executeCommand(command)
 }
 func tryouts(appId: String,
@@ -3463,7 +3471,7 @@ func typetalk() {
   let command = RubyCommand(commandID: "", methodName: "typetalk", className: nil, args: [])
   _ = runner.executeCommand(command)
 }
-func unlockKeychain(path: String,
+func unlockKeychain(path: String = "login",
                     password: String,
                     addToSearchList: Bool = true,
                     setDefault: Bool = false) {
@@ -3787,7 +3795,8 @@ func uploadToTestflight(username: String,
                         devPortalTeamId: String? = nil,
                         itcProvider: String? = nil,
                         groups: [String]? = nil,
-                        waitForUploadedBuild: Bool = false) {
+                        waitForUploadedBuild: Bool = false,
+                        rejectBuildWaitingForReview: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "upload_to_testflight", className: nil, args: [RubyCommand.Argument(name: "username", value: username),
                                                                                                       RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                                       RubyCommand.Argument(name: "app_platform", value: appPlatform),
@@ -3812,7 +3821,8 @@ func uploadToTestflight(username: String,
                                                                                                       RubyCommand.Argument(name: "dev_portal_team_id", value: devPortalTeamId),
                                                                                                       RubyCommand.Argument(name: "itc_provider", value: itcProvider),
                                                                                                       RubyCommand.Argument(name: "groups", value: groups),
-                                                                                                      RubyCommand.Argument(name: "wait_for_uploaded_build", value: waitForUploadedBuild)])
+                                                                                                      RubyCommand.Argument(name: "wait_for_uploaded_build", value: waitForUploadedBuild),
+                                                                                                      RubyCommand.Argument(name: "reject_build_waiting_for_review", value: rejectBuildWaitingForReview)])
   _ = runner.executeCommand(command)
 }
 func verifyBuild(provisioningType: String? = nil,
@@ -4041,4 +4051,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.20]
+// FastlaneRunnerAPIVersion [0.9.21]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.97.0
+// Generated with fastlane 2.98.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.97.0
+// Generated with fastlane 2.98.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.97.0
+// Generated with fastlane 2.98.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.97.0
+// Generated with fastlane 2.98.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.97.0
+// Generated with fastlane 2.98.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.97.0
+// Generated with fastlane 2.98.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.97.0':**

* [supply] set google client send_timeout (#12732) via Josh Holtz
* fixes doc on how to use export_options in Gymfile (#12730) via Josh Holtz
* Prevent automatic_code_signing spec from changing test fixture (#12716) via Josh Holtz
* [pilot] - reject previous 'waiting for review' build (#12565) via Rishabh Tayal
* Lock xcpretty at 0.2.x to prevent auto 0.3.x updates (#12715) via Josh Holtz
* [action] app_store_build_number now nicely alerts user when no live version (#12742) via Josh Holtz
* [snapshot] initialize directories on retry and clear collected_errors on retry (#12737) via Josh Holtz
* [mailgun] Add ability to pass custom placeholders (#12720) via Alexandre Lision
* Make Carthage action support dependencies for bootstrap command (#12684) via Michael Sanders
* [nexus_upload] Add support for Nexus 3 (#12620) via Michael Diodone
* Login is the default keychain name (#12614) via Dylan Gyesbreghs
* Update push_notifications to push_notification (#12736) via devingops
* Ensure correct formatting for code snippets (#12735) via Iulian Onofrei
* require terminal-table in files that didn't (#12727) via Josh Holtz
* Add support for the latest capabilities available in the Developer Portal (#12685) via Sergio Campamá
