### PR TITLE
New action category: App Store Connect

### DIFF
--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -15,6 +15,7 @@ module Fastlane
       :production,
       :source_control,
       :notifications,
+      :app_store_connect,
       :misc,
       :deprecated # This should be the last item
     ]

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -182,7 +182,7 @@ module Fastlane
       end
 
       def self.category
-        :misc
+        :app_store_connect
       end
 
       def self.is_supported?(platform)

--- a/fastlane/lib/fastlane/actions/check_app_store_metadata.rb
+++ b/fastlane/lib/fastlane/actions/check_app_store_metadata.rb
@@ -46,7 +46,7 @@ module Fastlane
       end
 
       def self.category
-        :misc
+        :app_store_connect
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/create_app_online.rb
+++ b/fastlane/lib/fastlane/actions/create_app_online.rb
@@ -68,7 +68,7 @@ module Fastlane
       end
 
       def self.category
-        :misc
+        :app_store_connect
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -232,7 +232,7 @@ module Fastlane
       end
 
       def self.category
-        :misc
+        :app_store_connect
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -133,7 +133,7 @@ module Fastlane
       end
 
       def self.category
-        :misc
+        :app_store_connect
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/set_changelog.rb
+++ b/fastlane/lib/fastlane/actions/set_changelog.rb
@@ -165,7 +165,7 @@ module Fastlane
       end
 
       def self.category
-        :beta
+        :app_store_connect
       end
     end
   end

--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -216,6 +216,8 @@ module Fastlane
         "Beta"
       when :production
         "Releasing your app"
+      when :app_store_connect
+        "App Store Connect"
       when :deprecated
         "Deprecated"
       else


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Several pretty important actions currently live in the Misc category.

### Description
Adds a category "App Store Connect" for all the actions, that interact with App Store Connect (excluding those that are already in better categories). Applies to 5 actions plus their 2 aliases.

Did I miss anything?
