### PR TITLE
[WIP] New action `validate_play_store_json_key`

### DIFF
--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -155,8 +155,7 @@ module Fastlane
 end
 
 require 'supply/client'
-GoogleServiceClient = Supply::GoogleServiceClient
-class PlaycustomappClient < GoogleServiceClient
+class PlaycustomappClient < Supply::AbstractGoogleServiceClient
   # Connecting with Google
   attr_accessor :client
 

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -190,7 +190,7 @@ module Fastlane
   end
 end
 
-# https://support.google.com/googleplay/android-developer/answer/3125566?hl=en 
+# https://support.google.com/googleplay/android-developer/answer/3125566?hl=en
 # => Add your own text translations & localized graphic assets => See available languages => replace `-` with `_`
 # %w => https://stackoverflow.com/a/1274703/252627
 class AvailablePlayStoreLanguages

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -159,20 +159,6 @@ class PlaycustomappClient < Supply::AbstractGoogleServiceClient
   SERVICE = Google::Apis::PlaycustomappV1::PlaycustomappService.new
   SCOPE = Google::Apis::PlaycustomappV1::AUTH_ANDROIDPUBLISHER
 
-  # Connecting with Google
-  attr_accessor :client
-
-  # instantiate a client given the supplied configuration
-  def self.make_from_config(params: nil)
-    super(params: params)
-  end
-
-  # Initializes the service and its auth_client using the specified information
-  # @param service_account_json: The raw service account Json data
-  def initialize(service_account_json: nil, params: nil)
-    self.client = super(service_account_json: service_account_json, params: params)
-  end
-
   #####################################################
   # @!group Create
   #####################################################

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -168,7 +168,6 @@ class PlaycustomappClient < GoogleServiceClient
   # Initializes the service and its auth_client using the specified information
   # @param service_account_json: The raw service account Json data
   def initialize(service_account_json: nil, params: nil)
-    # TODO: Can these be defined as a proper class variable somehow and not in `initialize`?
     @scope = Google::Apis::PlaycustomappV1::AUTH_ANDROIDPUBLISHER
     @service = Google::Apis::PlaycustomappV1::PlaycustomappService.new
 

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -1,0 +1,283 @@
+require 'fastlane/action'
+require_relative '../helper/managed_google_play_helper'
+
+module Fastlane
+  module Actions
+    class CreateAppOnManagedPlayStoreAction < Action
+      def self.run(params)
+        unless params[:json_key] || params[:json_key_data]
+          UI.important("To not be asked about this value, you can specify it using 'json_key'")
+          params[:json_key] = UI.input("The service account json file used to authenticate with Google: ")
+        end
+
+        FastlaneCore::PrintTable.print_values(
+          config: params,
+          mask_keys: [:json_key_data],
+          title: "Summary for CreateAppOnManagedPlayStoreAction" # TODO
+        )
+
+        require "google/apis/playcustomapp_v1"
+
+        # Auth Info
+        @keyfile = params[:json_key] # TODO json_key_data as alternative
+        @developer_account = params[:developer_account_id]
+
+        # App Info
+        @apk_path = params[:apk]
+        @app_title = params[:app_title]
+        @language_code = params[:language]
+
+        # login
+        scope = 'https://www.googleapis.com/auth/androidpublisher'
+        credentials = JSON.parse(File.open(@keyfile, 'rb').read)
+        auth_client = Signet::OAuth2::Client.new(
+          token_credential_uri: 'https://oauth2.googleapis.com/token',
+          audience: 'https://oauth2.googleapis.com/token',
+          scope: scope,
+          issuer: credentials['client_id'],
+          signing_key: OpenSSL::PKey::RSA.new(credentials['private_key'], nil)
+        )
+        UI.message('auth_client: ' + auth_client.inspect)
+        auth_client.fetch_access_token!
+
+        # service
+        play_custom_apps = Google::Apis::PlaycustomappV1::PlaycustomappService.new
+        play_custom_apps.authorization = auth_client
+        UI.message('play_custom_apps with auth: ' + play_custom_apps.inspect)
+
+        # app
+        custom_app = Google::Apis::PlaycustomappV1::CustomApp.new(title: @app_title, language_code: @language_code)
+        UI.message('custom_app: ' + custom_app.inspect)
+
+        # create app
+        returned = play_custom_apps.create_account_custom_app(
+          @developer_account,
+          custom_app,
+          upload_source: @apk_path
+        ) do |created_app, error|
+          if error.nil?
+            puts("Success: #{created_app}.")
+            UI.success(created_app)
+            UI.success(created_app.inspect)
+          else
+            puts("Error: #{error}")
+            UI.error(error.inspect)
+          end
+        end
+        UI.message('returned: ' + returned.inspect)
+      end
+
+      def self.description
+        "Create Managed Google Play Apps"
+      end
+
+      def self.authors
+        ["Jan Piotrowski"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        # Optional:
+        "none yet"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :json_key,
+            env_name: "SUPPLY_JSON_KEY", # TODO
+            short_option: "-j",
+            conflicting_options: [:json_key_data],
+            optional: true, # this shouldn't be optional but is until I find out how json_key OR json_key_data can be required
+            description: "The path to a file containing service account JSON, used to authenticate with Google",
+            code_gen_sensitive: true,
+            default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
+            default_value_dynamic: true,
+            verify_block: proc do |value|
+              UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
+              UI.user_error!("Could not find service account json file at path '#{File.expand_path(value)}'") unless File.exist?(File.expand_path(value))
+            end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :json_key_data,
+            env_name: "SUPPLY_JSON_KEY_DATA", # TODO
+            short_option: "-c",
+            conflicting_options: [:json_key],
+            optional: true,
+            description: "The raw service account JSON data used to authenticate with Google",
+            code_gen_sensitive: true,
+            default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
+            default_value_dynamic: true,
+            verify_block: proc do |value|
+              begin
+                JSON.parse(value)
+              rescue JSON::ParserError
+                UI.user_error!("Could not parse service account json: JSON::ParseError")
+              end
+            end
+          ),
+          # developer_account
+          FastlaneCore::ConfigItem.new(key: :developer_account_id,
+            short_option: "-k",
+            env_name: "PRODUCE_ITC_TEAM_ID", # TODO
+            description: "The ID of your Google Play Console account. Can be obtained from the URL when you log in (`https://play.google.com/apps/publish/?account=...` or when you 'Obtain private app publishing rights' (https://developers.google.com/android/work/play/custom-app-api/get-started#retrieve_the_developer_account_id)",
+            optional: false,
+            is_string: false, # as we also allow integers, which we convert to strings anyway
+            code_gen_sensitive: true,
+            default_value: CredentialsManager::AppfileConfig.try_fetch_value(:developer_account_id),
+            default_value_dynamic: true,
+            verify_block: proc do |value|
+              raise UI.error("No Developer Account ID given, pass using `developer_account_id: 123456789`") if value.to_s.empty?
+            end),
+          FastlaneCore::ConfigItem.new(
+            key: :apk,
+            env_name: "SUPPLY_APK", # TODO
+            description: "Path to the APK file to upload",
+            short_option: "-b",
+            conflicting_options: [:apk_paths, :aab],
+            code_gen_sensitive: true,
+            default_value: Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-Release.apk")].last,
+            default_value_dynamic: true,
+            optional: true,
+            verify_block: proc do |value|
+              UI.user_error!("Could not find apk file at path '#{value}'") unless File.exist?(value)
+              UI.user_error!("apk file is not an apk") unless value.end_with?('.apk')
+            end
+          ),
+          # title
+          FastlaneCore::ConfigItem.new(key: :app_title,
+            env_name: "PRODUCE_APP_NAME", # TODO
+            short_option: "-q",
+            description: "App Title",
+            optional: false,
+            verify_block: proc do |value|
+              raise UI.error("No App Title given, pass using `app_title: 'Title'`") if value.to_s.empty?
+            end),
+          # language
+          FastlaneCore::ConfigItem.new(key: :language,
+            short_option: "-m",
+            env_name: "PRODUCE_LANGUAGE", # TODO
+            description: "Default app language (e.g. 'en_US')",
+            default_value: "en_US",
+            optional: false,
+            verify_block: proc do |language|
+              unless AvailablePlayStoreLanguages.all_languages.include?(language)
+                UI.user_error!("Please enter one of available languages: #{AvailablePlayStoreLanguages.all_languages}")
+              end
+            end),
+          # copied from https://github.com/fastlane/fastlane/blob/2fec459d6f44a41eac1b086e8c181bd1669f7f5c/supply/lib/supply/options.rb#L193-L199
+          FastlaneCore::ConfigItem.new(key: :root_url,
+            env_name: "SUPPLY_ROOT_URL", # TODO
+            description: "Root URL for the Google Play API. The provided URL will be used for API calls in place of https://www.googleapis.com/", # TODO check if default is true
+            optional: true,
+            verify_block: proc do |value|
+              UI.user_error!("Could not parse URL '#{value}'") unless value =~ URI.regexp
+            end),
+          # copied from https://github.com/fastlane/fastlane/blob/2fec459d6f44a41eac1b086e8c181bd1669f7f5c/supply/lib/supply/options.rb#L206-L211
+          FastlaneCore::ConfigItem.new(key: :timeout,
+            env_name: "SUPPLY_TIMEOUT", # TODO
+            optional: true,
+            description: "Timeout for read, open, and send (in seconds)",
+            type: Integer,
+            default_value: 300)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        [:android].include?(platform)
+      end
+    end
+  end
+end
+
+# https://support.google.com/googleplay/android-developer/answer/3125566?hl=en 
+# => Add your own text translations & localized graphic assets => See available languages => replace `-` with `_`
+# %w => https://stackoverflow.com/a/1274703/252627
+class AvailablePlayStoreLanguages
+  def self.all_languages
+    %w[
+      af
+      am
+      ar
+      az_AZ
+      be
+      bg
+      bn_BD
+      ca
+      cs_CZ
+      da_DK
+      de_DE
+      el_GR
+      en_AU
+      en_CA
+      en_GB
+      en_IN
+      en_SG
+      en_US
+      en_ZA
+      es_419
+      es_ES
+      es_US
+      et
+      eu_ES
+      fa
+      fi_FI
+      fil
+      fr_CA
+      fr_FR
+      gl_ES
+      hi_IN
+      hr
+      hu_HU
+      hy_AM
+      id
+      is_IS
+      it_IT
+      iw_IL
+      ja_JP
+      ka_GE
+      km_KH
+      kn_IN
+      ko_KR
+      ky_KG
+      lo_LA
+      lt
+      lv
+      mk_MK
+      ml_IN
+      mn_MN
+      mr_IN
+      ms
+      ms_MY
+      my_MM
+      ne_NP
+      nl_NL
+      no_NO
+      pl_PL
+      pt_BR
+      pt_PT
+      rm
+      ro
+      ru_RU
+      si_LK
+      sk
+      sl
+      sr
+      sv_SE
+      sw
+      ta_IN
+      te_IN
+      th
+      tr_TR
+      uk
+      vi
+      zh_CN
+      zh_HK
+      zh_TW
+      zu
+    ]
+  end
+end

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -84,9 +84,9 @@ module Fastlane
         [
           "create_app_on_managed_play_store(
             json_key: 'path/to/you/json/key/file',
-            developer_account_id: 'developer_account_id', # obtained using the get_managed_play_store_publishing_rights action (or looking at the Play Console url),
-            app_title: 'Your app title',
-            language: 'en_US',
+            developer_account_id: 'developer_account_id', # obtained using the get_managed_play_store_publishing_rights action (or looking at the Play Console url)
+            app_title: 'Your new app\'s title',
+            language: 'en_US', # primary app language in BCP 47 format
             apk: '/files/app-release.apk'
           )"
         ]

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -10,13 +10,13 @@ module Fastlane
         FastlaneCore::PrintTable.print_values(
           config: params,
           mask_keys: [:json_key_data],
-          title: "Summary for CreateAppOnManagedPlayStoreAction" # TODO
+          title: "Summary for create_app_on_managed_play_store"
         )
 
         require "google/apis/playcustomapp_v1"
 
         # Auth Info
-        @keyfile = params[:json_key] # TODO json_key_data as alternative
+        @keyfile = params[:json_key]
         @developer_account = params[:developer_account_id]
 
         # App Info
@@ -96,7 +96,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(
             key: :json_key,
-            env_name: "SUPPLY_JSON_KEY", # TODO
+            env_name: "SUPPLY_JSON_KEY",
             short_option: "-j",
             conflicting_options: [:json_key_data],
             optional: true, # this shouldn't be optional but is until I find out how json_key OR json_key_data can be required
@@ -111,7 +111,7 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :json_key_data,
-            env_name: "SUPPLY_JSON_KEY_DATA", # TODO
+            env_name: "SUPPLY_JSON_KEY_DATA",
             short_option: "-c",
             conflicting_options: [:json_key],
             optional: true,
@@ -130,7 +130,7 @@ module Fastlane
           # developer_account
           FastlaneCore::ConfigItem.new(key: :developer_account_id,
             short_option: "-k",
-            env_name: "PRODUCE_ITC_TEAM_ID", # TODO
+            env_name: "PRODUCE_ITC_TEAM_ID",
             description: "The ID of your Google Play Console account. Can be obtained from the URL when you log in (`https://play.google.com/apps/publish/?account=...` or when you 'Obtain private app publishing rights' (https://developers.google.com/android/work/play/custom-app-api/get-started#retrieve_the_developer_account_id)",
             optional: false,
             is_string: false, # as we also allow integers, which we convert to strings anyway
@@ -142,7 +142,7 @@ module Fastlane
             end),
           FastlaneCore::ConfigItem.new(
             key: :apk,
-            env_name: "SUPPLY_APK", # TODO
+            env_name: "SUPPLY_APK",
             description: "Path to the APK file to upload",
             short_option: "-b",
             conflicting_options: [:apk_paths, :aab],
@@ -157,7 +157,7 @@ module Fastlane
           ),
           # title
           FastlaneCore::ConfigItem.new(key: :app_title,
-            env_name: "PRODUCE_APP_NAME", # TODO
+            env_name: "PRODUCE_APP_NAME",
             short_option: "-q",
             description: "App Title",
             optional: false,
@@ -167,7 +167,7 @@ module Fastlane
           # language
           FastlaneCore::ConfigItem.new(key: :language,
             short_option: "-m",
-            env_name: "PRODUCE_LANGUAGE", # TODO
+            env_name: "PRODUCE_LANGUAGE",
             description: "Default app language (e.g. 'en_US')",
             default_value: "en_US",
             optional: false,
@@ -176,7 +176,6 @@ module Fastlane
                 UI.user_error!("Please enter one of available languages: #{AvailablePlayStoreLanguages.all_languages}")
               end
             end)
-          # TODO readd root_url and timeout when supply is used
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -156,6 +156,9 @@ end
 
 require 'supply/client'
 class PlaycustomappClient < Supply::AbstractGoogleServiceClient
+  SERVICE = Google::Apis::PlaycustomappV1::PlaycustomappService.new
+  SCOPE = Google::Apis::PlaycustomappV1::AUTH_ANDROIDPUBLISHER
+
   # Connecting with Google
   attr_accessor :client
 
@@ -167,9 +170,6 @@ class PlaycustomappClient < Supply::AbstractGoogleServiceClient
   # Initializes the service and its auth_client using the specified information
   # @param service_account_json: The raw service account Json data
   def initialize(service_account_json: nil, params: nil)
-    @scope = Google::Apis::PlaycustomappV1::AUTH_ANDROIDPUBLISHER
-    @service = Google::Apis::PlaycustomappV1::PlaycustomappService.new
-
     self.client = super(service_account_json: service_account_json, params: params)
   end
 

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -185,6 +185,10 @@ module Fastlane
       def self.is_supported?(platform)
         [:android].include?(platform)
       end
+
+      def self.category
+        :misc
+      end
     end
   end
 end

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -69,7 +69,7 @@ module Fastlane
       end
 
       def self.authors
-        ["Jan Piotrowski"]
+        ["janpio"]
       end
 
       def self.return_value

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -1,6 +1,3 @@
-require 'fastlane/action'
-require_relative '../helper/managed_google_play_helper'
-
 module Fastlane
   module Actions
     class CreateAppOnManagedPlayStoreAction < Action

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -175,22 +175,8 @@ module Fastlane
               unless AvailablePlayStoreLanguages.all_languages.include?(language)
                 UI.user_error!("Please enter one of available languages: #{AvailablePlayStoreLanguages.all_languages}")
               end
-            end),
-          # copied from https://github.com/fastlane/fastlane/blob/2fec459d6f44a41eac1b086e8c181bd1669f7f5c/supply/lib/supply/options.rb#L193-L199
-          FastlaneCore::ConfigItem.new(key: :root_url,
-            env_name: "SUPPLY_ROOT_URL", # TODO
-            description: "Root URL for the Google Play API. The provided URL will be used for API calls in place of https://www.googleapis.com/", # TODO check if default is true
-            optional: true,
-            verify_block: proc do |value|
-              UI.user_error!("Could not parse URL '#{value}'") unless value =~ URI.regexp
-            end),
-          # copied from https://github.com/fastlane/fastlane/blob/2fec459d6f44a41eac1b086e8c181bd1669f7f5c/supply/lib/supply/options.rb#L206-L211
-          FastlaneCore::ConfigItem.new(key: :timeout,
-            env_name: "SUPPLY_TIMEOUT", # TODO
-            optional: true,
-            description: "Timeout for read, open, and send (in seconds)",
-            type: Integer,
-            default_value: 300)
+            end)
+          # TODO readd root_url and timeout when supply is used
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -105,8 +105,8 @@ module Fastlane
             default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
             default_value_dynamic: true,
             verify_block: proc do |value|
-              UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
               UI.user_error!("Could not find service account json file at path '#{File.expand_path(value)}'") unless File.exist?(File.expand_path(value))
+              UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
             end
           ),
           FastlaneCore::ConfigItem.new(

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -162,14 +162,13 @@ class PlaycustomappClient < GoogleServiceClient
 
   # instantiate a client given the supplied configuration
   def self.make_from_config(params: nil)
-    @param = params
     super(params: params)
   end
 
   # Initializes the service and its auth_client using the specified information
   # @param service_account_json: The raw service account Json data
   def initialize(service_account_json: nil, params: nil)
-    # TODO Can these be defined as a proper class variable somehow and not in `initialize`?
+    # TODO: Can these be defined as a proper class variable somehow and not in `initialize`?
     @scope = Google::Apis::PlaycustomappV1::AUTH_ANDROIDPUBLISHER
     @service = Google::Apis::PlaycustomappV1::PlaycustomappService.new
 

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -77,8 +77,7 @@ module Fastlane
       end
 
       def self.details
-        # Optional:
-        "none yet"
+        "TODO"
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -77,7 +77,19 @@ module Fastlane
       end
 
       def self.details
-        "TODO"
+        "Create new apps on Managed Google Play."
+      end
+
+      def self.example_code
+        [
+          "create_app_on_managed_play_store(
+            json_key: 'path/to/you/json/key/file',
+            developer_account_id: 'developer_account_id', # obtained using the get_managed_play_store_publishing_rights action (or looking at the Play Console url),
+            app_title: 'Your app title',
+            language: 'en_US',
+            apk: '/files/app-release.apk'
+          )"
+        ]
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -85,7 +85,7 @@ module Fastlane
           "create_app_on_managed_play_store(
             json_key: 'path/to/you/json/key/file',
             developer_account_id: 'developer_account_id', # obtained using the get_managed_play_store_publishing_rights action (or looking at the Play Console url)
-            app_title: 'Your new app\'s title',
+            app_title: 'Your app title',
             language: 'en_US', # primary app language in BCP 47 format
             apk: '/files/app-release.apk'
           )"

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -48,7 +48,8 @@ module Fastlane
       def self.details
         [
           'If you haven\'t done so before, start by following the first two steps of Googles ["Get started with custom app publishing"](https://developers.google.com/android/work/play/custom-app-api/get-started) -> ["Preliminary setup"](https://developers.google.com/android/work/play/custom-app-api/get-started#preliminary_setup) instructions:',
-          '"[Enable the Google Play Custom App Publishing API](https://developers.google.com/android/work/play/custom-app-api/get-started#enable_the_google_play_custom_app_publishing_api)" and "[Create a service account](https://developers.google.com/android/work/play/custom-app-api/get-started#create_a_service_account)". You need the "service account\'s private key file" to continue.',
+          '"[Enable the Google Play Custom App Publishing API](https://developers.google.com/android/work/play/custom-app-api/get-started#enable_the_google_play_custom_app_publishing_api)" and "[Create a service account](https://developers.google.com/android/work/play/custom-app-api/get-started#create_a_service_account)".',
+          'You need the "service account\'s private key file" to continue.',
           'Run the action and supply the "private key file" to it as the `json_key` parameter. The command will output a URL to visit. After logging in you are redirected to a page that outputs your "Developer Account ID" - take note of that, you will need it to be able to use [`create_app_on_managed_play_store`](https://docs.fastlane.tools/actions/create_app_on_managed_play_store/).'
         ].join("\n")
       end

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -46,8 +46,7 @@ module Fastlane
       end
 
       def self.details
-        # Optional:
-        "none yet"
+        "TODO"
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -20,7 +20,7 @@ module Fastlane
         # puts 'credentials: '+credentials.inspect
         # puts 'email: ' + credentials['client_email']
 
-        callback_uri = 'https://janpio.github.io/fastlane-plugin-managed_google_play/callback.html TODO'
+        callback_uri = 'https://fastlane.github.io/managed_google_play-callback/callback.html'
         uri = "https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{credentials['client_email']}&continueUrl=#{URI.escape(callback_uri)}"
 
         UI.message("To obtain publishing rights for custom apps on Managed Play Store, open the following URL and log in:")

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -10,10 +10,10 @@ module Fastlane
         FastlaneCore::PrintTable.print_values(
           config: params,
           mask_keys: [:json_key_data],
-          title: "Summary for GetManagedPlayStorePublishingRights" # TODO
+          title: "Summary for get_managed_play_store_publishing_rights"
         )
 
-        @keyfile = params[:json_key] # TODO: json_key_data as alternative
+        @keyfile = params[:json_key]
 
         # login
         credentials = JSON.parse(File.open(@keyfile, 'rb').read)
@@ -66,7 +66,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(
             key: :json_key,
-            env_name: "SUPPLY_JSON_KEY", # TODO
+            env_name: "SUPPLY_JSON_KEY",
             short_option: "-j",
             conflicting_options: [:json_key_data],
             optional: true, # this shouldn't be optional but is until I find out how json_key OR json_key_data can be required
@@ -81,7 +81,7 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :json_key_data,
-            env_name: "SUPPLY_JSON_KEY_DATA", # TODO
+            env_name: "SUPPLY_JSON_KEY_DATA",
             short_option: "-c",
             conflicting_options: [:json_key],
             optional: true,

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -47,7 +47,8 @@ module Fastlane
 
       def self.details
         [
-          'If you haven\'t done so before, start by following the first two steps of Googles ["Get started with custom app publishing"](https://developers.google.com/android/work/play/custom-app-api/get-started) -> ["Preliminary setup"](https://developers.google.com/android/work/play/custom-app-api/get-started#preliminary_setup) instructions: "[Enable the Google Play Custom App Publishing API](https://developers.google.com/android/work/play/custom-app-api/get-started#enable_the_google_play_custom_app_publishing_api)" and "[Create a service account](https://developers.google.com/android/work/play/custom-app-api/get-started#create_a_service_account)". You need the "service account\'s private key file" to continue.',
+          'If you haven\'t done so before, start by following the first two steps of Googles ["Get started with custom app publishing"](https://developers.google.com/android/work/play/custom-app-api/get-started) -> ["Preliminary setup"](https://developers.google.com/android/work/play/custom-app-api/get-started#preliminary_setup) instructions:',
+          '"[Enable the Google Play Custom App Publishing API](https://developers.google.com/android/work/play/custom-app-api/get-started#enable_the_google_play_custom_app_publishing_api)" and "[Create a service account](https://developers.google.com/android/work/play/custom-app-api/get-started#create_a_service_account)". You need the "service account\'s private key file" to continue.',
           'Run the action and supply the "private key file" to it as the `json_key` parameter. The command will output a URL to visit. After logging in you are redirected to a page that outputs your "Developer Account ID" - take note of that, you will need it to be able to use [`create_app_on_managed_play_store`](https://docs.fastlane.tools/actions/create_app_on_managed_play_store/).'
         ].join("\n")
       end

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -91,6 +91,10 @@ module Fastlane
       def self.is_supported?(platform)
         [:android].include?(platform)
       end
+
+      def self.category
+        :misc
+      end
     end
   end
 end

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -20,7 +20,7 @@ module Fastlane
         # puts 'credentials: '+credentials.inspect
         # puts 'email: ' + credentials['client_email']
 
-        callback_uri = 'https://janpio.github.io/fastlane-plugin-managed_google_play/callback.html'
+        callback_uri = 'https://janpio.github.io/fastlane-plugin-managed_google_play/callback.html TODO'
         uri = "https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{credentials['client_email']}&continueUrl=#{URI.escape(callback_uri)}"
 
         UI.message("To obtain publishing rights for custom apps on Managed Play Store, open the following URL and log in:")

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -49,6 +49,16 @@ module Fastlane
         "TODO"
       end
 
+      def self.example_code
+        [
+          'get_managed_play_store_publishing_rights(
+            json_key: "path/to/your/json/key/file"
+          )
+          # it is probably more useful to execute this action directly in the command line:
+          # $ fastlane run get_managed_play_store_publishing_rights'
+        ]
+      end
+
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -1,0 +1,98 @@
+require 'fastlane/action'
+require_relative '../helper/managed_google_play_helper'
+
+module Fastlane
+  module Actions
+    class GetManagedPlayStorePublishingRightsAction < Action
+      def self.run(params)
+        unless params[:json_key] || params[:json_key_data]
+          UI.important("To not be asked about this value, you can specify it using 'json_key'")
+          params[:json_key] = UI.input("The service account json file used to authenticate with Google: ")
+        end
+
+        FastlaneCore::PrintTable.print_values(
+          config: params,
+          mask_keys: [:json_key_data],
+          title: "Summary for GetManagedPlayStorePublishingRights" # TODO
+        )
+
+        @keyfile = params[:json_key] # TODO: json_key_data as alternative
+
+        # login
+        credentials = JSON.parse(File.open(@keyfile, 'rb').read)
+        # puts 'credentials: '+credentials.inspect
+        # puts 'email: ' + credentials['client_email']
+
+        callback_uri = 'https://janpio.github.io/fastlane-plugin-managed_google_play/callback.html'
+        uri = "https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{credentials['client_email']}&continueUrl=#{URI.escape(callback_uri)}"
+
+        UI.message("To obtain publishing rights for custom apps on Managed Play Store, open the following URL and log in:")
+        UI.message("")
+        UI.important(uri)
+        UI.message("([Cmd/Ctrl] + [Left click] lets you open this URL in many consoles/terminals/shells)")
+        UI.message("")
+        UI.message("After successful login you will be redirected to a page which outputs some information that is required for usage of the `create_app_on_managed_play_store` action.")
+      end
+
+      def self.description
+        "Obtain publishing rights for custom apps on Managed Google Play Store"
+      end
+
+      def self.authors
+        ["Jan Piotrowski"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        # Optional:
+        "none yet"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :json_key,
+            env_name: "SUPPLY_JSON_KEY", # TODO
+            short_option: "-j",
+            conflicting_options: [:json_key_data],
+            optional: true, # this shouldn't be optional but is until I find out how json_key OR json_key_data can be required
+            description: "The path to a file containing service account JSON, used to authenticate with Google",
+            code_gen_sensitive: true,
+            default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
+            default_value_dynamic: true,
+            verify_block: proc do |value|
+              UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
+              UI.user_error!("Could not find service account json file at path '#{File.expand_path(value)}'") unless File.exist?(File.expand_path(value))
+            end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :json_key_data,
+            env_name: "SUPPLY_JSON_KEY_DATA", # TODO
+            short_option: "-c",
+            conflicting_options: [:json_key],
+            optional: true,
+            description: "The raw service account JSON data used to authenticate with Google",
+            code_gen_sensitive: true,
+            default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
+            default_value_dynamic: true,
+            verify_block: proc do |value|
+              begin
+                JSON.parse(value)
+              rescue JSON::ParserError
+                UI.user_error!("Could not parse service account json: JSON::ParseError")
+              end
+            end
+          )
+
+        ]
+      end
+
+      def self.is_supported?(platform)
+        [:android].include?(platform)
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -29,6 +29,8 @@ module Fastlane
         UI.message("([Cmd/Ctrl] + [Left click] lets you open this URL in many consoles/terminals/shells)")
         UI.message("")
         UI.message("After successful login you will be redirected to a page which outputs some information that is required for usage of the `create_app_on_managed_play_store` action.")
+
+        return uri
       end
 
       def self.description
@@ -40,7 +42,7 @@ module Fastlane
       end
 
       def self.return_value
-        # If your method provides a return value, you can describe here what it does
+        "An URI to obtain publishing rights for custom apps on Managed Play Store"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -36,7 +36,7 @@ module Fastlane
       end
 
       def self.authors
-        ["Jan Piotrowski"]
+        ["janpio"]
       end
 
       def self.return_value

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -1,6 +1,3 @@
-require 'fastlane/action'
-require_relative '../helper/managed_google_play_helper'
-
 module Fastlane
   module Actions
     class GetManagedPlayStorePublishingRightsAction < Action

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -46,7 +46,10 @@ module Fastlane
       end
 
       def self.details
-        "TODO"
+        [
+          'If you haven\'t done so before, start by following the first two steps of Googles ["Get started with custom app publishing"](https://developers.google.com/android/work/play/custom-app-api/get-started) -> ["Preliminary setup"](https://developers.google.com/android/work/play/custom-app-api/get-started#preliminary_setup) instructions: "[Enable the Google Play Custom App Publishing API](https://developers.google.com/android/work/play/custom-app-api/get-started#enable_the_google_play_custom_app_publishing_api)" and "[Create a service account](https://developers.google.com/android/work/play/custom-app-api/get-started#create_a_service_account)". You need the "service account\'s private key file" to continue.',
+          'Run the action and supply the "private key file" to it as the `json_key` parameter. The command will output a URL to visit. After logging in you are redirected to a page that outputs your "Developer Account ID" - take note of that, you will need it to be able to use [`create_app_on_managed_play_store`](https://docs.fastlane.tools/actions/create_app_on_managed_play_store/).'
+        ].join("\n")
       end
 
       def self.example_code
@@ -54,7 +57,7 @@ module Fastlane
           'get_managed_play_store_publishing_rights(
             json_key: "path/to/your/json/key/file"
           )
-          # it is probably more useful to execute this action directly in the command line:
+          # it is probably easier to execute this action directly in the command line:
           # $ fastlane run get_managed_play_store_publishing_rights'
         ]
       end

--- a/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
+++ b/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
@@ -1,0 +1,104 @@
+require 'supply/client'
+
+module Fastlane
+  module Actions
+    class ValidatePlayStoreJsonKeyAction < Action
+      def self.run(params)
+        FastlaneCore::PrintTable.print_values(
+          config: params,
+          mask_keys: [:json_key_data],
+          title: "Summary for validate_play_store_json_key"
+        )
+
+        client = Supply::Client.make_from_config(params: params)
+
+        FastlaneCore::UI.success("Successfully established connection to Google Play.")
+        FastlaneCore::UI.verbose("client: " + client.inspect)
+      end
+
+      def self.description
+        "Validate that the Play Store `json_key` works"
+      end
+
+      def self.authors
+        ["janpio"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        "Use this action to test and validate your json key file used to connect and authenticate with the Google Play API"
+      end
+
+      def self.example_code
+        [
+          "validate_play_store_json_key(
+            json_key: 'path/to/you/json/key/file'
+          )"
+        ]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :json_key,
+            env_name: "SUPPLY_JSON_KEY",
+            short_option: "-j",
+            conflicting_options: [:json_key_data],
+            optional: true, # this shouldn't be optional but is until I find out how json_key OR json_key_data can be required
+            description: "The path to a file containing service account JSON, used to authenticate with Google",
+            code_gen_sensitive: true,
+            default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
+            default_value_dynamic: true,
+            verify_block: proc do |value|
+              UI.user_error!("Could not find service account json file at path '#{File.expand_path(value)}'") unless File.exist?(File.expand_path(value))
+              UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
+            end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :json_key_data,
+            env_name: "SUPPLY_JSON_KEY_DATA",
+            short_option: "-c",
+            conflicting_options: [:json_key],
+            optional: true,
+            description: "The raw service account JSON data used to authenticate with Google",
+            code_gen_sensitive: true,
+            default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
+            default_value_dynamic: true,
+            verify_block: proc do |value|
+              begin
+                JSON.parse(value)
+              rescue JSON::ParserError
+                UI.user_error!("Could not parse service account json: JSON::ParseError")
+              end
+            end
+          ),
+          # stuff
+          FastlaneCore::ConfigItem.new(key: :root_url,
+            env_name: "SUPPLY_ROOT_URL",
+            description: "Root URL for the Google Play API. The provided URL will be used for API calls in place of https://www.googleapis.com/",
+            optional: true,
+            verify_block: proc do |value|
+                UI.user_error!("Could not parse URL '#{value}'") unless value =~ URI.regexp
+            end),
+          FastlaneCore::ConfigItem.new(key: :timeout,
+            env_name: "SUPPLY_TIMEOUT",
+            optional: true,
+            description: "Timeout for read, open, and send (in seconds)",
+            type: Integer,
+            default_value: 300)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        [:android].include?(platform)
+      end
+
+      def self.category
+        :misc
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
+++ b/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
@@ -81,7 +81,7 @@ module Fastlane
             description: "Root URL for the Google Play API. The provided URL will be used for API calls in place of https://www.googleapis.com/",
             optional: true,
             verify_block: proc do |value|
-                UI.user_error!("Could not parse URL '#{value}'") unless value =~ URI.regexp
+              UI.user_error!("Could not parse URL '#{value}'") unless value =~ URI.regexp
             end),
           FastlaneCore::ConfigItem.new(key: :timeout,
             env_name: "SUPPLY_TIMEOUT",

--- a/fastlane/spec/actions_specs/create_app_on_managed_play_store_spec.rb
+++ b/fastlane/spec/actions_specs/create_app_on_managed_play_store_spec.rb
@@ -1,0 +1,6 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "create_app_on_managed_play_store" do
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/get_managed_play_store_publishing_rights_spec.rb
+++ b/fastlane/spec/actions_specs/get_managed_play_store_publishing_rights_spec.rb
@@ -1,0 +1,6 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "get_managed_play_store_publishing_rights" do
+    end
+  end
+end

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -64,6 +64,7 @@ describe Fastlane do
           echo
           xcov
           create_app_on_managed_play_store
+          validate_play_store_json_key
         )
       end
 

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -63,6 +63,7 @@ describe Fastlane do
           println
           echo
           xcov
+          create_app_on_managed_play_store
         )
       end
 

--- a/supply/lib/supply.rb
+++ b/supply/lib/supply.rb
@@ -23,7 +23,7 @@ module Supply
   CHANGELOGS_FOLDER_NAME = "changelogs"
 
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
-  UI = FastlaneCore::UI
+  UI = FastlaneCore::UI unless defined?(UI)
   ROOT = Pathname.new(File.expand_path('../..', __FILE__))
   DESCRIPTION = "Command line tool for updating Android apps and their metadata on the Google Play Store".freeze
 end

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -7,7 +7,7 @@ require 'net/http'
 module Supply
   UI = FastlaneCore::UI
 
-  class GoogleServiceClient
+  class AbstractGoogleServiceClient
     def self.make_from_config(params: nil)
       unless params[:json_key] || params[:json_key_data]
         UI.important("To not be asked about this value, you can specify it using 'json_key'")
@@ -65,7 +65,7 @@ module Supply
     end
   end
 
-  class Client < GoogleServiceClient
+  class Client < AbstractGoogleServiceClient
     # Connecting with Google
     attr_accessor :android_publisher
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -81,7 +81,7 @@ module Supply
 
     # instantiate a client given the supplied configuration
     def self.make_from_config(params: nil)
-      if(params.nil?)
+      if params.nil?
         params = Supply.config
       end
 
@@ -428,6 +428,5 @@ module Supply
     def ensure_active_edit!
       UI.user_error!("You need to have an active edit, make sure to call `begin_edit`") unless @current_edit
     end
-
   end
 end

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -5,7 +5,7 @@ Androidpublisher = Google::Apis::AndroidpublisherV2
 require 'net/http'
 
 module Supply
-  UI = FastlaneCore::UI
+  UI = FastlaneCore::UI unless defined?(UI)
 
   class AbstractGoogleServiceClient
     SCOPE = nil

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -69,8 +69,8 @@ module Supply
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
                                      default_value_dynamic: true,
                                      verify_block: proc do |value|
-                                       UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
                                        UI.user_error!("Could not find service account json file at path '#{File.expand_path(value)}'") unless File.exist?(File.expand_path(value))
+                                       UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
                                      end),
         FastlaneCore::ConfigItem.new(key: :json_key_data,
                                      env_name: "SUPPLY_JSON_KEY_DATA",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Using _supply_ requires a [setup step](https://docs.fastlane.tools/actions/supply/#setup) which includes a json file for authentication with Google Play Store. This is error prone and difficult to test without 

### Description
Implement `validate_play_store_json_key` that uses `Supply::client` to check if `json_key` can be used to establish a working connection to the Google Play API.

### Tasks

- [ ] Tests
- [ ] Check if it actually works
- [ ] Add to supply documentation



