### PR TITLE
Version bump to 2.108.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,29 +33,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
 <td id='manu-wallner'>
 <a href='https://github.com/milch'>
@@ -63,57 +45,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
-</tr>
-<tr>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
 <td id='matthew-ellis'>
 <a href='https://github.com/matthewellis'>
 <img src='https://github.com/matthewellis.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-</tr>
-<tr>
 <td id='luka-mirosevic'>
 <a href='https://github.com/lmirosevic'>
 <img src='https://github.com/lmirosevic.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 <td id='maksym-grebenets'>
 <a href='https://github.com/mgrebenets'>
@@ -121,19 +63,83 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
+</tr>
+<tr>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
 <td id='iulian-onofrei'>
 <a href='https://github.com/revolter'>
 <img src='https://github.com/revolter.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
 </tr>
 <tr>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
 <td id='danielle-tomlinson'>
 <a href='https://github.com/DanToml'>
 <img src='https://github.com/DanToml.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+</td>
+</tr>
+<tr>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
@@ -142,22 +148,16 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
 <td id='andrew-mcburney'>
-<a href='https://github.com/AndrewMcBurney'>
-<img src='https://github.com/AndrewMcBurney.png?size=140'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 </tr>
 </table>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,26 +15,26 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Fumiya Nakamura",
-                        "Josh Holtz",
-                        "Jorge Revuelta H",
-                        "Matthew Ellis",
-                        "Jérôme Lacoste",
-                        "Jimmy Dee",
+  spec.authors       = ["Matthew Ellis",
+                        "Joshua Liebowitz",
                         "Kohki Miki",
-                        "Aaron Brager",
-                        "Maksym Grebenets",
-                        "Danielle Tomlinson",
-                        "Felix Krause",
-                        "Manu Wallner",
+                        "Helmut Januschka",
+                        "Stefan Natchev",
+                        "Fumiya Nakamura",
+                        "Jimmy Dee",
+                        "Jorge Revuelta H",
                         "Olivier Halligon",
                         "Iulian Onofrei",
-                        "Joshua Liebowitz",
-                        "Jan Piotrowski",
-                        "Helmut Januschka",
                         "Andrew McBurney",
+                        "Manu Wallner",
+                        "Maksym Grebenets",
+                        "Aaron Brager",
+                        "Danielle Tomlinson",
+                        "Jérôme Lacoste",
+                        "Jan Piotrowski",
+                        "Felix Krause",
                         "Luka Mirosevic",
-                        "Stefan Natchev"]
+                        "Josh Holtz"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.107.0'.freeze
+  VERSION = '2.108.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.107.0
+// Generated with fastlane 2.108.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1079,6 +1079,24 @@ func crashlytics(ipaPath: String? = nil,
                                                                                              RubyCommand.Argument(name: "debug", value: debug)])
   _ = runner.executeCommand(command)
 }
+func createAppOnManagedPlayStore(jsonKey: String? = nil,
+                                 jsonKeyData: String? = nil,
+                                 developerAccountId: String,
+                                 apk: String,
+                                 appTitle: String,
+                                 language: String = "en_US",
+                                 rootUrl: String? = nil,
+                                 timeout: Int = 300) {
+  let command = RubyCommand(commandID: "", methodName: "create_app_on_managed_play_store", className: nil, args: [RubyCommand.Argument(name: "json_key", value: jsonKey),
+                                                                                                                  RubyCommand.Argument(name: "json_key_data", value: jsonKeyData),
+                                                                                                                  RubyCommand.Argument(name: "developer_account_id", value: developerAccountId),
+                                                                                                                  RubyCommand.Argument(name: "apk", value: apk),
+                                                                                                                  RubyCommand.Argument(name: "app_title", value: appTitle),
+                                                                                                                  RubyCommand.Argument(name: "language", value: language),
+                                                                                                                  RubyCommand.Argument(name: "root_url", value: rootUrl),
+                                                                                                                  RubyCommand.Argument(name: "timeout", value: timeout)])
+  _ = runner.executeCommand(command)
+}
 func createAppOnline(username: String,
                      appIdentifier: String,
                      bundleIdentifierSuffix: String? = nil,
@@ -1533,7 +1551,14 @@ func getGithubRelease(url: String,
                                                                                                           RubyCommand.Argument(name: "ipa", value: ipa)])
   return runner.executeCommand(command)
 }
+func getManagedPlayStorePublishingRights(jsonKey: String? = nil,
+                                         jsonKeyData: String? = nil) {
+  let command = RubyCommand(commandID: "", methodName: "get_managed_play_store_publishing_rights", className: nil, args: [RubyCommand.Argument(name: "json_key", value: jsonKey),
+                                                                                                                          RubyCommand.Argument(name: "json_key_data", value: jsonKeyData)])
+  _ = runner.executeCommand(command)
+}
 func getProvisioningProfile(adhoc: Bool = false,
+                            developerId: Bool = false,
                             development: Bool = false,
                             skipInstall: Bool = false,
                             force: Bool = false,
@@ -1553,6 +1578,7 @@ func getProvisioningProfile(adhoc: Bool = false,
                             readonly: Bool = false,
                             templateName: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "get_provisioning_profile", className: nil, args: [RubyCommand.Argument(name: "adhoc", value: adhoc),
+                                                                                                          RubyCommand.Argument(name: "developer_id", value: developerId),
                                                                                                           RubyCommand.Argument(name: "development", value: development),
                                                                                                           RubyCommand.Argument(name: "skip_install", value: skipInstall),
                                                                                                           RubyCommand.Argument(name: "force", value: force),
@@ -3012,6 +3038,7 @@ func setupTravis(force: Bool = false) {
   return runner.executeCommand(command)
 }
 func sigh(adhoc: Bool = false,
+          developerId: Bool = false,
           development: Bool = false,
           skipInstall: Bool = false,
           force: Bool = false,
@@ -3031,6 +3058,7 @@ func sigh(adhoc: Bool = false,
           readonly: Bool = false,
           templateName: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "sigh", className: nil, args: [RubyCommand.Argument(name: "adhoc", value: adhoc),
+                                                                                      RubyCommand.Argument(name: "developer_id", value: developerId),
                                                                                       RubyCommand.Argument(name: "development", value: development),
                                                                                       RubyCommand.Argument(name: "skip_install", value: skipInstall),
                                                                                       RubyCommand.Argument(name: "force", value: force),
@@ -3127,6 +3155,7 @@ func slather(buildDirectory: String? = nil,
              useBundleExec: Bool = false,
              binaryBasename: Bool = false,
              binaryFile: Bool = false,
+             arch: String? = nil,
              sourceFiles: Bool = false,
              decimals: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "slather", className: nil, args: [RubyCommand.Argument(name: "build_directory", value: buildDirectory),
@@ -3155,6 +3184,7 @@ func slather(buildDirectory: String? = nil,
                                                                                          RubyCommand.Argument(name: "use_bundle_exec", value: useBundleExec),
                                                                                          RubyCommand.Argument(name: "binary_basename", value: binaryBasename),
                                                                                          RubyCommand.Argument(name: "binary_file", value: binaryFile),
+                                                                                         RubyCommand.Argument(name: "arch", value: arch),
                                                                                          RubyCommand.Argument(name: "source_files", value: sourceFiles),
                                                                                          RubyCommand.Argument(name: "decimals", value: decimals)])
   _ = runner.executeCommand(command)
@@ -4013,7 +4043,7 @@ func xcov(workspace: String? = nil,
           coverallsServiceJobId: String? = nil,
           coverallsRepoToken: String? = nil,
           xcconfig: String? = nil,
-          ideFoundationPath: String = "/Applications/Xcode-10.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
+          ideFoundationPath: String = "/Applications/Xcode-10.1.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
           legacySupport: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "xcov", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                       RubyCommand.Argument(name: "project", value: project),
@@ -4121,4 +4151,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.32]
+// FastlaneRunnerAPIVersion [0.9.33]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.107.0
+// Generated with fastlane 2.108.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.107.0
+// Generated with fastlane 2.108.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.107.0
+// Generated with fastlane 2.108.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.107.0
+// Generated with fastlane 2.108.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.107.0
+// Generated with fastlane 2.108.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.107.0
+// Generated with fastlane 2.108.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.107.0':**

* Add support for arch parameter to slather (#13514) via Björn Dahlgren
* [sigh] support macOS and Developer ID in get_provisioning_profile action (#13607) via Matt Moriarity
* Use train_version to detect build on download_dsym action (#13585) via Kohki Miki
* Update team.json to fix Andrew McBurney's GitHub handle. (#13615) via Andrew McBurney
* iOS SnapshotHelper.swift Set locale only when not empty (#13556) via river2202
* Fixed typo in deliver options.rb (#13606) via Oleksii Kalentiev
* [action] Integrate Managed Google Play with get_managed_play_store_publishing_rights and create_app_on_managed_play_store (#13421) via Jan Piotrowski
