### PR TITLE
[action] remove UDID format validation from register_device

### DIFF
--- a/fastlane/lib/fastlane/actions/register_device.rb
+++ b/fastlane/lib/fastlane/actions/register_device.rb
@@ -3,8 +3,6 @@ require 'credentials_manager'
 module Fastlane
   module Actions
     class RegisterDeviceAction < Action
-      UDID_REGEXP = /^(\h{40}|\h{8}-\h{16})$/
-
       def self.is_supported?(platform)
         platform == :ios
       end
@@ -19,7 +17,6 @@ module Fastlane
         Spaceship.login(credentials.user, credentials.password)
         Spaceship.select_team
 
-        UI.user_error!("Passed invalid UDID: #{udid} for device: #{name}") unless UDID_REGEXP =~ udid
         Spaceship::Device.create!(name: name, udid: udid)
 
         UI.success("Successfully registered new device")

--- a/fastlane/lib/fastlane/actions/register_device.rb
+++ b/fastlane/lib/fastlane/actions/register_device.rb
@@ -20,9 +20,8 @@ module Fastlane
         begin
           Spaceship::Device.create!(name: name, udid: udid)
         rescue => ex
-          UI.error("Failed to register new device")
           UI.error(ex.to_s)
-          return nil
+          UI.crash!("Failed to register new device (name: #{name}, UDID: #{udid})")
         end
 
         UI.success("Successfully registered new device")

--- a/fastlane/lib/fastlane/actions/register_device.rb
+++ b/fastlane/lib/fastlane/actions/register_device.rb
@@ -17,7 +17,13 @@ module Fastlane
         Spaceship.login(credentials.user, credentials.password)
         Spaceship.select_team
 
-        Spaceship::Device.create!(name: name, udid: udid)
+        begin
+          Spaceship::Device.create!(name: name, udid: udid)
+        rescue => ex
+          UI.error("Failed to register new device")
+          UI.error(ex.to_s)
+          return nil
+        end
 
         UI.success("Successfully registered new device")
         return udid

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -51,8 +51,8 @@ module Fastlane
       def try_create_device(name, udid, mac)
         Spaceship::Device.create!(name: name, udid: udid, mac: mac)
       rescue => ex
-        UI.error("Failed to register new device (name #{name}, UDID: #{udid})")
         UI.error(ex.to_s)
+        UI.crash!("Failed to register new device (name: #{name}, UDID: #{udid})")
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -41,7 +41,7 @@ module Fastlane
             begin
               Spaceship::Device.create!(name: device[1], udid: device[0], mac: mac)
             rescue => ex
-              UI.error("Failed to register new device name #{device[1]}, UDID: #{device[0]}")
+              UI.error("Failed to register new device (name #{device[1]}, UDID: #{device[0]})")
               UI.error(ex.to_s)
             end
           end

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -36,7 +36,14 @@ module Fastlane
           device_objs = devices_file.drop(1).map do |device|
             next if existing_devices.map(&:udid).include?(device[0])
 
-            Spaceship::Device.create!(name: device[1], udid: device[0], mac: mac)
+            UI.user_error!("Invalid device line, please provide a file according to the Apple Sample UDID file (http://devimages.apple.com/downloads/devices/Multiple-Upload-Samples.zip)") unless device.count == 2
+
+            begin
+              Spaceship::Device.create!(name: device[1], udid: device[0], mac: mac)
+            rescue => ex
+              UI.error("Failed to register new device name #{device[1]}, UDID: #{device[0]}")
+              UI.error(ex.to_s)
+            end
           end
         else
           UI.user_error!("You must pass either a valid `devices` or `devices_file`. Please check the readme.")

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -25,7 +25,7 @@ module Fastlane
         if devices
           device_objs = devices.map do |k, v|
             next if existing_devices.map(&:udid).include?(v)
-            Spaceship::Device.create!(name: k, udid: v, mac: mac)
+            try_create_device(name: k, udid: v, mac: mac)
           end
         elsif devices_file
           require 'csv'
@@ -38,12 +38,7 @@ module Fastlane
 
             UI.user_error!("Invalid device line, please provide a file according to the Apple Sample UDID file (http://devimages.apple.com/downloads/devices/Multiple-Upload-Samples.zip)") unless device.count == 2
 
-            begin
-              Spaceship::Device.create!(name: device[1], udid: device[0], mac: mac)
-            rescue => ex
-              UI.error("Failed to register new device (name #{device[1]}, UDID: #{device[0]})")
-              UI.error(ex.to_s)
-            end
+            try_create_device(name: device[1], udid: device[0], mac: mac)
           end
         else
           UI.user_error!("You must pass either a valid `devices` or `devices_file`. Please check the readme.")
@@ -51,6 +46,13 @@ module Fastlane
 
         UI.success("Successfully registered new devices.")
         return device_objs
+      end
+
+      def try_create_device(name, udid, mac)
+        Spaceship::Device.create!(name: name, udid: udid, mac: mac)
+      rescue => ex
+        UI.error("Failed to register new device (name #{name}, UDID: #{udid})")
+        UI.error(ex.to_s)
       end
 
       def self.description

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -535,9 +535,12 @@ module Spaceship
       devices = parse_response(req, 'devices')
       return devices.first unless devices.empty?
 
-      raise parse_response(req, 'validationMessages').map { |message|
+      validation_messages = parse_response(req, 'validationMessages').map { |message|
         message["validationUserMessage"]
-      }.compact.uniq.join('\n')
+      }.compact.uniq
+
+      raise validation_messages.join('\n') unless validation_messages.empty?
+      raise UnexpectedResponse.new, "Couldn't register new device, got this: #{parse_response(req)}"
     end
 
     def disable_device!(device_id, device_udid, mac: false)

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -535,11 +535,9 @@ module Spaceship
       devices = parse_response(req, 'devices')
       return devices.first unless devices.empty?
 
-      validation_messages = parse_response(req, 'validationMessages').map { |message|
-        message["validationUserMessage"]
-      }.compact.uniq
+      validation_messages = parse_response(req, 'validationMessages').map { |message| message["validationUserMessage"] }.compact.uniq
 
-      raise validation_messages.join('\n') unless validation_messages.empty?
+      raise UnexpectedResponse.new, validation_messages.join('\n') unless validation_messages.empty?
       raise UnexpectedResponse.new, "Couldn't register new device, got this: #{parse_response(req)}"
     end
 

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -532,7 +532,12 @@ module Spaceship
         register: 'single'
       })
 
-      parse_response(req, 'devices').first
+      devices = parse_response(req, 'devices')
+      return devices.first unless devices.empty?
+
+      raise parse_response(req, 'validationMessages').map { |message|
+        message["validationUserMessage"]
+      }.compact.uniq.join('\n')
     end
 
     def disable_device!(device_id, device_udid, mac: false)

--- a/spaceship/spec/portal/device_spec.rb
+++ b/spaceship/spec/portal/device_spec.rb
@@ -116,6 +116,12 @@ describe Spaceship::Device do
       end.to raise_error("Device name must be 50 characters or less. \"Demo Device (Apple Watch Series 3 - 42mm GPS Black)\" has a 51 character length.")
     end
 
+    it "should fail to create a device with an invalid UDID" do
+      expect do
+        Spaceship::Device.create!(name: "Demo Device", udid: "1234")
+      end.to raise_error("An invalid value '1234' was provided for the parameter 'deviceNumber'.")
+    end
+
     it "doesn't trigger an ITC call if the device ID is already registered" do
       expect(client).to_not(receive(:create_device!))
       device = Spaceship::Device.create!(name: "Personal iPhone", udid: "e5814abb3b1d92087d48b64f375d8e7694932c39")

--- a/spaceship/spec/portal/fixtures/addDeviceFailureResponse.json
+++ b/spaceship/spec/portal/fixtures/addDeviceFailureResponse.json
@@ -1,0 +1,25 @@
+{
+  "creationTimestamp": "2018-09-28T14:05:17Z",
+  "resultCode": 0,
+  "userLocale": "en_US",
+  "protocolVersion": "QH65B2",
+  "requestId": "8286b5c1-ed85-4bf5-y65b-0cd7910f1d67",
+  "requestUrl": "https://developer.apple.com:443/services-account/QH65B2/account/ios/device/addDevices.action?content-type=text/x-url-arguments&accept=application/json&requestId=8286b5c1-ed85-4bf5-y65b-0cd7910f1d67&userLocale=en_US&teamId=47C5778P4P",
+  "responseId": "9bc3b97b-7ce1-46d9-9de6-23b4630b9525",
+  "isAdmin": true,
+  "isMember": false,
+  "isAgent": true,
+  "devices": [
+
+  ],
+  "failedDevices": [
+     "Demo Device"
+  ],
+  "validationMessages": [
+    {
+      "validationKey": "deviceNumber",
+      "validationUserMessage": "An invalid value '1234' was provided for the parameter 'deviceNumber'."
+    }
+  ],
+  "nextDeviceResetDate": null
+}

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -166,6 +166,11 @@ class PortalStubbing
         with(body: { "deviceClasses" => "iphone", "deviceNames" => "Demo Device", "deviceNumbers" => "7f6c8dc83d77134b5a3a1c53f1202b395b04482b", "register" => "single", "teamId" => "XXXXXXXXXX" }).
         to_return(status: 200, body: adp_read_fixture_file('addDeviceResponse.action.json'), headers: { 'Content-Type' => 'application/json' })
 
+      # Fail to register a new device with an invalid UDID
+      stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/device/addDevices.action").
+        with(body: { "deviceClasses" => "iphone", "deviceNames" => "Demo Device", "deviceNumbers" => "1234", "register" => "single", "teamId" => "XXXXXXXXXX" }).
+        to_return(status: 200, body: adp_read_fixture_file('addDeviceFailureResponse.json'), headers: { 'Content-Type' => 'application/json' })
+
       # Custom paging
       stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/device/listDevices.action").
         with(body: { "pageNumber" => "1", "pageSize" => "8", "sort" => "name=asc", "teamId" => "XXXXXXXXXX", includeRemovedDevices: "false" }).


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In the MDM Protocol Reference, Apple recommends to not hard code assumptions of UDID format as the format may change in the future.

https://developer.apple.com/enterprise/documentation/MDM-Protocol-Reference.pdf

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
Remove UDID format validation in `register_deivce` and `register_deivce` actions.