### PR TITLE
measure fastlane startup time via execution time of `--help` command 🏎️

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,6 +47,32 @@ lane :lint_source do
   end
 end
 
+desc "Measure the execution time of the --help command"
+lane :benchmark_help_command do
+  Dir.chdir("..") do
+    # install gnomon if not installed yet
+    Actions.sh("echo foo | gnomon", log: true, error_callback: lambda { |result|
+      if Helper.windows? || Helper.mac?
+        sh('npm install -g gnomon')
+      else
+        # install npm if not installed yet
+        Actions.sh("echo foo | npm", log: true, error_callback: lambda { |result2|
+          sh('curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -')
+          sh('sudo apt-get install -y nodejs')
+        })
+        sh('sudo npm install -g gnomon')
+      end
+    })
+    cmd = Helper.windows? ? "cd bin && fastlane --help | gnomon" : "bin/fastlane --help | gnomon"
+    3.times do
+      content = sh(cmd, log: false)
+      content.each_line do |line|
+        UI.message("🏎️ '#{line.strip}'") if ["Total", "real", "user", "sys"].any? { |word| line.include?(word) }
+      end
+    end
+  end
+end
+
 desc "Runs the tests"
 lane :execute_tests do
   version = local_version # has to be outside of the `Dir.chdir`
@@ -59,6 +85,8 @@ lane :execute_tests do
       UI.user_error!("--help missing information: '#{current}'") unless content.include?(current)
     end
   end
+
+  benchmark_help_command
 
   Dir.chdir("..") do
     # Install the bundle and the actual gem


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fastlane can be pretty slow to start. Slow startup is bad.

### Description
This PR adds a new lane `benchmark_help_command` that is also run during `execute_tests`. It installs a (cross platform) node tool via npm called [`gnomon`](https://github.com/paypal/gnomon) that prepends timestamps to lines of out and measures the total execution time. This total is extracted and output in the lane. To make sure we get a good overview, the lane runs `fastlane --help` 3 times and outputs it runtime.

In the future this lane can be used to benchmark `fastlane` and that way track and measure the effect of any changes (like https://github.com/fastlane/fastlane/pull/13167).