### PR TITLE
[scan] raise error if scan fails with a building/compiling error

### DIFF
--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -22,6 +22,11 @@ module Fastlane
           Scan::Manager.new.work(values)
 
           return true
+        rescue FastlaneCore::Interface::FastlaneBuildFailure => ex
+          # Specifically catching FastlaneBuildFailure to prevent build/compile errors from being
+          # silenced when :fail_build is set to false
+          # :fail_build should only suppress testing failures
+          raise ex
         rescue => ex
           if values[:fail_build]
             raise ex

--- a/fastlane/spec/actions_specs/run_tests_spec.rb
+++ b/fastlane/spec/actions_specs/run_tests_spec.rb
@@ -1,0 +1,47 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Scan Integration" do
+      context ":fail_build" do
+        it "raises an error if build/compile error and fail_build is true" do
+          allow(Scan).to receive(:config=).and_return(nil)
+          allow_any_instance_of(Scan::Manager).to receive(:work).and_raise(FastlaneCore::Interface::FastlaneBuildFailure.new)
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+                run_tests(fail_build: true)
+              end").runner.execute(:test)
+          end.to raise_error(FastlaneCore::Interface::FastlaneBuildFailure)
+        end
+
+        it "raises an error if build/compile error and fail_build is false" do
+          allow(Scan).to receive(:config=).and_return(nil)
+          allow_any_instance_of(Scan::Manager).to receive(:work).and_raise(FastlaneCore::Interface::FastlaneBuildFailure.new)
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+                run_tests(fail_build: false)
+              end").runner.execute(:test)
+          end.to raise_error(FastlaneCore::Interface::FastlaneBuildFailure)
+        end
+
+        it "raises an error if tests fail and fail_build is true" do
+          allow(Scan).to receive(:config=).and_return(nil)
+          allow_any_instance_of(Scan::Manager).to receive(:work).and_raise(FastlaneCore::Interface::FastlaneTestFailure.new)
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+                run_tests(fail_build: true)
+              end").runner.execute(:test)
+          end.to raise_error(FastlaneCore::Interface::FastlaneTestFailure)
+        end
+
+        it "does not raise an error if tests fail and fail_build is false" do
+          allow(Scan).to receive(:config=).and_return(nil)
+          allow_any_instance_of(Scan::Manager).to receive(:work).and_raise(FastlaneCore::Interface::FastlaneTestFailure.new)
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+                run_tests(fail_build: false)
+              end").runner.execute(:test)
+          end.not_to(raise_error)
+        end
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -128,16 +128,6 @@ describe Fastlane do
           command_1 = command + [File.expand_path(File.join("fastlane", dsym_1_path)).shellescape]
           command_2 = command + [File.expand_path(File.join("fastlane", dsym_2_path)).shellescape]
 
-          # Sometimes CI systems will pull dsym from other places so need to make sure its nil
-          # Need to make sure that :dsym_path is nil because we are only tesing :dsym_paths
-          allow_any_instance_of(FastlaneCore::Configuration).to receive(:[]).and_wrap_original do |m, *args|
-            if args[0] == :dsym_path
-              nil
-            else
-              m.call(*args)
-            end
-          end
-
           expect(Fastlane::Actions).to receive(:sh).with(command_1.join(" "), log: false).at_least(:once)
           expect(Fastlane::Actions).to receive(:sh).with(command_2.join(" "), log: false).at_least(:once)
 

--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -128,8 +128,8 @@ describe Fastlane do
           command_1 = command + [File.expand_path(File.join("fastlane", dsym_1_path)).shellescape]
           command_2 = command + [File.expand_path(File.join("fastlane", dsym_2_path)).shellescape]
 
-          expect(Fastlane::Actions).to receive(:sh).with(command_1.join(" "), log: false).at_least(:once)
-          expect(Fastlane::Actions).to receive(:sh).with(command_2.join(" "), log: false).at_least(:once)
+          expect(Fastlane::Actions).to receive(:sh).with(command_1.join(" "), log: false)
+          expect(Fastlane::Actions).to receive(:sh).with(command_2.join(" "), log: false)
 
           Fastlane::FastFile.new.parse("lane :test do
             upload_symbols_to_crashlytics(


### PR DESCRIPTION
Fixes #12343

## Issue
If I do `fail_build: true` then the build fails if the test fail.

|                     | State  | On build errors | On test failures |
| ----------- | ------ | --------------- | --------------- |
| `fail_build` | `true` | 🔴 | 🔴 |
| `fail_build` | `false` | 💚 | 💚 |
| Wish           |              | 🔴 | 💚 | 

Taken from https://github.com/fastlane/fastlane/issues/12343#issuecomment-386674205

## Solution
Catch `FastlaneCore::Interface::FastlaneBuildFailure` thrown from `UI.build_failure` to prevent passing on compile errors when `fail_build: false`
