### PR TITLE
added author_email to last_git_commit action

### DIFF
--- a/fastlane/lib/fastlane/actions/last_git_commit.rb
+++ b/fastlane/lib/fastlane/actions/last_git_commit.rb
@@ -14,7 +14,7 @@ module Fastlane
       end
 
       def self.return_value
-        "Returns the following dict: {commit_hash: \"commit hash\", abbreviated_commit_hash: \"abbreviated commit hash\" author: \"Author\", message: \"commit message\"}"
+        "Returns the following dict: {commit_hash: \"commit hash\", abbreviated_commit_hash: \"abbreviated commit hash\" author: \"Author\", author_email: \"author email\", message: \"commit message\"}"
       end
 
       def self.return_type
@@ -34,6 +34,7 @@ module Fastlane
           'commit = last_git_commit
           crashlytics(notes: commit[:message]) # message of commit
           author = commit[:author] # author of the commit
+          author_email = commit[:author_email] # email of the author of the commit
           hash = commit[:commit_hash] # long sha of commit
           short_hash = commit[:abbreviated_commit_hash] # short sha of commit'
         ]
@@ -47,6 +48,7 @@ module Fastlane
         {
           message: "message",
           author: "author",
+          author_email: "author_email",
           commit_hash: "commit_hash",
           abbreviated_commit_hash: "short_hash"
         }

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -42,6 +42,7 @@ module Fastlane
 
       {
           author: last_git_commit_formatted_with('%an'),
+          author_email: last_git_commit_formatted_with('%ae'),
           message: last_git_commit_formatted_with('%B'),
           commit_hash: last_git_commit_formatted_with('%H'),
           abbreviated_commit_hash: last_git_commit_formatted_with('%h')


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Needed to retrieve the author email of the last git commit

### Description
Added a new key, :author_email, in the dictionary returned by last_git_commit
