### PR TITLE
Testfairy upload timeout

### DIFF
--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -29,6 +29,7 @@ module Fastlane
 
         begin
           connection.post do |req|
+            req.options.timeout = options.delete(:timeout)
             req.url("/api/upload/")
             req.body = options
           end
@@ -221,7 +222,12 @@ module Fastlane
                                        type: Array,
                                        env_name: "FL_TESTFAIRY_OPTIONS",
                                        description: "Array of options (shake,video_only_wifi,anonymous)",
-                                       default_value: [])
+                                       default_value: []),
+          FastlaneCore::ConfigItem.new(key: :timeout,
+                                       env_name: "FL_TESTFAIRY_TIMEOUT",
+                                       description: "Request timeout in seconds",
+                                       type: Integer,
+                                       optional: true)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -90,6 +90,8 @@ module Fastlane
             ['auto-update', value]
           when :notify
             [key, value]
+          when :timeout
+            [key, value]
           when :options
             [key, options_to_client.call(value).join(',')]
           else


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
While in Australia, I could not upload my app to TestFairy because the request would often timeout. With this parameter, I can upload my apps even if I'm in the middle of no where with a bad connection.
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
I've added a timeout parameter to the TestFairy Action. This will allow users who are very far away from TestFairy servers to actually upload their apps before the timeout kicks in.
<!-- Please describe in detail how you tested your changes. -->
I used Charles Proxy to throttle my connection so that I could see my timeout value being used.