### PR TITLE
[docs] Fix test_sample_code to use ConfigItem methods for ensuring valid values

### DIFF
--- a/fastlane/actions/test_sample_code.rb
+++ b/fastlane/actions/test_sample_code.rb
@@ -59,8 +59,14 @@ module Fastlane
             config_item = available_options.find { |a| a.key == current_argument }
             UI.user_error!("Unknown parameter '#{current_argument}' for action '#{method_sym}'") if config_item.nil?
 
-            if config_item.data_type && !value.kind_of?(config_item.data_type) && !config_item.optional && !config_item.skip_type_validation
-              UI.user_error!("'#{current_argument}' value must be a #{config_item.data_type}! Found #{value.class} instead.")
+            if value.nil? && config_item.optional
+              next
+            end
+
+            if config_item.data_type == Fastlane::Boolean
+              config_item.ensure_boolean_type_passes_validation(value)
+            else
+              config_item.ensure_generic_type_passes_validation(value)
             end
           end
         else

--- a/fastlane/lib/fastlane/actions/import_from_git.rb
+++ b/fastlane/lib/fastlane/actions/import_from_git.rb
@@ -33,6 +33,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        description: "The version to checkout on the respository. Optimistic match operator or multiple conditions can be used to select the latest version within constraints",
                                        default_value: nil,
+                                       is_string: false,
                                        optional: true)
         ]
       end


### PR DESCRIPTION
Fixes some code sample issues that were created by #13098

## Problem
`test_sample_code` was actually falling with a config item that was marked as `type: Boolean` but not marked as `optional: true`. 

This was ended up falling because of...
```sh
'force' value must be a Fastlane::Boolean! Found TrueClass instead.
```

This was because there were no special test cases for `Fastlane::Boolean`. The only reason this was passing previously was  because it just so happened that every `type: Boolean` was marked as optional 🙃 

## Solution
The solution was to remove the custom testing of values and piggybacking off of the config item's `ensure_boolean_type_passes_validation` and `ensure_generic_type_passes_validation`.