### PR TITLE
Version bump to 2.107.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,61 +33,29 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/AndrewMcBurney'>
-<img src='https://github.com/AndrewMcBurney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-</tr>
-<tr>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/DanToml'>
-<img src='https://github.com/DanToml.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
 <td id='olivier-halligon'>
 <a href='https://github.com/AliSoftware'>
 <img src='https://github.com/AliSoftware.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
 </td>
 <td id='manu-wallner'>
 <a href='https://github.com/milch'>
@@ -97,23 +65,23 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
 <td id='matthew-ellis'>
 <a href='https://github.com/matthewellis'>
@@ -121,19 +89,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
 </a>
-<h4 align='center'>Jimmy Dee</h4>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
 </tr>
 <tr>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 <td id='maksym-grebenets'>
 <a href='https://github.com/mgrebenets'>
@@ -141,11 +121,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+</tr>
+<tr>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/DanToml'>
+<img src='https://github.com/DanToml.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/AndrewMcBurney'>
+<img src='https://github.com/AndrewMcBurney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
 <td id='felix-krause'>
 <a href='https://github.com/KrauseFx'>
@@ -153,11 +153,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+<h4 align='center'>Jimmy Dee</h4>
 </td>
 </tr>
 </table>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,26 +15,26 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Luka Mirosevic",
-                        "Iulian Onofrei",
-                        "Fumiya Nakamura",
-                        "Jimmy Dee",
-                        "Maksym Grebenets",
-                        "Danielle Tomlinson",
+  spec.authors       = ["Fumiya Nakamura",
+                        "Josh Holtz",
                         "Jorge Revuelta H",
                         "Matthew Ellis",
-                        "Aaron Brager",
-                        "Helmut Januschka",
                         "Jérôme Lacoste",
-                        "Jan Piotrowski",
-                        "Josh Holtz",
+                        "Jimmy Dee",
                         "Kohki Miki",
-                        "Joshua Liebowitz",
+                        "Aaron Brager",
+                        "Maksym Grebenets",
+                        "Danielle Tomlinson",
                         "Felix Krause",
-                        "Olivier Halligon",
-                        "Stefan Natchev",
                         "Manu Wallner",
-                        "Andrew McBurney"]
+                        "Olivier Halligon",
+                        "Iulian Onofrei",
+                        "Joshua Liebowitz",
+                        "Jan Piotrowski",
+                        "Helmut Januschka",
+                        "Andrew McBurney",
+                        "Luka Mirosevic",
+                        "Stefan Natchev"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.106.2'.freeze
+  VERSION = '2.107.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.106.2
+// Generated with fastlane 2.107.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -2637,6 +2637,7 @@ func runTests(workspace: String? = nil,
               outputFiles: String? = nil,
               buildlogPath: String = "~/Library/Logs/scan",
               includeSimulatorLogs: Bool = false,
+              suppressXcodeOutput: String? = nil,
               formatter: String? = nil,
               xcprettyArgs: String? = nil,
               maxConcurrentSimulators: Int? = nil,
@@ -2662,6 +2663,8 @@ func runTests(workspace: String? = nil,
               slackOnlyOnFailure: Bool = false,
               useClangReportName: Bool = false,
               customReportFileName: String? = nil,
+              appIdentifier: String? = nil,
+              reinstallApp: Bool = false,
               failBuild: Bool = true) {
   let command = RubyCommand(commandID: "", methodName: "run_tests", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                            RubyCommand.Argument(name: "project", value: project),
@@ -2681,6 +2684,7 @@ func runTests(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "output_files", value: outputFiles),
                                                                                            RubyCommand.Argument(name: "buildlog_path", value: buildlogPath),
                                                                                            RubyCommand.Argument(name: "include_simulator_logs", value: includeSimulatorLogs),
+                                                                                           RubyCommand.Argument(name: "suppress_xcode_output", value: suppressXcodeOutput),
                                                                                            RubyCommand.Argument(name: "formatter", value: formatter),
                                                                                            RubyCommand.Argument(name: "xcpretty_args", value: xcprettyArgs),
                                                                                            RubyCommand.Argument(name: "max_concurrent_simulators", value: maxConcurrentSimulators),
@@ -2706,6 +2710,8 @@ func runTests(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "slack_only_on_failure", value: slackOnlyOnFailure),
                                                                                            RubyCommand.Argument(name: "use_clang_report_name", value: useClangReportName),
                                                                                            RubyCommand.Argument(name: "custom_report_file_name", value: customReportFileName),
+                                                                                           RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
+                                                                                           RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                            RubyCommand.Argument(name: "fail_build", value: failBuild)])
   _ = runner.executeCommand(command)
 }
@@ -2767,6 +2773,7 @@ func scan(workspace: String? = scanfile.workspace,
           outputFiles: String? = scanfile.outputFiles,
           buildlogPath: String = scanfile.buildlogPath,
           includeSimulatorLogs: Bool = scanfile.includeSimulatorLogs,
+          suppressXcodeOutput: String? = scanfile.suppressXcodeOutput,
           formatter: String? = scanfile.formatter,
           xcprettyArgs: String? = scanfile.xcprettyArgs,
           maxConcurrentSimulators: Int? = scanfile.maxConcurrentSimulators,
@@ -2792,6 +2799,8 @@ func scan(workspace: String? = scanfile.workspace,
           slackOnlyOnFailure: Bool = scanfile.slackOnlyOnFailure,
           useClangReportName: Bool = scanfile.useClangReportName,
           customReportFileName: String? = scanfile.customReportFileName,
+          appIdentifier: String? = scanfile.appIdentifier,
+          reinstallApp: Bool = scanfile.reinstallApp,
           failBuild: Bool = scanfile.failBuild) {
   let command = RubyCommand(commandID: "", methodName: "scan", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                       RubyCommand.Argument(name: "project", value: project),
@@ -2811,6 +2820,7 @@ func scan(workspace: String? = scanfile.workspace,
                                                                                       RubyCommand.Argument(name: "output_files", value: outputFiles),
                                                                                       RubyCommand.Argument(name: "buildlog_path", value: buildlogPath),
                                                                                       RubyCommand.Argument(name: "include_simulator_logs", value: includeSimulatorLogs),
+                                                                                      RubyCommand.Argument(name: "suppress_xcode_output", value: suppressXcodeOutput),
                                                                                       RubyCommand.Argument(name: "formatter", value: formatter),
                                                                                       RubyCommand.Argument(name: "xcpretty_args", value: xcprettyArgs),
                                                                                       RubyCommand.Argument(name: "max_concurrent_simulators", value: maxConcurrentSimulators),
@@ -2836,6 +2846,8 @@ func scan(workspace: String? = scanfile.workspace,
                                                                                       RubyCommand.Argument(name: "slack_only_on_failure", value: slackOnlyOnFailure),
                                                                                       RubyCommand.Argument(name: "use_clang_report_name", value: useClangReportName),
                                                                                       RubyCommand.Argument(name: "custom_report_file_name", value: customReportFileName),
+                                                                                      RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
+                                                                                      RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                       RubyCommand.Argument(name: "fail_build", value: failBuild)])
   _ = runner.executeCommand(command)
 }
@@ -4109,4 +4121,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.31]
+// FastlaneRunnerAPIVersion [0.9.32]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.106.2
+// Generated with fastlane 2.107.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.106.2
+// Generated with fastlane 2.107.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.106.2
+// Generated with fastlane 2.107.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.106.2
+// Generated with fastlane 2.107.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -17,6 +17,7 @@ protocol ScanfileProtocol: class {
   var outputFiles: String? { get }
   var buildlogPath: String { get }
   var includeSimulatorLogs: Bool { get }
+  var suppressXcodeOutput: String? { get }
   var formatter: String? { get }
   var xcprettyArgs: String? { get }
   var maxConcurrentSimulators: Int? { get }
@@ -42,6 +43,8 @@ protocol ScanfileProtocol: class {
   var slackOnlyOnFailure: Bool { get }
   var useClangReportName: Bool { get }
   var customReportFileName: String? { get }
+  var appIdentifier: String? { get }
+  var reinstallApp: Bool { get }
   var failBuild: Bool { get }
 }
 
@@ -64,6 +67,7 @@ extension ScanfileProtocol {
   var outputFiles: String? { return nil }
   var buildlogPath: String { return "~/Library/Logs/scan" }
   var includeSimulatorLogs: Bool { return false }
+  var suppressXcodeOutput: String? { return nil }
   var formatter: String? { return nil }
   var xcprettyArgs: String? { return nil }
   var maxConcurrentSimulators: Int? { return nil }
@@ -89,9 +93,11 @@ extension ScanfileProtocol {
   var slackOnlyOnFailure: Bool { return false }
   var useClangReportName: Bool { return false }
   var customReportFileName: String? { return nil }
+  var appIdentifier: String? { return nil }
+  var reinstallApp: Bool { return false }
   var failBuild: Bool { return true }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.5]
+// FastlaneRunnerAPIVersion [0.9.6]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.106.2
+// Generated with fastlane 2.107.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.106.2
+// Generated with fastlane 2.107.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.106.2':**

* [match] need to encrypt before save (#13546) via Josh Holtz
* [scan] suppress xcode output and also open report if tests fail (#12274) via Iulian Onofrei
