### PR TITLE
iTMSTransporter support on Windows

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -219,7 +219,7 @@ module FastlaneCore
         UI.user_error!("Could not find transporter at usual locations. Please use environment variable `FASTLANE_ITUNES_TRANSPORTER_PATH` to specify your installation path.")
       else
         # not Mac or Windows
-        return '' 
+        return ''
       end
     end
 

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -200,16 +200,25 @@ module FastlaneCore
     # @return the full path to the iTMSTransporter executable
     def self.itms_path
       return ENV["FASTLANE_ITUNES_TRANSPORTER_PATH"] if FastlaneCore::Env.truthy?("FASTLANE_ITUNES_TRANSPORTER_PATH")
-      return '' unless self.mac? # so tests work on Linux and Windows too
+      return '' unless self.mac? || self.windows? # so tests work on Linux too
 
-      [
-        "../Applications/Application Loader.app/Contents/MacOS/itms",
-        "../Applications/Application Loader.app/Contents/itms"
-      ].each do |path|
-        result = File.expand_path(File.join(self.xcode_path, path))
-        return result if File.exist?(result)
+      if self.mac?
+        [
+          "../Applications/Application Loader.app/Contents/MacOS/itms",
+          "../Applications/Application Loader.app/Contents/itms"
+        ].each do |path|
+          result = File.expand_path(File.join(self.xcode_path, path))
+          return result if File.exist?(result)
+        end
+        UI.user_error!("Could not find transporter at #{self.xcode_path}. Please make sure you set the correct path to your Xcode installation.")
+      elsif self.windows?
+        [
+          "C:/Program Files (x86)/itms"
+        ].each do |path|
+          return path if File.exist?(path)
+        end
+        UI.user_error!("Could not find transporter at usual locations. Please use environment variable `FASTLANE_ITUNES_TRANSPORTER_PATH` to specify your installation path.")
       end
-      UI.user_error!("Could not find transporter at #{self.xcode_path}. Please make sure you set the correct path to your Xcode installation.")
     end
 
     # keychain

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -200,7 +200,6 @@ module FastlaneCore
     # @return the full path to the iTMSTransporter executable
     def self.itms_path
       return ENV["FASTLANE_ITUNES_TRANSPORTER_PATH"] if FastlaneCore::Env.truthy?("FASTLANE_ITUNES_TRANSPORTER_PATH")
-      return '' unless self.mac? || self.windows? # so tests work on Linux too
 
       if self.mac?
         [
@@ -218,6 +217,9 @@ module FastlaneCore
           return path if File.exist?(path)
         end
         UI.user_error!("Could not find transporter at usual locations. Please use environment variable `FASTLANE_ITUNES_TRANSPORTER_PATH` to specify your installation path.")
+      else
+        # not Mac or Windows
+        return '' 
       end
     end
 

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -193,7 +193,8 @@ module FastlaneCore
 
     # @return the full path to the iTMSTransporter executable
     def self.transporter_path
-      return File.join(self.itms_path, 'bin', 'iTMSTransporter')
+      return File.join(self.itms_path, 'bin', 'iTMSTransporter') unless Helper.windows?
+      return File.join(self.itms_path, 'iTMSTransporter')
     end
 
     # @return the full path to the iTMSTransporter executable

--- a/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -21,7 +21,7 @@ module FastlaneCore
         apple_id: app_id,
         file_size: File.size(ipa_path),
         ipa_path: File.basename(ipa_path), # this is only the base name as the ipa is inside the package
-        md5: Digest::MD5.hexdigest(File.read(ipa_path)),
+        md5: Digest::MD5.file(ipa_path).hexdigest,
         archive_type: "bundle",
         platform: (platform || "ios") # pass "appletvos" for Apple TV's IPA
       }

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -427,7 +427,7 @@ module FastlaneCore
         UI.error("")
         UI.error("Application specific password you provided using")
         UI.error("environment variable #{TWO_FACTOR_ENV_VARIABLE}")
-        UI.error("is invalid, please make sure it's correct.")
+        UI.error("is invalid, please make sure it's correct")
         UI.error("")
         UI.user_error!("Invalid application specific password provided")
       end
@@ -445,11 +445,11 @@ module FastlaneCore
       UI.error("Your account has 2 step verification enabled")
       UI.error("Please go to https://appleid.apple.com/account/manage")
       UI.error("and generate an application specific password for")
-      UI.error("the iTunes Transporter, which is used to upload builds.")
+      UI.error("the iTunes Transporter, which is used to upload builds")
       UI.error("")
       UI.error("To set the application specific password on a CI machine using")
       UI.error("an environment variable, you can set the")
-      UI.error("#{TWO_FACTOR_ENV_VARIABLE} variable.")
+      UI.error("#{TWO_FACTOR_ENV_VARIABLE} variable")
       @password = a.password(ask_if_missing: true) # to ask the user for the missing value
 
       return true

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -92,11 +92,11 @@ module FastlaneCore
       #  iTMSTransporter file transfer fails; iTMSTransporter will log an error
       #  but will then retry; if that retry is successful, we will see the error
       #  logged, but since the status code is zero, we want to return success
-      if @errors.count > 0 && exit_status.zero?
+      if @errors.count > 0 && exit_status == 0
         UI.important("Although errors occurred during execution of iTMSTransporter, it returned success status.")
       end
 
-      exit_status.zero?
+      exit_status == 0
     end
 
     private

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -166,6 +166,7 @@ module FastlaneCore
         ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
         "-t Signiant",
         "-k 100000",
+        ("-WONoPause true" if Helper.windows?), # Windows only: process instantly returns instead of waiting for key press
         ("-itc_provider #{provider_short_name}" unless provider_short_name.to_s.empty?)
       ].compact.join(' ')
     end

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -52,7 +52,7 @@ module FastlaneCore
       end
 
       begin
-        FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
+        exit_status = FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
           begin
             command_stdout.each do |line|
               @all_lines << line
@@ -61,16 +61,13 @@ module FastlaneCore
           rescue Errno::EIO
             # Exception ignored intentionally.
             # https://stackoverflow.com/questions/10238298/ruby-on-linux-pty-goes-away-without-eof-raises-errnoeio
-          ensure
-            Process.wait(pid)
           end
         end
       rescue => ex
         @errors << ex.to_s
       end
 
-      exit_status = $?.exitstatus
-      unless exit_status.zero?
+      if exit_status != 0
         @errors << "The call to the iTMSTransporter completed with a non-zero exit status: #{exit_status}. This indicates a failure."
       end
 

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -67,7 +67,7 @@ module FastlaneCore
         @errors << ex.to_s
       end
 
-      if exit_status != 0
+      unless exit_status.zero?
         @errors << "The call to the iTMSTransporter completed with a non-zero exit status: #{exit_status}. This indicates a failure."
       end
 
@@ -92,11 +92,11 @@ module FastlaneCore
       #  iTMSTransporter file transfer fails; iTMSTransporter will log an error
       #  but will then retry; if that retry is successful, we will see the error
       #  logged, but since the status code is zero, we want to return success
-      if @errors.count > 0 && exit_status == 0
+      if @errors.count > 0 && exit_status.zero?
         UI.important("Although errors occurred during execution of iTMSTransporter, it returned success status.")
       end
 
-      exit_status == 0
+      exit_status.zero?
     end
 
     private

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -209,7 +209,7 @@ module FastlaneCore
         "'\"\\'\"'"
       end
 
-      # wrap the fully-escaped password in single quotes, since the transporter expects a escaped password string 
+      # wrap the fully-escaped password in single quotes, since the transporter expects a escaped password string
       # (which must be single-quoted for the shell's benefit [on non-Windows platforms])
       password = "'" + password + "'" unless Helper.windows?
 

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -422,8 +422,11 @@ module FastlaneCore
     def handle_two_step_failure(ex)
       if ENV[TWO_FACTOR_ENV_VARIABLE].to_s.length > 0
         # Password provided, however we already used it
-        UI.error("Application specific password you provided using #{TWO_FACTOR_ENV_VARIABLE}")
-        UI.error("is invalid, please make sure it's correct")
+        UI.error("")
+        UI.error("Application specific password you provided using")
+        UI.error("environment variable #{TWO_FACTOR_ENV_VARIABLE}")
+        UI.error("is invalid, please make sure it's correct.")
+        UI.error("")
         UI.user_error!("Invalid application specific password provided")
       end
 
@@ -436,13 +439,15 @@ module FastlaneCore
         UI.error("Please make sure to follow the instructions")
         a.remove_from_keychain
       end
+      UI.error("")
       UI.error("Your account has 2 step verification enabled")
       UI.error("Please go to https://appleid.apple.com/account/manage")
       UI.error("and generate an application specific password for")
-      UI.error("the iTunes Transporter, which is used to upload builds")
+      UI.error("the iTunes Transporter, which is used to upload builds.")
+      UI.error("")
       UI.error("To set the application specific password on a CI machine using")
       UI.error("an environment variable, you can set the")
-      UI.error("#{TWO_FACTOR_ENV_VARIABLE} variable")
+      UI.error("#{TWO_FACTOR_ENV_VARIABLE} variable.")
       @password = a.password(ask_if_missing: true) # to ask the user for the missing value
 
       return true

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -185,13 +185,14 @@ module FastlaneCore
 
     def handle_error(password)
       # rubocop:disable Style/CaseEquality
-      unless password === /^[0-9a-zA-Z\.\$\_]*$/
+      unless password === /^[0-9a-zA-Z\.\$\_\-]*$/
         UI.error([
           "Password contains special characters, which may not be handled properly by iTMSTransporter.",
           "If you experience problems uploading to App Store Connect, please consider changing your password to something with only alphanumeric characters."
         ].join(' '))
       end
       # rubocop:enable Style/CaseEquality
+
       UI.error("Could not download/upload from App Store Connect! It's probably related to your password or your internet connection.")
     end
 

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -185,13 +185,15 @@ module FastlaneCore
 
     def handle_error(password)
       # rubocop:disable Style/CaseEquality
-      unless password === /^[0-9a-zA-Z\.\$\_\-]*$/
+      # rubocop:disable Style/YodaCondition
+      unless /^[0-9a-zA-Z\.\$\_\-]*$/ === password
         UI.error([
           "Password contains special characters, which may not be handled properly by iTMSTransporter.",
           "If you experience problems uploading to App Store Connect, please consider changing your password to something with only alphanumeric characters."
         ].join(' '))
       end
       # rubocop:enable Style/CaseEquality
+      # rubocop:enable Style/YodaCondition
 
       UI.error("Could not download/upload from App Store Connect! It's probably related to your password or your internet connection.")
     end

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -207,8 +207,11 @@ module FastlaneCore
         "'\"\\'\"'"
       end
 
-      # wrap the fully-escaped password in single quotes, since the transporter expects a escaped password string (which must be single-quoted for the shell's benefit)
-      "'" + password + "'"
+      # wrap the fully-escaped password in single quotes, since the transporter expects a escaped password string 
+      # (which must be single-quoted for the shell's benefit [on non-Windows platforms])
+      password = "'" + password + "'" unless Helper.windows?
+
+      password
     end
   end
 

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -311,8 +311,9 @@ module FastlaneCore
     #                            short names
     def initialize(user = nil, password = nil, use_shell_script = false, provider_short_name = nil)
       # Xcode 6.x doesn't have the same iTMSTransporter Java setup as later Xcode versions, so
-      # we can't default to using the better direct Java invocation strategy for those versions.
-      use_shell_script ||= Helper.xcode_version.start_with?('6.')
+      # we can't default to using the newer direct Java invocation strategy for those versions.
+      use_shell_script ||= Helper.is_mac? && Helper.xcode_version.start_with?('6.')
+      use_shell_script ||= Helper.windows?
       use_shell_script ||= Feature.enabled?('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT')
 
       @user = user

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -162,9 +162,9 @@ module FastlaneCore
         "-m upload",
         "-u \"#{username}\"",
         "-p #{shell_escaped_password(password)}",
-        "-f '#{source}'",
+        "-f \"#{source}\"",
         ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
-        "-t 'Signiant'",
+        "-t Signiant",
         "-k 100000",
         ("-itc_provider #{provider_short_name}" unless provider_short_name.to_s.empty?)
       ].compact.join(' ')

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -217,5 +217,26 @@ describe FastlaneCore do
 
       after(:each) { ENV.delete("FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT") }
     end
+
+    describe "with the code running on Windows" do
+      before(:each) do
+        allow(FastlaneCore::Helper).to receive(:windows?).and_return(true)
+        ENV.delete("FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT")
+      end
+
+      describe "upload command generation" do
+        it 'generates a call to the shell script even without `FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT` being set' do
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
+          expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+        end
+      end
+
+      describe "download command generation" do
+        it 'generates a call to the shell scripteven without `FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT` being set' do
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
+          expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+        end
+      end
+    end
   end
 end

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -8,9 +8,10 @@ describe FastlaneCore do
         '"' + FastlaneCore::Helper.transporter_path + '"',
         "-m upload",
         '-u "fabric.devtools@gmail.com"',
-        "-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'",
-        "-f '/tmp/my.app.id.itmsp'",
-        "-t 'Signiant'",
+        ("-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'" unless FastlaneCore::Helper.windows?),
+        ("-p \\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<" if FastlaneCore::Helper.windows?),
+        "-f \"/tmp/my.app.id.itmsp\"",
+        "-t Signiant",
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name)
       ].compact.join(' ')
@@ -21,7 +22,8 @@ describe FastlaneCore do
         '"' + FastlaneCore::Helper.transporter_path + '"',
         '-m lookupMetadata',
         '-u "fabric.devtools@gmail.com"',
-        "-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'",
+        ("-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'" unless FastlaneCore::Helper.windows?),
+        ("-p \\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<" if FastlaneCore::Helper.windows?),
         "-apple_id my.app.id",
         "-destination '/tmp'",
         ("-itc_provider #{provider_short_name}" if provider_short_name)

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -197,5 +197,25 @@ describe FastlaneCore do
         end
       end
     end
+
+    describe "with `FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT` set" do
+      before(:each) { ENV["FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT"] = "1" }
+
+      describe "upload command generation" do
+        it 'generates a call to the shell script' do
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
+          expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+        end
+      end
+
+      describe "download command generation" do
+        it 'generates a call to the shell script' do
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
+          expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+        end
+      end
+
+      after(:each) { ENV.delete("FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT") }
+    end
   end
 end

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -76,6 +76,49 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
+    def java_upload_command_9(provider_short_name = nil)
+      [
+        FastlaneCore::Helper.transporter_java_executable_path.shellescape,
+        "-Djava.ext.dirs=#{FastlaneCore::Helper.transporter_java_ext_dir.shellescape}",
+        '-XX:NewSize=2m',
+        '-Xms32m',
+        '-Xmx1024m',
+        '-Xms1024m',
+        '-Djava.awt.headless=true',
+        '-Dsun.net.http.retryPost=false',
+        "-jar #{FastlaneCore::Helper.transporter_java_jar_path.shellescape}",
+        "-m upload",
+        "-u fabric.devtools@gmail.com",
+        "-p \\!\\>\\ p@\\$s_-\\+\\=w\\'o\\%rd\\\"\\&\\#\\*\\<",
+        "-f /tmp/my.app.id.itmsp",
+        "-t Signiant",
+        "-k 100000",
+        ("-itc_provider #{provider_short_name}" if provider_short_name),
+        '2>&1'
+      ].compact.join(' ')
+    end
+
+    def java_download_command_9(provider_short_name = nil)
+      [
+        FastlaneCore::Helper.transporter_java_executable_path.shellescape,
+        "-Djava.ext.dirs=#{FastlaneCore::Helper.transporter_java_ext_dir.shellescape}",
+        '-XX:NewSize=2m',
+        '-Xms32m',
+        '-Xmx1024m',
+        '-Xms1024m',
+        '-Djava.awt.headless=true',
+        '-Dsun.net.http.retryPost=false',
+        "-jar #{FastlaneCore::Helper.transporter_java_jar_path.shellescape}",
+        '-m lookupMetadata',
+        '-u fabric.devtools@gmail.com',
+        "-p \\!\\>\\ p@\\$s_-\\+\\=w\\'o\\%rd\\\"\\&\\#\\*\\<",
+        '-apple_id my.app.id',
+        '-destination /tmp',
+        ("-itc_provider #{provider_short_name}" if provider_short_name),
+        '2>&1'
+      ].compact.join(' ')
+    end
+
     describe "with Xcode 7.x installed", requires_xcode: true do
       before(:each) { allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('7.3') }
 
@@ -198,8 +241,29 @@ describe FastlaneCore do
       end
     end
 
+    describe "with Xcode 9.x installed", requires_xcode: true do
+      before(:each) { allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('9.1') }
+
+      describe "upload command generation" do
+        it 'generates a call to the shell script' do
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
+          expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9)
+        end
+      end
+
+      describe "download command generation" do
+        it 'generates a call to the shell script' do
+          transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
+          expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command_9)
+        end
+      end
+    end
+
     describe "with `FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT` set" do
-      before(:each) { ENV["FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT"] = "1" }
+      before(:each) do
+        ENV["FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT"] = "1"
+        allow(File).to receive(:exist?).with("C:/Program Files (x86)/itms").and_return(true) if FastlaneCore::Helper.windows?
+      end
 
       describe "upload command generation" do
         it 'generates a call to the shell script' do
@@ -218,23 +282,37 @@ describe FastlaneCore do
       after(:each) { ENV.delete("FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT") }
     end
 
-    describe "with the code running on Windows" do
+    describe "with no special configuration" do
       before(:each) do
-        allow(FastlaneCore::Helper).to receive(:windows?).and_return(true)
+        allow(File).to receive(:exist?).and_return(true) unless FastlaneCore::Helper.mac?
         ENV.delete("FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT")
       end
 
       describe "upload command generation" do
-        it 'generates a call to the shell script even without `FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT` being set' do
+        it 'generates the correct command' do
           transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
-          expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+          command = java_upload_command
+          # If we are on Windows, switch to shell script command
+          command = shell_upload_command if FastlaneCore::Helper.windows?
+          # If we are on Mac with Xcode 6.x, switch to shell script command
+          command = shell_upload_command if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_version.start_with?('6.')
+          # If we are on Mac with Xcode >= 9, switch to newer java command
+          command = java_upload_command_9 if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(9)
+          expect(transporter.upload('my.app.id', '/tmp')).to eq(command)
         end
       end
 
       describe "download command generation" do
-        it 'generates a call to the shell scripteven without `FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT` being set' do
+        it 'generates the correct command' do
           transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
-          expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+          command = java_download_command
+          # If we are on Windows, switch to shell script command
+          command = shell_download_command if FastlaneCore::Helper.windows?
+          # If we are on Mac with Xcode 6.x, switch to shell script command
+          command = shell_download_command if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_version.start_with?('6.')
+          # If we are on Mac with Xcode >= 9, switch to newer java command
+          command = java_download_command_9 if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(9)
+          expect(transporter.download('my.app.id', '/tmp')).to eq(command)
         end
       end
     end

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -13,6 +13,7 @@ describe FastlaneCore do
         "-f \"/tmp/my.app.id.itmsp\"",
         "-t Signiant",
         "-k 100000",
+        ("-WONoPause true" if FastlaneCore::Helper.windows?),
         ("-itc_provider #{provider_short_name}" if provider_short_name)
       ].compact.join(' ')
     end

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -76,7 +76,7 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    describe "with Xcode 7.x installed" do
+    describe "with Xcode 7.x installed", requires_xcode: true do
       before(:each) { allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('7.3') }
 
       describe "by default" do
@@ -180,7 +180,7 @@ describe FastlaneCore do
       end
     end
 
-    describe "with Xcode 6.x installed" do
+    describe "with Xcode 6.x installed", requires_xcode: true do
       before(:each) { allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('6.4') }
 
       describe "upload command generation" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
iTMSTransporter is available for Windows, but fastlane's implementation doesn't support it yet.

### Description
These commits add support for running `fastlane pilot upload` / `upload_to_testflight` and `fastlane deliver` / `upload_to_app_store` with binaries on Windows.

If iTMSTransporter is not installed, the tests still pass (as they just generate the command, but don't execute it) but on actual execution of `upload_to_testflight` or `upload_to_app_store` you get this error message:
```
...fastlane/fastlane_core/lib/fastlane_core/ui/interface.rb:141:in `user_error!': [!] Could not find transporter at usual locations. Please use environment variable `FASTLANE_ITUNES_TRANSPORTER_PATH` to specify your installation path. (FastlaneCore::Interface::FastlaneError)
```

Along the way several smaller bugs in the implementation were fixed and tests added (e.g. for special handling of Xcode >= 9).