### PR TITLE
Version bump to 2.105.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,43 +32,23 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 
 <table id='team'>
 <tr>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
 </td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
 </a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-</tr>
-<tr>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
 <td id='stefan-natchev'>
 <a href='https://github.com/snatchev'>
@@ -76,17 +56,69 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+</tr>
+<tr>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
 <td id='fumiya-nakamura'>
 <a href='https://github.com/nafu'>
 <img src='https://github.com/nafu.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/DanToml'>
+<img src='https://github.com/DanToml.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+</td>
+</tr>
+<tr>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 <td id='jorge-revuelta-h'>
 <a href='https://github.com/minuscorp'>
@@ -96,38 +128,18 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/AndrewMcBurney'>
-<img src='https://github.com/AndrewMcBurney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-</tr>
-<tr>
 <td id='luka-mirosevic'>
 <a href='https://github.com/lmirosevic'>
 <img src='https://github.com/lmirosevic.png?size=140'>
@@ -140,23 +152,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
+<td id='andrew-mcburney'>
+<a href='https://github.com/AndrewMcBurney'>
+<img src='https://github.com/AndrewMcBurney.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/DanToml'>
-<img src='https://github.com/DanToml.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
 </tr>
 </table>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -14,26 +14,26 @@ File.write("#{lib}/fastlane/plugins/template/.rubocop.yml", YAML.dump(config))
 Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
-  spec.authors       = ["Stefan Natchev",
-                        "Helmut Januschka",
-                        "Danielle Tomlinson",
-                        "Jérôme Lacoste",
-                        "Aaron Brager",
-                        "Olivier Halligon",
-                        "Iulian Onofrei",
-                        "Joshua Liebowitz",
+  spec.authors       = ["Olivier Halligon",
                         "Josh Holtz",
+                        "Aaron Brager",
+                        "Joshua Liebowitz",
                         "Manu Wallner",
-                        "Maksym Grebenets",
-                        "Jan Piotrowski",
-                        "Andrew McBurney",
+                        "Luka Mirosevic",
                         "Kohki Miki",
                         "Fumiya Nakamura",
-                        "Felix Krause",
-                        "Jimmy Dee",
-                        "Luka Mirosevic",
+                        "Iulian Onofrei",
+                        "Maksym Grebenets",
+                        "Andrew McBurney",
+                        "Jorge Revuelta H",
+                        "Jan Piotrowski",
                         "Matthew Ellis",
-                        "Jorge Revuelta H"]
+                        "Danielle Tomlinson",
+                        "Jimmy Dee",
+                        "Jérôme Lacoste",
+                        "Helmut Januschka",
+                        "Felix Krause",
+                        "Stefan Natchev"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.104.0'.freeze
+  VERSION = '2.105.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.104.0
+// Generated with fastlane 2.105.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1310,7 +1310,8 @@ func deploygate(apiToken: String,
                 message: String = "No changelog provided",
                 distributionKey: String? = nil,
                 releaseNote: String? = nil,
-                disableNotify: Bool = false) {
+                disableNotify: Bool = false,
+                distributionName: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "deploygate", className: nil, args: [RubyCommand.Argument(name: "api_token", value: apiToken),
                                                                                             RubyCommand.Argument(name: "user", value: user),
                                                                                             RubyCommand.Argument(name: "ipa", value: ipa),
@@ -1318,7 +1319,8 @@ func deploygate(apiToken: String,
                                                                                             RubyCommand.Argument(name: "message", value: message),
                                                                                             RubyCommand.Argument(name: "distribution_key", value: distributionKey),
                                                                                             RubyCommand.Argument(name: "release_note", value: releaseNote),
-                                                                                            RubyCommand.Argument(name: "disable_notify", value: disableNotify)])
+                                                                                            RubyCommand.Argument(name: "disable_notify", value: disableNotify),
+                                                                                            RubyCommand.Argument(name: "distribution_name", value: distributionName)])
   _ = runner.executeCommand(command)
 }
 func dotgpgEnvironment(dotgpgFile: String) {
@@ -1841,7 +1843,7 @@ func hockey(apk: String? = nil,
             uploadDsymOnly: Bool = false,
             ownerId: String? = nil,
             strategy: String = "add",
-            timeout: String? = nil,
+            timeout: Int? = nil,
             bypassCdn: Bool = false,
             dsaSignature: String = "") {
   let command = RubyCommand(commandID: "", methodName: "hockey", className: nil, args: [RubyCommand.Argument(name: "apk", value: apk),
@@ -2482,11 +2484,13 @@ func pushGitTags(force: Bool = false,
 func pushToGitRemote(localBranch: String? = nil,
                      remoteBranch: String? = nil,
                      force: Bool = false,
+                     forceWithLease: Bool = false,
                      tags: Bool = true,
                      remote: String = "origin") {
   let command = RubyCommand(commandID: "", methodName: "push_to_git_remote", className: nil, args: [RubyCommand.Argument(name: "local_branch", value: localBranch),
                                                                                                     RubyCommand.Argument(name: "remote_branch", value: remoteBranch),
                                                                                                     RubyCommand.Argument(name: "force", value: force),
+                                                                                                    RubyCommand.Argument(name: "force_with_lease", value: forceWithLease),
                                                                                                     RubyCommand.Argument(name: "tags", value: tags),
                                                                                                     RubyCommand.Argument(name: "remote", value: remote)])
   _ = runner.executeCommand(command)
@@ -2616,6 +2620,7 @@ func runTests(workspace: String? = nil,
               buildlogPath: String = "~/Library/Logs/scan",
               includeSimulatorLogs: Bool = false,
               formatter: String? = nil,
+              xcprettyArgs: String? = nil,
               maxConcurrentSimulators: Int? = nil,
               disableConcurrentTesting: Bool = false,
               testWithoutBuilding: Bool? = nil,
@@ -2659,6 +2664,7 @@ func runTests(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "buildlog_path", value: buildlogPath),
                                                                                            RubyCommand.Argument(name: "include_simulator_logs", value: includeSimulatorLogs),
                                                                                            RubyCommand.Argument(name: "formatter", value: formatter),
+                                                                                           RubyCommand.Argument(name: "xcpretty_args", value: xcprettyArgs),
                                                                                            RubyCommand.Argument(name: "max_concurrent_simulators", value: maxConcurrentSimulators),
                                                                                            RubyCommand.Argument(name: "disable_concurrent_testing", value: disableConcurrentTesting),
                                                                                            RubyCommand.Argument(name: "test_without_building", value: testWithoutBuilding),
@@ -2744,6 +2750,7 @@ func scan(workspace: String? = scanfile.workspace,
           buildlogPath: String = scanfile.buildlogPath,
           includeSimulatorLogs: Bool = scanfile.includeSimulatorLogs,
           formatter: String? = scanfile.formatter,
+          xcprettyArgs: String? = scanfile.xcprettyArgs,
           maxConcurrentSimulators: Int? = scanfile.maxConcurrentSimulators,
           disableConcurrentTesting: Bool = scanfile.disableConcurrentTesting,
           testWithoutBuilding: Bool? = scanfile.testWithoutBuilding,
@@ -2787,6 +2794,7 @@ func scan(workspace: String? = scanfile.workspace,
                                                                                       RubyCommand.Argument(name: "buildlog_path", value: buildlogPath),
                                                                                       RubyCommand.Argument(name: "include_simulator_logs", value: includeSimulatorLogs),
                                                                                       RubyCommand.Argument(name: "formatter", value: formatter),
+                                                                                      RubyCommand.Argument(name: "xcpretty_args", value: xcprettyArgs),
                                                                                       RubyCommand.Argument(name: "max_concurrent_simulators", value: maxConcurrentSimulators),
                                                                                       RubyCommand.Argument(name: "disable_concurrent_testing", value: disableConcurrentTesting),
                                                                                       RubyCommand.Argument(name: "test_without_building", value: testWithoutBuilding),
@@ -3281,7 +3289,8 @@ func supply(packageName: String,
             mappingPaths: [String]? = nil,
             rootUrl: String? = nil,
             checkSupersededTracks: Bool = false,
-            timeout: Int = 300) {
+            timeout: Int = 300,
+            deactivateOnPromote: Bool = true) {
   let command = RubyCommand(commandID: "", methodName: "supply", className: nil, args: [RubyCommand.Argument(name: "package_name", value: packageName),
                                                                                         RubyCommand.Argument(name: "track", value: track),
                                                                                         RubyCommand.Argument(name: "rollout", value: rollout),
@@ -3304,7 +3313,8 @@ func supply(packageName: String,
                                                                                         RubyCommand.Argument(name: "mapping_paths", value: mappingPaths),
                                                                                         RubyCommand.Argument(name: "root_url", value: rootUrl),
                                                                                         RubyCommand.Argument(name: "check_superseded_tracks", value: checkSupersededTracks),
-                                                                                        RubyCommand.Argument(name: "timeout", value: timeout)])
+                                                                                        RubyCommand.Argument(name: "timeout", value: timeout),
+                                                                                        RubyCommand.Argument(name: "deactivate_on_promote", value: deactivateOnPromote)])
   _ = runner.executeCommand(command)
 }
 func swiftlint(mode: String = "lint",
@@ -3771,7 +3781,8 @@ func uploadToPlayStore(packageName: String,
                        mappingPaths: [String]? = nil,
                        rootUrl: String? = nil,
                        checkSupersededTracks: Bool = false,
-                       timeout: Int = 300) {
+                       timeout: Int = 300,
+                       deactivateOnPromote: Bool = true) {
   let command = RubyCommand(commandID: "", methodName: "upload_to_play_store", className: nil, args: [RubyCommand.Argument(name: "package_name", value: packageName),
                                                                                                       RubyCommand.Argument(name: "track", value: track),
                                                                                                       RubyCommand.Argument(name: "rollout", value: rollout),
@@ -3794,7 +3805,8 @@ func uploadToPlayStore(packageName: String,
                                                                                                       RubyCommand.Argument(name: "mapping_paths", value: mappingPaths),
                                                                                                       RubyCommand.Argument(name: "root_url", value: rootUrl),
                                                                                                       RubyCommand.Argument(name: "check_superseded_tracks", value: checkSupersededTracks),
-                                                                                                      RubyCommand.Argument(name: "timeout", value: timeout)])
+                                                                                                      RubyCommand.Argument(name: "timeout", value: timeout),
+                                                                                                      RubyCommand.Argument(name: "deactivate_on_promote", value: deactivateOnPromote)])
   _ = runner.executeCommand(command)
 }
 func uploadToTestflight(username: String,
@@ -3971,7 +3983,7 @@ func xcov(workspace: String? = nil,
           coverallsServiceJobId: String? = nil,
           coverallsRepoToken: String? = nil,
           xcconfig: String? = nil,
-          ideFoundationPath: String = "/Applications/Xcode.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
+          ideFoundationPath: String = "/Applications/Xcode-10.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
           legacySupport: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "xcov", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                       RubyCommand.Argument(name: "project", value: project),
@@ -4017,10 +4029,12 @@ func xcversion(version: String) {
 }
 @discardableResult func zip(path: String,
                             outputPath: String? = nil,
-                            verbose: Bool = true) -> String {
+                            verbose: Bool = true,
+                            password: String? = nil) -> String {
   let command = RubyCommand(commandID: "", methodName: "zip", className: nil, args: [RubyCommand.Argument(name: "path", value: path),
                                                                                      RubyCommand.Argument(name: "output_path", value: outputPath),
-                                                                                     RubyCommand.Argument(name: "verbose", value: verbose)])
+                                                                                     RubyCommand.Argument(name: "verbose", value: verbose),
+                                                                                     RubyCommand.Argument(name: "password", value: password)])
   return runner.executeCommand(command)
 }
 
@@ -4077,4 +4091,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.28]
+// FastlaneRunnerAPIVersion [0.9.29]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.104.0
+// Generated with fastlane 2.105.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.104.0
+// Generated with fastlane 2.105.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.104.0
+// Generated with fastlane 2.105.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.104.0
+// Generated with fastlane 2.105.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -18,6 +18,7 @@ protocol ScanfileProtocol: class {
   var buildlogPath: String { get }
   var includeSimulatorLogs: Bool { get }
   var formatter: String? { get }
+  var xcprettyArgs: String? { get }
   var maxConcurrentSimulators: Int? { get }
   var disableConcurrentTesting: Bool { get }
   var testWithoutBuilding: Bool? { get }
@@ -64,6 +65,7 @@ extension ScanfileProtocol {
   var buildlogPath: String { return "~/Library/Logs/scan" }
   var includeSimulatorLogs: Bool { return false }
   var formatter: String? { return nil }
+  var xcprettyArgs: String? { return nil }
   var maxConcurrentSimulators: Int? { return nil }
   var disableConcurrentTesting: Bool { return false }
   var testWithoutBuilding: Bool? { return nil }
@@ -92,4 +94,4 @@ extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.4]
+// FastlaneRunnerAPIVersion [0.9.5]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.104.0
+// Generated with fastlane 2.105.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.104.0
+// Generated with fastlane 2.105.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.104.0':**

* [supply] prevent disabling of tracks on promotion (#13351) via Tom Wilson
* [action] encrypt the contents of the zip archive using a password. (#13393) via Max Shcheglov
* [produce] added auto_fill_credential to produce (#13377) via Timothy Costa
* [action] tryouts token is a combination of key and secret (#13348) via hdi-trae
* [action] return authority info for gather_cert_info (#13369) via Tadayuki Onishi
* [scan] add option to pass xcpretty options (#13324) via Jack Spargo
* [docs] fix CircleCI shield badge (#13396) via Josh Holtz
* [docs] fix test_sample_code to use ConfigItem methods for ensuring valid values (#13391) via Josh Holtz
* [action] distribution name with deploygate action (#13363) via 417-72KI
* [spaceship] include ApplePayMerchantIdentifier certificates (#13335) via Daniel Beard
* [action] add force-with-lease to push_to_git_remote (#13098) via Prabhuanand Sivashanmugam
* [core] delete circle.yml (#13375) via Felix Krause
* [docs] fix typo in changelog_from_git_commits options - (#13378) via Alejandro Paredes Alva
* [deliver] add screen size for iPhone XS Max (#13366) via Tatsuya Tanaka
* [core] add keychain as context to match error (#13357) via Robert Edwards
* [action] added type attribute to hockey upload timeout config item (#13322) via József Mihalicza
* [action] push only tags on `push_git_tags` (#13314) via Ivo
* [scan] make it clear that output_style: raw disables xcpretty (#13301) via Jason Hagglund
* [spaceship] adding a way to parse marketing url and privacy policy url (#13350) via heartofagoof
* [core] report fastlane.swift usage vs normal fastlane (ruby) usage (#13333) via Joshua Liebowitz
* [core] monkey patch Shellwords (`String.shellescape`, `Array.shelljoin`) for Windows support (#13230) via Jan Piotrowski
