### PR TITLE
[frameit] Fix downloading frames on Windows

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -19,8 +19,9 @@ module Frameit
       self.screenshot = screenshot
       prepare_image
 
-      if load_frame # Mac doesn't need a frame
-        self.frame = MiniMagick::Image.open(load_frame)
+      frame = load_frame
+      if frame # Mac doesn't need a frame
+        self.frame = MiniMagick::Image.open(frame)
         # Rotate the frame according to the device orientation
         self.frame.rotate(self.rotation_for_device_orientation)
       elsif self.class == Editor

--- a/frameit/lib/frameit/frame_downloader.rb
+++ b/frameit/lib/frameit/frame_downloader.rb
@@ -21,7 +21,7 @@ module Frameit
       files = JSON.parse(download_file("files.json"))
       files.each_with_index do |current, index|
         content = download_file(current, txt: "#{index + 1} of #{files.count} files")
-        File.write(File.join(templates_path, current), content)
+        File.binwrite(File.join(templates_path, current), content)
       end
       File.write(File.join(templates_path, "offsets.json"), download_file("offsets.json"))
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`frameit` downloaded broken frame files on Windows.

### Description
Use `File.binwrite` as those are binary files.