### PR TITLE
[get_version_number] look into xcconfig for plist

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -105,7 +105,7 @@ module Fastlane
 
         # This is needed to workaround the inconsistent return value of target.resolved_build_setting with second param `true` above
         # for normal values settings it returns relative paths, for ones that come from xcconfigs it returns absolute paths
-        unless(plist_file.include?(File.absolute_path(folder)))
+        unless plist_file.include?(File.absolute_path(folder))
           plist_file = File.join(folder, plist_file)
         end
         plist_file = File.absolute_path(plist_file)

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -103,10 +103,6 @@ module Fastlane
 
         UI.user_error!("Cannot find value for INFOPLIST_FILE build setting") if plist_file.nil?
 
-        # $(SRCROOT) is the path of where the XcodeProject is
-        # We can just set this as empty string since we join with `folder` below
-        if plist_file.include?("$(SRCROOT)/")
-          plist_file.gsub!("$(SRCROOT)/", "")
         end
 
         plist_file = File.absolute_path(File.join(folder, plist_file))

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -85,7 +85,7 @@ module Fastlane
       end
 
       def self.get_plist!(folder, target, configuration = nil)
-        plist_files = target.resolved_build_setting("INFOPLIST_FILE")
+        plist_files = target.resolved_build_setting("INFOPLIST_FILE", true)
         plist_files_count = plist_files.values.compact.uniq.count
 
         # Get plist file for specified configuration
@@ -100,6 +100,8 @@ module Fastlane
         else
           plist_file = plist_files.values.first
         end
+
+        UI.user_error!("Cannot find value for INFOPLIST_FILE build setting") if plist_file.nil?
 
         # $(SRCROOT) is the path of where the XcodeProject is
         # We can just set this as empty string since we join with `folder` below

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -103,9 +103,13 @@ module Fastlane
 
         UI.user_error!("Cannot find value for INFOPLIST_FILE build setting") if plist_file.nil?
 
+        # This is needed to workaround the inconsistent return value of target.resolved_build_setting with second param `true` above
+        # for normal values settings it returns relative paths, for ones that come from xcconfigs it returns absolute paths
+        unless(plist_file.include?(File.absolute_path(folder)))
+          plist_file = File.join(folder, plist_file)
         end
+        plist_file = File.absolute_path(plist_file)
 
-        plist_file = File.absolute_path(File.join(folder, plist_file))
         UI.user_error!("Cannot find plist file: #{plist_file}") unless File.exist?(plist_file)
 
         plist_file

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -5,70 +5,70 @@ describe Fastlane do
 
       path = File.absolute_path("./fastlane/spec/fixtures/actions/get_version_number/get_version_number/")
 
-      it "gets the correct version number for 'TargetA'", requires_xcodeproj: true do
+      it "gets the correct version number for 'TargetA'" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{path}', target: 'TargetA')
         end").runner.execute(:test)
         expect(result).to eq("4.3.2")
       end
 
-      it "gets the correct version number for 'TargetVariableParentheses'", requires_xcodeproj: true do
+      it "gets the correct version number for 'TargetVariableParentheses'" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{path}', target: 'TargetVariableParentheses')
         end").runner.execute(:test)
         expect(result).to eq("4.3.2")
       end
 
-      it "gets the correct version number for 'TargetVariableCurlyBraces'", requires_xcodeproj: true do
+      it "gets the correct version number for 'TargetVariableCurlyBraces'" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{path}', target: 'TargetVariableCurlyBraces')
         end").runner.execute(:test)
         expect(result).to eq("4.3.2")
       end
 
-      it "gets the correct version number for 'TargetATests'", requires_xcodeproj: true do
+      it "gets the correct version number for 'TargetATests'" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{path}', target: 'TargetATests')
         end").runner.execute(:test)
         expect(result).to eq("4.3.2")
       end
 
-      it "gets the correct version number for 'TargetB'", requires_xcodeproj: true do
+      it "gets the correct version number for 'TargetB'" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{path}', target: 'TargetB')
         end").runner.execute(:test)
         expect(result).to eq("5.4.3")
       end
 
-      it "gets the correct version number for 'TargetBTests'", requires_xcodeproj: true do
+      it "gets the correct version number for 'TargetBTests'" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{path}', target: 'TargetBTests')
         end").runner.execute(:test)
         expect(result).to eq("5.4.3")
       end
 
-      it "gets the correct version number for 'TargetC_internal'", requires_xcodeproj: true do
+      it "gets the correct version number for 'TargetC_internal'" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{path}', target: 'TargetC_internal')
         end").runner.execute(:test)
         expect(result).to eq("7.5.2")
       end
 
-      it "gets the correct version number for 'TargetC_production'", requires_xcodeproj: true do
+      it "gets the correct version number for 'TargetC_production'" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{path}', target: 'TargetC_production')
         end").runner.execute(:test)
         expect(result).to eq("6.4.9")
       end
 
-      it "gets the correct version number for 'SampleProject_tests'", requires_xcodeproj: true do
+      it "gets the correct version number for 'SampleProject_tests'" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{path}', target: 'SampleProject_tests')
         end").runner.execute(:test)
         expect(result).to eq("1.0")
       end
 
-      it "gets the correct version number with no target specified (and one target)", requires_xcodeproj: true do
+      it "gets the correct version number with no target specified (and one target)" do
         allow_any_instance_of(Xcodeproj::Project).to receive(:targets).and_wrap_original do |m, *args|
           [m.call(*args).first]
         end
@@ -79,7 +79,7 @@ describe Fastlane do
         expect(result).to eq("4.3.2")
       end
 
-      it "gets the correct version number with no target specified (and one target and multiple test targets)", requires_xcodeproj: true do
+      it "gets the correct version number with no target specified (and one target and multiple test targets)" do
         allow_any_instance_of(Xcodeproj::Project).to receive(:targets).and_wrap_original do |m, *args|
           targets = m.call(*args)
           targets.select do |target|
@@ -93,14 +93,14 @@ describe Fastlane do
         expect(result).to eq("4.3.2")
       end
 
-      it "gets the correct version with $(SRCROOT)", requires_xcodeproj: true do
+      it "gets the correct version with $(SRCROOT)" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{path}', target: 'TargetSRC')
         end").runner.execute(:test)
         expect(result).to eq("1.5.9")
       end
 
-      it "raises if one target and specified wrong target name", requires_xcodeproj: true do
+      it "raises if one target and specified wrong target name" do
         allow_any_instance_of(Xcodeproj::Project).to receive(:targets).and_wrap_original do |m, *args|
           [m.call(*args).first]
         end
@@ -112,7 +112,7 @@ describe Fastlane do
         end.to raise_error(FastlaneCore::Interface::FastlaneError, "Cannot find target named 'ThisIsNotATarget'")
       end
 
-      it "raises if in non-interactive mode with no target", requires_xcodeproj: true do
+      it "raises if in non-interactive mode with no target" do
         expect do
           result = Fastlane::FastFile.new.parse("lane :test do
             get_version_number(xcodeproj: '#{path}')
@@ -120,7 +120,7 @@ describe Fastlane do
         end.to raise_error(FastlaneCore::Interface::FastlaneCrash, /non-interactive mode/)
       end
 
-      it "raises if in non-interactive mode if cannot infer configuration", requires_xcodeproj: true do
+      it "raises if in non-interactive mode if cannot infer configuration" do
         expect do
           result = Fastlane::FastFile.new.parse("lane :test do
             get_version_number(xcodeproj: '#{path}', target: 'TargetDifferentConfigurations')
@@ -128,7 +128,7 @@ describe Fastlane do
         end.to raise_error(FastlaneCore::Interface::FastlaneCrash, /non-interactive mode/)
       end
 
-      it "gets correct version for different configurations", requires_xcodeproj: true do
+      it "gets correct version for different configurations" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{path}', target: 'TargetDifferentConfigurations', configuration: 'Debug')
         end").runner.execute(:test)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass: had 8 failures that seem unrelated to my change.
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

`get_version_number` crashes when `INFOPLIST_FILE` is defined in a xcconfig file.

### Description

When `get_version_number` uses Xcodeproj's `target.resolved_build_setting` to look for the `INFOPLIST_FILE` build setting, it will crash if the value can't be found, as can happen if the value is defined in xcconfig files. I resolved this by adding a test to make sure we do find a value, and by also checking inside xcconfig files.