### PR TITLE
Fix issue that uploading aab with mapping file

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -23,8 +23,10 @@ module Supply
         end
       end
 
-      upload_binaries unless Supply.config[:skip_upload_apk]
-      upload_bundles unless Supply.config[:skip_upload_aab]
+      apk_version_codes = []
+      apk_version_codes.concat(upload_apks) unless Supply.config[:skip_upload_apk]
+      apk_version_codes.concat(upload_bundles) unless Supply.config[:skip_upload_aab]
+      upload_binaries(apk_version_codes)
 
       promote_track if Supply.config[:track_promote_to]
 
@@ -120,7 +122,7 @@ module Supply
       end
     end
 
-    def upload_binaries
+    def upload_apks
       apk_paths = [Supply.config[:apk]] unless (apk_paths = Supply.config[:apk_paths])
       apk_paths.compact!
 
@@ -130,6 +132,10 @@ module Supply
         apk_version_codes.push(upload_binary_data(apk_path))
       end
 
+      return apk_version_codes
+    end
+
+    def upload_binaries(apk_version_codes)
       mapping_paths = [Supply.config[:mapping]] unless (mapping_paths = Supply.config[:mapping_paths])
       mapping_paths.zip(apk_version_codes).each do |mapping_path, version_code|
         if mapping_path
@@ -147,11 +153,7 @@ module Supply
       return unless aab_path
 
       UI.message("Preparing aab at path '#{aab_path}' for upload...")
-      apk_version_codes = [client.upload_bundle(aab_path)]
-
-      # Only update tracks if we have version codes
-      # Updating a track with empty version codes can completely clear out a track
-      update_track(apk_version_codes) unless apk_version_codes.empty?
+      return [client.upload_bundle(aab_path)]
     end
 
     private

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -26,7 +26,7 @@ module Supply
       apk_version_codes = []
       apk_version_codes.concat(upload_apks) unless Supply.config[:skip_upload_apk]
       apk_version_codes.concat(upload_bundles) unless Supply.config[:skip_upload_aab]
-      upload_binaries(apk_version_codes)
+      upload_mapping(apk_version_codes)
 
       promote_track if Supply.config[:track_promote_to]
 
@@ -135,7 +135,7 @@ module Supply
       return apk_version_codes
     end
 
-    def upload_binaries(apk_version_codes)
+    def upload_mapping(apk_version_codes)
       mapping_paths = [Supply.config[:mapping]] unless (mapping_paths = Supply.config[:mapping_paths])
       mapping_paths.zip(apk_version_codes).each do |mapping_path, version_code|
         if mapping_path

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -28,6 +28,10 @@ module Supply
       apk_version_codes.concat(upload_bundles) unless Supply.config[:skip_upload_aab]
       upload_mapping(apk_version_codes)
 
+      # Only update tracks if we have version codes
+      # Updating a track with empty version codes can completely clear out a track
+      update_track(apk_version_codes) unless apk_version_codes.empty?
+
       promote_track if Supply.config[:track_promote_to]
 
       if Supply.config[:validate_only]
@@ -142,10 +146,6 @@ module Supply
           client.upload_mapping(mapping_path, version_code)
         end
       end
-
-      # Only update tracks if we have version codes
-      # Updating a track with empty version codes can completely clear out a track
-      update_track(apk_version_codes) unless apk_version_codes.empty?
     end
 
     def upload_bundles


### PR DESCRIPTION
Fixes #12900

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

When I uploaded app bundle file with mapping.txt, I got error `Google Api Error: Invalid request`.

```
FastlaneCore::Interface::FastlaneError: [!] Google Api Error: Invalid request
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane_core/lib/fastlane_core/ui/interface.rb:141:in `user_error!'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane_core/lib/fastlane_core/ui/ui.rb:17:in `method_missing'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/supply/lib/supply/client.rb:390:in `rescue in call_google_api'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/supply/lib/supply/client.rb:387:in `call_google_api'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/supply/lib/supply/client.rb:228:in `upload_mapping'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/supply/lib/supply/uploader.rb:136:in `block in upload_binaries'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/supply/lib/supply/uploader.rb:134:in `each'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/supply/lib/supply/uploader.rb:134:in `upload_binaries'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/supply/lib/supply/uploader.rb:26:in `perform_upload'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/actions/upload_to_play_store.rb:21:in `run'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/runner.rb:257:in `block (2 levels) in execute_action'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/actions/actions_helper.rb:50:in `execute_action'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/runner.rb:236:in `block in execute_action'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/runner.rb:231:in `chdir'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/runner.rb:231:in `execute_action'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/runner.rb:157:in `trigger_action_by_name'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/fast_file.rb:149:in `method_missing'
  Fastfile:64:in `block (2 levels) in parsing_binding'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/lane.rb:33:in `call'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/runner.rb:49:in `block in execute'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/runner.rb:45:in `chdir'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/runner.rb:45:in `execute'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/lane_manager.rb:59:in `cruise_lane'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/command_line_handler.rb:36:in `handle'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/commands_generator.rb:107:in `block (2 levels) in run'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/commander-fastlane-4.4.6/lib/commander/command.rb:178:in `call'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/commander-fastlane-4.4.6/lib/commander/command.rb:153:in `run'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/commander-fastlane-4.4.6/lib/commander/runner.rb:476:in `run_active_command'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:75:in `run!'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/commander-fastlane-4.4.6/lib/commander/delegates.rb:15:in `run!'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/commands_generator.rb:332:in `run'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/commands_generator.rb:41:in `start'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/fastlane/lib/fastlane/cli_tools_distributor.rb:108:in `take_off'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/fastlane-2.98.0/bin/fastlane:20:in `<top (required)>'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bin/fastlane:23:in `load'
  /Users/takao-chiba/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bin/fastlane:23:in `<top (required)>'
```

This is caused that supply upload mapping.txt before app bundle file.

I tested this PR with lane to supply app bundle and mapping file and got successfully upload.

```
    supply(
        aab: ENV["ARTIFACTS"] + '/bundle/productRelease/app.aab',
        track: "internal",
        mapping: ENV["ARTIFACTS"] + '/mapping/product/release/mapping.txt',
        skip_upload_metadata: true,
        validate_only: true
    )
```

### Description
<!-- Describe your changes in detail -->

At `upload_binaries`, upload apks and mapping.txt after that `upload_bundles` would upload aab file.
But when we upload aab and mapping file, `apk_version_codes` is not supplied yet.
So, we have to upload mapping file after both apks uploadind and aab uploading.

I split `upload_binaries` to apk upload and mapping upload. And call mapping upload process after apk and aab uploading. 