### PR TITLE
New action `download_from_play_store` that does as an action what `fastlane supply init` does as a command

### DIFF
--- a/fastlane/lib/fastlane/actions/download_from_play_store.rb
+++ b/fastlane/lib/fastlane/actions/download_from_play_store.rb
@@ -1,0 +1,61 @@
+module Fastlane
+  module Actions
+    class DownloadFromPlayStoreAction < Action
+      def self.run(params)
+        require 'supply'
+        require 'supply/options'
+
+        Supply.config = params # we already have the finished config
+
+        require 'supply/setup'
+        Supply::Setup.new.perform_download
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Download metadata and binaries from Google Play (via _supply_)"
+      end
+
+      def self.details
+        "More information: https://docs.fastlane.tools/actions/download_from_play_store/"
+      end
+
+      def self.available_options
+        require 'supply'
+        require 'supply/options'
+        options = Supply::Options.available_options.clone
+
+        # remove all the unnecessary (for this action) options
+        options_to_keep = [:package_name, :metadata_path, :json_key, :json_key_data, :root_url, :timeout]
+        options.delete_if { |option| options_to_keep.include?(option.key) == false }
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+      end
+
+      def self.authors
+        ["janpio"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+
+      def self.example_code
+        [
+          'download_from_play_store'
+        ]
+      end
+
+      def self.category
+        :production
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/download_from_play_store.rb
+++ b/fastlane/lib/fastlane/actions/download_from_play_store.rb
@@ -29,7 +29,7 @@ module Fastlane
         options = Supply::Options.available_options.clone
 
         # remove all the unnecessary (for this action) options
-        options_to_keep = [:package_name, :metadata_path, :json_key, :json_key_data, :root_url, :timeout]
+        options_to_keep = [:package_name, :metadata_path, :json_key, :json_key_data, :root_url, :timeout, :key, :issuer]
         options.delete_if { |option| options_to_keep.include?(option.key) == false }
       end
 

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -63,6 +63,7 @@ describe Fastlane do
           println
           echo
           xcov
+          download_from_play_store
         )
       end
 


### PR DESCRIPTION
This is a proof of concept for one of the ideas I suggested in https://github.com/fastlane/docs/issues/671: adding actions for all the `fastlane <toolname> init` commands that do more than creating a config file.

- Similar to `upload_to_play_store` this is a thin wrapper around the code that is already present in `supply`. 
- To make the options list more manageable, I hardcoded a manual list of options this action actually needs and removed all the others.
- As the action doesn't contain its actual code, I had to exclude it from the check in `fastlane/spec/unused_options_spec.rb` as well.