### PR TITLE
[frameit] Allow specifying frame colour override in Framefile.json

### DIFF
--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -69,35 +69,41 @@ module Frameit
         if value.kind_of?(Hash)
           validate_values(value) # recursive call
         else
-          case key
-          when 'font'
-            UI.user_error!("Could not find font at path '#{File.expand_path(value)}'") unless File.exist?(value)
-          when 'fonts'
-            UI.user_error!("`fonts` must be an array") unless value.kind_of?(Array)
-
-            value.each do |current|
-              UI.user_error!("You must specify a font path") if current.fetch('font', '').length == 0
-              UI.user_error!("Could not find font at path '#{File.expand_path(current.fetch('font'))}'") unless File.exist?(current.fetch('font'))
-              UI.user_error!("`supported` must be an array") unless current.fetch('supported', []).kind_of?(Array)
-            end
-          when 'background'
-            UI.user_error!("Could not find background image at path '#{File.expand_path(value)}'") unless File.exist?(value)
-          when 'color'
-            UI.user_error!("Invalid color '#{value}'. Must be valid Hex #123123") unless value.include?("#")
-          when 'padding'
-            unless integer_or_percentage(value) || value.split('x').length == 2
-              UI.user_error!("padding must be an integer, or pair of integers of format 'AxB', or a percentage of screen size")
-            end
-          when 'title_min_height'
-            unless integer_or_percentage(value)
-              UI.user_error!("padding must be an integer, or a percentage of screen size")
-            end
-          when 'show_complete_frame', 'title_below_image'
-            UI.user_error!("'#{key}' must be a Boolean") unless [true, false].include?(value)
-          when 'font_scale_factor'
-            UI.user_error!("font_scale_factor must be numeric") unless value.kind_of?(Numeric)
-          end
+          validate_key(key, value)
         end
+      end
+    end
+
+    def validate_key(key, value)
+      case key
+      when 'font'
+        UI.user_error!("Could not find font at path '#{File.expand_path(value)}'") unless File.exist?(value)
+      when 'fonts'
+        UI.user_error!("`fonts` must be an array") unless value.kind_of?(Array)
+
+        value.each do |current|
+          UI.user_error!("You must specify a font path") if current.fetch('font', '').length == 0
+          UI.user_error!("Could not find font at path '#{File.expand_path(current.fetch('font'))}'") unless File.exist?(current.fetch('font'))
+          UI.user_error!("`supported` must be an array") unless current.fetch('supported', []).kind_of?(Array)
+        end
+      when 'background'
+        UI.user_error!("Could not find background image at path '#{File.expand_path(value)}'") unless File.exist?(value)
+      when 'color'
+        UI.user_error!("Invalid color '#{value}'. Must be valid Hex #123123") unless value.include?("#")
+      when 'padding'
+        unless integer_or_percentage(value) || value.split('x').length == 2
+          UI.user_error!("padding must be an integer, or pair of integers of format 'AxB', or a percentage of screen size")
+        end
+      when 'title_min_height'
+        unless integer_or_percentage(value)
+          UI.user_error!("padding must be an integer, or a percentage of screen size")
+        end
+      when 'show_complete_frame', 'title_below_image'
+        UI.user_error!("'#{key}' must be a Boolean") unless [true, false].include?(value)
+      when 'font_scale_factor'
+        UI.user_error!("font_scale_factor must be numeric") unless value.kind_of?(Numeric)
+      when 'frame'
+        UI.user_error!("device must be BLACK, WHITE, GOLD, ROSE_GOLD") unless ["BLACK", "WHITE", "GOLD", "ROSE_GOLD"].include?(value)
       end
     end
 

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -6,6 +6,7 @@ require_relative 'module'
 require_relative 'offsets'
 require_relative 'config_parser'
 require_relative 'strings_parser'
+require_relative 'device_types'
 
 module Frameit
   # Currently the class is 2 lines too long. Reevaluate refactoring when it's length changes significantly
@@ -41,6 +42,10 @@ module Frameit
     end
 
     def load_frame
+      color = fetch_frame_color
+      if color
+        screenshot.color = color
+      end
       TemplateFinder.get_template(screenshot)
     end
 
@@ -486,6 +491,21 @@ module Frameit
       end
 
       return text
+    end
+
+    def fetch_frame_color
+      color = fetch_config['frame']
+      if color == "BLACK"
+        return Frameit::Color::BLACK
+      elsif color == "WHITE"
+        return Frameit::Color::SILVER
+      elsif color == "GOLD"
+        return Frameit::Color::GOLD
+      elsif color == "ROSE_GOLD"
+        return Frameit::Color::ROSE_GOLD
+      end
+
+      return nil
     end
 
     # The font we want to use


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Allows you to specify different device colours for each screenshot.

<!-- If it fixes an open issue, please link to the issue here. -->
This fixes an issue I was having, documented here #12676 

<!-- Please describe in detail how you tested your changes. -->
I added unit tests and ensured existing tests still passed. I also ran frameit locally and specified the `frame` property in the `Framefile.json`. When frameit was run, each device frame matched the value in the json file. I also tested it with my personal app's screenshots. I used the following devices: [iPhone 8, iPhone 8 Plus, iPhone SE, iPhone X, iPad Pro 12.9", iPad Pro 9.7"] and a mix of White and Black devices (specified in the `Framefile.json`).

### Description
<!-- Describe your changes in detail -->
I updated the template finder to take an optional parameter (device colour). If this parameter is present, it is used over the one specified in the screenshot object. For each screenshot, the config file is consulted to see if there is a colour override present, under the key `frame`.