### PR TITLE
[changelog_from_git_commits] Added quiet parameter

### DIFF
--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -45,9 +45,11 @@ module Fastlane
           changelog = changelog.gsub("\n\n", "\n") if changelog # as there are duplicate newlines
           Actions.lane_context[SharedValues::FL_CHANGELOG] = changelog
 
-          puts("")
-          puts(changelog)
-          puts("")
+          if params[:quiet] == false
+            puts("")
+            puts(changelog)
+            puts("")
+          end
 
           changelog
         end
@@ -127,6 +129,12 @@ module Fastlane
                                        description: 'Whether or not to match a lightweight tag when searching for the last one',
                                        optional: true,
                                        default_value: true,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :quiet,
+                                       env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_TAG_QUIET',
+                                       description: 'Whether or not to disbale changelog output',
+                                       optional: true,
+                                       default_value: false,
                                        is_string: false),
           FastlaneCore::ConfigItem.new(key: :include_merges,
                                        deprecated: "Use `:merge_commit_filtering` instead",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Fixes: https://github.com/fastlane/fastlane/issues/13240

### Description
Added parameter to suppress output. Tested with bundle