### PR TITLE
[deliver] fix submission of tvos build on combined ios/tvos apps

### DIFF
--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -7,7 +7,7 @@ module Deliver
       select_build(options)
 
       UI.message("Submitting the app for review...")
-      submission = app.create_submission
+      submission = app.create_submission(platform: options[:platform])
 
       # Set app submission information
       # Default Values
@@ -31,7 +31,7 @@ module Deliver
 
     def select_build(options)
       app = options[:app]
-      v = app.edit_version
+      v = app.edit_version(platform: options[:platform])
 
       if options[:build_number] && options[:build_number] != "latest"
         UI.message("Selecting existing build-number: #{options[:build_number]}")

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -226,7 +226,7 @@ module Deliver
       # Collect all languages we need
       # We only care about languages from user provided values
       # as the other languages are on iTC already anyway
-      v = options[:app].edit_version
+      v = options[:app].edit_version(platform: options[:platform])
       UI.user_error!("Could not find a version to edit for app '#{options[:app].name}', the app metadata is read-only currently") unless v
 
       enabled_languages = options[:languages] || []

--- a/spaceship/lib/spaceship/tunes/app_submission.rb
+++ b/spaceship/lib/spaceship/tunes/app_submission.rb
@@ -12,6 +12,11 @@ module Spaceship
       # @return (AppVersion) The version to use for this submission
       attr_accessor :version
 
+      # @return (String) The platform of the device. This is usually "ios"
+      # @example
+      #   "appletvos"
+      attr_accessor :platform
+
       # @return (Boolean) Submitted for Review
       attr_accessor :submitted_for_review
 
@@ -115,10 +120,11 @@ module Spaceship
         end
 
         # @param application (Spaceship::Tunes::Application) The app this submission is for
-        def create(application, version)
-          attrs = client.prepare_app_submissions(application.apple_id, application.edit_version.version_id)
+        def create(application, version, platform: nil)
+          attrs = client.prepare_app_submissions(application.apple_id, application.edit_version(platform: platform).version_id)
           attrs[:application] = application
           attrs[:version] = version
+          attrs[:platform] = platform
 
           return self.factory(attrs)
         end
@@ -142,7 +148,7 @@ module Spaceship
           )
         end
 
-        client.send_app_submission(application.apple_id, application.edit_version.version_id, raw_data_clone)
+        client.send_app_submission(application.apple_id, application.edit_version(platform: platform).version_id, raw_data_clone)
         @submitted_for_review = true
       end
 

--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -357,13 +357,13 @@ module Spaceship
       # @!group Submit for Review
       #####################################################
 
-      def create_submission
-        version = self.latest_version
+      def create_submission(platform: nil)
+        version = self.latest_version(platform: platform)
         if version.nil?
           raise "Could not find a valid version to submit for review"
         end
 
-        Spaceship::Tunes::AppSubmission.create(self, version)
+        Spaceship::Tunes::AppSubmission.create(self, version, platform: platform)
       end
 
       # Cancels all ongoing TestFlight beta submission for this application


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I have a combined app on the App Store with both tvos and ios builds under the same bundle. When I try to deliver tvos builds, it fails because the code was only considering ios builds for submission.

### Description

Simply passing through platform so the correct candidate builds are considered.