### PR TITLE
[docs] Update docs for importing external testers

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
@@ -173,7 +173,7 @@ fastlane pilot export
 
 ### Import testers
 
-Add external testers from a CSV file. Create an empty `tester_import.csv` file with the following format:
+Add external testers from a CSV file. Create a file called `tester_import.csv` and fill it with the following format:
 
 ```no-highlight
 John,Appleseed,appleseed_john@mac.com,group-1;group-2

--- a/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
@@ -173,7 +173,7 @@ fastlane pilot export
 
 ### Import testers
 
-Add external testers from a CSV file. Create a file called `tester_import.csv` and fill it with the following format:
+Add external testers from a CSV file. Create a file (ex: `testers.csv`) and fill it with the following format:
 
 ```no-highlight
 John,Appleseed,appleseed_john@mac.com,group-1;group-2

--- a/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
@@ -179,8 +179,6 @@ Add external testers from a CSV file. Create a file (ex: `testers.csv`) and fill
 John,Appleseed,appleseed_john@mac.com,group-1;group-2
 ```
 
-Importing the CSV is as simple as:
-
 ```no-highlight
 fastlane pilot import
 ```

--- a/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
@@ -173,7 +173,13 @@ fastlane pilot export
 
 ### Import testers
 
-Add external testers from a CSV file. Sample CSV file available [here](https://itunesconnect.apple.com/itc/docs/tester_import.csv).
+Add external testers from a CSV file. Create an empty `tester_import.csv` file with the following format:
+
+```no-highlight
+John,Appleseed,appleseed_john@mac.com,group-1;group-2
+```
+
+Importing the CSV is as simple as:
 
 ```no-highlight
 fastlane pilot import


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Sample CSV provided by Apple does not show how to add testers to testing-groups. I had to dig in the implementation of pilot to find out it was actually possible.

### Description
I removed the link and provided an example CSV in-line.
