### PR TITLE
[test] Fix failing tests on master

### DIFF
--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -108,6 +108,13 @@ describe Fastlane do
       end
 
       context "with dsym_paths" do
+        before :each do
+          # dsym_path option to be nil
+          ENV[Fastlane::Actions::SharedValues::DSYM_OUTPUT_PATH.to_s] = nil
+          Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DSYM_PATHS] = nil
+          allow(Dir).to receive(:[]).and_return([])
+        end
+
         it "uploads dSYM files with gsp_path" do
           binary_path = './spec/fixtures/screenshots/screenshot1.png'
           dsym_1_path = './spec/fixtures/dSYM/Themoji.dSYM'


### PR DESCRIPTION
As `dsym_path` has the default value which is dynamic, need to stub `Dir` to purely test `dsym_paths` parameter.

https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb#L150

Also updated to clear env and lane_context just in case.