### PR TITLE
Invalidate group list when a group is created

### DIFF
--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -114,7 +114,7 @@ module Spaceship
         end
 
         # This is invalid now.
-        @cached_groups.delete(app_id)
+        @cached_groups.delete(app_id) if @cached_groups
 
         handle_response(response)
       end

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -112,6 +112,10 @@ module Spaceship
           req.body = body.to_json
           req.headers['Content-Type'] = 'application/json'
         end
+
+        # This is invalid now.
+        @cached_groups.delete(app_id)
+
         handle_response(response)
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Because of the way caching and creating works for testflight groups - if you try to query the created group during the same session it was created, it won't show up in the list of groups. invalidating the cached groups for that app ids after creating a new group allows the list to be updated properly. 
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

```
bundle console
require ‘spaceship’
Spaceship::Tunes.login(name, password)
Spaceship::Tunes.select_team
# Create a new group with new name
Spaceship::TestFlight::Group.create!(app_id: app_id ,group_name: some_name)
```

After that - without this change - if you query 

```
Spaceship::TestFlight::Group.all(app_id: app_id)
```

The new group won't be listed in the groups returned. 

It will be with this change. 

### Description

Deleted the entry for the app_id in `cached_groups` when a group associated with the app id is created.