### PR TITLE
[deliver] wait for candidate builds to appear if not available immediately

### DIFF
--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -59,7 +59,7 @@ module Deliver
 
       loop do
         # Sometimes candidate_builds don't appear immediately after submittion
-        # Wait for candidate_builds to appear on iTunes
+        # Wait for candidate_builds to appear on App Store Connect
         # Issue https://github.com/fastlane/fastlane/issues/10411
         candidate_builds = app.latest_version.candidate_builds
         if (candidate_builds || []).count == 0

--- a/deliver/spec/submit_for_review_spec.rb
+++ b/deliver/spec/submit_for_review_spec.rb
@@ -12,29 +12,57 @@ describe Deliver::SubmitForReview do
     end
   end
 
+  def make_fake_version
+    return OpenStruct.new({})
+  end
+
+  def make_fake_candidates(number_of_candidates)
+    (0...number_of_candidates).map do |num|
+      OpenStruct.new({})
+    end
+  end
+
   describe :find_build do
     context 'one build' do
       let(:fake_builds) { make_fake_builds(1) }
       it 'finds the one build' do
+        allow(review_submitter).to receive(:wait_for_candidate).and_return(fake_builds)
         only_build = fake_builds.first
-        expect(review_submitter.find_build(fake_builds)).to eq(only_build)
-      end
-    end
-
-    context 'no builds' do
-      let(:fake_builds) { make_fake_builds(0) }
-      it 'throws a UI error' do
-        expect do
-          review_submitter.find_build(fake_builds)
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not find any available candidate builds on App Store Connect to submit")
+        expect(review_submitter.find_build(make_fake_version)).to eq(only_build)
       end
     end
 
     context 'two builds' do
       let(:fake_builds) { make_fake_builds(2) }
       it 'finds the one build' do
+        allow(review_submitter).to receive(:wait_for_candidate).and_return(fake_builds)
         newest_build = fake_builds.last
-        expect(review_submitter.find_build(fake_builds)).to eq(newest_build)
+        expect(review_submitter.find_build(make_fake_version)).to eq(newest_build)
+      end
+    end
+  end
+
+  describe :wait_for_candidate do
+    context 'has the candidate immediately' do
+      let(:fake_candidates) { make_fake_candidates(2) }
+      it 'returns all candidates' do
+        fake_version = make_fake_version
+        allow(fake_version).to receive(:candidate_builds).and_return(fake_candidates)
+        expect(review_submitter.wait_for_candidate(fake_version)).to eq(fake_candidates)
+      end
+    end
+
+    context 'waits for candidates for more than 5 minutes' do
+      let(:fake_candidates) { make_fake_candidates(0) }
+      let(:time_now) { Time.now }
+      # Stub Time.now to return current time on first call and 6 minutes later on second
+      before { allow(Time).to receive(:now).and_return(time_now, (time_now + 60 * 6)) }
+      it 'throws a UI error' do
+        fake_version = make_fake_version
+        allow(fake_version).to receive(:candidate_builds).and_return(fake_candidates)
+        expect do
+          review_submitter.wait_for_candidate(fake_version)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not find any available candidate builds on App Store Connect to submit")
       end
     end
   end

--- a/deliver/spec/submit_for_review_spec.rb
+++ b/deliver/spec/submit_for_review_spec.rb
@@ -8,61 +8,70 @@ describe Deliver::SubmitForReview do
   # the builds will be in date ascending order
   def make_fake_builds(number_of_builds)
     (0...number_of_builds).map do |num|
-      OpenStruct.new({ upload_date: Time.now.utc + 60 * num }) # minutes_from_now
+      OpenStruct.new({ upload_date: Time.now.utc + 60 * num, processing: false }) # minutes_from_now
     end
+  end
+
+  def make_fake_app
+    return OpenStruct.new({})
   end
 
   def make_fake_version
     return OpenStruct.new({})
   end
 
-  def make_fake_candidates(number_of_candidates)
-    (0...number_of_candidates).map do |num|
-      OpenStruct.new({})
-    end
-  end
-
   describe :find_build do
     context 'one build' do
       let(:fake_builds) { make_fake_builds(1) }
       it 'finds the one build' do
-        allow(review_submitter).to receive(:wait_for_candidate).and_return(fake_builds)
         only_build = fake_builds.first
-        expect(review_submitter.find_build(make_fake_version)).to eq(only_build)
+        expect(review_submitter.find_build(fake_builds)).to eq(only_build)
+      end
+    end
+
+    context 'no builds' do
+      let(:fake_builds) { make_fake_builds(0) }
+      it 'throws a UI error' do
+        expect do
+          review_submitter.find_build(fake_builds)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not find any available candidate builds on App Store Connect to submit")
       end
     end
 
     context 'two builds' do
       let(:fake_builds) { make_fake_builds(2) }
       it 'finds the one build' do
-        allow(review_submitter).to receive(:wait_for_candidate).and_return(fake_builds)
         newest_build = fake_builds.last
-        expect(review_submitter.find_build(make_fake_version)).to eq(newest_build)
-      end
-    end
-  end
-
-  describe :wait_for_candidate do
-    context 'has the candidate immediately' do
-      let(:fake_candidates) { make_fake_candidates(2) }
-      it 'returns all candidates' do
-        fake_version = make_fake_version
-        allow(fake_version).to receive(:candidate_builds).and_return(fake_candidates)
-        expect(review_submitter.wait_for_candidate(fake_version)).to eq(fake_candidates)
+        expect(review_submitter.find_build(fake_builds)).to eq(newest_build)
       end
     end
 
-    context 'waits for candidates for more than 5 minutes' do
-      let(:fake_candidates) { make_fake_candidates(0) }
-      let(:time_now) { Time.now }
-      # Stub Time.now to return current time on first call and 6 minutes later on second
-      before { allow(Time).to receive(:now).and_return(time_now, (time_now + 60 * 6)) }
-      it 'throws a UI error' do
-        fake_version = make_fake_version
-        allow(fake_version).to receive(:candidate_builds).and_return(fake_candidates)
-        expect do
-          review_submitter.wait_for_candidate(fake_version)
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not find any available candidate builds on App Store Connect to submit")
+    describe :wait_for_build do
+      context 'no candidates' do
+        let(:fake_app) { make_fake_app }
+        let(:fake_version) { make_fake_version }
+        let(:time_now) { Time.now }
+        # Stub Time.now to return current time on first call and 6 minutes later on second
+        before { allow(Time).to receive(:now).and_return(time_now, (time_now + 60 * 6)) }
+        it 'throws a UI error' do
+          allow(fake_app).to receive(:latest_version).and_return(fake_version)
+          allow(fake_version).to receive(:candidate_builds).and_return([])
+          expect do
+            review_submitter.wait_for_build(fake_app)
+          end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not find any available candidate builds on App Store Connect to submit")
+        end
+      end
+
+      context 'has candidates and one build' do
+        let(:fake_app) { make_fake_app }
+        let(:fake_version) { make_fake_version }
+        let(:fake_builds) { make_fake_builds(1) }
+        it 'finds the one build' do
+          allow(fake_app).to receive(:latest_version).and_return(fake_version)
+          allow(fake_version).to receive(:candidate_builds).and_return(fake_builds)
+          only_build = fake_builds.first
+          expect(review_submitter.wait_for_build(fake_app)).to eq(only_build)
+        end
       end
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
In deliver action, when submitting apps automatically, sometimes (maybe in 20% of cases) candidate builds can not be fetched immediately after the binary upload. Submit for review fails with the message `Could not find any available candidate builds on App Store Connect to submit`.
https://github.com/fastlane/fastlane/issues/10411

Log excerpt from the failed submission:
```
[16:54:28]: Finished the upload to iTunes Connect
[16:54:28]: Selecting the latest build...
+---------------------+--------------------------------------+
| Lane Context |
+---------------------+--------------------------------------+
| DEFAULT_PLATFORM | ios |
| PLATFORM_NAME | ios |
| LANE_NAME | ios deploy |
| VERSION_NUMBER | ***** |
| BUILD_NUMBER | ***** |
| PRODUCE_APPLE_ID | ***** |
| CERT_FILE_PATH | ***** |
| CERT_CERTIFICATE_ID | ***** |
| SIGH_PROFILE_PATH | ***** |
| SIGH_PROFILE_PATHS | ***** |
| SIGH_UDID | *****|
| SIGH_UUID | ***** |
| SIGH_NAME | ***** |
| SIGH_PROFILE_TYPE | app-store |
| IPA_OUTPUT_PATH | ***** |
| DSYM_OUTPUT_PATH | ***** |
| XCODEBUILD_ARCHIVE | ***** |
+---------------------+--------------------------------------+
[16:54:29]: Could not find any available candidate builds on iTunes Connect to submit
```

### Description
I've added a wait loop that tries to fetch candidate builds every 30 seconds. It raises and error if candidate builds don't appear in 5 minutes.

I've used the changes on our CI machine, and it solved the issue. Here's the example output when builds are available:
```
[19:39:22]: Finished the upload to App Store Connect
[19:39:23]: Selecting the latest build...
[19:39:25]: Waiting App Store Connect processing for build ******... this might take a while...
```

Here's the example output when wait loop fixed the issue which used to cause the deliver to fail:
```
[18:51:22]: Finished the upload to App Store Connect
[18:51:22]: Selecting the latest build...
[18:51:23]: Waiting for candidate builds to appear...
[18:51:54]: Waiting App Store Connect processing for build ******... this might take a while...
```
Note the `Waiting for candidate builds to appear...` message indicating the wait for candidates loop is used.