### PR TITLE
[frameit] Fix frameit for iPad 10.5

### DIFF
--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -41,7 +41,7 @@ module Frameit
         return 'iPhone 4'
       when sizes::IOS_IPAD
         return 'iPad Air 2'
-      when sizes::IOS_IPAD_PRO
+      when sizes::IOS_IPAD_PRO, sizes::IOS_IPAD_10_5
         return 'iPad Pro'
       when sizes::MAC
         return 'MacBook'


### PR DESCRIPTION
Add sizes::IOS_IPAD_10_5 to iPad Pro case

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Currently frameit is not able to find a frame for the iPad Pro 10.5.
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/fastlane/fastlane/issues/9651 
<!-- Please describe in detail how you tested your changes. -->
Ran frameit on a universal app, localized in 11 languages.
### Description
<!-- Describe your changes in detail -->

Added another case for the iPad Pro frame.