### PR TITLE
Move `rescue Errno::EIO` into FastlanePty

### DIFF
--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -63,9 +63,6 @@ module FastlaneCore
 
                 UI.command_output(line)
               end
-            rescue Errno::EIO
-              # This is expected on some linux systems, that indicates that the subcommand finished
-              # and we kept trying to read, ignore it
             end
           end
         rescue => ex

--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -49,20 +49,18 @@ module FastlaneCore
 
         begin
           status = FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
-            begin
-              command_stdout.each do |l|
-                line = l.strip # strip so that \n gets removed
-                output << line
+            command_stdout.each do |l|
+              line = l.strip # strip so that \n gets removed
+              output << line
 
-                next unless print_all
+              next unless print_all
 
-                # Prefix the current line with a string
-                prefix.each do |element|
-                  line = element[:prefix] + line if element[:block] && element[:block].call(line)
-                end
-
-                UI.command_output(line)
+              # Prefix the current line with a string
+              prefix.each do |element|
+                line = element[:prefix] + line if element[:block] && element[:block].call(line)
               end
+
+              UI.command_output(line)
             end
           end
         rescue => ex

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -14,7 +14,11 @@ module FastlaneCore
           # This is expected on some linux systems, that indicates that the subcommand finished
           # and we kept trying to read, ignore it
         ensure
-          Process.wait(pid)
+          begin
+            Process.wait(pid)
+          rescue Errno::ECHILD, PTY::ChildExited
+            # The process might have exited.
+          end
         end
       end
       $?.exitstatus

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -7,7 +7,7 @@ module FastlaneCore
       require 'pty'
       PTY.spawn(command) do |command_stdout, command_stdin, pid|
         begin
-          block.call(command_stdout, command_stdin, pid)
+          yield(command_stdout, command_stdin, pid)
         rescue Errno::EIO
           # Exception ignored intentionally.
           # https://stackoverflow.com/questions/10238298/ruby-on-linux-pty-goes-away-without-eof-raises-errnoeio

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -3,7 +3,7 @@
 # https://github.com/DragonBox/u3d/blob/59e471ad78ac00cb629f479dbe386c5ad2dc5075/lib/u3d_core/command_runner.rb#L88-L96
 module FastlaneCore
   class FastlanePty
-    def self.spawn(command, &block)
+    def self.spawn(command)
       require 'pty'
       PTY.spawn(command) do |command_stdout, command_stdin, pid|
         begin

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -8,6 +8,11 @@ module FastlaneCore
       PTY.spawn(command) do |command_stdout, command_stdin, pid|
         begin
           block.call(command_stdout, command_stdin, pid)
+        rescue Errno::EIO
+          # Exception ignored intentionally.
+          # https://stackoverflow.com/questions/10238298/ruby-on-linux-pty-goes-away-without-eof-raises-errnoeio
+          # This is expected on some linux systems, that indicates that the subcommand finished
+          # and we kept trying to read, ignore it
         ensure
           Process.wait(pid)
         end

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -58,11 +58,6 @@ module FastlaneCore
               @all_lines << line
               parse_line(line, hide_output) # this is where the parsing happens
             end
-          rescue Errno::EIO
-            # Exception ignored intentionally.
-            # https://stackoverflow.com/questions/10238298/ruby-on-linux-pty-goes-away-without-eof-raises-errnoeio
-          ensure
-            Process.wait(pid)
           end
         end
       rescue => ex

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -11,20 +11,25 @@ describe FastlaneCore do
         expect(result).to eq('foo')
       end
 
-      it 'handles reading which throws a EIO exception' do
+      it 'handles reading which throws a EIO exception', requires_pty: true do
         explodes_on_strip = 'danger! lasers!'
         fake_std_in = ['a_filename', explodes_on_strip]
 
-        # This is really raised by the `each` call, but for easier mocking
-        # we raise when the line is cleaned up with `strip` afterward
+        # In reality the exception is raised by the `each` call, but for easier mocking
+        # we manually raise the exception when the line is cleaned up with `strip` afterward
         expect(explodes_on_strip).to receive(:strip).and_raise(Errno::EIO)
 
-        # Make a fake child process so we have a valid PID and $? is set correctly
         child_process_id = 1
-        expect(FastlaneCore::FastlanePty).to receive(:spawn) do |command, &block|
+        expect(Process).to receive(:wait).with(child_process_id)
+
+        # Hacky approach because $? is not be defined since we skip the actual spawn
+        allow_message_expectations_on_nil
+        expect($?).to receive(:exitstatus).and_return(0)
+
+        # Make a fake child process so we have a valid PID and $? is set correctly
+        expect(PTY).to receive(:spawn) do |command, &block|
           expect(command).to eq('ls')
           block.yield(fake_std_in, 'not_really_std_out', child_process_id)
-          $?.exitstatus
         end
 
         result = FastlaneCore::CommandExecutor.execute(command: 'ls')

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -111,6 +111,9 @@ RSpec.configure do |config|
     config.define_derived_metadata(:requires_xar) do |meta|
       meta[:skip] = "Skipped: Requires `xar` to be installed (which is not possible on Windows and no workaround has been implemented)"
     end
+    config.define_derived_metadata(:requires_pty) do |meta|
+      meta[:skip] = "Skipped: Requires `pty` to be available (which is not possible on Windows and no workaround has been implemented)"
+    end
   end
 end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`CommandExecutor` and other users of `FastlanePty` still have some duplicated in its usage.

### Description
To solve this I moved the `rescue` into `FastlanePty` itself. 
Test is (pretty much) back to the state before I started to create `FastlanePty`: https://github.com/fastlane/fastlane/blob/924ebfbd98dfaa60d05ed2be46d9b92fb1097c74/fastlane_core/spec/command_executor_spec.rb#L4-L30
In return it is not executed any more on windows, as `Pty` doesn't exist there and so can't be tested.

### Testing
`FastlanePty` is used in `CommandExecutor.execute` and `ItunesTransporter` (`pilot upload`, `deliver`). 
`CommandExecutor.execute` is used all over the place: gym, scan, snapshot, match.

---
closes #13132 
