### PR TITLE
[supply] always return empty array for tracks

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -298,7 +298,7 @@ module Supply
           current_edit.id,
           track
         )
-        return result.version_codes
+        return result.version_codes.nil? ? [] : result.version_codes
       rescue Google::Apis::ClientError => e
         return [] if e.status_code == 404 && e.to_s.include?("trackEmpty")
         raise

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -298,7 +298,7 @@ module Supply
           current_edit.id,
           track
         )
-        return result.version_codes.nil? ? [] : result.version_codes
+        return result.version_codes || []
       rescue Google::Apis::ClientError => e
         return [] if e.status_code == 404 && e.to_s.include?("trackEmpty")
         raise


### PR DESCRIPTION
Return empty array when result.version_codes is nil. 
Fix issue #13076

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR will fix #13076 

### Description
Looks like google doesn't return 404 error for empty tracks and we should return empty array for empty tracks.
