### PR TITLE
[action] deprecate options in cocoapods that no longer exist

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -52,16 +52,6 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :clean,
-                                       env_name: "FL_COCOAPODS_CLEAN",
-                                       description: "Remove SCM directories",
-                                       is_string: false,
-                                       default_value: true),
-          FastlaneCore::ConfigItem.new(key: :integrate,
-                                       env_name: "FL_COCOAPODS_INTEGRATE",
-                                       description: "Integrate the Pods libraries into the Xcode project(s)",
-                                       is_string: false,
-                                       default_value: true),
           FastlaneCore::ConfigItem.new(key: :repo_update,
                                        env_name: "FL_COCOAPODS_REPO_UPDATE",
                                        description: "Add `--repo-update` flag to `pod install` command",
@@ -107,7 +97,21 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        default_value: false,
-                                       type: Boolean)
+                                       type: Boolean),
+
+          # Deprecated
+          FastlaneCore::ConfigItem.new(key: :clean,
+                                       env_name: "FL_COCOAPODS_CLEAN",
+                                       description: "(Option removed from cocoapods) Remove SCM directories",
+                                       deprecated: true,
+                                       is_string: false,
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :integrate,
+                                       env_name: "FL_COCOAPODS_INTEGRATE",
+                                       description: "(Option removed from cocoapods) Integrate the Pods libraries into the Xcode project(s)",
+                                       deprecated: true,
+                                       is_string: false,
+                                       default_value: true)
         ]
         # Please don't add a version parameter to the `cocoapods` action. If you need to specify a version when running
         # `cocoapods`, please start using a Gemfile and lock the version there


### PR DESCRIPTION
Fixes #13104

## Problem
`--no-clean` and `--no-integrate` are no longer options in cocoapods and make things go 💥 

## Solution
Deprecate these options because they are no longer things we can do in cocoapods