### PR TITLE
update xcodeproj gem to 1.6.0

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = Dir["*/lib"]
 
   spec.add_dependency('slack-notifier', '>= 2.0.0', '< 3.0.0') # Slack notifications
-  spec.add_dependency('xcodeproj', '>= 1.5.7', '< 2.0.0') # Needed for commit_version_bump action and gym code_signing_mapping
+  spec.add_dependency('xcodeproj', '>= 1.6.0', '< 2.0.0') # Needed for commit_version_bump action and gym code_signing_mapping
   spec.add_dependency('xcpretty', '~> 0.2.8') # prettify xcodebuild output
   spec.add_dependency('terminal-notifier', '>= 1.6.2', '< 2.0.0') # macOS notifications
   spec.add_dependency('terminal-table', '>= 1.4.5', '< 2.0.0') # Actions documentation

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = Dir["*/lib"]
 
   spec.add_dependency('slack-notifier', '>= 2.0.0', '< 3.0.0') # Slack notifications
-  spec.add_dependency('xcodeproj', '>= 1.6.0', '< 2.0.0') # Needed for commit_version_bump action and gym code_signing_mapping
+  spec.add_dependency('xcodeproj', '>= 1.6.0', '< 2.0.0') # Modify Xcode projects
   spec.add_dependency('xcpretty', '~> 0.2.8') # prettify xcodebuild output
   spec.add_dependency('terminal-notifier', '>= 1.6.2', '< 2.0.0') # macOS notifications
   spec.add_dependency('terminal-table', '>= 1.4.5', '< 2.0.0') # Actions documentation

--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane do
       allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
     end
 
-    it "enable_automatic_code_signing", requires_xcodeproj: true do
+    it "enable_automatic_code_signing" do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Automatic'")
       result = Fastlane::FastFile.new.parse("lane :test do
@@ -30,7 +30,7 @@ describe Fastlane do
       end
     end
 
-    it "disable_automatic_code_signing for specific target", requires_xcodeproj: true do
+    it "disable_automatic_code_signing for specific target" do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
       expect(UI).to receive(:success).with("\t * today")
@@ -52,7 +52,7 @@ describe Fastlane do
       end
     end
 
-    it "disable_automatic_code_signing", requires_xcodeproj: true do
+    it "disable_automatic_code_signing" do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
       result = Fastlane::FastFile.new.parse("lane :test do
@@ -72,7 +72,7 @@ describe Fastlane do
       end
     end
 
-    it "sets team id", requires_xcodeproj: true do
+    it "sets team id" do
       # G3KGXDXQL9
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
@@ -99,7 +99,7 @@ describe Fastlane do
       end
     end
 
-    it "sets code sign identity", requires_xcodeproj: true do
+    it "sets code sign identity" do
       temp_dir = Dir.tmpdir
       FileUtils.copy_entry('./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', temp_dir)
 
@@ -138,7 +138,7 @@ describe Fastlane do
       end
     end
 
-    it "sets profile name", requires_xcodeproj: true do
+    it "sets profile name" do
       # G3KGXDXQL9
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
@@ -170,7 +170,7 @@ describe Fastlane do
       end
     end
 
-    it "sets profile uuid", requires_xcodeproj: true do
+    it "sets profile uuid" do
       # G3KGXDXQL9
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
@@ -202,7 +202,7 @@ describe Fastlane do
       end
     end
 
-    it "sets bundle identifier", requires_xcodeproj: true do
+    it "sets bundle identifier" do
       # G3KGXDXQL9
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
@@ -234,7 +234,7 @@ describe Fastlane do
       end
     end
 
-    it "targets not found notice", requires_xcodeproj: true do
+    it "targets not found notice" do
       allow(UI).to receive(:important)
       expect(UI).to receive(:important).with("None of the specified targets has been modified")
       result = Fastlane::FastFile.new.parse("lane :test do
@@ -243,7 +243,7 @@ describe Fastlane do
       expect(result).to eq(false)
     end
 
-    it "raises exception on old projects", requires_xcodeproj: true do
+    it "raises exception on old projects" do
       expect(UI).to receive(:user_error!).with("Seems to be a very old project file format - please open your project file in a more recent version of Xcode")
       result = Fastlane::FastFile.new.parse("lane :test do
         disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic-code-signing-old.xcodeproj')

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -89,9 +89,6 @@ RSpec.configure do |config|
     config.define_derived_metadata(:requires_security) do |meta|
       meta[:skip] = "Skipped: Requires `security` to be installed (which is not possible on this platform and no workaround has been implemented)"
     end
-    config.define_derived_metadata(:requires_xcodeproj) do |meta|
-      meta[:skip] = "Skipped: Requires `xcodeproj` which is unfortunately currently broken on Windows: https://github.com/CocoaPods/Xcodeproj/issues/549"
-    end
 
     # also skip `before()` for test groups that are skipped because of their tags.
     # only works for `describe` groups (that are parents of the `before`, not if the tag is set on `it`.


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`xcodeproj` has a new version `1.6.0` that comes with some nice bugfixes.

### Description
Update the gemspec to make sure at least 1.6.0 or newer are used. 
Also improve the description of the gem in the gemspec.
And undo some tests disabling that had to be done on Windows because of one of the bugs fixed.

---
closes #13220
closes #13156
reverts #11897
