### PR TITLE
Add trailing slash to generated (and individual) docs links

### DIFF
--- a/fastlane/lib/assets/Actions.md.erb
+++ b/fastlane/lib/assets/Actions.md.erb
@@ -22,12 +22,12 @@ You can import another `Fastfile` by using the `import` action. This is useful i
 import './path/to/other/Fastfile'
 ```
 
-For _fastlane_ plugins, check out the [available plugins](https://docs.fastlane.tools/plugins/available-plugins) page.
+For _fastlane_ plugins, check out the [available plugins](https://docs.fastlane.tools/plugins/available-plugins/) page.
 
 <%- @categories.each do |category, actions| -%>
 - [<%= category %>](#<%= category.gsub(" ", "-").downcase %>)
 <%- end -%>
-- [Plugins](https://docs.fastlane.tools/plugins/available-plugins)
+- [Plugins](https://docs.fastlane.tools/plugins/available-plugins/)
 
 <%- @categories.each do |category, actions| %>
 # <%= category %>

--- a/fastlane/lib/assets/Actions.md.erb
+++ b/fastlane/lib/assets/Actions.md.erb
@@ -35,7 +35,7 @@ For _fastlane_ plugins, check out the [available plugins](https://docs.fastlane.
 Action | Description
 ---|---
 <%- actions.sort.to_h.each do |_number_of_launches, action| -%>
-<%- link = "/actions/#{action.action_name}" -%>
+<%- link = "/actions/#{action.action_name}/" -%>
 <a href="<%= link %>"><%= action.action_name %></a> | <%= action.description %>
 <%- end %><%# End of actions.sort... %>
 

--- a/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
@@ -6,7 +6,7 @@
 
 <hr />
 <h4 align="center">
-  Check out the new <a href="https://docs.fastlane.tools/getting-started/ios/screenshots">fastlane documentation</a> on how to generate screenshots
+  Check out the new <a href="https://docs.fastlane.tools/getting-started/ios/screenshots/">fastlane documentation</a> on how to generate screenshots
 </h4>
 <hr />
 

--- a/fastlane/lib/fastlane/actions/ipa.rb
+++ b/fastlane/lib/fastlane/actions/ipa.rb
@@ -232,7 +232,7 @@ module Fastlane
           "You are using legacy `shenzhen` to build your app, which will be removed soon!",
           "It is recommended to upgrade to _gym_.",
           "To do so, just replace `ipa(...)` with `gym(...)` in your Fastfile.",
-          "To make code signing work, follow [https://docs.fastlane.tools/codesigning/xcode-project](https://docs.fastlane.tools/codesigning/xcode-project)."
+          "To make code signing work, follow [https://docs.fastlane.tools/codesigning/xcode-project/](https://docs.fastlane.tools/codesigning/xcode-project/)."
         ].join("\n")
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

The fastlane docs site has trailing slashes at the end of its URLs. Unfortunately some individual links and the generated list of actions doesn't have this, which causes an unnecessary redirect for all users clicking on these links.

### Description

This PR changes this as it fixes the individual links I could find and more importantly adds the trailing slash to the generated list of actions.

This PR closes https://github.com/fastlane/docs/issues/643
