### PR TITLE
[deliver] Handle frameit "fonts" directory

### DIFF
--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -14,7 +14,7 @@ module Deliver
 
     SPECIAL_DIR_NAMES = [APPLE_TV_DIR_NAME, IMESSAGE_DIR_NAME, DEFAULT_DIR_NAME].freeze
 
-    # Some exception directories may exist from other projects that should not be iterated through
+    # Some exception directories may exist from other actions that should not be iterated through
     SUPPLY_DIR_NAME = "android".freeze
     FRAMEIT_FONTS_DIR_NAME = "fonts".freeze
     META_DIR_NAMES = UploadMetadata::ALL_META_SUB_DIRS.map(&:downcase)

--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -14,10 +14,12 @@ module Deliver
 
     SPECIAL_DIR_NAMES = [APPLE_TV_DIR_NAME, IMESSAGE_DIR_NAME, DEFAULT_DIR_NAME].freeze
 
-    # If the user also uses `supply` in the same project, an 'android' folder might exist
+    # Some exception directories may exist from other projects that should not be iterated through
     SUPPLY_DIR_NAME = "android".freeze
+    FRAMEIT_FONTS_DIR_NAME = "fonts".freeze
+    META_DIR_NAMES = UploadMetadata::ALL_META_SUB_DIRS.map(&:downcase)
 
-    EXCEPTION_DIRECTORIES = (UploadMetadata::ALL_META_SUB_DIRS.map(&:downcase) << SUPPLY_DIR_NAME).freeze
+    EXCEPTION_DIRECTORIES =  (META_DIR_NAMES << SUPPLY_DIR_NAME << FRAMEIT_FONTS_DIR_NAME).freeze
 
     def self.language_folders(root, ignore_validation)
       folders = Dir.glob(File.join(root, '*'))

--- a/deliver/spec/loader_spec.rb
+++ b/deliver/spec/loader_spec.rb
@@ -51,6 +51,6 @@ describe Deliver::Loader do
 
     @folders = Deliver::Loader.language_folders(@root, false)
     basenames = @folders.map { |f| File.basename(f) }
-    expect(basenames.include? 'fonts').to eq(false)
+    expect(basenames.include?('fonts')).to eq(false)
   end
 end

--- a/deliver/spec/loader_spec.rb
+++ b/deliver/spec/loader_spec.rb
@@ -50,6 +50,7 @@ describe Deliver::Loader do
     FileUtils.mkdir(File.join(@root, 'fonts'))
 
     @folders = Deliver::Loader.language_folders(@root, false)
+    
     basenames = @folders.map { |f| File.basename(f) }
     expect(basenames.include?('fonts')).to eq(false)
   end

--- a/deliver/spec/loader_spec.rb
+++ b/deliver/spec/loader_spec.rb
@@ -50,7 +50,7 @@ describe Deliver::Loader do
     FileUtils.mkdir(File.join(@root, 'fonts'))
 
     @folders = Deliver::Loader.language_folders(@root, false)
-    
+
     basenames = @folders.map { |f| File.basename(f) }
     expect(basenames.include?('fonts')).to eq(false)
   end

--- a/deliver/spec/loader_spec.rb
+++ b/deliver/spec/loader_spec.rb
@@ -45,4 +45,12 @@ describe Deliver::Loader do
                                                                "\nValid directory names are: #{allowed_directory_names}" \
                                                                "\n\nEnable 'ignore_language_directory_validation' to prevent this validation from happening")
   end
+
+  it 'allows but ignores the special "fonts" directory used by frameit"' do
+    FileUtils.mkdir(File.join(@root, 'fonts'))
+
+    @folders = Deliver::Loader.language_folders(@root, false)
+    basenames = @folders.map { |f| File.basename(f) }
+    expect(basenames.include? 'fonts').to eq(false)
+  end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Frameit [documentation](https://docs.fastlane.tools/actions/frameit/#example) uses a special folder of "fonts" in the screenshots dir to store the custom fonts for framed screenshots.  Previously, Fastlane deliver would output an error if this "fonts" directory was present leaving the user to either 
1) Put the "fonts" directory elsewhere (not consistent with the documentation) or
2) Use the `ignore_language_directory_validation` (removes the safety check provided by deliver)

<!-- If it fixes an open issue, please link to the issue here. -->
This fixes #12375

<!-- Please describe in detail how you tested your changes. -->
Tested by:
1) Adding an automated test. 
2) Created a sample project with the fonts dir present and ran `fastlane deliver` before and after the change to verify the change works as expected

### Description
<!-- Describe your changes in detail -->

This PR adds "fonts" to the set of exception directories for Deliver to ignore when looking for the language folders.  
