### PR TITLE
[spaceship] add function to retrieve contract messages

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -521,6 +521,16 @@ module Spaceship
       raise AppleTimeoutError.new, "Could not receive latest API key from App Store Connect, this might be a server issue."
     end
 
+    def contract_messages
+      response = request(:get, "https://olympus.itunes.apple.com/v1/contractMessages")
+      body = response.body
+      if body
+        body = JSON.parse(body) if body.kind_of?(String)
+      end
+
+      return body
+    end
+
     #####################################################
     # @!group Helpers
     #####################################################


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Sometimes Apple updates its Program License Agreement which causes the release to fail until we manually login to AppStore Connect and accept it.

Since we build multiple custom apps, this would often block us and cause delays in our releases.
Thus, we needed a way to proactively check when a new License Agreement needs to be accepted so that we can react in time for our releases. And this can be done by fetching the contract messages for that account.

### Description
This adds a call to the Spaceship client that allows to retrieve all the contract messages
