### PR TITLE
Remove default destination argument for build-for-testing builds

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -202,6 +202,11 @@ module Scan
         return
       end
 
+      # Do not set destination by default for build_for_testing
+      if Scan.config[:build_for_testing]
+        return
+      end
+
       # building up the destination now
       if Scan.devices && Scan.devices.count > 0
         Scan.config[:destination] = Scan.devices.map { |d| "platform=#{d.os_type} Simulator,id=#{d.udid}" }

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -127,7 +127,7 @@ module Scan
 
     # Generate destination parameters
     def destination
-      unless Scan.cache[:destination]
+      if !Scan.cache[:destination] && Scan.config[:destination]
         Scan.cache[:destination] = [*Scan.config[:destination]].map { |dst| "-destination '#{dst}'" }.join(' ')
       end
       Scan.cache[:destination]


### PR DESCRIPTION
…codebuild

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Firebase Testlab only accepts builds done without destination for some reasons, but scan plugin always makes one.

### Description
This PR makes it default not to include destination for build-for-testing type of builds.