### PR TITLE
[snapshot] Improve screenshot rotation code

### DIFF
--- a/snapshot/lib/snapshot/screenshot_rotate.rb
+++ b/snapshot/lib/snapshot/screenshot_rotate.rb
@@ -25,16 +25,11 @@ module Snapshot
           command = "sips -r 180 '#{file}'"
         end
 
+        # Only rotate if we need to
         next unless command
 
-        # Only rotate if we need to
-        FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
-          command_stdout.sync
-          command_stdout.each do |line|
-            # We need to read this otherwise things hang
-          end
-          ::Process.wait(pid)
-        end
+        # Rotate
+        FastlaneCore::CommandExecutor.execute(command: command, print_all: false, print_command: false)
       end
     end
   end


### PR DESCRIPTION
Screenshot rotation in `snapshot` was still using `FastlaneCore::FastlanePty.spawn` directly. Changed it to use `FastlaneCore::CommandExecutor.execute` (which then uses `FastlaneCore::FastlanePty.spawn` internally, but also properly handles errors etc.)