### PR TITLE
[deliver,spaceship] Support a new screenshot (Apple Watch Series 4)

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -240,10 +240,10 @@ module Deliver
           [2560, 1600]
         ],
         ScreenSize::IOS_APPLE_WATCH => [
-          [312, 390],
+          [312, 390]
         ],
         ScreenSize::IOS_APPLE_WATCH_SERIES4 => [
-          [368, 448],
+          [368, 448]
         ],
         ScreenSize::APPLE_TV => [
           [1920, 1080]

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -43,6 +43,8 @@ module Deliver
       IOS_IPAD_PRO_MESSAGES = "iOS-iPad-Pro-messages"
       # Apple Watch
       IOS_APPLE_WATCH = "iOS-Apple-Watch"
+      # Apple Watch Series 4
+      IOS_APPLE_WATCH_SERIES4 = "iOS-Apple-Watch-Series4"
       # Mac
       MAC = "Mac"
       # Apple TV
@@ -93,6 +95,7 @@ module Deliver
         ScreenSize::IOS_IPAD_10_5_MESSAGES => "ipad105",
         ScreenSize::MAC => "desktop",
         ScreenSize::IOS_APPLE_WATCH => "watch",
+        ScreenSize::IOS_APPLE_WATCH_SERIES4 => "watchSeries4",
         ScreenSize::APPLE_TV => "appleTV"
       }
       return matching[self.screen_size]
@@ -120,6 +123,7 @@ module Deliver
         ScreenSize::IOS_IPAD_10_5_MESSAGES => "iPad 10.5 (iMessage)",
         ScreenSize::MAC => "Mac",
         ScreenSize::IOS_APPLE_WATCH => "Watch",
+        ScreenSize::IOS_APPLE_WATCH_SERIES4 => "Watch Series4",
         ScreenSize::APPLE_TV => "Apple TV"
       }
       return matching[self.screen_size]
@@ -236,7 +240,10 @@ module Deliver
           [2560, 1600]
         ],
         ScreenSize::IOS_APPLE_WATCH => [
-          [312, 390]
+          [312, 390],
+        ],
+        ScreenSize::IOS_APPLE_WATCH_SERIES4 => [
+          [368, 448],
         ],
         ScreenSize::APPLE_TV => [
           [1920, 1080]

--- a/spaceship/lib/spaceship/du/du_client.rb
+++ b/spaceship/lib/spaceship/du/du_client.rb
@@ -102,6 +102,7 @@ module Spaceship
       # rubocop:enable Layout/ExtraSpacing
       {
         watch:        "MZPFT.SortedN27ScreenShot",
+        watchSeries4: "MZPFT.SortedN131ScreenShot",
         ipad:         "MZPFT.SortedTabletScreenShot",
         ipadPro:      "MZPFT.SortedJ99ScreenShot",
         ipad105:      "MZPFT.SortedJ207ScreenShot",
@@ -134,6 +135,7 @@ module Spaceship
       # rubocop:enable Layout/ExtraSpacing
       {
         watch:        [[312, 390]],
+        watchSeries4: [[368, 448]],
         ipad:         [[1024, 748], [1024, 768], [2048, 1496], [2048, 1536], [768, 1004], [768, 1024], [1536, 2008], [1536, 2048]],
         ipadPro:      [[2048, 2732], [2732, 2048]],
         ipad105:      [[1668, 2224], [2224, 1668]],

--- a/spaceship/lib/spaceship/tunes/device_type.rb
+++ b/spaceship/lib/spaceship/tunes/device_type.rb
@@ -1,7 +1,7 @@
 module Spaceship
   module Tunes
     class DeviceType
-      @types = ['iphone4', 'iphone35', 'iphone6', 'iphone6Plus', 'iphone58', 'iphone65', 'ipad', 'ipadPro', 'ipad105', 'watch', 'appleTV', 'desktop']
+      @types = ['iphone4', 'iphone35', 'iphone6', 'iphone6Plus', 'iphone58', 'iphone65', 'ipad', 'ipadPro', 'ipad105', 'watch', 'watchSeries4', 'appleTV', 'desktop']
       class << self
         attr_accessor :types
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This change enables to upload 368 x 448 (Apple Watch Series 4) screenshots.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
I added necessary constants for uploading screenshots.
I tried it with my app, and then it was successful for uploading screenshots.

related: https://github.com/fastlane/fastlane/pull/13366