### PR TITLE
Add support for release notes from bundles

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -156,13 +156,22 @@ module Supply
       end
     end
 
-    # Get a list of all apks verion codes - returns the list of version codes
+    # Get a list of all APK version codes - returns the list of version codes
     def apks_version_codes
       ensure_active_edit!
 
       result = call_google_api { android_publisher.list_apks(current_package_name, current_edit.id) }
 
       return Array(result.apks).map(&:version_code)
+    end
+
+    # Get a list of all AAB version codes - returns the list of version codes
+    def aab_version_codes
+      ensure_active_edit!
+
+      result = call_google_api { android_publisher.list_edit_bundles(current_package_name, current_edit.id) }
+
+      return Array(result.bundles).map(&:version_code)
     end
 
     # Get a list of all apk listings (changelogs) - returns the list

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -66,13 +66,16 @@ module Supply
       client.apks_version_codes.each do |apk_version_code|
         upload_changelog(language, apk_version_code)
       end
+      client.aab_version_codes.each do |aab_version_code|
+        upload_changelog(language, aab_version_code)
+      end
     end
 
-    def upload_changelog(language, apk_version_code)
-      path = File.join(metadata_path, language, Supply::CHANGELOGS_FOLDER_NAME, "#{apk_version_code}.txt")
+    def upload_changelog(language, version_code)
+      path = File.join(metadata_path, language, Supply::CHANGELOGS_FOLDER_NAME, "#{version_code}.txt")
       if File.exist?(path)
-        UI.message("Updating changelog for code version '#{apk_version_code}' and language '#{language}'...")
-        apk_listing = ApkListing.new(File.read(path, encoding: 'UTF-8'), language, apk_version_code)
+        UI.message("Updating changelog for code version '#{version_code}' and language '#{language}'...")
+        apk_listing = ApkListing.new(File.read(path, encoding: 'UTF-8'), language, version_code)
         client.update_apk_listing_for_language(apk_listing)
       end
     end

--- a/supply/spec/client_spec.rb
+++ b/supply/spec/client_spec.rb
@@ -13,6 +13,7 @@ describe Supply do
         expect(subject.class.method_defined?(:insert_edit)).to eq(true)
         expect(subject.class.method_defined?(:list_apk_listings)).to eq(true)
         expect(subject.class.method_defined?(:list_apks)).to eq(true)
+        expect(subject.class.method_defined?(:list_edit_bundles)).to eq(true)
         expect(subject.class.method_defined?(:list_images)).to eq(true)
         expect(subject.class.method_defined?(:list_listings)).to eq(true)
         expect(subject.class.method_defined?(:update_apk_listing)).to eq(true)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
For projects that use AAB instead of APK, the release notes functionality of fastlane wasn't working. This is because the `upload_changelogs` functionality specifically looks for APK version codes - which obviously don't include AABs. 

Another approach would be to change the `apk_version_codes` client library call to also include bundles. This felt like it would be more disruptive for other use cases.

### Description
This PR is quite simple - it extends the `client` class to be able to list bundle versions in addition to APK versions. It then uses this in `uploader` to upload changelogs for bundles as well.

This was tested locally by using the "dry run" functionality to verify upload of metadata succeeded on a project with bundles. No errors were reported from Play using the new uploads.
