### PR TITLE
[Fastlane.swift] init Deliverfile with Deliverfile swift class

### DIFF
--- a/deliver/lib/assets/DeliverfileDefault.swift
+++ b/deliver/lib/assets/DeliverfileDefault.swift
@@ -1,3 +1,13 @@
 // The Deliverfile allows you to store various App Store Connect metadata
 // For more information, check out the docs
 // https://docs.fastlane.tools/actions/deliver/
+
+// In general, you can use the options available
+// fastlane deliver --help
+
+// Remove the // in front of the line to enable the option
+
+class Deliverfile: DeliverfileProtocol {
+  //var username: String { return "" }
+  //var appIdentifier: String? { return "" }
+}


### PR DESCRIPTION
Fixes #13193

## Problem
The `DeliverfileDefault.swift` that gets used in `Deliver::Setup` (which is called by `fastlane init swift`) didn't declare `class Deliverfile` which was causing a compile error.

## Solution
Now it does. (see similar https://github.com/fastlane/fastlane/blob/master/gym/lib/assets/GymfileTemplate.swift if curious)