### PR TITLE
[Fastlane.swift] Now has access to lane name with laneContext() and environmentVariable()

### DIFF
--- a/fastlane/lib/fastlane/swift_lane_manager.rb
+++ b/fastlane/lib/fastlane/swift_lane_manager.rb
@@ -10,6 +10,10 @@ module Fastlane
       UI.user_error!("lane must be a string") unless lane.kind_of?(String) || lane.nil?
       UI.user_error!("parameters must be a hash") unless parameters.kind_of?(Hash) || parameters.nil?
 
+      # Sets environment variable and lane context for lane name
+      ENV["FASTLANE_LANE_NAME"] = lane
+      Actions.lane_context[Actions::SharedValues::LANE_NAME] = lane
+
       # xcodeproj has a bug in certain versions that causes it to change directories
       # and not return to the original working directory
       # https://github.com/CocoaPods/Xcodeproj/issues/426


### PR DESCRIPTION
Fixes #12776

## What
- `Fastlane.swift` was not setting lane context or environment variable for current lane 

### Example
```swift
let laneContextInfo = laneContext()
let contextLaneName = laneContextInfo["LANE_NAME"]
puts(message: "contextLaneName: \(contextLaneName)")

let envLaneName = environmentVariable(get: "FASTLANE_LANE_NAME")
puts(message: "envLaneName: \(envLaneName)")
```