### PR TITLE
Fix FastlanePty.spawn on Windows

### DIFF
--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -48,7 +48,7 @@ module FastlaneCore
         end
 
         begin
-          FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
+          status = FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
             begin
               command_stdout.each do |l|
                 line = l.strip # strip so that \n gets removed
@@ -66,8 +66,6 @@ module FastlaneCore
             rescue Errno::EIO
               # This is expected on some linux systems, that indicates that the subcommand finished
               # and we kept trying to read, ignore it
-            ensure
-              Process.wait(pid)
             end
           end
         rescue => ex
@@ -84,7 +82,6 @@ module FastlaneCore
         end
 
         # Exit status for build command, should be 0 if build succeeded
-        status = $?.exitstatus
         if status != 0
           o = output.join("\n")
           puts(o) # the user has the right to see the raw output

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -6,8 +6,13 @@ module FastlaneCore
     def self.spawn(command, &block)
       require 'pty'
       PTY.spawn(command) do |command_stdout, command_stdin, pid|
-        block.call(command_stdout, command_stdin, pid)
+        begin
+          block.call(command_stdout, command_stdin, pid)
+        ensure
+          Process.wait(pid)
+        end
       end
+      $?.exitstatus
     rescue LoadError
       require 'open3'
       Open3.popen2e(command) do |command_stdin, command_stdout, p| # note the inversion

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -2,7 +2,12 @@ describe FastlaneCore do
   describe FastlaneCore::CommandExecutor do
     describe "execute" do
       it 'executes a simple command successfully' do
+        unless FastlaneCore::Helper.windows?
+          expect(Process).to receive(:wait)
+        end
+
         result = FastlaneCore::CommandExecutor.execute(command: 'echo foo')
+
         expect(result).to eq('foo')
       end
 
@@ -14,17 +19,12 @@ describe FastlaneCore do
         # we raise when the line is cleaned up with `strip` afterward
         expect(explodes_on_strip).to receive(:strip).and_raise(Errno::EIO)
 
-        child_process_id = 1
-        expect(Process).to receive(:wait).with(child_process_id)
-
-        # Hacky approach because $? is not be defined since we skip the actual spawn
-        allow_message_expectations_on_nil
-        expect($?).to receive(:exitstatus).and_return(0)
-
         # Make a fake child process so we have a valid PID and $? is set correctly
+        child_process_id = 1
         expect(FastlaneCore::FastlanePty).to receive(:spawn) do |command, &block|
           expect(command).to eq('ls')
           block.yield(fake_std_in, 'not_really_std_out', child_process_id)
+          $?.exitstatus
         end
 
         result = FastlaneCore::CommandExecutor.execute(command: 'ls')

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -1,6 +1,11 @@
 describe FastlaneCore do
   describe FastlaneCore::CommandExecutor do
     describe "execute" do
+      it 'executes a simple command successfully' do
+        result = FastlaneCore::CommandExecutor.execute(command: 'echo foo')
+        expect(result).to eq('foo')
+      end
+
       it 'handles reading which throws a EIO exception' do
         explodes_on_strip = 'danger! lasers!'
         fake_std_in = ['a_filename', explodes_on_strip]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

As reported in #12144 fastlane currently can't successfully execute commands via `FastlaneCore::CommandExecutor.execute` on Windows (which screengrab does with `adb devices -l` to get a list of devices to run the tests on).

`FastlaneCore::CommandExecutor.execute` internally uses `FastlaneCore::FastlanePty.spawn` to spawn the command, which first tries to `PTY.spawn` and if that fails - which it does on Windows as PTY.spawn is not available - uses an alternative method of `Open3.popen2e`.

Problem is, that the code in `CommandExecutor.execute` tries to `Process.wait(pid)` to fill `$?`, from which it tries to get the exit status via `$?.exitstatus`. On Windows `Process.wait` triggers the `No child processes (Errno::ECHILD)` exception, as documented: https://www.w3cschool.cn/doc_ruby_2_4/ruby_2_4-process.html#method-c-wait

### Description

Lucky for us, the code I cobbled/stole together that is executed on Windows via `Open3.popen2e` already semi takes this into account - it returns the exit status code, making the `Process.wait` and `$?.exitstatus` unnecessary in this case.

I moved both `Process.wait` and `$?.exitstatus` to the `PTY.spawn` part of `FastlaneCore::FastlanePty.spawn` and return the exit status similat ro how the `Open3.popen2e` already works.

There is one test that tests for some EIO exception special case. I had to get rid of 2 `expect`s there - the code was moved inside a function that is not actually run by that test.

To avoid this bug in the future, I also added a test that runs a super simple command via  `CommandExecutor.execute` - without all these changes here it fails, now it doesn't.

---

closes #12144