### PR TITLE
Add trailing slash to docs links

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
@@ -303,7 +303,7 @@ Radar [23062925](https://openradar.appspot.com/radar?id=5056366381105152) has be
 
 <hr />
 <h4 align="center">
-  Check out the new <a href="https://docs.fastlane.tools/getting-started/ios/screenshots">fastlane documentation</a> on how to generate screenshots
+  Check out the new <a href="https://docs.fastlane.tools/getting-started/ios/screenshots/">fastlane documentation</a> on how to generate screenshots
 </h4>
 <hr />
 


### PR DESCRIPTION
fix docs link