### PR TITLE
Pull in new test result path for Xcode 10.

### DIFF
--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -77,7 +77,15 @@ module Fastlane
       private_class_method
 
       def self.test_summary_filenames(derived_data_path)
-        Dir["#{derived_data_path}/**/Logs/Test/*TestSummaries.plist"]
+        files = []
+
+        # Xcode < 10
+        files += Dir["#{derived_data_path}/**/Logs/Test/*TestSummaries.plist"]
+
+        # Xcode 10
+        files += Dir["#{derived_data_path}/**/Logs/Test/*.xcresult/TestSummaries.plist"]
+
+        return files
       end
 
       def self.example_code


### PR DESCRIPTION
Fixes #13034.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Xcode 10 changes where test reports are placed, and this breaks existing code that locates the test report plist files. This PR looks in both the old and new locations to determine where the test logs live.

### Description
The `test_summary_filenames` method now builds an array of files from both locations. This is purely additive, so the existing code should continue to work fine on Xcode 9.