### PR TITLE
Make CredentialsManager output more Windows friendly

### DIFF
--- a/credentials_manager/lib/credentials_manager/account_manager.rb
+++ b/credentials_manager/lib/credentials_manager/account_manager.rb
@@ -50,10 +50,8 @@ module CredentialsManager
       end
 
       unless @password
-        if mac?
-          item = Security::InternetPassword.find(server: server_name)
-          @password ||= item.password if item
-        end
+        item = Security::InternetPassword.find(server: server_name)
+        @password ||= item.password if item
       end
       ask_for_login while ask_if_missing && @password.to_s.length == 0
       return @password
@@ -72,10 +70,8 @@ module CredentialsManager
       end
 
       if force || agree("Do you want to re-enter your password? (y/n)", true)
-        if mac?
-          puts("Removing Keychain entry for user '#{user}'...".yellow)
-          remove_from_keychain
-        end
+        puts("Removing Keychain entry for user '#{user}'...".yellow) if mac?
+        remove_from_keychain
         ask_for_login
         return true
       end

--- a/credentials_manager/lib/credentials_manager/account_manager.rb
+++ b/credentials_manager/lib/credentials_manager/account_manager.rb
@@ -50,8 +50,10 @@ module CredentialsManager
       end
 
       unless @password
-        item = Security::InternetPassword.find(server: server_name)
-        @password ||= item.password if item
+        if FastlaneCore::Helper.mac?
+          item = Security::InternetPassword.find(server: server_name)
+          @password ||= item.password if item
+        end
       end
       ask_for_login while ask_if_missing && @password.to_s.length == 0
       return @password
@@ -70,8 +72,10 @@ module CredentialsManager
       end
 
       if force || agree("Do you want to re-enter your password? (y/n)", true)
-        puts("Removing Keychain entry for user '#{user}'...".yellow)
-        remove_from_keychain
+        if FastlaneCore::Helper.mac?
+          puts("Removing Keychain entry for user '#{user}'...".yellow)
+          remove_from_keychain 
+        end
         ask_for_login
         return true
       end
@@ -111,12 +115,12 @@ module CredentialsManager
       if ENV["FASTLANE_HIDE_LOGIN_INFORMATION"].to_s.length == 0
         puts("-------------------------------------------------------------------------------------".green)
         puts("Please provide your Apple Developer Program account credentials".green)
-        puts("The login information you enter will be stored in your macOS Keychain".green)
+        puts("The login information you enter will be stored in your macOS Keychain".green) if FastlaneCore::Helper.mac?
         if default_prefix?
           # We don't want to show this message, if we ask for the application specific password
           # which has a different prefix
           puts("You can also pass the password using the `FASTLANE_PASSWORD` environment variable".green)
-          puts("See more information about it on GitHub: https://github.com/fastlane/fastlane/tree/master/credentials_manager".green)
+          puts("See more information about it on GitHub: https://github.com/fastlane/fastlane/tree/master/credentials_manager".green) if FastlaneCore::Helper.mac?
         end
         puts("-------------------------------------------------------------------------------------".green)
       end
@@ -138,7 +142,7 @@ module CredentialsManager
       end
 
       return true if ENV["FASTLANE_DONT_STORE_PASSWORD"]
-      return true if (/darwin/ =~ RUBY_PLATFORM).nil? # mac?, since we don't have access to the helper here
+      return true if (/darwin/ =~ RUBY_PLATFORM).nil? # Helper.mac? - but we don't have access to the helper here
 
       # Now we store this information in the keychain
       if add_to_keychain

--- a/credentials_manager/lib/credentials_manager/account_manager.rb
+++ b/credentials_manager/lib/credentials_manager/account_manager.rb
@@ -50,7 +50,7 @@ module CredentialsManager
       end
 
       unless @password
-        if FastlaneCore::Helper.mac?
+        if mac?
           item = Security::InternetPassword.find(server: server_name)
           @password ||= item.password if item
         end
@@ -72,9 +72,9 @@ module CredentialsManager
       end
 
       if force || agree("Do you want to re-enter your password? (y/n)", true)
-        if FastlaneCore::Helper.mac?
+        if mac?
           puts("Removing Keychain entry for user '#{user}'...".yellow)
-          remove_from_keychain 
+          remove_from_keychain
         end
         ask_for_login
         return true
@@ -115,12 +115,12 @@ module CredentialsManager
       if ENV["FASTLANE_HIDE_LOGIN_INFORMATION"].to_s.length == 0
         puts("-------------------------------------------------------------------------------------".green)
         puts("Please provide your Apple Developer Program account credentials".green)
-        puts("The login information you enter will be stored in your macOS Keychain".green) if FastlaneCore::Helper.mac?
+        puts("The login information you enter will be stored in your macOS Keychain".green) if mac?
         if default_prefix?
           # We don't want to show this message, if we ask for the application specific password
           # which has a different prefix
           puts("You can also pass the password using the `FASTLANE_PASSWORD` environment variable".green)
-          puts("See more information about it on GitHub: https://github.com/fastlane/fastlane/tree/master/credentials_manager".green) if FastlaneCore::Helper.mac?
+          puts("See more information about it on GitHub: https://github.com/fastlane/fastlane/tree/master/credentials_manager".green) if mac?
         end
         puts("-------------------------------------------------------------------------------------".green)
       end
@@ -142,7 +142,7 @@ module CredentialsManager
       end
 
       return true if ENV["FASTLANE_DONT_STORE_PASSWORD"]
-      return true if (/darwin/ =~ RUBY_PLATFORM).nil? # Helper.mac? - but we don't have access to the helper here
+      return true unless mac?
 
       # Now we store this information in the keychain
       if add_to_keychain
@@ -151,6 +151,11 @@ module CredentialsManager
         puts("Could not store password in keychain".red)
         return false
       end
+    end
+
+    # Helper.mac? - but we don't have access to the helper here
+    def self.mac?
+      (/darwin/ =~ RUBY_PLATFORM) != nil
     end
   end
 end

--- a/credentials_manager/lib/credentials_manager/account_manager.rb
+++ b/credentials_manager/lib/credentials_manager/account_manager.rb
@@ -154,7 +154,7 @@ module CredentialsManager
     end
 
     # Helper.mac? - but we don't have access to the helper here
-    def self.mac?
+    def mac?
       (/darwin/ =~ RUBY_PLATFORM) != nil
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`CredentialsManager ` currently talks about Keychain. This of course doesn't mean anything to Windows users as Keychain doesn't exist.

### Description
This PR disables some output by checking if fastlane is running on Windows.
