### PR TITLE
Accept `utf8` as valid locale + Automatically parse `locale` command

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -46,7 +46,7 @@ module Fastlane
         end
 
         # Try to check UTF-8 with `locale`, fallback to environment variables
-        unless (FastlaneCore::CommandExecutor.which('locale') && `locale charmap` == "UTF-8") || (ENV['LANG'] || "").end_with?("UTF-8") || (ENV['LC_ALL'] || "").end_with?("UTF-8")
+        unless (ENV['LANG'] || "").end_with?("UTF-8") || (ENV['LANG'] || "").end_with?("utf8") || (ENV['LC_ALL'] || "").end_with?("UTF-8") || (ENV['LC_ALL'] || "").end_with?("utf8") || (FastlaneCore::CommandExecutor.which('locale') && `locale charmap` == "UTF-8")
           warn = "WARNING: fastlane requires your locale to be set to UTF-8. To learn more go to https://docs.fastlane.tools/getting-started/ios/setup/#set-up-environment-variables"
           UI.error(warn)
           at_exit do

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -15,6 +15,10 @@ module Fastlane
       def running_init_command?
         ARGV.include?("init")
       end
+      
+      def utf8_locale?
+        (ENV['LANG'] || "").end_with?("UTF-8", "utf8") || (ENV['LC_ALL'] || "").end_with?("UTF-8", "utf8") || (FastlaneCore::CommandExecutor.which('locale') && `locale charmap` == "UTF-8")
+      end
 
       def take_off
         before_import_time = Time.now
@@ -46,7 +50,7 @@ module Fastlane
         end
 
         # Try to check UTF-8 with `locale`, fallback to environment variables
-        unless (ENV['LANG'] || "").end_with?("UTF-8", "utf8") || (ENV['LC_ALL'] || "").end_with?("UTF-8", "utf8") || (FastlaneCore::CommandExecutor.which('locale') && `locale charmap` == "UTF-8")
+        unless utf8_locale?
           warn = "WARNING: fastlane requires your locale to be set to UTF-8. To learn more go to https://docs.fastlane.tools/getting-started/ios/setup/#set-up-environment-variables"
           UI.error(warn)
           at_exit do

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -17,7 +17,7 @@ module Fastlane
       end
 
       def utf8_locale?
-        (ENV['LANG'] || "").end_with?("UTF-8", "utf8") || (ENV['LC_ALL'] || "").end_with?("UTF-8", "utf8") || (FastlaneCore::CommandExecutor.which('locale') && `locale charmap` == "UTF-8")
+        (ENV['LANG'] || "").end_with?("UTF-8", "utf8") || (ENV['LC_ALL'] || "").end_with?("UTF-8", "utf8") || (FastlaneCore::CommandExecutor.which('locale') && `locale charmap`.strip == "UTF-8")
       end
 
       def take_off

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -45,7 +45,7 @@ module Fastlane
           print_bundle_exec_warning(is_slow: (Time.now - before_import_time > 3))
         end
 
-        unless (ENV['LANG'] || "").end_with?("UTF-8") || (ENV['LC_ALL'] || "").end_with?("UTF-8")
+        unless `locale chapmap` == "UTF-8"
           warn = "WARNING: fastlane requires your locale to be set to UTF-8. To learn more go to https://docs.fastlane.tools/getting-started/ios/setup/#set-up-environment-variables"
           UI.error(warn)
           at_exit do

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -15,7 +15,7 @@ module Fastlane
       def running_init_command?
         ARGV.include?("init")
       end
-      
+
       def utf8_locale?
         (ENV['LANG'] || "").end_with?("UTF-8", "utf8") || (ENV['LC_ALL'] || "").end_with?("UTF-8", "utf8") || (FastlaneCore::CommandExecutor.which('locale') && `locale charmap` == "UTF-8")
       end

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -45,7 +45,7 @@ module Fastlane
           print_bundle_exec_warning(is_slow: (Time.now - before_import_time > 3))
         end
 
-        unless `locale chapmap` == "UTF-8"
+        unless `locale charmap` == "UTF-8"
           warn = "WARNING: fastlane requires your locale to be set to UTF-8. To learn more go to https://docs.fastlane.tools/getting-started/ios/setup/#set-up-environment-variables"
           UI.error(warn)
           at_exit do

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -45,7 +45,8 @@ module Fastlane
           print_bundle_exec_warning(is_slow: (Time.now - before_import_time > 3))
         end
 
-        unless `locale charmap` == "UTF-8"
+        # Try to check UTF-8 with `locale`, fallback to environment variables
+        unless (FastlaneCore::CommandExecutor.which('locale') && `locale charmap` == "UTF-8") || (ENV['LANG'] || "").end_with?("UTF-8") || (ENV['LC_ALL'] || "").end_with?("UTF-8")
           warn = "WARNING: fastlane requires your locale to be set to UTF-8. To learn more go to https://docs.fastlane.tools/getting-started/ios/setup/#set-up-environment-variables"
           UI.error(warn)
           at_exit do

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -46,7 +46,7 @@ module Fastlane
         end
 
         # Try to check UTF-8 with `locale`, fallback to environment variables
-        unless (ENV['LANG'] || "").end_with?("UTF-8") || (ENV['LANG'] || "").end_with?("utf8") || (ENV['LC_ALL'] || "").end_with?("UTF-8") || (ENV['LC_ALL'] || "").end_with?("utf8") || (FastlaneCore::CommandExecutor.which('locale') && `locale charmap` == "UTF-8")
+        unless (ENV['LANG'] || "").end_with?("UTF-8", "utf8") || (ENV['LC_ALL'] || "").end_with?("UTF-8", "utf8") || (FastlaneCore::CommandExecutor.which('locale') && `locale charmap` == "UTF-8")
           warn = "WARNING: fastlane requires your locale to be set to UTF-8. To learn more go to https://docs.fastlane.tools/getting-started/ios/setup/#set-up-environment-variables"
           UI.error(warn)
           at_exit do


### PR DESCRIPTION
 fix #13438

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Locale is handled manually by checking environment variable, should use `locale charmap` instead which automatically maps `utf8` to `UTF-8`.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
Check if output of `locale charmap` matches `UTF-8`.
