### PR TITLE
[core] revert bootsnap to fix brew install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ gem "xcode-install", ">= 2.2.1" # needed for running xcode-install related tests
 gem "danger", ">= 4.2.1", "< 5.0.0"
 gem "danger-junit", ">= 0.7.3", "< 1.0.0"
 
-gem 'bootsnap', require: false
-
 gemspec(path: ".")
 
 plugins_path = File.join(File.expand_path("..", __FILE__), 'fastlane', 'Pluginfile')

--- a/bin/fastlane
+++ b/bin/fastlane
@@ -9,26 +9,6 @@ def self.windows?
   (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
 end
 
-if ENV["FASTLANE_OPTIMIZE_BOOT"]
-  require 'bootsnap'
-  require 'tmpdir'
-  require 'fileutils'
-  require_relative "../fastlane/lib/fastlane/version.rb"
-  cache_dir = "#{Dir.tmpdir}/fastlane/bootsnap-cache/" + Fastlane::VERSION
-  unless File.directory?(cache_dir)
-    FileUtils.mkdir_p(cache_dir)
-  end
-  Bootsnap.setup(
-    cache_dir:            cache_dir, # Path to your cache
-    development_mode:     false, # Current working environment
-    load_path_cache:      true, # Optimize the LOAD_PATH with a cache
-    autoload_paths_cache: false, # Not relevant for fastlane (Optimize ActiveSupport autoloads with cache)
-    disable_trace:        true, # (Alpha) Set `RubyVM::InstructionSequence.compile_option = { trace_instruction: false }`
-    compile_cache_iseq:   !self.windows?, # Compile Ruby code into ISeq cache, breaks coverage reporting.
-    compile_cache_yaml:   true # Compile YAML into a cache
-  )
-end
-
 require "fastlane/cli_tools_distributor"
 
 if Fastlane::CLIToolsDistributor.running_version_command?

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -97,7 +97,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('google-api-client', '>= 0.21.2', '< 0.24.0') # Google API Client to access Play Publishing API
 
   spec.add_dependency('emoji_regex', '~> 0.1') # Used to scan for Emoji in the changelog
-  spec.add_dependency('bootsnap', '>= 1.3.1', '< 1.4.0') # Optimize ruby startup time
 
   # Development only
   spec.add_development_dependency('rake', '< 12')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -70,16 +70,6 @@ lane :benchmark_help_command do
         UI.message("🏎️ '#{line.strip}'") if ["Total", "real", "user", "sys"].any? { |word| line.include?(word) }
       end
     end
-    ENV["FASTLANE_OPTIMIZE_BOOT"] = '1'
-    UI.important("Turning on FASTLANE_OPTIMIZE_BOOT:")
-    3.times do
-      content = sh(cmd, log: false)
-      content.each_line do |line|
-        UI.message("🏎️ '#{line.strip}'") if ["Total", "real", "user", "sys"].any? { |word| line.include?(word) }
-      end
-    end
-    ENV.delete("FASTLANE_OPTIMIZE_BOOT")
-    UI.important("Turning off FASTLANE_OPTIMIZE_BOOT again.")
   end
 end
 


### PR DESCRIPTION
Fixes #13520

## Issue
- Homebrew installation would fail to install `msgpack` (due to failing of building native extensions)
- `msgpack` is a dependency of `bootsnap` which was add in PR #13167
- This resulted in trying to update to `2.106.90` but falling back to `2.28.3` 

### brew installation output
```
Fetching: msgpack-1.2.4.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing fastlane:
        ERROR: Failed to build gem native extension.
    current directory: /Users/josh/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/msgpack-1.2.4/ext/msgpack
/Users/josh/.fastlane/bin/bundle/bin/ruby -r ./siteconf20181011-17138-ljknxw.rb extconf.rb
checking for ruby/st.h... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/Users/josh/.fastlane/bin/bundle/bin/$(RUBY_BASE_NAME)
/Users/josh/.fastlane/bin/bundle/lib/ruby/2.2.0/mkmf.rb:456:in `try_do': The compiler failed to generate an executable file. (RuntimeError)
You have to install development tools first.
        from /Users/josh/.fastlane/bin/bundle/lib/ruby/2.2.0/mkmf.rb:587:in `try_cpp'
        from /Users/josh/.fastlane/bin/bundle/lib/ruby/2.2.0/mkmf.rb:1060:in `block in have_header'
        from /Users/josh/.fastlane/bin/bundle/lib/ruby/2.2.0/mkmf.rb:911:in `block in checking_for'
        from /Users/josh/.fastlane/bin/bundle/lib/ruby/2.2.0/mkmf.rb:351:in `block (2 levels) in postpone'
        from /Users/josh/.fastlane/bin/bundle/lib/ruby/2.2.0/mkmf.rb:321:in `open'
        from /Users/josh/.fastlane/bin/bundle/lib/ruby/2.2.0/mkmf.rb:351:in `block in postpone'
        from /Users/josh/.fastlane/bin/bundle/lib/ruby/2.2.0/mkmf.rb:321:in `open'
        from /Users/josh/.fastlane/bin/bundle/lib/ruby/2.2.0/mkmf.rb:347:in `postpone'
        from /Users/josh/.fastlane/bin/bundle/lib/ruby/2.2.0/mkmf.rb:910:in `checking_for'
Gems updated: slack-notifier atomos claide nanaimo xcodeproj rouge xcpretty tty-screen tty-cursor tty-spinner commander-fastlane gh_inspector rubyzip naturally simctl declarative declarative-option representable signet google-api-client em
oji_regex msgpack
        from /Users/josh/.fastlane/bin/bundle/lib/ruby/2.2.0/mkmf.rb:1059:in `have_header'
        from extconf.rb:3:in `<main>'
```

## Solution
- Revert PR #13167

## Future
- Will need to revert this revert but with a proper solution for installing with homebrew