### PR TITLE
[spaceship] use itunesconnect.com hostname when looking up itc_service_key for olympus session

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -508,7 +508,10 @@ module Spaceship
       itc_service_key_path = "/tmp/spaceship_itc_service_key.txt"
       return File.read(itc_service_key_path) if File.exist?(itc_service_key_path)
 
-      response = request(:get, "https://olympus.itunes.apple.com/v1/app/config?hostname=appstoreconnect.apple.com")
+      # Fixes issue https://github.com/fastlane/fastlane/issues/13281
+      # Even though we are using https://appstoreconnect.apple.com, the service key needs to still use a
+      # hostname through itunesconnect.apple.com
+      response = request(:get, "https://olympus.itunes.apple.com/v1/app/config?hostname=itunesconnect.apple.com")
       @service_key = response.body["authServiceKey"].to_s
 
       raise "Service key is empty" if @service_key.length == 0

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -23,7 +23,7 @@ class TunesStubbing
         to_return(status: 200, body: "")
       stub_request(:get, "https://olympus.itunes.apple.com/v1/session").
         to_return(status: 200, body: itc_read_fixture_file('olympus_session.json'))
-      stub_request(:get, "https://olympus.itunes.apple.com/v1/app/config?hostname=appstoreconnect.apple.com").
+      stub_request(:get, "https://olympus.itunes.apple.com/v1/app/config?hostname=itunesconnect.apple.com").
         to_return(status: 200, body: { authServiceKey: 'e0abc' }.to_json, headers: { 'Content-Type' => 'application/json' })
 
       # Actual login


### PR DESCRIPTION
Fixes #13281
Fixes #13282

## Motivation
Regression was introduced in #13272. Needed to switch over from itunesconnect.apple.com to appstoreconnect.apple.com for API end points (some users were getting gateway errors because of this). It turns out that the `itc_sevice_key` needs to use the `itunesconnect.apple.com` as the hostname still when looking up using the olympus session
