### PR TITLE
iOS SnapshotHelper.swift Set locale only when not empty

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -277,4 +277,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.12]
+// SnapshotHelperVersion [1.13]

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -114,6 +114,7 @@ open class Snapshot: NSObject {
         } catch {
             print("Couldn't detect/set locale...")
         }
+        
         if locale.isEmpty {
             locale = Locale(identifier: deviceLanguage).identifier
         }

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -117,7 +117,10 @@ open class Snapshot: NSObject {
         if locale.isEmpty {
             locale = Locale(identifier: deviceLanguage).identifier
         }
-        app.launchArguments += ["-AppleLocale", "\"\(locale)\""]
+        
+        if !locale.isEmpty {
+            app.launchArguments += ["-AppleLocale", "\"\(locale)\""]
+        }
     }
 
     class func setLaunchArguments(_ app: XCUIApplication) {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Few of our CI machines were missing ~/Library/Caches/tools.fastlane/locale.txt and SnapshotHelper set the app locale to empty string and cause date time format returning wrong string like: expecting "01 Jan 2018" but got "01 M01 2018"

<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/fastlane/fastlane/issues/13555

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
setLocale will skip -AppleLocale parameter if locale.isEmpty as setLanguage did when deviceLanguage is empty  
