### PR TITLE
Use absolute app icon path for deliver upload preview

### DIFF
--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -144,13 +144,13 @@
         <% if @options[:app_icon] %>
         <div class="app-icon">
           Large App Icon:<br>
-          <img src="<%= @options[:app_icon] %>">
+          <img src="<%= File.expand_path(@options[:app_icon]) %>">
         </div>
         <% end %>
         <% if @options[:apple_watch_app_icon] %>
         <div class="watch-icon">
           Watch App Icon:<br>
-          <img src="<%= @options[:apple_watch_app_icon] %>">
+          <img src="<%= File.expand_path(@options[:apple_watch_app_icon]) %>">
         </div>
         <% end %>
       </div>


### PR DESCRIPTION
**Note** this is not a good solution, I'm wondering if this works for anyone else? Does the _deliver_ preview show the app icon at all for you? 

Using an absolute path is bad, as it doesn't allow you to zip and share the preview or just move it around

```
[2] pry(#<Deliver::HtmlGenerator>)> @options[:app_icon]
=> "./fastlane/metadata/app_icon.png"
```