### PR TITLE
[produce] Allow to enable/disable `access_wifi` service

### DIFF
--- a/produce/lib/produce/commands_generator.rb
+++ b/produce/lib/produce/commands_generator.rb
@@ -45,6 +45,7 @@ module Produce
         c.description = 'Enable specific Application Services for a specific app on the Apple Developer Portal'
         c.example('Enable HealthKit, HomeKit and Passbook', 'fastlane produce enable_services -a com.example.app --healthkit --homekit --passbook')
 
+        c.option('--access-wifi', 'Enable Access WiFi')
         c.option('--app-group', 'Enable App Groups')
         c.option('--apple-pay', 'Enable Apple Pay')
         c.option('--auto-fill-credential', 'Enable AutoFill Credential')
@@ -85,6 +86,7 @@ module Produce
         c.description = 'Disable specific Application Services for a specific app on the Apple Developer Portal'
         c.example('Disable HealthKit', 'fastlane produce disable_services -a com.example.app --healthkit')
 
+        c.option('--access-wifi', 'Disable Access WiFi')
         c.option('--app-group', 'Disable App Groups')
         c.option('--apple-pay', 'Disable Apple Pay')
         c.option('--auto-fill-credential', 'Disable AutoFill Credential')

--- a/produce/lib/produce/service.rb
+++ b/produce/lib/produce/service.rb
@@ -36,7 +36,7 @@ module Produce
     end
 
     def valid_services_for(options)
-      allowed_keys = [:app_group, :apple_pay, :associated_domains, :auto_fill_credential, :data_protection, :game_center, :healthkit, :homekit,
+      allowed_keys = [:access_wifi, :app_group, :apple_pay, :associated_domains, :auto_fill_credential, :data_protection, :game_center, :healthkit, :homekit,
                       :hotspot, :icloud, :in_app_purchase, :inter_app_audio, :multipath, :network_extension,
                       :nfc_tag_reading, :personal_vpn, :passbook, :push_notification, :sirikit, :vpn_conf,
                       :wallet, :wireless_conf]
@@ -46,6 +46,15 @@ module Produce
     # rubocop:disable Metrics/PerceivedComplexity
     def update(on, app, options)
       updated = valid_services_for(options).count
+
+      if options.access_wifi
+        UI.message("\tAccess WiFi")
+        if on
+          app.update_service(Spaceship.app_service.access_wifi.on)
+        else
+          app.update_service(Spaceship.app_service.access_wifi.off)
+        end
+      end
 
       if options.app_group
         UI.message("\tApp Groups")

--- a/spaceship/docs/DeveloperPortal.md
+++ b/spaceship/docs/DeveloperPortal.md
@@ -40,6 +40,7 @@ App Services are part of the application, however, they are one of the few thing
 Currently available services include (all require the `Spaceship::Portal.app_service.` prefix)
 
 ```
+access_wifi.(on|off)
 app_group.(on|off)
 apple_pay.(on|off)
 associated_domains.(on|off)

--- a/spaceship/lib/spaceship/portal/app_service.rb
+++ b/spaceship/lib/spaceship/portal/app_service.rb
@@ -40,7 +40,7 @@ module Spaceship
         return m
       end
 
-      AccessWiFi = AppService.new_service("AWEQ28MY3E")
+      AccessWifi = AppService.new_service("AWEQ28MY3E")
       AppGroup = AppService.new_service("APG3427HIY")
       ApplePay = AppService.new_service("OM633U5T5G")
       AssociatedDomains = AppService.new_service("SKC3T5S89Y")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
iOS 12 added `Access WiFi Information` entitlement. Support for this was added to `spaceship.portal.app_service` but the triggers were not updated. Updating them in this PR.

### Description
Allow produce to enable/disable `access_wifi` service

Added the following options to `produce enable_services`
```
--access-wifi          Enable Access WiFi
```

Added the following options to `produce disable_services`
```
--access-wifi         Disable Access WiFi
```
