### PR TITLE
Document api_token as optional in the action create_pull_request

### DIFF
--- a/fastlane/lib/fastlane/actions/create_pull_request.rb
+++ b/fastlane/lib/fastlane/actions/create_pull_request.rb
@@ -111,7 +111,7 @@ module Fastlane
       def self.example_code
         [
           'create_pull_request(
-            api_token: ENV["GITHUB_TOKEN"],
+            api_token: "secret",                # optional, defaults to ENV["GITHUB_API_TOKEN"]
             repo: "fastlane/fastlane",
             title: "Amazing new feature",
             head: "my-feature",                 # optional, defaults to current branch name


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The example does not reflect the optionality of the parameter `api_token` in the action `create_pull_request`

### Description
The parameter `api_token`  in the action `create_pull_request` defaults to `ENV["GITHUB_API_TOKEN"]` which makes it optional. The example, on the other hand, does not reflect this optionality, and it uses a different env variable making it a bit confusing.