### PR TITLE
[WIP] [frameit] Add iPad Pro 11, 10.5 and 9.7 frames (by resizing 12.9)

### DIFF
--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -80,7 +80,6 @@ def resize_missing_frames
     width = resize_config["width"]
     output_path = resize_config["output_path"]
 
-
     system("sips --resampleHeightWidth #{height} #{width} '#{current_raw}' --out '#{output_path}'")
   end
 end

--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -28,6 +28,8 @@ task(:generate_device_frames) do
   sh("rm -rf output")
   mkdir_p(output) unless File.directory?(output)
 
+  resize_missing_frames
+
   image_assets = []
   (Dir["raw/Phones/Apple*/Device/*.png"] + Dir["raw/Computers/Apple*/Device/*.png"] + Dir["raw/Tablets/Apple*/Device/*.png"]).each do |current_raw|
     basename = File.basename(current_raw)
@@ -60,6 +62,27 @@ task(:generate_device_frames) do
   puts("To do so, clone https://github.com/fastlane/frameit-frames, make sure to check out the `gh-pages` branch".green)
   puts("and overwrite the 'latest' folder, and copy the time stamp folder into the root.".green)
   puts("Push the changes, and run `fastlane frameit update_frames` to ensure everything worked as expected".green)
+end
+
+def resize_missing_frames
+  file = File.read('resizes.json')
+  data = JSON.parse(file)
+
+  (Dir["raw/Phones/Apple*/Device/*.png"] + Dir["raw/Computers/Apple*/Device/*.png"] + Dir["raw/Tablets/Apple*/Device/*.png"]).each do |current_raw|
+    basename = File.basename(current_raw)
+
+    output_dir = File.dirname(current_raw)
+    FileUtils.mkdir_p(File.dirname(output_dir))
+
+    resize_config = data[basename]
+    next unless resize_config
+    height = resize_config["height"]
+    width = resize_config["width"]
+    output_path = resize_config["output_path"]
+
+
+    system("sips --resampleHeightWidth #{height} #{width} '#{current_raw}' --out '#{output_path}'")
+  end
 end
 
 def confirm

--- a/frameit/frames_generator/offsets.json
+++ b/frameit/frames_generator/offsets.json
@@ -35,6 +35,10 @@
     "iPad Pro": {
       "offset": "+118+215",
       "width": 2050
+    },
+    "iPad Pro 10-5": {
+      "offset": "+100+175",
+      "width": 1668
     }
   }
 }

--- a/frameit/frames_generator/resizes.json
+++ b/frameit/frames_generator/resizes.json
@@ -1,0 +1,17 @@
+{
+  "Apple iPad Pro Gold.png": {
+    "height": 2798,
+    "width": 1996,
+    "output_path": "raw/Tablets/Apple iPad Pro 10-5/Device/Apple iPad Pro 10-5 Gold.png"
+  },
+  "Apple iPad Pro Silver.png": {
+    "height": 2798,
+    "width": 1996,
+    "output_path": "raw/Tablets/Apple iPad Pro 10-5/Device/Apple iPad Pro 10-5 Silver.png"
+  },
+  "Apple iPad Pro Space Gray.png": {
+    "height": 2798,
+    "width": 1996,
+    "output_path": "raw/Tablets/Apple iPad Pro 10-5/Device/Apple iPad Pro 10-5 Space Gray.png"
+  }
+}

--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -43,6 +43,8 @@ module Frameit
         return 'iPad Air 2'
       when sizes::IOS_IPAD_PRO
         return 'iPad Pro'
+      when sizes::IOS_IPAD_10_5
+        return 'iPad Pro 10-5'
       when sizes::MAC
         return 'MacBook'
       else


### PR DESCRIPTION
⚠️ WIP - still need to add 9.7 and 11 support

Fixes #9651 + #14079

This is a replacement for #12837 as new frame files are actually needed (closes #12837)

## Problem
iPad Pro 10.5 and 9.7 frames are not supported by _frameit_. The frame images that are used by _frameit_ are pulled from https://facebook.design/devices but this only contains frames for iPad Pro 12.9.

## Solution
This solution adds a new file called `resizes.json` which will take existing frames and resize them. This **shouldn't** be used heavily as it it mess up the aspect ratio but this works as an automated approach for making iPad Pro 10.5 and 9.7 frames without modifying the aspect ratio 😬 