### PR TITLE
[frameit] Support multiple cascading filters

### DIFF
--- a/frameit/lib/frameit/config_parser.rb
+++ b/frameit/lib/frameit/config_parser.rb
@@ -26,11 +26,14 @@ module Frameit
     # Fetches the finished configuration for a given path. This will try to look for a specific value
     # and fallback to a default value if nothing was found
     def fetch_value(path)
-      specific = @data['data'].find { |a| path.include?(a['filter']) }
+      specifics = @data['data'].select { |a| path.include?(a['filter']) }
 
       default = @data['default']
 
-      values = default.fastlane_deep_merge(specific || {})
+      values = default.clone
+      specifics.each do |specific|
+        values = values.fastlane_deep_merge(specific)
+      end
 
       change_paths_to_absolutes!(values)
       validate_values(values)


### PR DESCRIPTION
🔑 

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

My existing #11014 PR didn't get merged – admittedly, it wasn't easy to review – and got stale. However, it mixed different changes and some of them have been already addressed now (I believe) by #11585.

This part hasn't been addressed though, so I would like to resubmit if for review:

#### Add cascading filters

You may want to adjust the layout not only based on the screenshot number/name, but also on the device. Currently, only the first filter matching the screenshot path is applied. With this change, the filters are applied in order.

This lets modify the iPad screenshot without modifying the iPhone's:

```
{
  "device_frame_version": "latest",
  "default": {
    "title": {
      "color": "#ffffff"
    },
    "background": "./Frameit-background.png",
    "padding": "3%",
    "show_complete_frame": false,
    "stack_title" : true,
    "title_below_image": false,
    "font_scale_factor": 0.05
  },
   "data": [
    {
      "filter": "scan"
    },
    {
      "filter": "edit"
    },
    {
      "filter": "multipage_pdf"
    },
    {
      "filter": "organize"
    },
    {
      "filter": "export"
    },
    {
      "filter" : "iPad",
      "show_complete_frame" : true,
      "font_scale_factor": 0.035
    }
  ]
}
```

### Documentation

Regarding the documentation update, here is the proposed change:

Before:
```
This is mandatory to link the individual configuration to the screenshot, based on part of the file name.
Example:
If a screenshot is named iPhone 8-Brainstorming.png you can use value Brainstorming for filter. All other keys from that array element will only be applied on this specific screenshot.
```
After:
```
This is mandatory to link the individual configuration to the screenshot, based on part of the file name.
Example:
If a screenshot is named `iPhone5_Brainstorming.png` the first entry in the `data` array will be used. If there are more than one `filter` matching an entry, they will all be applied in order (which means that the last one has the highest precedence).
```
If I understand correctly, I will need to make the corresponding PR to the fastlane/docs repo?