### PR TITLE
[spm] add missing options

### DIFF
--- a/fastlane/lib/fastlane/actions/spm.rb
+++ b/fastlane/lib/fastlane/actions/spm.rb
@@ -77,7 +77,7 @@ module Fastlane
       end
 
       def self.authors
-        ["Flávio Caetano (@fjcaetano)", "Arjan Duijzer (@arjanduz)"]
+        ["fjcaetano", "nxtstep"]
       end
 
       def self.is_supported?(platform)

--- a/fastlane/lib/fastlane/actions/spm.rb
+++ b/fastlane/lib/fastlane/actions/spm.rb
@@ -9,11 +9,14 @@ module Fastlane
         cmd << "--package-path #{params[:package_path]}" if params[:package_path]
         cmd << "--configuration #{params[:configuration]}" if params[:configuration]
         cmd << "--verbose" if params[:verbose]
+        cmd << params[:command] if package_commands.include?(params[:command])
+        if params[:xcconfig]
+          cmd << "--xcconfig-overrides #{params[:xcconfig]}"
+        end
         if params[:xcpretty_output]
           cmd += ["2>&1", "|", "xcpretty", "--#{params[:xcpretty_output]}"]
           cmd = %w(set -o pipefail &&) + cmd
         end
-        cmd << params[:command] if package_commands.include?(params[:command])
 
         FastlaneCore::CommandExecutor.execute(command: cmd.join(" "),
                                               print_all: true,
@@ -45,6 +48,10 @@ module Fastlane
                                        env_name: "FL_SPM_PACKAGE_PATH",
                                        description: "Change working directory before any other operation",
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :xcconfig,
+                                       env_name: "FL_SPM_XCCONFIG",
+                                       description: "Use xcconfig file to override swift package generate-xcodeproj defaults",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :configuration,
                                        short_option: "-c",
                                        env_name: "FL_SPM_CONFIGURATION",
@@ -70,7 +77,7 @@ module Fastlane
       end
 
       def self.authors
-        ["Flávio Caetano (@fjcaetano)"]
+        ["Flávio Caetano (@fjcaetano)", "Arjan Duijzer (@arjanduz)"]
       end
 
       def self.is_supported?(platform)
@@ -84,6 +91,10 @@ module Fastlane
             command: "build",
             build_path: "./build",
             configuration: "release"
+          )',
+          'spm(
+            command: "generate-xcodeproj",
+            xcconfig: "Package.xcconfig"
           )'
         ]
       end
@@ -97,7 +108,7 @@ module Fastlane
       end
 
       def self.package_commands
-        %w(clean reset update)
+        %w(clean reset update resolve generate-xcodeproj init)
       end
 
       def self.valid_configurations


### PR DESCRIPTION
🔑

Added `generate-xcodeproj`, `resolve` and `init` as possible `swift package` command options.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The existing `spm` action was missing commands that are available to use with `swift package *`. E.g. the non-trivial `generate-xcodeproj` was missing.

And aprospo I discovered a bug when using this action with xcpretty and a command in the package range.

### Description
Added `generate-xcodeproj`, `resolve` and `init` as `spm` command options.

And:
- Fixed a bug where the `spm` package commands would not execute correctly when xcpretty_output is used.