### PR TITLE
[action] add dsym_paths option to upload_symbols_to_crashlytics

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -16,8 +16,10 @@ module Fastlane
 
         dsym_paths = []
         dsym_paths << params[:dsym_path] if params[:dsym_path]
-        dsym_paths += params[:dsym_paths] if params[:dsym_paths]
         dsym_paths += Actions.lane_context[SharedValues::DSYM_PATHS] if Actions.lane_context[SharedValues::DSYM_PATHS]
+
+        # Allows adding of additional multiple dsym_paths since :dsym_path can be autoset by other actions
+        dsym_paths += params[:dsym_paths] if params[:dsym_paths]
 
         if dsym_paths.count == 0
           UI.error("Couldn't find any dSYMs, please pass them using the dsym_path option")

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -16,6 +16,7 @@ module Fastlane
 
         dsym_paths = []
         dsym_paths << params[:dsym_path] if params[:dsym_path]
+        dsym_paths += params[:dsym_paths] if params[:dsym_paths]
         dsym_paths += Actions.lane_context[SharedValues::DSYM_PATHS] if Actions.lane_context[SharedValues::DSYM_PATHS]
 
         if dsym_paths.count == 0
@@ -150,6 +151,17 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find file at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                          UI.user_error!("Symbolication file needs to be dSYM or zip") unless value.end_with?(".zip", ".dSYM")
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :dsym_paths,
+                                       env_name: "FL_UPLOAD_SYMBOLS_TO_CRASHLYTICS_DSYM_PATHs",
+                                       description: "Paths to the DSYM files or zips to upload",
+                                       optional: true,
+                                       type: Array,
+                                       verify_block: proc do |values|
+                                         values.each do |value|
+                                           UI.user_error!("Couldn't find file at path '#{File.expand_path(value)}'") unless File.exist?(value)
+                                           UI.user_error!("Symbolication file needs to be dSYM or zip") unless value.end_with?(".zip", ".dSYM")
+                                         end
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_token,
                                        env_name: "CRASHLYTICS_API_TOKEN",

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -153,7 +153,7 @@ module Fastlane
                                          UI.user_error!("Symbolication file needs to be dSYM or zip") unless value.end_with?(".zip", ".dSYM")
                                        end),
           FastlaneCore::ConfigItem.new(key: :dsym_paths,
-                                       env_name: "FL_UPLOAD_SYMBOLS_TO_CRASHLYTICS_DSYM_PATHs",
+                                       env_name: "FL_UPLOAD_SYMBOLS_TO_CRASHLYTICS_DSYM_PATHS",
                                        description: "Paths to the DSYM files or zips to upload",
                                        optional: true,
                                        type: Array,

--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -106,6 +106,50 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error(FastlaneCore::Interface::FastlaneError)
       end
+
+      context "with dsym_paths" do
+        it "uploads dSYM files with gsp_path" do
+          binary_path = './spec/fixtures/screenshots/screenshot1.png'
+          dsym_1_path = './spec/fixtures/dSYM/Themoji.dSYM'
+          dsym_2_path = './spec/fixtures/dSYM/Themoji2.dSYM'
+          gsp_path = './spec/fixtures/plist/With Space.plist'
+
+          command = []
+          command << File.expand_path(File.join("fastlane", binary_path)).shellescape
+          command << "-gsp #{File.expand_path(File.join('fastlane', gsp_path)).shellescape}"
+          command << "-p ios"
+          command_1 = command + [File.expand_path(File.join("fastlane", dsym_1_path)).shellescape]
+          command_2 = command + [File.expand_path(File.join("fastlane", dsym_2_path)).shellescape]
+
+          expect(Fastlane::Actions).to receive(:sh).with(command_1.join(" "), log: false)
+          expect(Fastlane::Actions).to receive(:sh).with(command_2.join(" "), log: false)
+
+          Fastlane::FastFile.new.parse("lane :test do
+            upload_symbols_to_crashlytics(
+              dsym_paths: ['fastlane/#{dsym_1_path}', 'fastlane/#{dsym_2_path}'],
+              gsp_path: 'fastlane/#{gsp_path}',
+              binary_path: 'fastlane/#{binary_path}')
+          end").runner.execute(:test)
+        end
+
+        it "raises exception if a dsym_paths not found" do
+          binary_path = './spec/fixtures/screenshots/screenshot1.png'
+          dsym_1_path = './spec/fixtures/dSYM/Themoji.dSYM'
+          dsym_not_here_path = './spec/fixtures/dSYM/Themoji_not_here.dSYM'
+          gsp_path = './spec/fixtures/plist/With Space.plist'
+
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              upload_symbols_to_crashlytics(
+                dsym_paths: ['fastlane/#{dsym_1_path}', 'fastlane/#{dsym_not_here_path}'],
+                gsp_path: 'fastlane/#{gsp_path}',
+                binary_path: 'fastlane/#{binary_path}')
+            end").runner.execute(:test)
+          end.to raise_error(FastlaneCore::Interface::FastlaneError)
+
+        end
+      end
+
     end
   end
 end

--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -146,10 +146,8 @@ describe Fastlane do
                 binary_path: 'fastlane/#{binary_path}')
             end").runner.execute(:test)
           end.to raise_error(FastlaneCore::Interface::FastlaneError)
-
         end
       end
-
     end
   end
 end

--- a/fastlane/spec/fixtures/dSYM/Themoji2.dSYM/Contents/Info.plist
+++ b/fastlane/spec/fixtures/dSYM/Themoji2.dSYM/Contents/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>CFBundleDevelopmentRegion</key>
+		<string>English</string>
+		<key>CFBundleIdentifier</key>
+		<string>com.apple.xcode.dsym.libswiftCore.dylib</string>
+		<key>CFBundleInfoDictionaryVersion</key>
+		<string>6.0</string>
+		<key>CFBundlePackageType</key>
+		<string>dSYM</string>
+		<key>CFBundleSignature</key>
+		<string>????</string>
+		<key>CFBundleShortVersionString</key>
+		<string>1.0</string>
+		<key>CFBundleVersion</key>
+		<string>1</string>
+	</dict>
+</plist>

--- a/fastlane/spec/fixtures/dSYM/Themoji2.dSYM/Contents/Resources/BA84E1C7-148F-37B0-B36D-2DC5C6493464.plist
+++ b/fastlane/spec/fixtures/dSYM/Themoji2.dSYM/Contents/Resources/BA84E1C7-148F-37B0-B36D-2DC5C6493464.plist
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>DBGOriginalUUID</key>
+   <string>3AA3A790-552D-3052-9E7B-A97225E2D4FF</string>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes #12774

# What
- `upload_symbols_to_crashlytics` didn't allow manually uploading with multiple dsym paths but now it does