### PR TITLE
[actions, zip] Encrypt the contents of the zip archive using a password.

### DIFF
--- a/fastlane/lib/fastlane/actions/zip.rb
+++ b/fastlane/lib/fastlane/actions/zip.rb
@@ -19,7 +19,12 @@ module Fastlane
         Dir.chdir(File.expand_path("..", params[:path])) do # required to properly zip
           zip_options = params[:verbose] ? "r" : "rq"
 
-          Actions.sh("zip -#{zip_options} #{absolute_output_path.shellescape} #{File.basename(params[:path]).shellescape}")
+          if params[:password]
+            password_option = "-P '#{params[:password]}'"
+            Actions.sh("zip -#{zip_options} #{password_option} #{absolute_output_path.shellescape} #{File.basename(params[:path]).shellescape}")
+          else
+            Actions.sh("zip -#{zip_options} #{absolute_output_path.shellescape} #{File.basename(params[:path]).shellescape}")
+          end
         end
 
         UI.success("Successfully generated zip file at path '#{File.expand_path(absolute_output_path)}'")
@@ -51,6 +56,10 @@ module Fastlane
                                        description: "Enable verbose output of zipped file",
                                        default_value: true,
                                        type: Boolean,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :password,
+                                       env_name: "FL_ZIP_PASSWORD",
+                                       description: "Encrypt the contents of the zip archive using a password",
                                        optional: true)
         ]
       end

--- a/fastlane/spec/actions_specs/zip_spec.rb
+++ b/fastlane/spec/actions_specs/zip_spec.rb
@@ -47,6 +47,15 @@ describe Fastlane do
 
         expect(result).to eq(File.absolute_path(@output_path_with_zip))
       end
+
+      it "encrypts the contents of the zip archive using a password" do
+        password = "5O#RUKp0Zgop"
+        expect(Fastlane::Actions).to receive(:sh).with("zip -rq -P '#{password}' #{File.expand_path(@path)}.zip archive.rb")
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          zip(path: '#{@path}', verbose: false, password: '#{password}')
+        end").runner.execute(:test)
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- It might be helpful to encrypt the contents of the zip archive using a password.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
- Provided an option to encrypt the contents of the zip archive using a password.