### PR TITLE
[snapshot] add new apple devices to device mapping

### DIFF
--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -69,6 +69,9 @@ module Snapshot
       {
         # snapshot in Xcode 9 saves screenshots with the SIMULATOR_DEVICE_NAME
         # which includes spaces
+        'iPhone XS Max' => "iPhone XS Max",
+        'iPhone XS' => "iPhone XS",
+        'iPhone XR' => "iPhone XR",
         'iPhone 8 Plus' => "iPhone 8 Plus",
         'iPhone 8' => "iPhone 8",
         'iPhone X' => "iPhone X",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
iPhone XR, XS and XS Max were treated as iPhone X on the report html. They were missing in the device name mapping in `reports_generator.rb`

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
Added those devices to the device mapping in `reports_generator.rb`.
I tested this with following Snapfile.
```ruby
devices([
   "iPhone X",
   "iPhone XR",
   "iPhone XS",
   "iPhone XS Max",
])
```