### PR TITLE
[deliver] make screenshots path relative to Preview.html file

### DIFF
--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -144,13 +144,13 @@
         <% if @options[:app_icon] %>
         <div class="app-icon">
           Large App Icon:<br>
-          <img src="<%= @options[:app_icon] %>">
+          <img src="<%= render_relative_path(@export_path, @options[:app_icon]) %>">
         </div>
         <% end %>
         <% if @options[:apple_watch_app_icon] %>
         <div class="watch-icon">
           Watch App Icon:<br>
-          <img src="<%= @options[:apple_watch_app_icon] %>">
+          <img src="<%= render_relative_path(@export_path, @options[:apple_watch_app_icon]) %>">
         </div>
         <% end %>
       </div>
@@ -237,7 +237,7 @@
               <div class="app-screenshot-row">
 
               <% screenshots.each_with_index do |screenshot, index| %>
-                <a href="<%= URI.escape(screenshot.path) %>" target="_blank"><img class="app-screenshot" src="<%= URI.escape(screenshot.path) %>" title="Screenshot #<%=index%> for <%=language%>"></a>
+                <a href="<%= URI.escape(screenshot.path) %>" target="_blank"><img class="app-screenshot" src="<%= render_relative_path(@export_path, URI.escape(screenshot.path)) %>" title="Screenshot #<%=index%> for <%=language%>"></a>
               <% end %>
               </div>
             <% end %>

--- a/deliver/lib/deliver/html_generator.rb
+++ b/deliver/lib/deliver/html_generator.rb
@@ -31,11 +31,20 @@ module Deliver
       end
     end
 
+    # Returns a path relative to FastlaneFolder.path
+    # This is needed as the Preview.html file is located inside FastlaneFolder.path
+    def render_relative_path(export_path, path)
+      export_path = Pathname.new(export_path)
+      path = Pathname.new(path).relative_path_from(export_path)
+      return path.to_path
+    end
+
     # Renders all data available to quickly see if everything was correctly generated.
     # @param export_path (String) The path to a folder where the resulting HTML file should be stored.
     def render(options, screenshots, export_path = nil)
       @screenshots = screenshots || []
       @options = options
+      @export_path = export_path
 
       @app_name = (options[:name]['en-US'] || options[:name].values.first) if options[:name]
       @app_name ||= options[:app].name


### PR DESCRIPTION
Fixes #13176

## Problem
The images in `Preview.html` were relative on the project root but the `Preview.html` file is located inside of the `fastlane` directory.

## Solution
The images (app icon, watch app, and screenshots) get a path that is rendered realtive to the `fastlane` directory