### PR TITLE
providing the ability to update b2b users

### DIFF
--- a/spaceship/lib/spaceship/tunes/availability.rb
+++ b/spaceship/lib/spaceship/tunes/availability.rb
@@ -24,6 +24,7 @@ module Spaceship
       # @return (Bool) b2b available for distribution
       attr_accessor :b2b_unavailable
 
+      # @return (Array of Spaceship::Tunes::B2bUser objects) A list of users
       attr_accessor :b2b_users
 
       attr_mapping(
@@ -98,27 +99,33 @@ module Spaceship
         @b2b_app_enabled = true
         # need to set the educational discount to false
         @educational_discount = false
-        self
+        return self
       end
 
       # Adds users for b2b enabled apps
       def add_b2b_users(user_list = [])
         raise "Cannot add b2b users if b2b is not enabled" unless b2b_app_enabled
         @b2b_users = user_list.map { |user| B2bUser.from_username(user) }
-        self
+        return self
       end
 
       # Updates users for b2b enabled apps
       def update_b2b_users(user_list = [])
         raise "Cannot add b2b users if b2b is not enabled" unless b2b_app_enabled
+
         added_users = b2b_users.map(&:ds_username)
+
+        # Returns if list is unchanged
         return self if (added_users - user_list) == (user_list - added_users)
+
         users_to_add = user_list.reject { |user| added_users.include?(user) }
         users_to_remove = added_users.reject { |user| user_list.include?(user) }
+
         @b2b_users = b2b_users.reject { |user| users_to_remove.include?(user.ds_username) }
         @b2b_users.concat(users_to_add.map { |user| B2bUser.from_username(user) })
         @b2b_users.concat(users_to_remove.map { |user| B2bUser.from_username(user, is_add_type: false) })
-        self
+
+        return self
       end
     end
   end

--- a/spaceship/lib/spaceship/tunes/b2b_user.rb
+++ b/spaceship/lib/spaceship/tunes/b2b_user.rb
@@ -20,6 +20,11 @@ module Spaceship
       def self.from_username(username, is_add_type: true)
         self.new({ 'value' => { 'add' => is_add_type, 'delete' => !is_add_type, 'dsUsername' => username } })
       end
+
+      # equality check for the two objects (for cleaning up some tests etc)
+      def ==(other)
+        add == other.add && delete == other.delete && ds_username == other.ds_username
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/tunes/b2b_user.rb
+++ b/spaceship/lib/spaceship/tunes/b2b_user.rb
@@ -17,8 +17,8 @@ module Spaceship
         'value.dsUsername' => :ds_username
       )
 
-      def self.from_username(username)
-        self.new({ 'value' => { 'add' => true, 'delete' => false, 'dsUsername' => username } })
+      def self.from_username(username, is_add_type: true)
+        self.new({ 'value' => { 'add' => is_add_type, 'delete' => !is_add_type, 'dsUsername' => username } })
       end
     end
   end

--- a/spaceship/lib/spaceship/tunes/b2b_user.rb
+++ b/spaceship/lib/spaceship/tunes/b2b_user.rb
@@ -21,7 +21,7 @@ module Spaceship
         self.new({ 'value' => { 'add' => is_add_type, 'delete' => !is_add_type, 'dsUsername' => username } })
       end
 
-      # equality check for the two objects (for cleaning up some tests etc)
+      # equality check for the two objects
       def ==(other)
         add == other.add && delete == other.delete && ds_username == other.ds_username
       end

--- a/spaceship/spec/tunes/availability_spec.rb
+++ b/spaceship/spec/tunes/availability_spec.rb
@@ -194,41 +194,60 @@ describe Spaceship::Tunes::Availability do
         expect { availability.add_b2b_users(["abc@def.com"]) }.to raise_error("Cannot add b2b users if b2b is not enabled")
       end
 
-      it "removes the overlapping b2b user from the existing users list" do
+      it "does not do anything for same b2b_user_list" do
         TunesStubbing.itc_stub_app_pricing_intervals_vpp
         availability = client.availability(app.apple_id)
-        new_availability = availability.update_b2b_users(users_to_add: ["abc@def.com"], users_to_remove: ["b2b1@abc.com"])
+        old_b2b_users = availability.b2b_users
+        new_availability = availability.update_b2b_users(%w(b2b1@abc.com b2b2@def.com))
         expect(new_availability).to be_an_instance_of(Spaceship::Tunes::Availability)
-        expect(new_availability.b2b_users.length).to eq(3)
-        expect(new_availability.b2b_users[1].ds_username).to eq("abc@def.com")
-        expect(new_availability.b2b_users[1].add).to eq(true)
-        expect(new_availability.b2b_users[1].delete).to eq(false)
-        expect(new_availability.b2b_users[2].ds_username).to eq("b2b1@abc.com")
-        expect(new_availability.b2b_users[2].add).to eq(false)
-        expect(new_availability.b2b_users[2].delete).to eq(true)
+        new_b2b_users = new_availability.b2b_users
+        expect(new_b2b_users).to eq(old_b2b_users)
       end
 
-      it "works correctly with both inputs" do
+      it "removes existing user" do
         TunesStubbing.itc_stub_app_pricing_intervals_vpp
         availability = client.availability(app.apple_id)
-        new_availability = availability.update_b2b_users(users_to_add: ["abc@def.com"], users_to_remove: ["jkl@mno.com"])
+        new_availability = availability.update_b2b_users(%w(b2b1@abc.com))
         expect(new_availability).to be_an_instance_of(Spaceship::Tunes::Availability)
-        expect(new_availability.b2b_users.length).to eq(4)
-        expect(new_availability.b2b_users[2].ds_username).to eq("abc@def.com")
+        expect(new_availability.b2b_users.length).to eq(2)
+        expect(new_availability.b2b_users[0].ds_username).to eq("b2b1@abc.com")
+        expect(new_availability.b2b_users[0].add).to eq(false)
+        expect(new_availability.b2b_users[0].delete).to eq(false)
+        expect(new_availability.b2b_users[1].ds_username).to eq("b2b2@def.com")
+        expect(new_availability.b2b_users[1].add).to eq(false)
+        expect(new_availability.b2b_users[1].delete).to eq(true)
+      end
+
+      it "adds new user" do
+        TunesStubbing.itc_stub_app_pricing_intervals_vpp
+        availability = client.availability(app.apple_id)
+        new_availability = availability.update_b2b_users(%w(b2b1@abc.com b2b2@def.com jkl@mno.com))
+        expect(new_availability).to be_an_instance_of(Spaceship::Tunes::Availability)
+        expect(new_availability.b2b_users.length).to eq(3)
+        expect(new_availability.b2b_users[0].ds_username).to eq("b2b1@abc.com")
+        expect(new_availability.b2b_users[0].add).to eq(false)
+        expect(new_availability.b2b_users[0].delete).to eq(false)
+        expect(new_availability.b2b_users[1].ds_username).to eq("b2b2@def.com")
+        expect(new_availability.b2b_users[1].add).to eq(false)
+        expect(new_availability.b2b_users[1].delete).to eq(false)
+        expect(new_availability.b2b_users[2].ds_username).to eq("jkl@mno.com")
         expect(new_availability.b2b_users[2].add).to eq(true)
         expect(new_availability.b2b_users[2].delete).to eq(false)
-        expect(new_availability.b2b_users[3].ds_username).to eq("jkl@mno.com")
-        expect(new_availability.b2b_users[3].add).to eq(false)
-        expect(new_availability.b2b_users[3].delete).to eq(true)
       end
 
-      it "works correctly with just one input" do
+      it "adds and removes appropriate users" do
         TunesStubbing.itc_stub_app_pricing_intervals_vpp
         availability = client.availability(app.apple_id)
-        new_availability = availability.update_b2b_users(users_to_remove: ["jkl@mno.com"])
+        new_availability = availability.update_b2b_users(%w(b2b1@abc.com jkl@mno.com))
         expect(new_availability).to be_an_instance_of(Spaceship::Tunes::Availability)
         expect(new_availability.b2b_users.length).to eq(3)
-        expect(new_availability.b2b_users[2].ds_username).to eq("jkl@mno.com")
+        expect(new_availability.b2b_users[0].ds_username).to eq("b2b1@abc.com")
+        expect(new_availability.b2b_users[0].add).to eq(false)
+        expect(new_availability.b2b_users[0].delete).to eq(false)
+        expect(new_availability.b2b_users[1].ds_username).to eq("jkl@mno.com")
+        expect(new_availability.b2b_users[1].add).to eq(true)
+        expect(new_availability.b2b_users[1].delete).to eq(false)
+        expect(new_availability.b2b_users[2].ds_username).to eq("b2b2@def.com")
         expect(new_availability.b2b_users[2].add).to eq(false)
         expect(new_availability.b2b_users[2].delete).to eq(true)
       end

--- a/spaceship/spec/tunes/b2b_user_spec.rb
+++ b/spaceship/spec/tunes/b2b_user_spec.rb
@@ -40,6 +40,20 @@ class B2bUserSpec
         !expect(b2b_user_created.delete)
         expect(b2b_user_created.ds_username).to eq('b2b2@def.com')
       end
+
+      it 'creates correct object to add with explicit input' do
+        b2b_user_created = Spaceship::Tunes::B2bUser.from_username("b2b2@def.com", is_add_type: true)
+        expect(b2b_user_created.add)
+        !expect(b2b_user_created.delete)
+        expect(b2b_user_created.ds_username).to eq('b2b2@def.com')
+      end
+
+      it 'creates correct object to remove' do
+        b2b_user_created = Spaceship::Tunes::B2bUser.from_username("b2b2@def.com", is_add_type: false)
+        !expect(b2b_user_created.add)
+        expect(b2b_user_created.delete)
+        expect(b2b_user_created.ds_username).to eq('b2b2@def.com')
+      end
     end
   end
 end

--- a/spaceship/spec/tunes/b2b_user_spec.rb
+++ b/spaceship/spec/tunes/b2b_user_spec.rb
@@ -27,8 +27,8 @@ class B2bUserSpec
     describe 'b2b_user' do
       it 'parses the data correctly' do
         expect(b2b_user).to be_instance_of(Spaceship::Tunes::B2bUser)
-        !expect(b2b_user.add)
-        !expect(b2b_user.delete)
+        expect(b2b_user.add).to eq(false)
+        expect(b2b_user.delete).to eq(false)
         expect(b2b_user.ds_username).to eq('b2b1@abc.com')
       end
     end
@@ -36,22 +36,22 @@ class B2bUserSpec
     describe 'from_username' do
       it 'creates correct object to add' do
         b2b_user_created = Spaceship::Tunes::B2bUser.from_username("b2b2@def.com")
-        expect(b2b_user_created.add)
-        !expect(b2b_user_created.delete)
+        expect(b2b_user_created.add).to eq(true)
+        expect(b2b_user_created.delete).to eq(false)
         expect(b2b_user_created.ds_username).to eq('b2b2@def.com')
       end
 
       it 'creates correct object to add with explicit input' do
         b2b_user_created = Spaceship::Tunes::B2bUser.from_username("b2b2@def.com", is_add_type: true)
-        expect(b2b_user_created.add)
-        !expect(b2b_user_created.delete)
+        expect(b2b_user_created.add).to eq(true)
+        expect(b2b_user_created.delete).to eq(false)
         expect(b2b_user_created.ds_username).to eq('b2b2@def.com')
       end
 
       it 'creates correct object to remove' do
         b2b_user_created = Spaceship::Tunes::B2bUser.from_username("b2b2@def.com", is_add_type: false)
-        !expect(b2b_user_created.add)
-        expect(b2b_user_created.delete)
+        expect(b2b_user_created.add).to eq(false)
+        expect(b2b_user_created.delete).to eq(true)
         expect(b2b_user_created.ds_username).to eq('b2b2@def.com')
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This change will provide an ability to add and remove b2b users. The payload required for the "update" also changed a bit. So I am including it in the new method. 
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
I tried to remove, add, and add and remove b2b users together. I have also added new rspec tests and updated existing ones that test the payload for correct behaviour.
### Description
<!-- Describe your changes in detail -->

1. added method `update_b2b_users` in `availability.rb`.
2. removed the accessor for `b2b_users` from availability - this was a bug which only manifested itself in the new implementation. 
3. updated method `from_username` in `b2b_user.rb` to be able to mark a user to be deleted or added.
4. added `rspec` tests for functionality and updated existing tests to reflect the changes to existing methods - while ensuring that the legacy behaviour works fine for anyone that might be using the method.
