### PR TITLE
[action] fix version_get_podspec to allow parsing pre-release suffix

### DIFF
--- a/fastlane/lib/fastlane/helper/podspec_helper.rb
+++ b/fastlane/lib/fastlane/helper/podspec_helper.rb
@@ -10,7 +10,7 @@ module Fastlane
       def initialize(path = nil, require_variable_prefix = true)
         version_var_name = 'version'
         variable_prefix = require_variable_prefix ? /\w\./ : //
-        @version_regex = /^(?<begin>[^#]*#{variable_prefix}#{version_var_name}\s*=\s*['"])(?<value>(?<major>[0-9]+)(\.(?<minor>[0-9]+))?(\.(?<patch>[0-9]+))?(?<appendix>(\.[0-9]+)*)?)(?<end>['"])/i
+        @version_regex = /^(?<begin>[^#]*#{variable_prefix}#{version_var_name}\s*=\s*['"])(?<value>(?<major>[0-9]+)(\.(?<minor>[0-9]+))?(\.(?<patch>[0-9]+))?(?<appendix>(\.[0-9]+)*)?(-(?<prerelease>(.+)))?)(?<end>['"])/i
 
         return unless (path || '').length > 0
         UI.user_error!("Could not find podspec file at path '#{path}'") unless File.exist?(path)

--- a/fastlane/spec/helper/podspec_helper_spec.rb
+++ b/fastlane/spec/helper/podspec_helper_spec.rb
@@ -36,26 +36,28 @@ describe Fastlane::Actions do
         expect(@version_podspec_file.version_match[:patch]).to eq('2')
       end
 
-      it "returns the current version once parsed with appendix" do
-        test_content = 'spec.version = "1.3.2.4"'
-        result = @version_podspec_file.parse(test_content)
-        expect(result).to eq('1.3.2.4')
-        expect(@version_podspec_file.version_value).to eq('1.3.2.4')
-        expect(@version_podspec_file.version_match[:major]).to eq('1')
-        expect(@version_podspec_file.version_match[:minor]).to eq('3')
-        expect(@version_podspec_file.version_match[:patch]).to eq('2')
-        expect(@version_podspec_file.version_match[:appendix]).to eq('.4')
-      end
+      context "with appendix" do
+        it "returns the current version once parsed with appendix" do
+          test_content = 'spec.version = "1.3.2.4"'
+          result = @version_podspec_file.parse(test_content)
+          expect(result).to eq('1.3.2.4')
+          expect(@version_podspec_file.version_value).to eq('1.3.2.4')
+          expect(@version_podspec_file.version_match[:major]).to eq('1')
+          expect(@version_podspec_file.version_match[:minor]).to eq('3')
+          expect(@version_podspec_file.version_match[:patch]).to eq('2')
+          expect(@version_podspec_file.version_match[:appendix]).to eq('.4')
+        end
 
-      it "returns the current version once parsed with longer appendix" do
-        test_content = 'spec.version = "1.3.2.4.5"'
-        result = @version_podspec_file.parse(test_content)
-        expect(result).to eq('1.3.2.4.5')
-        expect(@version_podspec_file.version_value).to eq('1.3.2.4.5')
-        expect(@version_podspec_file.version_match[:major]).to eq('1')
-        expect(@version_podspec_file.version_match[:minor]).to eq('3')
-        expect(@version_podspec_file.version_match[:patch]).to eq('2')
-        expect(@version_podspec_file.version_match[:appendix]).to eq('.4.5')
+        it "returns the current version once parsed with longer appendix" do
+          test_content = 'spec.version = "1.3.2.4.5"'
+          result = @version_podspec_file.parse(test_content)
+          expect(result).to eq('1.3.2.4.5')
+          expect(@version_podspec_file.version_value).to eq('1.3.2.4.5')
+          expect(@version_podspec_file.version_match[:major]).to eq('1')
+          expect(@version_podspec_file.version_match[:minor]).to eq('3')
+          expect(@version_podspec_file.version_match[:patch]).to eq('2')
+          expect(@version_podspec_file.version_match[:appendix]).to eq('.4.5')
+        end
       end
 
       it "returns the current version once parsed with prerelease" do

--- a/fastlane/spec/helper/podspec_helper_spec.rb
+++ b/fastlane/spec/helper/podspec_helper_spec.rb
@@ -47,6 +47,17 @@ describe Fastlane::Actions do
         expect(@version_podspec_file.version_match[:appendix]).to eq('.4')
       end
 
+      it "returns the current version once parsed with longer appendix" do
+        test_content = 'spec.version = "1.3.2.4.5"'
+        result = @version_podspec_file.parse(test_content)
+        expect(result).to eq('1.3.2.4.5')
+        expect(@version_podspec_file.version_value).to eq('1.3.2.4.5')
+        expect(@version_podspec_file.version_match[:major]).to eq('1')
+        expect(@version_podspec_file.version_match[:minor]).to eq('3')
+        expect(@version_podspec_file.version_match[:patch]).to eq('2')
+        expect(@version_podspec_file.version_match[:appendix]).to eq('.4.5')
+      end
+
       it "returns the current version once parsed with prerelease" do
         test_content = 'spec.version = "1.3.2-SNAPSHOT"'
         result = @version_podspec_file.parse(test_content)

--- a/fastlane/spec/helper/podspec_helper_spec.rb
+++ b/fastlane/spec/helper/podspec_helper_spec.rb
@@ -1,0 +1,74 @@
+require "stringio"
+
+describe Fastlane::Actions do
+  describe "#podspechelper" do
+    before do
+      @version_podspec_file = Fastlane::Helper::PodspecHelper.new
+    end
+
+    it "raises an exception when an incorrect path is given" do
+      expect do
+        Fastlane::Helper::PodspecHelper.new('invalid_podspec')
+      end.to raise_error("Could not find podspec file at path 'invalid_podspec'")
+    end
+
+    it "raises an exception when there is no version in podspec" do
+      expect do
+        Fastlane::Helper::PodspecHelper.new.parse("")
+      end.to raise_error("Could not find version in podspec content ''")
+    end
+
+    it "raises an exception when the version is commented-out in podspec" do
+      test_content = '# s.version = "1.3.2"'
+      expect do
+        Fastlane::Helper::PodspecHelper.new.parse(test_content)
+      end.to raise_error("Could not find version in podspec content '#{test_content}'")
+    end
+
+    context "when semantic version" do
+      it "returns the current version once parsed" do
+        test_content = 'spec.version = "1.3.2"'
+        result = @version_podspec_file.parse(test_content)
+        expect(result).to eq('1.3.2')
+        expect(@version_podspec_file.version_value).to eq('1.3.2')
+        expect(@version_podspec_file.version_match[:major]).to eq('1')
+        expect(@version_podspec_file.version_match[:minor]).to eq('3')
+        expect(@version_podspec_file.version_match[:patch]).to eq('2')
+      end
+
+      it "returns the current version once parsed with appendix" do
+        test_content = 'spec.version = "1.3.2.4"'
+        result = @version_podspec_file.parse(test_content)
+        expect(result).to eq('1.3.2.4')
+        expect(@version_podspec_file.version_value).to eq('1.3.2.4')
+        expect(@version_podspec_file.version_match[:major]).to eq('1')
+        expect(@version_podspec_file.version_match[:minor]).to eq('3')
+        expect(@version_podspec_file.version_match[:patch]).to eq('2')
+        expect(@version_podspec_file.version_match[:appendix]).to eq('.4')
+      end
+
+      it "returns the current version once parsed with prerelease" do
+        test_content = 'spec.version = "1.3.2-SNAPSHOT"'
+        result = @version_podspec_file.parse(test_content)
+        expect(result).to eq('1.3.2-SNAPSHOT')
+        expect(@version_podspec_file.version_value).to eq('1.3.2-SNAPSHOT')
+        expect(@version_podspec_file.version_match[:major]).to eq('1')
+        expect(@version_podspec_file.version_match[:minor]).to eq('3')
+        expect(@version_podspec_file.version_match[:patch]).to eq('2')
+        expect(@version_podspec_file.version_match[:prerelease]).to eq('SNAPSHOT')
+      end
+
+      it "returns the current version once parsed with appendix and prerelease" do
+        test_content = 'spec.version = "1.3.2.4-SNAPSHOT"'
+        result = @version_podspec_file.parse(test_content)
+        expect(result).to eq('1.3.2.4-SNAPSHOT')
+        expect(@version_podspec_file.version_value).to eq('1.3.2.4-SNAPSHOT')
+        expect(@version_podspec_file.version_match[:major]).to eq('1')
+        expect(@version_podspec_file.version_match[:minor]).to eq('3')
+        expect(@version_podspec_file.version_match[:patch]).to eq('2')
+        expect(@version_podspec_file.version_match[:appendix]).to eq('.4')
+        expect(@version_podspec_file.version_match[:prerelease]).to eq('SNAPSHOT')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #12717

## What
- `version_get_spec` only allow for parsing of versions that were:
  - `<major>`
   - `<major>.<minor>`
   - `<major>.<minor>.<patch>`
   - `<major>.<minor>.<patch><appendix>` where in  `1.2.3.4.5` the appendix is `.4.5`
- This fix allows for parsing of `<major>.<minor>.<patch><appendix>-<prerelease>`
  - Examples:
    - `1.2.3-SNAPSHOT`
    - `1.2.3.4-BETA`
- Also added some tests for `podspec_helper.rb`