### PR TITLE
[scan] should_zip_build_products sets SCAN_ZIP_BUILD_PRODUCTS_PATH in lane context

### DIFF
--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -22,7 +22,8 @@ module Fastlane
           values[:destination] = destination # restore destination value
           Scan::Manager.new.work(values)
 
-          Actions.lane_context[SharedValues::SCAN_ZIP_BUILD_PRODUCTS_PATH] = Scan::Runner.zip_build_products_path if Scan::Runner.zip_build_products_path
+          zip_build_products_path = Scan.cache[:zip_build_products_path]
+          Actions.lane_context[SharedValues::SCAN_ZIP_BUILD_PRODUCTS_PATH] = zip_build_products_path if zip_build_products_path
 
           return true
         rescue FastlaneCore::Interface::FastlaneBuildFailure => ex

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -4,6 +4,7 @@ module Fastlane
       SCAN_DERIVED_DATA_PATH = :SCAN_DERIVED_DATA_PATH
       SCAN_GENERATED_PLIST_FILE = :SCAN_GENERATED_PLIST_FILE
       SCAN_GENERATED_PLIST_FILES = :SCAN_GENERATED_PLIST_FILES
+      SCAN_ZIP_BUILD_PRODUCTS_PATH = :SCAN_ZIP_BUILD_PRODUCTS_PATH
     end
 
     class RunTestsAction < Action
@@ -20,6 +21,8 @@ module Fastlane
 
           values[:destination] = destination # restore destination value
           Scan::Manager.new.work(values)
+
+          Actions.lane_context[SharedValues::SCAN_ZIP_BUILD_PRODUCTS_PATH] = Scan::Runner.zip_build_products_path if Scan::Runner.zip_build_products_path
 
           return true
         rescue FastlaneCore::Interface::FastlaneBuildFailure => ex

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -94,23 +94,19 @@ module Scan
       end
     end
 
-    def self.zip_build_products_path
+    def zip_build_products
       return unless Scan.config[:should_zip_build_products]
+
+      # Gets :derived_data_path/Build/Products directory for zipping zip
+      derived_data_path = Scan.config[:derived_data_path]
+      path = File.join(derived_data_path, "Build/Products")
 
       # Gets absolute path of output directory
       output_directory = File.absolute_path(Scan.config[:output_directory])
       output_path = File.join(output_directory, "build_products.zip")
 
-      return output_path
-    end
-
-    def zip_build_products
-      output_path = Scan::Runner.zip_build_products_path
-      return unless output_path
-
-      # Gets :derived_data_path/Build/Products directory for zipping zip
-      derived_data_path = Scan.config[:derived_data_path]
-      path = File.join(derived_data_path, "Build/Products")
+      # Caching path for action to put into lane_context
+      Scan.cache[:zip_build_products_path] = output_path
 
       # Zips build products and moves it to output directory
       UI.message("Zipping build products")

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -94,16 +94,23 @@ module Scan
       end
     end
 
-    def zip_build_products
+    def self.zip_build_products_path
       return unless Scan.config[:should_zip_build_products]
-
-      # Gets :derived_data_path/Build/Products directory for zipping zip
-      derived_data_path = Scan.config[:derived_data_path]
-      path = File.join(derived_data_path, "Build/Products")
 
       # Gets absolute path of output directory
       output_directory = File.absolute_path(Scan.config[:output_directory])
       output_path = File.join(output_directory, "build_products.zip")
+
+      return output_path
+    end
+
+    def zip_build_products
+      output_path = Scan::Runner.zip_build_products_path
+      return unless output_path
+
+      # Gets :derived_data_path/Build/Products directory for zipping zip
+      derived_data_path = Scan.config[:derived_data_path]
+      path = File.join(derived_data_path, "Build/Products")
 
       # Zips build products and moves it to output directory
       UI.message("Zipping build products")


### PR DESCRIPTION
Fixes #13108

## Problem
The path generated by _scan_'s `should_zip_build_products` was not nicely available for anybody to use.

## Solution
Now it is available via `SCAN_ZIP_BUILD_PRODUCTS_PATH` in lane context