### PR TITLE
[docs] update readme with bypass device instructions

### DIFF
--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -133,14 +133,14 @@ export FASTLANE_SESSION='---\n- !ruby/object:HTTP::Cookie\n  name: DES5c148586df
 
 Copy everything from `---\n` to your CI server and provide it as environment variable named `FASTLANE_SESSION`.
 
-#### Bypass device and use SMS for verification
+#### Bypass trusted device and use SMS for verification
 
-If you have a trusted device configured for your Apple account, then Apple will not send a SMS code to your phone when you try to generate a web session with fastlane — instead a code will be displayed on one of your account's trusted devices. This can be problematic if you are trying to authenticate, but don't have access to a device. To circumvent the device and use SMS instead, take the following steps:
+Apple will not send a SMS code to your phone if you have a trusted device configured for your Apple account when you try to generate a web session with _fastlane_ — instead a code will be displayed on one of your account's trusted devices. This can be problematic if you are trying to authenticate but don't have access to a trusted device. Take the following steps to circumvent the device and use SMS instead:
 
-- Attempt to generate a web session with `fastlane spaceauth -u apple@krausefx.com` and wait for security code prompt to appear
-- Open a browser to appleid.apple.com or an address that requires you to login with your Apple ID, and logout of any previous session
-- Login with your Apple ID, and when prompted for a security code, request a code be sent to the desired phone
-- Use the code sent to phone with fastlane instead of with the browser
+- Attempt to generate a web session with `fastlane spaceauth -u [email]` and wait for security code prompt to appear
+- Open a browser to [appleid.apple.com](https://appleid.apple.com) or an address that requires you to login with your Apple ID, and logout of any previous session
+- Login with your Apple ID and request a code be sent to the desired phone when prompted for a security code
+- Use the code sent to phone with _fastlane_ instead of with the browser
 
 #### Transporter
 

--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -135,7 +135,7 @@ Copy everything from `---\n` to your CI server and provide it as environment var
 
 #### Bypass trusted device and use SMS for verification
 
-Apple will not send a SMS code to your phone if you have a trusted device configured for your Apple account when you try to generate a web session with _fastlane_ — instead a code will be displayed on one of your account's trusted devices. This can be problematic if you are trying to authenticate but don't have access to a trusted device. Take the following steps to circumvent the device and use SMS instead:
+If you have a trusted device configured, Apple will not send a SMS code to your phone for your Apple account when you try to generate a web session with _fastlane_. Instead, a code will be displayed on one of your account's trusted devices. This can be problematic if you are trying to authenticate but don't have access to a trusted device. Take the following steps to circumvent the device and use SMS instead:
 
 - Attempt to generate a web session with `fastlane spaceauth -u [email]` and wait for security code prompt to appear
 - Open a browser to [appleid.apple.com](https://appleid.apple.com) or an address that requires you to login with your Apple ID, and logout of any previous session

--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -113,7 +113,7 @@ This requires you to install `pry` using `sudo gem install pry`. `pry` is not in
 
 ## 2 Step Verification
 
-When your Apple account has 2 factor verification enabled, you'll automatically be asked to verify your identity using your phone. The resulting session will be stored in `~/.fastlane/spaceship/[email]/cookie`. The session should be valid for about one month, however there is no way to test this without actually waiting for over a month.
+When your Apple account has 2 factor verification enabled, you'll automatically be asked to verify your identity. If you have a trusted device configured for your account, then a code will appear on the device. If you don't have any devices configured, but have trusted a phone number, then a code will be sent to your phone. The resulting session will be stored in `~/.fastlane/spaceship/[email]/cookie`. The session should be valid for about one month, however there is no way to test this without actually waiting for over a month.
 
 ### Support for CI machines
 
@@ -132,6 +132,15 @@ export FASTLANE_SESSION='---\n- !ruby/object:HTTP::Cookie\n  name: DES5c148586df
 ```
 
 Copy everything from `---\n` to your CI server and provide it as environment variable named `FASTLANE_SESSION`.
+
+#### Bypass device and use SMS for verification
+
+If you have a trusted device configured for your Apple account, then Apple will not send a SMS code to your phone when you try to generate a web session with fastlane — instead a code will be displayed on one of your account's trusted devices. This can be problematic if you are trying to authenticate, but don't have access to a device. To circumvent the device and use SMS instead, take the following steps:
+
+- Attempt to generate a web session with `fastlane spaceauth -u apple@krausefx.com` and wait for security code prompt to appear
+- Open a browser to appleid.apple.com or an address that requires you to login with your Apple ID; logout of any previous session
+- Login with your Apple ID, and when prompted for a security code, request a code be sent to the desired phone
+- Use the code sent to phone with fastlane instead of with the browser
 
 #### Transporter
 

--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -138,7 +138,7 @@ Copy everything from `---\n` to your CI server and provide it as environment var
 If you have a trusted device configured for your Apple account, then Apple will not send a SMS code to your phone when you try to generate a web session with fastlane — instead a code will be displayed on one of your account's trusted devices. This can be problematic if you are trying to authenticate, but don't have access to a device. To circumvent the device and use SMS instead, take the following steps:
 
 - Attempt to generate a web session with `fastlane spaceauth -u apple@krausefx.com` and wait for security code prompt to appear
-- Open a browser to appleid.apple.com or an address that requires you to login with your Apple ID; logout of any previous session
+- Open a browser to appleid.apple.com or an address that requires you to login with your Apple ID, and logout of any previous session
 - Login with your Apple ID, and when prompted for a security code, request a code be sent to the desired phone
 - Use the code sent to phone with fastlane instead of with the browser
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

Quick backstory — I manage Apple developer accounts for ~100 different customers, some organization accounts, some individual accounts. For the individual accounts, I'm forced to access the Apple developer portal using their credentials which means 2FA in most cases. Thankfully, by coordinating with the customer, I can add my phone as a trusted device so that I don't have to contact them each time I need to access their account or generate a session...

But, the problem arises when I try to generate a web session using `fastlane spaceauth -u [apple_id_email]`. Since most of these Apple accounts have devices other than my phone registered, fastlane never prompts me to choose my phone for sending the code. Looking at the documentation and this closed issue #10790, there is no way to force fastlane to send the code to a certain number. One option would be to remove all the registered devices from the account, leaving only the desired phone number, but this is problematic because many of the customers I work with are using their devices with Apple throughout the day and logging them out would be BAD. The other option is to take the route recommended in this updated documentation:

- Attempt to generate a web session with `fastlane spaceauth -u apple@krausefx.com` and wait for security code prompt to appear
- Open a browser to appleid.apple.com or an address that requires you to login with your Apple ID; logout of any previous session
- Login with your Apple ID, and when prompted for a security code, request a code be sent to the desired phone
- Use the code sent to phone with fastlane instead of with the browser

<!-- If it fixes an open issue, please link to the issue here. -->

It isn't an open issue, but it still helps with this closed issue https://github.com/fastlane/fastlane/issues/10790.

### Description

<!-- Describe your changes in detail -->

Changed the documentation to include a way to bypass trusted devices and use a trusted phone number instead.

<!-- Please describe in detail how you tested your changes. -->

See the steps listed in the documentation. I've been able to reproduce the steps, and I've successfully generate a web session multiple times using this method.