### PR TITLE
[CI/AppVeyor] Remove dependency on Chocolatey

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,8 @@ init:
 install:
   - set PATH=C:\Ruby24-x64\bin;%PATH%
   - bundle install
-  - cinst gtk-runtime # includes iconv
+  # - cinst gtk-runtime # includes iconv
+  - ps: Install-ChocolateyPackage "gtk-runtime" "exe" "/S" "http://downloads.sourceforge.net/gtk-win/gtk2-runtime-2.24.10-2012-10-10-ash.exe?download" -validExitCodes @(0) -checksum "afd74fbc35743a5528f07f21837978e10c078965" -checksumType "sha1"
 
 environment:
   LC_ALL: en_US.UTF-8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,8 @@ install:
   - set PATH=C:\Ruby24-x64\bin;%PATH%
   - bundle install
   # - cinst gtk-runtime # includes iconv
-  - ps: Install-ChocolateyPackage "gtk-runtime" "exe" "/S" "http://downloads.sourceforge.net/gtk-win/gtk2-runtime-2.24.10-2012-10-10-ash.exe?download" -validExitCodes @(0) -checksum "afd74fbc35743a5528f07f21837978e10c078965" -checksumType "sha1"
+  - ps: Start-FileDownload 'http://downloads.sourceforge.net/gtk-win/gtk2-runtime-2.24.10-2012-10-10-ash.exe?download'
+  - gtk2-runtime-2.24.10-2012-10-10-ash.exe
 
 environment:
   LC_ALL: en_US.UTF-8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,10 @@ init:
 install:
   - set PATH=C:\Ruby24-x64\bin;%PATH%
   - bundle install
-  # - cinst gtk-runtime # includes iconv
+  # gtk-runtime includes `iconv`
+  # - cinst gtk-runtime 
   - ps: Start-FileDownload 'http://downloads.sourceforge.net/gtk-win/gtk2-runtime-2.24.10-2012-10-10-ash.exe?download'
-  - gtk2-runtime-2.24.10-2012-10-10-ash.exe
+  - gtk2-runtime-2.24.10-2012-10-10-ash.exe /S
 
 environment:
   LC_ALL: en_US.UTF-8


### PR DESCRIPTION
Right now we use `cinst gtk-runtime` to install the `gtk-runtime` package via Chocolatey (compareable to Homebrew for Mac, but for Windows). Unfortunately their server are not very reliable in the last few days and weeks, failing builds for no good reason.

This change replaces the usage of Chocolatey (`cinst`) by downloading the `.exe` and executing it manually. These are the exact same steps Chocolatey would have taken internally as well - just without the use of the Chocolatey package server and install script.