### PR TITLE
Show opt-out message the first time fastlane runs

### DIFF
--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -19,6 +19,10 @@ module FastlaneCore
     end
 
     def action_launched(launch_context: nil)
+      unless did_show_message?
+        show_message
+      end
+
       if @launch_event_sent || launch_context.p_hash.nil?
         return
       end
@@ -38,6 +42,25 @@ module FastlaneCore
     end
 
     def action_completed(completion_context: nil)
+    end
+
+    def show_message
+      UI.message("Sending anonymous analytics information")
+      UI.message("Learn more at https://docs.fastlane.tools/#metrics")
+      UI.message("No personal or sensitive data is sent.")
+      UI.message("You can disable this by adding `opt_out_usage` at the top of your Fastfile")
+    end
+
+    def did_show_message?
+      file_name = ".did_show_opt_info"
+
+      new_path = File.join(FastlaneCore.fastlane_user_dir, file_name)
+      did_show = File.exist?(new_path)
+
+      return did_show if did_show
+
+      File.write(new_path, '1')
+      false
     end
 
     def finalize_session


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
We want to provide clear disclaimer on fastlane collecting analytics data.

### Description
This PR would make fastlane show a message the first time it runs, after which a file is generated under the user folder and it will not display again.
