### PR TITLE
[gemspec] Make Google API Client gemspec version looser

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -93,7 +93,7 @@ Gem::Specification.new do |spec|
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.
   # If you upgrade this gem, make sure to upgrade the users of it as well.
-  spec.add_dependency('google-api-client', '>= 0.21.2', '< 0.22.0') # Google API Client to access Play Publishing API
+  spec.add_dependency('google-api-client', '>= 0.21.2', '< 0.24.0') # Google API Client to access Play Publishing API
 
   spec.add_dependency('emoji_regex', '~> 0.1') # Used to scan for Emoji in the changelog
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

We are using `google-cloud-storage` in our fastlane flow but it has no version compatible with the latest `fastlane` so we are not able to upgrade `fastlane` nor `google-cloud-storage` because the spec of `google-api-client` version is too tight.

- [x] `google-cloud-storage 1.13.0` depends on `google-api-client ~> 0.23`
- [x] `google-cloud-storage 1.12.0` depends on `google-api-client ~> 0.19.0`


### Description

This PR makes `google-api-client` gem version specification looser. Looks there is no breaking change which affects fastlane so far so chose `0.24.0`.
