### PR TITLE
[Improvement] Filter out non-xcodeproj files from the list returned by `project_paths`.

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -456,6 +456,9 @@ module FastlaneCore
         @_project_paths = workspace_data.scan(/\"group:(.*)\"/).collect do |current_match|
           # It's a relative path from the workspace file
           File.join(File.expand_path("..", path), current_match.first)
+        end.select do |current_match|
+          # Xcode workspaces can contain loose files now, so let's filter non-xcodeproj files.
+          current_match.end_with?(".xcodeproj")
         end.reject do |current_match|
           # We're not interested in a `Pods` project, as it doesn't contain any relevant
           # information about code signing

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -456,10 +456,10 @@ module FastlaneCore
         @_project_paths = workspace_data.scan(/\"group:(.*)\"/).collect do |current_match|
           # It's a relative path from the workspace file
           File.join(File.expand_path("..", path), current_match.first)
-        end.find_all do |current_match|
+        end.reject do |current_match|
           # We're not interested in a `Pods` project, as it doesn't contain any relevant
           # information about code signing
-          !current_match.end_with?("Pods/Pods.xcodeproj")
+          current_match.end_with?("Pods/Pods.xcodeproj")
         end
 
         return @_project_paths

--- a/gym/spec/fixtures/projects/cocoapods/Example.xcworkspace/contents.xcworkspacedata
+++ b/gym/spec/fixtures/projects/cocoapods/Example.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,10 @@
    <FileRef
       location = "group:Example.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:somefile">
+   </FileRef>
 </Workspace>


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Xcode workspace files can contain any type of file, not only `xcodeproj` ones. Prior to this PR Fastlane was iterating over a list of all `FileRef` entries found in the workspace and only filtered entries that ended with the `Pods\Pods.xcodeproj`.

In case a workspace contained non-xcodeproj files Fastlane would still try to open them as they were a valid `xcodeproj` file and fail with a message:

```
[Xcodeproj] Unable to open `/some/path/to/a/project/file` because it doesn't exist.
```

### Description
This PR improves the filtering mechanism in a way that only files ending with `.xcodeproj` will be returned from the `project_paths` method. 

I also added the above mentioned edge cases (loose files and `Pods.xcodeproj`) to the workspace fixture being used to test this method.