### PR TITLE
Re-add metrics

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -220,11 +220,7 @@ module Fastlane
       actions_path = File.join(File.expand_path("..", path), 'actions')
       Fastlane::Actions.load_external_actions(actions_path) if File.directory?(actions_path)
 
-      action_launched('import')
-
       return_value = parse(File.read(path), path)
-
-      action_completed('import', status: FastlaneCore::ActionCompletionStatus::SUCCESS)
 
       return return_value
     end
@@ -238,8 +234,6 @@ module Fastlane
 
       Actions.execute_action('import_from_git') do
         require 'tmpdir'
-
-        action_launched('import_from_git')
 
         # Checkout the repo
         repo_name = url.split("/").last
@@ -273,8 +267,6 @@ module Fastlane
           end
 
           return_value = import(File.join(clone_folder, path))
-
-          action_completed('import_from_git', status: FastlaneCore::ActionCompletionStatus::SUCCESS)
 
           return return_value
         end
@@ -316,28 +308,12 @@ module Fastlane
       # Overwrite this, since there is already a 'puts' method defined in the Ruby standard library
       value ||= yield if block_given?
 
-      action_launched('puts')
-      return_value = Fastlane::Actions::PutsAction.run([value])
-      action_completed('puts', status: FastlaneCore::ActionCompletionStatus::SUCCESS)
-      return return_value
+      return Fastlane::Actions::PutsAction.run([value])
     end
 
     def test(params = {})
       # Overwrite this, since there is already a 'test' method defined in the Ruby standard library
       self.runner.try_switch_to_lane(:test, [params])
-    end
-
-    def action_launched(action_name)
-      action_launch_context = FastlaneCore::ActionLaunchContext.context_for_action_name(action_name,
-                                                                                        configuration_language: "ruby",
-                                                                                        args: ARGV)
-      FastlaneCore.session.action_launched(launch_context: action_launch_context)
-    end
-
-    def action_completed(action_name, status: nil)
-      completion_context = FastlaneCore::ActionCompletionContext.context_for_action_name(action_name, args: ARGV,
-                                                                                         status: status)
-      FastlaneCore.session.action_completed(completion_context: completion_context)
     end
   end
 end

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -328,15 +328,16 @@ module Fastlane
     end
 
     def action_launched(action_name)
-      # https://github.com/fastlane/fastlane/issues/11913
-      # action_launch_context = FastlaneCore::ActionLaunchContext.context_for_action_name(action_name, configuration_language: "ruby", args: ARGV)
-      # FastlaneCore.session.action_launched(launch_context: action_launch_context)
+      action_launch_context = FastlaneCore::ActionLaunchContext.context_for_action_name(action_name,
+                                                                                        configuration_language: "ruby",
+                                                                                        args: ARGV)
+      FastlaneCore.session.action_launched(launch_context: action_launch_context)
     end
 
     def action_completed(action_name, status: nil)
-      # https://github.com/fastlane/fastlane/issues/11913
-      # completion_context = FastlaneCore::ActionCompletionContext.context_for_action_name(action_name, args: ARGV, status: status)
-      # FastlaneCore.session.action_completed(completion_context: completion_context)
+      completion_context = FastlaneCore::ActionCompletionContext.context_for_action_name(action_name, args: ARGV,
+                                                                                         status: status)
+      FastlaneCore.session.action_completed(completion_context: completion_context)
     end
   end
 end

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -42,9 +42,6 @@ module Fastlane
 
       platform, lane = choose_lane(ff, platform) unless lane
 
-      # https://github.com/fastlane/fastlane/issues/11913
-      # FastlaneCore.session.is_fastfile = true
-
       # xcodeproj has a bug in certain versions that causes it to change directories
       # and not return to the original working directory
       # https://github.com/CocoaPods/Xcodeproj/issues/426

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -224,9 +224,10 @@ module Fastlane
       verify_supported_os(method_sym, class_ref)
 
       begin
-        # https://github.com/fastlane/fastlane/issues/11913
-        # launch_context = FastlaneCore::ActionLaunchContext.context_for_action_name(method_sym.to_s, configuration_language: configuration_language, args: ARGV)
-        # FastlaneCore.session.action_launched(launch_context: launch_context)
+        launch_context = FastlaneCore::ActionLaunchContext
+                           .context_for_action_name(method_sym.to_s,configuration_language: configuration_language,
+                                                    args: ARGV)
+        FastlaneCore.session.action_launched(launch_context: launch_context)
 
         Dir.chdir(custom_dir) do # go up from the fastlane folder, to the project folder
           # If another action is calling this action, we shouldn't show it in the summary

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -224,11 +224,6 @@ module Fastlane
       verify_supported_os(method_sym, class_ref)
 
       begin
-        launch_context = FastlaneCore::ActionLaunchContext
-                           .context_for_action_name(method_sym.to_s,configuration_language: configuration_language,
-                                                    args: ARGV)
-        FastlaneCore.session.action_launched(launch_context: launch_context)
-
         Dir.chdir(custom_dir) do # go up from the fastlane folder, to the project folder
           # If another action is calling this action, we shouldn't show it in the summary
           # (see https://github.com/fastlane/fastlane/issues/4546)
@@ -255,11 +250,7 @@ module Fastlane
               puts("==========================================\n".deprecated)
             end
             class_ref.runner = self # needed to call another action form an action
-            return_value = class_ref.run(arguments)
-
-            action_completed(method_sym.to_s, status: FastlaneCore::ActionCompletionStatus::SUCCESS)
-
-            return return_value
+            return class_ref.run(arguments)
           end
         end
       rescue Interrupt => e

--- a/fastlane/lib/fastlane/swift_lane_manager.rb
+++ b/fastlane/lib/fastlane/swift_lane_manager.rb
@@ -15,8 +15,6 @@ module Fastlane
       # https://github.com/CocoaPods/Xcodeproj/issues/426
       # Setting this environment variable causes xcodeproj to work around the problem
       ENV["FORK_XCODE_WRITING"] = "true"
-      # https://github.com/fastlane/fastlane/issues/11913
-      # FastlaneCore.session.is_fastfile = true
 
       Fastlane::Helper::DotenvHelper.load_dot_env(env)
 

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_event_builder.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_event_builder.rb
@@ -1,50 +1,21 @@
 module FastlaneCore
   class AnalyticsEventBuilder
-    attr_accessor :base_hash
     attr_accessor :action_name
 
-    def initialize(oauth_app_name: nil, p_hash: nil, session_id: nil, action_name: nil, timestamp_millis: (Time.now.to_f * 1000).to_i)
+    def initialize(p_hash: nil, session_id: nil, action_name: nil)
+      @p_hash = p_hash
+      @session_id = session_id
       @action_name = action_name
-      @base_hash = {
-        event_source: {
-          oauth_app_name: oauth_app_name,
-          product: 'fastlane'
-        },
-        actor: {
-          name: p_hash,
-          detail: session_id
-        },
-        millis_since_epoch: timestamp_millis,
-        version: 1
+    end
+
+    def new_event(action_stage)
+      {
+        client_id: @session_id,
+        category: :undefined,
+        action: action_stage,
+        label: action_name,
+        value: nil
       }
-    end
-
-    def launched_event(primary_target_hash: nil, secondary_target_hash: nil)
-      return new_event(
-        stage: 'launched',
-        primary_target_hash: primary_target_hash,
-        secondary_target_hash: secondary_target_hash
-      )
-    end
-
-    def completed_event(primary_target_hash: nil, secondary_target_hash: nil)
-      return new_event(
-        stage: 'completed',
-        primary_target_hash: primary_target_hash,
-        secondary_target_hash: secondary_target_hash
-      )
-    end
-
-    def new_event(stage: nil, primary_target_hash: nil, secondary_target_hash: nil)
-      raise 'Need at least a primary_target_hash' if primary_target_hash.nil?
-      event = base_hash.dup
-      event[:action] = {
-          name: stage,
-          detail: action_name
-      }
-      event[:primary_target] = primary_target_hash
-      event[:secondary_target] = secondary_target_hash unless secondary_target_hash.nil?
-      return event
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_event_builder.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_event_builder.rb
@@ -10,7 +10,7 @@ module FastlaneCore
 
     def new_event(action_stage)
       {
-        client_id: @session_id,
+        client_id: @p_hash,
         category: :undefined,
         action: action_stage,
         label: action_name,

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_ingester_client.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_ingester_client.rb
@@ -11,7 +11,9 @@ module FastlaneCore
     end
 
     def post_events(events)
-      unless Helper.test?
+      # If our users want to opt out of usage metrics, don't post the events.
+      # Learn more at https://docs.fastlane.tools/#metrics
+    unless Helper.test? or FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
         Thread.new do
           send_request(events)
         end

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_ingester_client.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_ingester_client.rb
@@ -14,55 +14,40 @@ module FastlaneCore
       @ga_tracking = ga_tracking
     end
 
-    def post_events(events)
+    def post_event(event)
       # If our users want to opt out of usage metrics, don't post the events.
       # Learn more at https://docs.fastlane.tools/#metrics
       if Helper.test? || FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
-        return
+        return nil
       end
-      Thread.new do
-        send_request(events)
+      return Thread.new do
+        send_request(event)
       end
     end
 
-    def send_request(events, retries: 2)
-      post_request(events)
+    def send_request(event, retries: 2)
+      post_request(event)
     rescue
       retries -= 1
       retry if retries >= 0
     end
 
-    def post_request(events)
-      if ENV['METRICS_DEBUG']
-        write_json(events.to_json)
-      end
-
+    def post_request(event)
       connection = Faraday.new(GA_URL) do |conn|
         conn.request(:url_encoded)
         conn.adapter(Faraday.default_adapter)
-        if ENV['METRICS_DEBUG']
-          conn.proxy = "https://127.0.0.1:8888"
-          conn.ssl[:verify_mode] = OpenSSL::SSL::VERIFY_NONE
-        end
       end
-      connection.headers[:user_agent] = 'fastlane'
-      events.each do |event|
-        connection.post("/collect", {
-          v: "1",                                            # API Version
-          tid: @ga_tracking,                                 # Tracking ID / Property ID
-          cid: event[:category],                             # Client ID
-          t: "event",                                        # Event hit type
-          ec: event[:category],                              # Event category
-          ea: event[:action],                                # Event action
-          el: event[:label] || "na",                         # Event label
-          ev: event[:value] || "0"                           # Event value
-        })
-      end
-    end
-
-    # This method is only for debugging purposes
-    def write_json(body)
-      File.write("#{ENV['HOME']}/Desktop/mock_analytics-#{Time.now.to_i}.json", body)
+      connection.headers[:user_agent] = 'fastlane/' + Fastlane::VERSION
+      connection.post("/collect", {
+        v: "1",                                            # API Version
+        tid: @ga_tracking,                                 # Tracking ID / Property ID
+        cid: event[:client_id],                            # Client ID
+        t: "event",                                        # Event hit type
+        ec: event[:category],                              # Event category
+        ea: event[:action],                                # Event action
+        el: event[:label] || "na",                         # Event label
+        ev: event[:value] || "0"                           # Event value
+      })
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_ingester_client.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_ingester_client.rb
@@ -1,43 +1,57 @@
+require 'faraday'
 require 'openssl'
+require 'json'
 
 require_relative '../helper'
 
 module FastlaneCore
   class AnalyticsIngesterClient
+    def initialize(ga_tracking)
+      @ga_tracking = ga_tracking
+    end
+
     def post_events(events)
       unless Helper.test?
         Thread.new do
-          send_request(json: { analytics: events }.to_json)
+          send_request(events)
         end
       end
       return true
     end
 
-    def send_request(json: nil, retries: 2)
-      post_request(body: json)
+    def send_request(events, retries: 2)
+      post_request(events)
     rescue
       retries -= 1
       retry if retries >= 0
     end
 
-    def post_request(body: nil)
+    def post_request(events)
       if ENV['METRICS_DEBUG']
-        write_json(body)
+        write_json(events.to_json)
       end
-      url = ENV["FASTLANE_METRICS_URL"] || "https://fastlane-metrics.fabric.io"
+      url = "https://www.google-analytics.com"
 
-      require 'faraday'
       connection = Faraday.new(url) do |conn|
+        conn.request(:url_encoded)
         conn.adapter(Faraday.default_adapter)
         if ENV['METRICS_DEBUG']
           conn.proxy = "https://127.0.0.1:8888"
           conn.ssl[:verify_mode] = OpenSSL::SSL::VERIFY_NONE
         end
       end
-      connection.post do |req|
-        req.url('/public')
-        req.headers['Content-Type'] = 'application/json'
-        req.body = body
+      connection.headers[:user_agent] = 'Fastlane'
+      events.each do |event|
+        connection.post("/collect", {
+          v: "1",                                            # API Version
+          tid: @ga_tracking,                                 # Tracking ID / Property ID
+          cid: event[:category],                             # Client ID
+          t: "event",                                        # Event hit type
+          ec: event[:category],                              # Event category
+          ea: event[:action],                                # Event action
+          el: event[:label] || "na",                         # Event label
+          ev: event[:value] || "0"                           # Event value
+        })
       end
     end
 

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -35,9 +35,7 @@ module FastlaneCore
     end
 
     def finalize_session
-      @threads.each do |thread|
-        thread.join
-      end
+      @threads.map(&:join)
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -15,9 +15,15 @@ module FastlaneCore
       @session_id = SecureRandom.uuid
       @client = analytics_ingester_client
       @threads = []
+      @launch_event_sent = false
     end
 
     def action_launched(launch_context: nil)
+      if @launch_event_sent || launch_context.p_hash.nil?
+        return
+      end
+
+      @launch_event_sent = true
       builder = AnalyticsEventBuilder.new(
         p_hash: launch_context.p_hash,
         session_id: session_id,

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -7,21 +7,19 @@ module FastlaneCore
     attr_accessor :session_id
     attr_accessor :client
     attr_accessor :events
-    attr_accessor :fastfile_id
     attr_accessor :is_fastfile
     alias fastfile? is_fastfile
 
-    # make this a method so that we can override it in monkey patches
-    def oauth_app_name
-      return 'fastlane_v2'
-    end
-
-    def initialize(analytics_ingester_client: AnalyticsIngesterClient.new)
+    def initialize(analytics_ingester_client: AnalyticsIngesterClient.new(ENV['GA_TRACKING_ID'] || "UA-120900387-1"))
       require 'securerandom'
       @session_id = SecureRandom.uuid
       @client = analytics_ingester_client
       @events = []
       @is_fastfile = false
+    end
+
+    def opt_out_metrics?
+      FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
     end
 
     def backfill_p_hashes(p_hash: nil)
@@ -31,94 +29,12 @@ module FastlaneCore
         # to be sent to analytics ingester.
         # If they are nil, we want to fill them in until we reach
         # an event that already has a p_hash.
-        if event[:actor][:name].nil? || event[:actor][:name] == ActionLaunchContext::UNKNOWN_P_HASH
-          event[:actor][:name] = p_hash
+        if event[:p_hash].nil? || event[:p_hash] == ActionLaunchContext::UNKNOWN_P_HASH
+          event[:p_hash] = p_hash
         else
           break
         end
       end
-    end
-
-    def action_launched(launch_context: nil)
-      backfill_p_hashes(p_hash: launch_context.p_hash)
-
-      builder = AnalyticsEventBuilder.new(
-        oauth_app_name: oauth_app_name,
-        p_hash: launch_context.p_hash,
-        session_id: session_id,
-        action_name: launch_context.action_name
-      )
-
-      @events << builder.launched_event(
-        primary_target_hash: {
-          name: 'fastlane_version',
-          detail: fastlane_version
-        }
-      )
-
-      @events << builder.launched_event(
-        primary_target_hash: {
-          name: 'configuration_language',
-          detail: launch_context.configuration_language
-        }
-      )
-
-      @events << builder.launched_event(
-        primary_target_hash: {
-          name: 'install_method',
-          detail: install_method
-        }
-      )
-
-      @events << builder.launched_event(
-        primary_target_hash: {
-          name: 'operating_system',
-          detail: operating_system
-        },
-        secondary_target_hash: {
-          name: 'version',
-          detail: operating_system_version
-        }
-      )
-
-      @events << builder.launched_event(
-        primary_target_hash: {
-          name: 'build_tool_version',
-          detail: launch_context.build_tool_version
-        }
-      )
-
-      @events << builder.launched_event(
-        primary_target_hash: {
-          name: 'ci',
-          detail: ci?.to_s
-        }
-      )
-
-      @events << builder.launched_event(
-        primary_target_hash: {
-          name: 'fastfile',
-          detail: fastfile?.to_s
-        },
-        secondary_target_hash: {
-          name: 'fastfile_id',
-          detail: fastfile_id.to_s
-        }
-      )
-
-      @events << builder.launched_event(
-        primary_target_hash: {
-          name: 'platform',
-          detail: launch_context.platform.to_s
-        }
-      )
-
-      @events << builder.launched_event(
-        primary_target_hash: {
-          name: 'ruby_version',
-          detail: ruby_version
-        }
-      )
     end
 
     def is_fastfile=(value)
@@ -128,34 +44,33 @@ module FastlaneCore
         # We don't want to update if this is false because once we
         # detect a true value, that is the one to be trusted
         @events.reverse_each do |event|
-          event[:primary_target][:name] == 'fastfile' ? event[:primary_target][:detail] = value.to_s : next
+          # Follow-up: decide whether we need this
+          # event[:primary_target][:name] == 'fastfile' ? event[:primary_target][:detail] = value.to_s : next
         end
       end
       @is_fastfile = value
     end
 
-    def action_completed(completion_context: nil)
-      backfill_p_hashes(p_hash: completion_context.p_hash)
+    def action_launched(launch_context: nil)
+      backfill_p_hashes(p_hash: launch_context.p_hash)
 
       builder = AnalyticsEventBuilder.new(
-        oauth_app_name: oauth_app_name,
-        p_hash: completion_context.p_hash,
+        p_hash: launch_context.p_hash,
         session_id: session_id,
-        action_name: completion_context.action_name
+        action_name: nil
       )
 
-      @events << builder.completed_event(
-        primary_target_hash: {
-          name: 'status',
-          detail: completion_context.status
-        }
-      )
+      launch_events = [builder.new_event(:launch)]
+      client.post_events(launch_events)
+    end
+
+    def action_completed(completion_context: nil)
     end
 
     def finalize_session
       # If our users want to opt out of usage metrics, don't post the events.
       # Learn more at https://docs.fastlane.tools/#metrics
-      return if FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
+      return if opt_out_metrics?
 
       client.post_events(@events)
     end

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -4,18 +4,18 @@ require_relative 'analytics_event_builder'
 
 module FastlaneCore
   class AnalyticsSession
+    GA_TRACKING = "UA-121171860-1"
+
+    private_constant :GA_TRACKING
     attr_accessor :session_id
     attr_accessor :client
     attr_accessor :events
-    attr_accessor :is_fastfile
-    alias fastfile? is_fastfile
 
-    def initialize(analytics_ingester_client: AnalyticsIngesterClient.new(ENV['GA_TRACKING_ID'] || "UA-120900387-1"))
+    def initialize(analytics_ingester_client: AnalyticsIngesterClient.new(GA_TRACKING))
       require 'securerandom'
       @session_id = SecureRandom.uuid
       @client = analytics_ingester_client
       @events = []
-      @is_fastfile = false
     end
 
     def backfill_p_hashes(p_hash: nil)
@@ -31,20 +31,6 @@ module FastlaneCore
           break
         end
       end
-    end
-
-    def is_fastfile=(value)
-      if value
-        # If true, update all of the events to reflect
-        # that the execution is running within a Fastfile context.
-        # We don't want to update if this is false because once we
-        # detect a true value, that is the one to be trusted
-        @events.reverse_each do |event|
-          # Follow-up: decide whether we need this
-          # event[:primary_target][:name] == 'fastfile' ? event[:primary_target][:detail] = value.to_s : next
-        end
-      end
-      @is_fastfile = value
     end
 
     def action_launched(launch_context: nil)
@@ -65,49 +51,5 @@ module FastlaneCore
 
     def finalize_session
     end
-
-    # def fastlane_version
-    #   return Fastlane::VERSION
-    # end
-    #
-    # def ruby_version
-    #   patch_level = RUBY_PATCHLEVEL == 0 ? nil : "p#{RUBY_PATCHLEVEL}"
-    #   return "#{RUBY_VERSION}#{patch_level}"
-    # end
-    #
-    # def operating_system
-    #   return Helper.operating_system
-    # end
-    #
-    # def install_method
-    #   if Helper.rubygems?
-    #     return 'gem'
-    #   elsif Helper.bundler?
-    #     return 'bundler'
-    #   elsif Helper.mac_app?
-    #     return 'mac_app'
-    #   elsif Helper.contained_fastlane?
-    #     return 'standalone'
-    #   elsif Helper.homebrew?
-    #     return 'homebrew'
-    #   else
-    #     return 'unknown'
-    #   end
-    # end
-    #
-    # def ci?
-    #   return Helper.ci?
-    # end
-    #
-    # def operating_system_version
-    #   os = self.operating_system
-    #   case os
-    #   when "macOS"
-    #     return system('sw_vers', out: File::NULL) ? `sw_vers -productVersion`.strip : 'unknown'
-    #   else
-    #     # Need to test in Windows and Linux... not sure this is enough
-    #     return Gem::Platform.local.version
-    #   end
-    # end
   end
 end

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -9,47 +9,35 @@ module FastlaneCore
     private_constant :GA_TRACKING
     attr_accessor :session_id
     attr_accessor :client
-    attr_accessor :events
 
     def initialize(analytics_ingester_client: AnalyticsIngesterClient.new(GA_TRACKING))
       require 'securerandom'
       @session_id = SecureRandom.uuid
       @client = analytics_ingester_client
-      @events = []
-    end
-
-    def backfill_p_hashes(p_hash: nil)
-      return if p_hash.nil? || p_hash == ActionLaunchContext::UNKNOWN_P_HASH || @events.count == 0
-      @events.reverse_each do |event|
-        # event[:actor][:name] is the field in which we store the p_hash
-        # to be sent to analytics ingester.
-        # If they are nil, we want to fill them in until we reach
-        # an event that already has a p_hash.
-        if event[:p_hash].nil? || event[:p_hash] == ActionLaunchContext::UNKNOWN_P_HASH
-          event[:p_hash] = p_hash
-        else
-          break
-        end
-      end
+      @threads = []
     end
 
     def action_launched(launch_context: nil)
-      backfill_p_hashes(p_hash: launch_context.p_hash)
-
       builder = AnalyticsEventBuilder.new(
         p_hash: launch_context.p_hash,
         session_id: session_id,
         action_name: nil
       )
 
-      launch_events = [builder.new_event(:launch)]
-      client.post_events(launch_events)
+      launch_event = builder.new_event(:launch)
+      post_thread = client.post_event(launch_event)
+      unless post_thread.nil?
+        @threads << post_thread
+      end
     end
 
     def action_completed(completion_context: nil)
     end
 
     def finalize_session
+      @threads.each do |thread|
+        thread.join
+      end
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -18,10 +18,6 @@ module FastlaneCore
       @is_fastfile = false
     end
 
-    def opt_out_metrics?
-      FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
-    end
-
     def backfill_p_hashes(p_hash: nil)
       return if p_hash.nil? || p_hash == ActionLaunchContext::UNKNOWN_P_HASH || @events.count == 0
       @events.reverse_each do |event|
@@ -68,55 +64,50 @@ module FastlaneCore
     end
 
     def finalize_session
-      # If our users want to opt out of usage metrics, don't post the events.
-      # Learn more at https://docs.fastlane.tools/#metrics
-      return if opt_out_metrics?
-
-      client.post_events(@events)
     end
 
-    def fastlane_version
-      return Fastlane::VERSION
-    end
-
-    def ruby_version
-      patch_level = RUBY_PATCHLEVEL == 0 ? nil : "p#{RUBY_PATCHLEVEL}"
-      return "#{RUBY_VERSION}#{patch_level}"
-    end
-
-    def operating_system
-      return Helper.operating_system
-    end
-
-    def install_method
-      if Helper.rubygems?
-        return 'gem'
-      elsif Helper.bundler?
-        return 'bundler'
-      elsif Helper.mac_app?
-        return 'mac_app'
-      elsif Helper.contained_fastlane?
-        return 'standalone'
-      elsif Helper.homebrew?
-        return 'homebrew'
-      else
-        return 'unknown'
-      end
-    end
-
-    def ci?
-      return Helper.ci?
-    end
-
-    def operating_system_version
-      os = self.operating_system
-      case os
-      when "macOS"
-        return system('sw_vers', out: File::NULL) ? `sw_vers -productVersion`.strip : 'unknown'
-      else
-        # Need to test in Windows and Linux... not sure this is enough
-        return Gem::Platform.local.version
-      end
-    end
+    # def fastlane_version
+    #   return Fastlane::VERSION
+    # end
+    #
+    # def ruby_version
+    #   patch_level = RUBY_PATCHLEVEL == 0 ? nil : "p#{RUBY_PATCHLEVEL}"
+    #   return "#{RUBY_VERSION}#{patch_level}"
+    # end
+    #
+    # def operating_system
+    #   return Helper.operating_system
+    # end
+    #
+    # def install_method
+    #   if Helper.rubygems?
+    #     return 'gem'
+    #   elsif Helper.bundler?
+    #     return 'bundler'
+    #   elsif Helper.mac_app?
+    #     return 'mac_app'
+    #   elsif Helper.contained_fastlane?
+    #     return 'standalone'
+    #   elsif Helper.homebrew?
+    #     return 'homebrew'
+    #   else
+    #     return 'unknown'
+    #   end
+    # end
+    #
+    # def ci?
+    #   return Helper.ci?
+    # end
+    #
+    # def operating_system_version
+    #   os = self.operating_system
+    #   case os
+    #   when "macOS"
+    #     return system('sw_vers', out: File::NULL) ? `sw_vers -productVersion`.strip : 'unknown'
+    #   else
+    #     # Need to test in Windows and Linux... not sure this is enough
+    #     return Gem::Platform.local.version
+    #   end
+    # end
   end
 end

--- a/fastlane_core/lib/fastlane_core/analytics/app_identifier_guesser.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/app_identifier_guesser.rb
@@ -31,7 +31,7 @@ module FastlaneCore
     # Use the `FASTLANE_OPT_OUT_USAGE` variable to opt out
     # The resulting value is e.g. ce12f8371df11ef6097a83bdf2303e4357d6f5040acc4f76019489fa5deeae0d
     def generate_p_hash(app_id)
-      unless !FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE") && !app_id.nil?
+      if app_id.nil?
         return nil
       end
 

--- a/fastlane_core/lib/fastlane_core/module.rb
+++ b/fastlane_core/lib/fastlane_core/module.rb
@@ -12,14 +12,13 @@ module FastlaneCore
   # Specifically, in AnalyticsSession.finalize_session
   # Learn more at https://docs.fastlane.tools/#metrics
   def self.session
-    return nil
     # https://github.com/fastlane/fastlane/issues/11913
-    # @session ||= AnalyticsSession.new
+    @session ||= AnalyticsSession.new
   end
 
   def self.reset_session
     # https://github.com/fastlane/fastlane/issues/11913
-    # @session = nil
+    @session = nil
   end
 
   # A directory that's being used to user-wide fastlane configs

--- a/fastlane_core/lib/fastlane_core/module.rb
+++ b/fastlane_core/lib/fastlane_core/module.rb
@@ -12,12 +12,10 @@ module FastlaneCore
   # Specifically, in AnalyticsSession.finalize_session
   # Learn more at https://docs.fastlane.tools/#metrics
   def self.session
-    # https://github.com/fastlane/fastlane/issues/11913
     @session ||= AnalyticsSession.new
   end
 
   def self.reset_session
-    # https://github.com/fastlane/fastlane/issues/11913
     @session = nil
   end
 

--- a/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
+++ b/fastlane_core/lib/fastlane_core/ui/errors/fastlane_error.rb
@@ -20,7 +20,6 @@ end
 
 class Exception
   def fastlane_should_report_metrics?
-    # https://github.com/fastlane/fastlane/issues/11913
     return false
   end
 end

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -127,8 +127,8 @@ module Commander
         rescue_connection_failed_error(e)
       rescue => e # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
         rescue_unknown_error(e)
-        ensure
-          FastlaneCore.session.finalize_session
+      ensure
+        FastlaneCore.session.finalize_session
       end
     end
 

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -68,7 +68,6 @@ module Commander
           FastlaneCore::UI.user_error!("fastlane requires a minimum version of Xcode #{Fastlane::MINIMUM_XCODE_RELEASE}, please upgrade and make sure to use `sudo xcode-select -s /Applications/Xcode.app`")
         end
 
-        # https://github.com/fastlane/fastlane/issues/11913
         action_launch_context = FastlaneCore::ActionLaunchContext.context_for_action_name(@program[:name], args: ARGV)
         FastlaneCore.session.action_launched(launch_context: action_launch_context)
 
@@ -128,9 +127,8 @@ module Commander
         rescue_connection_failed_error(e)
       rescue => e # high chance this is actually FastlaneCore::Interface::FastlaneCrash, but can be anything else
         rescue_unknown_error(e)
-        # https://github.com/fastlane/fastlane/issues/11913
-        # ensure
-        #   FastlaneCore.session.finalize_session
+        ensure
+          FastlaneCore.session.finalize_session
       end
     end
 

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -69,8 +69,8 @@ module Commander
         end
 
         # https://github.com/fastlane/fastlane/issues/11913
-        # action_launch_context = FastlaneCore::ActionLaunchContext.context_for_action_name(@program[:name], args: ARGV)
-        # FastlaneCore.session.action_launched(launch_context: action_launch_context)
+        action_launch_context = FastlaneCore::ActionLaunchContext.context_for_action_name(@program[:name], args: ARGV)
+        FastlaneCore.session.action_launched(launch_context: action_launch_context)
 
         return_value = run_active_command
 

--- a/fastlane_core/spec/analytics/analytics_event_builder_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_event_builder_spec.rb
@@ -1,120 +1,26 @@
 describe FastlaneCore::AnalyticsEventBuilder do
-  let(:oauth_app_name) { 'fastlane-tests' }
   let(:p_hash) { 'some.phash.value' }
   let(:session_id) { 's0m3s3ss10n1D' }
   let(:action_name) { 'some_action' }
-  let(:timestamp_millis) { 1_507_142_046_000 }
 
   let(:builder) do
     FastlaneCore::AnalyticsEventBuilder.new(
-      oauth_app_name: oauth_app_name,
       p_hash: p_hash,
       session_id: session_id,
-      action_name: action_name,
-      timestamp_millis: timestamp_millis
+      action_name: action_name
     )
   end
 
-  context '#launched_event' do
-    it 'creates a new launched event with primary target' do
-      event = builder.launched_event(
-        primary_target_hash: {
-          name: 'primary target name',
-          detail: 'primary target detail'
-        }
-      )
+  context '#launch_event' do
+    it 'creates a launch event' do
+      event = builder.new_event(:launch)
       expect(event).to eq(
         {
-          event_source: {
-            oauth_app_name: oauth_app_name,
-            product: 'fastlane'
-          },
-          actor: {
-            name: p_hash,
-            detail: session_id
-          },
-          action: {
-            name: 'launched',
-            detail: action_name
-          },
-          primary_target: {
-            name: 'primary target name',
-            detail: 'primary target detail'
-          },
-          millis_since_epoch: timestamp_millis,
-          version: 1
-        }
-      )
-    end
-
-    it 'creates a new launched event with primary and secondary targets' do
-      event = builder.launched_event(
-        primary_target_hash: {
-          name: 'primary target name',
-          detail: 'primary target detail'
-        },
-        secondary_target_hash: {
-          name: 'secondary target name',
-          detail: 'secondary target detail'
-        }
-      )
-      expect(event).to eq(
-        {
-          event_source: {
-            oauth_app_name: oauth_app_name,
-            product: 'fastlane'
-          },
-          actor: {
-            name: p_hash,
-            detail: session_id
-          },
-          action: {
-            name: 'launched',
-            detail: action_name
-          },
-          primary_target: {
-            name: 'primary target name',
-            detail: 'primary target detail'
-          },
-          secondary_target: {
-            name: 'secondary target name',
-            detail: 'secondary target detail'
-          },
-          millis_since_epoch: timestamp_millis,
-          version: 1
-        }
-      )
-    end
-  end
-
-  context '#completed_event' do
-    it 'creates a completed_event with a primary target' do
-      event = builder.completed_event(
-        primary_target_hash: {
-          name: 'primary target name',
-          detail: 'primary target detail'
-        }
-      )
-      expect(event).to eq(
-        {
-          event_source: {
-            oauth_app_name: oauth_app_name,
-            product: 'fastlane'
-          },
-          actor: {
-            name: p_hash,
-            detail: session_id
-          },
-          action: {
-            name: 'completed',
-            detail: action_name
-          },
-          primary_target: {
-            name: 'primary target name',
-            detail: 'primary target detail'
-          },
-          millis_since_epoch: timestamp_millis,
-          version: 1
+          client_id: p_hash,
+          category: :undefined,
+          action: :launch,
+          label: action_name,
+          value: nil
         }
       )
     end

--- a/fastlane_core/spec/analytics/analytics_session_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_session_spec.rb
@@ -26,7 +26,7 @@ describe FastlaneCore::AnalyticsSession do
         expect(SecureRandom).to receive(:uuid).and_return(session_id)
 
         # Stub out calls related to the execution environment
-        client = double('AnalyticsIngesterClient')
+        client = double("ingester_client")
         session = FastlaneCore::AnalyticsSession.new(analytics_ingester_client: client)
         expect(client).to receive(:post_events).with(instance_of(Array))
 

--- a/fastlane_core/spec/analytics/analytics_session_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_session_spec.rb
@@ -28,7 +28,13 @@ describe FastlaneCore::AnalyticsSession do
         # Stub out calls related to the execution environment
         client = double("ingester_client")
         session = FastlaneCore::AnalyticsSession.new(analytics_ingester_client: client)
-        expect(client).to receive(:post_events).with(instance_of(Array))
+        expect(client).to receive(:post_event).with({
+            client_id: p_hash,
+            category: :undefined,
+            action: :launch,
+            label: nil,
+            value: nil
+        })
 
         session.action_launched(launch_context: launch_context)
       end

--- a/fastlane_core/spec/analytics/analytics_session_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_session_spec.rb
@@ -1,13 +1,7 @@
 describe FastlaneCore::AnalyticsSession do
-  let(:oauth_app_name) { 'fastlane-tests' }
   let(:configuration_language) { 'ruby' }
   let(:p_hash) { 'some.phash.value' }
   let(:session_id) { 's0m3s3ss10n1D' }
-  let(:timestamp_millis) { 1_507_142_046 }
-  let(:fixture_dirname) do
-    dirname = File.expand_path(File.dirname(__FILE__))
-    File.join(dirname, './fixtures/')
-  end
 
   before(:each) do
     # This value needs to be set or our event fixtures will not match
@@ -28,162 +22,15 @@ describe FastlaneCore::AnalyticsSession do
         )
       end
 
-      let(:fixture_data) do
-        JSON.parse(File.read(File.join(fixture_dirname, '/launched.json')))
-      end
-
-      it "adds all events to the session's events array" do
+      it 'analytics session: launch' do
         expect(SecureRandom).to receive(:uuid).and_return(session_id)
-        allow(Time).to receive(:now).and_return(timestamp_millis)
 
         # Stub out calls related to the execution environment
-        session = FastlaneCore::AnalyticsSession.new
-        session.is_fastfile = true
-        allow(session).to receive(:oauth_app_name).and_return(oauth_app_name)
-        expect(session).to receive(:fastlane_version).and_return('2.5.0')
-        expect(session).to receive(:ruby_version).and_return('2.4.0')
-        expect(session).to receive(:operating_system_version).and_return('10.12')
-        expect(session).to receive(:fastfile_id).and_return('')
-
-        expect(FastlaneCore::Helper).to receive(:xcode_version).and_return('9.0.1')
+        client = double('AnalyticsIngesterClient')
+        session = FastlaneCore::AnalyticsSession.new(analytics_ingester_client: client)
+        expect(client).to receive(:post_events).with(instance_of(Array))
 
         session.action_launched(launch_context: launch_context)
-
-        parsed_events = JSON.parse(session.events.to_json)
-        parsed_events.zip(fixture_data).each do |parsed, fixture|
-          expect(parsed).to eq(fixture)
-        end
-      end
-
-      it 'is not executed via Fastfile' do
-        expect(SecureRandom).to receive(:uuid).and_return(session_id)
-        allow(Time).to receive(:now).and_return(timestamp_millis)
-
-        # Stub out calls related to the execution environment
-        session = FastlaneCore::AnalyticsSession.new
-        allow(session).to receive(:oauth_app_name).and_return(oauth_app_name)
-        expect(session).to receive(:fastlane_version).and_return('2.5.0')
-        expect(session).to receive(:ruby_version).and_return('2.4.0')
-        expect(session).to receive(:operating_system_version).and_return('10.12')
-
-        session.action_launched(launch_context: launch_context)
-
-        fastfile_events = session.events.select { |event| event[:primary_target][:name] == 'fastfile' }
-        expect(fastfile_events.count).to eq(1)
-        expect(fastfile_events.first[:primary_target][:detail]).to eq(false.to_s)
-      end
-    end
-
-    context 'action completion' do
-      let(:completion_context) do
-        FastlaneCore::ActionCompletionContext.new(
-          p_hash: p_hash,
-          status: FastlaneCore::ActionCompletionStatus::SUCCESS,
-          action_name: action_name
-        )
-      end
-
-      let(:fixture_data) do
-        event = JSON.parse(File.read(File.join(fixture_dirname, '/completed_success.json')))
-        event["action"]["detail"] = action_name
-        event
-      end
-
-      it 'appends a completion event to the events array' do
-        expect(SecureRandom).to receive(:uuid).and_return(session_id)
-        expect(Time).to receive(:now).and_return(timestamp_millis)
-
-        session = FastlaneCore::AnalyticsSession.new
-        expect(session).to receive(:oauth_app_name).and_return(oauth_app_name)
-
-        session.action_completed(completion_context: completion_context)
-        expect(JSON.parse(session.events.last.to_json)).to eq(fixture_data)
-      end
-    end
-  end
-
-  context 'two action execution' do
-    let(:session) { FastlaneCore::AnalyticsSession.new }
-    let(:action_1_name) { 'some_action1' }
-    let(:action_2_name) { 'some_action2' }
-
-    context 'action launch' do
-      let(:action_1_launch_context) do
-        FastlaneCore::ActionLaunchContext.new(
-          action_name: action_1_name,
-          p_hash: p_hash,
-          platform: 'ios',
-          configuration_language: configuration_language
-        )
-      end
-      let(:action_1_completion_context) do
-        FastlaneCore::ActionCompletionContext.new(
-          p_hash: p_hash,
-          status: FastlaneCore::ActionCompletionStatus::SUCCESS,
-          action_name: action_1_name
-        )
-      end
-      let(:action_2_launch_context) do
-        FastlaneCore::ActionLaunchContext.new(
-          action_name: action_2_name,
-          p_hash: p_hash,
-          platform: 'ios',
-          configuration_language: configuration_language
-        )
-      end
-      let(:action_2_completion_context) do
-        FastlaneCore::ActionCompletionContext.new(
-          p_hash: p_hash,
-          status: FastlaneCore::ActionCompletionStatus::SUCCESS,
-          action_name: action_2_name
-        )
-      end
-      let(:fixture_data_action_1_launched) do
-        events = JSON.parse(File.read(File.join(fixture_dirname, '/launched.json')))
-        events.each { |event| event["action"]["detail"] = action_1_name }
-        events
-      end
-      let(:fixture_data_action_2_launched) do
-        events = JSON.parse(File.read(File.join(fixture_dirname, '/launched.json')))
-        events.each { |event| event["action"]["detail"] = action_2_name }
-        events
-      end
-      let(:fixture_data_action_1_completed) do
-        event = JSON.parse(File.read(File.join(fixture_dirname, '/completed_success.json')))
-        event["action"]["detail"] = action_1_name
-        event
-      end
-      let(:fixture_data_action_2_completed) do
-        event = JSON.parse(File.read(File.join(fixture_dirname, '/completed_success.json')))
-        event["action"]["detail"] = action_2_name
-        event
-      end
-
-      it "adds all events to the session's events array" do
-        expect(SecureRandom).to receive(:uuid).and_return(session_id)
-        allow(Time).to receive(:now).and_return(timestamp_millis)
-
-        # Stub out calls related to the execution environment
-        session.is_fastfile = true
-        allow(session).to receive(:oauth_app_name).and_return(oauth_app_name)
-        expect(session).to receive(:fastlane_version).and_return('2.5.0').twice
-        expect(session).to receive(:ruby_version).and_return('2.4.0').twice
-        expect(session).to receive(:operating_system_version).and_return('10.12').twice
-        expect(session).to receive(:fastfile_id).and_return('').twice
-
-        expect(FastlaneCore::Helper).to receive(:xcode_version).and_return('9.0.1').twice
-
-        session.action_launched(launch_context: action_1_launch_context)
-        session.action_completed(completion_context: action_1_completion_context)
-        session.action_launched(launch_context: action_2_launch_context)
-        session.action_completed(completion_context: action_2_completion_context)
-
-        expected_final_array = fixture_data_action_1_launched + [fixture_data_action_1_completed] + fixture_data_action_2_launched + [fixture_data_action_2_completed]
-        parsed_events = JSON.parse(session.events.to_json)
-
-        parsed_events.zip(expected_final_array).each do |parsed, fixture|
-          expect(parsed).to eq(fixture)
-        end
       end
     end
   end


### PR DESCRIPTION
_fastlane_ tracks a few key metrics to understand how developers are using the tool and to help us know what areas need improvement. No personal/sensitive information is ever collected. Metrics that are collected include: 
 
* The number of _fastlane_ runs
* A salted hash of the app identifier or package name, which helps us anonymously identify unique usage of _fastlane_
 
You can easily opt-out of metrics collection by adding `opt_out_usage` at the top of your `Fastfile` or by setting the environment variable `FASTLANE_OPT_OUT_USAGE`.

Related https://github.com/fastlane/docs/pull/627

Remaining tasks:

- [x] One bug has to be fixed that sends analytics events per action @powerivq 
- [x] We should remove the `backfill_p_hashes` method
- [x] We have to fix sending the request for short Fastfiles @krausefx
- [x] Update code to not take an `events` array, but just a single `event`
- [x] Update user agent to include fastlane version number