### PR TITLE
make `Helper.ci?` return true when running on Azure DevOps (VSTS)

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -72,7 +72,7 @@ module FastlaneCore
     # @return [boolean] true if building in a known CI environment
     def self.ci?
       # Check for Jenkins, Travis CI, ... environment variables
-      ['JENKINS_HOME', 'JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'APPCENTER_BUILD_ID', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI', 'XCS'].each do |current|
+      ['JENKINS_HOME', 'JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'APPCENTER_BUILD_ID', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI', 'XCS', 'TF_BUILD'].each do |current|
         return true if ENV.key?(current)
       end
       return false

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -61,6 +61,11 @@ describe FastlaneCore do
         stub_const('ENV', { 'XCS' => true })
         expect(FastlaneCore::Helper.ci?).to be(true)
       end
+
+      it "returns true when building in Azure DevOps (VSTS) " do
+        stub_const('ENV', { 'TF_BUILD' => true })
+        expect(FastlaneCore::Helper.ci?).to be(true)
+      end
     end
 
     describe "#keychain_path" do


### PR DESCRIPTION
🔑
### Checklist
- ~[ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass~ ran into https://github.com/fastlane/fastlane/issues/9177 so only ran the Helper tests
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
While running `fastlane` on Azure DevOps ( VSTS ) some code that was meant to run on CI did not run. I noticed that calling `Helper.ci?` was returning `false` which in turn caused the CI pipeline to fail.

### Description
I added `TF_BUILD` to the list of environment variables that the Helper checks for to determine if it is running on a CI server. [The `TF_BUILD` env variable is present on Microsoft's Azure DevOps (used to be called VSTS)](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=vsts)
I ran `bundle exec rspec ./fastlane_core/spec/helper_spec.rb` to make sure the new test I added and the existing helper tests still work and they all passed ✅ .
