### PR TITLE
Fix modify_services by adding missing keys to services_mapping (13090)

### DIFF
--- a/fastlane/lib/fastlane/actions/modify_services.rb
+++ b/fastlane/lib/fastlane/actions/modify_services.rb
@@ -52,18 +52,20 @@ module Fastlane
             game_center: 'game_center',
             health_kit: 'healthkit',
             home_kit: 'homekit',
-            wireless_accessory: 'wireless_conf',
+            hotspot: 'hotspot',
             icloud: 'icloud',
             in_app_purchase: 'in_app_purchase',
             inter_app_audio: 'inter_app_audio',
+            multipath: 'multipath',
+            network_extension: 'network_extension',
+            nfc_tag_reading: 'nfc_tag_reading',
+            personal_vpn: 'personal_vpn',
             passbook: 'passbook',
             push_notification: 'push_notification',
             siri_kit: 'sirikit',
             vpn_configuration: 'vpn_conf',
-            network_extension: 'network_extension',
-            hotspot: 'hotspot',
-            multipath: 'multipath',
-            nfc_tag_reading: 'nfc_tag_reading'
+            wallet: 'wallet',
+            wireless_accessory: 'wireless_conf'
         }
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes: https://github.com/fastlane/fastlane/issues/13090

### Description
<!-- Describe your changes in detail -->
Added missing keys to action: 
- wallet
- personal_vpn

Also sorted keys to match order in `produce/lib/produce/developer_center.rb`

<!-- Please describe in detail how you tested your changes. -->
To test, I ran `bundle exec fastlane test` && `bundle exec fastlane rspec` as docs described.
