### PR TITLE
FL_HOCKEY_TIMEOUT fix for "undefined method `zero?'"

### DIFF
--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -323,7 +323,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :timeout,
                                       env_name: "FL_HOCKEY_TIMEOUT",
                                       description: "Request timeout in seconds",
-                                      is_string: false,
+                                      type: Integer,
                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :bypass_cdn,
                                       env_name: "FL_HOCKEY_BYPASS_CDN",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
There was no type specified for `FL_HOCKEY_TIMEOUT`, and therefore it was passed to _faraday_ as string, causing: ``undefined method `zero?'``

### Description
I set the config item type to `Integer`.
I did not actually test it, but given that the original version leads to undefined method, that path of execution can only become better with the change.