### PR TITLE
Add support for iPad 10.5

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -35,6 +35,7 @@ module Spaceship
             'iphone6Plus' => [2208, 1242],
             'iphone58' => [2436, 1125],
             'ipad' => [1024, 768],
+            'ipad105' => [2224, 1668],
             'ipadPro' => [2732, 2048]
         }
 


### PR DESCRIPTION
`upload_trailer` method for device `ipad105` currently fails. Traced the console error back to this place, where the accepted resolution was simply missing.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Add support for "new" iPad.

### Description
Added device accepted resolution.
