### PR TITLE
Remove copyright from iOS source files (.h, .m, .swift)

### DIFF
--- a/fastlane/spec/fixtures/actions/get_version_number/get_version_number/AppDelegate.swift
+++ b/fastlane/spec/fixtures/actions/get_version_number/get_version_number/AppDelegate.swift
@@ -3,7 +3,6 @@
 //  get_version_number
 //
 //  Created by Josh Holtz on 3/12/18.
-//  Copyright © 2018 fastlane. All rights reserved.
 //
 
 import UIKit

--- a/fastlane/spec/fixtures/actions/get_version_number/get_version_number/ViewController.swift
+++ b/fastlane/spec/fixtures/actions/get_version_number/get_version_number/ViewController.swift
@@ -3,7 +3,6 @@
 //  get_version_number
 //
 //  Created by Josh Holtz on 3/12/18.
-//  Copyright © 2018 fastlane. All rights reserved.
 //
 
 import UIKit

--- a/fastlane/spec/fixtures/actions/get_version_number/get_version_numberTests/get_version_numberTests.swift
+++ b/fastlane/spec/fixtures/actions/get_version_number/get_version_numberTests/get_version_numberTests.swift
@@ -3,7 +3,6 @@
 //  get_version_numberTests
 //
 //  Created by Josh Holtz on 3/12/18.
-//  Copyright © 2018 fastlane. All rights reserved.
 //
 
 import XCTest

--- a/fastlane/swift/ArgumentProcessor.swift
+++ b/fastlane/swift/ArgumentProcessor.swift
@@ -3,7 +3,6 @@
 //  FastlaneRunner
 //
 //  Created by Joshua Liebowitz on 9/28/17.
-//  Copyright © 2017 Joshua Liebowitz. All rights reserved.
 //
 
 //

--- a/fastlane/swift/ControlCommand.swift
+++ b/fastlane/swift/ControlCommand.swift
@@ -3,7 +3,6 @@
 //  FastlaneRunner
 //
 //  Created by Joshua Liebowitz on 1/3/18.
-//  Copyright © 2018 Joshua Liebowitz. All rights reserved.
 
 //
 //  ** NOTE **

--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -3,7 +3,6 @@
 //  FastlaneSwiftRunner
 //
 //  Created by Joshua Liebowitz on 8/4/17.
-//  Copyright © 2017 Joshua Liebowitz. All rights reserved.
 //
 
 //

--- a/fastlane/swift/RubyCommand.swift
+++ b/fastlane/swift/RubyCommand.swift
@@ -3,7 +3,6 @@
 //  FastlaneSwiftRunner
 //
 //  Created by Joshua Liebowitz on 8/4/17.
-//  Copyright © 2017 Joshua Liebowitz. All rights reserved.
 //
 
 //

--- a/fastlane/swift/RubyCommandable.swift
+++ b/fastlane/swift/RubyCommandable.swift
@@ -3,7 +3,6 @@
 //  FastlaneRunner
 //
 //  Created by Joshua Liebowitz on 1/4/18.
-//  Copyright © 2018 Joshua Liebowitz. All rights reserved.
 //
 
 //

--- a/fastlane/swift/Runner.swift
+++ b/fastlane/swift/Runner.swift
@@ -3,7 +3,6 @@
 //  FastlaneSwiftRunner
 //
 //  Created by Joshua Liebowitz on 8/26/17.
-//  Copyright © 2017 Joshua Liebowitz. All rights reserved.
 //
 
 //

--- a/fastlane/swift/RunnerArgument.swift
+++ b/fastlane/swift/RunnerArgument.swift
@@ -3,7 +3,6 @@
 //  FastlaneSwiftRunner
 //
 //  Created by Joshua Liebowitz on 9/1/17.
-//  Copyright © 2017 Joshua Liebowitz. All rights reserved.
 //
 
 //

--- a/fastlane/swift/SocketClient.swift
+++ b/fastlane/swift/SocketClient.swift
@@ -3,7 +3,6 @@
 //  FastlaneSwiftRunner
 //
 //  Created by Joshua Liebowitz on 7/30/17.
-//  Copyright © 2017 Joshua Liebowitz. All rights reserved.
 //
 
 //

--- a/fastlane/swift/SocketClientDelegateProtocol.swift
+++ b/fastlane/swift/SocketClientDelegateProtocol.swift
@@ -3,7 +3,6 @@
 //  FastlaneSwiftRunner
 //
 //  Created by Joshua Liebowitz on 8/12/17.
-//  Copyright © 2017 Joshua Liebowitz. All rights reserved.
 //
 
 //

--- a/fastlane/swift/SocketResponse.swift
+++ b/fastlane/swift/SocketResponse.swift
@@ -3,7 +3,6 @@
 //  FastlaneSwiftRunner
 //
 //  Created by Joshua Liebowitz on 7/30/17.
-//  Copyright © 2017 Joshua Liebowitz. All rights reserved.
 //
 
 //

--- a/fastlane/swift/main.swift
+++ b/fastlane/swift/main.swift
@@ -3,7 +3,6 @@
 //  FastlaneSwiftRunner
 //
 //  Created by Joshua Liebowitz on 8/26/17.
-//  Copyright © 2017 Joshua Liebowitz. All rights reserved.
 //
 
 //

--- a/gym/examples/Mac/Mac/AppDelegate.h
+++ b/gym/examples/Mac/Mac/AppDelegate.h
@@ -3,7 +3,6 @@
 //  Mac
 //
 //  Created by Felix Krause on 19/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <Cocoa/Cocoa.h>

--- a/gym/examples/Mac/Mac/AppDelegate.m
+++ b/gym/examples/Mac/Mac/AppDelegate.m
@@ -3,7 +3,6 @@
 //  Mac
 //
 //  Created by Felix Krause on 19/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/gym/examples/Mac/Mac/main.m
+++ b/gym/examples/Mac/Mac/main.m
@@ -3,7 +3,6 @@
 //  Mac
 //
 //  Created by Felix Krause on 19/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <Cocoa/Cocoa.h>

--- a/gym/examples/WatchKit/WatchKit WatchKit 1 Extension/InterfaceController.h
+++ b/gym/examples/WatchKit/WatchKit WatchKit 1 Extension/InterfaceController.h
@@ -3,7 +3,6 @@
 //  WatchKit WatchKit 1 Extension
 //
 //  Created by Felix Krause on 19/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <WatchKit/WatchKit.h>

--- a/gym/examples/WatchKit/WatchKit WatchKit 1 Extension/InterfaceController.m
+++ b/gym/examples/WatchKit/WatchKit WatchKit 1 Extension/InterfaceController.m
@@ -3,7 +3,6 @@
 //  WatchKit WatchKit 1 Extension
 //
 //  Created by Felix Krause on 19/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "InterfaceController.h"

--- a/gym/examples/WatchKit/WatchKit WatchKit 1 Extension/NotificationController.h
+++ b/gym/examples/WatchKit/WatchKit WatchKit 1 Extension/NotificationController.h
@@ -3,7 +3,6 @@
 //  WatchKit WatchKit 1 Extension
 //
 //  Created by Felix Krause on 19/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <WatchKit/WatchKit.h>

--- a/gym/examples/WatchKit/WatchKit WatchKit 1 Extension/NotificationController.m
+++ b/gym/examples/WatchKit/WatchKit WatchKit 1 Extension/NotificationController.m
@@ -3,7 +3,6 @@
 //  WatchKit WatchKit 1 Extension
 //
 //  Created by Felix Krause on 19/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "NotificationController.h"

--- a/gym/examples/WatchKit/WatchKit/AppDelegate.h
+++ b/gym/examples/WatchKit/WatchKit/AppDelegate.h
@@ -3,7 +3,6 @@
 //  WatchKit
 //
 //  Created by Felix Krause on 19/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/WatchKit/WatchKit/AppDelegate.m
+++ b/gym/examples/WatchKit/WatchKit/AppDelegate.m
@@ -3,7 +3,6 @@
 //  WatchKit
 //
 //  Created by Felix Krause on 19/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/gym/examples/WatchKit/WatchKit/ViewController.h
+++ b/gym/examples/WatchKit/WatchKit/ViewController.h
@@ -3,7 +3,6 @@
 //  WatchKit
 //
 //  Created by Felix Krause on 19/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/WatchKit/WatchKit/ViewController.m
+++ b/gym/examples/WatchKit/WatchKit/ViewController.m
@@ -3,7 +3,6 @@
 //  WatchKit
 //
 //  Created by Felix Krause on 19/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "ViewController.h"

--- a/gym/examples/WatchKit/WatchKit/main.m
+++ b/gym/examples/WatchKit/WatchKit/main.m
@@ -3,7 +3,6 @@
 //  WatchKit
 //
 //  Created by Felix Krause on 19/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/cocoapods/Example/AppDelegate.h
+++ b/gym/examples/cocoapods/Example/AppDelegate.h
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/cocoapods/Example/AppDelegate.m
+++ b/gym/examples/cocoapods/Example/AppDelegate.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/gym/examples/cocoapods/Example/ViewController.h
+++ b/gym/examples/cocoapods/Example/ViewController.h
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/cocoapods/Example/ViewController.m
+++ b/gym/examples/cocoapods/Example/ViewController.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "ViewController.h"

--- a/gym/examples/cocoapods/Example/main.m
+++ b/gym/examples/cocoapods/Example/main.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/cocoapods/ExampleTests/ExampleTests.m
+++ b/gym/examples/cocoapods/ExampleTests/ExampleTests.m
@@ -3,7 +3,6 @@
 //  ExampleTests
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/gym/examples/cocoapods/ExampleUITests/ExampleUITests.m
+++ b/gym/examples/cocoapods/ExampleUITests/ExampleUITests.m
@@ -3,7 +3,6 @@
 //  ExampleUITests
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/gym/examples/multipleSchemes/Example/AppDelegate.h
+++ b/gym/examples/multipleSchemes/Example/AppDelegate.h
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/multipleSchemes/Example/AppDelegate.m
+++ b/gym/examples/multipleSchemes/Example/AppDelegate.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/gym/examples/multipleSchemes/Example/ViewController.h
+++ b/gym/examples/multipleSchemes/Example/ViewController.h
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/multipleSchemes/Example/ViewController.m
+++ b/gym/examples/multipleSchemes/Example/ViewController.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "ViewController.h"

--- a/gym/examples/multipleSchemes/Example/main.m
+++ b/gym/examples/multipleSchemes/Example/main.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/multipleSchemes/ExampleTests/ExampleTests.m
+++ b/gym/examples/multipleSchemes/ExampleTests/ExampleTests.m
@@ -3,7 +3,6 @@
 //  ExampleTests
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/gym/examples/multipleSchemes/ExampleUITests/ExampleUITests.m
+++ b/gym/examples/multipleSchemes/ExampleUITests/ExampleUITests.m
@@ -3,7 +3,6 @@
 //  ExampleUITests
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/gym/examples/standard/Example/AppDelegate.h
+++ b/gym/examples/standard/Example/AppDelegate.h
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/standard/Example/AppDelegate.m
+++ b/gym/examples/standard/Example/AppDelegate.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/gym/examples/standard/Example/ViewController.h
+++ b/gym/examples/standard/Example/ViewController.h
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/standard/Example/ViewController.m
+++ b/gym/examples/standard/Example/ViewController.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "ViewController.h"

--- a/gym/examples/standard/Example/main.m
+++ b/gym/examples/standard/Example/main.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/standard/ExampleTests/ExampleTests.m
+++ b/gym/examples/standard/ExampleTests/ExampleTests.m
@@ -3,7 +3,6 @@
 //  ExampleTests
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/gym/examples/standard/ExampleUITests/ExampleUITests.m
+++ b/gym/examples/standard/ExampleUITests/ExampleUITests.m
@@ -3,7 +3,6 @@
 //  ExampleUITests
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/gym/examples/today/Example/AppDelegate.h
+++ b/gym/examples/today/Example/AppDelegate.h
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/today/Example/AppDelegate.m
+++ b/gym/examples/today/Example/AppDelegate.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/gym/examples/today/Example/ViewController.h
+++ b/gym/examples/today/Example/ViewController.h
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/today/Example/ViewController.m
+++ b/gym/examples/today/Example/ViewController.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "ViewController.h"

--- a/gym/examples/today/Example/main.m
+++ b/gym/examples/today/Example/main.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/today/ExampleTests/ExampleTests.m
+++ b/gym/examples/today/ExampleTests/ExampleTests.m
@@ -3,7 +3,6 @@
 //  ExampleTests
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/gym/examples/today/ExampleUITests/ExampleUITests.m
+++ b/gym/examples/today/ExampleUITests/ExampleUITests.m
@@ -3,7 +3,6 @@
 //  ExampleUITests
 //
 //  Created by Felix Krause on 30/07/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/gym/examples/tvapp/tvapp/AppDelegate.h
+++ b/gym/examples/tvapp/tvapp/AppDelegate.h
@@ -3,7 +3,6 @@
 //  tvapp
 //
 //  Created by Felix Krause on 30/12/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/tvapp/tvapp/AppDelegate.m
+++ b/gym/examples/tvapp/tvapp/AppDelegate.m
@@ -3,7 +3,6 @@
 //  tvapp
 //
 //  Created by Felix Krause on 30/12/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/gym/examples/tvapp/tvapp/FirstViewController.h
+++ b/gym/examples/tvapp/tvapp/FirstViewController.h
@@ -3,7 +3,6 @@
 //  tvapp
 //
 //  Created by Felix Krause on 30/12/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/tvapp/tvapp/FirstViewController.m
+++ b/gym/examples/tvapp/tvapp/FirstViewController.m
@@ -3,7 +3,6 @@
 //  tvapp
 //
 //  Created by Felix Krause on 30/12/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "FirstViewController.h"

--- a/gym/examples/tvapp/tvapp/SecondViewController.h
+++ b/gym/examples/tvapp/tvapp/SecondViewController.h
@@ -3,7 +3,6 @@
 //  tvapp
 //
 //  Created by Felix Krause on 30/12/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/tvapp/tvapp/SecondViewController.m
+++ b/gym/examples/tvapp/tvapp/SecondViewController.m
@@ -3,7 +3,6 @@
 //  tvapp
 //
 //  Created by Felix Krause on 30/12/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "SecondViewController.h"

--- a/gym/examples/tvapp/tvapp/main.m
+++ b/gym/examples/tvapp/tvapp/main.m
@@ -3,7 +3,6 @@
 //  tvapp
 //
 //  Created by Felix Krause on 30/12/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/with spaces/With Spaces WatchKit 1 Extension/InterfaceController.h
+++ b/gym/examples/with spaces/With Spaces WatchKit 1 Extension/InterfaceController.h
@@ -3,7 +3,6 @@
 //  With Spaces WatchKit 1 Extension
 //
 //  Created by Felix Krause on 11/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <WatchKit/WatchKit.h>

--- a/gym/examples/with spaces/With Spaces WatchKit 1 Extension/InterfaceController.m
+++ b/gym/examples/with spaces/With Spaces WatchKit 1 Extension/InterfaceController.m
@@ -3,7 +3,6 @@
 //  With Spaces WatchKit 1 Extension
 //
 //  Created by Felix Krause on 11/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "InterfaceController.h"

--- a/gym/examples/with spaces/With Spaces WatchKit 1 Extension/NotificationController.h
+++ b/gym/examples/with spaces/With Spaces WatchKit 1 Extension/NotificationController.h
@@ -3,7 +3,6 @@
 //  With Spaces WatchKit 1 Extension
 //
 //  Created by Felix Krause on 11/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <WatchKit/WatchKit.h>

--- a/gym/examples/with spaces/With Spaces WatchKit 1 Extension/NotificationController.m
+++ b/gym/examples/with spaces/With Spaces WatchKit 1 Extension/NotificationController.m
@@ -3,7 +3,6 @@
 //  With Spaces WatchKit 1 Extension
 //
 //  Created by Felix Krause on 11/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "NotificationController.h"

--- a/gym/examples/with spaces/With Spaces/AppDelegate.h
+++ b/gym/examples/with spaces/With Spaces/AppDelegate.h
@@ -3,7 +3,6 @@
 //  With Spaces
 //
 //  Created by Felix Krause on 11/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/with spaces/With Spaces/AppDelegate.m
+++ b/gym/examples/with spaces/With Spaces/AppDelegate.m
@@ -3,7 +3,6 @@
 //  With Spaces
 //
 //  Created by Felix Krause on 11/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/gym/examples/with spaces/With Spaces/ViewController.h
+++ b/gym/examples/with spaces/With Spaces/ViewController.h
@@ -3,7 +3,6 @@
 //  With Spaces
 //
 //  Created by Felix Krause on 11/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/gym/examples/with spaces/With Spaces/ViewController.m
+++ b/gym/examples/with spaces/With Spaces/ViewController.m
@@ -3,7 +3,6 @@
 //  With Spaces
 //
 //  Created by Felix Krause on 11/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "ViewController.h"

--- a/gym/examples/with spaces/With Spaces/main.m
+++ b/gym/examples/with spaces/With Spaces/main.m
@@ -3,7 +3,6 @@
 //  With Spaces
 //
 //  Created by Felix Krause on 11/08/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/scan/examples/Mac/Mac/AppDelegate.h
+++ b/scan/examples/Mac/Mac/AppDelegate.h
@@ -3,7 +3,6 @@
 //  Mac
 //
 //  Created by Felix Krause on 10/14/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <Cocoa/Cocoa.h>

--- a/scan/examples/Mac/Mac/AppDelegate.m
+++ b/scan/examples/Mac/Mac/AppDelegate.m
@@ -3,7 +3,6 @@
 //  Mac
 //
 //  Created by Felix Krause on 10/14/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/scan/examples/Mac/Mac/main.m
+++ b/scan/examples/Mac/Mac/main.m
@@ -3,7 +3,6 @@
 //  Mac
 //
 //  Created by Felix Krause on 10/14/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <Cocoa/Cocoa.h>

--- a/scan/examples/Mac/MacTests/MacTests.m
+++ b/scan/examples/Mac/MacTests/MacTests.m
@@ -3,7 +3,6 @@
 //  MacTests
 //
 //  Created by Felix Krause on 10/14/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/scan/examples/standard/app/AppDelegate.h
+++ b/scan/examples/standard/app/AppDelegate.h
@@ -3,7 +3,6 @@
 //  app
 //
 //  Created by Felix Krause on 01/10/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/scan/examples/standard/app/AppDelegate.m
+++ b/scan/examples/standard/app/AppDelegate.m
@@ -3,7 +3,6 @@
 //  app
 //
 //  Created by Felix Krause on 01/10/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/scan/examples/standard/app/ViewController.h
+++ b/scan/examples/standard/app/ViewController.h
@@ -3,7 +3,6 @@
 //  app
 //
 //  Created by Felix Krause on 01/10/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/scan/examples/standard/app/ViewController.m
+++ b/scan/examples/standard/app/ViewController.m
@@ -3,7 +3,6 @@
 //  app
 //
 //  Created by Felix Krause on 01/10/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import "ViewController.h"

--- a/scan/examples/standard/app/main.m
+++ b/scan/examples/standard/app/main.m
@@ -3,7 +3,6 @@
 //  app
 //
 //  Created by Felix Krause on 01/10/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/scan/examples/standard/appTests/appTests.m
+++ b/scan/examples/standard/appTests/appTests.m
@@ -3,7 +3,6 @@
 //  appTests
 //
 //  Created by Felix Krause on 01/10/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/scan/examples/standard/appUITests/appUITests.m
+++ b/scan/examples/standard/appUITests/appUITests.m
@@ -3,7 +3,6 @@
 //  appUITests
 //
 //  Created by Felix Krause on 01/10/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -85,7 +85,7 @@ module Scan
 
       formatter = []
       if (custom_formatter = Scan.config[:formatter])
-        if custom_formatter.end_with? ".rb"
+        if custom_formatter.end_with?(".rb")
           formatter << "-f '#{custom_formatter}'"
         else
           formatter << "-f `#{custom_formatter}`"

--- a/snapshot/example/Example/AppDelegate.h
+++ b/snapshot/example/Example/AppDelegate.h
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 10.11.14.
-//  Copyright (c) 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/snapshot/example/Example/AppDelegate.m
+++ b/snapshot/example/Example/AppDelegate.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 10.11.14.
-//  Copyright (c) 2015 Felix Krause. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/snapshot/example/Example/FirstViewController.h
+++ b/snapshot/example/Example/FirstViewController.h
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 10.11.14.
-//  Copyright (c) 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/snapshot/example/Example/FirstViewController.m
+++ b/snapshot/example/Example/FirstViewController.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 10.11.14.
-//  Copyright (c) 2015 Felix Krause. All rights reserved.
 //
 
 #import "FirstViewController.h"

--- a/snapshot/example/Example/SecondViewController.h
+++ b/snapshot/example/Example/SecondViewController.h
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 10.11.14.
-//  Copyright (c) 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/snapshot/example/Example/SecondViewController.m
+++ b/snapshot/example/Example/SecondViewController.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 10.11.14.
-//  Copyright (c) 2015 Felix Krause. All rights reserved.
 //
 
 #import "SecondViewController.h"

--- a/snapshot/example/Example/main.m
+++ b/snapshot/example/Example/main.m
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 10.11.14.
-//  Copyright (c) 2015 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/snapshot/example/ExampleMacOS/AppDelegate.swift
+++ b/snapshot/example/ExampleMacOS/AppDelegate.swift
@@ -3,7 +3,6 @@
 //  ExampleMacOS
 //
 //  Created by Alexander Semenov on 1/19/17.
-//  Copyright © 2017 Felix Krause. All rights reserved.
 //
 
 import Cocoa

--- a/snapshot/example/ExampleMacOSUITests/ExampleMacOSUITests.swift
+++ b/snapshot/example/ExampleMacOSUITests/ExampleMacOSUITests.swift
@@ -3,7 +3,6 @@
 //  ExampleMacOSUITests
 //
 //  Created by Alexander Semenov on 1/19/17.
-//  Copyright © 2017 Felix Krause. All rights reserved.
 //
 
 import XCTest

--- a/snapshot/example/ExampleTV/AppDelegate.h
+++ b/snapshot/example/ExampleTV/AppDelegate.h
@@ -3,7 +3,6 @@
 //  ExampleTV
 //
 //  Created by Aman Gupta on 8/9/16.
-//  Copyright © 2016 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/snapshot/example/ExampleTV/AppDelegate.m
+++ b/snapshot/example/ExampleTV/AppDelegate.m
@@ -3,7 +3,6 @@
 //  ExampleTV
 //
 //  Created by Aman Gupta on 8/9/16.
-//  Copyright © 2016 Felix Krause. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/snapshot/example/ExampleTV/ViewController.h
+++ b/snapshot/example/ExampleTV/ViewController.h
@@ -3,7 +3,6 @@
 //  ExampleTV
 //
 //  Created by Aman Gupta on 8/9/16.
-//  Copyright © 2016 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/snapshot/example/ExampleTV/ViewController.m
+++ b/snapshot/example/ExampleTV/ViewController.m
@@ -3,7 +3,6 @@
 //  ExampleTV
 //
 //  Created by Aman Gupta on 8/9/16.
-//  Copyright © 2016 Felix Krause. All rights reserved.
 //
 
 #import "ViewController.h"

--- a/snapshot/example/ExampleTV/main.m
+++ b/snapshot/example/ExampleTV/main.m
@@ -3,7 +3,6 @@
 //  ExampleTV
 //
 //  Created by Aman Gupta on 8/9/16.
-//  Copyright © 2016 Felix Krause. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/snapshot/example/ExampleTVUITests/ExampleTVUITests.swift
+++ b/snapshot/example/ExampleTVUITests/ExampleTVUITests.swift
@@ -3,7 +3,6 @@
 //  ExampleUITests
 //
 //  Created by Felix Krause on 19/06/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 import Foundation

--- a/snapshot/example/ExampleUITests/ExampleUITests.swift
+++ b/snapshot/example/ExampleUITests/ExampleUITests.swift
@@ -3,7 +3,6 @@
 //  ExampleUITests
 //
 //  Created by Felix Krause on 19/06/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 import Foundation

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 10/8/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 // -----------------------------------------------------

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -277,4 +277,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.10]
+// SnapshotHelperVersion [1.11]

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -277,4 +277,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.11]
+// SnapshotHelperVersion [1.10]

--- a/snapshot/lib/assets/SnapshotHelperXcode8.swift
+++ b/snapshot/lib/assets/SnapshotHelperXcode8.swift
@@ -3,7 +3,6 @@
 //  Example
 //
 //  Created by Felix Krause on 10/8/15.
-//  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
 // -----------------------------------------------------

--- a/snapshot/lib/assets/SnapshotHelperXcode8.swift
+++ b/snapshot/lib/assets/SnapshotHelperXcode8.swift
@@ -169,4 +169,4 @@ extension XCUIElement {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperXcode8Version [1.4]
+// SnapshotHelperXcode8Version [1.5]

--- a/snapshot/lib/assets/SnapshotHelperXcode8.swift
+++ b/snapshot/lib/assets/SnapshotHelperXcode8.swift
@@ -169,4 +169,4 @@ extension XCUIElement {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperXcode8Version [1.5]
+// SnapshotHelperXcode8Version [1.4]


### PR DESCRIPTION
## What
- Removed `// Copyright © <year> <name>` from iOS source files
  - Removed only ones that were "fastlane", "Felix Krause" or "Joshua Liebowitz"
- Important ones (that actually can get copied into other open source projects)
  - Snapshot
    - `SnapshotHelper.swift`
    - `SnapshotHelperXcode8.swift`
  - Fastlane.swift
    - `ArgumentProcessor.swift`
    - `ControlCommand.swift`
    - `LaneFileProtocol.swift`
    - `RubyCommand.swift`
    - `RubyCommandable.swift`
    - `Runner.swift`
    - `RunnerArgument.swift`
    - `SocketClient.swift`
    - `SocketClientDelegateProtocol.swift`
    - `SocketResponse.swift`
    - `main.swift`
- The rest are files located in fixtures or tests
  - Can revert these if we'd like

## Why
- For use of these files in other open source projects
  - See https://github.com/mozilla-lockbox/lockbox-ios/pull/490/files#r198003723