### PR TITLE
[CI/Appveyor] cleaner way to install iconv on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,10 +25,9 @@ init:
 install:
   - set PATH=C:\Ruby24-x64\bin;%PATH%
   - bundle install
-  # gtk-runtime includes `iconv`
-  # - cinst gtk-runtime 
-  - ps: Start-FileDownload 'http://downloads.sourceforge.net/gtk-win/gtk2-runtime-2.24.10-2012-10-10-ash.exe?download'
-  - gtk2-runtime-2.24.10-2012-10-10-ash.exe /S
+  # iconv
+  - appveyor DownloadFile 'https://downloads.sourceforge.net/project/gnuwin32/libiconv/1.9.2-1/libiconv-1.9.2-1.exe?download'
+  - libiconv-1.9.2-1.exe /SILENT /SUPPRESSMSGBOXES
 
 environment:
   LC_ALL: en_US.UTF-8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - set PATH=C:\Ruby24-x64\bin;%PATH%
   - bundle install
   # iconv
-  - appveyor DownloadFile 'https://downloads.sourceforge.net/project/gnuwin32/libiconv/1.9.2-1/libiconv-1.9.2-1.exe?download'
+  - appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/libiconv/1.9.2-1/libiconv-1.9.2-1.exe?download
   - libiconv-1.9.2-1.exe /SILENT /SUPPRESSMSGBOXES
 
 environment:


### PR DESCRIPTION
This installs http://gnuwin32.sourceforge.net/packages/libiconv.htm instead of this other, strange package I have been using as it also included `iconv`. Still a download from Sourceforge, but at least a very popular one.