### PR TITLE
[sigh] support macOS and Developer ID in get_provisioning_profile action

### DIFF
--- a/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
@@ -65,7 +65,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include?(platform)
       end
 
       def self.example_code

--- a/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
@@ -36,6 +36,7 @@ module Fastlane
         profile_type = "app-store"
         profile_type = "ad-hoc" if values[:adhoc]
         profile_type = "development" if values[:development]
+        profile_type = "developer-id" if values[:developer_id]
         profile_type = "enterprise" if enterprise
 
         UI.message("Setting Provisioning Profile type to '#{profile_type}'")

--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -44,6 +44,19 @@ module FastlaneCore
         parse(path, keychain_path).fetch("Name")
       end
 
+      def mac?(path, keychain_path = nil)
+        parse(path, keychain_path).fetch("Platform", []).include? 'OSX'
+      end
+
+      def profile_filename(path, keychain_path = nil)
+        basename = uuid(path, keychain_path)
+        if mac?(path, keychain_path)
+          basename + ".provisionprofile"
+        else
+          basename + ".mobileprovision"
+        end
+      end
+
       def profiles_path
         path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
         # If the directory doesn't exist, create it first
@@ -57,8 +70,7 @@ module FastlaneCore
       # Installs a provisioning profile for Xcode to use
       def install(path, keychain_path = nil)
         UI.message("Installing provisioning profile...")
-        profile_filename = uuid(path, keychain_path) + ".mobileprovision"
-        destination = File.join(profiles_path, profile_filename)
+        destination = File.join(profiles_path, profile_filename(path, keychain_path))
 
         if path != destination
           # copy to Xcode provisioning profile directory

--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -45,7 +45,7 @@ module FastlaneCore
       end
 
       def mac?(path, keychain_path = nil)
-        parse(path, keychain_path).fetch("Platform", []).include? 'OSX'
+        parse(path, keychain_path).fetch("Platform", []).include?('OSX')
       end
 
       def profile_filename(path, keychain_path = nil)

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -14,18 +14,27 @@ module Sigh
                                      description: "Setting this flag will generate AdHoc profiles instead of App Store Profiles",
                                      is_string: false,
                                      default_value: false,
-                                     conflicting_options: [:development],
-                                     conflict_block: proc do |value|
-                                       UI.user_error!("You can't enable both :development and :adhoc")
+                                     conflicting_options: [:developer_id, :development],
+                                     conflict_block: proc do |option|
+                                       UI.user_error!("You can't enable both :#{option.key} and :adhoc")
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :developer_id,
+                                     env_name: "SIGH_DEVELOPER_ID",
+                                     description: "Setting his flag will generate Developer ID profiles instead of App Store Profiles",
+                                     is_string: false,
+                                     default_value: false,
+                                     conflicting_options: [:adhoc, :development],
+                                     conflict_block: proc do |option|
+                                       UI.user_error!("You can't enable both :#{option.key} and :developer_id")
                                      end),
         FastlaneCore::ConfigItem.new(key: :development,
                                      env_name: "SIGH_DEVELOPMENT",
                                      description: "Renew the development certificate instead of the production one",
                                      is_string: false,
                                      default_value: false,
-                                     conflicting_options: [:adhoc],
-                                     conflict_block: proc do |value|
-                                       UI.user_error!("You can't enable both :development and :adhoc")
+                                     conflicting_options: [:adhoc, :developer_id],
+                                     conflict_block: proc do |option|
+                                       UI.user_error!("You can't enable both :#{option.key} and :development")
                                      end),
         FastlaneCore::ConfigItem.new(key: :skip_install,
                                      env_name: "SIGH_SKIP_INSTALL",

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -58,6 +58,7 @@ module Sigh
       @profile_type = Spaceship.provisioning_profile.app_store
       @profile_type = Spaceship.provisioning_profile.in_house if Spaceship.client.in_house?
       @profile_type = Spaceship.provisioning_profile.ad_hoc if Sigh.config[:adhoc]
+      @profile_type = Spaceship.provisioning_profile.direct if Sigh.config[:developer_id]
       @profile_type = Spaceship.provisioning_profile.development if Sigh.config[:development]
 
       @profile_type

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -260,7 +260,11 @@ module Sigh
         profile_name += "_tvos"
       end
 
-      profile_name += '.mobileprovision'
+      if Sigh.config[:platform].to_s == 'macos'
+        profile_name += '.provisionprofile'
+      else
+        profile_name += '.mobileprovision'
+      end
 
       tmp_path = Dir.mktmpdir("profile_download")
       output_path = File.join(tmp_path, profile_name)

--- a/spaceship/lib/spaceship/portal/certificate.rb
+++ b/spaceship/lib/spaceship/portal/certificate.rb
@@ -107,10 +107,10 @@ module Spaceship
       class MacInstallerDistribution < Certificate; end
 
       # A Mac Developer ID signing certificate for building .app bundles
-      class DeveloperIDApplication < Certificate; end
+      class DeveloperIdApplication < Certificate; end
 
       # A Mac Developer ID signing certificate for building .pkg installers
-      class DeveloperIDInstaller < Certificate; end
+      class DeveloperIdInstaller < Certificate; end
 
       #####################################################
       # Certs that are specific for one app
@@ -175,11 +175,11 @@ module Spaceship
         "749Y1QAGU7" => MacDevelopment,
         "HXZEUKP0FP" => MacAppDistribution,
         "2PQI8IDXNH" => MacInstallerDistribution,
-        "OYVN2GW35E" => DeveloperIDInstaller,
-        "W0EURJRMC5" => DeveloperIDApplication,
+        "OYVN2GW35E" => DeveloperIdInstaller,
+        "W0EURJRMC5" => DeveloperIdApplication,
         "CDZ7EMXIZ1" => MacProductionPush,
         "HQ4KP3I34R" => MacDevelopmentPush,
-        "DIVN2GW3XT" => DeveloperIDApplication
+        "DIVN2GW3XT" => DeveloperIdApplication
       }
 
       CERTIFICATE_TYPE_IDS = IOS_CERTIFICATE_TYPE_IDS.merge(MAC_CERTIFICATE_TYPE_IDS)

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -445,7 +445,7 @@ module Spaceship
             if self.kind_of?(Development)
               self.certificates = [Spaceship::Portal::Certificate::MacDevelopment.all.first]
             elsif self.kind_of?(Direct)
-              self.certificates = [Spaceship::Portal::Certificate::DeveloperIDApplication.all.first]
+              self.certificates = [Spaceship::Portal::Certificate::DeveloperIdApplication.all.first]
             else
               self.certificates = [Spaceship::Portal::Certificate::MacAppDistribution.all.first]
             end


### PR DESCRIPTION
🔑 

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I really want Fastlane to have good support for building macOS apps (#13573). One piece of low-hanging fruit is getting provisioning profiles.

### Description
A lot of support is already present in Fastlane for macOS provisioning profiles, so this is mostly a matter of fixing a few issues on the edges. It adds checks on the profile type so that we use the right file extension (`.mobileprovision` vs. `.provisionprofile`). It also adds an option to Sigh for Developer ID certificates in addition to the existing types.

I also needed to make a change to the class names for Developer ID certificates in Spaceship: `DeveloperID -> DeveloperId`. This is to support the automatic class name inference that Spaceship does, so that `Spaceship.certificate.developer_id_application` maps to the right class, for instance.

With these changes, you can successfully use `sigh` in Fastlane to get a Developer ID provisioning profile for a macOS app:

```
get_provisioning_profile(
  developer_id: true,
  platform: 'macos'
)
```
