### PR TITLE
Take the AAB from Gradle in supply

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_to_play_store.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_play_store.rb
@@ -17,8 +17,15 @@ module Fastlane
         end
 
         # If no AAB param was provided, try to fill in the value from lane context.
+        # First GRADLE_ALL_AAB_OUTPUT_PATHS if only one
+        # Else from GRADLE_AAB_OUTPUT_PATH
         if params[:aab].nil?
-          params[:aab] = Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]
+          all_aab_paths = Actions.lane_context[SharedValues::GRADLE_ALL_AAB_OUTPUT_PATHS] || []
+          if all_aab_paths.count == 1
+            params[:aab] = all_aab_paths.first
+          else
+            params[:aab] = Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]
+          end
         end
 
         Supply.config = params # we already have the finished config

--- a/fastlane/lib/fastlane/actions/upload_to_play_store.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_play_store.rb
@@ -16,6 +16,11 @@ module Fastlane
           end
         end
 
+        # If no AAB param was provided, try to fill in the value from lane context.
+        if params[:aab].nil?
+          params[:aab] = Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]
+        end
+
         Supply.config = params # we already have the finished config
 
         Supply::Uploader.new.perform_upload

--- a/fastlane/spec/actions_specs/supply_spec.rb
+++ b/fastlane/spec/actions_specs/supply_spec.rb
@@ -25,6 +25,7 @@ describe Fastlane do
 
           expect(Supply.config[:apk]).to eq(apk_path)
           expect(Supply.config[:apk_paths]).to be_nil
+          expect(Supply.config[:aab]).to be_nil
         end
 
         it "uses the lane context APK path if no other APK info is present" do
@@ -36,6 +37,7 @@ describe Fastlane do
 
           expect(Supply.config[:apk]).to eq(apk_path)
           expect(Supply.config[:apk_paths]).to be_nil
+          expect(Supply.config[:aab]).to be_nil
         end
 
         it "ignores the lane context APK path if the APK param is present" do
@@ -47,6 +49,7 @@ describe Fastlane do
 
           expect(Supply.config[:apk]).to eq(apk_path)
           expect(Supply.config[:apk_paths]).to be_nil
+          expect(Supply.config[:aab]).to be_nil
         end
 
         it "ignores the lane context APK paths if the APK param is present" do
@@ -62,6 +65,7 @@ describe Fastlane do
 
           expect(Supply.config[:apk]).to eq(apk_path)
           expect(Supply.config[:apk_paths]).to be_nil
+          expect(Supply.config[:aab]).to be_nil
         end
       end
 
@@ -79,6 +83,7 @@ describe Fastlane do
 
           expect(Supply.config[:apk]).to be_nil
           expect(Supply.config[:apk_paths]).to eq(apk_paths)
+          expect(Supply.config[:aab]).to be_nil
         end
 
         it "uses the lane context APK paths if no other APK info is present" do
@@ -90,6 +95,7 @@ describe Fastlane do
 
           expect(Supply.config[:apk]).to be_nil
           expect(Supply.config[:apk_paths]).to eq(apk_paths)
+          expect(Supply.config[:aab]).to be_nil
         end
 
         it "ignores the lane context APK paths if the APK paths param is present" do
@@ -101,6 +107,7 @@ describe Fastlane do
 
           expect(Supply.config[:apk]).to be_nil
           expect(Supply.config[:apk_paths]).to eq(apk_paths)
+          expect(Supply.config[:aab]).to be_nil
         end
 
         it "ignores the lane context APK path if the APK paths param is present" do
@@ -114,6 +121,7 @@ describe Fastlane do
 
           expect(Supply.config[:apk]).to be_nil
           expect(Supply.config[:apk_paths]).to eq(apk_paths)
+          expect(Supply.config[:aab]).to be_nil
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Support for Android App Bundle has been added to #12568. However, it does not automatically finds the correct .aab file that has been generated by Gradle. 
There is an issue about it, but it has been closed #13171.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

I added support for automatic AAB by taking inspiration with what is already in `supply`. I have tested with one project and it works. I added corresponding unit tests.

One thing however is weird:
* `supply` accepts only one AAB file: https://github.com/fastlane/fastlane/blob/c646fabfdf5692b94fa80a7e7ebe875ad3a68811/supply/lib/supply/options.rb#L118-L130
* Gradle generates two `lane_context` values, one for one file, one for multiple files: https://github.com/fastlane/fastlane/blob/c646fabfdf5692b94fa80a7e7ebe875ad3a68811/fastlane/lib/fastlane/actions/gradle.rb#L9-L10

To me it does not make sense to have multiple AABs, so my code only checks for the first aab it finds.

I think it's safe to use one file now and see if users expect to upload multiple files later.