### PR TITLE
Report fastlane.swift usage vs normal fastlane (ruby) usage

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -329,7 +329,7 @@ module Fastlane
 
     def action_launched(action_name)
       action_launch_context = FastlaneCore::ActionLaunchContext.context_for_action_name(action_name,
-                                                                                        configuration_language: "ruby",
+                                                                                        fastlane_client_language: :ruby,
                                                                                         args: ARGV)
       FastlaneCore.session.action_launched(launch_context: action_launch_context)
     end

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -215,7 +215,7 @@ module Fastlane
       end
     end
 
-    def execute_action(method_sym, class_ref, arguments, custom_dir: nil, from_action: false, configuration_language: nil)
+    def execute_action(method_sym, class_ref, arguments, custom_dir: nil, from_action: false)
       if custom_dir.nil?
         custom_dir ||= "." if Helper.test?
         custom_dir ||= ".."

--- a/fastlane/lib/fastlane/server/socket_server_action_command_executor.rb
+++ b/fastlane/lib/fastlane/server/socket_server_action_command_executor.rb
@@ -70,7 +70,7 @@ module Fastlane
     end
 
     def run(action_named: nil, action_class_ref: nil, parameter_map: nil)
-      action_return = runner.execute_action(action_named, action_class_ref, [parameter_map], custom_dir: '.', configuration_language: "swift")
+      action_return = runner.execute_action(action_named, action_class_ref, [parameter_map], custom_dir: '.')
       return action_return
     end
 

--- a/fastlane_core/lib/fastlane_core/analytics/action_completion_context.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/action_completion_context.rb
@@ -12,19 +12,22 @@ module FastlaneCore
     attr_accessor :p_hash
     attr_accessor :action_name
     attr_accessor :status
+    attr_accessor :fastlane_client_language
 
-    def initialize(p_hash: nil, action_name: nil, status: nil)
+    def initialize(p_hash: nil, action_name: nil, status: nil, fastlane_client_language: nil)
       @p_hash = p_hash
       @action_name = action_name
       @status = status
+      @fastlane_client_language = fastlane_client_language
     end
 
-    def self.context_for_action_name(action_name, args: nil, status: nil)
+    def self.context_for_action_name(action_name, fastlane_client_language: :ruby, args: nil, status: nil)
       app_id_guesser = FastlaneCore::AppIdentifierGuesser.new(args: args)
       return self.new(
         action_name: action_name,
         p_hash: app_id_guesser.p_hash,
-        status: status
+        status: status,
+        fastlane_client_language: fastlane_client_language
       )
     end
   end

--- a/fastlane_core/lib/fastlane_core/analytics/action_launch_context.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/action_launch_context.rb
@@ -8,22 +8,22 @@ module FastlaneCore
     attr_accessor :action_name
     attr_accessor :p_hash
     attr_accessor :platform
-    attr_accessor :configuration_language # example: ruby fastfile, swift fastfile
+    attr_accessor :fastlane_client_language # example: ruby fastfile, swift fastfile
 
-    def initialize(action_name: nil, p_hash: UNKNOWN_P_HASH, platform: nil, configuration_language: nil)
+    def initialize(action_name: nil, p_hash: UNKNOWN_P_HASH, platform: nil, fastlane_client_language: nil)
       @action_name = action_name
       @p_hash = p_hash
       @platform = platform
-      @configuration_language = configuration_language
+      @fastlane_client_language = fastlane_client_language
     end
 
-    def self.context_for_action_name(action_name, configuration_language: "ruby", args: nil)
+    def self.context_for_action_name(action_name, fastlane_client_language: :ruby, args: nil)
       app_id_guesser = FastlaneCore::AppIdentifierGuesser.new(args: args)
       return self.new(
         action_name: action_name,
         p_hash: app_id_guesser.p_hash || UNKNOWN_P_HASH,
         platform: app_id_guesser.platform,
-        configuration_language: configuration_language
+        fastlane_client_language: fastlane_client_language
       )
     end
 

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_event_builder.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_event_builder.rb
@@ -13,7 +13,7 @@ module FastlaneCore
     def new_event(action_stage)
       {
         client_id: @p_hash,
-        category: @fastlane_client_language,
+        category: "fastlane Client Langauge - #{@fastlane_client_language}",
         action: action_stage,
         label: action_name,
         value: nil

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_event_builder.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_event_builder.rb
@@ -2,16 +2,18 @@ module FastlaneCore
   class AnalyticsEventBuilder
     attr_accessor :action_name
 
-    def initialize(p_hash: nil, session_id: nil, action_name: nil)
+    # fastlane_client_language valid options are :ruby or :swift
+    def initialize(p_hash: nil, session_id: nil, action_name: nil, fastlane_client_language: :ruby)
       @p_hash = p_hash
       @session_id = session_id
       @action_name = action_name
+      @fastlane_client_language = fastlane_client_language
     end
 
     def new_event(action_stage)
       {
         client_id: @p_hash,
-        category: :undefined,
+        category: @fastlane_client_language,
         action: action_stage,
         label: action_name,
         value: nil

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -31,7 +31,8 @@ module FastlaneCore
       builder = AnalyticsEventBuilder.new(
         p_hash: launch_context.p_hash,
         session_id: session_id,
-        action_name: nil
+        action_name: nil,
+        fastlane_client_language: launch_context.fastlane_client_language
       )
 
       launch_event = builder.new_event(:launch)

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -68,7 +68,9 @@ module Commander
           FastlaneCore::UI.user_error!("fastlane requires a minimum version of Xcode #{Fastlane::MINIMUM_XCODE_RELEASE}, please upgrade and make sure to use `sudo xcode-select -s /Applications/Xcode.app`")
         end
 
-        action_launch_context = FastlaneCore::ActionLaunchContext.context_for_action_name(@program[:name], args: ARGV)
+        is_swift = FastlaneCore::FastlaneFolder.swift?
+        fastlane_client_language = is_swift ? :swift : :ruby
+        action_launch_context = FastlaneCore::ActionLaunchContext.context_for_action_name(@program[:name], fastlane_client_language: fastlane_client_language, args: ARGV)
         FastlaneCore.session.action_launched(launch_context: action_launch_context)
 
         return_value = run_active_command

--- a/fastlane_core/spec/analytics/analytics_event_builder_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_event_builder_spec.rb
@@ -26,7 +26,7 @@ describe FastlaneCore::AnalyticsEventBuilder do
       expect(event).to eq(
         {
           client_id: p_hash,
-          category: :ruby,
+          category: 'fastlane Client Langauge - ruby',
           action: :launch,
           label: action_name,
           value: nil
@@ -39,7 +39,7 @@ describe FastlaneCore::AnalyticsEventBuilder do
       expect(event).to eq(
         {
           client_id: p_hash,
-          category: :ruby,
+          category: 'fastlane Client Langauge - ruby',
           action: :launch,
           label: action_name,
           value: nil
@@ -52,7 +52,7 @@ describe FastlaneCore::AnalyticsEventBuilder do
       expect(event).to eq(
         {
           client_id: p_hash,
-          category: :swift,
+          category: 'fastlane Client Langauge - swift',
           action: :launch,
           label: action_name,
           value: nil

--- a/fastlane_core/spec/analytics/analytics_event_builder_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_event_builder_spec.rb
@@ -11,13 +11,48 @@ describe FastlaneCore::AnalyticsEventBuilder do
     )
   end
 
+  let(:swift_builder) do
+    FastlaneCore::AnalyticsEventBuilder.new(
+      p_hash: p_hash,
+      session_id: session_id,
+      action_name: action_name,
+      fastlane_client_language: :swift
+    )
+  end
+
   context '#launch_event' do
-    it 'creates a launch event' do
+    it 'creates a default launch event' do
       event = builder.new_event(:launch)
       expect(event).to eq(
         {
           client_id: p_hash,
-          category: :undefined,
+          category: :ruby,
+          action: :launch,
+          label: action_name,
+          value: nil
+        }
+      )
+    end
+
+    it 'creates a ruby launch event' do
+      event = builder.new_event(:launch)
+      expect(event).to eq(
+        {
+          client_id: p_hash,
+          category: :ruby,
+          action: :launch,
+          label: action_name,
+          value: nil
+        }
+      )
+    end
+
+    it 'creates a swift launch event' do
+      event = swift_builder.new_event(:launch)
+      expect(event).to eq(
+        {
+          client_id: p_hash,
+          category: :swift,
           action: :launch,
           label: action_name,
           value: nil

--- a/fastlane_core/spec/analytics/analytics_session_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_session_spec.rb
@@ -1,5 +1,5 @@
 describe FastlaneCore::AnalyticsSession do
-  let(:configuration_language) { 'ruby' }
+  let(:fastlane_client_language) { :ruby }
   let(:p_hash) { 'some.phash.value' }
   let(:session_id) { 's0m3s3ss10n1D' }
 
@@ -18,7 +18,7 @@ describe FastlaneCore::AnalyticsSession do
           action_name: action_name,
           p_hash: p_hash,
           platform: 'ios',
-          configuration_language: configuration_language
+          fastlane_client_language: fastlane_client_language
         )
       end
 
@@ -30,7 +30,7 @@ describe FastlaneCore::AnalyticsSession do
         session = FastlaneCore::AnalyticsSession.new(analytics_ingester_client: client)
         expect(client).to receive(:post_event).with({
             client_id: p_hash,
-            category: :undefined,
+            category: :ruby,
             action: :launch,
             label: nil,
             value: nil

--- a/fastlane_core/spec/analytics/analytics_session_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_session_spec.rb
@@ -30,7 +30,7 @@ describe FastlaneCore::AnalyticsSession do
         session = FastlaneCore::AnalyticsSession.new(analytics_ingester_client: client)
         expect(client).to receive(:post_event).with({
             client_id: p_hash,
-            category: :ruby,
+            category: 'fastlane Client Langauge - ruby',
             action: :launch,
             label: nil,
             value: nil
@@ -40,94 +40,4 @@ describe FastlaneCore::AnalyticsSession do
       end
     end
   end
-
-  # context 'mock Fastfile executions' do
-  #   before(:each) do
-  #     FastlaneCore.reset_session
-  #   end
-
-  #   let(:fixture_data) do
-  #     events = JSON.parse(File.read(File.join(fixture_dirname, '/launched.json')))
-  #     events.each { |event| event["action"]["detail"] = 'lane_switch' }
-  #     events
-  #   end
-
-  #   let(:guesser) { FastlaneCore::AppIdentifierGuesser.new }
-
-  #   it 'records more than one action from a Fastfile' do
-  #     allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(File.absolute_path('./fastlane/spec/fixtures/fastfiles/'))
-  #     ff = Fastlane::LaneManager.cruise_lane('ios', 'beta')
-  #     version_events = FastlaneCore.session.events.select do |event|
-  #       event[:primary_target][:name] == 'fastlane_version'
-  #     end
-  #     expect(version_events.count).to eq(4)
-  #     action_names = version_events.map { |event| event[:action][:detail] }
-  #     expect(action_names).to match_array([
-  #                                           'default_platform',
-  #                                           'frameit',
-  #                                           'team_id',
-  #                                           'team_id'
-  #                                         ])
-  #   end
-
-  #   it 'has a completion event for each action' do
-  #     allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(File.absolute_path('./fastlane/spec/fixtures/fastfiles/'))
-  #     ff = Fastlane::LaneManager.cruise_lane('ios', 'beta')
-  #     completion_events = FastlaneCore.session.events.select do |event|
-  #       event[:action][:name] == 'completed'
-  #     end
-  #     expect(completion_events.count).to eq(4)
-  #     action_names = completion_events.map { |event| event[:action][:detail] }
-  #     expect(action_names).to match_array([
-  #                                           'default_platform',
-  #                                           'frameit',
-  #                                           'team_id',
-  #                                           'team_id'
-  #                                         ])
-  #   end
-
-  #   it 'has a fastfile value of true for each event' do
-  #     allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(File.absolute_path('./fastlane/spec/fixtures/fastfiles/'))
-  #     ff = Fastlane::LaneManager.cruise_lane('ios', 'beta')
-  #     fastfile_events = FastlaneCore.session.events.select do |event|
-  #       event[:primary_target][:name] == 'fastfile'
-  #     end
-  #     expect(fastfile_events.count).to eq(4)
-  #     fastfile_values = fastfile_events.map { |event| event[:primary_target][:detail] }
-  #     expect(fastfile_values).to all(be == "true")
-  #   end
-  # end
-
-  # context 'opt out' do
-  #   it "does not post the collected data if the opt-out ENV var is set" do
-  #     with_env_values('FASTLANE_OPT_OUT_USAGE' => '1') do
-  #       FastlaneCore.reset_session
-  #       allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(File.absolute_path('./fastlane/spec/fixtures/fastfiles/'))
-  #       ff = Fastlane::LaneManager.cruise_lane('ios', 'beta')
-  #       completion_events = FastlaneCore.session.events.select do |event|
-  #         event[:action][:name] == 'completed'
-  #       end
-  #       expect(completion_events.count).to eq(4)
-  #       expect(FastlaneCore.session.client).not_to(receive(:post_events))
-  #       FastlaneCore.session.finalize_session
-  #     end
-  #   end
-  # end
 end
-
-# here are a bunch of tests we should also have
-# these were scattered around, but I think we should put them in one place
-
-# it "tracks which tool raises an error" do
-#   collector.did_raise_error(:scan)
-
-#   expect(collector.error).to eq(:scan)
-#   expect(collector.crash).to be(false)
-# end
-
-# it "tracks which tool crashes" do
-#   collector.did_crash(:scan)
-
-#   expect(collector.error).to eq(:scan)
-#   expect(collector.crash).to be(true)
-# end


### PR DESCRIPTION
We want to understand how many folks are using fastlane.swift, so we need to report execution of fastlane.swift vs normal fastlane.
Also includes a tiny bit of cleanup.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
