### PR TITLE
Fix ensure code samples where a block in all_actions was required

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -504,7 +504,7 @@ private_lane :ensure_code_samples do
     action_count += 1
   end
   test_sample_code(content: all_content) # to not have to call the action 200 times
-  UI.success("✅  All fastlane code samples (from #{action_count}) work as expected")
+  UI.success("✅  All fastlane code samples (from #{action_count} actions) work as expected")
 end
 
 private_lane :ensure_code_snippets do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -496,13 +496,15 @@ end
 private_lane :ensure_code_samples do
   UI.message("🕗  Verifying all code samples work with the current fastlane release")
   all_content = ""
+  action_count = 0
   ActionsList.all_actions do |action|
     all_content += "```ruby\n"
     all_content += action.example_code.map { |code| code.gsub(/^\s+/, '') }.join("\n") if action.example_code
     all_content += "\n```"
+    action_count += 1
   end
   test_sample_code(content: all_content) # to not have to call the action 200 times
-  UI.success("✅  All fastlane code samples (from #{ActionsList.all_actions.length} actions) work as expected")
+  UI.success("✅  All fastlane code samples (from #{action_count}) work as expected")
 end
 
 private_lane :ensure_code_snippets do


### PR DESCRIPTION
`all_actions` requires a block (and isn't an array) so doing count this way