### PR TITLE
[supply] prevent disabling of tracks on promotion

### DIFF
--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -208,8 +208,13 @@ module Supply
                                      optional: true,
                                      description: "Timeout for read, open, and send (in seconds)",
                                      type: Integer,
-                                     default_value: 300)
-
+                                     default_value: 300),
+        FastlaneCore::ConfigItem.new(key: :deactivate_on_promote,
+                                     env_name: "SUPPLY_DEACTIVATE_ON_PROMOTE",
+                                     optional: true,
+                                     description: "When promoting to a new track, deactivate the binary in the origin track",
+                                     is_string: false,
+                                     default_value: true)
       ]
     end
     # rubocop:enable Metrics/PerceivedComplexity

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -208,13 +208,8 @@ module Supply
                                      optional: true,
                                      description: "Timeout for read, open, and send (in seconds)",
                                      type: Integer,
-                                     default_value: 300),
-        FastlaneCore::ConfigItem.new(key: :deactivate_on_promote,
-                                     env_name: "SUPPLY_DEACTIVATE_ON_PROMOTE",
-                                     optional: true,
-                                     description: "When promoting to a new track, deactivate the binary in the origin track",
-                                     is_string: false,
-                                     default_value: true)
+                                     default_value: 300)
+
       ]
     end
     # rubocop:enable Metrics/PerceivedComplexity

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -64,7 +64,7 @@ module Supply
       version_codes = client.track_version_codes(Supply.config[:track])
       # the actual value passed for the rollout argument does not matter because it will be ignored by the Google Play API
       # but it has to be between 0.0 and 1.0 to pass the validity check. So we are passing the default value 0.1
-      client.update_track(Supply.config[:track], 0.1, nil)
+      client.update_track(Supply.config[:track], 0.1, nil) if Supply.config[:deactivate_on_promote]
       client.update_track(Supply.config[:track_promote_to], Supply.config[:rollout] || 0.1, version_codes)
     end
 

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -64,7 +64,6 @@ module Supply
       version_codes = client.track_version_codes(Supply.config[:track])
       # the actual value passed for the rollout argument does not matter because it will be ignored by the Google Play API
       # but it has to be between 0.0 and 1.0 to pass the validity check. So we are passing the default value 0.1
-      client.update_track(Supply.config[:track], 0.1, nil) if Supply.config[:deactivate_on_promote]
       client.update_track(Supply.config[:track_promote_to], Supply.config[:rollout] || 0.1, version_codes)
     end
 

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -64,6 +64,7 @@ module Supply
       version_codes = client.track_version_codes(Supply.config[:track])
       # the actual value passed for the rollout argument does not matter because it will be ignored by the Google Play API
       # but it has to be between 0.0 and 1.0 to pass the validity check. So we are passing the default value 0.1
+      client.update_track(Supply.config[:track], 0.1, nil) if Supply.config[:deactivate_on_promote]
       client.update_track(Supply.config[:track_promote_to], Supply.config[:rollout] || 0.1, version_codes)
     end
 

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -167,13 +167,28 @@ describe Supply do
         Supply.config = config
         allow(Supply::Client).to receive(:make_from_config).and_return(client)
         allow(client).to receive(:track_version_codes).and_return(version_codes)
+        allow(client).to receive(:update_track).with(config[:track], 0.1, nil)
         allow(client).to receive(:update_track).with(config[:track_promote_to], 0.1, version_codes)
       end
 
-      it 'should only update track once' do
-        expect(client).not_to(receive(:update_track).with(config[:track], 0.1, nil))
-        expect(client).to receive(:update_track).with(config[:track_promote_to], 0.1, version_codes).once
-        subject
+      context 'when deactivate_on_promote is true' do
+        it 'should update track multiple times' do
+          Supply.config[:deactivate_on_promote] = true
+
+          expect(client).to receive(:update_track).with(config[:track], 0.1, nil).once
+          expect(client).to receive(:update_track).with(config[:track_promote_to], 0.1, version_codes).once
+          subject
+        end
+      end
+
+      context 'when deactivate_on_promote is false' do
+        it 'should only update track once' do
+          Supply.config[:deactivate_on_promote] = false
+
+          expect(client).not_to(receive(:update_track).with(config[:track], 0.1, nil))
+          expect(client).to receive(:update_track).with(config[:track_promote_to], 0.1, version_codes).once
+          subject
+        end
       end
     end
 

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -167,28 +167,13 @@ describe Supply do
         Supply.config = config
         allow(Supply::Client).to receive(:make_from_config).and_return(client)
         allow(client).to receive(:track_version_codes).and_return(version_codes)
-        allow(client).to receive(:update_track).with(config[:track], 0.1, nil)
         allow(client).to receive(:update_track).with(config[:track_promote_to], 0.1, version_codes)
       end
 
-      context 'when deactivate_on_promote is true' do
-        it 'should update track multiple times' do
-          Supply.config[:deactivate_on_promote] = true
-
-          expect(client).to receive(:update_track).with(config[:track], 0.1, nil).once
-          expect(client).to receive(:update_track).with(config[:track_promote_to], 0.1, version_codes).once
-          subject
-        end
-      end
-
-      context 'when deactivate_on_promote is false' do
-        it 'should only update track once' do
-          Supply.config[:deactivate_on_promote] = false
-
-          expect(client).not_to(receive(:update_track).with(config[:track], 0.1, nil))
-          expect(client).to receive(:update_track).with(config[:track_promote_to], 0.1, version_codes).once
-          subject
-        end
+      it 'should only update track once' do
+        expect(client).not_to(receive(:update_track).with(config[:track], 0.1, nil))
+        expect(client).to receive(:update_track).with(config[:track_promote_to], 0.1, version_codes).once
+        subject
       end
     end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR fixes an odd bug with Supply’s `promote` functionality. If a user is using Supply to promote APKs between tracks, the current code will deactivate the binary in the lower track. This is not the desired behavior - generally, you want to leave the binary in the lower track untouched. This PR adds an option to bypass this behavior if desired.

This will fix https://github.com/fastlane/fastlane/issues/13313 if accepted.

### Description
Added an option to allow bypassing the "deactivate on promote" behavior. By default, this is set to true to preserve the current behavior. Tested in the wild by using this to promote my most recent build, and observing that the existing binaries are untouched.
