### PR TITLE
[deliver] allow metadata items to be uploaded one at a time

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -257,6 +257,13 @@ module Deliver
                                      default_value: :warn),
 
         # App Metadata
+        FastlaneCore::ConfigItem.new(key: :individual_metadata_items,
+                                     env_name: "DELIVER_INDIVUDAL_METADATA_ITEMS",
+                                     description: "An array of localized metadata items to upload individually by language so that errors can be identified. E.g. ['name', 'keywords', 'description']. Note: slow",
+                                     is_string: false,
+                                     type: Array,
+                                     default_value: []),
+
         # Non Localised
         FastlaneCore::ConfigItem.new(key: :app_icon,
                                      description: "Metadata: The path to the app icon",

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -94,7 +94,7 @@ module Deliver
         non_localised_options = (NON_LOCALISED_VERSION_VALUES + NON_LOCALISED_APP_VALUES)
       end
 
-      individual = options[:individual_metadata_items]
+      individual = options[:individual_metadata_items] || []
       localised_options.each do |key|
         current = options[key]
         next unless current

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -134,6 +134,61 @@ describe Deliver::UploadMetadata do
     end
   end
 
+  context "with metadata" do
+    let(:app) { double('app') }
+    let(:version) { double('version') }
+    let(:details) { double('details') }
+    let(:version_info) { {} }
+    let(:details_info) { {} }
+
+    before do
+      allow(uploader).to receive(:verify_available_languages!)
+      allow(version).to receive(:save!)
+      allow(version).to receive(:release_on_approval=)
+      allow(version).to receive(:toggle_phased_release)
+      allow(version).to receive(:auto_release_date=)
+      allow(version).to receive(:description)
+      allow(version).to receive(:send).and_return(version_info)
+      allow(app).to receive(:edit_version).and_return(version)
+      allow(app).to receive(:details).and_return(details)
+      allow(details).to receive(:save!)
+      allow(details).to receive(:send).and_return(details_info)
+    end
+
+    context "normal metadata" do
+      it "saves metadata" do
+        options = {
+            app: app,
+            details: details,
+            name: { "en-US" => "App name" },
+            description: { "en-US" => "App description" }
+        }
+        uploader.upload(options)
+        expect(version_info).to eql({ "en-US" => "App description" })
+        expect(details_info).to eql({ "en-US" => "App name" })
+        expect(version).to have_received(:save!)
+        expect(details).to have_received(:save!)
+      end
+    end
+
+    context "individual metadata items" do
+      it "saves individual metadata items" do
+        options = {
+            app: app,
+            details: details,
+            name: { "en-US" => "App name" },
+            description: { "en-US" => "App description" },
+            individual_metadata_items: [:name, :description]
+        }
+        uploader.upload(options)
+        expect(version_info).to eql({ "en-US" => "App description" })
+        expect(details_info).to eql({ "en-US" => "App name" })
+        expect(version).to have_received(:save!)
+        expect(details).to have_received(:save!)
+      end
+    end
+  end
+
   context "with auto_release_date" do
     let(:app) { double('app') }
     let(:version) { double('version') }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
When uploading localized metadata it can be difficult to determine which specific items have issues.  ITC does not return a detailed report of which languages had errors.

<!-- If it fixes an open issue, please link to the issue here. -->
Addresses [this issue](https://github.com/fastlane/fastlane/issues/11841), though not via precheck.

### Description
<!-- Describe your changes in detail -->
Added an option `individual_metadata_items`.  Items in this array will be uploaded one at a time instead of in bulk.  Rather than using `UI.user_error!` issues are displayed with `UI.error` so that all problems can be identified in one run

<!-- Please describe in detail how you tested your changes. -->
I set my metadata to use a known-unavailable `name` and uploaded it, receiving an error.  Also tried with `marketing_url` to ensure that both categories of metadata (version and app) work.