### PR TITLE
[pilot] fix `fastlane pilot find`

### DIFF
--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -205,7 +205,7 @@ module Pilot
       end
 
       if tester.latest_installed_date
-        rows << ["Latest Version", tester.latest_build]
+        rows << ["Latest Version", "#{tester.latest_install_info['latestInstalledShortVersion']} (#{tester.latest_install_info['latestInstalledVersion']})"]
         rows << ["Latest Install Date", tester.pretty_install_date]
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`fastlane pilot find` was broken because it used a non-existant field which caused a crash.

### Description
replace it with the correct data structure that contains the wanted information.

closes https://github.com/fastlane/fastlane/issues/13127