### PR TITLE
Limit reviews upto date specified.

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_ratings.rb
+++ b/spaceship/lib/spaceship/tunes/app_ratings.rb
@@ -46,8 +46,8 @@ module Spaceship
       end
 
       # @return (Array) of Review Objects
-      def reviews(store_front = '', version_id = '')
-        raw_reviews = client.get_reviews(application.apple_id, application.platform, store_front, version_id)
+      def reviews(store_front = '', version_id = '', upto_date = '')
+        raw_reviews = client.get_reviews(application.apple_id, application.platform, store_front, version_id, upto_date)
         raw_reviews.map do |review|
           review["value"]["application"] = self.application
           AppReview.factory(review["value"])

--- a/spaceship/lib/spaceship/tunes/app_ratings.rb
+++ b/spaceship/lib/spaceship/tunes/app_ratings.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require_relative 'app_review'
 
 module Spaceship

--- a/spaceship/lib/spaceship/tunes/app_ratings.rb
+++ b/spaceship/lib/spaceship/tunes/app_ratings.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require_relative 'app_review'
 
 module Spaceship
@@ -46,7 +47,7 @@ module Spaceship
       end
 
       # @return (Array) of Review Objects
-      def reviews(store_front = '', version_id = '', upto_date = '')
+      def reviews(store_front = '', version_id = '', upto_date = nil)
         raw_reviews = client.get_reviews(application.apple_id, application.platform, store_front, version_id, upto_date)
         raw_reviews.map do |review|
           review["value"]["application"] = self.application

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -358,7 +358,7 @@ module Spaceship
       parse_response(r, 'data')
     end
 
-    def get_reviews(app_id, platform, storefront, version_id)
+    def get_reviews(app_id, platform, storefront, version_id, upto_date)
       index = 0
       per_page = 100 # apple default
       all_reviews = []
@@ -371,6 +371,12 @@ module Spaceship
 
         r = request(:get, rating_url)
         all_reviews.concat(parse_response(r, 'data')['reviews'])
+
+        last_review_date = Date.parse(Time.at(all_reviews[-1]['value']['lastModified']/1000).to_s).to_date
+        if last_review_date < DateTime.parse(upto_date).to_date
+          break
+        end
+
         if all_reviews.count < parse_response(r, 'data')['reviewCount']
           index += per_page
         else

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -374,20 +374,20 @@ module Spaceship
 
         r = request(:get, rating_url)
         all_reviews.concat(parse_response(r, 'data')['reviews'])
-        last_review_date = Time.at(all_reviews[-1]['value']['lastModified']/1000)
+        last_review_date = Time.at(all_reviews[-1]['value']['lastModified'] / 1000)
 
         if upto_date && last_review_date < upto_date
-          all_reviews = all_reviews.select { |review| Time.at(review['value']['lastModified']/1000) > upto_date  }
+          all_reviews = all_reviews.select { |review| Time.at(review['value']['lastModified'] / 1000) > upto_date }
           break
         end
-        
+
         if all_reviews.count < parse_response(r, 'data')['reviewCount']
           index += per_page
         else
           break
         end
       end
-      
+
       all_reviews
     end
 

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -375,8 +375,11 @@ module Spaceship
         r = request(:get, rating_url)
         all_reviews.concat(parse_response(r, 'data')['reviews'])
         last_review_date = Time.at(all_reviews[-1]['value']['lastModified']/1000)
-        
-        break if last_review_date < upto_date && !upto_date.nil?
+
+        if upto_date && last_review_date < upto_date
+          all_reviews = all_reviews.select { |review| Time.at(review['value']['lastModified']/1000) > upto_date  }
+          break
+        end
         
         if all_reviews.count < parse_response(r, 'data')['reviewCount']
           index += per_page
@@ -384,10 +387,8 @@ module Spaceship
           break
         end
       end
-
-      return all_reviews if upto_date.nil?
-
-      return all_reviews.select { |review| Time.at(review['value']['lastModified']/1000) > upto_date  }
+      
+      all_reviews
     end
 
     #####################################################

--- a/spaceship/spec/tunes/app_ratings_spec.rb
+++ b/spaceship/spec/tunes/app_ratings_spec.rb
@@ -48,16 +48,16 @@ describe Spaceship::Tunes::AppRatings do
     it "contains the right information" do
       TunesStubbing.itc_stub_ratings
       ratings = app.ratings
-      reviews = ratings.reviews("US", "", upto_date = "2018-08-13")
+      reviews = ratings.reviews("US", "", "2018-08-13")
 
       expect(reviews.count).to eq(5)
       expect(reviews.last.store_front).to eq("US")
       expect(reviews.last.id).to eq(1_000_000_004)
-      expect(reviews.first.rating).to eq(4)
-      expect(reviews.first.title).to eq("Title 5")
-      expect(reviews.first.review).to eq("Review 5")
-      expect(reviews.first.nickname).to eq("Reviewer5")
-      expect(reviews.first.last_modified).to be < 1_534_171_273_000
+      expect(reviews.last.rating).to eq(4)
+      expect(reviews.last.title).to eq("Title 5")
+      expect(reviews.last.review).to eq("Review 5")
+      expect(reviews.last.nickname).to eq("Reviewer5")
+      expect(reviews.last.last_modified).to be < 1_534_171_273_000
     end
   end
 

--- a/spaceship/spec/tunes/app_ratings_spec.rb
+++ b/spaceship/spec/tunes/app_ratings_spec.rb
@@ -48,16 +48,16 @@ describe Spaceship::Tunes::AppRatings do
     it "contains the right information" do
       TunesStubbing.itc_stub_ratings
       ratings = app.ratings
-      reviews = ratings.reviews("US", "", "2018-08-13")
+      reviews = ratings.reviews("US", "", upto_date = "2018-08-13")
 
       expect(reviews.count).to eq(5)
       expect(reviews.last.store_front).to eq("US")
       expect(reviews.last.id).to eq(1_000_000_004)
-      expect(reviews.last.rating).to eq(4)
-      expect(reviews.last.title).to eq("Title 5")
-      expect(reviews.last.review).to eq("Review 5")
-      expect(reviews.last.nickname).to eq("Reviewer5")
-      expect(reviews.last.last_modified).to be < 1_534_171_273_000
+      expect(reviews.first.rating).to eq(4)
+      expect(reviews.first.title).to eq("Title 5")
+      expect(reviews.first.review).to eq("Review 5")
+      expect(reviews.first.nickname).to eq("Reviewer5")
+      expect(reviews.first.last_modified).to be < 1_534_171_273_000
     end
   end
 

--- a/spaceship/spec/tunes/app_ratings_spec.rb
+++ b/spaceship/spec/tunes/app_ratings_spec.rb
@@ -33,7 +33,7 @@ describe Spaceship::Tunes::AppRatings do
       ratings = app.ratings
       reviews = ratings.reviews("US")
 
-      expect(reviews.count).to eq(4)
+      expect(reviews.count).to eq(5)
       expect(reviews.first.store_front).to eq("NZ")
       expect(reviews.first.id).to eq(1_000_000_000)
       expect(reviews.first.rating).to eq(2)
@@ -41,6 +41,23 @@ describe Spaceship::Tunes::AppRatings do
       expect(reviews.first.review).to eq("Review 1")
       expect(reviews.first.last_modified).to eq(1_463_887_020_000)
       expect(reviews.first.nickname).to eq("Reviewer1")
+    end
+  end
+
+  describe "successfully loads reviews upto date ('2018-08-13')" do
+    it "contains the right information" do
+      TunesStubbing.itc_stub_ratings
+      ratings = app.ratings
+      reviews = ratings.reviews("US", "", upto_date = "2018-08-13")
+
+      expect(reviews.count).to eq(5)
+      expect(reviews.last.store_front).to eq("US")
+      expect(reviews.last.id).to eq(1_000_000_004)
+      expect(reviews.first.rating).to eq(4)
+      expect(reviews.first.title).to eq("Title 5")
+      expect(reviews.first.review).to eq("Review 5")
+      expect(reviews.first.nickname).to eq("Reviewer5")
+      expect(reviews.first.last_modified).to be < 1_534_171_273_000
     end
   end
 

--- a/spaceship/spec/tunes/app_ratings_spec.rb
+++ b/spaceship/spec/tunes/app_ratings_spec.rb
@@ -33,7 +33,7 @@ describe Spaceship::Tunes::AppRatings do
       ratings = app.ratings
       reviews = ratings.reviews("US")
 
-      expect(reviews.count).to eq(5)
+      expect(reviews.count).to eq(4)
       expect(reviews.first.store_front).to eq("NZ")
       expect(reviews.first.id).to eq(1_000_000_000)
       expect(reviews.first.rating).to eq(2)
@@ -41,23 +41,6 @@ describe Spaceship::Tunes::AppRatings do
       expect(reviews.first.review).to eq("Review 1")
       expect(reviews.first.last_modified).to eq(1_463_887_020_000)
       expect(reviews.first.nickname).to eq("Reviewer1")
-    end
-  end
-
-  describe "successfully loads reviews upto date ('2018-08-13')" do
-    it "contains the right information" do
-      TunesStubbing.itc_stub_ratings
-      ratings = app.ratings
-      reviews = ratings.reviews("US", "", upto_date = "2018-08-13")
-
-      expect(reviews.count).to eq(5)
-      expect(reviews.last.store_front).to eq("US")
-      expect(reviews.last.id).to eq(1_000_000_004)
-      expect(reviews.first.rating).to eq(4)
-      expect(reviews.first.title).to eq("Title 5")
-      expect(reviews.first.review).to eq("Review 5")
-      expect(reviews.first.nickname).to eq("Reviewer5")
-      expect(reviews.first.last_modified).to be < 1_534_171_273_000
     end
   end
 

--- a/spaceship/spec/tunes/app_ratings_spec.rb
+++ b/spaceship/spec/tunes/app_ratings_spec.rb
@@ -42,6 +42,29 @@ describe Spaceship::Tunes::AppRatings do
       expect(reviews.first.last_modified).to eq(1_463_887_020_000)
       expect(reviews.first.nickname).to eq("Reviewer1")
     end
+
+    it "contains the right information with upto_date" do
+      TunesStubbing.itc_stub_ratings
+      ratings = app.ratings
+      reviews = ratings.reviews("US", "", "2016-03-27")
+
+      expect(reviews.count).to eq(2)
+      expect(reviews.first.store_front).to eq("NZ")
+      expect(reviews.first.id).to eq(1_000_000_000)
+      expect(reviews.first.rating).to eq(2)
+      expect(reviews.first.title).to eq("Title 1")
+      expect(reviews.first.review).to eq("Review 1")
+      expect(reviews.first.last_modified).to eq(1_463_887_020_000)
+      expect(reviews.first.nickname).to eq("Reviewer1")
+
+      expect(reviews.last.store_front).to eq("NZ")
+      expect(reviews.last.id).to eq(1_000_000_001)
+      expect(reviews.last.rating).to eq(2)
+      expect(reviews.last.title).to eq("Title 2")
+      expect(reviews.last.review).to eq("Review 2")
+      expect(reviews.last.last_modified).to eq(1_459_152_540_000)
+      expect(reviews.last.nickname).to eq("Reviewer2")
+    end
   end
 
   describe "Manages Developer Response" do

--- a/spaceship/spec/tunes/fixtures/review_by_storefront.json
+++ b/spaceship/spec/tunes/fixtures/review_by_storefront.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "reviewCount": 4,
+        "reviewCount": 5,
         "reviews": [{
             "value": {
                 "id": 1000000000,
@@ -49,7 +49,17 @@
                 "nickname": "Reviewer4",
                 "storeFront": "NZ"
             }
-        }]
+        }, {
+          "value": {
+              "id": 1000000004,
+              "rating": 4,
+              "title": "Title 5",
+              "review": "Review 5",
+              "lastModified": 1534086069000,
+              "nickname": "Reviewer5",
+              "storeFront": "US"
+          }
+      }]
     },
     "messages": {
         "warn": null,

--- a/spaceship/spec/tunes/fixtures/review_by_storefront.json
+++ b/spaceship/spec/tunes/fixtures/review_by_storefront.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "reviewCount": 5,
+        "reviewCount": 4,
         "reviews": [{
             "value": {
                 "id": 1000000000,
@@ -49,17 +49,7 @@
                 "nickname": "Reviewer4",
                 "storeFront": "NZ"
             }
-        }, {
-          "value": {
-              "id": 1000000004,
-              "rating": 4,
-              "title": "Title 5",
-              "review": "Review 5",
-              "lastModified": 1534086069000,
-              "nickname": "Reviewer5",
-              "storeFront": "US"
-          }
-      }]
+        }]
     },
     "messages": {
         "warn": null,


### PR DESCRIPTION
Issue: https://github.com/fastlane/fastlane/issues/13030

Solution: Added an optional `upto_date` parameter to `get_review` methods. By limiting `get_reviews` upto a certain date, the time to return from the method is reduced from hours to seconds!

Examples - 
**Before:** Time taken to get **all** reviews: ~ upto 2 hours (best case). Up to 5 hours (worst case), and the script crashes in the end. 
```
2018-08-03 11:14:33 PM -04 EDT - INFO - [apple_reviews] | Finding all available reviews for "bundleid1" ...
2018-08-04 02:18:39 AM -04 EDT - INFO - [apple_reviews] | Found 90,000 reviews.
...
2018-08-03 11:14:33 PM -04 EDT - INFO - [apple_reviews] | Finding all available reviews for "bundleid2" ...
2018-08-04 02:18:39 AM -04 EDT - ERROR - [apple_reviews] | It seems the script crashed in iteration 1 while getting reviews for App: "bundleid2".
```

**After:** Time taken to get reviews up to a specified date: ~ 2 secs (best case) to ~ 30 secs. 
```
2018-08-05 12:41:00 PM -04 EDT - INFO - [apple_reviews] | Finding all available reviews ...
2018-08-05 12:41:02 PM -04 EDT - INFO - [apple_reviews] | 	Found 100 reviews upto date "2018-07-01"
...
2018-08-05 12:40:12 PM -04 EDT - INFO - [apple_reviews] | Finding all available reviews ...
2018-08-05 12:40:38 PM -04 EDT - INFO - [apple_reviews] | 	Found 1700 reviews upto date "2018-07-01"
```

