### PR TITLE
docs: add trailing slash to link

### DIFF
--- a/fastlane/lib/assets/ActionDetails.md.erb
+++ b/fastlane/lib/assets/ActionDetails.md.erb
@@ -59,4 +59,4 @@ fastlane action <%= action.action_name %>
 
 <hr />
 
-<a href="/actions"><b>Back to actions</b></a>
+<a href="/actions/"><b>Back to actions</b></a>

--- a/fastlane/lib/fastlane/actions/docs/get_certificates.md
+++ b/fastlane/lib/fastlane/actions/docs/get_certificates.md
@@ -20,7 +20,7 @@ In the gif we used `cert && sigh`, which will first create an iOS code signing c
 
 # Usage
 
-**Note**: It is recommended to use [_match_](/actions/match) according to the [codesigning.guide](https://codesigning.guide) for generating and maintaining your certificates. Use _cert_ directly only if you want full control over what's going on and know more about codesigning.
+**Note**: It is recommended to use [_match_](/actions/match/) according to the [codesigning.guide](https://codesigning.guide) for generating and maintaining your certificates. Use _cert_ directly only if you want full control over what's going on and know more about codesigning.
 
 ```no-highlight
 fastlane cert

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -26,7 +26,7 @@ _deliver_ uploads screenshots, metadata and binaries to App Store Connect. Use _
 - Get a HTML preview of the fetched metadata before uploading the app metadata and screenshots to iTC
 - Automatically uses [_precheck_](/actions/precheck) to ensure your app has the highest chances of passing app review the first time
 
-To upload builds to TestFlight check out [_pilot_](/actions/pilot).
+To upload builds to TestFlight check out [_pilot_](/actions/pilot/).
 
 # Quick Start
 

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -24,7 +24,7 @@ _deliver_ uploads screenshots, metadata and binaries to App Store Connect. Use _
 - Easily implement a real Continuous Deployment process using [_fastlane_](https://fastlane.tools)
 - Store the configuration in git to easily deploy from **any** Mac, including your Continuous Integration server
 - Get a HTML preview of the fetched metadata before uploading the app metadata and screenshots to iTC
-- Automatically uses [_precheck_](/actions/precheck) to ensure your app has the highest chances of passing app review the first time
+- Automatically uses [_precheck_](/actions/precheck/) to ensure your app has the highest chances of passing app review the first time
 
 To upload builds to TestFlight check out [_pilot_](/actions/pilot/).
 


### PR DESCRIPTION
Fixes some links that are still without trailing slash to action pages.