### PR TITLE
[screengrab] Docs: add instructions how to build APKs via lane

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/capture_android_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/capture_android_screenshots.md
@@ -55,7 +55,21 @@ Ensure that the following permissions exist in your **src/debug/AndroidManifest.
 
 # Generating Screenshots with Screengrab
 - Then, before running `fastlane screengrab` you'll need a debug and test apk
-  - You can create your APKs with `./gradlew assembleDebug assembleAndroidTest`
+  - You can create your APKs manually with `./gradlew assembleDebug assembleAndroidTest`
+  - You can also create a lane and use `build_android_app`:
+    ```ruby
+    desc "Build debug and test APK for screenshots"
+    lane :buildForScreengrab do
+      build_android_app(
+        task: 'assemble',
+        build_type: 'Debug'
+      )
+      build_android_app(
+        task: 'assemble',
+        build_type: 'AndroidTest'
+      )
+    end
+    ```
 - Once complete run `fastlane screengrab` in your app project directory to generate screenshots
   - You will be prompted to provide any required parameters which are not in your **Screengrabfile** or provided as command line arguments
 - Your screenshots will be saved to `fastlane/metadata/android` in the directory where you ran _screengrab_


### PR DESCRIPTION
No reason why people have to build this manually, the old way. 
We have an action that does the exact same thing.

Related: https://github.com/fastlane/docs/pull/686