### PR TITLE
[Pilot] Print error when failing to import tester

### DIFF
--- a/pilot/lib/pilot/tester_importer.rb
+++ b/pilot/lib/pilot/tester_importer.rb
@@ -42,8 +42,8 @@ module Pilot
         begin
           tester_manager.add_tester(config)
           imported_tester_count += 1
-        rescue
-          # do nothing, move on to the next row
+        rescue  => exception
+          UI.error("Error adding tester #{email}: #{exception}")
         end
       end
 

--- a/pilot/lib/pilot/tester_importer.rb
+++ b/pilot/lib/pilot/tester_importer.rb
@@ -42,7 +42,7 @@ module Pilot
         begin
           tester_manager.add_tester(config)
           imported_tester_count += 1
-        rescue  => exception
+        rescue => exception
           UI.error("Error adding tester #{email}: #{exception}")
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Right now this fails silently. I was hitting errors due to being rate-limited and I had no way of knowing what was happening.
 
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
I tested this by running it locally on my machine, where I was getting rate-limit errors.
