### PR TITLE
[spaceship] remove defaulting push notifications on in create_app

### DIFF
--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -81,8 +81,8 @@ module Produce
       app_service = Spaceship.app_service
       enabled_clean_options = {}
 
-      # "enable_services" was deprecated in favor of "enable_services"
-      config_enabled_services = Produce.config[:enable_services] || Produce.config[:enable_services]
+      # "enabled_features" was deprecated in favor of "enable_services"
+      config_enabled_services = Produce.config[:enable_services] || Produce.config[:enabled_features]
 
       config_enabled_services.each do |k, v|
         if k.to_sym == :data_protection

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -184,7 +184,6 @@ module Spaceship
                        {
                          type: 'explicit',
                          identifier: bundle_id,
-                         push: 'on',
                          inAppPurchase: 'on',
                          gameCenter: 'on'
                        }

--- a/spaceship/spec/portal/fixtures/addAppId.action.apostroph.json
+++ b/spaceship/spec/portal/fixtures/addAppId.action.apostroph.json
@@ -21,7 +21,7 @@
     "isWildCard": false,
     "isDuplicate": false,
     "features": {
-      "push": true,
+      "push": false,
       "inAppPurchase": true,
       "gameCenter": true,
       "passbook": false,
@@ -39,8 +39,7 @@
     },
     "enabledFeatures": [
       "gameCenter",
-      "inAppPurchase",
-      "push"
+      "inAppPurchase"
     ],
     "isDevPushEnabled": false,
     "isProdPushEnabled": false,

--- a/spaceship/spec/portal/fixtures/addAppId.action.explicit.json
+++ b/spaceship/spec/portal/fixtures/addAppId.action.explicit.json
@@ -21,7 +21,7 @@
     "isWildCard": false,
     "isDuplicate": false,
     "features": {
-      "push": true,
+      "push": false,
       "inAppPurchase": true,
       "gameCenter": true,
       "passbook": false,
@@ -39,8 +39,7 @@
     },
     "enabledFeatures": [
       "gameCenter",
-      "inAppPurchase",
-      "push"
+      "inAppPurchase"
     ],
     "isDevPushEnabled": false,
     "isProdPushEnabled": false,

--- a/spaceship/spec/portal/fixtures/addAppId.action.push.json
+++ b/spaceship/spec/portal/fixtures/addAppId.action.push.json
@@ -39,7 +39,8 @@
     },
     "enabledFeatures": [
       "gameCenter",
-      "inAppPurchase"
+      "inAppPurchase",
+      "push"
     ],
     "isDevPushEnabled": false,
     "isProdPushEnabled": false,

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -149,11 +149,11 @@ describe Spaceship::Client do
         expect(response['identifier']).to eq('tools.fastlane.spaceship.some-explicit-app')
       end
 
-      it 'should make a request create an explicit app id with no push feature' do
+      it 'should make a request create an explicit app id with push feature' do
         payload = {}
         payload[Spaceship.app_service.push_notification.on.service_id] = Spaceship.app_service.push_notification.on
         response = subject.create_app!(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', enable_services: payload)
-        expect(response['enabledFeatures']).to_not(include("push"))
+        expect(response['enabledFeatures']).to(include("push"))
         expect(response['identifier']).to eq('tools.fastlane.spaceship.some-explicit-app')
       end
     end

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -213,7 +213,7 @@ class PortalStubbing
         to_return(status: 200, body: adp_read_fixture_file('getAppIdDetail.action.json'), headers: { 'Content-Type' => 'application/json' })
 
       stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
-        with(body: { "name" => "Production App", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "gameCenter" => "on", "inAppPurchase" => "on", "push" => "on", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
+        with(body: { "name" => "Production App", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "gameCenter" => "on", "inAppPurchase" => "on", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
         to_return(status: 200, body: adp_read_fixture_file('addAppId.action.explicit.json'), headers: { 'Content-Type' => 'application/json' })
 
       stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
@@ -221,7 +221,7 @@ class PortalStubbing
         to_return(status: 200, body: adp_read_fixture_file('addAppId.action.wildcard.json'), headers: { 'Content-Type' => 'application/json' })
 
       stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
-        with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "pp Test 1ed9e25c93ac7142ff9df53e7f80e84c", "push" => "on", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
+        with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "pp Test 1ed9e25c93ac7142ff9df53e7f80e84c", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
         to_return(status: 200, body: adp_read_fixture_file('addAppId.action.apostroph.json'), headers: { 'Content-Type' => 'application/json' })
 
       stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/deleteAppId.action").
@@ -229,8 +229,8 @@ class PortalStubbing
         to_return(status: 200, body: adp_read_fixture_file('deleteAppId.action.json'), headers: { 'Content-Type' => 'application/json' })
 
       stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/identifiers/addAppId.action").
-        with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "name" => "Production App", "push" => "true", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
-        to_return(status: 200, body: adp_read_fixture_file('addAppId.action.nopush.json'), headers: { 'Content-Type' => 'application/json' })
+        with(body: { "gameCenter" => "on", "identifier" => "tools.fastlane.spaceship.some-explicit-app", "inAppPurchase" => "on", "push" => "true", "name" => "Production App", "teamId" => "XXXXXXXXXX", "type" => "explicit" }).
+        to_return(status: 200, body: adp_read_fixture_file('addAppId.action.push.json'), headers: { 'Content-Type' => 'application/json' })
     end
 
     def adp_stub_persons


### PR DESCRIPTION
Fixes #12853

## What
- _spaceships_'s `create_app!` method would enable the push notification feature/service for any app is created (along with game center and in-app payments)
- Apple enabled (and doesn't allow disabling) of game center and in-app payments but **does not** enable push notifications by default
- This PR removes push notifications from getting enabled by default
 
## Side Effects?
- One side effect I _thought_ could happen would be that `pem` wouldn't be able to create the push certificate if the push notifications feature/service was disable
- After some testing, it does appear that `pem` can still create a push certificate (and enable the push notification feature/service) if it is disabled so this is not an issue 👍 

## Bonus Fix
- And added a bonus fix for some duplicate looking up of `enable_services` when should have been also looking for deprecated `enabled_features`