### PR TITLE
Fix new try_create_device method

### DIFF
--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -48,7 +48,7 @@ module Fastlane
         return device_objs
       end
 
-      def self.try_create_device(name:, udid:, mac:)
+      def self.try_create_device(name: nil, udid: nil, mac: false)
         Spaceship::Device.create!(name: name, udid: udid, mac: mac)
       rescue => ex
         UI.error(ex.to_s)

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -48,7 +48,7 @@ module Fastlane
         return device_objs
       end
 
-      def try_create_device(name, udid, mac)
+      def self.try_create_device(name:, udid:, mac:)
         Spaceship::Device.create!(name: name, udid: udid, mac: mac)
       rescue => ex
         UI.error(ex.to_s)

--- a/spaceship/lib/spaceship/portal/device.rb
+++ b/spaceship/lib/spaceship/portal/device.rb
@@ -155,7 +155,6 @@ module Spaceship
           return existing if existing
 
           # It is valid to have the same name for multiple devices
-
           device = client.create_device!(name, udid, mac: mac)
 
           # Update self with the new device


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Master is broken when attempting to register devices
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
Updated the new method to be a class method with keyword arguments since that's how it's being called

<!-- Please describe in detail how you tested your changes. -->
Our ios dev ran a build for a client
