### PR TITLE
Push only tags on `push_git_tags`

### DIFF
--- a/fastlane/lib/fastlane/actions/push_git_tags.rb
+++ b/fastlane/lib/fastlane/actions/push_git_tags.rb
@@ -5,9 +5,14 @@ module Fastlane
         command = [
           'git',
           'push',
-          params[:remote],
-          params[:tag] || '--tags'
+          params[:remote]
         ]
+
+        if params[:tag]
+          command << "refs/tags/#{params[:tag].shellescape}"
+        else
+          command << '--tags'
+        end
 
         # optionally add the force component
         command << '--force' if params[:force]

--- a/fastlane/lib/fastlane/actions/push_git_tags.rb
+++ b/fastlane/lib/fastlane/actions/push_git_tags.rb
@@ -9,7 +9,7 @@ module Fastlane
         ]
 
         if params[:tag]
-          command << "refs/tags/#{params[:tag].shellescape}"
+          command << "refs/tags/#{params[:tag]}"
         else
           command << '--tags'
         end

--- a/fastlane/spec/actions_specs/push_git_tags_spec.rb
+++ b/fastlane/spec/actions_specs/push_git_tags_spec.rb
@@ -38,7 +38,7 @@ describe Fastlane do
           push_git_tags(remote: 'foo', tag: 'v1.0')
         end").runner.execute(:test)
 
-        expect(result).to eq("git push foo v1.0")
+        expect(result).to eq("git push foo refs/tags/v1.0")
       end
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The `push_git_tags` command seemed to be ambiguous. As an example, if by accident a tag had the same name as a branch, that branch could be pushed to the remote.

### Description
Changed the command to get the tag to push from `refs/tags/` in order to disambiguate and make sure that only tags can be pushed.

Also updated tests in order to test this behaviour.