### PR TITLE
[Fastlane.swift] pod_lib_lint and pod_push sources option is now an array

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_lib_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_lib_lint.rb
@@ -61,6 +61,7 @@ module Fastlane
                                          description: "The sources of repos you want the pod spec to lint with, separated by commas",
                                          optional: true,
                                          is_string: false,
+                                         type: Array,
                                          verify_block: proc do |value|
                                            UI.user_error!("Sources must be an array.") unless value.kind_of?(Array)
                                          end),

--- a/fastlane/lib/fastlane/actions/pod_push.rb
+++ b/fastlane/lib/fastlane/actions/pod_push.rb
@@ -80,6 +80,7 @@ module Fastlane
                                        description: "The sources of repos you want the pod spec to lint with, separated by commas",
                                        optional: true,
                                        is_string: false,
+                                       type: Array,
                                        verify_block: proc do |value|
                                          UI.user_error!("Sources must be an array.") unless value.kind_of?(Array)
                                        end),


### PR DESCRIPTION
Fixes #12807

## What
- `pod_lib_lint` and `pod_push` have a `:sources` option that did not have a type defined
  - _Fastlane.swift_ assumes these to be `String` if no type (which was wrong since these need to be arrays)
   - `:sources` are now `type: Array` which shows up as `[String]` in _Fastlane.swift_