### PR TITLE
Display success logs in git_add only when it has been a success

### DIFF
--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -6,7 +6,7 @@ module Fastlane
 
         if params[:pathspec]
           paths = params[:pathspec]
-          UI.success("Successfully added from \"#{paths}\" 💾.")
+          success_message = "Successfully added from \"#{paths}\" 💾."
         elsif params[:path]
           if params[:path].kind_of?(String)
             paths = shell_escape(params[:path], should_escape)
@@ -15,13 +15,14 @@ module Fastlane
               shell_escape(p, should_escape)
             end.join(' ')
           end
-          UI.success("Successfully added \"#{paths}\" 💾.")
+          success_message = "Successfully added \"#{paths}\" 💾."
         else
           paths = "."
-          UI.success("Successfully added all files 💾.")
+          success_message = "Successfully added all files 💾."
         end
 
         result = Actions.sh("git add #{paths}", log: FastlaneCore::Globals.verbose?).chomp
+        UI.success(success_message)
         return result
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I have experienced some problems on my personal projects when adding files to git. It is very difficult to address these problems since git_add display a success message "Successfully added <file>" BUT can't add file (for various reasons in my projects). git_add displays success log BEFORE trying to add files. It does not make sense and may be confusing. This PR fixes this.

### Description
Instead of displaying success message I create a string "success_message" with it and display this message after shell command "git add"
