### PR TITLE
Support .gradle.kts project

### DIFF
--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -58,7 +58,7 @@ module Fastlane
         Gem.path.any? { |gem_path| File.expand_path(path).start_with?(gem_path) }
       end
       ios_projects.delete_if { |path| path.match("fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj") }
-      android_projects = Dir["**/*.gradle"]
+      android_projects = Dir["**/*.gradle"] + Dir["**/*.gradle.kts"]
 
       spinner.success
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently, we can write Gradle file with Kotlin that file name with `.gradle.kts`. 
But the current version of Fastlane does not support this file type.
To detect the project platform, require the setup.rb should know `.gradle.kts` is also an Android project.

https://github.com/gradle/kotlin-dsl

### Description
I add the line that `.kts` is also an Android project.
And I test with my `.gradle.kts` project.

