### PR TITLE
[core] bubble up FastlanePty exit status in FastlanePtyError

### DIFF
--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -63,7 +63,8 @@ module FastlaneCore
               UI.command_output(line)
             end
           end
-        rescue => ex
+        rescue FastlaneCore::FastlanePtyError => ex
+          status = ex.exit_status
           # This could happen when the environment is wrong:
           # > invalid byte sequence in US-ASCII (ArgumentError)
           output << ex.to_s

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -2,6 +2,15 @@
 # https://github.com/fastlane/fastlane/pull/11384#issuecomment-356084518 and
 # https://github.com/DragonBox/u3d/blob/59e471ad78ac00cb629f479dbe386c5ad2dc5075/lib/u3d_core/command_runner.rb#L88-L96
 module FastlaneCore
+  class FastlanePtyError < StandardError
+    attr_reader :exit_status
+    def initialize(e, exit_status)
+      super(e)
+      set_backtrace(e.backtrace) if e
+      @exit_status = exit_status
+    end
+  end
+
   class FastlanePty
     def self.spawn(command)
       require 'pty'
@@ -31,6 +40,11 @@ module FastlaneCore
         command_stdout.close
         p.value.exitstatus
       end
+    rescue StandardError => e
+      # Wrapping any error in FastlanePtyError to allow
+      # callers to see and use $?.exitstatus that
+      # would usually get returned
+      raise FastlanePtyError.new(e, $?.exitstatus)
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -60,7 +60,8 @@ module FastlaneCore
             end
           end
         end
-      rescue => ex
+      rescue FastlaneCore::FastlanePtyError => ex
+        exit_status = ex.exit_status
         @errors << ex.to_s
       end
 


### PR DESCRIPTION
Fixes #13305
Fixes #13321
Fixes #13323

## Problem
The `$?.exitstatus` was recently changed to being returned from `FastlanePty.spawn`. If an error got raised from within `FastlanePty.spawn`, the exit status would not be returned. This would make the exit status variable that was expected to return actually end up being `nil` which would cause things to 💥 

## Solution
`FastlanePty.spawn` now wraps all exceptions in a `FastlanePtyError` which has a `exit_status` attributes which can be used by any of the callers.