### PR TITLE
[CI] Add "forgotten" documentation and code sample checks to lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -322,6 +322,13 @@ lane :validate_docs do
 
   # Verify docs are still working
   verify_docs
+
+  # Validate docs content
+  ensure_tool_name_formatting
+  ensure_code_samples
+  ensure_code_snippets
+  # (Validate action documentation)
+  ensure_actions_config_items_formatting
 end
 
 desc "Makes sure the tests on https://docs.fastlane.tools still work with the latest version"


### PR DESCRIPTION
Seems somewhere along our journey some checks, that make sure the documentation content follows certain guidelines ("Ensure the correct formatting for the fastlane tools", "Verifying all code samples work with the current fastlane release", "Verifying all code snippets are correctly formatted", "Verifying actions' config items formatting"), got lost in the lanes that are actually executed on CI.

I stumbled upon this when changed something in the CI of the docs itself, which then somehow ran similar checks over there and crashed. Upon investigation of the failing lanes (and fixing the actual problem!), I discovered that those also existed here and seem to have been used.

So I put them into a lane that current should validate the docs already to be executed on CI.

--- 

Surprisingly, as you can see with the succeeding tests below, this still didn't cause any tests to fail. Further investigation lead to https://github.com/fastlane/fastlane/pull/13107, which is a follow up to this PR.
