### PR TITLE
[spaceship] Parametrize view_by in analytics API

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_analytics.rb
+++ b/spaceship/lib/spaceship/tunes/app_analytics.rb
@@ -72,44 +72,48 @@ module Spaceship
         app_crashes_interval(start_t, end_t)
       end
 
-      def app_units_interval(start_t, end_t)
-        client.time_series_analytics([apple_id], ['units'], start_t, end_t, "DAY")
+      def dimension_interval(start_t, end_t, dimension, filter = nil)
+        client.time_series_analytics([apple_id], [dimension], start_t, end_t, "DAY", filter)
       end
 
-      def app_views_interval(start_t, end_t)
-        client.time_series_analytics([apple_id], ['pageViewCount'], start_t, end_t, "DAY")
+      def app_units_interval(start_t, end_t, filter = nil)
+        client.time_series_analytics([apple_id], ['units'], start_t, end_t, "DAY", filter)
       end
 
-      def app_in_app_purchases_interval(start_t, end_t)
-        client.time_series_analytics([apple_id], ['iap'], start_t, end_t, "DAY")
+      def app_views_interval(start_t, end_t, filter = nil)
+        client.time_series_analytics([apple_id], ['pageViewCount'], start_t, end_t, "DAY", filter)
       end
 
-      def app_sales_interval(start_t, end_t)
-        client.time_series_analytics([apple_id], ['sales'], start_t, end_t, "DAY")
+      def app_in_app_purchases_interval(start_t, end_t, filter = nil)
+        client.time_series_analytics([apple_id], ['iap'], start_t, end_t, "DAY", filter)
       end
 
-      def app_paying_users_interval(start_t, end_t)
-        client.time_series_analytics([apple_id], ['payingUsers'], start_t, end_t, "DAY")
+      def app_sales_interval(start_t, end_t, filter = nil)
+        client.time_series_analytics([apple_id], ['sales'], start_t, end_t, "DAY", filter)
       end
 
-      def app_installs_interval(start_t, end_t)
-        client.time_series_analytics([apple_id], ['installs'], start_t, end_t, "DAY")
+      def app_paying_users_interval(start_t, end_t, filter = nil)
+        client.time_series_analytics([apple_id], ['payingUsers'], start_t, end_t, "DAY", filter)
       end
 
-      def app_sessions_interval(start_t, end_t)
-        client.time_series_analytics([apple_id], ['sessions'], start_t, end_t, "DAY")
+      def app_installs_interval(start_t, end_t, filter = nil)
+        client.time_series_analytics([apple_id], ['installs'], start_t, end_t, "DAY", filter)
       end
 
-      def app_active_devices_interval(start_t, end_t)
-        client.time_series_analytics([apple_id], ['activeDevices'], start_t, end_t, "DAY")
+      def app_sessions_interval(start_t, end_t, filter = nil)
+        client.time_series_analytics([apple_id], ['sessions'], start_t, end_t, "DAY", filter)
       end
 
-      def app_active_last_30_days_interval(start_t, end_t)
-        client.time_series_analytics([apple_id], ['rollingActiveDevices'], start_t, end_t, "DAY")
+      def app_active_devices_interval(start_t, end_t, filter = nil)
+        client.time_series_analytics([apple_id], ['activeDevices'], start_t, end_t, "DAY", filter)
       end
 
-      def app_crashes_interval(start_t, end_t)
-        client.time_series_analytics([apple_id], ['crashes'], start_t, end_t, "DAY")
+      def app_active_last_30_days_interval(start_t, end_t, filter = nil)
+        client.time_series_analytics([apple_id], ['rollingActiveDevices'], start_t, end_t, "DAY", filter)
+      end
+
+      def app_crashes_interval(start_t, end_t, filter = nil)
+        client.time_series_analytics([apple_id], ['crashes'], start_t, end_t, "DAY", filter)
       end
 
       def time_last_7_days

--- a/spaceship/lib/spaceship/tunes/app_analytics.rb
+++ b/spaceship/lib/spaceship/tunes/app_analytics.rb
@@ -72,48 +72,48 @@ module Spaceship
         app_crashes_interval(start_t, end_t)
       end
 
-      def dimension_interval(start_t, end_t, dimension, filter = nil)
-        client.time_series_analytics([apple_id], [dimension], start_t, end_t, "DAY", filter)
+      def dimension_interval(start_t, end_t, dimension, view_by = nil)
+        client.time_series_analytics([apple_id], [dimension], start_t, end_t, "DAY", view_by)
       end
 
-      def app_units_interval(start_t, end_t, filter = nil)
-        client.time_series_analytics([apple_id], ['units'], start_t, end_t, "DAY", filter)
+      def app_units_interval(start_t, end_t, view_by = nil)
+        client.time_series_analytics([apple_id], ['units'], start_t, end_t, "DAY", view_by)
       end
 
-      def app_views_interval(start_t, end_t, filter = nil)
-        client.time_series_analytics([apple_id], ['pageViewCount'], start_t, end_t, "DAY", filter)
+      def app_views_interval(start_t, end_t, view_by = nil)
+        client.time_series_analytics([apple_id], ['pageViewCount'], start_t, end_t, "DAY", view_by)
       end
 
-      def app_in_app_purchases_interval(start_t, end_t, filter = nil)
-        client.time_series_analytics([apple_id], ['iap'], start_t, end_t, "DAY", filter)
+      def app_in_app_purchases_interval(start_t, end_t, view_by = nil)
+        client.time_series_analytics([apple_id], ['iap'], start_t, end_t, "DAY", view_by)
       end
 
-      def app_sales_interval(start_t, end_t, filter = nil)
-        client.time_series_analytics([apple_id], ['sales'], start_t, end_t, "DAY", filter)
+      def app_sales_interval(start_t, end_t, view_by = nil)
+        client.time_series_analytics([apple_id], ['sales'], start_t, end_t, "DAY", view_by)
       end
 
-      def app_paying_users_interval(start_t, end_t, filter = nil)
-        client.time_series_analytics([apple_id], ['payingUsers'], start_t, end_t, "DAY", filter)
+      def app_paying_users_interval(start_t, end_t, view_by = nil)
+        client.time_series_analytics([apple_id], ['payingUsers'], start_t, end_t, "DAY", view_by)
       end
 
-      def app_installs_interval(start_t, end_t, filter = nil)
-        client.time_series_analytics([apple_id], ['installs'], start_t, end_t, "DAY", filter)
+      def app_installs_interval(start_t, end_t, view_by = nil)
+        client.time_series_analytics([apple_id], ['installs'], start_t, end_t, "DAY", view_by)
       end
 
-      def app_sessions_interval(start_t, end_t, filter = nil)
-        client.time_series_analytics([apple_id], ['sessions'], start_t, end_t, "DAY", filter)
+      def app_sessions_interval(start_t, end_t, view_by = nil)
+        client.time_series_analytics([apple_id], ['sessions'], start_t, end_t, "DAY", view_by)
       end
 
-      def app_active_devices_interval(start_t, end_t, filter = nil)
-        client.time_series_analytics([apple_id], ['activeDevices'], start_t, end_t, "DAY", filter)
+      def app_active_devices_interval(start_t, end_t, view_by = nil)
+        client.time_series_analytics([apple_id], ['activeDevices'], start_t, end_t, "DAY", view_by)
       end
 
-      def app_active_last_30_days_interval(start_t, end_t, filter = nil)
-        client.time_series_analytics([apple_id], ['rollingActiveDevices'], start_t, end_t, "DAY", filter)
+      def app_active_last_30_days_interval(start_t, end_t, view_by = nil)
+        client.time_series_analytics([apple_id], ['rollingActiveDevices'], start_t, end_t, "DAY", view_by)
       end
 
-      def app_crashes_interval(start_t, end_t, filter = nil)
-        client.time_series_analytics([apple_id], ['crashes'], start_t, end_t, "DAY", filter)
+      def app_crashes_interval(start_t, end_t, view_by = nil)
+        client.time_series_analytics([apple_id], ['crashes'], start_t, end_t, "DAY", view_by)
       end
 
       def time_last_7_days

--- a/spaceship/lib/spaceship/tunes/app_analytics.rb
+++ b/spaceship/lib/spaceship/tunes/app_analytics.rb
@@ -72,7 +72,7 @@ module Spaceship
         app_crashes_interval(start_t, end_t)
       end
 
-      def measure_interval(start_t, end_t, measure, view_by = nil)
+      def app_measure_interval(start_t, end_t, measure, view_by = nil)
         client.time_series_analytics([apple_id], [measure], start_t, end_t, "DAY", view_by)
       end
 

--- a/spaceship/lib/spaceship/tunes/app_analytics.rb
+++ b/spaceship/lib/spaceship/tunes/app_analytics.rb
@@ -72,8 +72,8 @@ module Spaceship
         app_crashes_interval(start_t, end_t)
       end
 
-      def dimension_interval(start_t, end_t, dimension, view_by = nil)
-        client.time_series_analytics([apple_id], [dimension], start_t, end_t, "DAY", view_by)
+      def measure_interval(start_t, end_t, measure, view_by = nil)
+        client.time_series_analytics([apple_id], [measure], start_t, end_t, "DAY", view_by)
       end
 
       def app_units_interval(start_t, end_t, view_by = nil)

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -515,13 +515,13 @@ module Spaceship
     # @!group AppAnalytics
     #####################################################
 
-    def time_series_analytics(app_ids, measures, start_time, end_time, frequency, filter)
+    def time_series_analytics(app_ids, measures, start_time, end_time, frequency, view_by)
       data = {
         adamId: app_ids,
         dimensionFilters: [],
         endTime: end_time,
         frequency: frequency,
-        group: {metric: measures.first, dimension: filter, rank: "DESCENDING", limit: 3},
+        group: group_for_view_by(view_by, measures),
         measures: measures,
         startTime: start_time
       }
@@ -1407,6 +1407,20 @@ module Spaceship
     # the ssoTokenForVideo found in the AppVersionRef instance
     def sso_token_for_video
       @sso_token_for_video ||= ref_data.sso_token_for_video
+    end
+
+    # generates group hash used in the analytics time_series API
+    def group_for_view_by(view_by, measures)
+      if view_by.nil? || measures.nil?
+        return nil
+      else
+        return { 
+          metric: measures.first, 
+          dimension: filter, 
+          rank: "DESCENDING", 
+          limit: 3 
+        }  
+      end
     end
 
     def update_tester_from_app!(tester, app_id, testing)

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -1416,7 +1416,7 @@ module Spaceship
       else
         return {
           metric: measures.first,
-          dimension: filter,
+          dimension: view_by,
           rank: "DESCENDING",
           limit: 3
         }

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -1409,7 +1409,8 @@ module Spaceship
       @sso_token_for_video ||= ref_data.sso_token_for_video
     end
 
-    # generates group hash used in the analytics time_series API
+    # generates group hash used in the analytics time_series API.
+    # Using rank=DESCENDING and limit=3 as this is what the App Store Connect analytics dashboard uses.
     def group_for_view_by(view_by, measures)
       if view_by.nil? || measures.nil?
         return nil

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -515,13 +515,13 @@ module Spaceship
     # @!group AppAnalytics
     #####################################################
 
-    def time_series_analytics(app_ids, measures, start_time, end_time, frequency)
+    def time_series_analytics(app_ids, measures, start_time, end_time, frequency, filter)
       data = {
         adamId: app_ids,
         dimensionFilters: [],
         endTime: end_time,
         frequency: frequency,
-        group: nil,
+        group: {metric: measures.first, dimension: filter, rank: "DESCENDING", limit: 3},
         measures: measures,
         startTime: start_time
       }

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -1414,12 +1414,12 @@ module Spaceship
       if view_by.nil? || measures.nil?
         return nil
       else
-        return { 
-          metric: measures.first, 
-          dimension: filter, 
-          rank: "DESCENDING", 
-          limit: 3 
-        }  
+        return {
+          metric: measures.first,
+          dimension: filter,
+          rank: "DESCENDING",
+          limit: 3
+        }
       end
     end
 

--- a/spaceship/spec/tunes/app_analytics_spec.rb
+++ b/spaceship/spec/tunes/app_analytics_spec.rb
@@ -75,14 +75,19 @@ describe Spaceship::Tunes::AppAnalytics do
       end
       expect(val['meetsThreshold']).to eq(true)
 
-      measure_installs = app_measure_interval(start_t, end_t, 'installs')
+      measure_installs = analytics.app_measure_interval(start_time, end_time, 'installs')
       expect(measure_installs['size']).to eq(1)
       val = measure_installs['results'].find do |a|
         a['adamId'].include?('898536088')
       end
       expect(val['meetsThreshold']).to eq(true)
+    end
 
-      measure_installs_by_source = app_measure_interval(start_t, end_t, 'installs', 'source')
+    it "grabs live analytics split by view_by" do
+      start_time, end_time = app.analytics.time_last_7_days
+      TunesStubbing.itc_stub_analytics(start_time, end_time)
+      analytics = app.analytics
+      measure_installs_by_source = analytics.app_measure_interval(start_time, end_time, 'installs', 'source')
       expect(measure_installs_by_source['size']).to eq(5)
       val = measure_installs_by_source['results'].find do |a|
         a['adamId'].include?('898536088')

--- a/spaceship/spec/tunes/app_analytics_spec.rb
+++ b/spaceship/spec/tunes/app_analytics_spec.rb
@@ -74,6 +74,20 @@ describe Spaceship::Tunes::AppAnalytics do
         a['adamId'].include?('898536088')
       end
       expect(val['meetsThreshold']).to eq(true)
+
+      measure_installs = app_measure_interval(start_t, end_t, 'installs')
+      expect(measure_installs['size']).to eq(1)
+      val = measure_installs['results'].find do |a|
+        a['adamId'].include?('898536088')
+      end
+      expect(val['meetsThreshold']).to eq(true)
+
+      measure_installs_by_source = app_measure_interval(start_t, end_t, 'installs', 'source')
+      expect(measure_installs_by_source['size']).to eq(5)
+      val = measure_installs_by_source['results'].find do |a|
+        a['adamId'].include?('898536088')
+      end
+      expect(val['meetsThreshold']).to eq(true)
     end
 
     it "accesses non-live analytics details" do

--- a/spaceship/spec/tunes/fixtures/app_analytics_installs_by_source.json
+++ b/spaceship/spec/tunes/fixtures/app_analytics_installs_by_source.json
@@ -1,0 +1,100 @@
+{
+  "size": 5,
+  "results": [
+    {
+      "adamId": "898536088",
+      "meetsThreshold": true,
+      "group": {
+        "key": "AppRef",
+        "title": "App Referrer"
+      },
+      "data": [
+        {
+          "date": "2018-07-29T00:00:00Z",
+          "installs": 0.0
+        }
+      ],
+      "totals": {
+        "value": 0.0,
+        "type": "COUNT",
+        "key": "installs"
+      }
+    },
+    {
+      "adamId": "898536088",
+      "meetsThreshold": true,
+      "group": {
+        "key": "Other",
+        "title": "App Store Browse"
+      },
+      "data": [
+        {
+          "date": "2018-07-29T00:00:00Z",
+          "installs": 0.0
+        }
+      ],
+      "totals": {
+        "value": 0.0,
+        "type": "COUNT",
+        "key": "installs"
+      }
+    },
+    {
+      "adamId": "898536088",
+      "meetsThreshold": true,
+      "group": {
+        "key": "Search",
+        "title": "App Store Search"
+      },
+      "data": [
+        {
+          "date": "2018-07-29T00:00:00Z",
+          "installs": 0.0
+        }
+      ],
+      "totals": {
+        "value": 0.0,
+        "type": "COUNT",
+        "key": "installs"
+      }
+    },
+    {
+      "adamId": "898536088",
+      "meetsThreshold": true,
+      "group": {
+        "key": "Unknown",
+        "title": "Unavailable"
+      },
+      "data": [
+        {
+          "date": "2018-07-29T00:00:00Z",
+          "installs": 0.0
+        }
+      ],
+      "totals": {
+        "value": 0.0,
+        "type": "COUNT",
+        "key": "installs"
+      }
+    },
+    {
+      "adamId": "898536088",
+      "meetsThreshold": true,
+      "group": {
+        "key": "WebRef",
+        "title": "Web Referrer"
+      },
+      "data": [
+        {
+          "date": "2018-07-29T00:00:00Z",
+          "installs": 0.0
+        }
+      ],
+      "totals": {
+        "value": 0.0,
+        "type": "COUNT",
+        "key": "installs"
+      }
+    }
+  ]
+}

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -584,7 +584,7 @@ class TunesStubbing
                   headers: { "Content-Type" => "application/json" })
 
       stub_request(:post, "https://analytics.itunes.apple.com/analytics/api/v1/data/time-series").
-        with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => {metric: "installs", dimension: "source", rank: "DESCENDING", limit: 3 }, "measures" => ["installs"], "startTime" => start_time }.to_json).
+        with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => { metric: "installs", dimension: "source", rank: "DESCENDING", limit: 3 }, "measures" => ["installs"], "startTime" => start_time }.to_json).
         to_return(status: 200, body: itc_read_fixture_file("app_analytics_installs_by_source.json"),
                   headers: { "Content-Type" => "application/json" })
     end

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -582,6 +582,11 @@ class TunesStubbing
         with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => nil, "measures" => ["crashes"], "startTime" => start_time }.to_json).
         to_return(status: 200, body: itc_read_fixture_file("app_analytics_crashes.json"),
                   headers: { "Content-Type" => "application/json" })
+
+      stub_request(:post, "https://analytics.itunes.apple.com/analytics/api/v1/data/time-series").
+        with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => {metric: "installs", dimension: "source", rank: "DESCENDING", limit: 3 }, "measures" => ["installs"], "startTime" => start_time }.to_json).
+        to_return(status: 200, body: itc_read_fixture_file("app_analytics_installs_by_source.json"),
+                  headers: { "Content-Type" => "application/json" })
     end
 
     def itc_stub_no_live_version


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When calling iTunes analytics IPA I had the need to get the analytics split by country/source so that 
I added an additional optional parameter that can be passed via command line.

### Description
This PR adds optional `view_by` parameter to `*_interval` methods that allow retrieving iTunes statistics split by country/source.
It also adds `measure_interval(start_t, end_t, measure, filter = nil)` method that will allow passing the measure as a command line parameter.

I don't have much experience in writing Ruby so please be easy on me 🙇 