### PR TITLE
[action] fix reset_simulator_contents to work with Xcode 9 and later

### DIFF
--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -5,13 +5,13 @@ module Fastlane
         ios_versions = params[:ios]
 
         if Helper.xcode_at_least?("9")
-          reset_at_least_xcode9(ios_versions)
+          reset_xcode9_and_higher(ios_versions)
         else
           reset_up_to_xcode8(ios_versions)
         end
       end
 
-      def self.reset_at_least_xcode9(ios_versions)
+      def self.reset_xcode9_and_higher(ios_versions)
         UI.verbose("Resetting simulator contents for Xcode 9 and later")
         simulators = FastlaneCore::DeviceManager.simulators('iOS')
         if ios_versions

--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -12,7 +12,7 @@ module Fastlane
       end
 
       def self.reset_at_least_xcode9(ios_versions)
-        UI.verbose("Resetting simulator contents forXcode9 and later")
+        UI.verbose("Resetting simulator contents for Xcode 9 and later")
         simulators = FastlaneCore::DeviceManager.simulators('iOS')
         if ios_versions
           simulators.select! { |s| ios_versions.include?(s.os_version) }
@@ -24,7 +24,7 @@ module Fastlane
       end
 
       def self.reset_up_to_xcode8(ios_versions)
-        UI.verbose("Resetting simulator contents for Xcode8 and earlier")
+        UI.verbose("Resetting simulator contents for Xcode 8 and earlier")
         if ios_versions
           ios_versions.each do |os_version|
             FastlaneCore::Simulator.reset_all_by_version(os_version: os_version)


### PR DESCRIPTION
Fixes #12731

## What
- The `reset_simulator_contents` action was not implemented for Xcode9 or later
- This adds support for Xcode9 simulators
- Separated out the Xcode8 and under and the Xcode9 and over into separate methods

## What was tested?
- Xcode9
  - I tested resetting contents of all Xcode 9 simulators and when specifying a specific version
- Xcode8
  - I installed a version of Xcode8 but could not successfully reset contents due to `xcrun simctl list device` errors I wasn't able to run
  - Not sure if anybody can still run this, TBH 😊 
  - It might be worth deleting at some point 🤔 