### PR TITLE
[WIP] fix checking for gsp_path

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -10,7 +10,7 @@ module Fastlane
         find_api_token(params)
         find_gsp_path(params)
 
-        if !params[:api_token] && !params[:gsp_path]
+        if !params[:api_token] || !params[:gsp_path]
           UI.user_error!('Either Fabric API key or path to Firebase Crashlytics GoogleService-Info.plist must be given.')
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x ] I've updated the documentation if necessary.

### Motivation and Context
Unable to upload dSYM file to Fabric if not using Firebase currently. 

### Description
The current error is: "Either Fabric API key or path to Firebase Crashlytics GoogleService-Info.plist must be given." which means you wither add api key or path but the logic checks for both api key and path.
Checking for gsp_path should be optional as user already added Fabric API. 
