### PR TITLE
[WIP] [snapshot][screengrab] offer option for snapshot reports for generating rows by screenshot

### DIFF
--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -86,6 +86,14 @@ module Snapshot
                                      description: "By default, the latest version should be used automatically. If you want to change it, do it here",
                                      short_option: "-i",
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :html_summary_format,
+                                     env_name: 'SNAPSHOT_HTML_SUMMARY_FORMAT',
+                                     description: "The format of how the HTML summary should be generated",
+                                     default_value: "group_by_device",
+                                     verify_block: proc do |value|
+                                       valid_values = %w(group_by_device group_by_screenshot)
+                                       UI.user_error!("Unsupported export_method '#{value}', must be: #{valid_values}") unless valid_values.include?(value)
+                                     end),
         FastlaneCore::ConfigItem.new(key: :skip_open_summary,
                                      env_name: 'SNAPSHOT_SKIP_OPEN_SUMMARY',
                                      description: "Don't open the HTML summary after running _snapshot_",

--- a/snapshot/lib/snapshot/page.html.erb
+++ b/snapshot/lib/snapshot/page.html.erb
@@ -11,11 +11,14 @@
       .language {
 
       }
-      .deviceName {
+      .deviceName, .languageName, .screenshotTitle  {
         display: block;
         font-size: 30px;
         padding-bottom: 24px;
         padding-top: 45px;
+      }
+      .screenshotName  {
+        font-size: 30px;
       }
       .screenshot {
         cursor: pointer;
@@ -64,23 +67,57 @@
       }
     </style>
   </head>
-  <body><% image_counter = 0 %><% @data.each do |language, content| %>
-    <h1 id="<%= language %>" class="language"><%= language %></h1>
-    <hr>
-    <table><% content.each do |device_name, screens| %>
-      <tr>
-        <th colspan="<%= screens.count %>">
-          <a id="<%= language %>-<%= device_name %>" class="deviceName" href="#<%= language %>-<%= device_name %>"><%= device_name %></a>
-        </th>
-      </tr>
-      <tr><% screens.each do |screen_path| %><% next if screen_path.include?"_framed.png" %>
-        <td><% image_counter += 1 %>
-          <a href="<%= screen_path %>" target="_blank" class="screenshotLink">
-            <img class="screenshot" src="<%= screen_path %>" style="width: 100%;" alt="<%= language %> <%= device_name %>" data-counter="<%= image_counter %>">
-          </a>
-        </td><% end %>
-      </tr><% end %>
-    </table><% end %>
+  <body>
+    <% image_counter = 0 %>
+
+    <% if @html_summary_format == "group_by_screenshot" %>
+      <% @devices.each do |device_name, output_name| %>
+      <h1 id="<%= device_name %>" class="language"><%= device_name %></h1>
+      <hr>
+      <table>
+        <tr>
+          <th class="screenshotTitle">Name</th>
+          <% @languages.each do |language| %>
+          <th>
+            <a id="<%= device_name %>-<%= language %>" class="languageName" href="#<%= device_name %>-<%= language %>"><%= language %></a>
+          </th>
+          <% end %>
+        </tr>
+        <% @screenshot_names.each do |screenshot_name| %>
+          <tr>
+            <td class="screenshotName"><%= screenshot_name %></td>
+            <% @languages.each do |language| %>
+              <% image_counter += 1 %>
+              <td>
+                <% screen_path = @screenshots[language][screenshot_name][output_name] %>
+                <img class="screenshot" src="<%= screen_path %>" style="width: 100%;" alt="<%= device_name %> <%= language %>" data-counter="<%= image_counter %>">
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </table>
+      <% end %>
+    <% else %>
+      <% @data.each do |language, content| %>
+      <h1 id="<%= language %>" class="language"><%= language %></h1>
+      <hr>
+      <table><% content.each do |device_name, screens| %>
+        <tr>
+          <th colspan="<%= screens.count %>">
+            <a id="<%= language %>-<%= device_name %>" class="deviceName" href="#<%= language %>-<%= device_name %>"><%= device_name %></a>
+          </th>
+        </tr>
+        <tr><% screens.each do |screen_path| %><% next if screen_path.include?"_framed.png" %>
+          <td><% image_counter += 1 %>
+            <a href="<%= screen_path %>" target="_blank" class="screenshotLink">
+              <img class="screenshot" src="<%= screen_path %>" style="width: 100%;" alt="<%= language %> <%= device_name %>" data-counter="<%= image_counter %>">
+            </a>
+          </td><% end %>
+        </tr><% end %>
+      </table>
+      <% end %>
+    <% end %>
+
     <div id="overlay">
       <img id="imageDisplay" src="" alt="" />
       <div id="imageInfo"></div>

--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -12,21 +12,43 @@ module Snapshot
 
       @data = {}
 
+      @screenshots = {}
+      @devices = {}
+      @languages = []
+      @screenshot_names = []
+
+      @html_summary_format = Snapshot.config[:html_summary_format]
+
       Dir[File.join(screens_path, "*")].sort.each do |language_folder|
         language = File.basename(language_folder)
         Dir[File.join(language_folder, '*.png')].sort.each do |screenshot|
           available_devices.each do |key_name, output_name|
             next unless File.basename(screenshot).include?(key_name)
+
+            screenshot_name = File.basename(screenshot).split("-").drop(1).join("-")
+            @screenshot_names << screenshot_name
+
+            @languages << language
+            @devices[output_name] = key_name
+
             # This screenshot is from this device
             @data[language] ||= {}
             @data[language][output_name] ||= []
 
             resulting_path = File.join('.', language, File.basename(screenshot))
             @data[language][output_name] << resulting_path
+
+            @screenshots[language] ||= {}
+            @screenshots[language][screenshot_name] ||= {}
+            @screenshots[language][screenshot_name][key_name] = resulting_path
+
             break # to not include iPhone 6 and 6 Plus (name is contained in the other name)
           end
         end
       end
+
+      @languages.uniq!
+      @screenshot_names.uniq!
 
       html_path = File.join(Snapshot::ROOT, "lib", "snapshot/page.html.erb")
       html = ERB.new(File.read(html_path)).result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system


### PR DESCRIPTION
Fixes #12949

## Tasks
- [x] Add `html_summary_format` to _snapshot_
- [ ] Add `html_summary_format` to _screengrab_
- [ ] Clean up code for _snapshot_
- [ ] Write tests

## Description
- Adds new `html_summary_format` option to `snapshot`
  - Ex: `html_summary_format: "group_by_device"` (this is what original implementation was)
  - Ex: `html_summary_format: "group_by_screenshot"` (this is new implementation)
- `group_by_device`
  - Original implementation
  - Groups rows for each language and columns for each screenshot
- `group_by_screenshot`
  - Groups rows by screenshot and each column by language

<img width="630" alt="screen shot 2018-07-23 at 10 13 22 pm" src="https://user-images.githubusercontent.com/401294/43115936-19887838-8ecb-11e8-9ba4-3ecdee2bce43.png">
