### PR TITLE
Refactor Supply::Client to be usable by create_app_on_managed_play_store

### DIFF
--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -155,8 +155,7 @@ module Fastlane
 end
 
 require 'supply/client'
-GoogleServiceClient = Supply::GoogleServiceClient
-class PlaycustomappClient < GoogleServiceClient
+class PlaycustomappClient < Supply::AbstractGoogleServiceClient
   # Connecting with Google
   attr_accessor :client
 

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -156,7 +156,7 @@ end
 
 require 'supply/client'
 class PlaycustomappClient < Supply::AbstractGoogleServiceClient
-  SERVICE = Google::Apis::PlaycustomappV1::PlaycustomappService.new
+  SERVICE = Google::Apis::PlaycustomappV1::PlaycustomappService
   SCOPE = Google::Apis::PlaycustomappV1::AUTH_ANDROIDPUBLISHER
 
   #####################################################

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -159,20 +159,6 @@ class PlaycustomappClient < Supply::AbstractGoogleServiceClient
   SERVICE = Google::Apis::PlaycustomappV1::PlaycustomappService.new
   SCOPE = Google::Apis::PlaycustomappV1::AUTH_ANDROIDPUBLISHER
 
-  # Connecting with Google
-  attr_accessor :client
-
-  # instantiate a client given the supplied configuration
-  def self.make_from_config(params: nil)
-    super(params: params)
-  end
-
-  # Initializes the service and its auth_client using the specified information
-  # @param service_account_json: The raw service account Json data
-  def initialize(service_account_json: nil, params: nil)
-    self.client = super(service_account_json: service_account_json, params: params)
-  end
-
   #####################################################
   # @!group Create
   #####################################################

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -168,7 +168,6 @@ class PlaycustomappClient < GoogleServiceClient
   # Initializes the service and its auth_client using the specified information
   # @param service_account_json: The raw service account Json data
   def initialize(service_account_json: nil, params: nil)
-    # TODO: Can these be defined as a proper class variable somehow and not in `initialize`?
     @scope = Google::Apis::PlaycustomappV1::AUTH_ANDROIDPUBLISHER
     @service = Google::Apis::PlaycustomappV1::PlaycustomappService.new
 

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -156,6 +156,9 @@ end
 
 require 'supply/client'
 class PlaycustomappClient < Supply::AbstractGoogleServiceClient
+  SERVICE = Google::Apis::PlaycustomappV1::PlaycustomappService.new
+  SCOPE = Google::Apis::PlaycustomappV1::AUTH_ANDROIDPUBLISHER
+
   # Connecting with Google
   attr_accessor :client
 
@@ -167,9 +170,6 @@ class PlaycustomappClient < Supply::AbstractGoogleServiceClient
   # Initializes the service and its auth_client using the specified information
   # @param service_account_json: The raw service account Json data
   def initialize(service_account_json: nil, params: nil)
-    @scope = Google::Apis::PlaycustomappV1::AUTH_ANDROIDPUBLISHER
-    @service = Google::Apis::PlaycustomappV1::PlaycustomappService.new
-
     self.client = super(service_account_json: service_account_json, params: params)
   end
 

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -105,8 +105,8 @@ module Fastlane
             default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
             default_value_dynamic: true,
             verify_block: proc do |value|
-              UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
               UI.user_error!("Could not find service account json file at path '#{File.expand_path(value)}'") unless File.exist?(File.expand_path(value))
+              UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
             end
           ),
           FastlaneCore::ConfigItem.new(

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -162,14 +162,13 @@ class PlaycustomappClient < GoogleServiceClient
 
   # instantiate a client given the supplied configuration
   def self.make_from_config(params: nil)
-    @param = params
     super(params: params)
   end
 
   # Initializes the service and its auth_client using the specified information
   # @param service_account_json: The raw service account Json data
   def initialize(service_account_json: nil, params: nil)
-    # TODO Can these be defined as a proper class variable somehow and not in `initialize`?
+    # TODO: Can these be defined as a proper class variable somehow and not in `initialize`?
     @scope = Google::Apis::PlaycustomappV1::AUTH_ANDROIDPUBLISHER
     @service = Google::Apis::PlaycustomappV1::PlaycustomappService.new
 

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -63,6 +63,7 @@ describe Fastlane do
           println
           echo
           xcov
+          create_app_on_managed_play_store
         )
       end
 

--- a/supply/lib/supply.rb
+++ b/supply/lib/supply.rb
@@ -23,7 +23,7 @@ module Supply
   CHANGELOGS_FOLDER_NAME = "changelogs"
 
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
-  UI = FastlaneCore::UI
+  UI = FastlaneCore::UI unless defined?(UI)
   ROOT = Pathname.new(File.expand_path('../..', __FILE__))
   DESCRIPTION = "Command line tool for updating Android apps and their metadata on the Google Play Store".freeze
 end

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -49,7 +49,7 @@ module Supply
       Google::Apis::ClientOptions.default.send_timeout_sec = params[:timeout]
       Google::Apis::RequestOptions.default.retries = 5
 
-      service = self.class::SERVICE
+      service = self.class::SERVICE.new
       service.authorization = auth_client
 
       if params[:root_url]
@@ -71,7 +71,7 @@ module Supply
   end
 
   class Client < AbstractGoogleServiceClient
-    SERVICE = Androidpublisher::AndroidPublisherService.new
+    SERVICE = Androidpublisher::AndroidPublisherService
     SCOPE = Androidpublisher::AUTH_ANDROIDPUBLISHER
 
     # Editing something

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -7,7 +7,7 @@ require 'net/http'
 module Supply
   UI = FastlaneCore::UI
 
-  class GoogleServiceClient
+  class AbstractGoogleServiceClient
     def self.make_from_config(params: nil)
       unless params[:json_key] || params[:json_key_data]
         UI.important("To not be asked about this value, you can specify it using 'json_key'")
@@ -65,7 +65,7 @@ module Supply
     end
   end
 
-  class Client < GoogleServiceClient
+  class Client < AbstractGoogleServiceClient
     # Connecting with Google
     attr_accessor :android_publisher
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -81,7 +81,7 @@ module Supply
 
     # instantiate a client given the supplied configuration
     def self.make_from_config(params: nil)
-      if(params.nil?)
+      if params.nil?
         params = Supply.config
       end
 
@@ -428,6 +428,5 @@ module Supply
     def ensure_active_edit!
       UI.user_error!("You need to have an active edit, make sure to call `begin_edit`") unless @current_edit
     end
-
   end
 end

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -5,7 +5,7 @@ Androidpublisher = Google::Apis::AndroidpublisherV2
 require 'net/http'
 
 module Supply
-  UI = FastlaneCore::UI
+  UI = FastlaneCore::UI unless defined?(UI)
 
   class AbstractGoogleServiceClient
     SCOPE = nil

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -69,8 +69,8 @@ module Supply
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
                                      default_value_dynamic: true,
                                      verify_block: proc do |value|
-                                       UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
                                        UI.user_error!("Could not find service account json file at path '#{File.expand_path(value)}'") unless File.exist?(File.expand_path(value))
+                                       UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
                                      end),
         FastlaneCore::ConfigItem.new(key: :json_key_data,
                                      env_name: "SUPPLY_JSON_KEY_DATA",


### PR DESCRIPTION
`create_app_on_managed_play_store` does very similar things as `supply`, so effectively had a copy of the API communication logic that was worse than what `supply` had.

This PR extracts parts of `Supply::Client` into `Supply::GoogleServiceClient` which `Supply::Client` then inherits from and which can be used by `create_app_on_managed_play_store` with its own implementation.

--- 

Some notes:

- I kept the handling of deprecated params in Supply::Client only
- The refactor decouples `make_from_config` and `initialize` from `Supply.config` a bit so it doesn't _have to_ be used



There are some icky areas:

- ~~The idea was, that `scope` and `service` could be overwritten or set in the child class for other uses of the client. But `@scope` and `@service` didn't work if I just set them in the class, I had to overwrite their values in `initialize`.~~ Fixed.

- During development I noticed that `supply` is almost untested. I could do pretty much what I wanted in the client, the tests still passed. But I manually tested this branch now (`bundle exec fastlane suppy init`, lane that uses `supply` to upload downloaded metadata to another app), and it seems to work fine)