### PR TITLE
[WIP] Another try to fix FastlanePty

### DIFF
--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -48,26 +48,19 @@ module FastlaneCore
         end
 
         begin
-          FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
-            begin
-              command_stdout.each do |l|
-                line = l.strip # strip so that \n gets removed
-                output << line
+          status = FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
+            command_stdout.each do |l|
+              line = l.strip # strip so that \n gets removed
+              output << line
 
-                next unless print_all
+              next unless print_all
 
-                # Prefix the current line with a string
-                prefix.each do |element|
-                  line = element[:prefix] + line if element[:block] && element[:block].call(line)
-                end
-
-                UI.command_output(line)
+              # Prefix the current line with a string
+              prefix.each do |element|
+                line = element[:prefix] + line if element[:block] && element[:block].call(line)
               end
-            rescue Errno::EIO
-              # This is expected on some linux systems, that indicates that the subcommand finished
-              # and we kept trying to read, ignore it
-            ensure
-              Process.wait(pid)
+
+              UI.command_output(line)
             end
           end
         rescue => ex
@@ -84,7 +77,6 @@ module FastlaneCore
         end
 
         # Exit status for build command, should be 0 if build succeeded
-        status = $?.exitstatus
         if status != 0
           o = output.join("\n")
           puts(o) # the user has the right to see the raw output

--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -49,18 +49,23 @@ module FastlaneCore
 
         begin
           status = FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
-            command_stdout.each do |l|
-              line = l.strip # strip so that \n gets removed
-              output << line
+            begin
+              command_stdout.each do |l|
+                line = l.strip # strip so that \n gets removed
+                output << line
 
-              next unless print_all
+                next unless print_all
 
-              # Prefix the current line with a string
-              prefix.each do |element|
-                line = element[:prefix] + line if element[:block] && element[:block].call(line)
+                # Prefix the current line with a string
+                prefix.each do |element|
+                  line = element[:prefix] + line if element[:block] && element[:block].call(line)
+                end
+
+                UI.command_output(line)
               end
-
-              UI.command_output(line)
+            rescue Errno::EIO
+              # This is expected on some linux systems, that indicates that the subcommand finished
+              # and we kept trying to read, ignore it
             end
           end
         rescue => ex
@@ -84,7 +89,7 @@ module FastlaneCore
           if error
             error.call(o, status)
           else
-            UI.user_error!("Exit status: #{status}")
+            #UI.user_error!("Exit status: #{status}")
           end
         end
 

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -1,3 +1,4 @@
+# PTY that also works on platforms that don't have PTY (e.g. Windows) by falling back on Open3.popen2e
 # Source: Mix of https://github.com/fastlane/fastlane/pull/7202/files,
 # https://github.com/fastlane/fastlane/pull/11384#issuecomment-356084518 and
 # https://github.com/DragonBox/u3d/blob/59e471ad78ac00cb629f479dbe386c5ad2dc5075/lib/u3d_core/command_runner.rb#L88-L96
@@ -6,7 +7,15 @@ module FastlaneCore
     def self.spawn(command, &block)
       require 'pty'
       PTY.spawn(command) do |command_stdout, command_stdin, pid|
-        block.call(command_stdout, command_stdin, pid)
+        begin
+          block.call(command_stdout, command_stdin, pid)
+        rescue Errno::EIO
+          # This is expected on some linux systems, that indicates that the subcommand finished
+          # and we kept trying to read, ignore it
+        ensure
+          Process.wait(pid)
+        end
+        $CHILD_STATUS.exitstatus
       end
     rescue LoadError
       require 'open3'

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -9,9 +9,6 @@ module FastlaneCore
       PTY.spawn(command) do |command_stdout, command_stdin, pid|
         begin
           block.call(command_stdout, command_stdin, pid)
-        rescue Errno::EIO
-          # This is expected on some linux systems, that indicates that the subcommand finished
-          # and we kept trying to read, ignore it
         ensure
           Process.wait(pid)
         end


### PR DESCRIPTION
WORK IN PROGRESS!!

Open3.popen2e doesn't set `$?.exitstatus` but return the statuscode ,so we need change the PTY.spawn part of the code to also return the status




<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->
