### PR TITLE
Fix option to disable ssl verification

### DIFF
--- a/fastlane/lib/fastlane/actions/github_api.rb
+++ b/fastlane/lib/fastlane/actions/github_api.rb
@@ -17,7 +17,6 @@ module Fastlane
           payload = construct_body(params[:body], params[:raw_body])
           error_handlers = params[:error_handlers] || {}
           secure = params[:secure]
-          secure = true if secure.nil?
 
           response = call_endpoint(
             url,
@@ -141,7 +140,7 @@ module Fastlane
             FastlaneCore::ConfigItem.new(key: :secure,
                                          env_name: "FL_GITHUB_API_SECURE",
                                          description: "Optionally disable secure requests (ssl_verify_peer)",
-                                         is_string: false,
+                                         type: Boolean,
                                          default_value: true,
                                          optional: true)
           ]

--- a/fastlane/lib/fastlane/actions/github_api.rb
+++ b/fastlane/lib/fastlane/actions/github_api.rb
@@ -16,7 +16,8 @@ module Fastlane
           headers = construct_headers(params[:api_token], params[:headers])
           payload = construct_body(params[:body], params[:raw_body])
           error_handlers = params[:error_handlers] || {}
-          secure = params[:secure] || true
+          secure = params[:secure]
+          secure = true if secure.nil?
 
           response = call_endpoint(
             url,

--- a/fastlane/spec/actions_specs/github_api_spec.rb
+++ b/fastlane/spec/actions_specs/github_api_spec.rb
@@ -262,7 +262,7 @@ describe Fastlane do
               end
             end
           end
-          
+
           context 'secure is set' do
             it 'correctly submits without ssl verification' do
               Excon.defaults[:ssl_verify_peer] = true

--- a/fastlane/spec/actions_specs/github_api_spec.rb
+++ b/fastlane/spec/actions_specs/github_api_spec.rb
@@ -262,6 +262,64 @@ describe Fastlane do
               end
             end
           end
+          
+          context 'secure is set' do
+            it 'correctly submits without ssl verification' do
+              Excon.defaults[:ssl_verify_peer] = true
+              result = Fastlane::FastFile.new.parse("
+                lane :test do
+                  github_api(
+                    api_token: '123456789',
+                    http_method: 'PUT',
+                    path: 'repos/fastlane/fastlane/contents/TEST_FILE.md',
+                    secure: false
+                  )
+                end
+              ").runner.execute(:test)
+
+              expect(Excon.defaults[:ssl_verify_peer]).to eq(false)
+              expect(result[:status]).to eq(200)
+              expect(result[:body]).to eq(response_body)
+              expect(result[:json]).to eq(JSON.parse(response_body))
+            end
+
+            it 'correctly submits with ssl verification' do
+              Excon.defaults[:ssl_verify_peer] = false
+              result = Fastlane::FastFile.new.parse("
+                lane :test do
+                  github_api(
+                    api_token: '123456789',
+                    http_method: 'PUT',
+                    path: 'repos/fastlane/fastlane/contents/TEST_FILE.md',
+                    secure: true
+                  )
+                end
+              ").runner.execute(:test)
+
+              expect(Excon.defaults[:ssl_verify_peer]).to eq(true)
+              expect(result[:status]).to eq(200)
+              expect(result[:body]).to eq(response_body)
+              expect(result[:json]).to eq(JSON.parse(response_body))
+            end
+
+            it 'correctly submits using default verification' do
+              Excon.defaults[:ssl_verify_peer] = false
+              result = Fastlane::FastFile.new.parse("
+                lane :test do
+                  github_api(
+                    api_token: '123456789',
+                    http_method: 'PUT',
+                    path: 'repos/fastlane/fastlane/contents/TEST_FILE.md'
+                  )
+                end
+              ").runner.execute(:test)
+
+              expect(Excon.defaults[:ssl_verify_peer]).to eq(true)
+              expect(result[:status]).to eq(200)
+              expect(result[:body]).to eq(response_body)
+              expect(result[:json]).to eq(JSON.parse(response_body))
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Fix logic to respect false value for params[:secure]

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
Currently even if params[:secure] is passed as false it is overwritten to true.  This means ssl verification _cannot_ be disabled.

Using the following simple Ruby snippet
```ruby
x = false || true
```
we can see that x is equal to true at the end.

Similarly if we run
```ruby
y = false
x = y || true
```
we can see that x is equal to true again.

### Description
Only coerce secure to be true if it is not specified at all.  In general since the default is `true` anyway, we can probably get away with not touching it at all.