### PR TITLE
Fastfile: output number of checked files in `ensure_code_samples`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -501,7 +501,7 @@ private_lane :ensure_code_samples do
     all_content += "\n```"
   end
   test_sample_code(content: all_content) # to not have to call the action 200 times
-  UI.success("✅  All fastlane code samples work as expected")
+  UI.success("✅  All fastlane code samples (from #{ActionsList.all_actions.length} actions) work as expected")
 end
 
 private_lane :ensure_code_snippets do


### PR DESCRIPTION
Helpful output to understand what the lane is actually doing.

Similar to https://github.com/fastlane/docs/pull/677