### PR TITLE
[CI] check "special action docs" code samples

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,6 +17,7 @@ lane :validate_repo do
   validate_docs
   ensure_tool_name_formatting
   ensure_code_samples
+  ensure_special_docs_code_samples
   ensure_code_snippets
   ensure_actions_config_items_formatting
 end
@@ -326,6 +327,7 @@ lane :validate_docs do
   # Validate docs content
   ensure_tool_name_formatting
   ensure_code_samples
+  ensure_special_docs_code_samples
   ensure_code_snippets
   # (Validate action documentation)
   ensure_actions_config_items_formatting
@@ -501,7 +503,7 @@ end
 
 # Run the code samples, yo
 private_lane :ensure_code_samples do
-  UI.message("🕗  Verifying all code samples work with the current fastlane release")
+  UI.message("🕗  Verifying all action code samples work with the current fastlane release")
   all_content = ""
   ActionsList.all_actions do |action|
     all_content += "```ruby\n"
@@ -509,7 +511,19 @@ private_lane :ensure_code_samples do
     all_content += "\n```"
   end
   test_sample_code(content: all_content) # to not have to call the action 200 times
-  UI.success("✅  All fastlane code samples (from #{ActionsList.all_actions.length} actions) work as expected")
+  UI.success("✅  All fastlane action code samples (from #{ActionsList.all_actions.length} actions) work as expected")
+end
+
+# Run the other code samples, yo
+private_lane :ensure_special_docs_code_samples do
+  UI.message("🕗  Verifying all action special docs (`fastlane/lib/fastlane/actions/docs`) code samples work with the latest fastlane release")
+  all_content = ""
+  files = Dir["../fastlane/lib/fastlane/actions/docs/*.md"]
+  files.each do |special_docs_page_path|
+    all_content += File.read(special_docs_page_path)
+  end
+  test_sample_code(content: all_content) # to not have to call the action 200 times
+  UI.success("✅  All fastlane action special docs code samples (from #{files.length} files) work as expected")
 end
 
 private_lane :ensure_code_snippets do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -322,6 +322,13 @@ lane :validate_docs do
 
   # Verify docs are still working
   verify_docs
+
+  # Validate docs content
+  ensure_tool_name_formatting
+  ensure_code_samples
+  ensure_code_snippets
+  # (Validate action documentation)
+  ensure_actions_config_items_formatting
 end
 
 desc "Makes sure the tests on https://docs.fastlane.tools still work with the latest version"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -505,13 +505,15 @@ end
 private_lane :ensure_code_samples do
   UI.message("🕗  Verifying all action code samples work with the current fastlane release")
   all_content = ""
+  count_actions = 0
   ActionsList.all_actions do |action|
     all_content += "```ruby\n"
     all_content += action.example_code.map { |code| code.gsub(/^\s+/, '') }.join("\n") if action.example_code
     all_content += "\n```"
+    count_actions += 1
   end
   test_sample_code(content: all_content) # to not have to call the action 200 times
-  UI.success("✅  All fastlane action code samples (from #{ActionsList.all_actions.length} actions) work as expected")
+  UI.success("✅  All fastlane action code samples (from #{count_actions} actions) work as expected")
 end
 
 # Run the other code samples, yo

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -316,14 +316,6 @@ end
 
 desc "Validates the docs still are good"
 lane :validate_docs do
-  # Test if generating the docs is successful
-  clone_docs do
-    generate_markdown_docs(target_path: ".")
-  end
-
-  # Verify docs are still working
-  verify_docs
-
   # Validate docs content
   ensure_tool_name_formatting
   ensure_code_samples
@@ -331,6 +323,14 @@ lane :validate_docs do
   ensure_code_snippets
   # (Validate action documentation)
   ensure_actions_config_items_formatting
+
+  # Test if generating the docs is successful
+  clone_docs do
+    generate_markdown_docs(target_path: ".")
+  end
+
+  # Verify docs are still working
+  verify_docs
 end
 
 desc "Makes sure the tests on https://docs.fastlane.tools still work with the latest version"

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -29,7 +29,7 @@ module Fastlane
       content.scan(/^\s*require (.*)/).each do |current|
         gem_name = current.last
         next if gem_name.include?(".") # these are local gems
-        UI.important("You have require'd a gem, if this is a third party gem, please use `fastlane_require #{gem_name}` to ensure the gem is installed locally.")
+        UI.important("You have required a gem, if this is a third party gem, please use `fastlane_require #{gem_name}` to ensure the gem is installed locally.")
       end
 
       parse(content, @path)


### PR DESCRIPTION
Until now the code samples of the "special action docs" (https://github.com/fastlane/fastlane/tree/master/fastlane/lib/fastlane/actions) were not tested at all. This PR adds a new private lane to the `Fastfile` that does this.

This PR includes https://github.com/fastlane/fastlane/pull/13105 (which was first proposed as a standalone PR, but then merged here because of convenience)