### PR TITLE
Catch syntax errors in imported actions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -249,6 +249,7 @@ AllCops:
     - '**/lib/assets/custom_action_template.rb'
     - './vendor/**/*'
     - '**/lib/assets/DefaultFastfileTemplate'
+    - '**/spec/fixtures/broken_files/broken_file.rb'
 
 # They have not to be snake_case
 Style/FileName:

--- a/fastlane/spec/actions_helper_spec.rb
+++ b/fastlane/spec/actions_helper_spec.rb
@@ -42,9 +42,17 @@ describe Fastlane do
         Fastlane::Actions::ArchiveAction.run(nil)
       end
 
-      it "can throws an error if plugin is damaged" do
+      it "throws an error if plugin is damaged" do
         expect(UI).to receive(:user_error!).with("Action 'broken_action' is damaged!", { show_github_issues: true })
         Fastlane::Actions.load_external_actions("./fastlane/spec/fixtures/broken_actions")
+      end
+
+      it "throws errors when syntax is incorrect" do
+        content = File.read('./fastlane/spec/fixtures/broken_files/broken_file.rb', encoding: 'utf-8')
+        expect(UI).to receive(:content_error).with(content, '7')
+        expect(UI).to receive(:content_error).with(content, '8')
+        expect(UI).to receive(:user_error!).with("Syntax error in broken_file.rb")
+        Fastlane::Actions.load_external_actions("./fastlane/spec/fixtures/broken_files")
       end
     end
 

--- a/fastlane/spec/fixtures/broken_files/broken_file.rb
+++ b/fastlane/spec/fixtures/broken_files/broken_file.rb
@@ -1,0 +1,13 @@
+module Fastlane
+  module Actions
+    class BrokenAction
+      def run(params)
+        # Missing comma
+        puts {
+          a: 123
+          b: 345
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
#### Problem
I tried to use `import_from_git` action, since we were having the exact same use-case, but were always doing it manually. While doing it, I had some ruby syntax errors inside my imported actions and the only thing I got was a generic:
```
/Users/aculeva/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.101.1/fastlane/lib/fastlane/fast_file.rb:59:in `rescue in block in parse': [!] undefined method `[]' for nil:NilClass (NoMethodError)
```
This is because **fastlane** knows an error occured, and it assumes it occured in the main `FastFile`, so it tries to pretty output the error by stripping `FastFile` from it. Because the error actually occured in the other file, it throws an exception.

#### Solution
I thought it would be nice to catch all syntax errors inside imported actions, and at least print them to the user. Now the output looks like this:
```sh
➜  git:(develop) ✗ fastlane alpha submit:false
[✔] 🚀
[19:26:47]: Get started using a Gemfile for fastlane https://docs.fastlane.tools/getting-started/ios/setup/#use-a-gemfile
[19:26:48]: -----------------------------
[19:26:48]: --- Step: import_from_git ---
[19:26:48]: -----------------------------
[19:26:48]: Cloning remote git repo...
[19:26:48]: $ GIT_TERMINAL_PROMPT=0 git clone 'git@github.com:repo/name.git' '/var/folders/bs/464b8xxj2pzg534wczlh41rh0000gp/T/fl_clone20180816-63544-1rzsaze/name.git' --depth 1 -n --branch import-from-git
[19:26:48]: ▸ Cloning into '/var/folders/bs/464b8xxj2pzg534wczlh41rh0000gp/T/fl_clone20180816-63544-1rzsaze/name.git'...
[19:26:57]: $ cd '/var/folders/bs/464b8xxj2pzg534wczlh41rh0000gp/T/fl_clone20180816-63544-1rzsaze/name.git' && git checkout import-from-git 'fastlane/Fastfile'
[19:26:57]: $ cd '/var/folders/bs/464b8xxj2pzg534wczlh41rh0000gp/T/fl_clone20180816-63544-1rzsaze/name.git' && git checkout import-from-git 'fastlane/actions'
[19:26:57]:     64:	                                       type: String,
[19:26:57]:     65:	                                       default_value: 'Sandbox Tester'
[19:26:57]:  => 66:	                                       optional: true),
[19:26:57]:     67:	          FastlaneCore::ConfigItem.new(key: :last_name,
[19:26:57]:     68:	                                       description: 'Last name of the sandbbox tester.',
[19:26:57]:     69:	                                       type: String,
[19:26:57]:     70:	                                       default_value: 'Dev',
[19:26:57]:  => 71:	                                       optional: true),
[19:26:57]:     72:	          FastlaneCore::ConfigItem.new(key: :country,
[19:26:57]:     73:	                                       description: 'Country of the sandbox tester in short format.',
[19:26:57]:     75:	                                       dfault_value: 'US',
[19:26:57]:     76:	                                       optional: true)
[19:26:57]:  => 77:	        ]
[19:26:57]:     78:	      end
[19:26:57]:     79:
[19:26:57]:     87:	    end
[19:26:57]:     88:	  end
[19:26:57]:  => 89:	end

[!] Syntax error in create_sandbox_tester.rb
```

### Description
<!-- Describe your changes in detail -->
I added the `require file` inside a try block and handle all `SyntaxError` exceptions that ruby might throw, then for each line I decided to show a `UI.content_error` at that line. I also thought about showing the explicit error to the user, that's the **last part of the regex** (it **should be removed** if we decide to go like this). At the end we throw a `UI.user_error!` so that the execution stops and the user knows which file failed.
