### PR TITLE
[docs] fix CircleCI shield badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Twitter: @FastlaneTools](https://img.shields.io/badge/contact-@FastlaneTools-blue.svg?style=flat)](https://twitter.com/FastlaneTools)
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/fastlane/fastlane/blob/master/LICENSE)
 [![Gem](https://img.shields.io/gem/v/fastlane.svg?style=flat)](https://rubygems.org/gems/fastlane)
-[![Build Status](https://img.shields.io/circleci/project/fastlane/fastlane/master.svg?style=flat)](https://circleci.com/gh/fastlane/fastlane)
+[![Build Status](https://img.shields.io/circleci/project/github/fastlane/fastlane/master.svg)](https://circleci.com/gh/fastlane/fastlane)
 
 _fastlane_ is a tool for iOS and Android developers to automate tedious tasks like generating screenshots, dealing with provisioning profiles, and releasing your application.
 


### PR DESCRIPTION
## Problem
CircleCI badge was broken

<img width="515" alt="screen shot 2018-09-19 at 7 27 45 pm" src="https://user-images.githubusercontent.com/401294/45788776-276b3180-bc42-11e8-8cb7-cfe9ac0e6ebf.png">

## Solution
Now its not. Add to add version control type to url 🙃  

<img width="561" alt="screen shot 2018-09-19 at 7 29 11 pm" src="https://user-images.githubusercontent.com/401294/45788810-571a3980-bc42-11e8-916e-4a4fb117e7c0.png">
