### PR TITLE
[supply] remove unused CredentialsLoader

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -1,7 +1,6 @@
 require 'googleauth'
 require 'google/apis/androidpublisher_v2'
 Androidpublisher = Google::Apis::AndroidpublisherV2
-CredentialsLoader = Google::Auth::CredentialsLoader
 
 require 'net/http'
 


### PR DESCRIPTION
`supply/client` was defining `CredentialsLoader = Google::Auth::CredentialsLoader` which was not used anywhere, so I removed it.