### PR TITLE
[deliver] Sort and comment options

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -31,8 +31,8 @@ module Deliver
         FastlaneCore::ConfigItem.new(key: :app_version,
                                      short_option: '-z',
                                      description: "The version that should be edited or created",
-                                     optional: true),        
-        
+                                     optional: true),
+
         # binary / build
         FastlaneCore::ConfigItem.new(key: :ipa,
                                      short_option: "-i",

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -27,18 +27,8 @@ module Deliver
                                      code_gen_sensitive: true,
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
                                      default_value_dynamic: true),
-        FastlaneCore::ConfigItem.new(key: :app,
-                                     short_option: "-p",
-                                     env_name: "DELIVER_APP_ID",
-                                     description: "The app ID of the app you want to use/modify",
-                                     is_string: false), # don't add any verification here, as it's used to store a spaceship ref
-        FastlaneCore::ConfigItem.new(key: :edit_live,
-                                     short_option: "-o",
-                                     optional: true,
-                                     default_value: false,
-                                     env_name: "DELIVER_EDIT_LIVE",
-                                     description: "Modify live metadata, this option disables ipa upload and screenshot upload",
-                                     is_string: false),
+
+        # binary
         FastlaneCore::ConfigItem.new(key: :ipa,
                                      short_option: "-i",
                                      optional: true,
@@ -80,6 +70,21 @@ module Deliver
                                      verify_block: proc do |value|
                                        UI.user_error!("The platform can only be ios, appletvos, or osx") unless %('ios', 'appletvos', 'osx').include?(value)
                                      end),
+
+        # live version
+        FastlaneCore::ConfigItem.new(key: :edit_live,
+                                     short_option: "-o",
+                                     optional: true,
+                                     default_value: false,
+                                     env_name: "DELIVER_EDIT_LIVE",
+                                     description: "Modify live metadata, this option disables ipa upload and screenshot upload",
+                                     is_string: false),
+        FastlaneCore::ConfigItem.new(key: :use_live_version,
+                                     description: "Force usage of live version rather than edit version",
+                                     is_string: false,
+                                     default_value: false),
+
+        # paths
         FastlaneCore::ConfigItem.new(key: :metadata_path,
                                      short_option: '-m',
                                      description: "Path to the folder containing the metadata files",
@@ -88,22 +93,16 @@ module Deliver
                                      short_option: '-w',
                                      description: "Path to the folder containing the screenshots",
                                      optional: true),
+
+        # skip
         FastlaneCore::ConfigItem.new(key: :skip_binary_upload,
                                      description: "Skip uploading an ipa or pkg to App Store Connect",
-                                     is_string: false,
-                                     default_value: false),
-        FastlaneCore::ConfigItem.new(key: :use_live_version,
-                                     description: "Force usage of live version rather than edit version",
                                      is_string: false,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :skip_screenshots,
                                      description: "Don't upload the screenshots",
                                      is_string: false,
                                      default_value: false),
-        FastlaneCore::ConfigItem.new(key: :app_version,
-                                     short_option: '-z',
-                                     description: "The version that should be edited or created",
-                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :skip_metadata,
                                      description: "Don't upload the metadata (e.g. title, description). This will still upload screenshots",
                                      is_string: false,
@@ -112,9 +111,30 @@ module Deliver
                                      description: "Don't update app version for submission",
                                      is_string: false,
                                      default_value: false),
+
+        # version and build number
+        FastlaneCore::ConfigItem.new(key: :app_version,
+                                     short_option: '-z',
+                                     description: "The version that should be edited or created",
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :build_number,
+                                     short_option: "-n",
+                                     description: "If set the given build number (already uploaded to iTC) will be used instead of the current built one",
+                                     optional: true,
+                                     conflicting_options: [:ipa, :pkg],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("You can't use 'build_number' and '#{value.key}' options in one run.")
+                                     end),
+
+        # how to operate
         FastlaneCore::ConfigItem.new(key: :force,
                                      short_option: "-f",
                                      description: "Skip the HTML report file verification",
+                                     is_string: false,
+                                     default_value: false),
+        FastlaneCore::ConfigItem.new(key: :overwrite_screenshots,
+                                     env_name: "DELIVER_OVERWRITE_SCREENSHOTS",
+                                     description: "Clear all previously uploaded screenshots before uploading the new ones",
                                      is_string: false,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :submit_for_review,
@@ -127,6 +147,8 @@ module Deliver
                                      description: "Rejects the previously submitted build if it's in a state where it's possible",
                                      is_string: false,
                                      default_value: false),
+
+        # release
         FastlaneCore::ConfigItem.new(key: :automatic_release,
                                      description: "Should the app be automatically released once it's approved?",
                                      is_string: false,
@@ -145,19 +167,13 @@ module Deliver
                                      optional: true,
                                      is_string: false,
                                      default_value: false),
+
+        # other app configuration
         FastlaneCore::ConfigItem.new(key: :price_tier,
                                      short_option: "-r",
                                      description: "The price tier of this application",
                                      is_string: false,
                                      optional: true),
-        FastlaneCore::ConfigItem.new(key: :build_number,
-                                     short_option: "-n",
-                                     description: "If set the given build number (already uploaded to iTC) will be used instead of the current built one",
-                                     optional: true,
-                                     conflicting_options: [:ipa, :pkg],
-                                     conflict_block: proc do |value|
-                                       UI.user_error!("You can't use 'build_number' and '#{value.key}' options in one run.")
-                                     end),
         FastlaneCore::ConfigItem.new(key: :app_rating_config_path,
                                      short_option: "-g",
                                      description: "Path to the app rating's config",
@@ -172,6 +188,8 @@ module Deliver
                                      description: "Extra information for the submission (e.g. third party content)",
                                      is_string: false,
                                      optional: true),
+
+        # affiliation
         FastlaneCore::ConfigItem.new(key: :team_id,
                                      short_option: "-k",
                                      env_name: "DELIVER_TEAM_ID",
@@ -224,11 +242,8 @@ module Deliver
                                      description: "The provider short name to be used with the iTMSTransporter to identify your team. To get provider short name run `pathToXcode.app/Contents/Applications/Application\\ Loader.app/Contents/itms/bin/iTMSTransporter -m provider -u 'USERNAME' -p 'PASSWORD' -account_type itunes_connect -v off`. The short names of providers should be listed in the second column",
                                      optional: true),
         # rubocop:enable Metrics/LineLength
-        FastlaneCore::ConfigItem.new(key: :overwrite_screenshots,
-                                     env_name: "DELIVER_OVERWRITE_SCREENSHOTS",
-                                     description: "Clear all previously uploaded screenshots before uploading the new ones",
-                                     is_string: false,
-                                     default_value: false),
+
+        # precheck
         FastlaneCore::ConfigItem.new(key: :run_precheck_before_submit,
                                      short_option: "-x",
                                      env_name: "DELIVER_RUN_PRECHECK_BEFORE_SUBMIT",
@@ -238,7 +253,7 @@ module Deliver
         FastlaneCore::ConfigItem.new(key: :precheck_default_rule_level,
                                      short_option: "-d",
                                      env_name: "DELIVER_PRECHECK_DEFAULT_RULE_LEVEL",
-                                     description: "The default rule level unless otherwise configured",
+                                     description: "The default precheck rule level unless otherwise configured",
                                      is_string: false,
                                      default_value: :warn),
 
@@ -370,7 +385,14 @@ module Deliver
                                      description: "Should precheck check in-app purchases?",
                                      is_string: false,
                                      optional: true,
-                                     default_value: true)
+                                     default_value: true),
+
+        # internal
+        FastlaneCore::ConfigItem.new(key: :app,
+                                     short_option: "-p",
+                                     env_name: "DELIVER_APP_ID",
+                                     description: "The (spaceship) app ID of the app you want to use/modify",
+                                     is_string: false) # don't add any verification here, as it's used to store a spaceship ref
       ]
     end
   end

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -27,8 +27,13 @@ module Deliver
                                      code_gen_sensitive: true,
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
                                      default_value_dynamic: true),
-
-        # binary
+        # version
+        FastlaneCore::ConfigItem.new(key: :app_version,
+                                     short_option: '-z',
+                                     description: "The version that should be edited or created",
+                                     optional: true),        
+        
+        # binary / build
         FastlaneCore::ConfigItem.new(key: :ipa,
                                      short_option: "-i",
                                      optional: true,
@@ -60,6 +65,14 @@ module Deliver
                                      conflicting_options: [:ipa],
                                      conflict_block: proc do |value|
                                        UI.user_error!("You can't use 'pkg' and '#{value.key}' options in one run.")
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :build_number,
+                                     short_option: "-n",
+                                     description: "If set the given build number (already uploaded to iTC) will be used instead of the current built one",
+                                     optional: true,
+                                     conflicting_options: [:ipa, :pkg],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("You can't use 'build_number' and '#{value.key}' options in one run.")
                                      end),
         FastlaneCore::ConfigItem.new(key: :platform,
                                      short_option: "-j",
@@ -111,20 +124,6 @@ module Deliver
                                      description: "Don't update app version for submission",
                                      is_string: false,
                                      default_value: false),
-
-        # version and build number
-        FastlaneCore::ConfigItem.new(key: :app_version,
-                                     short_option: '-z',
-                                     description: "The version that should be edited or created",
-                                     optional: true),
-        FastlaneCore::ConfigItem.new(key: :build_number,
-                                     short_option: "-n",
-                                     description: "If set the given build number (already uploaded to iTC) will be used instead of the current built one",
-                                     optional: true,
-                                     conflicting_options: [:ipa, :pkg],
-                                     conflict_block: proc do |value|
-                                       UI.user_error!("You can't use 'build_number' and '#{value.key}' options in one run.")
-                                     end),
 
         # how to operate
         FastlaneCore::ConfigItem.new(key: :force,


### PR DESCRIPTION
While working with `deliver` I noticed that the list of options was not very organized. 
I moved some options around and added some code comments to at least get some structure in the source.
