### PR TITLE
Adding a way to parse marketing url and privacy policy url

### DIFF
--- a/spaceship/lib/spaceship/test_flight/test_info.rb
+++ b/spaceship/lib/spaceship/test_flight/test_info.rb
@@ -7,7 +7,7 @@ module Spaceship::TestFlight
     # For now, when we set a value it sets the same value for all locales
     # When getting a value, we return the first locale values
 
-    attr_accessor :description, :feedback_email, :whats_new
+    attr_accessor :description, :feedback_email, :whats_new, :privacy_policy_url, :marketing_url
 
     def description
       raw_data.first['description']
@@ -23,6 +23,22 @@ module Spaceship::TestFlight
 
     def feedback_email=(value)
       raw_data.each { |locale| locale['feedbackEmail'] = value }
+    end
+
+    def privacy_policy_url
+      raw_data.first['privacyPolicyUrl']
+    end
+
+    def privacy_policy_url=(value)
+      raw_data.each { |locale| locale['privacyPolicyUrl'] = value }
+    end
+
+    def marketing_url
+      raw_data.first['marketingUrl']
+    end
+
+    def marketing_url=(value)
+      raw_data.each { |locale| locale['marketingUrl'] = value }
     end
 
     def whats_new

--- a/spaceship/spec/test_flight/test_info_spec.rb
+++ b/spaceship/spec/test_flight/test_info_spec.rb
@@ -7,19 +7,25 @@ describe Spaceship::TestFlight::TestInfo do
                                             'locale' => 'en-US',
                                             'description' => 'en-US description',
                                             'feedbackEmail' => 'enUS@email.com',
-                                            'whatsNew' => 'US News'
+                                            'whatsNew' => 'US News',
+                                            'marketingUrl' => 'www.markingurl.com/en',
+                                            'privacyPolicyUrl' => 'www.privacypolicy.com/en'
                                           },
                                           {
                                             'locale' => 'de-DE',
                                             'description' => 'de-DE description',
                                             'feedbackEmail' => 'deDE@email.com',
-                                            'whatsNew' => 'German News'
+                                            'whatsNew' => 'German News',
+                                            'marketingUrl' => 'www.markingurl.com/de',
+                                            'privacyPolicyUrl' => 'www.privacypolicy.com/de'
                                           },
                                           {
                                             'locale' => 'de-AT',
                                             'description' => 'de-AT description',
                                             'feedbackEmail' => 'deAT@email.com',
-                                            'whatsNew' => 'Austrian News'
+                                            'whatsNew' => 'Austrian News',
+                                            'marketingUrl' => 'www.markingurl.com/at',
+                                            'privacyPolicyUrl' => 'www.privacypolicy.com/at'
                                           }
                                         ])
   end
@@ -36,6 +42,8 @@ describe Spaceship::TestFlight::TestInfo do
     expect(test_info.feedback_email).to eq('enUS@email.com')
     expect(test_info.description).to eq('en-US description')
     expect(test_info.whats_new).to eq('US News')
+    expect(test_info.marketing_url).to eq('www.markingurl.com/en')
+    expect(test_info.privacy_policy_url).to eq('www.privacypolicy.com/en')
   end
 
   it 'sets values to all locales' do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Currently the `TestFlight` class did not have a way to parse marketing url and privacy policy url or set it. With the apple's policy change, we are going to need to set it starting October 3rd. 

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
Added the attr mapping for `marketingUrl` and `privacyPolicyUrl` and updated tests to check that. 