### PR TITLE
added default value for cocoapods option

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -107,6 +107,7 @@ module Fastlane
                                        description: 'Retry with --repo-update if action was finished with error',
                                        optional: true,
                                        is_string: false,
+                                       default_value: false,
                                        type: Boolean,
                                        conflicting_options: [:repo_update])
         ]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

Currently there is no default value for `try_repo_update_on_error` option in `cocoapods` action.