### PR TITLE
match multiple storage implementation reworks/cleanup

### DIFF
--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -24,7 +24,7 @@ module Match
       storage.download
 
       encryption = Encryption.for_storage_mode(params[:storage_mode], {
-        git_url: storage.git_url,
+        git_url: params[:git_url],
         working_directory: storage.working_directory
       })
       encryption.decrypt_files

--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -9,7 +9,7 @@ module Match
     def self.update(params: nil)
       ensure_ui_interactive
 
-      to ||= ChangePassword.ask_password(message: "New passphrase for Git Repo: ", confirm: true)
+      to = ChangePassword.ask_password(message: "New passphrase for Git Repo: ", confirm: true)
 
       # Choose the right storage and encryption implementations
       storage = Storage.for_mode(params[:storage_mode], {
@@ -23,10 +23,10 @@ module Match
       })
       storage.download
 
-      encryption = Encryption::Interface.encryption_class_for_storage_mode(params[:storage_mode]).new(
+      encryption = Encryption.for_storage_mode(params[:storage_mode], {
         git_url: storage.git_url,
         working_directory: storage.working_directory
-      )
+      })
       encryption.decrypt_files
 
       encryption.clear_password

--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -12,15 +12,15 @@ module Match
       to ||= ChangePassword.ask_password(message: "New passphrase for Git Repo: ", confirm: true)
 
       # Choose the right storage and encryption implementations
-      storage = Storage::Interface.storage_class_for_storage_mode(params[:storage_mode]).new
-
-      storage.configure(git_url: params[:git_url],
-                    shallow_clone: params[:shallow_clone],
-                    skip_docs: params[:skip_docs],
-                    branch: params[:git_branch],
-                    git_full_name: params[:git_full_name],
-                    git_user_email: params[:git_user_email],
-                    clone_branch_directly: params[:clone_branch_directly])
+      storage = Storage.for_mode(params[:storage_mode], {
+        git_url: params[:git_url],
+        shallow_clone: params[:shallow_clone],
+        skip_docs: params[:skip_docs],
+        git_branch: params[:git_branch],
+        git_full_name: params[:git_full_name],
+        git_user_email: params[:git_user_email],
+        clone_branch_directly: params[:clone_branch_directly]
+      })
       storage.download
 
       encryption = Encryption::Interface.encryption_class_for_storage_mode(params[:storage_mode]).new(

--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -113,13 +113,12 @@ module Match
           params = FastlaneCore::Configuration.create(Match::Options.available_options, options.__hash__)
           params.load_configuration_file("Matchfile")
 
-          storage = Storage::Interface.storage_class_for_storage_mode(params[:storage_mode]).new
-          storage.configure(
+          storage = Storage.for_mode(params[:storage_mode], {
             git_url: params[:git_url],
             shallow_clone: params[:shallow_clone],
-            branch: params[:git_branch],
+            git_branch: params[:git_branch],
             clone_branch_directly: params[:clone_branch_directly]
-          )
+          })
           storage.download
 
           encryption = Encryption::Interface.encryption_class_for_storage_mode(params[:storage_mode]).new(

--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -121,10 +121,10 @@ module Match
           })
           storage.download
 
-          encryption = Encryption::Interface.encryption_class_for_storage_mode(params[:storage_mode]).new(
+          encryption = Encryption.for_storage_mode(params[:storage_mode], {
             git_url: storage.git_url,
             working_directory: storage.working_directory
-          )
+          })
           encryption.decrypt_files
           UI.success("Repo is at: '#{storage.working_directory}'")
         end

--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -122,7 +122,7 @@ module Match
           storage.download
 
           encryption = Encryption.for_storage_mode(params[:storage_mode], {
-            git_url: storage.git_url,
+            git_url: params[:git_url],
             working_directory: storage.working_directory
           })
           encryption.decrypt_files

--- a/match/lib/match/encryption.rb
+++ b/match/lib/match/encryption.rb
@@ -1,2 +1,17 @@
 require_relative 'encryption/interface'
 require_relative 'encryption/openssl'
+
+module Match
+  module Encryption
+    # Returns the class to be used for a given `storage_mode`
+    def self.for_storage_mode(storage_mode, params)
+      if storage_mode == "git"
+        return Encryption::OpenSSL.configure(params)
+      elsif storage_mode == "google_cloud"
+        # return Encryption::GoogleCloudKMS.configure(params)
+      else
+        UI.user_error!("Invalid storage mode '#{storage_mode}'")
+      end
+    end
+  end
+end

--- a/match/lib/match/encryption.rb
+++ b/match/lib/match/encryption.rb
@@ -6,6 +6,7 @@ module Match
     # Returns the class to be used for a given `storage_mode`
     def self.for_storage_mode(storage_mode, params)
       if storage_mode == "git"
+        params[:keychain_name] = params[:git_url]
         return Encryption::OpenSSL.configure(params)
       elsif storage_mode == "google_cloud"
         # return Encryption::GoogleCloudKMS.configure(params)

--- a/match/lib/match/encryption/interface.rb
+++ b/match/lib/match/encryption/interface.rb
@@ -1,18 +1,6 @@
 module Match
   module Encryption
     class Interface
-      # Returns the class to be used for a given `storage_mode`
-      def self.encryption_class_for_storage_mode(storage_mode)
-        if storage_mode == "git"
-          require_relative './openssl'
-          return Encryption::OpenSSL
-        elsif storage_mode == "google_cloud"
-          # return Encryption::GoogleCloudKMS
-        else
-          UI.user_error!("Invalid storage mode '#{storage_mode}'")
-        end
-      end
-
       # Call this method to trigger the actual
       # encryption
       def encrypt_files

--- a/match/lib/match/encryption/openssl.rb
+++ b/match/lib/match/encryption/openssl.rb
@@ -14,6 +14,13 @@ module Match
 
       attr_accessor :working_directory
 
+      def self.configure(params)
+        return self.new(
+          git_url: params[:git_url],
+          working_directory: params[:working_directory]  
+        )
+      end
+
       # @param git_url: The Git URL is used for identifiying a specific repo
       #                 which is used to store the passphrase in the Keychain
       # @param working_directory: The path to where the certificates are stored

--- a/match/lib/match/encryption/openssl.rb
+++ b/match/lib/match/encryption/openssl.rb
@@ -17,7 +17,7 @@ module Match
       def self.configure(params)
         return self.new(
           keychain_name: params[:keychain_name],
-          working_directory: params[:working_directory]  
+          working_directory: params[:working_directory]
         )
       end
 

--- a/match/lib/match/module.rb
+++ b/match/lib/match/module.rb
@@ -11,7 +11,7 @@ module Match
   end
 
   def self.storage_modes
-    return %w(git google_cloud)
+    return %w(git)
   end
 
   def self.profile_type_sym(type)

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -25,14 +25,15 @@ module Match
       self.params = params
       self.type = type
 
-      self.storage = Storage::Interface.storage_class_for_storage_mode(params[:storage_mode]).new
-      self.storage.configure(git_url: params[:git_url],
-                             shallow_clone: params[:shallow_clone],
-                             skip_docs: params[:skip_docs],
-                             branch: params[:git_branch],
-                             git_full_name: params[:git_full_name],
-                             git_user_email: params[:git_user_email],
-                             clone_branch_directly: params[:clone_branch_directly])
+      self.storage = Storage.for_mode(params[:storage_mode], {
+        git_url: params[:git_url],
+        shallow_clone: params[:shallow_clone],
+        skip_docs: params[:skip_docs],
+        git_branch: params[:git_branch],
+        git_full_name: params[:git_full_name],
+        git_user_email: params[:git_user_email],
+        clone_branch_directly: params[:clone_branch_directly]
+      })
       self.storage.download
 
       # After the download was complete
@@ -134,7 +135,9 @@ module Match
         rows = self.profiles.collect do |p|
           status = p.status == 'Active' ? p.status.green : p.status.red
 
-          [p.name, p.id, status, p.type, p.expires.strftime("%Y-%m-%d")]
+          # Expires is somtimes nil
+          expires = p.expires ? p.expires.strftime("%Y-%m-%d") : nil
+          [p.name, p.id, status, p.type, expires]
         end
         puts(Terminal::Table.new({
           title: "Provisioning Profiles that are going to be revoked".green,

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -37,10 +37,10 @@ module Match
       self.storage.download
 
       # After the download was complete
-      self.encryption = Encryption::Interface.encryption_class_for_storage_mode(params[:storage_mode]).new(
+      self.encryption = Encryption.for_storage_mode(params[:storage_mode], {
         git_url: storage.git_url,
         working_directory: storage.working_directory
-      )
+      })
       self.encryption.decrypt_files
 
       had_app_identifier = self.params.fetch(:app_identifier, ask: false)

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -38,7 +38,7 @@ module Match
 
       # After the download was complete
       self.encryption = Encryption.for_storage_mode(params[:storage_mode], {
-        git_url: storage.git_url,
+        git_url: params[:git_url],
         working_directory: storage.working_directory
       })
       self.encryption.decrypt_files

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -38,7 +38,7 @@ module Match
 
       # Init the encryption only after the `storage.download` was called to have the right working directory
       encryption = Encryption.for_storage_mode(params[:storage_mode], {
-        git_url: storage.git_url,
+        git_url: params[:git_url],
         working_directory: storage.working_directory
       })
       encryption.decrypt_files

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -23,17 +23,17 @@ module Match
                                              title: "Summary for match #{Fastlane::VERSION}")
 
       # Choose the right storage and encryption implementations
-      storage = Storage::Interface.storage_class_for_storage_mode(params[:storage_mode]).new
-
-      storage.configure(git_url: params[:git_url],
-                    shallow_clone: params[:shallow_clone],
-                    skip_docs: params[:skip_docs],
-                    branch: params[:git_branch],
-                    git_full_name: params[:git_full_name],
-                    git_user_email: params[:git_user_email],
-                    clone_branch_directly: params[:clone_branch_directly],
-                    type: params[:type].to_s,
-                    platform: params[:platform].to_s)
+      storage = Storage.for_mode(params[:storage_mode], {
+        git_url: params[:git_url],
+        shallow_clone: params[:shallow_clone],
+        skip_docs: params[:skip_docs],
+        git_branch: params[:git_branch],
+        git_full_name: params[:git_full_name],
+        git_user_email: params[:git_user_email],
+        clone_branch_directly: params[:clone_branch_directly],
+        type: params[:type].to_s,
+        platform: params[:platform].to_s
+      })
       storage.download
 
       # Init the encryption only after the `storage.download` was called to have the right working directory

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -37,10 +37,10 @@ module Match
       storage.download
 
       # Init the encryption only after the `storage.download` was called to have the right working directory
-      encryption = Encryption::Interface.encryption_class_for_storage_mode(params[:storage_mode]).new(
+      encryption = Encryption.for_storage_mode(params[:storage_mode], {
         git_url: storage.git_url,
         working_directory: storage.working_directory
-      )
+      })
       encryption.decrypt_files
 
       unless params[:readonly]

--- a/match/lib/match/storage.rb
+++ b/match/lib/match/storage.rb
@@ -1,2 +1,16 @@
 require_relative 'storage/interface'
 require_relative 'storage/git_storage'
+
+module Match
+  module Storage
+    def self.for_mode(storage_mode, params)
+      if storage_mode == "git"
+        return Storage::GitStorage.configure(params)
+      elsif storage_mode == "google_cloud"
+        # return Storage::GoogleCloudStorage
+      else
+        UI.user_error!("Invalid storage mode '#{storage_mode}'")
+      end
+    end
+  end
+end

--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -20,7 +20,21 @@ module Match
       attr_accessor :type
       attr_accessor :platform
 
-      def configure(type: nil,
+      def self.configure(params)
+        return self.new(
+          type: params[:type].to_s,
+          platform: params[:platform].to_s,
+          git_url: params[:git_url],
+          shallow_clone: params[:shallow_clone],
+          skip_docs: params[:skip_docs],
+          branch: params[:git_branch],
+          git_full_name: params[:git_full_name],
+          git_user_email: params[:git_user_email],
+          clone_branch_directly: params[:clone_branch_directly]
+        )
+      end
+
+      def initialize(type: nil,
                     platform: nil,
                     git_url: nil,
                     shallow_clone: nil,

--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -35,14 +35,14 @@ module Match
       end
 
       def initialize(type: nil,
-                    platform: nil,
-                    git_url: nil,
-                    shallow_clone: nil,
-                    skip_docs: false,
-                    branch: "master",
-                    git_full_name: nil,
-                    git_user_email: nil,
-                    clone_branch_directly: false)
+                     platform: nil,
+                     git_url: nil,
+                     shallow_clone: nil,
+                     skip_docs: false,
+                     branch: "master",
+                     git_full_name: nil,
+                     git_user_email: nil,
+                     clone_branch_directly: false)
         self.git_url = git_url
         self.shallow_clone = shallow_clone
         self.skip_docs = skip_docs

--- a/match/lib/match/storage/interface.rb
+++ b/match/lib/match/storage/interface.rb
@@ -1,18 +1,6 @@
 module Match
   module Storage
     class Interface
-      # Returns the class to be used for a given `storage_mode`
-      def self.storage_class_for_storage_mode(storage_mode)
-        if storage_mode == "git"
-          require_relative './git_storage'
-          return Storage::GitStorage
-        elsif storage_mode == "google_cloud"
-          # return Storage::GoogleCloudStorage
-        else
-          UI.user_error!("Invalid storage mode '#{storage_mode}'")
-        end
-      end
-
       # The working directory in which we download all the profiles
       # and decrypt/encrypt them
       attr_accessor :working_directory

--- a/match/spec/commands_generator_spec.rb
+++ b/match/spec/commands_generator_spec.rb
@@ -82,7 +82,7 @@ describe Match::CommandsGenerator do
 
       expect(fake_storage).to receive(:download)
       allow(fake_storage).to receive(:working_directory).and_return("yolo_path")
-      allow(fake_storage).to receive(:git_url).and_return("https://github.com/fastlane/certs")
+      allow(fake_storage).to receive(:keychain_name).and_return("https://github.com/fastlane/certs")
 
       expect(FastlaneCore::UI).to receive(:success).with(/Successfully decrypted certificates/)
       expect(FastlaneCore::UI).to receive(:success).with(/Repo is at/)

--- a/match/spec/commands_generator_spec.rb
+++ b/match/spec/commands_generator_spec.rb
@@ -73,14 +73,12 @@ describe Match::CommandsGenerator do
   describe ":decrypt option handling" do
     def expect_githelper_clone_with(git_url, shallow_clone, git_branch)
       fake_storage = "fake_storage"
-      expect(Match::Storage::GitStorage).to receive(:new).and_return(fake_storage)
-
-      expect(fake_storage).to receive(:configure).with({
+      expect(Match::Storage::GitStorage).to receive(:configure).with({
         git_url: git_url,
         shallow_clone: shallow_clone,
-        branch: git_branch[:branch],
+        git_branch: git_branch[:branch],
         clone_branch_directly: git_branch[:clone_branch_directly]
-      })
+      }).and_return(fake_storage)
 
       expect(fake_storage).to receive(:download)
       allow(fake_storage).to receive(:working_directory).and_return("yolo_path")

--- a/match/spec/encryption/openssl_spec.rb
+++ b/match/spec/encryption/openssl_spec.rb
@@ -10,7 +10,7 @@ describe Match do
       ENV["MATCH_PASSWORD"] = '2"QAHg@v(Qp{=*n^'
 
       @e = Match::Encryption::OpenSSL.new(
-        git_url: @git_url,
+        keychain_name: @git_url,
         working_directory: @directory
       )
     end

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -39,7 +39,6 @@ describe Match do
 
       expect(fake_storage).to receive(:download).and_return(nil)
       expect(fake_storage).to receive(:clear_changes).and_return(nil)
-      expect(fake_storage).to receive(:git_url).and_return(git_url)
       allow(fake_storage).to receive(:working_directory).and_return(repo_dir)
       expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution, fake_storage.working_directory).and_return(cert_path)
       expect(Match::Generator).to receive(:generate_provisioning_profile).with(params: config,
@@ -107,7 +106,7 @@ describe Match do
       allow(fake_storage).to receive(:working_directory).and_return(repo_dir)
 
       fake_encryption = "fake_encryption"
-      expect(Match::Encryption::OpenSSL).to receive(:new).with(git_url: fake_storage.git_url, working_directory: fake_storage.working_directory).and_return(fake_encryption)
+      expect(Match::Encryption::OpenSSL).to receive(:new).with(keychain_name: fake_storage.git_url, working_directory: fake_storage.working_directory).and_return(fake_encryption)
       expect(fake_encryption).to receive(:decrypt_files).and_return(nil)
 
       expect(Match::Utils).to receive(:import).with(key_path, keychain, password: nil).and_return(nil)

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -25,18 +25,17 @@ describe Match do
       destination = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision")
 
       fake_storage = "fake_storage"
-      expect(Match::Storage::GitStorage).to receive(:new).and_return(fake_storage)
-      expect(fake_storage).to receive(:configure).with(
+      expect(Match::Storage::GitStorage).to receive(:configure).with(
         git_url: git_url,
         shallow_clone: true,
         skip_docs: false,
-        branch: "master",
+        git_branch: "master",
         git_full_name: nil,
         git_user_email: nil,
         clone_branch_directly: false,
         type: config[:type],
         platform: config[:platform]
-      ).and_return(repo_dir)
+      ).and_return(fake_storage)
 
       expect(fake_storage).to receive(:download).and_return(nil)
       expect(fake_storage).to receive(:clear_changes).and_return(nil)
@@ -90,18 +89,17 @@ describe Match do
       key_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.p12"
 
       fake_storage = "fake_storage"
-      expect(Match::Storage::GitStorage).to receive(:new).and_return(fake_storage)
-      expect(fake_storage).to receive(:configure).with(
+      expect(Match::Storage::GitStorage).to receive(:configure).with(
         git_url: git_url,
         shallow_clone: false,
         skip_docs: false,
-        branch: "master",
+        git_branch: "master",
         git_full_name: nil,
         git_user_email: nil,
         clone_branch_directly: false,
         type: config[:type],
         platform: config[:platform]
-      ).and_return(repo_dir)
+      ).and_return(fake_storage)
 
       expect(fake_storage).to receive(:download).and_return(nil)
       expect(fake_storage).to receive(:clear_changes).and_return(nil)

--- a/match/spec/storage/git_storage_spec.rb
+++ b/match/spec/storage/git_storage_spec.rb
@@ -1,16 +1,12 @@
 describe Match do
   describe Match::Storage::GitStorage do
-    before do
-      @storage = Match::Storage::GitStorage.new
-      @storage.configure(
-        type: "appstore",
-        platform: "ios"
-      )
-    end
-
     describe "#generate_commit_message" do
       it "works" do
-        result = @storage.generate_commit_message
+        storage = Match::Storage::GitStorage.new(
+          type: "appstore",
+          platform: "ios"
+        )
+        result = storage.generate_commit_message
         expect(result).to eq("[fastlane] Updated appstore and platform ios")
       end
     end
@@ -33,14 +29,14 @@ describe Match do
           with(to_params).
           and_return(nil)
 
-        @storage.configure(
+        storage = Match::Storage::GitStorage.new(
           git_url: git_url,
           shallow_clone: shallow_clone
         )
-        @storage.download
+        storage.download
 
-        expect(File.directory?(@storage.working_directory)).to eq(true)
-        expect(File.exist?(File.join(@storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
+        expect(File.directory?(storage.working_directory)).to eq(true)
+        expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
       end
 
       it "clones the repo (not shallow)" do
@@ -60,14 +56,14 @@ describe Match do
           with(to_params).
           and_return(nil)
 
-        @storage.configure(
+        storage = Match::Storage::GitStorage.new(
           git_url: git_url,
           shallow_clone: shallow_clone
         )
-        @storage.download
+        storage.download
 
-        expect(File.directory?(@storage.working_directory)).to eq(true)
-        expect(File.exist?(File.join(@storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
+        expect(File.directory?(storage.working_directory)).to eq(true)
+        expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
       end
 
       it "checks out a branch" do
@@ -91,15 +87,15 @@ describe Match do
           }).and_return("")
         end
 
-        @storage.configure(
+        storage = Match::Storage::GitStorage.new(
           git_url: git_url,
           shallow_clone: shallow_clone,
           branch: git_branch
         )
-        @storage.download
+        storage.download
 
-        expect(File.directory?(@storage.working_directory)).to eq(true)
-        expect(File.exist?(File.join(@storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
+        expect(File.directory?(storage.working_directory)).to eq(true)
+        expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
       end
     end
 
@@ -109,6 +105,14 @@ describe Match do
         expect(Dir).to receive(:mktmpdir).and_return(path)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         random_file = "random_file"
+        
+        storage = Match::Storage::GitStorage.new(
+          type: "appstore",
+          platform: "ios",
+          git_url: git_url,
+          shallow_clone: false,
+          skip_docs: true
+        )
 
         expected_commands = [
           "git add #{random_file}",
@@ -126,20 +130,15 @@ describe Match do
           }).and_return("")
         end
 
-        expect(@storage).to receive(:clear_changes).and_return(nil) # so we can inspect the folder
+        expect(storage).to receive(:clear_changes).and_return(nil) # so we can inspect the folder
 
-        @storage.configure(
-          git_url: git_url,
-          shallow_clone: false,
-          skip_docs: true
-        )
 
-        @storage.download
-        @storage.save_changes!(files_to_commit: [random_file])
+        storage.download
+        storage.save_changes!(files_to_commit: [random_file])
 
-        expect(File.directory?(@storage.working_directory)).to eq(true)
-        expect(File.exist?(File.join(@storage.working_directory, 'README.md'))).to eq(false)
-        expect(File.read(File.join(@storage.working_directory, 'match_version.txt'))).to eq(Fastlane::VERSION)
+        expect(File.directory?(storage.working_directory)).to eq(true)
+        expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false)
+        expect(File.read(File.join(storage.working_directory, 'match_version.txt'))).to eq(Fastlane::VERSION)
       end
     end
   end

--- a/match/spec/storage/git_storage_spec.rb
+++ b/match/spec/storage/git_storage_spec.rb
@@ -105,7 +105,7 @@ describe Match do
         expect(Dir).to receive(:mktmpdir).and_return(path)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         random_file = "random_file"
-        
+
         storage = Match::Storage::GitStorage.new(
           type: "appstore",
           platform: "ios",
@@ -131,7 +131,6 @@ describe Match do
         end
 
         expect(storage).to receive(:clear_changes).and_return(nil) # so we can inspect the folder
-
 
         storage.download
         storage.save_changes!(files_to_commit: [random_file])


### PR DESCRIPTION
## 1. Reworked Storage
`Match::Storage::Interface` was being used as a factory for creating which interface was needing to be used at runtime. Having implementation being referenced in the interface is what caused a some weird circular dependency issues in previous PR. This fixes those fixes and moves the factory creation into `Match::Storage`.

```rb
Storage::Interface.storage_class_for_storage_mode(params[:storage_mode])
```
is now
```rb
Storage.for_mode
```

## 2. Reworked Encryption
Similar to the above with storage but for `Match::Encryption::Interface` and `Match::Encryption`

```rb
Encryption::Interface.encryption_class_for_storage_mode
```
is now
```rb
Encryption.for_storage_mode
```

## 3. Relpalced `git_url` with `keychain_name` in OpenSSL
`Match::Encryption::OpenSSL` had an attribute for `git_url` which was only being used to set the Keychain server name (for storing the password). I renamed `git_url` to `keychain_name` so that this `Match::Encryption::OpenSSL` implementation could be used with other storage implementations in the future (svn, ftp, etc).

## 4. Removed `google_cloud` as option
This is going to get released out into the wild before `google_clould` implementation is completed so this is being removed as an option (for now).