### PR TITLE
[automatic_code_signing] create TargetAttributes for targets missing them

### DIFF
--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -17,8 +17,16 @@ module Fastlane
         end
 
         target_dictionary = project.targets.map { |f| { name: f.name, uuid: f.uuid, build_configuration_list: f.build_configuration_list } }
+        target_attributes = project.root_object.attributes["TargetAttributes"]
         changed_targets = []
-        project.root_object.attributes["TargetAttributes"].each do |target, sett|
+
+        target_dictionary.each do |props|
+          if !target_attributes.key?(props[:uuid])
+            target_attributes[props[:uuid]] = { }
+          end
+        end
+
+        target_attributes.each do |target, sett|
           found_target = target_dictionary.detect { |h| h[:uuid] == target }
           if params[:targets]
             # get target name

--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -21,8 +21,8 @@ module Fastlane
         changed_targets = []
 
         target_dictionary.each do |props|
-          if !target_attributes.key?(props[:uuid])
-            target_attributes[props[:uuid]] = { }
+          unless target_attributes.key?(props[:uuid])
+            target_attributes[props[:uuid]] = {}
           end
         end
 

--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -20,6 +20,7 @@ module Fastlane
         target_attributes = project.root_object.attributes["TargetAttributes"]
         changed_targets = []
 
+        # make sure TargetAttributes exist for all targets
         target_dictionary.each do |props|
           unless target_attributes.key?(props[:uuid])
             target_attributes[props[:uuid]] = {}


### PR DESCRIPTION

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
I have a project which had a `target` but did not have a `TargetAttributes` entry for that `target`. This was a new Cordova project.

<!-- Please describe in detail how you tested your changes. -->
I tested by creating a new project which exhibited the same issue as this problem solved. I used this code branch instead and was able to use the `automatic_code_signing` action on the target which I was previously having an issue with.

### Description
<!-- Describe your changes in detail -->
This change ensures a `TargetAttributes` entry exists for any `target`. Before looping through all `TargetAttributes` entries, this goes through all `Targets` and ensures an entry exists in `TargetAttributes`
