### PR TITLE
Remove broken LOAD_PATH.push

### DIFF
--- a/bin/fastlane
+++ b/bin/fastlane
@@ -4,8 +4,6 @@ if RUBY_VERSION < '2.0.0'
   abort("fastlane requires Ruby 2.0.0 or higher")
 end
 
-$LOAD_PATH.push(File.expand_path("../../lib", __FILE__))
-
 require "fastlane/cli_tools_distributor"
 
 if Fastlane::CLIToolsDistributor.running_version_command?


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently `bin/fastlane` tries to add a broken path to your LOAD_PATH

### Description

`puts $LOAD_PATH.inspect` before and after the line of code (I now removed in this PR):

load path before 
```                                                                                                                                                   
["C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/did_you_mean-1.1.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/slack-notifier-2.3.2/lib", "C:/Ruby24-x64/lib/ruby/gems/2.
.0/gems/atomos-0.1.3/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/claide-1.0.2/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/colored2-3.1.2/lib", "C:/Ruby24-x64/li
/ruby/gems/2.4.0/gems/nanaimo-0.2.6/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/xcodeproj-1.6.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rouge-2.0.7/lib", "C
/Ruby24-x64/lib/ruby/gems/2.4.0/gems/xcpretty-0.3.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/terminal-notifier-1.8.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/g
ms/terminal-table-1.8.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/multipart-post-2.0.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/word_wrap-1.0.0/lib", "C:/R
by24-x64/lib/ruby/gems/2.4.0/gems/public_suffix-2.0.5/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/tty-screen-0.6.5/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/t
y-cursor-0.6.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/tty-spinner-0.8.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/babosa-1.0.2/lib", "C:/Ruby24-x64/lib/r
by/gems/2.4.0/gems/colored-1.2/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/commander-fastlane-4.4.6/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/http-cookie-1.0.
/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/faraday-cookie_jar-0.0.6/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/gh_inspector-1.1.3/lib", "C:/Ruby24-x64/lib/ru
y/gems/2.4.0/gems/mini_magick-4.5.1/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/multi_xml-0.6.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rubyzip-1.2.2/lib", 
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/security-0.1.3/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/bundler-1.16.3/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/far
day_middleware-0.12.2/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/naturally-2.2.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/simctl-1.6.5/lib", "C:/Ruby24-x64/
ib/ruby/gems/2.4.0/gems/emoji_regex-0.1.1/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/credentials_manager/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.
/gems/fastlane-2.105.2/pem/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/snapshot/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/fr
meit/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/match/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/fastlane_core/lib", "C:/Rub
24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/deliver/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/scan/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.
/gems/fastlane-2.105.2/supply/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/cert/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/fas
lane/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/spaceship/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/pilot/lib", "C:/Ruby24-
64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/gym/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/precheck/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/ge
s/fastlane-2.105.2/screengrab/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/sigh/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/pro
uce/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/backload-0.2.0/lib", "C:/Ruby24-x64/lib/ruby/site_ruby/2.4.0", "C:/Ruby24-x64/lib/ruby/site_ruby/2.4.0/x64-msvcrt"
 "C:/Ruby24-x64/lib/ruby/site_ruby", "C:/Ruby24-x64/lib/ruby/vendor_ruby/2.4.0", "C:/Ruby24-x64/lib/ruby/vendor_ruby/2.4.0/x64-msvcrt", "C:/Ruby24-x64/lib/ruby/vend
r_ruby", "C:/Ruby24-x64/lib/ruby/2.4.0", "C:/Ruby24-x64/lib/ruby/2.4.0/x64-mingw32"]  
```                                                                              
load path after
```                                                                                                                                               
["C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/did_you_mean-1.1.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/slack-notifier-2.3.2/lib", "C:/Ruby24-x64/lib/ruby/gems/2.
.0/gems/atomos-0.1.3/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/claide-1.0.2/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/colored2-3.1.2/lib", "C:/Ruby24-x64/li
/ruby/gems/2.4.0/gems/nanaimo-0.2.6/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/xcodeproj-1.6.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rouge-2.0.7/lib", "C
/Ruby24-x64/lib/ruby/gems/2.4.0/gems/xcpretty-0.3.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/terminal-notifier-1.8.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/g
ms/terminal-table-1.8.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/multipart-post-2.0.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/word_wrap-1.0.0/lib", "C:/R
by24-x64/lib/ruby/gems/2.4.0/gems/public_suffix-2.0.5/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/tty-screen-0.6.5/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/t
y-cursor-0.6.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/tty-spinner-0.8.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/babosa-1.0.2/lib", "C:/Ruby24-x64/lib/r
by/gems/2.4.0/gems/colored-1.2/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/commander-fastlane-4.4.6/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/http-cookie-1.0.
/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/faraday-cookie_jar-0.0.6/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/gh_inspector-1.1.3/lib", "C:/Ruby24-x64/lib/ru
y/gems/2.4.0/gems/mini_magick-4.5.1/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/multi_xml-0.6.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rubyzip-1.2.2/lib", 
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/security-0.1.3/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/bundler-1.16.3/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/far
day_middleware-0.12.2/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/naturally-2.2.0/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/simctl-1.6.5/lib", "C:/Ruby24-x64/
ib/ruby/gems/2.4.0/gems/emoji_regex-0.1.1/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/credentials_manager/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.
/gems/fastlane-2.105.2/pem/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/snapshot/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/fr
meit/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/match/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/fastlane_core/lib", "C:/Rub
24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/deliver/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/scan/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.
/gems/fastlane-2.105.2/supply/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/cert/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/fas
lane/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/spaceship/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/pilot/lib", "C:/Ruby24-
64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/gym/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/precheck/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/ge
s/fastlane-2.105.2/screengrab/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/sigh/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/pro
uce/lib", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/backload-0.2.0/lib", "C:/Ruby24-x64/lib/ruby/site_ruby/2.4.0", "C:/Ruby24-x64/lib/ruby/site_ruby/2.4.0/x64-msvcrt"
 "C:/Ruby24-x64/lib/ruby/site_ruby", "C:/Ruby24-x64/lib/ruby/vendor_ruby/2.4.0", "C:/Ruby24-x64/lib/ruby/vendor_ruby/2.4.0/x64-msvcrt", "C:/Ruby24-x64/lib/ruby/vend
r_ruby", "C:/Ruby24-x64/lib/ruby/2.4.0", "C:/Ruby24-x64/lib/ruby/2.4.0/x64-mingw32", "C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/lib"]
```

The only difference is `C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/lib` - which does not exist.

`../../lib/` used to exist when this line of code was added to the file: https://github.com/fastlane/fastlane/tree/0.1.0

As this was broken for quite some time, we obviously don't need that line.

`fastlane/lib` is already part of the LOAD_PATH much earlier, together with multiple other fastlane libs:

```
...
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/credentials_manager/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4./gems/fastlane-2.105.2/pem/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/snapshot/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/frmeit/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/match/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/fastlane_core/lib",
"C:/Rub24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/deliver/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/scan/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4./gems/fastlane-2.105.2/supply/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/cert/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/faslane/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/spaceship/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/pilot/lib",
"C:/Ruby24-64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/gym/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/precheck/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/ges/fastlane-2.105.2/screengrab/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/sigh/lib",
"C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/fastlane-2.105.2/prouce/lib",
...
``` 