### PR TITLE
Add an option to overwrite zip file

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -279,14 +279,20 @@ module FastlaneCore
     end
 
     # Zips directory
-    def self.zip_directory(path, output_path, contents_only: false, print: true)
+    def self.zip_directory(path, output_path, contents_only: false, overwrite: false, print: true)
+      if overwrite
+        overwrite_command = " && rm -f '#{output_path}'"
+      else
+        overwrite_command = ""
+      end
+
       if contents_only
-        command = "cd '#{path}' && zip -r '#{output_path}' *"
+        command = "cd '#{path}'#{overwrite_command} && zip -r '#{output_path}' *"
       else
         containing_path = File.expand_path("..", path)
         contents_path = File.basename(path)
 
-        command = "cd '#{containing_path}' && zip -r '#{output_path}' '#{contents_path}'"
+        command = "cd '#{containing_path}'#{overwrite_command} && zip -r '#{output_path}' '#{contents_path}'"
       end
 
       UI.command(command) unless print

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -110,7 +110,7 @@ module Scan
 
       # Zips build products and moves it to output directory
       UI.message("Zipping build products")
-      FastlaneCore::Helper.zip_directory(path, output_path, contents_only: true, print: false)
+      FastlaneCore::Helper.zip_directory(path, output_path, contents_only: true, overwrite: true, print: false)
       UI.message("Succesfully zipped build products: #{output_path}")
     end
 

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -135,7 +135,7 @@ describe Scan do
         output_path = File.absolute_path('/tmp/scan_results/build_products.zip')
 
         expect(FastlaneCore::Helper).to receive(:backticks)
-          .with("cd '#{path}' && zip -r '#{output_path}' *", { print: false })
+          .with("cd '#{path}' && rm -f '#{output_path}' && zip -r '#{output_path}' *", { print: false })
           .exactly(1).times
 
         scan = Scan::Runner.new


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
By default `zip -r something.zip *` appends all the files into if the zip file already exists. This might cause unexpected behavior.

### Description
This PR adds an option to disable appending.
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
