### PR TITLE
Update `fastlane spaceauth` command to work with new API

### DIFF
--- a/spaceship/lib/spaceship/spaceauth_runner.rb
+++ b/spaceship/lib/spaceship/spaceauth_runner.rb
@@ -44,7 +44,7 @@ module Spaceship
 
       # We remove all the un-needed cookies
       cookies.select! do |cookie|
-        cookie.name.start_with?("DES5") || cookie.name == 'dqsid'
+        cookie.name.start_with?("myacinfo") || cookie.name == 'dqsid'
       end
 
       yaml = cookies.to_yaml.gsub("\n", "\\n")


### PR DESCRIPTION
It seems like either this was broken before, or the cookie names have changed. We need to use `myacinfo` here.