### PR TITLE
Add ability to specify Carthage execuatable

### DIFF
--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -5,7 +5,7 @@ module Fastlane
       def self.run(params)
         validate(params)
 
-        cmd = ["carthage"]
+        cmd = [params[:executable]]
         command_name = params[:command]
         cmd << command_name
 
@@ -167,7 +167,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :log_path,
                                        env_name: "FL_CARTHAGE_LOG_PATH",
                                        description: "Path to the xcode build output",
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :executable,
+                                       env_name: "FL_CARTHAGE_EXECUTABLE",
+                                       description: "Path to the `carthage` executable on your machine",
+                                       default_value: 'carthage')
         ]
       end
 

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -338,6 +338,17 @@ describe Fastlane do
           eq("carthage bootstrap --derived-data ../derived\\ data")
       end
 
+      it "use custom executable" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              executable: 'custom_carthage'
+            )
+          end").runner.execute(:test)
+
+        expect(result).to \
+          eq("custom_carthage bootstrap")
+      end
+
       it "updates with a single dependency" do
         result = Fastlane::FastFile.new.parse("lane :test do
             carthage(


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

The `swiftlint` action allows setting an executable. We've found this useful because we use [Mint](https://github.com/yonaskolb/Mint) to manage our Swift command line tools. We want to use Mint for Carthage as well, so we needed an `:executable` config item for it as well.

### Description

Added the `:executable` config item to the `carthage` action to allow providing an override for the executable path used to run Carthage.