### PR TITLE
Remove un-needed puts from configuration_file.rb

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -43,7 +43,7 @@ module FastlaneCore
 
       begin
         # rubocop:disable Security/Eval
-        puts(eval(content)) # this is okay in this case
+        eval(content) # this is okay in this case
         # rubocop:enable Security/Eval
 
         print_resulting_config_values unless skip_printing_values # only on success


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/pull/11946/files#r192949219

## What
- `puts` was not actually needed so it has been removed now