### PR TITLE
Fix detecting provisioning profiles

### DIFF
--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -26,6 +26,8 @@ module Gym
         end
       end
 
+      ensure_export_options_is_hash
+
       detect_scheme
       detect_platform # we can only do that *after* we have the scheme
       detect_selected_provisioning_profiles # we can only do that *after* we have the platform
@@ -143,6 +145,27 @@ module Gym
       if Gym.config[:toolchain].to_s == "swift_2_3"
         Gym.config[:toolchain] = "com.apple.dt.toolchain.Swift_2_3"
       end
+    end
+
+    def self.ensure_export_options_is_hash
+      return if Gym.config[:export_options].nil? || Gym.config[:export_options].kind_of?(Hash)
+
+      # Reads options from file
+      plist_file_path = Gym.config[:export_options]
+      UI.user_error!("Couldn't find plist file at path #{File.expand_path(plist_file_path)}") unless File.exist?(plist_file_path)
+      hash = Plist.parse_xml(plist_file_path)
+      UI.user_error!("Couldn't read provided plist at path #{File.expand_path(plist_file_path)}") if hash.nil?
+      # Convert keys to symbols
+      Gym.config[:export_options] = keys_to_symbols(hash)
+    end
+
+    def self.keys_to_symbols(hash)
+      # Convert keys to symbols
+      hash = hash.each_with_object({}) do |(k, v), memo|
+        memo[k.b.to_s.to_sym] = v
+        memo
+      end
+      hash
     end
   end
 end

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -124,30 +124,10 @@ module Gym
         hash
       end
 
-      def keys_to_symbols(hash)
-        # Convert keys to symbols
-        hash = hash.each_with_object({}) do |(k, v), memo|
-          memo[k.b.to_s.to_sym] = v
-          memo
-        end
-        hash
-      end
-
       def read_export_options
         # Reads export options
         if Gym.config[:export_options]
-          if Gym.config[:export_options].kind_of?(Hash)
-            # Reads options from hash
-            hash = normalize_export_options(Gym.config[:export_options])
-          else
-            # Reads options from file
-            plist_file_path = Gym.config[:export_options]
-            UI.user_error!("Couldn't find plist file at path #{File.expand_path(plist_file_path)}") unless File.exist?(plist_file_path)
-            hash = Plist.parse_xml(plist_file_path)
-            UI.user_error!("Couldn't read provided plist at path #{File.expand_path(plist_file_path)}") if hash.nil?
-            # Convert keys to symbols
-            hash = keys_to_symbols(hash)
-          end
+          hash = normalize_export_options(Gym.config[:export_options])
 
           # Saves configuration for later use
           Gym.config[:export_method] ||= hash[:method] || DEFAULT_EXPORT_METHOD


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I use `fastlane gym` from command line and provide export options as a path to a plist file (`--export-options export-options.plist`). I'm getting following error every time i run `fastlane gym`:
```
ERROR [2018-06-22 15:20:25.63]: Couldn't automatically detect the provisioning profile mapping
ERROR [2018-06-22 15:20:25.63]: Since Xcode 9 you need to provide an explicit mapping of what
ERROR [2018-06-22 15:20:25.63]: provisioning profile to use for each target of your app
ERROR [2018-06-22 15:20:25.63]: no implicit conversion of Symbol into Integer
DEBUG [2018-06-22 15:20:25.63]: /Users/dsokal/.rvm/gems/ruby-2.2.7/gems/fastlane-2.95.0/gym/lib/gym/detect_values.rb:80:in `[]'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/fastlane-2.95.0/gym/lib/gym/detect_values.rb:80:in `detect_selected_provisioning_profiles'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/fastlane-2.95.0/gym/lib/gym/detect_values.rb:31:in `set_additional_default_values'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/fastlane-2.95.0/gym/lib/gym/module.rb:15:in `config='
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/fastlane-2.95.0/gym/lib/gym/manager.rb:8:in `work'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/fastlane-2.95.0/gym/lib/gym/commands_generator.rb:44:in `block (2 levels) in run'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/commander-fastlane-4.4.6/lib/commander/command.rb:178:in `call'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/commander-fastlane-4.4.6/lib/commander/command.rb:178:in `call'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/commander-fastlane-4.4.6/lib/commander/command.rb:153:in `run'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/commander-fastlane-4.4.6/lib/commander/runner.rb:476:in `run_active_command'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/fastlane-2.95.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:75:in `run!'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/commander-fastlane-4.4.6/lib/commander/delegates.rb:15:in `run!'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/fastlane-2.95.0/gym/lib/gym/commands_generator.rb:75:in `run'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/fastlane-2.95.0/gym/lib/gym/commands_generator.rb:15:in `start'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/fastlane-2.95.0/fastlane/lib/fastlane/cli_tools_distributor.rb:100:in `take_off'
/Users/dsokal/.rvm/gems/ruby-2.2.7/gems/fastlane-2.95.0/bin/fastlane:20:in `<top (required)>'
/Users/dsokal/.rvm/gems/ruby-2.2.7/bin/fastlane:23:in `load'
/Users/dsokal/.rvm/gems/ruby-2.2.7/bin/fastlane:23:in `<main>'
/Users/dsokal/.rvm/gems/ruby-2.2.7/bin/ruby_executable_hooks:15:in `eval'
/Users/dsokal/.rvm/gems/ruby-2.2.7/bin/ruby_executable_hooks:15:in `<main>'
```
It's happening, because `DetectValues` assumes that `Gym.config[:export_options]` is a hash. 

### Description

I've moved some code, so that reading plist file in case a path to the file was provided happens before detecting selected provisioning profiles.

