### PR TITLE
[produce] reprompt app name on failed create_app_online setup

### DIFF
--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -470,14 +470,16 @@ module Fastlane
         produce_options[:skip_devcenter] = true
       end
 
-      Produce.config = FastlaneCore::Configuration.create(
-        Produce::Options.available_options,
-        produce_options
-      )
-
       # The retrying system allows people to correct invalid inputs
       # e.g. the app's name is already taken
       loop do
+        # Creating config in the loop so user will be reprompted
+        # for app name if app name is taken or too long
+        Produce.config = FastlaneCore::Configuration.create(
+          Produce::Options.available_options,
+          produce_options
+        )
+
         begin
           Produce::Manager.start_producing
           UI.success("✅  Successfully created app")


### PR DESCRIPTION
Fixes #13192

## Problem
If app name was too long or taken, `fastlane init` would fail when creating app on App Store Connect but ask if user wants to try again but without reprompting for app name

## Solution
Move `Produce.config` into loop so the app name prompt happens again