### PR TITLE
[gradle] Docs: Add `task: "clean"` example

### DIFF
--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -231,6 +231,10 @@ module Fastlane
             # ...
 
             flags: "--exitcode --xml file.xml"
+          )',
+          '# Delete the build directory and generated APKs
+          gradle(
+            task: "clean"
           )'
         ]
       end


### PR DESCRIPTION
Cleaning the project to get rid of the output folder and generated APKs is a quite useful and common task, so I aded it as a code example to the `gradle` action.