### PR TITLE
[match] need to encrypt before save

### DIFF
--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -36,6 +36,13 @@ module Match
       })
       self.storage.download
 
+      # After the download was complete
+      self.encryption = Encryption.for_storage_mode(params[:storage_mode], {
+        git_url: params[:git_url],
+        working_directory: storage.working_directory
+      })
+      self.encryption.decrypt_files
+
       had_app_identifier = self.params.fetch(:app_identifier, ask: false)
       self.params[:app_identifier] = '' # we don't really need a value here
       FastlaneCore::PrintTable.print_values(config: params,
@@ -184,6 +191,8 @@ module Match
       if self.files.count > 0
         delete_files!
       end
+
+      self.encryption.encrypt_files
 
       # Now we need to commit and push all this too
       message = ["[fastlane]", "Nuked", "files", "for", type.to_s].join(" ")


### PR DESCRIPTION
Fixes #13542

## Problem/Solution
- Need to decrypt before nuking so that we can inspect profiles for the correct UUID
- Also need encrypt before saving