### PR TITLE
[match] remove un-needed encryption from match nuke

### DIFF
--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -36,13 +36,6 @@ module Match
       })
       self.storage.download
 
-      # After the download was complete
-      self.encryption = Encryption.for_storage_mode(params[:storage_mode], {
-        git_url: params[:git_url],
-        working_directory: storage.working_directory
-      })
-      self.encryption.decrypt_files
-
       had_app_identifier = self.params.fetch(:app_identifier, ask: false)
       self.params[:app_identifier] = '' # we don't really need a value here
       FastlaneCore::PrintTable.print_values(config: params,


### PR DESCRIPTION
Fixes #13529

## Problem
- `nuke.rb` was decrypting files (added in https://github.com/fastlane/fastlane/pull/13405) but was not encryption them before a commit (which was messing up files that weren't being nuked) 

## Solution
- Removed the decrypt as its not needed