### PR TITLE
[action] crashlytics action handles user set crashlytics path better if submit binary not linked directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ rspec_logs.json
 test_output/
 .DS_STORE
 .keys
+*.swp 
 
 ## Specific to Android
 .gradle/

--- a/fastlane/spec/actions_specs/crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/crashlytics_spec.rb
@@ -14,7 +14,7 @@ describe Fastlane do
           it "works with valid parameters" do
             command = Fastlane::FastFile.new.parse('lane :test do
               crashlytics(
-                crashlytics_path: "./fastlane/spec/fixtures/fastfiles/Fastfile1",
+                crashlytics_path: "./fastlane/spec/fixtures/actions/crashlytics/submit",
                 api_token: "api_token",
                 build_secret: "build_secret",
                 apk_path: "./fastlane/spec/fixtures/fastfiles/Fastfile2",
@@ -56,7 +56,7 @@ describe Fastlane do
 
             Fastlane::FastFile.new.parse('lane :test do
             crashlytics(
-              crashlytics_path: "./fastlane/spec/fixtures/fastfiles/Fastfile1",
+              crashlytics_path: "./fastlane/spec/fixtures/actions/crashlytics/submit",
               api_token: "PEANUTS",
               build_secret: "MAJOR_KEY",
               apk_path: "./fastlane/spec/fixtures/fastfiles/Fastfile2",
@@ -74,7 +74,7 @@ describe Fastlane do
           it "works with valid parameters" do
             command = Fastlane::FastFile.new.parse("lane :test do
               crashlytics({
-                crashlytics_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+                crashlytics_path: './fastlane/spec/fixtures/actions/crashlytics/submit',
                 api_token: 'wadus',
                 build_secret: 'secret',
                 ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1'
@@ -93,6 +93,7 @@ describe Fastlane do
 
           it "hides sensitive parameters" do
             with_verbose(true) do
+              expect(UI).to receive(:verbose).with(/crashlytics_path/).once
               expect(UI).to receive(:verbose) do |message|
                 expect(message).to_not(include('PEANUTS'))
                 expect(message).to_not(include('MAJOR_KEY'))
@@ -100,9 +101,10 @@ describe Fastlane do
                 expect(message).to include('[[BUILD_SECRET]]')
                 expect(message).to include('[[API_TOKEN')
               end
+
               Fastlane::FastFile.new.parse("lane :test do
                 crashlytics({
-                  crashlytics_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+                  crashlytics_path: './fastlane/spec/fixtures/actions/crashlytics/submit',
                   api_token: 'MAJOR_KEY',
                   build_secret: 'PEANUTS',
                   ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1'
@@ -114,7 +116,7 @@ describe Fastlane do
           it "works automatically stores the notes in a file if given" do
             command = Fastlane::FastFile.new.parse("lane :test do
               crashlytics({
-                crashlytics_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+                crashlytics_path: './fastlane/spec/fixtures/actions/crashlytics/submit',
                 api_token: 'wadus',
                 build_secret: 'secret',
                 ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
@@ -135,7 +137,7 @@ describe Fastlane do
           it "works when using environment variables in place of parameters" do
             ENV["CRASHLYTICS_API_TOKEN"] = "wadus"
             ENV["CRASHLYTICS_BUILD_SECRET"] = "secret"
-            ENV["CRASHLYTICS_FRAMEWORK_PATH"] = "./fastlane/spec/fixtures/fastfiles/Fastfile1"
+            ENV["CRASHLYTICS_FRAMEWORK_PATH"] = "./fastlane/spec/fixtures/actions/crashlytics/submit"
 
             command = Fastlane::FastFile.new.parse("lane :test do
               crashlytics({
@@ -156,7 +158,7 @@ describe Fastlane do
           it "works when using TrueClass variable in place of notifications parameter" do
             ENV["CRASHLYTICS_API_TOKEN"] = "wadus"
             ENV["CRASHLYTICS_BUILD_SECRET"] = "secret"
-            ENV["CRASHLYTICS_FRAMEWORK_PATH"] = "./fastlane/spec/fixtures/fastfiles/Fastfile1"
+            ENV["CRASHLYTICS_FRAMEWORK_PATH"] = "./fastlane/spec/fixtures/actions/crashlytics/submit"
 
             command = Fastlane::FastFile.new.parse("lane :test do
                 crashlytics({
@@ -178,7 +180,7 @@ describe Fastlane do
           it "works when using 'false' String variable in place of notifications parameter" do
             ENV["CRASHLYTICS_API_TOKEN"] = "wadus"
             ENV["CRASHLYTICS_BUILD_SECRET"] = "secret"
-            ENV["CRASHLYTICS_FRAMEWORK_PATH"] = "./fastlane/spec/fixtures/fastfiles/Fastfile1"
+            ENV["CRASHLYTICS_FRAMEWORK_PATH"] = "./fastlane/spec/fixtures/actions/crashlytics/submit"
 
             command = Fastlane::FastFile.new.parse("lane :test do
               crashlytics({
@@ -200,7 +202,7 @@ describe Fastlane do
           it "works when using TrueClass variable in place of debug parameter" do
             ENV["CRASHLYTICS_API_TOKEN"] = "wadus"
             ENV["CRASHLYTICS_BUILD_SECRET"] = "secret"
-            ENV["CRASHLYTICS_FRAMEWORK_PATH"] = "./fastlane/spec/fixtures/fastfiles/Fastfile1"
+            ENV["CRASHLYTICS_FRAMEWORK_PATH"] = "./fastlane/spec/fixtures/actions/crashlytics/submit"
 
             command = Fastlane::FastFile.new.parse("lane :test do
                 crashlytics({
@@ -222,7 +224,7 @@ describe Fastlane do
           it "works when using 'false' String variable in place of debug parameter" do
             ENV["CRASHLYTICS_API_TOKEN"] = "wadus"
             ENV["CRASHLYTICS_BUILD_SECRET"] = "secret"
-            ENV["CRASHLYTICS_FRAMEWORK_PATH"] = "./fastlane/spec/fixtures/fastfiles/Fastfile1"
+            ENV["CRASHLYTICS_FRAMEWORK_PATH"] = "./fastlane/spec/fixtures/actions/crashlytics/submit"
 
             command = Fastlane::FastFile.new.parse("lane :test do
               crashlytics({
@@ -248,7 +250,7 @@ describe Fastlane do
 
             command = Fastlane::FastFile.new.parse("lane :test do
                 crashlytics({
-                  crashlytics_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+                  crashlytics_path: './fastlane/spec/fixtures/actions/crashlytics/submit',
                   notes_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
                   groups: ['groups', '123'],
                   emails: ['email1', 'email2'],
@@ -296,6 +298,20 @@ describe Fastlane do
                 })
               end").runner.execute(:test)
             end.to raise_error(%r{Couldn't find crashlytics at path .*fastlane/wadus})
+          end
+
+          it "raises an error if the given crashlytics path is not a submit binary" do
+            expect(Fastlane::Helper::CrashlyticsHelper).to receive(:discover_crashlytics_path).and_return("./fastfile/spec/fixtures/fastfiles/Fastfile1")
+            expect do
+              Fastlane::FastFile.new.parse("lane :test do
+                crashlytics({
+                  crashlytics_path: './fastlane/spec/fixtures/fastfiles/Fastfile1',
+                  api_token: 'wadus',
+                  build_secret: 'wadus',
+                  ipa_path: './fastlane/spec/fixtures/fastfiles/Fastfile1'
+                })
+              end").runner.execute(:test)
+            end.to raise_error(%r{Invalid crashlytics path was detected with '.*Fastfile1'. Path must point to the `submit` binary \(example: './Pods/Crashlytics/submit'\)})
           end
 
           it "raises an error if no api token was given" do

--- a/fastlane/spec/fixtures/actions/crashlytics/submit
+++ b/fastlane/spec/fixtures/actions/crashlytics/submit
@@ -1,0 +1,1 @@
+This file has no purpose expect for acting as a fake `submit` binary for the crashlytics action


### PR DESCRIPTION
Fixes #12894

## Issue
- Some users needed to have `CRASHLYTICS_FRAMEWORK_PATH` in the past for _fastlane_ to execute the correct `submit` binary
- This was causing issues if `CRASHLYTICS_FRAMEWORK_PATH` didn't point directly to a `Crashlytics.framework` directory
- This could result in a non `submit` binary trying to get executed

## Solution
- If passed in `:crashlytics_path` **DOES NOT** end in `submit`, we try to find a `submit` binary in that directory
- We now also error out if the `File.basename(submit_binary)` (after calling `discover_crashlytics_path`) does not end in `submit` that we error out on the user and explain what happened because thing just won't work
- Also added a fixture named `submit` so that the tests can more properly follow actual behavior of how this action works