### PR TITLE
[deliver,spaceship] Support new screen size (iPhone XS Max)

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -17,6 +17,8 @@ module Deliver
       IOS_55 = "iOS-5.5-in"
       # iPhone X
       IOS_58 = "iOS-5.8-in"
+      # iPhone XS Max
+      IOS_65 = "iOS-6.5-in"
       # iPad
       IOS_IPAD = "iOS-iPad"
       # iPad 10.5
@@ -31,6 +33,8 @@ module Deliver
       IOS_55_MESSAGES = "iOS-5.5-in-messages"
       # iPhone X iMessage
       IOS_58_MESSAGES = "iOS-5.8-in-messages"
+      # iPhone XS Max iMessage
+      IOS_65_MESSAGES = "iOS-6.5-in-messages"
       # iPad iMessage
       IOS_IPAD_MESSAGES = "iOS-iPad-messages"
       # iPad 10.5 iMessage
@@ -75,6 +79,7 @@ module Deliver
         ScreenSize::IOS_47 => "iphone6",
         ScreenSize::IOS_55 => "iphone6Plus",
         ScreenSize::IOS_58 => "iphone58",
+        ScreenSize::IOS_65 => "iphone65",
         ScreenSize::IOS_IPAD => "ipad",
         ScreenSize::IOS_IPAD_10_5 => "ipad105",
         ScreenSize::IOS_IPAD_PRO => "ipadPro",
@@ -82,6 +87,7 @@ module Deliver
         ScreenSize::IOS_47_MESSAGES => "iphone6",
         ScreenSize::IOS_55_MESSAGES => "iphone6Plus",
         ScreenSize::IOS_58_MESSAGES => "iphone58",
+        ScreenSize::IOS_65_MESSAGES => "iphone65",
         ScreenSize::IOS_IPAD_MESSAGES => "ipad",
         ScreenSize::IOS_IPAD_PRO_MESSAGES => "ipadPro",
         ScreenSize::IOS_IPAD_10_5_MESSAGES => "ipad105",
@@ -100,6 +106,7 @@ module Deliver
         ScreenSize::IOS_47 => "iPhone 6",
         ScreenSize::IOS_55 => "iPhone 6 Plus",
         ScreenSize::IOS_58 => "iPhone X",
+        ScreenSize::IOS_65 => "iPhone XS Max",
         ScreenSize::IOS_IPAD => "iPad",
         ScreenSize::IOS_IPAD_10_5 => "iPad 10.5",
         ScreenSize::IOS_IPAD_PRO => "iPad Pro",
@@ -107,6 +114,7 @@ module Deliver
         ScreenSize::IOS_47_MESSAGES => "iPhone 6 (iMessage)",
         ScreenSize::IOS_55_MESSAGES => "iPhone 6 Plus (iMessage)",
         ScreenSize::IOS_58_MESSAGES => "iPhone X (iMessage)",
+        ScreenSize::IOS_65_MESSAGES => "iPhone XS Max (iMessage)",
         ScreenSize::IOS_IPAD_MESSAGES => "iPad (iMessage)",
         ScreenSize::IOS_IPAD_PRO_MESSAGES => "iPad Pro (iMessage)",
         ScreenSize::IOS_IPAD_10_5_MESSAGES => "iPad 10.5 (iMessage)",
@@ -130,6 +138,7 @@ module Deliver
         ScreenSize::IOS_47_MESSAGES,
         ScreenSize::IOS_55_MESSAGES,
         ScreenSize::IOS_58_MESSAGES,
+        ScreenSize::IOS_65_MESSAGES,
         ScreenSize::IOS_IPAD_MESSAGES,
         ScreenSize::IOS_IPAD_PRO_MESSAGES,
         ScreenSize::IOS_IPAD_10_5_MESSAGES
@@ -138,6 +147,9 @@ module Deliver
 
     def self.device_messages
       return {
+        ScreenSize::IOS_65_MESSAGES => [
+          [1242, 2688]
+        ],
         ScreenSize::IOS_58_MESSAGES => [
           [1125, 2436]
         ],
@@ -176,6 +188,9 @@ module Deliver
 
     def self.devices
       return {
+        ScreenSize::IOS_65 => [
+          [1242, 2688]
+        ],
         ScreenSize::IOS_58 => [
           [1125, 2436]
         ],

--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -108,6 +108,7 @@ module Spaceship
         iphone6:      "MZPFT.SortedN61ScreenShot",
         iphone6Plus:  "MZPFT.SortedN56ScreenShot",
         iphone58:     "MZPFT.SortedD22ScreenShot",
+        iphone65:     "MZPFT.SortedD33ScreenShot",
         iphone4:      "MZPFT.SortedN41ScreenShot",
         iphone35:     "MZPFT.SortedScreenShot",
         appleTV:      "MZPFT.SortedATVScreenShot",
@@ -124,6 +125,7 @@ module Spaceship
         iphone6:      "MZPFT.SortedN61MessagesScreenShot",
         iphone6Plus:  "MZPFT.SortedN56MessagesScreenShot",
         iphone58:     "MZPFT.SortedD22MessagesScreenShot",
+        iphone65:     "MZPFT.SortedD33MessagesScreenShot",
         iphone4:      "MZPFT.SortedN41MessagesScreenShot"
       }
     end
@@ -137,6 +139,8 @@ module Spaceship
         ipad105:      [[1668, 2224], [2224, 1668]],
         iphone6:      [[750, 1334], [1334, 750]],
         iphone6Plus:  [[1242, 2208], [2208, 1242]],
+        iphone58:     [[1125, 2436], [2436, 1125]],
+        iphone65:     [[1242, 2688], [2688, 1242]],
         iphone4:      [[640, 1096], [640, 1136], [1136, 600], [1136, 640]],
         iphone35:     [[640, 960], [640, 920], [960, 600], [960, 640]],
         appleTV:      [[1920, 1080]],

--- a/spaceship/lib/spaceship/tunes/device_type.rb
+++ b/spaceship/lib/spaceship/tunes/device_type.rb
@@ -1,7 +1,7 @@
 module Spaceship
   module Tunes
     class DeviceType
-      @types = ['iphone4', 'iphone35', 'iphone6', 'iphone6Plus', 'iphone58', 'ipad', 'ipadPro', 'ipad105', 'watch', 'appleTV', 'desktop']
+      @types = ['iphone4', 'iphone35', 'iphone6', 'iphone6Plus', 'iphone58', 'iphone65', 'ipad', 'ipadPro', 'ipad105', 'watch', 'appleTV', 'desktop']
       class << self
         attr_accessor :types
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This change enables to upload 1242x2688 (iPhone XS Max) screenshots.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
I added necessary constants for uploading screenshots.
I tried it with my app, and then it was successful for uploading screenshots.
