### PR TITLE
[spaceship] Enable trusted number SMS verification

### DIFF
--- a/spaceship/lib/spaceship/two_step_client.rb
+++ b/spaceship/lib/spaceship/two_step_client.rb
@@ -44,7 +44,7 @@ module Spaceship
         puts("Please select a phone number to verify your identity")
 
         available = r.body["trustedPhoneNumbers"].collect do |current|
-          "#{current["numberWithDialCode"]}\tSMS\t(#{current["id"]})"
+          "#{current['numberWithDialCode']}\tSMS\t(#{current['id']})"
         end
         result = choose(*available)
         device_id = result.match(/.*\t.*\t\((.*)\)/)[1]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Currently spaceship fails for accounts that have 2FA with only trusted numbers, but no trusted devices.
<!-- If it fixes an open issue, please link to the issue here. -->
#13188

### Description
<!-- Describe your changes in detail -->
Added the ability to select a trusted phone number and enter in the response.
<!-- Please describe in detail how you tested your changes. -->
Tested on a client account we are working with.
