### PR TITLE
[downloads_dsyms] also check `displayVersionNumber`

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -59,15 +59,16 @@ module Fastlane
           # - App Store version set as 1.0 and app version set as 1.0.0;
           #
           # In that case, the response from API will be "versionString = 1.0" and "displayVersionString = 1.0.0"
-          UI.verbose("Found train: #{train.version_string}, comparing to supplied version: #{version}")
-          if version && train.version_string == train.display_version_string && version != train.version_string
-            UI.verbose("Version #{version} doesn't match: #{train.version_string}")
-            next
-          else
-            UI.verbose("Failed. Comparing to display_version_string: #{train.display_version_string}")
-            if version && version != train.display_version_string
-              UI.verbose("Version #{version} doesn't match: #{train.display_version_string}")
+          if version
+            if train.version_string == train.display_version_string && version != train.version_string
+              UI.verbose("Version #{version} doesn't match: #{train.version_string}")
               next
+            else
+              UI.verbose("Failed. Comparing to display_version_string: #{train.display_version_string}")
+              if version != train.display_version_string
+                UI.verbose("Version #{version} doesn't match: #{train.display_version_string}")
+                next
+              end
             end
           end
 

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -64,8 +64,7 @@ module Fastlane
             UI.verbose("Version #{version} doesn't match: #{train.version_string}")
             next
           else
-            UI.verbose("Version #{version} doesn't match: #{train.version_string}")
-            UI.verbose("Found train: #{train.display_version_string}, comparing to supplied version: #{train.display_version_string}")
+            UI.verbose("Failed. Comparing to display_version_string: #{train.display_version_string}")
             if version && version != train.display_version_string
               UI.verbose("Version #{version} doesn't match: #{train.display_version_string}")
               next
@@ -73,7 +72,7 @@ module Fastlane
           end
 
           app.tunes_all_builds_for_train(train: train.version_string, platform: platform).each do |build|
-            # This probably is not necessary, but as we have that situation mentioned above, better check for safety.
+            # This is probably not necessary, but as we have the situation mentioned above, better check for safety.
             UI.verbose("Comparing train version #{build.train_version} to supplied version #{version}")
             if version && version != build.train_version
               UI.verbose("Train version #{build.train_version} doesn't match with supplied version: #{version}")

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -52,12 +52,34 @@ module Fastlane
         UI.message(message.join(" "))
 
         app.tunes_all_build_trains(platform: platform).each do |train|
+          # We try to check first with version_string, but also we try to check with display_version_string since
+          # this value could be different.
+          #
+          # Example:
+          # - App Store version set as 1.0 and app version set as 1.0.0;
+          #
+          # In that case, the response from API will be "versionString = 1.0" and "displayVersionString = 1.0.0"
           UI.verbose("Found train: #{train.version_string}, comparing to supplied version: #{version}")
-          if version && version != train.version_string
+          if version && train.version_string == train.display_version_string && version != train.version_string
             UI.verbose("Version #{version} doesn't match: #{train.version_string}")
             next
+          else
+            UI.verbose("Version #{version} doesn't match: #{train.version_string}")
+            UI.verbose("Found train: #{train.display_version_string}, comparing to supplied version: #{train.display_version_string}")
+            if version && version != train.display_version_string
+              UI.verbose("Version #{version} doesn't match: #{train.display_version_string}")
+              next
+            end
           end
+
           app.tunes_all_builds_for_train(train: train.version_string, platform: platform).each do |build|
+            # This probably is not necessary, but as we have that situation mentioned above, better check for safety.
+            UI.verbose("Comparing train version #{build.train_version} to supplied version #{version}")
+            if version && version != build.train_version
+              UI.verbose("Train version #{build.train_version} doesn't match with supplied version: #{version}")
+              next
+            end
+
             UI.verbose("Found build version: #{build.build_version}, comparing to supplied build_number: #{build_number}")
             if build_number && build.build_version != build_number
               UI.verbose("build_version: #{build.build_version} doesn't match: #{build_number}")

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -52,6 +52,7 @@ module Fastlane
         UI.message(message.join(" "))
 
         app.tunes_all_build_trains(platform: platform).each do |train|
+          UI.verbose("Found train: version_string=#{train.version_string} / display_version_string=#{train.display_version_string}, comparing to supplied version: #{version}")
           # We try to check first with version_string, but also we try to check with display_version_string since
           # this value could be different.
           #
@@ -60,7 +61,7 @@ module Fastlane
           #
           # In that case, the response from API will be "versionString = 1.0" and "displayVersionString = 1.0.0"
           if version && version != train.version_string && version != train.display_version_string
-            UI.verbose("Version #{version} doesn't match: #{train.version_string} or #{trains.display_version_string}")
+            UI.verbose("Version #{version} doesn't match: version_string=#{train.version_string} or display_version_string=#{trains.display_version_string}")
             next
           end
 

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -59,27 +59,12 @@ module Fastlane
           # - App Store version set as 1.0 and app version set as 1.0.0;
           #
           # In that case, the response from API will be "versionString = 1.0" and "displayVersionString = 1.0.0"
-          if version
-            if train.version_string == train.display_version_string && version != train.version_string
-              UI.verbose("Version #{version} doesn't match: #{train.version_string}")
-              next
-            else
-              UI.verbose("Failed. Comparing to display_version_string: #{train.display_version_string}")
-              if version != train.display_version_string
-                UI.verbose("Version #{version} doesn't match: #{train.display_version_string}")
-                next
-              end
-            end
+          if version && version != train.version_string && version != train.display_version_string
+            UI.verbose("Version #{version} doesn't match: #{train.version_string} or #{trains.display_version_string}")
+            next
           end
 
           app.tunes_all_builds_for_train(train: train.version_string, platform: platform).each do |build|
-            # This is probably not necessary, but as we have the situation mentioned above, better check for safety.
-            UI.verbose("Comparing train version #{build.train_version} to supplied version #{version}")
-            if version && version != build.train_version
-              UI.verbose("Train version #{build.train_version} doesn't match with supplied version: #{version}")
-              next
-            end
-
             UI.verbose("Found build version: #{build.build_version}, comparing to supplied build_number: #{build_number}")
             if build_number && build.build_version != build_number
               UI.verbose("build_version: #{build.build_version} doesn't match: #{build_number}")

--- a/spaceship/lib/spaceship/tunes/build_train.rb
+++ b/spaceship/lib/spaceship/tunes/build_train.rb
@@ -20,6 +20,9 @@ module Spaceship
       # @return (String) The version number of this train
       attr_reader :version_string
 
+      # @return (String) The display version number of this train
+      attr_reader :display_version_string
+
       # @return (String) Platform (e.g. "ios")
       attr_reader :platform
 
@@ -40,6 +43,7 @@ module Spaceship
       attr_mapping(
         'application' => 'application',
         'versionString' => :version_string,
+        'displayVersionString' => :display_version_string,
         'platform' => :platform,
         'externalTesting.value' => :external_testing_enabled,
         'internalTesting.value' => :internal_testing_enabled


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I was facing a problem with `download_dsyms` action, it was caused firstly for a misconfiguration on App Store Connect. Below the steps to reproduce:

1. Register a new app with version 1.0
1. Set your app version (Xcode) to 1.0.0
1. Upload the app to TestFlight

I know that's not a common path, but could happen. The JSON provided by App Store Connect API will return a train with `versionString: "1.0"` (currently in use to check) and `displayVersionString: "1.0.0"`.

For some reason, Apple is using the app store version (1.0) as a key to get the builds but displaying (1.0.0) to the list.

I've tried to change the app store number from 1.0 to 1.0.0, but the JSON still using 1.0 as the identifier.

### Description

In order to fix that, I've added a new check to the action as a rescue check before return the error.
