### PR TITLE
Return empty array when aab not set

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -153,7 +153,7 @@ module Supply
 
     def upload_bundles
       aab_path = Supply.config[:aab]
-      return unless aab_path
+      return [] unless aab_path
 
       UI.message("Preparing aab at path '#{aab_path}' for upload...")
       return [client.upload_bundle(aab_path)]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [x] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I was getting an error upon submitting my builds to google play seems like the `concat` call can be made on a nil return. which results in `lib/supply/uploader.rb:28:in `concat': [!] no implicit conversion of nil into Array (TypeError)` :)
I reran the specs without a problem.

### Description
I've made sure the `upload_bundles` method returns an array when `aab` is not set so the `concat` call on the return value works.
