### PR TITLE
Fix fastlane session caching

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -394,7 +394,7 @@ module Spaceship
           # As this will raise an exception if the old session has expired
           # If the old session is still valid, we don't have to do anything else in this method
           # that's why we return true
-          return true if fetch_olympus_session.count > 0
+          return true if fetch_olympus_session
         rescue
           # If the `fetch_olympus_session` method raises an exception
           # we'll land here, and therefore continue doing a full login process
@@ -491,8 +491,13 @@ module Spaceship
         end
 
         provider = body["provider"]
-        self.provider = Spaceship::Provider.new(provider_hash: provider) unless provider.nil?
+        if provider
+          self.provider = Spaceship::Provider.new(provider_hash: provider)
+          return true
+        end
       end
+
+      false
     end
 
     def itc_service_key

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -497,7 +497,7 @@ module Spaceship
         end
       end
 
-      false
+      return false
     end
 
     def itc_service_key


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I set `SPACESHIP_COOKIE_PATH` and still saw fastlane login with password. Session caching didn't work. Resulted in a lot of 503 errors for me after a lot of operations.

After some debugging, found the line `return true if fetch_olympus_session.count > 0` expects the return value of `fetch_olympus_session` to be an array. But the change in https://github.com/fastlane/fastlane/commit/b11eaa929ecd0144066cdd92ebfaa8b19b40d489 modified the returning value type without updating usage site. Then `load_session_from_file` never really works because `fetch_olympus_session.count` always raises a NoMethodError.

### Description
<!-- Describe your changes in detail -->

Change the returning type of `fetch_olympus_session` to boolean and use simple truth test instead.
