### PR TITLE
[deliver] fix double screenshots directory on deliver setup

### DIFF
--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -126,8 +126,7 @@ module Deliver
       end
     end
 
-    def download_screenshots(deliver_path, options)
-      path = File.join(deliver_path, 'screenshots')
+    def download_screenshots(path, options)
       FileUtils.mkdir_p(path)
       Deliver::DownloadScreenshots.run(options, path)
     end


### PR DESCRIPTION
Fixes #13194

## Problem
The full screenshots path was getting generated here - https://github.com/fastlane/fastlane/blob/dd0b74f87915dec2666efe938123116b4129cc0c/deliver/lib/deliver/setup.rb#L27

But then `screenshots` was getting appended to the path again here - https://github.com/fastlane/fastlane/blob/dd0b74f87915dec2666efe938123116b4129cc0c/deliver/lib/deliver/setup.rb#L130

## Solution
Removed the second `screenshots` from getting appended in  the `download_screenshots` method