### PR TITLE
[core] Extend Shellwords (`String.shellescape`, `Array.shelljoin`) for Windows support

### DIFF
--- a/fastlane/lib/fastlane/actions/add_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/add_git_tag.rb
@@ -14,7 +14,7 @@ module Fastlane
         cmd << ["-am #{message.shellescape}"]
         cmd << '--force' if options[:force]
         cmd << '-s' if options[:sign]
-        cmd << "'#{tag}'"
+        cmd << tag.shellescape
         cmd << options[:commit].to_s if options[:commit]
 
         UI.message("Adding git tag '#{tag}' 🎯.")

--- a/fastlane/spec/actions_specs/add_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/add_git_tag_spec.rb
@@ -14,7 +14,9 @@ describe Fastlane do
           add_git_tag
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am builds/test/1337\\ \\(fastlane\\) \'builds/test/1337\'")
+        message = "builds/test/1337 (fastlane)"
+        tag = "builds/test/1337"
+        expect(result).to eq("git tag -am #{message.shellescape} #{tag.shellescape}")
       end
 
       it "allows you to specify grouping and build number" do
@@ -28,7 +30,9 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am #{grouping}/test/#{specified_build_number}\\ \\(fastlane\\) \'#{grouping}/test/#{specified_build_number}\'")
+        message = "#{grouping}/test/#{specified_build_number} (fastlane)"
+        tag = "#{grouping}/test/#{specified_build_number}"
+        expect(result).to eq("git tag -am #{message.shellescape} #{tag.shellescape}")
       end
 
       it "allows you to specify a prefix" do
@@ -40,7 +44,9 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am builds/test/#{prefix}#{build_number}\\ \\(fastlane\\) \'builds/test/#{prefix}#{build_number}\'")
+        message = "builds/test/#{prefix}#{build_number} (fastlane)"
+        tag = "builds/test/#{prefix}#{build_number}"
+        expect(result).to eq("git tag -am #{message.shellescape} #{tag.shellescape}")
       end
 
       it "allows you to specify a postfix" do
@@ -52,7 +58,9 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am builds/test/#{build_number}#{postfix}\\ \\(fastlane\\) \'builds/test/#{build_number}#{postfix}\'")
+        message = "builds/test/#{build_number}#{postfix} (fastlane)"
+        tag = "builds/test/#{build_number}#{postfix}"
+        expect(result).to eq("git tag -am #{message.shellescape} #{tag.shellescape}")
       end
 
       it "allows you to specify your own tag" do
@@ -64,7 +72,8 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am #{tag}\\ \\(fastlane\\) \'#{tag}\'")
+        message = "#{tag} (fastlane)"
+        expect(result).to eq("git tag -am #{message.shellescape} #{tag.shellescape}")
       end
 
       it "specified tag overrides generate tag" do
@@ -79,7 +88,8 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am #{tag}\\ \\(fastlane\\) \'#{tag}\'")
+        message = "#{tag} (fastlane)"
+        expect(result).to eq("git tag -am #{message.shellescape} #{tag.shellescape}")
       end
 
       it "allows you to specify your own message" do
@@ -93,13 +103,12 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am message \'#{tag}\'")
+        expect(result).to eq("git tag -am #{message.shellescape} #{tag.shellescape}")
       end
 
       it "properly shell escapes its message" do
         tag = '2.0.0'
         message = "message with 'quotes' (and parens)"
-        escaped_message = "message\\ with\\ \\'quotes\\'\\ \\(and\\ parens\\)"
 
         result = Fastlane::FastFile.new.parse("lane :test do
           add_git_tag ({
@@ -108,7 +117,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am #{escaped_message} \'#{tag}\'")
+        expect(result).to eq("git tag -am #{message.shellescape} #{tag.shellescape}")
       end
 
       it "allows you to force the tag creation" do
@@ -123,7 +132,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am message --force \'#{tag}\'")
+        expect(result).to eq("git tag -am #{message.shellescape} --force #{tag.shellescape}")
       end
 
       it "allows you to specify the commit where to add the tag" do
@@ -139,7 +148,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am #{message} \'#{tag}\' #{commit}")
+        expect(result).to eq("git tag -am #{message.shellescape} #{tag.shellescape} #{commit}")
       end
 
       it "allows you to sign the tag using the default e-mail address's key." do
@@ -154,7 +163,7 @@ describe Fastlane do
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("git tag -am #{message} -s \'#{tag}\'")
+        expect(result).to eq("git tag -am #{message.shellescape} -s #{tag.shellescape}")
       end
     end
   end

--- a/fastlane/spec/actions_specs/appledoc_spec.rb
+++ b/fastlane/spec/actions_specs/appledoc_spec.rb
@@ -14,27 +14,29 @@ describe Fastlane do
       end
 
       it "accepts an input path with spaces" do
+        input_dir = "input/dir with spaces/file"
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
             project_name: 'Project Name',
             project_company: 'Company',
-            input: 'input/dir with spaces/file'
+            input: '#{input_dir}'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" input/dir\\ with\\ spaces/file")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" #{input_dir.shellescape}")
       end
 
       it "accepts an array of input paths" do
+        input_dir_with_spaces = "second/input dir with spaces"
         result = Fastlane::FastFile.new.parse("lane :test do
           appledoc(
             project_name: 'Project Name',
             project_company: 'Company',
-            input: ['input/dir', 'second/input dir with spaces', 'third/input/file.h']
+            input: ['input/dir', '#{input_dir_with_spaces}', 'third/input/file.h']
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" input/dir second/input\\ dir\\ with\\ spaces third/input/file.h")
+        expect(result).to eq("appledoc --project-name \"Project Name\" --project-company \"Company\" --exit-threshold \"2\" input/dir #{input_dir_with_spaces.shellescape} third/input/file.h")
       end
 
       it "adds output param to command" do

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -328,14 +328,15 @@ describe Fastlane do
       end
 
       it "use custom derived data" do
+        path = "../derived data"
         result = Fastlane::FastFile.new.parse("lane :test do
             carthage(
-              derived_data: '../derived data'
+              derived_data: '#{path}'
             )
           end").runner.execute(:test)
 
         expect(result).to \
-          eq("carthage bootstrap --derived-data ../derived\\ data")
+          eq("carthage bootstrap --derived-data #{path.shellescape}")
       end
 
       it "use custom executable" do

--- a/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -6,7 +6,10 @@ describe Fastlane do
           changelog_from_git_commits
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD")
+        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
+        # this is not really the command that would have been executed, but a "fabricated" representation for tests (by Actions.sh) that includes both command that would have been run
+        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD"
+        expect(result).to eq(pseudocommand)
       end
 
       it "Uses the provided pretty format to collect log messages" do
@@ -14,7 +17,9 @@ describe Fastlane do
           changelog_from_git_commits(pretty: '%s%n%b')
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%s%n%b\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD")
+        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
+        pseudocommand = "git log --pretty=\"%s%n%b\" #{inner_command.shellescape}...HEAD"
+        expect(result).to eq(pseudocommand)
       end
 
       it "Uses the provided date format to collect log messages if specified" do
@@ -22,7 +27,9 @@ describe Fastlane do
           changelog_from_git_commits(pretty: '%s%n%b', date_format: 'short')
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%s%n%b\" --date=\"short\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD")
+        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
+        pseudocommand = "git log --pretty=\"%s%n%b\" --date=\"short\" #{inner_command.shellescape}...HEAD"
+        expect(result).to eq(pseudocommand)
       end
 
       it "Does not match lightweight tags when searching for the last one if so requested" do
@@ -30,7 +37,9 @@ describe Fastlane do
           changelog_from_git_commits(match_lightweight_tag: false)
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD")
+        inner_command = "git describe `git rev-list --tags --max-count=1`"
+        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD"
+        expect(result).to eq(pseudocommand)
       end
 
       it "Collects logs in the specified revision range if specified" do
@@ -42,11 +51,12 @@ describe Fastlane do
       end
 
       it "Handles tag names with characters that need shell escaping" do
+        tag = 'v1.8.0(30)'
         result = Fastlane::FastFile.new.parse("lane :test do
-          changelog_from_git_commits(between: ['v1.8.0(30)', 'HEAD'])
+          changelog_from_git_commits(between: ['#{tag}', 'HEAD'])
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" v1.8.0\\(30\\)...HEAD")
+        expect(result).to eq("git log --pretty=\"%B\" #{tag.shellescape}...HEAD")
       end
 
       it "Does not accept a :between array of size 1" do
@@ -113,7 +123,9 @@ describe Fastlane do
           changelog_from_git_commits(include_merges: false)
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD --no-merges")
+        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
+        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD --no-merges"
+        expect(result).to eq(pseudocommand)
       end
 
       it "Only include merge commits if merge_commit_filtering is only_include_merges" do
@@ -121,7 +133,9 @@ describe Fastlane do
           changelog_from_git_commits(merge_commit_filtering: 'only_include_merges')
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD --merges")
+        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
+        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD --merges"
+        expect(result).to eq(pseudocommand)
       end
 
       it "Include merge commits if merge_commit_filtering is include_merges" do
@@ -129,7 +143,9 @@ describe Fastlane do
           changelog_from_git_commits(merge_commit_filtering: 'include_merges')
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD")
+        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
+        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD"
+        expect(result).to eq(pseudocommand)
       end
 
       it "Does not include merge commits if merge_commit_filtering is exclude_merges" do
@@ -137,15 +153,20 @@ describe Fastlane do
           changelog_from_git_commits(merge_commit_filtering: 'exclude_merges')
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD --no-merges")
+        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
+        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD --no-merges"
+        expect(result).to eq(pseudocommand)
       end
 
       it "Uses pattern matching for tag name if requested" do
+        tag_match_pattern = '*1.8*'
         result = Fastlane::FastFile.new.parse("lane :test do
-          changelog_from_git_commits(tag_match_pattern: '*1.8*')
+          changelog_from_git_commits(tag_match_pattern: '#{tag_match_pattern}')
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\=\\\\\\*1.8\\\\\\*\\ --max-count\\=1\\`...HEAD")
+        inner_command = "git describe --tags `git rev-list --tags=#{tag_match_pattern.shellescape} --max-count=1`"
+        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD"
+        expect(result).to eq(pseudocommand)
       end
 
       it "Does not use pattern matching for tag name if so requested" do
@@ -153,7 +174,9 @@ describe Fastlane do
           changelog_from_git_commits()
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" git\\ describe\\ --tags\\ \\`git\\ rev-list\\ --tags\\ --max-count\\=1\\`...HEAD")
+        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
+        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD"
+        expect(result).to eq(pseudocommand)
       end
 
       it "Runs between option from command line" do

--- a/fastlane/spec/actions_specs/create_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/create_keychain_spec.rb
@@ -22,15 +22,16 @@ describe Fastlane do
       end
 
       it "works with name and password that contain spaces or `\"`" do
+        password = "\"test password\""
         result = Fastlane::FastFile.new.parse("lane :test do
           create_keychain ({
             name: 'test.keychain',
-            password: '\"test password\"',
+            password: '#{password}',
           })
         end").runner.execute(:test)
 
         expect(result.size).to eq(3)
-        expect(result[0]).to eq(%(security create-keychain -p \\\"test\\ password\\\" ~/Library/Keychains/test.keychain))
+        expect(result[0]).to eq(%(security create-keychain -p #{password.shellescape} ~/Library/Keychains/test.keychain))
       end
 
       it "works with keychain-settings and name and password" do

--- a/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
@@ -62,10 +62,11 @@ describe Fastlane do
       end
 
       it "shellescapes the exclude_dirs correctly" do
+        directory = "My Dir"
         result = Fastlane::FastFile.new.parse("lane :test do
-          ensure_no_debug_code(text: 'pry', path: '.', exclude_dirs: ['My Dir'])
+          ensure_no_debug_code(text: 'pry', path: '.', exclude_dirs: ['#{directory}'])
         end").runner.execute(:test)
-        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('./')}' --exclude-dir My\\ Dir")
+        expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('./')}' --exclude-dir #{directory.shellescape}")
       end
 
       it "handles the exclude_dirs parameter with multiple  elements correctly" do

--- a/fastlane/spec/actions_specs/git_add_spec.rb
+++ b/fastlane/spec/actions_specs/git_add_spec.rb
@@ -31,7 +31,7 @@ describe Fastlane do
         let(:path) { "my file.txt" }
 
         it "executes the correct git command" do
-          allow(Fastlane::Actions).to receive(:sh).with("git add my\\ file.txt", anything).and_return("")
+          allow(Fastlane::Actions).to receive(:sh).with("git add #{path.shellescape}", anything).and_return("")
           result = Fastlane::FastFile.new.parse("lane :test do
             git_add(path: '#{path}')
           end").runner.execute(:test)
@@ -42,7 +42,7 @@ describe Fastlane do
         let(:path) { ["my file.txt", "some dir/your file.txt"] }
 
         it "executes the correct git command" do
-          allow(Fastlane::Actions).to receive(:sh).with("git add my\\ file.txt some\\ dir/your\\ file.txt", anything).and_return("")
+          allow(Fastlane::Actions).to receive(:sh).with("git add #{path[0].shellescape} #{path[1].shellescape}", anything).and_return("")
           result = Fastlane::FastFile.new.parse("lane :test do
             git_add(path: #{path})
           end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/git_commit_spec.rb
+++ b/fastlane/spec/actions_specs/git_commit_spec.rb
@@ -26,7 +26,7 @@ describe Fastlane do
           git_commit(path: ['./fastlane/*.md', './LICENSE'], message: 'message')
         end").runner.execute(:test)
 
-        expect(result).to eq("git commit -m message ./fastlane/\\*.md ./LICENSE")
+        expect(result).to eq("git commit -m message #{'./fastlane/*.md'.shellescape} ./LICENSE")
       end
 
       it "generates the correct git command with shell-escaped-paths" do
@@ -38,10 +38,11 @@ describe Fastlane do
       end
 
       it "generates the correct git command with a shell-escaped message" do
+        message = "message with 'quotes' (and parens)"
         result = Fastlane::FastFile.new.parse("lane :test do
-          git_commit(path: './fastlane/README.md', message: \"message with 'quotes' (and parens)\")
+          git_commit(path: './fastlane/README.md', message: \"#{message}\")
         end").runner.execute(:test)
-        expect(result).to eq("git commit -m message\\ with\\ \\'quotes\\'\\ \\(and\\ parens\\) ./fastlane/README.md")
+        expect(result).to eq("git commit -m #{message.shellescape} ./fastlane/README.md")
       end
     end
   end

--- a/fastlane/spec/actions_specs/import_certificate_spec.rb
+++ b/fastlane/spec/actions_specs/import_certificate_spec.rb
@@ -14,7 +14,7 @@ describe Fastlane do
         expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{keychain_path.shellescape} &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain_path.shellescape} &> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         allow(File).to receive(:file?).with(keychain_path).and_return(true)
@@ -69,7 +69,7 @@ describe Fastlane do
         expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{keychain_path.shellescape}"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain_path.shellescape}"
 
         allow(File).to receive(:file?).and_return(false)
         allow(File).to receive(:file?).with(keychain_path).and_return(true)

--- a/fastlane/spec/actions_specs/install_on_device_spec.rb
+++ b/fastlane/spec/actions_specs/install_on_device_spec.rb
@@ -9,10 +9,11 @@ describe Fastlane do
       end
 
       it "generates a valid command using app name with space" do
+        ipa = "demo app.ipa"
         result = Fastlane::FastFile.new.parse("lane :test do
-          install_on_device(ipa: 'demo app.ipa')
+          install_on_device(ipa: '#{ipa}')
         end").runner.execute(:test)
-        expect(result).to eq("ios-deploy --bundle demo\\ app.ipa")
+        expect(result).to eq("ios-deploy --bundle #{ipa.shellescape}")
       end
     end
   end

--- a/fastlane/spec/actions_specs/oclint_spec.rb
+++ b/fastlane/spec/actions_specs/oclint_spec.rb
@@ -68,16 +68,17 @@ describe Fastlane do
       end
 
       it "works with single quote in rule name" do
+        rule = "CoveredSwitchStatementsDon'tNeedDefault"
         result = Fastlane::FastFile.new.parse("lane :test do
             oclint(
               compile_commands: './fastlane/spec/fixtures/oclint/compile_commands.json',
-              enable_rules: [\"CoveredSwitchStatementsDon'tNeedDefault\"],
-              disable_rules: [\"CoveredSwitchStatementsDon'tNeedDefault\"]
+              enable_rules: [\"#{rule}\"],
+              disable_rules: [\"#{rule}\"]
             )
           end").runner.execute(:test)
 
-        expect(result).to include(" -rule CoveredSwitchStatementsDon\\'tNeedDefault ")
-        expect(result).to include(" -disable-rule CoveredSwitchStatementsDon\\'tNeedDefault ")
+        expect(result).to include(" -rule #{rule.shellescape} ")
+        expect(result).to include(" -disable-rule #{rule.shellescape} ")
       end
 
       it "works with select regex" do

--- a/fastlane/spec/actions_specs/slather_spec.rb
+++ b/fastlane/spec/actions_specs/slather_spec.rb
@@ -4,6 +4,7 @@ describe Fastlane do
       let(:action) { Fastlane::Actions::SlatherAction }
       it "works with all parameters" do
         allow(Fastlane::Actions::SlatherAction).to receive(:slather_version).and_return(Gem::Version.create('2.4.1'))
+        source_files = "*.swift"
         result = Fastlane::FastFile.new.parse("lane :test do
           slather({
             use_bundle_exec: false,
@@ -32,7 +33,7 @@ describe Fastlane do
             binary_basename: ['YourApp', 'YourFramework'],
             binary_file: 'you',
             workspace: 'foo.xcworkspace',
-            source_files: '*.swift',
+            source_files: '#{source_files}',
             decimals: '2'
           })
         end").runner.execute(:test)
@@ -63,7 +64,7 @@ describe Fastlane do
                     --binary-file you
                     --binary-basename YourApp
                     --binary-basename YourFramework
-                    --source-files \\*.swift
+                    --source-files #{source_files.shellescape}
                     --decimals 2 foo.xcodeproj".gsub(/\s+/, ' ')
         expect(result).to eq(expected)
       end
@@ -157,39 +158,46 @@ describe Fastlane do
       end
 
       it "works with spaces in paths" do
+        build_dir = "build dir"
+        source_dir = "source dir"
+        output_dir = "output dir"
+        ignore = "nothing to ignore"
+        scheme = "Foo App"
+        proj = "foo bar.xcodeproj"
         result = Fastlane::FastFile.new.parse("lane :test do
           slather({
-            build_directory: 'build dir',
+            build_directory: '#{build_dir}',
             input_format: 'bah',
-            scheme: 'Foo App',
-            source_directory: 'source dir',
-            output_directory: 'output dir',
-            ignore: 'nothing to ignore',
-            proj: 'foo bar.xcodeproj'
+            scheme: '#{scheme}',
+            source_directory: '#{source_dir}',
+            output_directory: '#{output_dir}',
+            ignore: '#{ignore}',
+            proj: '#{proj}'
           })
         end").runner.execute(:test)
 
         expected = "slather coverage
-                    --build-directory build\\ dir
-                    --source-directory source\\ dir
-                    --output-directory output\\ dir
-                    --ignore nothing\\ to\\ ignore
+                    --build-directory #{build_dir.shellescape}
+                    --source-directory #{source_dir.shellescape}
+                    --output-directory #{output_dir.shellescape}
+                    --ignore #{ignore.shellescape}
                     --input-format bah
-                    --scheme Foo\\ App
-                    foo\\ bar.xcodeproj".gsub(/\s+/, ' ')
-
+                    --scheme #{scheme.shellescape}
+                    #{proj.shellescape}".gsub(/\s+/, ' ')
         expect(result).to eq(expected)
       end
 
       it "works with multiple ignore patterns" do
+        pattern1 = "Pods/*"
+        pattern2 = "../**/*/Xcode*"
         result = Fastlane::FastFile.new.parse("lane :test do
           slather({
-            ignore: ['Pods/*', '../**/*/Xcode*'],
+            ignore: ['#{pattern1}', '#{pattern2}'],
             proj: 'foo.xcodeproj'
           })
         end").runner.execute(:test)
 
-        expect(result).to eq("slather coverage --ignore Pods/\\* --ignore ../\\*\\*/\\*/Xcode\\* foo.xcodeproj")
+        expect(result).to eq("slather coverage --ignore #{pattern1.shellescape} --ignore #{pattern2.shellescape} foo.xcodeproj")
       end
 
       describe "#configuration_available?" do

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -218,24 +218,27 @@ describe Fastlane do
 
       context "when file paths contain spaces" do
         it "escapes spaces in output and config file paths" do
+          output_file = "output path with spaces.txt"
+          config_file = ".config file with spaces.yml"
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(
-              output_file: 'output path with spaces.txt',
-              config_file: '.config file with spaces.yml'
+              output_file: '#{output_file}',
+              config_file: '#{config_file}'
             )
           end").runner.execute(:test)
 
-          expect(result).to eq("swiftlint lint --config .config\\ file\\ with\\ spaces.yml > output\\ path\\ with\\ spaces.txt")
+          expect(result).to eq("swiftlint lint --config #{config_file.shellescape} > #{output_file.shellescape}")
         end
 
         it "escapes spaces in list of files to process" do
+          file = "path/to/my project/source code/AppDelegate.swift"
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(
-                files: ['path/to/my project/source code/AppDelegate.swift']
+                files: ['#{file}']
             )
           end").runner.execute(:test)
 
-          expect(result).to eq("SCRIPT_INPUT_FILE_COUNT=1 SCRIPT_INPUT_FILE_0=path/to/my\\ project/source\\ code/AppDelegate.swift swiftlint lint --use-script-input-files")
+          expect(result).to eq("SCRIPT_INPUT_FILE_COUNT=1 SCRIPT_INPUT_FILE_0=#{file.shellescape} swiftlint lint --use-script-input-files")
         end
       end
 

--- a/fastlane/spec/helper/sh_helper_spec.rb
+++ b/fastlane/spec/helper/sh_helper_spec.rb
@@ -106,18 +106,22 @@ describe Fastlane::Actions do
     end
 
     it 'shelljoins multiple args' do
-      command = command_from_args("git", "commit", "-m", "A message")
-      expect(command).to eq('git commit -m A\ message')
+      message = "A message"
+      command = command_from_args("git", "commit", "-m", message)
+      expect(command).to eq("git commit -m #{message.shellescape}")
     end
 
     it 'adds an environment Hash at the beginning' do
-      command = command_from_args({ "PATH" => "/usr/local/bin" }, "git", "commit", "-m", "A message")
-      expect(command).to eq('PATH=/usr/local/bin git commit -m A\ message')
+      message = "A message"
+      command = command_from_args({ "PATH" => "/usr/local/bin" }, "git", "commit", "-m", message)
+      expect(command).to eq("PATH=/usr/local/bin git commit -m #{message.shellescape}")
     end
 
     it 'shell-escapes environment variable values' do
-      command = command_from_args({ "PATH" => "/usr/my local/bin" }, "git", "commit", "-m", "A message")
-      expect(command).to eq('PATH=/usr/my\ local/bin git commit -m A\ message')
+      message = "A message"
+      path = "/usr/my local/bin"
+      command = command_from_args({ "PATH" => path }, "git", "commit", "-m", message)
+      expect(command).to eq("PATH=#{path.shellescape} git commit -m #{message.shellescape}")
     end
 
     it 'recognizes an array as the only element of a command' do
@@ -126,8 +130,9 @@ describe Fastlane::Actions do
     end
 
     it 'recognizes an array as the first element of a command' do
-      command = command_from_args(["/usr/local/bin/git", "git"], "commit", "-m", "A message")
-      expect(command).to eq('/usr/local/bin/git commit -m A\ message')
+      message = "A message"
+      command = command_from_args(["/usr/local/bin/git", "git"], "commit", "-m", message)
+      expect(command).to eq("/usr/local/bin/git commit -m #{message.shellescape}")
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core.rb
+++ b/fastlane_core/lib/fastlane_core.rb
@@ -1,6 +1,7 @@
 require_relative 'fastlane_core/globals'
 # Ruby monkey-patches - should be before almost all else
 require_relative 'fastlane_core/core_ext/string'
+require_relative 'fastlane_core/core_ext/shellwords'
 
 require_relative 'fastlane_core/env'
 require_relative 'fastlane_core/feature/feature'

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -238,7 +238,7 @@ module FastlaneCore
       elsif data_type == Float
         return value.to_f if value.to_f.to_s == value.to_s
       elsif allow_shell_conversion
-        return Shellwords.join(value) if value.kind_of?(Array)
+        return value.shelljoin if value.kind_of?(Array)
         return value.map { |k, v| "#{k.to_s.shellescape}=#{v.shellescape}" }.join(' ') if value.kind_of?(Hash)
       elsif data_type != String
         # Special treatment if the user specified true, false or YES, NO

--- a/fastlane_core/lib/fastlane_core/core_ext/shellwords.rb
+++ b/fastlane_core/lib/fastlane_core/core_ext/shellwords.rb
@@ -24,6 +24,9 @@ module CrossplatformShellwords
     if FastlaneCore::Helper.windows?
       WindowsShellwords.shellescape(str)
     else
+      # using `escape` instead of expected `shellescape` here 
+      # which corresponds to Shellword's `String.shellescape` implementation 
+      # https://github.com/ruby/ruby/blob/1cf2bb4b2085758112503e7da7414d1ef52d4f48/lib/shellwords.rb#L216
       Shellwords.escape(str)
     end
   end

--- a/fastlane_core/lib/fastlane_core/core_ext/shellwords.rb
+++ b/fastlane_core/lib/fastlane_core/core_ext/shellwords.rb
@@ -1,0 +1,60 @@
+require_relative '../helper'
+require 'shellwords'
+
+# Here be monkey patches
+
+class String
+  # CrossplatformShellwords
+  def shellescape
+    CrossplatformShellwords.shellescape(self)
+  end
+end
+
+class Array
+  def shelljoin
+    CrossplatformShellwords.shelljoin(self)
+  end
+end
+
+# Here be helper
+
+module CrossplatformShellwords
+  # handle switching between implementations of shellescape
+  def shellescape(str)
+    if FastlaneCore::Helper.windows?
+      WindowsShellwords.shellescape(str)
+    else
+      Shellwords.escape(str)
+    end
+  end
+  module_function :shellescape
+
+  # make sure local implementation is also used in shelljoin
+  def shelljoin(array)
+    array.map { |arg| shellescape(arg) }.join(' ')
+  end
+  module_function :shelljoin
+end
+
+# Windows implementation
+module WindowsShellwords
+  def shellescape(str)
+    str = str.to_s
+
+    # An empty argument will be skipped, so return empty quotes.
+    # https://github.com/ruby/ruby/blob/a6413848153e6c37f6b0fea64e3e871460732e34/lib/shellwords.rb#L142-L143
+    return '""'.dup if str.empty?
+
+    str = str.dup
+
+    # wrap in double quotes if contains space
+    if str =~ /\s/
+      # double quotes have to be doubled if will be quoted
+      str.gsub!('"', '""')
+      return '"' + str + '"'
+    else
+      return str
+    end
+  end
+  module_function :shellescape
+end

--- a/fastlane_core/lib/fastlane_core/core_ext/shellwords.rb
+++ b/fastlane_core/lib/fastlane_core/core_ext/shellwords.rb
@@ -24,8 +24,8 @@ module CrossplatformShellwords
     if FastlaneCore::Helper.windows?
       WindowsShellwords.shellescape(str)
     else
-      # using `escape` instead of expected `shellescape` here 
-      # which corresponds to Shellword's `String.shellescape` implementation 
+      # using `escape` instead of expected `shellescape` here
+      # which corresponds to Shellword's `String.shellescape` implementation
       # https://github.com/ruby/ruby/blob/1cf2bb4b2085758112503e7da7414d1ef52d4f48/lib/shellwords.rb#L216
       Shellwords.escape(str)
     end

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -34,7 +34,8 @@ describe FastlaneCore do
         # We have to execute *something* using ` since otherwise we set expectations to `nil`, which is not healthy
         `ls`
 
-        cmd = %r{curl -f -o (([A-Z]\:)?\/.+) https://developer\.apple\.com/certificationauthority/AppleWWDRCA.cer && security import \1 -k keychain\\ with\\ spaces\.keychain}
+        keychain = "keychain with spaces.keychain"
+        cmd = %r{curl -f -o (([A-Z]\:)?\/.+) https://developer\.apple\.com/certificationauthority/AppleWWDRCA.cer && security import \1 -k #{Regexp.escape(keychain.shellescape)}}
         require "open3"
 
         expect(Open3).to receive(:capture3).with(cmd).and_return("")

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -235,9 +235,10 @@ describe FastlaneCore do
                                                      description: 'xcargs',
                                                      type: :shell_string)
 
-          value = config_item.auto_convert_value(['a b', 'c d', :e])
+          array = ['a b', 'c d', :e]
+          value = config_item.auto_convert_value(array)
 
-          expect(value).to eq('a\\ b c\\ d e')
+          expect(value).to eq(array.shelljoin)
         end
 
         it "auto converts Hash values to Strings if allowed" do
@@ -245,9 +246,12 @@ describe FastlaneCore do
                                                      description: 'xcargs',
                                                      type: :shell_string)
 
-          value = config_item.auto_convert_value({ 'FOO BAR' => 'I\'m foo bar', :BAZ => 'And I\'m baz' })
+          hash = { 'FOO BAR' => 'I\'m foo bar', :BAZ => 'And I\'m baz' }
+          value = config_item.auto_convert_value(hash)
 
-          expect(value).to eq('FOO\\ BAR=I\\\'m\\ foo\\ bar BAZ=And\\ I\\\'m\\ baz')
+          expected = 'FOO\\ BAR=I\\\'m\\ foo\\ bar BAZ=And\\ I\\\'m\\ baz'
+          expected = "\"FOO BAR\"=\"I'm foo bar\" BAZ=\"And I'm baz\"" if FastlaneCore::Helper.windows?
+          expect(value).to eq(expected)
         end
 
         it "does not auto convert Array values to Strings if not allowed" do

--- a/fastlane_core/spec/core_ext/shellwords_ext_spec.rb
+++ b/fastlane_core/spec/core_ext/shellwords_ext_spec.rb
@@ -1,0 +1,372 @@
+# references
+# normal implementation:
+# https://ruby-doc.org/stdlib-2.3.0/libdoc/shellwords/rdoc/Shellwords.html
+# https://github.com/ruby/ruby/blob/trunk/lib/shellwords.rb
+# "tests":
+# https://github.com/ruby/ruby/blob/trunk/test/test_shellwords.rb
+# https://github.com/ruby/ruby/blob/trunk/spec/ruby/library/shellwords/shellwords_spec.rb
+# other windows implementation:
+# https://github.com/larskanis/shellwords/tree/master/test
+
+# shellescape
+
+shellescape_testcases = [
+  # baseline
+  {
+    'it' => '(#1) on simple string',
+    'it_result' => {
+      'windows' => "doesn't change it",
+      'other'   => "doesn't change it"
+    },
+    'str' => 'normal_string_without_spaces',
+    'expect' => {
+      'windows' => 'normal_string_without_spaces',
+      'other'   => 'normal_string_without_spaces'
+    }
+  },
+  {
+    'it' => '(#2) on empty string',
+    'it_result' => {
+      'windows' => "wraps it in double quotes",
+      'other'   => 'wraps it in single quotes'
+    },
+    'str' => '',
+    'expect' => {
+      'windows' => '""',
+      'other'   => '\'\''
+    }
+  },
+  # spaces
+  {
+    'it' => '(#3) on string with spaces',
+    'it_result' => {
+      'windows' => "wraps it in double quotes",
+      'other'   => 'escapes spaces with <backslash>'
+    },
+    'str' => 'string with spaces',
+    'expect' => {
+      'windows' => '"string with spaces"',
+      'other'   => 'string\ with\ spaces'
+    }
+  },
+  # double quotes
+  {
+    'it' => '(#4) on simple string that is already wrapped in double quotes',
+    'it_result' => {
+      'windows' => "doesn't touch it",
+      'other'   => 'escapes the double quotes with <backslash>'
+    },
+    'str' => '"normal_string_without_spaces"',
+    'expect' => {
+      'windows' => '"normal_string_without_spaces"',
+      'other'   => '\"normal_string_without_spaces\"'
+    }
+  },
+  {
+    'it' => '(#5) on string with spaces that is already wrapped in double quotes',
+    'it_result' => {
+      'windows' => "wraps in double quotes and duplicates existing double quotes",
+      'other'   => 'escapes the double quotes and spaces with <backslash>'
+    },
+    'str' => '"string with spaces already wrapped in double quotes"',
+    'expect' => {
+      'windows' => '"""string with spaces already wrapped in double quotes"""',
+      'other'   => '\"string\ with\ spaces\ already\ wrapped\ in\ double\ quotes\"'
+    }
+  },
+  {
+    'it' => '(#6) on string with spaces and double quotes',
+    'it_result' => {
+      'windows' => "wraps in double quotes and duplicates existing double quotes",
+      'other'   => 'escapes the double quotes and spaces with <backslash>'
+    },
+    'str' => 'string with spaces and "double" quotes',
+    'expect' => {
+      'windows' => '"string with spaces and ""double"" quotes"',
+      'other'   => 'string\ with\ spaces\ and\ \"double\"\ quotes'
+    }
+  },
+  # https://github.com/ruby/ruby/blob/ac543abe91d7325ace7254f635f34e71e1faaf2e/test/test_shellwords.rb#L64-L65
+  {
+    'it' => '(#7) on simple int',
+    'it_result' => {
+      'windows' => "doesn't change it",
+      'other'   => "doesn't change it"
+    },
+    'str' => 3,
+    'expect' => {
+      'windows' => '3',
+      'other'   => '3'
+    }
+  },
+  # single quotes
+  {
+    'it' => '(#8) on simple string that is already wrapped in single quotes',
+    'it_result' => {
+      'windows' => "doesn't touch it",
+      'other'   => 'escapes the single quotes with <backslash>'
+    },
+    'str' => "'normal_string_without_spaces'",
+    'expect' => {
+      'windows' => "'normal_string_without_spaces'",
+      'other'   => "\\'normal_string_without_spaces\\'"
+    }
+  },
+  {
+    'it' => '(#9) on string with spaces that is already wrapped in single quotes',
+    'it_result' => {
+      'windows' => "wraps in double quotes",
+      'other'   => 'escapes the single quotes and spaces with <backslash>'
+    },
+    'str' => "'string with spaces already wrapped in single quotes'",
+    'expect' => {
+      'windows' => "\"'string with spaces already wrapped in single quotes'\"",
+      'other'   => "\\'string\\ with\\ spaces\\ already\\ wrapped\\ in\\ single\\ quotes\\'"
+    }
+  },
+  {
+    'it' => '(#10) string with spaces and single quotes',
+    'it_result' => {
+      'windows' => "wraps in double quotes and leaves single quotes",
+      'other'   => 'escapes the single quotes and spaces with <backslash>'
+    },
+    'str' => "string with spaces and 'single' quotes",
+    'expect' => {
+      'windows' => "\"string with spaces and 'single' quotes\"",
+      'other'   => 'string\ with\ spaces\ and\ \\\'single\\\'\ quotes'
+    }
+  },
+  {
+    'it' => '(#11) string with spaces and <backslash>',
+    'it_result' => {
+      'windows' => "wraps in double quotes and escapes the backslash with backslash",
+      'other'   => 'escapes the spaces and the backslash (which in results in quite a lot of them)'
+    },
+    'str' => "string with spaces and \\ in it",
+    'expect' => {
+      'windows' => "\"string with spaces and \\ in it\"",
+      'other'   => "string\\ with\\ spaces\\ and\\ \\\\\\ in\\ it"
+    }
+  },
+  {
+    'it' => '(#12) string with spaces and <slash>',
+    'it_result' => {
+      'windows' => "wraps in double quotes",
+      'other'   => 'escapes the spaces'
+    },
+    'str' => "string with spaces and / in it",
+    'expect' => {
+      'windows' =>  "\"string with spaces and / in it\"",
+      'other'   => "string\\ with\\ spaces\\ and\\ /\\ in\\ it"
+    }
+  },
+  {
+    'it' => '(#13) string with spaces and parens',
+    'it_result' => {
+      'windows' => "wraps in double quotes",
+      'other'   => 'escapes the spaces and parens'
+    },
+    'str' => "string with spaces and (parens) in it",
+    'expect' => {
+      'windows' => "\"string with spaces and (parens) in it\"",
+      'other'   => "string\\ with\\ spaces\\ and\\ \\(parens\\)\\ in\\ it"
+    }
+  },
+  {
+    'it' => '(#14) string with spaces, single quotes and parens',
+    'it_result' => {
+      'windows' => "wraps in double quotes",
+      'other'   => 'escapes the spaces, single quotes and parens'
+    },
+    'str' => "string with spaces and 'quotes' (and parens) in it",
+    'expect' => {
+      'windows' => "\"string with spaces and 'quotes' (and parens) in it\"",
+      'other'   => "string\\ with\\ spaces\\ and\\ \\'quotes\\'\\ \\(and\\ parens\\)\\ in\\ it"
+    }
+  }
+]
+
+# test shellescape Windows implementation directly
+describe "WindowsShellwords#shellescape" do
+  os = 'windows'
+  shellescape_testcases.each do |testcase|
+    it testcase['it'] + ': ' + testcase['it_result'][os] do
+      str = testcase['str']
+      escaped = WindowsShellwords.shellescape(str)
+
+      expect(escaped).to eq(testcase['expect'][os])
+      confirm_shell_unescapes_string_correctly(str, escaped)
+    end
+  end
+end
+
+# confirms that the escaped string that is generated actually
+# gets turned back into the source string by the actual shell.
+# abuses a `grep` (or `find`) error message because that should be cross platform
+def confirm_shell_unescapes_string_correctly(string, escaped)
+  compare_string = string.to_s.dup
+
+  if FastlaneCore::CommandExecutor.which('grep')
+    if FastlaneCore::Helper.windows?
+      compare_string = simulate_windows_shell_unwrapping(compare_string)
+    else
+      compare_string = simulate_normal_shell_unwrapping(compare_string)
+    end
+    compare_command = "grep 'foo' #{escaped}"
+    expected_compare_error = "grep: " + compare_string + ": No such file or directory"
+  elsif FastlaneCore::CommandExecutor.which('find')
+    compare_string = simulate_normal_shell_unwrapping(compare_string)
+    compare_string = compare_string.upcase
+    compare_command = "find \"foo\" #{escaped}"
+    expected_compare_error = "File not found - " + compare_string
+  end
+
+  # https://stackoverflow.com/a/18623297/252627, last variant
+  require 'open3'
+  Open3.popen3(compare_command) do |stdin, stdout, stderr, thread|
+    error = stderr.read.chomp
+    # expect(error).to eq(expected_compare_error)
+    expect(error).to eq(expected_compare_error) # match(/#{expected_compare_error}/)
+  end
+end
+
+# remove (double and single) quote pairs
+# un-double-double quote resulting string
+def simulate_windows_shell_unwrapping(string)
+  regex = /^("|')(([^"])(\S*)([^"]))("|')$/
+  unless string.to_s.match(regex).nil?
+    string = string.to_s.match(regex)[2] # get only part in quotes
+    string.to_s.gsub!('""', '"') # remove double double quotes
+  end
+  return string
+end
+
+# remove all double quotes completely
+def simulate_normal_shell_unwrapping(string)
+  string.gsub!('"', '')
+  regex = /^(')(\S*)(')$/
+  unless string.to_s.match(regex).nil?
+    string = string.to_s.match(regex)[2] # get only part in quotes
+  end
+  return string
+end
+
+# test monkey patched method on both (simulated) OSes
+describe "monkey patch of String.shellescape (via CrossplatformShellwords)" do
+  describe "on Windows" do
+    before(:each) do
+      allow(FastlaneCore::Helper).to receive(:windows?).and_return(true)
+    end
+
+    os = 'windows'
+    shellescape_testcases.each do |testcase|
+      it testcase['it'] + ': ' + testcase['it_result'][os] do
+        str = testcase['str'].to_s
+        escaped = str.shellescape
+        expect(escaped).to eq(testcase['expect'][os])
+      end
+    end
+  end
+
+  describe "on other OSs (macOS, Linux)" do
+    before(:each) do
+      allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
+    end
+
+    os = 'other'
+    shellescape_testcases.each do |testcase|
+      it testcase['it'] + ': ' + testcase['it_result'][os] do
+        str = testcase['str'].to_s
+        escaped = str.shellescape
+        expect(escaped).to eq(testcase['expect'][os])
+      end
+    end
+  end
+end
+
+# shelljoin
+# based on (reversal of) https://github.com/ruby/ruby/blob/trunk/spec/ruby/library/shellwords/shellwords_spec.rb
+
+shelljoin_testcases = [
+  {
+    'it' => '(#1) on array with entry with space',
+    'it_result' => {
+      'windows' => 'wraps this entry in double quotes',
+      'other'   => 'escapes the space in this entry'
+    },
+    'input' => ['a', 'b c', 'd'],
+    'expect' => {
+      'windows' => 'a "b c" d',
+      'other'   => 'a b\ c d'
+    }
+  },
+  {
+    'it' => '(#2) on array with entry with string wrapped in double quotes and space',
+    'it_result' => {
+      'windows' => 'wraps the entry with space in quote, and doubles the double quotes',
+      'other'   => 'escapes the double quotes and escapes the space'
+    },
+    'input' => ['a', '"b" c', 'd'],
+    'expect' => {
+      'windows' => 'a """b"" c" d',
+      'other'   => 'a \"b\"\ c d'
+    }
+  },
+  {
+    'it' => '(#3) on array with entry with string wrapped in single quotes and space',
+    'it_result' => {
+      'windows' => 'no changes',
+      'other'   => 'escapes the single quotes and space'
+    },
+    'input' => ['a', "'b' c", 'd'],
+    'expect' => {
+      'windows' => "a \"'b' c\" d",
+      'other'   => "a \\'b\\'\\ c d"
+    }
+  },
+  # https://github.com/ruby/ruby/blob/ac543abe91d7325ace7254f635f34e71e1faaf2e/test/test_shellwords.rb#L67-L68
+  {
+    'it' => '(#4) on array with entry that is funny $$',
+    'it_result' => {
+      'windows' => 'no idea',
+      'other'   => 'no idea'
+    },
+    'input' => ['ps', '-p', $$],
+    'expect' => {
+      'windows' => "ps -p #{$$}",
+      'other'   => "ps -p #{$$}"
+    }
+  }
+]
+
+describe "monkey patch of Array.shelljoin (via CrossplatformShellwords)" do
+  describe "on Windows" do
+    before(:each) do
+      allow(FastlaneCore::Helper).to receive(:windows?).and_return(true)
+    end
+
+    os = 'windows'
+    shelljoin_testcases.each do |testcase|
+      it testcase['it'] + ': ' + testcase['it_result'][os] do
+        array = testcase['input']
+        joined = array.shelljoin
+        expect(joined).to eq(testcase['expect'][os])
+      end
+    end
+  end
+
+  describe "on other OSs (macOS, Linux)" do
+    before(:each) do
+      allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
+    end
+
+    os = 'other'
+    shelljoin_testcases.each do |testcase|
+      it testcase['it'] + ': ' + testcase['it_result'][os] do
+        array = testcase['input']
+        joined = array.shelljoin
+        expect(joined).to eq(testcase['expect'][os])
+      end
+    end
+  end
+end

--- a/fastlane_core/spec/core_ext/shellwords_ext_spec.rb
+++ b/fastlane_core/spec/core_ext/shellwords_ext_spec.rb
@@ -326,10 +326,10 @@ shelljoin_testcases = [
   },
   # https://github.com/ruby/ruby/blob/ac543abe91d7325ace7254f635f34e71e1faaf2e/test/test_shellwords.rb#L67-L68
   {
-    'it' => '(#4) on array with entry that is funny $$',
+    'it' => '(#4) on array with entry that is `$$`',
     'it_result' => {
-      'windows' => 'no idea',
-      'other'   => 'no idea'
+      'windows' => 'the result includes the process id',
+      'other'   => 'the result includes the process id'
     },
     'input' => ['ps', '-p', $$],
     'expect' => {

--- a/fastlane_core/spec/core_ext/shellwords_ext_spec.rb
+++ b/fastlane_core/spec/core_ext/shellwords_ext_spec.rb
@@ -377,16 +377,15 @@ end
 
 def expect_correct_implementation_to_be_called(obj, method, os)
   if method == :shellescape
-    # String.shellescape => ...
+    # String.shellescape => CrossplatformShellwords.shellescape => ...
     expect(obj).to receive(:shellescape).and_call_original
+    expect(CrossplatformShellwords).to receive(:shellescape).with(obj).and_call_original
     if os == 'windows'
-      # ... CrossplatformShellwords.shellescape => WindowsShellwords.shellescape
-      expect(CrossplatformShellwords).to receive(:shellescape).with(obj).and_call_original
+      # WindowsShellwords.shellescape
       expect(WindowsShellwords).to receive(:shellescape).with(obj).and_call_original
       expect(Shellwords).not_to(receive(:escape))
     else
-      # ... CrossplatformShellwords.shellescape => Shellswords.escape
-      expect(CrossplatformShellwords).to receive(:shellescape).with(obj).and_call_original
+      # Shellswords.escape
       expect(Shellwords).to receive(:escape).with(obj).and_call_original
       expect(WindowsShellwords).not_to(receive(:shellescape))
     end

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -6,10 +6,10 @@ describe Match do
 
     describe 'import' do
       it 'finds a normal keychain name relative to ~/Library/Keychains' do
-        expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P '' -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
+        expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{Dir.home}/Library/Keychains/login.keychain &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain &> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
@@ -25,10 +25,10 @@ describe Match do
       it 'treats a keychain name it cannot find in ~/Library/Keychains as the full keychain path' do
         tmp_path = Dir.mktmpdir
         keychain = "#{tmp_path}/my/special.keychain"
-        expected_command = "security import item.path -k '#{keychain}' -P '' -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
+        expected_command = "security import item.path -k '#{keychain}' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{keychain} &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain} &> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with(keychain).and_return(true)
@@ -50,10 +50,10 @@ describe Match do
       end
 
       it "tries to find the macOS Sierra keychain too" do
-        expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain-db' -P '' -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
+        expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain-db' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k '' #{Dir.home}/Library/Keychains/login.keychain-db &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db &> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain-db").and_return(true)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

[`Shellwords.shellescape` is not cross platform safe](https://github.com/fastlane/fastlane/issues/13213). This causes problems for commands that are to be used on the shell and contain e.g. paths with spaces or other non-[A-Z0-9] characters.

### Description

This PR monkey patches the `String.shellescape` and `Array.shelljoin` methods that `Shellwords` usually supplies. The patch uses a new module `CrossplatformShellwords` that decides if the normal `Shellwords` or a new `WindowsShellwords` should be used to call the methods.

The PR fixes all the tests that started failing on Windows after the monkey patch became active: all the tests that had hardcoded expected command strings that were compared to command strings generated by the actions (mostly via `Actions.sh` internally) via `var.shellescape`. 

The PR also adds tests for the monkey patched methods, both `WindowsShellwords` and the `*.shell*` methods (in a mock Windows and non-Windows environment) are tested.

#### Limitations

`WindowsShellwords` itself is a pretty basic implementation of mainly `shellescape`. I don't expect this version to cover all use cases and edge cases. Those will be discovered over time when fastlane actions will fail because of malformed commands that do not run on Windows as expected - but it is a starting point.

Tests for actions and methods that compare a hardcoded string to a manually built command string could **not** be identified automatically during this PR. I hope there aren't to many, but it will only affect usage on Windows anyway. macOS is not affected.

This PR also could do nothing to actually _test_ the generated commands, as during test execution all the commands are just returned from `Actions.sh` and not executed. Those tests will have to happen in actual usage of the actions.

--- 
closes #13213