### PR TITLE
Make Scan::ErrorHandler account for Xcode 10 parallel testing failures

### DIFF
--- a/scan/lib/scan/error_handler.rb
+++ b/scan/lib/scan/error_handler.rb
@@ -29,6 +29,13 @@ module Scan
           # we don't want to raise an exception here
           # as we handle this in runner.rb at a later point
           # after parsing the actual test results
+          # ------------------------------------------------
+          # For the "Failing tests:" case, this covers Xcode
+          # 10 parallel testing failure, which doesn't
+          # print out the "Executed" line that would show
+          # test summary (number of tests passed, etc.).
+          # Instead, it just prints "Failing tests:"
+          # followed by a list of tests that failed.
           return
         end
         UI.build_failure!("Error building/testing the application - see the log above")

--- a/scan/lib/scan/error_handler.rb
+++ b/scan/lib/scan/error_handler.rb
@@ -24,7 +24,7 @@ module Scan
           print("https://stackoverflow.com/a/17031697/445598")
         when /Testing failed/
           UI.build_failure!("Error building the application - see the log above")
-        when /Executed/
+        when /Executed/, /Failing tests:/
           # this is *really* important:
           # we don't want to raise an exception here
           # as we handle this in runner.rb at a later point

--- a/scan/spec/error_handler_spec.rb
+++ b/scan/spec/error_handler_spec.rb
@@ -1,0 +1,32 @@
+require 'scan'
+
+describe Scan do
+  describe Scan::ErrorHandler do
+    describe "handle_build_error" do
+      describe "when parsing parallel test failure output" do
+        it "does not report a build failure" do
+          output = File.open('./scan/spec/fixtures/parallel_testing_failure.log', &:read)
+          expect do
+            Scan::ErrorHandler.handle_build_error(output)
+          end.to_not(raise_error(FastlaneCore::Interface::FastlaneBuildFailure))
+        end
+      end
+      describe "when parsing non-parallel test failure output" do
+        it "does not report a build failure" do
+          output = File.open('./scan/spec/fixtures/non_parallel_testing_failure.log', &:read)
+          expect do
+            Scan::ErrorHandler.handle_build_error(output)
+          end.to_not(raise_error(FastlaneCore::Interface::FastlaneBuildFailure))
+        end
+      end
+      describe "when parsing early failure output" do
+        it "reports a build failure" do
+          output = File.open('./scan/spec/fixtures/early_testing_failure.log', &:read)
+          expect do
+            Scan::ErrorHandler.handle_build_error(output)
+          end.to(raise_error(FastlaneCore::Interface::FastlaneBuildFailure))
+        end
+      end
+    end
+  end
+end

--- a/scan/spec/fixtures/early_testing_failure.log
+++ b/scan/spec/fixtures/early_testing_failure.log
@@ -1,0 +1,27 @@
+Testing started on 'iPad Air 2'
+2018-11-04 10:33:12.548 xcodebuild[29559:2319983]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/Users/basher/Library/Developer/Xcode/DerivedData/TestingTest-gdgaczvhjqcyjkdnismgbepkohom/Logs/Test/Run-TestingTest-2018.11.04_10-33-09--0800.xcresult/2_Test/Diagnostics/TestingTestTests-2AB26E26-E9AB-4C2F-B5C6-8635107CFC73/TestingTestTests-956F4A0D-DFAB-4F84-AA47-8CA22766F658/Session-TestingTestTests-2018-11-04_103312-uwb1nH.log
+2018-11-04 10:33:12.549 xcodebuild[29559:2319971] [MT] IDETestOperationsObserverDebug: (D350D682-C021-400C-B6B9-D10FAD114613) Beginning test session TestingTestTests-D350D682-C021-400C-B6B9-D10FAD114613 at 2018-11-04 10:33:12.549 with Xcode 10B61 on target <DVTiPhoneSimulator: 0x7fdd1f6a0590> {
+		SimDevice: iPad Air 2 (8CB426F7-7F07-48E8-B7B8-7A7F21E0A618, iOS 12.1, Shutdown)
+} (12.1 (16B91))
+2018-11-04 10:33:21.784927-0800 TestingTest[30007:2321848] libMobileGestalt MobileGestalt.c:890: MGIsDeviceOneOfType is not supported on this platform.
+Precondition failed: : file /Users/basher/Code/TestingTest/TestingTest/AppDelegate.swift, line 19
+2018-11-04 10:33:21.838307-0800 TestingTest[30007:2321848] Precondition failed: : file /Users/basher/Code/TestingTest/TestingTest/AppDelegate.swift, line 19
+2018-11-04 10:33:45.319 xcodebuild[29559:2321846]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/Users/basher/Library/Developer/Xcode/DerivedData/TestingTest-gdgaczvhjqcyjkdnismgbepkohom/Logs/Test/Run-TestingTest-2018.11.04_10-33-09--0800.xcresult/2_Test/Diagnostics/TestingTestTestsClone-1839D686-073A-4949-992D-C29FB0972E47/TestingTestTestsClone-15AA3B6A-3C63-4500-A25C-C3E9C5140FDF/Session-TestingTestTestsClone-2018-11-04_103345-pcZlMv.log
+2018-11-04 10:33:45.319 xcodebuild[29559:2319971] [MT] IDETestOperationsObserverDebug: (34D322DB-5B96-4E2D-A60C-05E80A51EE55) Beginning test session TestingTestTestsClone-34D322DB-5B96-4E2D-A60C-05E80A51EE55 at 2018-11-04 10:33:45.319 with Xcode 10B61 on target <DVTiPhoneSimulator: 0x7fdd1f6a0590> {
+		SimDevice: iPad Air 2 (8CB426F7-7F07-48E8-B7B8-7A7F21E0A618, iOS 12.1, Booted)
+} (12.1 (16B91))
+2018-11-04 10:33:48.382674-0800 TestingTest[30033:2322616] libMobileGestalt MobileGestalt.c:890: MGIsDeviceOneOfType is not supported on this platform.
+Precondition failed: : file /Users/basher/Code/TestingTest/TestingTest/AppDelegate.swift, line 19
+2018-11-04 10:33:48.427073-0800 TestingTest[30033:2322616] Precondition failed: : file /Users/basher/Code/TestingTest/TestingTest/AppDelegate.swift, line 19
+2018-11-04 10:34:05.284 xcodebuild[29559:2319971] [MT] IDETestOperationsObserverDebug: 52.741 elapsed -- Testing started completed.
+2018-11-04 10:34:05.284 xcodebuild[29559:2319971] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
+2018-11-04 10:34:05.284 xcodebuild[29559:2319971] [MT] IDETestOperationsObserverDebug: 52.741 sec, +52.741 sec -- end
+2018-11-04 10:34:05.285 xcodebuild[29559:2319971] Error Domain=IDETestOperationsObserverErrorDomain Code=6 "Early unexpected exit, operation never finished bootstrapping - no restart will be attempted" UserInfo={NSLocalizedDescription=Early unexpected exit, operation never finished bootstrapping - no restart will be attempted, NSUnderlyingError=0x7fdd1f417390 {Error Domain=IDETestOperationsObserverErrorDomain Code=5 "Test runner exited before starting test execution." UserInfo={NSLocalizedDescription=Test runner exited before starting test execution., NSLocalizedRecoverySuggestion=If you believe this error represents a bug, please attach the result bundle at /Users/basher/Library/Developer/Xcode/DerivedData/TestingTest-gdgaczvhjqcyjkdnismgbepkohom/Logs/Test/Run-TestingTest-2018.11.04_10-33-09--0800.xcresult}}}
+2018-11-04 10:34:05.285 xcodebuild[29559:2319971] Error Domain=IDETestOperationsObserverErrorDomain Code=6 "Early unexpected exit, operation never finished bootstrapping - no restart will be attempted" UserInfo={NSLocalizedDescription=Early unexpected exit, operation never finished bootstrapping - no restart will be attempted, NSUnderlyingError=0x7fdd1f42b1c0 {Error Domain=IDETestOperationsObserverErrorDomain Code=5 "Test runner exited before starting test execution." UserInfo={NSLocalizedDescription=Test runner exited before starting test execution., NSLocalizedRecoverySuggestion=If you believe this error represents a bug, please attach the result bundle at /Users/basher/Library/Developer/Xcode/DerivedData/TestingTest-gdgaczvhjqcyjkdnismgbepkohom/Logs/Test/Run-TestingTest-2018.11.04_10-33-09--0800.xcresult}}}
+
+Testing failed:
+	TestingTest.app (30007) encountered an error (Early unexpected exit, operation never finished bootstrapping - no restart will be attempted. (Underlying error: Test runner exited before starting test execution.))
+	TestingTest.app (30033) encountered an error (Early unexpected exit, operation never finished bootstrapping - no restart will be attempted. (Underlying error: Test runner exited before starting test execution.))
+** TEST FAILED **

--- a/scan/spec/fixtures/non_parallel_testing_failure.log
+++ b/scan/spec/fixtures/non_parallel_testing_failure.log
@@ -1,0 +1,90 @@
+Test Suite 'All tests' started at 2018-11-04 10:28:22.431
+Test Suite 'TestingTestTests.xctest' started at 2018-11-04 10:28:22.432
+Test Suite 'TestingTestTests' started at 2018-11-04 10:28:22.432
+Test Case '-[TestingTestTests.TestingTestTests testA]' started.
+Test Case '-[TestingTestTests.TestingTestTests testA]' passed (0.001 seconds).
+Test Case '-[TestingTestTests.TestingTestTests testB]' started.
+Test Case '-[TestingTestTests.TestingTestTests testB]' passed (0.000 seconds).
+Test Case '-[TestingTestTests.TestingTestTests testC]' started.
+Test Case '-[TestingTestTests.TestingTestTests testC]' passed (0.000 seconds).
+Test Case '-[TestingTestTests.TestingTestTests testD]' started.
+Test Case '-[TestingTestTests.TestingTestTests testD]' passed (0.000 seconds).
+Test Case '-[TestingTestTests.TestingTestTests testE]' started.
+Test Case '-[TestingTestTests.TestingTestTests testE]' passed (0.000 seconds).
+Test Case '-[TestingTestTests.TestingTestTests testF]' started.
+Test Case '-[TestingTestTests.TestingTestTests testF]' passed (0.000 seconds).
+Test Case '-[TestingTestTests.TestingTestTests testFailure]' started.
+Fatal error: Unexpectedly found nil while unwrapping an Optional value
+2018-11-04 10:28:22.440644-0800 TestingTest[28750:2314289] Fatal error: Unexpectedly found nil while unwrapping an Optional value
+2018-11-04 10:28:37.684 xcodebuild[28288:2312297]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/Users/basher/Library/Developer/Xcode/DerivedData/TestingTest-gdgaczvhjqcyjkdnismgbepkohom/Logs/Test/Run-TestingTest-2018.11.04_10-28-04--0800.xcresult/2_Test/Diagnostics/TestingTestTests-83EB5B33-3051-4535-A51E-7850989104A1/TestingTestTests-D47F259D-E153-4666-8AE8-BCC1CC2C93AC/Session-TestingTestTests-2018-11-04_102837-HHL6RY.log
+2018-11-04 10:28:37.684 xcodebuild[28288:2312282] [MT] IDETestOperationsObserverDebug: (A82144CB-A0CC-4563-953C-8937FD395D8D) Beginning test session TestingTestTests-A82144CB-A0CC-4563-953C-8937FD395D8D at 2018-11-04 10:28:37.684 with Xcode 10B61 on target <DVTiPhoneSimulator: 0x7fa92eac65d0> {
+		SimDevice: iPad Air 2 (8CB426F7-7F07-48E8-B7B8-7A7F21E0A618, iOS 12.1, Booted)
+} (12.1 (16B91))
+2018-11-04 10:28:40.745379-0800 TestingTest[28769:2314916] libMobileGestalt MobileGestalt.c:890: MGIsDeviceOneOfType is not supported on this platform.
+
+Restarting after unexpected exit or crash in TestingTestTests/testFailure(); summary will include totals from previous launches.
+
+Test Suite 'Selected tests' started at 2018-11-04 10:28:40.939
+Test Suite 'TestingTestTests.xctest' started at 2018-11-04 10:28:40.940
+Test Suite 'TestingTestTests' started at 2018-11-04 10:28:40.940
+Test Case '-[TestingTestTests.TestingTestTests testG]' started.
+Test Case '-[TestingTestTests.TestingTestTests testG]' passed (0.001 seconds).
+Test Case '-[TestingTestTests.TestingTestTests testH]' started.
+Test Case '-[TestingTestTests.TestingTestTests testH]' passed (0.001 seconds).
+Test Suite 'TestingTestTests' failed at 2018-11-04 10:28:40.943.
+	 Executed 9 tests, with 1 failure (0 unexpected) in 0.002 (0.003) seconds
+Test Suite 'TestingTestTests.xctest' failed at 2018-11-04 10:28:40.944.
+	 Executed 9 tests, with 1 failure (0 unexpected) in 0.002 (0.004) seconds
+Test Suite 'Selected tests' failed at 2018-11-04 10:28:40.945.
+	 Executed 9 tests, with 1 failure (0 unexpected) in 0.002 (0.006) seconds
+
+
+Test session results and logs:
+	/Users/basher/Library/Developer/Xcode/DerivedData/TestingTest-gdgaczvhjqcyjkdnismgbepkohom/Logs/Test/Run-TestingTest-2018.11.04_10-28-04--0800.xcresult
+
+2018-11-04 10:28:41.222 xcodebuild[28288:2313256]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/Users/basher/Library/Developer/Xcode/DerivedData/TestingTest-gdgaczvhjqcyjkdnismgbepkohom/Logs/Test/Run-TestingTest-2018.11.04_10-28-04--0800.xcresult/2_Test/Diagnostics/TestingTestTestsClone-DC884BA5-E8CA-437F-9E85-4388CDA39574/TestingTestTestsClone-28AC8B97-9869-4367-9767-4256883A8563/Session-TestingTestTestsClone-2018-11-04_102841-YBCI4E.log
+2018-11-04 10:28:41.222 xcodebuild[28288:2312282] [MT] IDETestOperationsObserverDebug: (56A4804A-8CB1-483E-8D55-9AC48553984B) Beginning test session TestingTestTestsClone-56A4804A-8CB1-483E-8D55-9AC48553984B at 2018-11-04 10:28:41.223 with Xcode 10B61 on target <DVTiPhoneSimulator: 0x7fa92eac65d0> {
+		SimDevice: iPad Air 2 (8CB426F7-7F07-48E8-B7B8-7A7F21E0A618, iOS 12.1, Booted)
+} (12.1 (16B91))
+2018-11-04 10:28:43.997956-0800 TestingTest[28773:2314975] libMobileGestalt MobileGestalt.c:890: MGIsDeviceOneOfType is not supported on this platform.
+Test Suite 'All tests' started at 2018-11-04 10:28:44.201
+Test Suite 'TestingTestTestsClone.xctest' started at 2018-11-04 10:28:44.202
+Test Suite 'TestingTestPassing' started at 2018-11-04 10:28:44.202
+Test Case '-[TestingTestTestsClone.TestingTestPassing testA]' started.
+Test Case '-[TestingTestTestsClone.TestingTestPassing testA]' passed (0.001 seconds).
+Test Case '-[TestingTestTestsClone.TestingTestPassing testB]' started.
+Test Case '-[TestingTestTestsClone.TestingTestPassing testB]' passed (0.001 seconds).
+Test Case '-[TestingTestTestsClone.TestingTestPassing testC]' started.
+Test Case '-[TestingTestTestsClone.TestingTestPassing testC]' passed (0.000 seconds).
+Test Case '-[TestingTestTestsClone.TestingTestPassing testD]' started.
+Test Case '-[TestingTestTestsClone.TestingTestPassing testD]' passed (0.001 seconds).
+Test Case '-[TestingTestTestsClone.TestingTestPassing testE]' started.
+Test Case '-[TestingTestTestsClone.TestingTestPassing testE]' passed (0.001 seconds).
+Test Case '-[TestingTestTestsClone.TestingTestPassing testF]' started.
+Test Case '-[TestingTestTestsClone.TestingTestPassing testF]' passed (0.001 seconds).
+Test Case '-[TestingTestTestsClone.TestingTestPassing testG]' started.
+Test Case '-[TestingTestTestsClone.TestingTestPassing testG]' passed (0.001 seconds).
+Test Case '-[TestingTestTestsClone.TestingTestPassing testH]' started.
+Test Case '-[TestingTestTestsClone.TestingTestPassing testH]' passed (0.001 seconds).
+Test Case '-[TestingTestTestsClone.TestingTestPassing testPass]' started.
+Test Case '-[TestingTestTestsClone.TestingTestPassing testPass]' passed (0.001 seconds).
+Test Suite 'TestingTestPassing' passed at 2018-11-04 10:28:44.213.
+	 Executed 9 tests, with 0 failures (0 unexpected) in 0.006 (0.010) seconds
+Test Suite 'TestingTestTestsClone.xctest' passed at 2018-11-04 10:28:44.213.
+	 Executed 9 tests, with 0 failures (0 unexpected) in 0.006 (0.011) seconds
+Test Suite 'All tests' passed at 2018-11-04 10:28:44.214.
+	 Executed 9 tests, with 0 failures (0 unexpected) in 0.006 (0.013) seconds
+
+
+Test session results and logs:
+	/Users/basher/Library/Developer/Xcode/DerivedData/TestingTest-gdgaczvhjqcyjkdnismgbepkohom/Logs/Test/Run-TestingTest-2018.11.04_10-28-04--0800.xcresult
+
+2018-11-04 10:28:47.208 xcodebuild[28288:2312282] [MT] IDETestOperationsObserverDebug: 37.885 elapsed -- Testing started completed.
+2018-11-04 10:28:47.208 xcodebuild[28288:2312282] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
+2018-11-04 10:28:47.209 xcodebuild[28288:2312282] [MT] IDETestOperationsObserverDebug: 37.885 sec, +37.885 sec -- end
+Failing tests:
+	TestingTestTests.testFailure()
+** TEST FAILED **
+

--- a/scan/spec/fixtures/parallel_testing_failure.log
+++ b/scan/spec/fixtures/parallel_testing_failure.log
@@ -1,0 +1,43 @@
+Testing started on 'iPad Air 2'
+2018-11-04 09:51:11.194 xcodebuild[20236:2278157]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/Users/basher/Library/Developer/Xcode/DerivedData/TestingTest-gdgaczvhjqcyjkdnismgbepkohom/Logs/Test/Run-TestingTest-2018.11.04_09-50-56--0800.xcresult/2_Test/Diagnostics/TestingTestTests-4274CC02-E915-4281-B716-7A53DFCB144F/TestingTestTests-AAF3E4FA-0854-4747-B7A5-9A1DC94C2459/Session-TestingTestTests-2018-11-04_095111-wB10Tk.log
+2018-11-04 09:51:11.194 xcodebuild[20236:2276847] [MT] IDETestOperationsObserverDebug: (94DB09C3-9CD2-46C9-AB44-051A05F06292) Beginning test session TestingTestTests-94DB09C3-9CD2-46C9-AB44-051A05F06292 at 2018-11-04 09:51:11.194 with Xcode 10B61 on target <DVTiPhoneSimulator: 0x7f916e93fce0> {
+		SimDevice: Clone 1 of iPad Air 2 (FA4660C5-5923-40BC-A89F-24071E553387, iOS 12.1, Shutdown)
+} (12.1 (16B91))
+Test suite 'TestingTestTests' started on 'Clone 1 of iPad Air 2 - TestingTest.app (20698)'
+Test case 'TestingTestTests.testA()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20698)' (0.001 seconds)
+Test case 'TestingTestTests.testB()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20698)' (0.001 seconds)
+Test case 'TestingTestTests.testC()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20698)' (0.001 seconds)
+Test case 'TestingTestTests.testD()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20698)' (0.001 seconds)
+Test case 'TestingTestTests.testE()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20698)' (0.001 seconds)
+Test case 'TestingTestTests.testF()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20698)' (0.001 seconds)
+Test case 'TestingTestTests.testFailure()' failed on 'Clone 1 of iPad Air 2 - TestingTest.app (20698)' (0.000 seconds)
+2018-11-04 09:51:39.669 xcodebuild[20236:2279785]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/Users/basher/Library/Developer/Xcode/DerivedData/TestingTest-gdgaczvhjqcyjkdnismgbepkohom/Logs/Test/Run-TestingTest-2018.11.04_09-50-56--0800.xcresult/2_Test/Diagnostics/TestingTestTests-4274CC02-E915-4281-B716-7A53DFCB144F/TestingTestTests-AAF3E4FA-0854-4747-B7A5-9A1DC94C2459/Session-TestingTestTests-2018-11-04_095139-qTnnGX.log
+2018-11-04 09:51:39.669 xcodebuild[20236:2276847] [MT] IDETestOperationsObserverDebug: (09BC7D56-CC8E-4F93-AC28-5B4696DC1E8E) Beginning test session TestingTestTests-09BC7D56-CC8E-4F93-AC28-5B4696DC1E8E at 2018-11-04 09:51:39.669 with Xcode 10B61 on target <DVTiPhoneSimulator: 0x7f916e93fce0> {
+		SimDevice: Clone 1 of iPad Air 2 (FA4660C5-5923-40BC-A89F-24071E553387, iOS 12.1, Booted)
+} (12.1 (16B91))
+Test case 'TestingTestTests.testG()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20724)' (0.001 seconds)
+Test case 'TestingTestTests.testH()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20724)' (0.001 seconds)
+2018-11-04 09:51:43.017 xcodebuild[20236:2279786]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
+/Users/basher/Library/Developer/Xcode/DerivedData/TestingTest-gdgaczvhjqcyjkdnismgbepkohom/Logs/Test/Run-TestingTest-2018.11.04_09-50-56--0800.xcresult/2_Test/Diagnostics/TestingTestTestsClone-F5EF068D-5921-4075-858E-385D4CE9C9BD/TestingTestTestsClone-00616530-14C1-4516-9C4B-526CEF2F4A5E/Session-TestingTestTestsClone-2018-11-04_095143-v3hYjt.log
+2018-11-04 09:51:43.017 xcodebuild[20236:2276847] [MT] IDETestOperationsObserverDebug: (FB26CA52-D3F2-463A-98AE-608B3C80BE65) Beginning test session TestingTestTestsClone-FB26CA52-D3F2-463A-98AE-608B3C80BE65 at 2018-11-04 09:51:43.018 with Xcode 10B61 on target <DVTiPhoneSimulator: 0x7f916e93fce0> {
+		SimDevice: Clone 1 of iPad Air 2 (FA4660C5-5923-40BC-A89F-24071E553387, iOS 12.1, Booted)
+} (12.1 (16B91))
+Test suite 'TestingTestPassing' started on 'Clone 1 of iPad Air 2 - TestingTest.app (20726)'
+Test case 'TestingTestPassing.testA()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20726)' (0.001 seconds)
+Test case 'TestingTestPassing.testB()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20726)' (0.001 seconds)
+Test case 'TestingTestPassing.testC()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20726)' (0.001 seconds)
+Test case 'TestingTestPassing.testD()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20726)' (0.001 seconds)
+Test case 'TestingTestPassing.testE()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20726)' (0.001 seconds)
+Test case 'TestingTestPassing.testF()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20726)' (0.001 seconds)
+Test case 'TestingTestPassing.testG()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20726)' (0.001 seconds)
+Test case 'TestingTestPassing.testH()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20726)' (0.001 seconds)
+Test case 'TestingTestPassing.testPass()' passed on 'Clone 1 of iPad Air 2 - TestingTest.app (20726)' (0.001 seconds)
+2018-11-04 09:51:49.990 xcodebuild[20236:2276847] [MT] IDETestOperationsObserverDebug: 48.243 elapsed -- Testing started completed.
+2018-11-04 09:51:49.990 xcodebuild[20236:2276847] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
+2018-11-04 09:51:49.990 xcodebuild[20236:2276847] [MT] IDETestOperationsObserverDebug: 48.243 sec, +48.243 sec -- end
+Failing tests:
+	TestingTestTests.testFailure()
+** TEST FAILED **
+


### PR DESCRIPTION
🔑
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
With Xcode 10 parallel testing enabled, test output doesn't include the word "Executed".
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #13414 
### Description
<!-- Describe your changes in detail -->

With Xcode 10 parallel testing enabled, test output doesn't include the word "Executed", so this is no longer a reliable indicator that a build failure is actually a test failure. Instead, we need to also check for the phrase "Failing tests:" (which is followed by a list of tests that are failing).

This updates `Scan::ErrorHandler.handle_build_error` to handle failing test error output, when parallel testing is enabled.

<!-- Please describe in detail how you tested your changes. -->

I added a spec for `Scan::ErrorHandler`, which uses fixtures, which I made from logs from a sample app.