### PR TITLE
[action] remove conflicting_options on repo_update in cocoapods action

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -25,7 +25,7 @@ module Fastlane
         cmd << '--no-ansi' unless params[:ansi]
 
         Actions.sh(cmd.join(' '), error_callback: lambda { |result|
-          if params[:try_repo_update_on_error]
+          if !params[:repo_update] && params[:try_repo_update_on_error]
             cmd << '--repo-update'
             Actions.sh(cmd.join(' '), error_callback: lambda { |retry_result|
               call_error_callback(params, retry_result)
@@ -66,8 +66,7 @@ module Fastlane
                                        env_name: "FL_COCOAPODS_REPO_UPDATE",
                                        description: "Add `--repo-update` flag to `pod install` command",
                                        is_string: false,
-                                       default_value: false,
-                                       conflicting_options: [:try_repo_update_on_error]),
+                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :silent,
                                        env_name: "FL_COCOAPODS_SILENT",
                                        description: "Execute command without logging output",
@@ -108,8 +107,7 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        default_value: false,
-                                       type: Boolean,
-                                       conflicting_options: [:repo_update])
+                                       type: Boolean)
         ]
         # Please don't add a version parameter to the `cocoapods` action. If you need to specify a version when running
         # `cocoapods`, please start using a Gemfile and lock the version there


### PR DESCRIPTION
Fixes #12924

## Problem
The `default_value` on `repo_update` was conflicting with the option in `conflicting_options`

## Solution
Remove the `conflicting_options` on `:repo_update` handle logic inside of action for not calling with `--repo-update` on error if `:repo_update` was set to true