### PR TITLE
Fix itms tests on Windows

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -199,7 +199,7 @@ module FastlaneCore
     # @return the full path to the iTMSTransporter executable
     def self.itms_path
       return ENV["FASTLANE_ITUNES_TRANSPORTER_PATH"] if FastlaneCore::Env.truthy?("FASTLANE_ITUNES_TRANSPORTER_PATH")
-      return '' unless self.mac? # so tests work on Linux and Windows too
+      return './' unless self.mac? # so tests work on Linux and Windows too
 
       [
         "../Applications/Application Loader.app/Contents/MacOS/itms",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
ITMS tests currently get an empty string as path for Windows so tests can run instead of looking for a non-existing ITMS. But those empty strings as path cause crashes:

```
  1) FastlaneCore FastlaneCore::ItunesTransporter with Xcode 7.x installed by default upload command generation generates a call to java directly
     Failure/Error: expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)

     Errno::EINVAL:
       Invalid argument @ dir_chdir -
     # ./fastlane_core/lib/fastlane_core/itunes_transporter.rb:286:in `execute'
     # ./fastlane_core/lib/fastlane_core/itunes_transporter.rb:379:in `upload'
     # ./fastlane_core/spec/itunes_transporter_spec.rb:83:in `block (6 levels) in <top (required)>'
```
<!-- Please describe in detail how you tested your changes. -->

### Description
Using './' doesn't.
