### PR TITLE
[core] add exit_status to FastlanePty errors

### DIFF
--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -63,8 +63,10 @@ module FastlaneCore
               UI.command_output(line)
             end
           end
-        rescue FastlaneCore::FastlanePtyError => ex
+        rescue => ex
+          # FastlanePty adds exit_status on to StandardError so every error will have a status code
           status = ex.exit_status
+
           # This could happen when the environment is wrong:
           # > invalid byte sequence in US-ASCII (ArgumentError)
           output << ex.to_s

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -1,6 +1,13 @@
 # Source: Mix of https://github.com/fastlane/fastlane/pull/7202/files,
 # https://github.com/fastlane/fastlane/pull/11384#issuecomment-356084518 and
 # https://github.com/DragonBox/u3d/blob/59e471ad78ac00cb629f479dbe386c5ad2dc5075/lib/u3d_core/command_runner.rb#L88-L96
+
+class StandardError
+  def exit_status
+    return -1
+  end
+end
+
 module FastlaneCore
   class FastlanePtyError < StandardError
     attr_reader :exit_status

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -60,7 +60,8 @@ module FastlaneCore
             end
           end
         end
-      rescue FastlaneCore::FastlanePtyError => ex
+      rescue => ex
+        # FastlanePty adds exit_status on to StandardError so every error will have a status code
         exit_status = ex.exit_status
         @errors << ex.to_s
       end

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -316,5 +316,24 @@ describe FastlaneCore do
         end
       end
     end
+
+    describe "with simulated no-test environment" do
+      before(:each) do
+        allow(FastlaneCore::Helper).to receive(:test?).and_return(false)
+        @transporter = FastlaneCore::ItunesTransporter.new('fabric.devtools@gmail.com', "!> p@$s_-+=w'o%rd\"&#*<", false)
+      end
+
+      describe "and faked command execution" do
+        it 'handles successful execution with no errors' do
+          expect(FastlaneCore::FastlanePty).to receive(:spawn).and_return(0)
+          expect(@transporter.upload('my.app.id', '/tmp')).to eq(true)
+        end
+
+        it 'handles exceptions' do
+          expect(FastlaneCore::FastlanePty).to receive(:spawn).and_raise(StandardError, "It's all broken now.")
+          expect(@transporter.upload('my.app.id', '/tmp')).to eq(false)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Follow up to https://github.com/fastlane/fastlane/pull/13325

## Problem
The status was specific to catching of `FastlanePtyError`s but exit status wouldn't show for other types of errors (if they would occure)

## Solution
Add `exit_status` on to `StandardError`