### PR TITLE
[match] fixes device count in match runner

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -166,7 +166,7 @@ module Match
 
       if params[:force_for_new_devices] && !params[:readonly]
         if prov_type != :appstore
-          params[:force] = device_count_different?(profile: profile, keychain_path: keychain_path, platform: params[:platform].to_s) unless params[:force]
+          params[:force] = device_count_different?(profile: profile, keychain_path: keychain_path, platform: params[:platform].to_sym) unless params[:force]
         else
           # App Store provisioning profiles don't contain device identifiers and
           # thus shouldn't be renewed if the device count has changed.
@@ -241,11 +241,11 @@ module Match
 
         portal_device_count =
           case platform
-          when :ios.to_s
+          when :ios
             Spaceship.device.all_ios_profile_devices.count
-          when :tvos.to_s
+          when :tvos
             Spaceship.device.all_apple_tvs.count
-          when :mac.to_s
+          when :mac
             Spaceship.device.all_macs.count
           else
             Spaceship.device.all.count

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -238,7 +238,20 @@ module Match
 
       if portal_profile
         profile_device_count = portal_profile.devices.count
-        portal_device_count = Spaceship.device.all.count
+
+        platform = params[:platform].to_s
+        portal_device_count =
+          case platform
+          when :ios.to_s
+            Spaceship.device.all_ios_profile_devices.count
+          when :tvos.to_s
+            Spaceship.device.all_apple_tvs.count
+          when :mac.to_s
+            Spaceship.device.all_macs.count
+          else
+            Spaceship.device.all.count
+          end
+
         return portal_device_count != profile_device_count
       end
       return false

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -166,7 +166,7 @@ module Match
 
       if params[:force_for_new_devices] && !params[:readonly]
         if prov_type != :appstore
-          params[:force] = device_count_different?(profile: profile, keychain_path: keychain_path) unless params[:force]
+          params[:force] = device_count_different?(profile: profile, keychain_path: keychain_path, platform: params[:platform].to_s) unless params[:force]
         else
           # App Store provisioning profiles don't contain device identifiers and
           # thus shouldn't be renewed if the device count has changed.
@@ -229,7 +229,7 @@ module Match
       return uuid
     end
 
-    def device_count_different?(profile: nil, keychain_path: nil)
+    def device_count_different?(profile: nil, keychain_path: nil, platform: nil)
       return false unless profile
 
       parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
@@ -239,7 +239,6 @@ module Match
       if portal_profile
         profile_device_count = portal_profile.devices.count
 
-        platform = params[:platform].to_s
         portal_device_count =
           case platform
           when :ios.to_s


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Currently (tested with version `2.108.0`), when passing `force_for_new_devices` into `match`, it determines if profiles should be renewed if `Spaceship.device.all.count` differs from the target instance of `Space.Portal.ProvisioningProfile` device count. There is a subtle bug here in that `Spaceship.device.all.count` includes _all_ devices, even those outside the realm of what the user intended via the `platform` parameter.

This commit makes the counting logic a tad smarter, to avoid unnecessary profile renewals 🎉