### PR TITLE
[core] fix for when FastlaneFolder.swift? when no Fastfile or Fastfile.swift?

### DIFF
--- a/fastlane_core/lib/fastlane_core/fastlane_folder.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_folder.rb
@@ -21,6 +21,7 @@ module FastlaneCore
     end
 
     def self.swift?
+      return false unless self.fastfile_path
       return self.fastfile_path.downcase.end_with?(".swift")
     end
 

--- a/fastlane_core/spec/fastlane_folder_spec.rb
+++ b/fastlane_core/spec/fastlane_folder_spec.rb
@@ -42,4 +42,21 @@ describe FastlaneCore::FastlaneFolder do
       end
     end
   end
+
+  describe "#swift?" do
+    it "returns false if nil fastfile_path" do
+      allow(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return(nil)
+      expect(FastlaneCore::FastlaneFolder.swift?).to eq(false)
+    end
+
+    it "returns false if not Fastfile" do
+      allow(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("Fastfile")
+      expect(FastlaneCore::FastlaneFolder.swift?).to eq(false)
+    end
+
+    it "returns true if Fastfile.swift" do
+      allow(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("Fastfile.swift")
+      expect(FastlaneCore::FastlaneFolder.swift?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #13403 #13411

## Problem
`FastlaneFolder.swift?` was trying to downcase `fastfile_path` which could be `nil` which was introduced in https://github.com/fastlane/fastlane/pull/13333

## Solution
This prevents that and adds tests