### PR TITLE
Fix two typos in sync_code_signing.md decryption

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
+++ b/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
@@ -344,7 +344,7 @@ _match_ stores the certificate (`.cer`) and the private key (`.p12`) files separ
 Decrypt your cert found in `certs/<type>/<unique-id>.cer` as a pem file:
 
 ```no-highlight
-openssl aes-256-cbc -k "<password>" -in "certs/<type>/<unique-id>.cer" -out "cert.dem" -a -d
+openssl aes-256-cbc -k "<password>" -in "certs/<type>/<unique-id>.cer" -out "cert.der" -a -d
 openssl x509 -inform der -in cert.der -out cert.pem
 ```
 
@@ -357,7 +357,7 @@ openssl aes-256-cbc -k "<password>" -in "certs/distribution/<unique-id>.p12" -ou
 Generate an encrypted p12 file with the same or new password:
 
 ```no-highlight
-openssl pkcs12 -export -out "cert.p12" -inkey "key.pem' -in "cert.pem" -password pass:<password>
+openssl pkcs12 -export -out "cert.p12" -inkey "key.pem" -in "cert.pem" -password pass:<password>
 ```
 
 ## Is this secure?


### PR DESCRIPTION
The example commands to decrypt the cert and generate an encrypted p12 are now self-consistent.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I noticed this while following the example commands and thought I'd save other people a bit of time figuring out why the commands fail. You should now be able to copy and paste the commands, replacing only the placeholder arguments.
