### PR TITLE
Hide plugin_scores action from the action overview

### DIFF
--- a/fastlane/actions/plugin_scores.rb
+++ b/fastlane/actions/plugin_scores.rb
@@ -56,10 +56,6 @@ module Fastlane
         true
       end
 
-      def self.category
-        :misc
-      end
-
       # Those are plugins that are now part of fastlane core actions, so we don't want to show them in the directory
       def self.hidden_plugins
         [

--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -147,9 +147,7 @@ module Fastlane
         @action = action # to provide a reference in the .html.erb template
         @action_filename = filename_for_action(action)
 
-        unless @action_filename
-          next
-        end
+        next if @action_filename.nil?
 
         # Make sure to always assign `@custom_content`, as we're in a loop and `@` is needed for the `erb`
         @custom_content = load_custom_action_md(action)


### PR DESCRIPTION
Fixes https://github.com/fastlane/docs/issues/700

This works as all actions without categories aren't rendered