### PR TITLE
[supply] added new timeout option

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -68,9 +68,9 @@ module Supply
 
       Google::Apis::ClientOptions.default.application_name = "fastlane - supply"
       Google::Apis::ClientOptions.default.application_version = Fastlane::VERSION
-      Google::Apis::ClientOptions.default.read_timeout_sec = 300
-      Google::Apis::ClientOptions.default.open_timeout_sec = 300
-      Google::Apis::ClientOptions.default.send_timeout_sec = 300
+      Google::Apis::ClientOptions.default.read_timeout_sec = Supply.config[:timeout]
+      Google::Apis::ClientOptions.default.open_timeout_sec = Supply.config[:timeout]
+      Google::Apis::ClientOptions.default.send_timeout_sec = Supply.config[:timeout]
       Google::Apis::RequestOptions.default.retries = 5
 
       self.android_publisher = Androidpublisher::AndroidPublisherService.new

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -202,7 +202,13 @@ module Supply
                                      optional: true,
                                      description: "Check the other tracks for superseded versions and disable them",
                                      is_string: false,
-                                     default_value: false)
+                                     default_value: false),
+        FastlaneCore::ConfigItem.new(key: :timeout,
+                                     env_name: "SUPPLY_TIMEOUT",
+                                     optional: true,
+                                     description: "Timeout for read, open, and send (in seconds)",
+                                     type: Integer,
+                                     default_value: 300)
 
       ]
     end


### PR DESCRIPTION
Fixes #12943

## Problem
The `300` default for `read_timeout_sec`, `open_timeout_sec`, and `send_timeout_sec` wasn't long enough for all internet connections and APK sizes

## Solution
Added new `timeout` option that defaults to `300` but can be set to whatever 😊 