### PR TITLE
[upload_symbols_to_crashlytics] Get rid of the limit of the number of threads

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -191,9 +191,7 @@ module Fastlane
                                        description: "The number of threads to use for simultaneous dSYM upload",
                                        verify_block: proc do |value|
                                          min_threads = 1
-                                         max_threads = 15
                                          UI.user_error!("Too few threads (#{value}) minimum number of threads: #{min_threads}") unless value >= min_threads
-                                         UI.user_error!("Too many threads (#{value}) maximum number of threads: #{max_threads}") unless value <= max_threads
                                        end)
         ]
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I was using `sysctl -n hw.ncpu` for this option but recently noticed that I cannot do on iMac Pro as it has at least 16 of them (8 * 2).

### Description

Just increasing this value also works, however as computers are getting more and more powerful, I thought it’s hard to maintain this value. Also I think calculating the limit from the number of cores is too much as the way to get it is different on each platforms, so went with getting rid of the limit.
