### PR TITLE
Set ConnectHardwareKeyboard to false for all simulators. Issue #12325.

### DIFF
--- a/snapshot/lib/snapshot/fixes/hardware_keyboard_fix.rb
+++ b/snapshot/lib/snapshot/fixes/hardware_keyboard_fix.rb
@@ -10,6 +10,17 @@ module Snapshot
         UI.verbose("Patching simulator to work with secure text fields")
 
         Helper.backticks("defaults write com.apple.iphonesimulator ConnectHardwareKeyboard 0", print: FastlaneCore::Globals.verbose?)
+
+        # For > Xcode 9
+        # https://stackoverflow.com/questions/38010494/is-it-possible-to-toggle-software-keyboard-via-the-code-in-ui-test/47820883#47820883
+        Helper.backticks("/usr/libexec/PlistBuddy "\
+                         "-c \"Print :DevicePreferences\" ~/Library/Preferences/com.apple.iphonesimulator.plist | "\
+                         "perl -lne 'print $1 if /^    (\\S*) =/' | while read -r a; do /usr/libexec/PlistBuddy "\
+                         "-c \"Set :DevicePreferences:$a:ConnectHardwareKeyboard false\" "\
+                         "~/Library/Preferences/com.apple.iphonesimulator.plist "\
+                         "|| /usr/libexec/PlistBuddy "\
+                         "-c \"Add :DevicePreferences:$a:ConnectHardwareKeyboard bool false\" "\
+                         "~/Library/Preferences/com.apple.iphonesimulator.plist; done", print: FastlaneCore::Globals.verbose?)
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The ConnectHardwareKeyboard doesn't work in Xcode 9 or greater.
Issue #12325.
I ran my UI Test suit and saw that the hardware keyboard had been disabled. I also looked in `~/Library/Preferences/com.apple.iphonesimulator.plist` and verified that it was correctly updated. 

### Description
The additional script inserts the `ConnectHardwareKeyboard` under each `DevicePreferences`. It first tries to set `ConnectHardwareKeyboard`. If that fails it adds `ConnectHardwareKeyboard`.
