### PR TITLE
Deliver: skip version check when no icons are provided.

### DIFF
--- a/deliver/lib/deliver/upload_assets.rb
+++ b/deliver/lib/deliver/upload_assets.rb
@@ -4,9 +4,9 @@ module Deliver
   class UploadAssets
     SUPPORTED_ICON_EXTENSIONS = [".png", ".jpg", ".jpeg"]
     def upload(options)
+      return unless options[:app_icon] || options[:apple_watch_app_icon]
       return if options[:edit_live]
       app = options[:app]
-      app_modified = false
 
       v = app.edit_version(platform: options[:platform])
       UI.user_error!("Could not find a version to edit for app '#{app.name}'") unless v
@@ -14,16 +14,14 @@ module Deliver
       if options[:app_icon]
         UI.message("Uploading app icon...")
         v.upload_large_icon!(options[:app_icon])
-        app_modified = true
       end
 
       if options[:apple_watch_app_icon]
         UI.message("Uploading apple watchapp icon...")
         v.upload_watch_icon!(options[:apple_watch_app_icon])
-        app_modified = true
       end
 
-      v.save! if app_modified
+      v.save!
     end
   end
 end

--- a/deliver/spec/upload_assets_spec.rb
+++ b/deliver/spec/upload_assets_spec.rb
@@ -1,0 +1,55 @@
+require 'deliver/upload_metadata'
+
+describe Deliver::UploadAssets do
+  let(:uploader) { Deliver::UploadAssets.new }
+  let(:app) { double('app') }
+  let(:version) { double('version') }
+  let(:app_icon) { double('app_icon') }
+  let(:apple_watch_app_icon) { double('apple_watch_app_icon') }
+
+  before do
+    allow(version).to receive(:upload_large_icon!)
+    allow(version).to receive(:upload_watch_icon!)
+    allow(version).to receive(:save!)
+    allow(app).to receive(:edit_version).and_return(version)
+    allow(app).to receive(:name).and_return("MyApp")
+  end
+
+  it "should upload app icon and save when app icon is given" do
+    options = { app: app, app_icon: app_icon }
+    uploader.upload(options)
+    expect(version).to have_received(:upload_large_icon!).with(app_icon)
+    expect(version).to have_received(:save!)
+  end
+
+  it "should upload apple watch app icon and save when only apple watch app icon is given" do
+    options = { app: app, apple_watch_app_icon: apple_watch_app_icon }
+    uploader.upload(options)
+    expect(version).to have_received(:upload_watch_icon!).with(apple_watch_app_icon)
+    expect(version).to have_received(:save!)
+  end
+
+  it "should not upload or save when icons are not given" do
+    options = { app: app }
+    uploader.upload(options)
+    expect(version).to_not(have_received(:upload_watch_icon!))
+    expect(version).to_not(have_received(:upload_large_icon!))
+    expect(version).to_not(have_received(:save!))
+  end
+
+  it "should not upload or save when editing live even if icon is given" do
+    options = { app: app, edit_live: true, app_icon: app_icon }
+    uploader.upload(options)
+    expect(version).to_not(have_received(:upload_watch_icon!))
+    expect(version).to_not(have_received(:upload_large_icon!))
+    expect(version).to_not(have_received(:save!))
+  end
+
+  it "should raise when app icon is given but version is nil" do
+    options = { app: app, app_icon: app_icon }
+    allow(app).to receive(:edit_version).and_return(nil)
+    expect do
+      uploader.upload(options)
+    end.to raise_error(FastlaneCore::Interface::FastlaneError)
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When uploading an IPA with a version that already exists, and without changing metadata, assets or icons (by using `skip_*` flags and not providing icons), the upload fails with the error `Could not find a version to edit for app "MyApp"`.This is because in this case the method `edit_version` in the `Spaceship::Tunes::Application` class return `nil`. The class `UploadAssets` does the `nil` verification regardless if icons were provided.

`UploadScreenshots` has the same check but the `skip_screenshots` flag can be used if screenshop uploading is not needed,  but I don't think another `skip_assets` flag is necessary.

### Description
My fix adds early bail if icons are not provided, thus also skipping precious calls to the server.
