### PR TITLE
Return authority info for gather_cert_info

### DIFF
--- a/fastlane/lib/fastlane/actions/verify_build.rb
+++ b/fastlane/lib/fastlane/actions/verify_build.rb
@@ -53,6 +53,10 @@ module Fastlane
             type = part.split('=')[1].split(':')[0]
             values['provisioning_type'] = type.downcase =~ /distribution/i ? "distribution" : "development"
           end
+          if part.start_with?("Authority")
+            values['authority'] ||= []
+            values['authority'] << part.split('=')[1]
+          end
           if part.start_with?("TeamIdentifier")
             values['team_identifier'] = part.split('=')[1]
           end

--- a/fastlane/spec/actions_specs/verify_build_spec.rb
+++ b/fastlane/spec/actions_specs/verify_build_spec.rb
@@ -21,7 +21,8 @@ describe Fastlane do
           "team_identifier" => "TestFixture",
           "app_name" => "very-capable-app",
           "provisioning_uuid" => "12345678-1234-1234-1234-123456789012",
-          "team_name" => "TestFixture"
+          "team_name" => "TestFixture",
+          "authority" => ["TestFixture"]
         }
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
First motivation is I want to fix https://github.com/KrauseFx/xcode-install/issues/298 issue.
For that, I think the authority information is useful.

Of course, I can write the logic to pause on the xcode-install library.
But then I thought it was against DRY.
Also, since the method name is `gather_cert_info`, I thought that there was no problem that many results were returned.

### Description
I made `Fastlane::Actions::VerifyBuildAction.gather_cert_info` return authority information as array.
I added the authority item in `verify_build_action` rspec.
And I have run the rspec tests in my forked project.
