### PR TITLE
[scan] add skip_detect_devices

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -166,27 +166,33 @@ module Scan
         set_of_simulators.to_a
       end
 
-      default = lambda do
-        UI.error("Couldn't find any matching simulators for '#{devices}' - falling back to default simulator") if (devices || []).count > 0
+      unless Scan.config[:skip_detect_devices]
+        default = lambda do
+          UI.error("Couldn't find any matching simulators for '#{devices}' - falling back to default simulator") if (devices || []).count > 0
 
-        result = Array(
-          simulators
-            .select { |sim| sim.name == default_device_name }
-            .reverse # more efficient, because `simctl` prints higher versions first
-            .sort_by! { |sim| Gem::Version.new(sim.os_version) }
-            .last || simulators.first
-        )
+          result = Array(
+            simulators
+              .select { |sim| sim.name == default_device_name }
+              .reverse # more efficient, because `simctl` prints higher versions first
+              .sort_by! { |sim| Gem::Version.new(sim.os_version) }
+              .last || simulators.first
+          )
 
-        UI.message("Found simulator \"#{result.first.name} (#{result.first.os_version})\"") if result.first
+          UI.message("Found simulator \"#{result.first.name} (#{result.first.os_version})\"") if result.first
 
-        result
+          result
+        end
       end
 
       # grab the first unempty evaluated array
-      Scan.devices = [matches, default].lazy.map { |x|
-        arr = x.call
-        arr unless arr.empty?
-      }.reject(&:nil?).first
+      if default
+        Scan.devices = [matches, default].lazy.map { |x|
+          arr = x.call
+          arr unless arr.empty?
+        }.reject(&:nil?).first
+      else
+        Scan.devices = []
+      end
     end
 
     def self.min_xcode8?
@@ -205,7 +211,7 @@ module Scan
       # building up the destination now
       if Scan.devices && Scan.devices.count > 0
         Scan.config[:destination] = Scan.devices.map { |d| "platform=#{d.os_type} Simulator,id=#{d.udid}" }
-      else
+      elsif Scan.project.mac_app?
         Scan.config[:destination] = min_xcode8? ? ["platform=macOS"] : ["platform=OS X"]
       end
     end

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -61,6 +61,11 @@ module Scan
                                      conflict_block: proc do |value|
                                        UI.user_error!("You can't use 'device' and 'devices' options in one run")
                                      end),
+        FastlaneCore::ConfigItem.new(key: :skip_detect_devices,
+                                     description: "Should skip auto detecting of devices if none were specified",
+                                     default_value: false,
+                                     type: Boolean,
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :scheme,
                                      short_option: "-s",
                                      optional: true,


### PR DESCRIPTION
## Motivation
_scan_'s `detect_values.rb` was auto detecting simulators which was auto filing the `:destination` config. This is great but not if wanting to be able to run tests on a real device.

## Description
This PR allows the user to opt-out in detecting simulators using the `:skip_detect_devices` option. This also fixes the `detect_destination` flag to only set as macos/osx so that it can only happen on a mac project.