### PR TITLE
[action] updated crashlytics to search for submit binary location outside of framework

### DIFF
--- a/fastlane/spec/actions_specs/crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/crashlytics_spec.rb
@@ -273,7 +273,7 @@ describe Fastlane do
 
         describe "Invalid Parameters" do
           it "raises an error if no crashlytics path was given" do
-            expect(Fastlane::Helper::CrashlyticsHelper).to receive(:discover_default_crashlytics_path).and_return(nil)
+            expect(Fastlane::Helper::CrashlyticsHelper).to receive(:discover_crashlytics_path).and_return(nil)
             expect do
               Fastlane::FastFile.new.parse("lane :test do
                 crashlytics({
@@ -282,7 +282,7 @@ describe Fastlane do
                   ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1'
                 })
               end").runner.execute(:test)
-            end.to raise_error("No value found for 'crashlytics_path'")
+            end.to raise_error("Couldn't find Crashlytics' submit binary in current directory. Make sure to add the 'Crashlytics' pod to your 'Podfile' and run `pod update`")
           end
 
           it "raises an error if the given crashlytics path was not found" do


### PR DESCRIPTION
Partially fixes #12820

# Issue (taken from https://github.com/fastlane/fastlane/issues/12820#issuecomment-403868587)

## Part 1: Moved `submit` binary (This is the part _fastlane_ can fix)

The Crashlytics pod actually had three `submit` binaries. Two of them could successfully run (see Part 2) and one would fail with an error.
- ✅ `${PODS_ROOT}/Crashlytics/submit`
  - This is the one that Crashlytics suggests users use but _fastlane_ was not looking at this one yet
  - PR #12876 will fix this
- ✅ `${PODS_ROOT}/Crashlytics/iOS/Crashlytics.framework/submit`
  - This is the binary that _fastlane_ was able to find and did use most of the time
  - This binary could successfully upload an IPA in version `3.10.3` and `3.10.4` but **only if** notes were not trying to be set (see Part 2)
- ❌ `${PODS_ROOT}/Crashlytics/Crashlytics.framework/submit`
  - There is also a binary at this location but executing this binary results in the following error
    - `error: The submit binary delivered by cocoapods is in a new location, under '${PODS_ROOT}/Crashlytics/submit'. This script was put in place for backwards compatibility, but it relies on PODS_ROOT, which does not have a value in your current setup. Please update the path to the submit binary to fix this issue`
  - _fastlane_ could have ended up potentially pointing to this location if `${PODS_ROOT}/Crashlytics/iOS/Crashlytics.framework/submit` wasn't found or if a _fastlane_ user explicitly pointed to this binary
  - This binary cannot be used at all

## Part 2: Broken binary when setting `:notes` and `:notes_path`

This part of the issue was caused by upgrading to Crashlytics version `3.10.3` and `3.10.4`. The `submit` binary located at `${PODS_ROOT}/Crashlytics/submit` and `${PODS_ROOT}/Crashlytics/iOS/Crashlytics.framework/submit`. Both of these binaries segfaulted when trying to attach `:notes` and `:notes_path` via the _fastlane_ action.

This segfault also occurred when attempting to execute both `${PODS_ROOT}/Crashlytics/submit` and `${PODS_ROOT}/Crashlytics/iOS/Crashlytics.framework/submit` directly via the command line (outside of _fastlane_) with the `-notesPath` argument.

Both of these above binaries succeeded in uploading a binary **if and only if** `-notesPath` argument was left out.

# Fix

- Look for `${PODS_ROOT}/Crashlytics/submit` first