### PR TITLE
[match] Refactor to storage/encryption interfaces

### DIFF
--- a/match/lib/match/encryption.rb
+++ b/match/lib/match/encryption.rb
@@ -3,17 +3,39 @@ require_relative 'encryption/openssl'
 
 module Match
   module Encryption
-    # Returns the class to be used for a given `storage_mode`
-    def self.for_storage_mode(storage_mode, params)
-      if storage_mode == "git"
-        # OpenSSL is storage agnostic so this maps git_url
-        # to keychain_name for the name of the keychain entry
-        params[:keychain_name] = params[:git_url]
-        return Encryption::OpenSSL.configure(params)
-      elsif storage_mode == "google_cloud"
-        # return Encryption::GoogleCloudKMS.configure(params)
-      else
-        UI.user_error!("Invalid storage mode '#{storage_mode}'")
+    class << self
+      def backends
+        @backends ||= {
+          "git" => lambda { |params|
+            # OpenSSL is storage agnostic so this maps git_url
+            # to keychain_name for the name of the keychain entry
+            params[:keychain_name] = params[:git_url]
+            return Encryption::OpenSSL.configure(params)
+          }
+        }
+      end
+
+      def register_backend(type: nil, encryption_class: nil, &configurator)
+        UI.user_error!("No type specified for encryption backend") if type.nil?
+
+        normalized_name = type.to_s
+        UI.message("Replacing Match::Encryption backend for type '#{normalized_name}'") if backends.include?(normalized_name)
+
+        if configurator
+          @backends[normalized_name] = configurator
+        elsif encryption_class
+          @backends[normalized_name] = ->(params) { return encryption_class.configure(params) }
+        else
+          UI.user_error!("Specify either a `encryption_class` or a configuration block when registering a encryption backend")
+        end
+      end
+
+      # Returns the class to be used for a given `storage_mode`
+      def for_storage_mode(storage_mode, params)
+        configurator = backends[storage_mode.to_s]
+        return configurator.call(params) if configurator
+
+        UI.user_error!("No encryption backend for storage mode '#{storage_mode}'")
       end
     end
   end

--- a/match/lib/match/storage.rb
+++ b/match/lib/match/storage.rb
@@ -3,13 +3,35 @@ require_relative 'storage/git_storage'
 
 module Match
   module Storage
-    def self.for_mode(storage_mode, params)
-      if storage_mode == "git"
-        return Storage::GitStorage.configure(params)
-      elsif storage_mode == "google_cloud"
-        # return Storage::GoogleCloudStorage
-      else
-        UI.user_error!("Invalid storage mode '#{storage_mode}'")
+    class << self
+      def backends
+        @backends ||= {
+          "git" => lambda { |params|
+            return Storage::GitStorage.configure(params)
+          }
+        }
+      end
+
+      def register_backend(type: nil, storage_class: nil, &configurator)
+        UI.user_error!("No type specified for storage backend") if type.nil?
+
+        normalized_name = type.to_s
+        UI.message("Replacing Match::Encryption backend for type '#{normalized_name}'") if backends.include?(normalized_name)
+
+        if configurator
+          @backends[normalized_name] = configurator
+        elsif storage_class
+          @backends[normalized_name] = ->(params) { return storage_class.configure(params) }
+        else
+          UI.user_error!("Specify either a `storage_class` or a configuration block when registering a storage backend")
+        end
+      end
+
+      def for_mode(storage_mode, params)
+        configurator = backends[storage_mode.to_s]
+        return configurator.call(params) if configurator
+
+        UI.user_error!("No storage backend for storage mode '#{storage_mode}'")
       end
     end
   end

--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -99,7 +99,7 @@ module Match
       def delete_files(files_to_delete: [], custom_message: nil)
         # No specific list given, e.g. this happens on `fastlane match nuke`
         # We just want to run `git add -A` to commit everything
-        git_push(commands: ["git add -A"], custom_message: custom_message)
+        git_push(commands: ["git add -A"], commit_message: custom_message)
       end
 
       def upload_files(files_to_upload: [], custom_message: nil)
@@ -107,7 +107,7 @@ module Match
           "git add #{current_file.shellescape}"
         end
 
-        git_push(commands: commands, custom_message: custom_message)
+        git_push(commands: commands, commit_message: custom_message)
       end
 
       def clear_changes
@@ -189,7 +189,7 @@ module Match
       private # rubocop:disable Lint/UselessAccessModifier
 
       def git_push(commands: [], commit_message: nil)
-        commit_message = custom_message || generate_commit_message
+        commit_message ||= generate_commit_message
         commands << "git commit -m #{commit_message.shellescape}"
         commands << "GIT_TERMINAL_PROMPT=0 git push origin #{self.branch.shellescape}"
 

--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -7,8 +7,6 @@ module Match
   module Storage
     # Store the code signing identities in a git repo
     class GitStorage < Interface
-      MATCH_VERSION_FILE_NAME = "match_version.txt"
-
       # User provided values
       attr_accessor :git_url
       attr_accessor :shallow_clone
@@ -98,54 +96,18 @@ module Match
         checkout_branch unless self.branch == "master"
       end
 
-      def save_changes!(files_to_commit: [], custom_message: nil)
-        Dir.chdir(File.expand_path(self.working_directory)) do
-          commands = []
+      def delete_files(files_to_delete: [], custom_message: nil)
+        # No specific list given, e.g. this happens on `fastlane match nuke`
+        # We just want to run `git add -A` to commit everything
+        git_push(commands: ["git add -A"], custom_message: custom_message)
+      end
 
-          if files_to_commit.count > 0 # e.g. for nuke this is treated differently
-            if !File.exist?(MATCH_VERSION_FILE_NAME) || File.read(MATCH_VERSION_FILE_NAME) != Fastlane::VERSION.to_s
-              files_to_commit << MATCH_VERSION_FILE_NAME
-              File.write(MATCH_VERSION_FILE_NAME, Fastlane::VERSION) # stored unencrypted
-            end
-
-            template = File.read("#{Match::ROOT}/lib/assets/READMETemplate.md")
-            readme_path = "README.md"
-            if (!File.exist?(readme_path) || File.read(readme_path) != template) && !self.skip_docs
-              files_to_commit << readme_path
-              File.write(readme_path, template)
-            end
-
-            # `git add` each file we want to commit
-            #   - Fixes https://github.com/fastlane/fastlane/issues/8917
-            #   - Fixes https://github.com/fastlane/fastlane/issues/8793
-            #   - Replaces, closes and fixes https://github.com/fastlane/fastlane/pull/8919
-            commands += files_to_commit.map do |current_file|
-              "git add #{current_file.shellescape}"
-            end
-          else
-            # No specific list given, e.g. this happens on `fastlane match nuke`
-            # We just want to run `git add -A` to commit everything
-            commands << "git add -A"
-          end
-          commit_message = custom_message || generate_commit_message
-          commands << "git commit -m #{commit_message.shellescape}"
-          commands << "GIT_TERMINAL_PROMPT=0 git push origin #{self.branch.shellescape}"
-
-          UI.message("Pushing changes to remote git repo...")
-
-          begin
-            commands.each do |command|
-              FastlaneCore::CommandExecutor.execute(command: command,
-                                                  print_all: FastlaneCore::Globals.verbose?,
-                                              print_command: FastlaneCore::Globals.verbose?)
-            end
-
-            self.clear_changes
-          rescue => ex
-            UI.error("Couldn't commit or push changes back to git...")
-            UI.error(ex)
-          end
+      def upload_files(files_to_upload: [], custom_message: nil)
+        commands = files_to_upload.map do |current_file|
+          "git add #{current_file.shellescape}"
         end
+
+        git_push(commands: commands, custom_message: custom_message)
       end
 
       def clear_changes
@@ -222,6 +184,26 @@ module Match
                                                   print_command: FastlaneCore::Globals.verbose?)
           end
         end
+      end
+
+      private
+
+      def git_push(commands: [], commit_message: nil)
+        commit_message = custom_message || generate_commit_message
+        commands << "git commit -m #{commit_message.shellescape}"
+        commands << "GIT_TERMINAL_PROMPT=0 git push origin #{self.branch.shellescape}"
+
+        UI.message("Pushing changes to remote git repo...")
+        commands.each do |command|
+          FastlaneCore::CommandExecutor.execute(command: command,
+                                                print_all: FastlaneCore::Globals.verbose?,
+                                                print_command: FastlaneCore::Globals.verbose?)
+        end
+
+        self.clear_changes
+      rescue => ex
+        UI.error("Couldn't commit or push changes back to git...")
+        UI.error(ex)
       end
     end
   end

--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -186,7 +186,7 @@ module Match
         end
       end
 
-      private
+      private # rubocop:disable Lint/UselessAccessModifier
 
       def git_push(commands: [], commit_message: nil)
         commit_message = custom_message || generate_commit_message

--- a/match/lib/match/storage/interface.rb
+++ b/match/lib/match/storage/interface.rb
@@ -1,6 +1,8 @@
 module Match
   module Storage
     class Interface
+      MATCH_VERSION_FILE_NAME = "match_version.txt"
+
       # The working directory in which we download all the profiles
       # and decrypt/encrypt them
       attr_accessor :working_directory
@@ -37,7 +39,41 @@ module Match
       #   that should be committed to the storage provider
       # @parameter custom_message: [String] Custom change message
       #           that's optional, is used for commit title
-      def save_changes!(files_to_commit: [], custom_message: nil)
+      def save_changes!(files_to_commit: [], files_to_delete: [], custom_message: nil)
+        Dir.chdir(File.expand_path(self.working_directory)) do
+          if files_to_commit.count > 0 # everything that isn't `match nuke`
+            UI.user_error!("You can't provide both `files_to_delete` and `files_to_commit` right now") if files_to_delete.count > 0
+
+            if !File.exist?(MATCH_VERSION_FILE_NAME) || File.read(MATCH_VERSION_FILE_NAME) != Fastlane::VERSION.to_s
+              files_to_commit << MATCH_VERSION_FILE_NAME
+              File.write(MATCH_VERSION_FILE_NAME, Fastlane::VERSION) # stored unencrypted
+            end
+
+            template = File.read("#{Match::ROOT}/lib/assets/READMETemplate.md")
+            readme_path = "README.md"
+            if (!File.exist?(readme_path) || File.read(readme_path) != template) && !self.skip_docs
+              files_to_commit << readme_path
+              File.write(readme_path, template)
+            end
+
+            self.upload_files(files_to_upload: files_to_commit, custom_message: custom_message)
+          elsif files_to_delete.count > 0
+            self.delete_files(files_to_delete: files_to_delete, custom_message: custom_message)
+          else
+            UI.user_error!("Neither `files_to_commit` nor `files_to_delete` were provided to the `save_changes!` method call")
+          end
+        end
+      end
+
+      def upload_files(files_to_upload: [], custom_message: nil)
+        not_implemented(__method__)
+      end
+
+      def delete_files(files_to_delete: [], custom_message: nil)
+        not_implemented(__method__)
+      end
+
+      def skip_docs
         not_implemented(__method__)
       end
 

--- a/match/lib/match/storage/interface.rb
+++ b/match/lib/match/storage/interface.rb
@@ -1,3 +1,5 @@
+require_relative '../module'
+
 module Match
   module Storage
     class Interface


### PR DESCRIPTION
- Make it possible to dynamically change backends, e.g. so that plugins can provide their own
- Refactor storage interface so common operations on file upload aren’t repeated

Tested by creating an example backend. 

Note that I can't seem to run the tests, so I'll rely on the CI to do that. Some unrelated tests fail, I think potentially due to the AV installed on the corporate Mac because the AV is going crazy when running the tests. 