### PR TITLE
Add swift-version to pod_lib_lint action

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_lib_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_lib_lint.rb
@@ -17,6 +17,11 @@ module Fastlane
           command << "--sources='#{sources}'"
         end
 
+        if params[:swift_version]
+          swift_version = params[:swift_version]
+          command << "--swift-version=#{swift_version}"
+        end
+
         if params[:allow_warnings]
           command << "--allow-warnings"
         end
@@ -46,25 +51,29 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :use_bundle_exec,
-                                         description: "Use bundle exec when there is a Gemfile presented",
-                                         is_string: false,
-                                         default_value: true),
+                                       description: "Use bundle exec when there is a Gemfile presented",
+                                       is_string: false,
+                                       default_value: true),
           FastlaneCore::ConfigItem.new(key: :verbose,
-                                         description: "Allow output detail in console",
-                                         optional: true,
-                                         is_string: false),
+                                       description: "Allow output detail in console",
+                                       optional: true,
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :allow_warnings,
-                                         description: "Allow warnings during pod lint",
-                                         optional: true,
-                                         is_string: false),
+                                       description: "Allow warnings during pod lint",
+                                       optional: true,
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :sources,
-                                         description: "The sources of repos you want the pod spec to lint with, separated by commas",
-                                         optional: true,
-                                         is_string: false,
-                                         type: Array,
-                                         verify_block: proc do |value|
-                                           UI.user_error!("Sources must be an array.") unless value.kind_of?(Array)
-                                         end),
+                                       description: "The sources of repos you want the pod spec to lint with, separated by commas",
+                                       optional: true,
+                                       is_string: false,
+                                       type: Array,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Sources must be an array.") unless value.kind_of?(Array)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :swift_version,
+                                       description: "The SWIFT_VERSION that should be used to lint the spec. This takes precedence over a .swift-version file",
+                                       optional: true,
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :use_libraries,
                                        description: "Lint uses static libraries to install the spec",
                                        is_string: false,

--- a/fastlane/lib/fastlane/actions/pod_lib_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_lib_lint.rb
@@ -73,7 +73,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :swift_version,
                                        description: "The SWIFT_VERSION that should be used to lint the spec. This takes precedence over a .swift-version file",
                                        optional: true,
-                                       is_string: false),
+                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :use_libraries,
                                        description: "Lint uses static libraries to install the spec",
                                        is_string: false,

--- a/fastlane/lib/fastlane/actions/pod_push.rb
+++ b/fastlane/lib/fastlane/actions/pod_push.rb
@@ -87,7 +87,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :swift_version,
                                        description: "The SWIFT_VERSION that should be used to lint the spec. This takes precedence over a .swift-version file",
                                        optional: true,
-                                       is_string: false),
+                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :verbose,
                                        description: "Show more debugging information",
                                        optional: true,

--- a/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
+++ b/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
@@ -60,6 +60,14 @@ describe Fastlane do
 
         expect(result).to eq("bundle exec pod lib lint --use-libraries")
       end
+
+      it "generates the correct pod lib lint command with swift-version parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_lib_lint(swift_version: "4.2")
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod lib lint --swift-version=4.2")
+      end
     end
   end
 end

--- a/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
+++ b/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
@@ -63,7 +63,7 @@ describe Fastlane do
 
       it "generates the correct pod lib lint command with swift-version parameter" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          pod_lib_lint(swift_version: "4.2")
+          pod_lib_lint(swift_version: '4.2')
         end").runner.execute(:test)
 
         expect(result).to eq("bundle exec pod lib lint --swift-version=4.2")

--- a/fastlane/spec/actions_specs/pod_push_spec.rb
+++ b/fastlane/spec/actions_specs/pod_push_spec.rb
@@ -31,7 +31,7 @@ describe Fastlane do
 
       it "generates the correct pod push command with a repo parameter with the swift version flag" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          pod_push(path: './fastlane/spec/fixtures/podspecs/test.podspec', repo: 'MyRepo', swift_version: 4.0)
+          pod_push(path: './fastlane/spec/fixtures/podspecs/test.podspec', repo: 'MyRepo', swift_version: '4.0')
         end").runner.execute(:test)
 
         expect(result).to eq("pod repo push MyRepo './fastlane/spec/fixtures/podspecs/test.podspec' --swift-version=4.0")


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The `swift_version` parameter currently exists on the `pod_push` action but _not_ the `pod_lib_lint` action, meaning we're still required to have a `.swift-version` file in our repo to run this action. Adding the `--swift-version` flag to the `pod_lib_lint` action maintains consistency across these commands.

Source: https://guides.cocoapods.org/terminal/commands.html#pod_lib_lint

### Description
- Added `--swift-version` to `pod_lib_lint.rb`, exactly as it exists in `pod_push.rb`.
- Added `swift_version` parameter documentation to `pod_lib_lint.rb`, exactly as it exists in `pod_push.rb`.
- Added `--swift-version='4.2'` test to `pod_lib_lint_spec.rb`.
