### PR TITLE
[documentation - changelog_from_git_commits] Fixes typo - 

### DIFF
--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -132,7 +132,7 @@ module Fastlane
                                        is_string: false),
           FastlaneCore::ConfigItem.new(key: :quiet,
                                        env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_TAG_QUIET',
-                                       description: 'Whether or not to disbale changelog output',
+                                       description: 'Whether or not to disable changelog output',
                                        optional: true,
                                        default_value: false,
                                        is_string: false),


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
It's a big project with great documentation, where sometimes it easy to miss some typos. This is one I found.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
Fixes a typo in documentation (changelog_from_git_commits)
