### PR TITLE
[precheck] support IDN: normalize URI before creating connection

### DIFF
--- a/precheck/lib/precheck/rules/unreachable_urls_rule.rb
+++ b/precheck/lib/precheck/rules/unreachable_urls_rule.rb
@@ -34,8 +34,8 @@ module Precheck
             connection.adapter(:net_http)
           end
           return RuleReturn.new(validation_state: Precheck::VALIDATION_STATES[:failed], failure_data: url) unless request.head.status == 200
-        rescue
-          UI.verbose("URL #{url} not reachable 😵")
+        rescue StandardError => e  
+          UI.verbose("URL #{url} not reachable 😵: #{e.message}")
           # I can only return :fail here, but I also want to return #{url}
           return RuleReturn.new(validation_state: VALIDATION_STATES[:failed], failure_data: "unreachable: #{url}")
         end

--- a/precheck/lib/precheck/rules/unreachable_urls_rule.rb
+++ b/precheck/lib/precheck/rules/unreachable_urls_rule.rb
@@ -29,7 +29,7 @@ module Precheck
         begin
           uri = Addressable::URI.parse(url)
           uri.fragment = nil
-          request = Faraday.new(URI.encode(uri.to_s)) do |connection|
+          request = Faraday.new(URI.encode(uri.normalize.to_s)) do |connection|
             connection.use(FaradayMiddleware::FollowRedirects)
             connection.adapter(:net_http)
           end

--- a/precheck/lib/precheck/rules/unreachable_urls_rule.rb
+++ b/precheck/lib/precheck/rules/unreachable_urls_rule.rb
@@ -29,7 +29,7 @@ module Precheck
         begin
           uri = Addressable::URI.parse(url)
           uri.fragment = nil
-          request = Faraday.new(URI.encode(uri.normalize.to_s)) do |connection|
+          request = Faraday.new(uri.normalize.to_s) do |connection|
             connection.use(FaradayMiddleware::FollowRedirects)
             connection.adapter(:net_http)
           end

--- a/precheck/lib/precheck/rules/unreachable_urls_rule.rb
+++ b/precheck/lib/precheck/rules/unreachable_urls_rule.rb
@@ -34,7 +34,7 @@ module Precheck
             connection.adapter(:net_http)
           end
           return RuleReturn.new(validation_state: Precheck::VALIDATION_STATES[:failed], failure_data: url) unless request.head.status == 200
-        rescue StandardError => e  
+        rescue StandardError => e
           UI.verbose("URL #{url} not reachable 😵: #{e.message}")
           # I can only return :fail here, but I also want to return #{url}
           return RuleReturn.new(validation_state: VALIDATION_STATES[:failed], failure_data: "unreachable: #{url}")

--- a/precheck/spec/rules/unreachable_urls_rule_spec.rb
+++ b/precheck/spec/rules/unreachable_urls_rule_spec.rb
@@ -15,7 +15,8 @@ module Precheck
         allow(request).to receive(:adapter).and_return(nil)
         allow(request).to receive(:head).and_return(head_object)
 
-        allow(Faraday).to receive(:new).with(url).and_return(request)
+        uri = Addressable::URI.parse(url)
+        allow(Faraday).to receive(:new).with(uri.normalize.to_s).and_return(request)
       end
 
       it "passes for 200 status URL" do
@@ -27,7 +28,7 @@ module Precheck
       end
 
       it "passes for valid non encoded URL" do
-        setup_url_rule_mock(url: "http://fastlane.tools/%E3%83%86%E3%82%B9%E3%83%88")
+        setup_url_rule_mock(url: "http://fastlane.tools/%25E3%2583%2586%25E3%2582%25B9%25E3%2583%2588")
 
         item = URLItemToCheck.new("http://fastlane.tools/テスト", "some_url", "test URL")
         result = rule.check_item(item)

--- a/precheck/spec/rules/unreachable_urls_rule_spec.rb
+++ b/precheck/spec/rules/unreachable_urls_rule_spec.rb
@@ -28,7 +28,7 @@ module Precheck
       end
 
       it "passes for valid non encoded URL" do
-        setup_url_rule_mock(url: "http://fastlane.tools/%25E3%2583%2586%25E3%2582%25B9%25E3%2583%2588")
+        setup_url_rule_mock(url: "http://fastlane.tools/%E3%83%86%E3%82%B9%E3%83%88")
 
         item = URLItemToCheck.new("http://fastlane.tools/テスト", "some_url", "test URL")
         result = rule.check_item(item)


### PR DESCRIPTION
* Use `.normalize` on the adressable `uri` before opening a connection so IDN (e.g. Umlaut domains) are converted to a format that can be understood by the following coe
*  Also output the exception in the verbose output in case of an error for easier debugging

closes #13119
