### PR TITLE
[screengrab] strip whitespace from device_ext_storage to get rid of newline on Windows

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -142,6 +142,7 @@ module Screengrab
       device_ext_storage = run_adb_command("adb -s #{device_serial} #{command}",
                                            print_all: true,
                                            print_command: true)
+      device_ext_storage = device_ext_storage.strip
       File.join(device_ext_storage, @config[:app_package_name], 'screengrab')
     end
 


### PR DESCRIPTION
On Windows the executed adb command returns the wanted string - and a newline. To make sure this works everywhere, we `.strip` the string before working with it.

closes #13061