### PR TITLE
Distribution name with deploygate action

### DIFF
--- a/fastlane/lib/fastlane/actions/deploygate.rb
+++ b/fastlane/lib/fastlane/actions/deploygate.rb
@@ -45,7 +45,7 @@ module Fastlane
         user_name = options[:user]
         binary = options[:ipa] || options[:apk]
         upload_options = options.values.select do |key, _|
-          [:message, :distribution_key, :release_note, :disable_notify].include?(key)
+          [:message, :distribution_key, :release_note, :disable_notify, :distribution_name].include?(key)
         end
 
         UI.user_error!('missing `ipa` and `apk`. deploygate action needs least one.') unless binary
@@ -160,7 +160,13 @@ module Fastlane
                                        is_string: false,
                                        default_value: false,
                                        env_name: "DEPLOYGATE_DISABLE_NOTIFY",
-                                       description: "Disables Push notification emails")
+                                       description: "Disables Push notification emails"),
+          FastlaneCore::ConfigItem.new(key: :distribution_name,
+                                       optional: true,
+                                       is_string: true,
+                                       default_value: false,
+                                       env_name: "DEPLOYGATE_DISTRIBUTION_NAME",
+                                       description: "Target Distribution Name")
         ]
       end
 
@@ -179,14 +185,16 @@ module Fastlane
             user: "target username or organization name",
             ipa: "./ipa_file.ipa",
             message: "Build #{lane_context[SharedValues::BUILD_NUMBER]}",
-            distribution_key: "(Optional) Target Distribution Key"
+            distribution_key: "(Optional) Target Distribution Key",
+            distribution_name: "(Optional) Target Distribution Name"
           )',
           'deploygate(
             api_token: "...",
             user: "target username or organization name",
             apk: "./apk_file.apk",
             message: "Build #{lane_context[SharedValues::BUILD_NUMBER]}",
-            distribution_key: "(Optional) Target Distribution Key"
+            distribution_key: "(Optional) Target Distribution Key",
+            distribution_name: "(Optional) Target Distribution Name"
           )'
         ]
       end

--- a/fastlane/lib/fastlane/actions/deploygate.rb
+++ b/fastlane/lib/fastlane/actions/deploygate.rb
@@ -164,7 +164,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :distribution_name,
                                        optional: true,
                                        is_string: true,
-                                       default_value: false,
                                        env_name: "DEPLOYGATE_DISTRIBUTION_NAME",
                                        description: "Target Distribution Name")
         ]

--- a/fastlane/spec/actions_specs/deploygate_spec.rb
+++ b/fastlane/spec/actions_specs/deploygate_spec.rb
@@ -91,6 +91,7 @@ describe Fastlane do
               api_token: 'thisistest',
               release_note: 'This is a test release.',
               disable_notify: true,
+              distribution_name: 'test_name',
             })
           end").runner.execute(:test)
         end.not_to(raise_error)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I want to use `distribution_name` option on `deploygate` action, 
but current action doesn't have it.
API reference here: https://docs.deploygate.com/reference#upload

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
Refer to the addition of `distribution_key` (#3840), I added `distribution_name`.
