### PR TITLE
Fixed typo in deliver options.rb

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -376,7 +376,7 @@ module Deliver
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :ignore_language_directory_validation,
                                      env_name: "DELIVER_IGNORE_LANGUAGE_DIRECTORY_VALIDATION",
-                                     description: "Ignore errors when invalid languages are found in metadata and screeenshot directories",
+                                     description: "Ignore errors when invalid languages are found in metadata and screenshot directories",
                                      default_value: false,
                                      is_string: false),
         FastlaneCore::ConfigItem.new(key: :precheck_include_in_app_purchases,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
screeenshot has too many 'e'

### Description
screeenshot => screenshot
