### PR TITLE
allow fastlane to fetch list of available bundle ids

### DIFF
--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -101,6 +101,10 @@ module Spaceship
                                     platform: platform,
                                     itunes_connect_users: itunes_connect_users)
         end
+
+        def available_bundle_ids(platform: nil)
+          client.get_available_bundle_ids(platform: platform)
+        end
       end
 
       #####################################################

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -334,6 +334,13 @@ module Spaceship
       handle_itc_response(data)
     end
 
+    def get_available_bundle_ids(platform: nil)
+      platform ||= "ios"
+      r = request(:get, "ra/apps/create/v2/?platformString=#{platform}")
+      data = parse_response(r, 'data')
+      return data['bundleIds'].keys
+    end
+
     def get_resolution_center(app_id, platform)
       r = request(:get, "ra/apps/#{app_id}/platforms/#{platform}/resolutionCenter?v=latest")
       parse_response(r, 'data')

--- a/spaceship/spec/tunes/application_spec.rb
+++ b/spaceship/spec/tunes/application_spec.rb
@@ -110,6 +110,19 @@ describe Spaceship::Application do
       end
     end
 
+    describe '#available_bundle_ids' do
+      it "returns the list of bundle ids" do
+        TunesStubbing.itc_stub_applications_first_create
+        bundle_ids = Spaceship::Tunes::Application.available_bundle_ids
+        expect(bundle_ids.length).to eq(5)
+        expect(bundle_ids[0]).to eq("com.krausefx.app_name")
+        expect(bundle_ids[1]).to eq("net.sunapps.*")
+        expect(bundle_ids[2]).to eq("net.sunapps.947474")
+        expect(bundle_ids[3]).to eq("*")
+        expect(bundle_ids[4]).to eq("net.sunapps.100")
+      end
+    end
+
     describe "#resolution_center" do
       it "when the app was rejected" do
         TunesStubbing.itc_stub_resolution_center


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
A way to query the list of bundle ids available in AppStoreConnect to create a new app. 

This solves a problem where creating the appId in developer portal does not propagate 
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
To test : 

run `bundle exec irb` using the fastlane repo with these changes
```
> Spaceship::Tunes.login(uname,pword)
> Spaceship::Tunes.select_team
> Spaceship::Tunes::Application.available_bundle_ids
```
The last command should return an array of available bundle ids

### Description
<!-- Describe your changes in detail -->
Added the method `available_bundle_ids` in the `application` class - it makes sense to put it in there because it is something you d do before creating the application. 
Added client method and test for them. 