### PR TITLE
Fix UDID format for new iPhone XS

### DIFF
--- a/fastlane/lib/fastlane/actions/register_device.rb
+++ b/fastlane/lib/fastlane/actions/register_device.rb
@@ -3,7 +3,7 @@ require 'credentials_manager'
 module Fastlane
   module Actions
     class RegisterDeviceAction < Action
-      UDID_REGEXP = /^\h{40}$/
+      UDID_REGEXP = /^(\h{40}|\h{8}-\h{16})$/
 
       def self.is_supported?(platform)
         platform == :ios

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -3,7 +3,7 @@ require 'credentials_manager'
 module Fastlane
   module Actions
     class RegisterDevicesAction < Action
-      UDID_REGEXP_IOS = /^\h{40}$/
+      UDID_REGEXP_IOS = /^(\h{40}|\h{8}-\h{16})$/
       UDID_REGEXP_MAC = /^[\h\-]{36}$/
 
       def self.is_supported?(platform)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The newly released iPhones (iPhone XS, iPhone XS Max, etc) has a new UDID format, and the `add_device` and` add_devices` actions failed because they do not correspond to this new format.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

UDID format has changed like this:

before:
`1234567890123456789012345678901234567890` (HEX, 40 characters)

to:
`12345678-1234567890123456` (HEX, 8 & 16 characters, hyphen separated)
