### PR TITLE
Added auto_fill_credential to produce enable_services

### DIFF
--- a/fastlane/lib/fastlane/actions/modify_services.rb
+++ b/fastlane/lib/fastlane/actions/modify_services.rb
@@ -47,6 +47,7 @@ module Fastlane
             app_group: 'app_group',
             apple_pay: 'apple_pay',
             associated_domains: 'associated_domains',
+            auto_fill_credential: 'auto_fill_credential',
             data_protection: 'data_protection',
             game_center: 'game_center',
             health_kit: 'healthkit',

--- a/produce/lib/produce/commands_generator.rb
+++ b/produce/lib/produce/commands_generator.rb
@@ -47,6 +47,7 @@ module Produce
 
         c.option('--app-group', 'Enable App Groups')
         c.option('--apple-pay', 'Enable Apple Pay')
+        c.option('--auto-fill-credential', 'Enable AutoFill Credential')
         c.option('--associated-domains', 'Enable Associated Domains')
         c.option('--data-protection STRING', String, 'Enable Data Protection, suitable values are "complete", "unlessopen" and "untilfirstauth"')
         c.option('--game-center', 'Enable Game Center')
@@ -86,6 +87,7 @@ module Produce
 
         c.option('--app-group', 'Disable App Groups')
         c.option('--apple-pay', 'Disable Apple Pay')
+        c.option('--auto-fill-credential', 'Disable AutoFill Credential')
         c.option('--associated-domains', 'Disable Associated Domains')
         c.option('--data-protection', 'Disable Data Protection')
         c.option('--game-center', 'Disable Game Center')

--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -15,6 +15,7 @@ module Produce
       app_group: [SERVICE_ON, SERVICE_OFF],
       apple_pay: [SERVICE_ON, SERVICE_OFF],
       associated_domains: [SERVICE_ON, SERVICE_OFF],
+      auto_fill_credential: [SERVICE_ON, SERVICE_OFF],
       data_protection: [
         SERVICE_COMPLETE,
         SERVICE_UNLESS_OPEN,

--- a/produce/lib/produce/service.rb
+++ b/produce/lib/produce/service.rb
@@ -36,7 +36,7 @@ module Produce
     end
 
     def valid_services_for(options)
-      allowed_keys = [:app_group, :apple_pay, :associated_domains, :data_protection, :game_center, :healthkit, :homekit,
+      allowed_keys = [:app_group, :apple_pay, :associated_domains, :auto_fill_credential, :data_protection, :game_center, :healthkit, :homekit,
                       :hotspot, :icloud, :in_app_purchase, :inter_app_audio, :multipath, :network_extension,
                       :nfc_tag_reading, :personal_vpn, :passbook, :push_notification, :sirikit, :vpn_conf,
                       :wallet, :wireless_conf]
@@ -74,6 +74,16 @@ module Produce
           app.update_service(Spaceship.app_service.associated_domains.on)
         else
           app.update_service(Spaceship.app_service.associated_domains.off)
+        end
+      end
+
+      if options.auto_fill_credential
+        UI.message("\tAutoFill Credential")
+
+        if on
+          app.update_service(Spaceship.app_service.auto_fill_credential.on)
+        else
+          app.update_service(Spaceship.app_service.auto_fill_credential.off)
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Adds support for AutoFill Credential in Xcode 10
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
Adds `auto_fill_credential` to `produce enable/disable_services`
<!-- Please describe in detail how you tested your changes. -->
Checked that `AutoFill Credential Provider` was enabled/disabled on the developer portal after running.
