### PR TITLE
Adding Bundle Array

### DIFF
--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -92,7 +92,7 @@ module Supply
                                      env_name: "SUPPLY_APK",
                                      description: "Path to the APK file to upload",
                                      short_option: "-b",
-                                     conflicting_options: [:apk_paths, :aab],
+                                     conflicting_options: [:apk_paths, :aab, :aab_paths],
                                      code_gen_sensitive: true,
                                      default_value: Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-Release.apk")].last,
                                      default_value_dynamic: true,
@@ -103,7 +103,7 @@ module Supply
                                      end),
         FastlaneCore::ConfigItem.new(key: :apk_paths,
                                      env_name: "SUPPLY_APK_PATHS",
-                                     conflicting_options: [:apk, :aab],
+                                     conflicting_options: [:apk, :aab, :aab_paths],
                                      optional: true,
                                      type: Array,
                                      description: "An array of paths to APK files to upload",
@@ -119,7 +119,7 @@ module Supply
                                      env_name: "SUPPLY_AAB",
                                      description: "Path to the AAB file to upload",
                                      short_option: "-f",
-                                     conflicting_options: [:apk_path, :apk_paths],
+                                     conflicting_options: [:apk_path, :apk_paths, :aab_paths],
                                      code_gen_sensitive: true,
                                      default_value: Dir["*.aab"].last || Dir[File.join("app", "build", "outputs", "bundle", "release", "bundle.aab")].last,
                                      default_value_dynamic: true,
@@ -128,6 +128,20 @@ module Supply
                                        UI.user_error!("Could not find aab file at path '#{value}'") unless File.exist?(value)
                                        UI.user_error!("aab file is not an aab") unless value.end_with?('.aab')
                                      end),
+       FastlaneCore::ConfigItem.new(key: :aab_paths,
+                                    env_name: "SUPPLY_AAB_PATHS",
+                                    conflicting_options: [:apk_path, :apk_paths, :aab],
+                                    optional: true,
+                                    type: Array,
+                                    description: "An array of paths to Bundle files to upload",
+                                    short_option: "-z",
+                                    verify_block: proc do |value|
+                                      UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
+                                      value.each do |path|
+                                        UI.user_error!("Could not find aab file at path '#{path}'") unless File.exist?(path)
+                                        UI.user_error!("file at path '#{path}' is not an aab") unless path.end_with?('.aab')
+                                      end
+                                    end),
         FastlaneCore::ConfigItem.new(key: :skip_upload_apk,
                                      env_name: "SUPPLY_SKIP_UPLOAD_APK",
                                      optional: true,

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -119,7 +119,7 @@ module Supply
                                      env_name: "SUPPLY_AAB",
                                      description: "Path to the AAB file to upload",
                                      short_option: "-f",
-                                     conflicting_options: [:apk_path, :apk_paths, :aab_paths],
+                                     conflicting_options: [:apk, :apk_paths, :aab_paths],
                                      code_gen_sensitive: true,
                                      default_value: Dir["*.aab"].last || Dir[File.join("app", "build", "outputs", "bundle", "release", "bundle.aab")].last,
                                      default_value_dynamic: true,
@@ -130,10 +130,10 @@ module Supply
                                      end),
         FastlaneCore::ConfigItem.new(key: :aab_paths,
                                      env_name: "SUPPLY_AAB_PATHS",
-                                     conflicting_options: [:apk_path, :apk_paths, :aab],
+                                     conflicting_options: [:apk, :apk_paths, :aab],
                                      optional: true,
                                      type: Array,
-                                     description: "An array of paths to Bundle files to upload",
+                                     description: "An array of paths to AAB files to upload",
                                      short_option: "-z",
                                      verify_block: proc do |value|
                                        UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -128,20 +128,20 @@ module Supply
                                        UI.user_error!("Could not find aab file at path '#{value}'") unless File.exist?(value)
                                        UI.user_error!("aab file is not an aab") unless value.end_with?('.aab')
                                      end),
-       FastlaneCore::ConfigItem.new(key: :aab_paths,
-                                    env_name: "SUPPLY_AAB_PATHS",
-                                    conflicting_options: [:apk_path, :apk_paths, :aab],
-                                    optional: true,
-                                    type: Array,
-                                    description: "An array of paths to Bundle files to upload",
-                                    short_option: "-z",
-                                    verify_block: proc do |value|
-                                      UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
-                                      value.each do |path|
-                                        UI.user_error!("Could not find aab file at path '#{path}'") unless File.exist?(path)
-                                        UI.user_error!("file at path '#{path}' is not an aab") unless path.end_with?('.aab')
-                                      end
-                                    end),
+        FastlaneCore::ConfigItem.new(key: :aab_paths,
+                                     env_name: "SUPPLY_AAB_PATHS",
+                                     conflicting_options: [:apk_path, :apk_paths, :aab],
+                                     optional: true,
+                                     type: Array,
+                                     description: "An array of paths to Bundle files to upload",
+                                     short_option: "-z",
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
+                                       value.each do |path|
+                                         UI.user_error!("Could not find aab file at path '#{path}'") unless File.exist?(path)
+                                         UI.user_error!("file at path '#{path}' is not an aab") unless path.end_with?('.aab')
+                                       end
+                                     end),
         FastlaneCore::ConfigItem.new(key: :skip_upload_apk,
                                      env_name: "SUPPLY_SKIP_UPLOAD_APK",
                                      optional: true,

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -46,7 +46,7 @@ module Supply
     end
 
     def verify_config!
-      unless metadata_path || Supply.config[:apk] || Supply.config[:apk_paths] || Supply.config[:aab] || (Supply.config[:track] && Supply.config[:track_promote_to])
+      unless metadata_path || Supply.config[:apk] || Supply.config[:apk_paths] || Supply.config[:aab] || Supply.config[:aab_paths] || (Supply.config[:track] && Supply.config[:track_promote_to])
         UI.user_error!("No local metadata, apks, aab, or track to promote were found, make sure to run `fastlane supply init` to setup supply")
       end
 
@@ -152,11 +152,17 @@ module Supply
     end
 
     def upload_bundles
-      aab_path = Supply.config[:aab]
-      return [] unless aab_path
+      aab_paths = [Supply.config[:aab]] unless (aab_paths = Supply.config[:aab_paths])
+      # return [] unless aab_paths
 
-      UI.message("Preparing aab at path '#{aab_path}' for upload...")
-      return [client.upload_bundle(aab_path)]
+      aab_version_codes = []
+
+      aab_paths.each do |aab_path|
+        UI.message("Preparing aab at path '#{aab_path}' for upload...")
+        aab_version_codes.push(client.upload_bundle(aab_path))
+      end
+
+      return aab_version_codes
     end
 
     private

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -153,7 +153,7 @@ module Supply
 
     def upload_bundles
       aab_paths = [Supply.config[:aab]] unless (aab_paths = Supply.config[:aab_paths])
-      return [] unless aab_paths
+      return [] unless aab_paths.compact
 
       aab_version_codes = []
 

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -153,7 +153,7 @@ module Supply
 
     def upload_bundles
       aab_paths = [Supply.config[:aab]] unless (aab_paths = Supply.config[:aab_paths])
-      # return [] unless aab_paths
+      return [] unless aab_paths
 
       aab_version_codes = []
 

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -153,7 +153,8 @@ module Supply
 
     def upload_bundles
       aab_paths = [Supply.config[:aab]] unless (aab_paths = Supply.config[:aab_paths])
-      return [] unless aab_paths.compact
+      return [] unless aab_paths
+      aab_paths.compact!
 
       aab_version_codes = []
 

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -58,6 +58,13 @@ describe Supply do
         subject.verify_config!
       end
 
+      it "does not raise error if only aab_paths" do
+        Supply.config = {
+          aab_paths: ['some/path/app1.aab', 'some/path/app2.aab']
+        }
+        subject.verify_config!
+      end
+
       it "does not raise error if only track and track_promote_to" do
         Supply.config = {
           track: 'alpha',


### PR DESCRIPTION
This is a PR to substitute #13543 so it only contains commits from me. 

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
fixes #13536. Add the possibility to pass multiple aab just like apk_paths. 

### Description
The code has the same logic as apk_path command. 
As a last test, I uploaded an array of aab to Play Store using the `aab_paths` without any problems.

