### PR TITLE
[deliver] generate Preview.html file in fastlane directory like gitignore docs suggests (see migration notes)

### DIFF
--- a/deliver/lib/deliver/html_generator.rb
+++ b/deliver/lib/deliver/html_generator.rb
@@ -9,7 +9,8 @@ module Deliver
 
     def run(options, screenshots)
       begin
-        html_path = self.render(options, screenshots, '.')
+        fastlane_path = FastlaneCore::FastlaneFolder.path
+        html_path = self.render(options, screenshots, fastlane_path)
       rescue => ex
         UI.error(ex.inspect)
         UI.error(ex.backtrace.join("\n"))


### PR DESCRIPTION
Fixes #12772

## What
- _deliver_'s `Preview.html` file was getting generated in the root (or current) directory
- All other fastlane generated types of files (report.xml, screenshots preview, etc) get created inside of the `fastlane` directory
- The sample `.gitignore` in the docs even show this file should be created in the `fastlane` directory
  - https://docs.fastlane.tools/best-practices/source-control/#source-control
