### PR TITLE
Replace Shellwords.*(var) with var.*

### DIFF
--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -69,7 +69,7 @@ module Fastlane
           if ENV['JAVA_HOME'].nil?
             command = ["java"]
           else
-            command = [Shellwords.escape(File.join(ENV['JAVA_HOME'], "/bin/java"))]
+            command = [File.join(ENV['JAVA_HOME'], "/bin/java").shellescape]
           end
           command << "-jar #{File.expand_path(params[:crashlytics_path])}"
           command << "-androidRes ."

--- a/fastlane/spec/actions_specs/apteligent_spec.rb
+++ b/fastlane/spec/actions_specs/apteligent_spec.rb
@@ -24,7 +24,7 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result).to include("https://api.crittercism.com/api_beta/dsym/123")
-        expect(result).to include("-F dsym=@#{Shellwords.shellescape(dsym_path)}")
+        expect(result).to include("-F dsym=@#{dsym_path.shellescape}")
         expect(result).to include("-F key=abc")
       end
     end

--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -292,7 +292,7 @@ module FastlaneCore
       def copy_logarchive(device, log_identity, logs_destination_dir)
         require 'shellwords'
 
-        logarchive_dst = Shellwords.escape(File.join(logs_destination_dir, "system_logs-#{log_identity}.logarchive"))
+        logarchive_dst = File.join(logs_destination_dir, "system_logs-#{log_identity}.logarchive").shellescape
         FileUtils.rm_rf(logarchive_dst)
         FileUtils.mkdir_p(File.expand_path("..", logarchive_dst))
         command = "xcrun simctl spawn #{device.udid} log collect --output #{logarchive_dst} 2>/dev/null"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Some places still used `Shellwords.*(var)` instead of the usual `var.*` we are using.

### Description
Fixed those.
