### PR TITLE
[resign] Fix typo in resign.sh

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -841,7 +841,7 @@ function resign {
     rm -f "$APP_ENTITLEMENTS"
     rm -f "$PATCHED_ENTITLEMENTS"
     rm -f "$PATCHED_ENTITLEMENTS.bak"
-    rm -r "$TEMP_DIR/old-embedded-profile.plist"
+    rm -f "$TEMP_DIR/old-embedded-profile.plist"
     rm -f "$TEMP_DIR/profile.plist"
     rm -f "$TEMP_DIR/old-embedded.mobileprovision"
     rm -f "$TEMP_DIR/oldInfo.plist"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

As @goraths has pointed out in #13517 the `-r` flag is wrong in this context because code is removing a file not a directory.
It does look as a typo.

### Description

Use correct flag for `rm` command.

### P.S.

I believe this does _not_ fix the #13517.

