### PR TITLE
[match] added comments for mapping git_url to keychain for openssl encryption

### DIFF
--- a/match/lib/match/encryption.rb
+++ b/match/lib/match/encryption.rb
@@ -6,6 +6,8 @@ module Match
     # Returns the class to be used for a given `storage_mode`
     def self.for_storage_mode(storage_mode, params)
       if storage_mode == "git"
+        # OpenSSL is storage agnostic so this maps git_url
+        # to keychain_name for the name of the keychain entry
         params[:keychain_name] = params[:git_url]
         return Encryption::OpenSSL.configure(params)
       elsif storage_mode == "google_cloud"


### PR DESCRIPTION
## Problem
There was no information on why `git_url` was being mapped to `keychain_name`. This could appear like an error and/or make others wonder what is going on when reading through this code in the future.

## Solution
Added a comment 💡