### PR TITLE
Accept an Array to github_api body

### DIFF
--- a/fastlane/lib/fastlane/actions/github_api.rb
+++ b/fastlane/lib/fastlane/actions/github_api.rb
@@ -224,6 +224,8 @@ module Fastlane
             raw_body
           elsif body.kind_of?(Hash)
             body.to_json
+          elsif body.kind_of?(Array)
+            body.to_json
           else
             UI.user_error!("Please provide valid JSON, or a hash as request body") unless parse_json(body)
             body

--- a/fastlane/spec/actions_specs/github_api_spec.rb
+++ b/fastlane/spec/actions_specs/github_api_spec.rb
@@ -42,6 +42,25 @@ describe Fastlane do
           end
         end
 
+        context 'with an array body' do
+          it 'correctly submits to github api' do
+            result = Fastlane::FastFile.new.parse("
+              lane :test do
+                github_api(
+                  api_token: '123456789',
+                  http_method: 'PUT',
+                  path: 'repos/fastlane/fastlane/contents/TEST_FILE.md',
+                  body: %w(foo bar),
+                )
+              end
+            ").runner.execute(:test)
+
+            expect(result[:status]).to eq(200)
+            expect(result[:body]).to eq(response_body)
+            expect(result[:json]).to eq(JSON.parse(response_body))
+          end
+        end
+
         context 'with raw JSON body' do
           it 'correctly submits to github api' do
             result = Fastlane::FastFile.new.parse(%{


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Some GitHub API requires an array as request body.
(e.g. https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue)

Currently, we can't pass an array directly as request body.

```ruby
lane :test do
  github_api(
    api_token: '123456789',
    http_method: 'PUT',
    path: 'repos/fastlane/fastlane/contents/TEST_FILE.md',
    body: %w(foo bar),
  )
end
```

### Description

When you pass an array as request body on `github_api` action, they will be encoded as JSON.

This change may not break backward compatibility.
