### PR TITLE
Add new option to "jira" action

### DIFF
--- a/fastlane/lib/fastlane/actions/jira.rb
+++ b/fastlane/lib/fastlane/actions/jira.rb
@@ -43,11 +43,11 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("No url for Jira given, pass using `url: 'url'`") if value.to_s.length == 0
                                        end),
-          FastlaneCore::ConfigItem.new(key: :self_hosted_server,
+          FastlaneCore::ConfigItem.new(key: :context_path,
                                       env_name: "FL_JIRA_CONTEXT_PATH",
-                                      description: "Is JIRA self hosted server and need custom context path",
+                                      description: "Appends to the url (ex: \"/jira\")",
                                       optional: true,
-                                      default_value: "",
+                                      default_value: ""),
           FastlaneCore::ConfigItem.new(key: :username,
                                        env_name: "FL_JIRA_USERNAME",
                                        description: "Username for JIRA instance",
@@ -98,7 +98,7 @@ module Fastlane
           )',
           'jira(
             url: "https://yourserverdomain.com",
-            context_path: "/jira", # append \'/jira\' path to your url
+            context_path: "/jira",
             username: "Your username",
             password: "Your password",
             ticket_id: "Ticket ID, i.e. IOS-123",

--- a/fastlane/lib/fastlane/actions/jira.rb
+++ b/fastlane/lib/fastlane/actions/jira.rb
@@ -6,12 +6,17 @@ module Fastlane
         require 'jira-ruby'
 
         site         = params[:url]
-        context_path = ""
         auth_type    = :basic
         username     = params[:username]
         password     = params[:password]
         ticket_id    = params[:ticket_id]
         comment_text = params[:comment_text]
+
+        if params[:self_hosted_server]
+          context_path = "/jira"
+        else
+          context_path = ""
+        end
 
         options = {
                     site: site,
@@ -43,6 +48,12 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("No url for Jira given, pass using `url: 'url'`") if value.to_s.length == 0
                                        end),
+          FastlaneCore::ConfigItem.new(key: :self_hosted_server,
+                                      env_name: "FL_JIRA_SELF_HOSTED_SERVER",
+                                      description: "Is JIRA self hosted server with context path",
+                                      optional: true,
+                                      default_value: false,
+                                      is_string: false),
           FastlaneCore::ConfigItem.new(key: :username,
                                        env_name: "FL_JIRA_USERNAME",
                                        description: "Username for JIRA instance",
@@ -86,6 +97,14 @@ module Fastlane
         [
           'jira(
             url: "https://bugs.yourdomain.com",
+            username: "Your username",
+            password: "Your password",
+            ticket_id: "Ticket ID, i.e. IOS-123",
+            comment_text: "Text to post as a comment"
+          )',
+          'jira(
+            url: "https://yourserverdomain.com",
+            self_hosted_server: true, # append \'/jira\' path to your url
             username: "Your username",
             password: "Your password",
             ticket_id: "Ticket ID, i.e. IOS-123",

--- a/fastlane/lib/fastlane/actions/jira.rb
+++ b/fastlane/lib/fastlane/actions/jira.rb
@@ -7,16 +7,11 @@ module Fastlane
 
         site         = params[:url]
         auth_type    = :basic
+        context_path = params[:context_path]
         username     = params[:username]
         password     = params[:password]
         ticket_id    = params[:ticket_id]
         comment_text = params[:comment_text]
-
-        if params[:self_hosted_server]
-          context_path = "/jira"
-        else
-          context_path = ""
-        end
 
         options = {
                     site: site,
@@ -49,11 +44,10 @@ module Fastlane
                                          UI.user_error!("No url for Jira given, pass using `url: 'url'`") if value.to_s.length == 0
                                        end),
           FastlaneCore::ConfigItem.new(key: :self_hosted_server,
-                                      env_name: "FL_JIRA_SELF_HOSTED_SERVER",
-                                      description: "Is JIRA self hosted server with context path",
+                                      env_name: "FL_JIRA_CONTEXT_PATH",
+                                      description: "Is JIRA self hosted server and need custom context path",
                                       optional: true,
-                                      default_value: false,
-                                      is_string: false),
+                                      default_value: "",
           FastlaneCore::ConfigItem.new(key: :username,
                                        env_name: "FL_JIRA_USERNAME",
                                        description: "Username for JIRA instance",
@@ -104,7 +98,7 @@ module Fastlane
           )',
           'jira(
             url: "https://yourserverdomain.com",
-            self_hosted_server: true, # append \'/jira\' path to your url
+            context_path: "/jira", # append \'/jira\' path to your url
             username: "Your username",
             password: "Your password",
             ticket_id: "Ticket ID, i.e. IOS-123",


### PR DESCRIPTION

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
After integrating fastlane into my project, I will need to use action `fastlane jira` to comment ticket at JIRA. But I have self-hosted JIRA server and that is a problem for me to use action with current options.
It resolves a problem for self-hosted JIRA servers via adding `"/jira"` into `context_path`.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->
Added `self_hosted_server` option to action. Option is optional, default - `false`
It appends `"/jira"` to context_path variable for self-hosted jira servers and corrects using in 'jira-ruby' gem.
Updated example with the new option.