### PR TITLE
[resign.sh] only create the archived-expanded-entitlements.xcent file if the version of Xcode < 9.3

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -84,8 +84,7 @@ warning() {
 function checkStatus {
 
     # shellcheck disable=SC2181
-    if [ $? -ne 0 ];
-    then
+    if [ $? -ne 0 ]; then
         error "Encountered an error, aborting!"
     fi
 }
@@ -224,8 +223,7 @@ while [ "$1" != "" ]; do
 done
 
 KEYCHAIN_FLAG=
-if [ -n "$KEYCHAIN_PATH" ]
-then
+if [ -n "$KEYCHAIN_PATH" ]; then
     KEYCHAIN_FLAG="--keychain $KEYCHAIN_PATH"
 fi
 
@@ -258,8 +256,7 @@ log "Certificate: '$CERTIFICATE'"
 [[ -n "${USE_APP_ENTITLEMENTS}" && -n ${ENTITLEMENTS} ]] && error "--use-app-entitlements option cannot be used in combination with -e, --entitlements option."
 
 # Check output file name
-if [ -z "$NEW_FILE" ];
-then
+if [ -z "$NEW_FILE" ]; then
     error "Output file name required"
 fi
 
@@ -268,8 +265,7 @@ if [[ "${#RAW_PROVISIONS[*]}" == "0" ]]; then
 fi
 
 # Check for and remove the temporary directory if it already exists
-if [ -d "$TEMP_DIR" ];
-then
+if [ -d "$TEMP_DIR" ]; then
     log "Removing previous temporary directory: '$TEMP_DIR'"
     rm -Rf "$TEMP_DIR"
 fi
@@ -279,13 +275,11 @@ extension="${filename##*.}"
 filename="${filename%.*}"
 
 # Check if the supplied file is an ipa or an app file
-if [ "${extension}" = "ipa" ]
-then
+if [ "${extension}" = "ipa" ]; then
     # Unzip the old ipa quietly
     unzip -q "$ORIGINAL_FILE" -d $TEMP_DIR
     checkStatus
-elif [ "${extension}" = "app" ]
-then
+elif [ "${extension}" = "app" ]; then
     # Copy the app file into an ipa-like structure
     mkdir -p "$TEMP_DIR/Payload"
     cp -Rf "${ORIGINAL_FILE}" "$TEMP_DIR/Payload/${filename}.app"
@@ -295,8 +289,7 @@ else
 fi
 
 # check the keychain
-if [ "${KEYCHAIN}" != "" ];
-then
+if [ "${KEYCHAIN}" != "" ]; then
     security list-keychains -s "$KEYCHAIN"
     security unlock "$KEYCHAIN"
     security default-keychain -s "$KEYCHAIN"
@@ -404,8 +397,7 @@ function resign {
     fi
 
     # Make sure that the Info.plist file is where we expect it
-    if [ ! -e "$APP_PATH/Info.plist" ];
-    then
+    if [ ! -e "$APP_PATH/Info.plist" ]; then
         error "Expected file does not exist: '$APP_PATH/Info.plist'"
     fi
 
@@ -451,10 +443,8 @@ function resign {
     log "New bundle identifier will be: '$BUNDLE_IDENTIFIER'"
 
     # Update the CFBundleDisplayName property in the Info.plist if a new name has been provided
-    if [ "${DISPLAY_NAME}" != "" ];
-    then
-        if [ "${DISPLAY_NAME}" != "${CURRENT_NAME}" ];
-        then
+    if [ "${DISPLAY_NAME}" != "" ]; then
+        if [ "${DISPLAY_NAME}" != "${CURRENT_NAME}" ]; then
             log "Changing display name from '$CURRENT_NAME' to '$DISPLAY_NAME'"
             PlistBuddy -c "Set :CFBundleDisplayName $DISPLAY_NAME" "$APP_PATH/Info.plist"
         fi
@@ -469,8 +459,7 @@ function resign {
     if [ "$APP_IDENTIFIER_PREFIX" == "" ];
     then
         APP_IDENTIFIER_PREFIX=$(PlistBuddy -c "Print :ApplicationIdentifierPrefix:0" "$TEMP_DIR/profile.plist")
-        if [ "$APP_IDENTIFIER_PREFIX" == "" ];
-        then
+        if [ "$APP_IDENTIFIER_PREFIX" == "" ]; then
             error "Failed to extract any app identifier prefix from '$NEW_PROVISION'"
         else
             warning "WARNING: extracted an app identifier prefix '$APP_IDENTIFIER_PREFIX' from '$NEW_PROVISION', but it was not found in the profile's entitlements"
@@ -483,11 +472,9 @@ function resign {
     PlistBuddy -c "Set :AppIdentifierPrefix $APP_IDENTIFIER_PREFIX." "$APP_PATH/Info.plist" 2>/dev/null
 
     TEAM_IDENTIFIER=$(PlistBuddy -c "Print :Entitlements:com.apple.developer.team-identifier" "$TEMP_DIR/profile.plist" | tr -d '\n')
-    if [ "$TEAM_IDENTIFIER" == "" ];
-    then
+    if [ "$TEAM_IDENTIFIER" == "" ]; then
         TEAM_IDENTIFIER=$(PlistBuddy -c "Print :TeamIdentifier:0" "$TEMP_DIR/profile.plist")
-        if [ "$TEAM_IDENTIFIER" == "" ];
-        then
+        if [ "$TEAM_IDENTIFIER" == "" ]; then
             warning "Failed to extract team identifier from '$NEW_PROVISION', resigned ipa may fail on iOS 8 and higher"
         else
             warning "WARNING: extracted a team identifier '$TEAM_IDENTIFIER' from '$NEW_PROVISION', but it was not found in the profile's entitlements, resigned ipa may fail on iOS 8 and higher"
@@ -503,19 +490,16 @@ function resign {
     cp -f "$NEW_PROVISION" "$APP_PATH/embedded.mobileprovision"
 
     #if the current bundle identifier is different from the new one in the provisioning profile, then change it.
-    if [ "$CURRENT_BUNDLE_IDENTIFIER" != "$BUNDLE_IDENTIFIER" ];
-    then
+    if [ "$CURRENT_BUNDLE_IDENTIFIER" != "$BUNDLE_IDENTIFIER" ]; then
         log "Updating the bundle identifier from '$CURRENT_BUNDLE_IDENTIFIER' to '$BUNDLE_IDENTIFIER'"
         PlistBuddy -c "Set :CFBundleIdentifier $BUNDLE_IDENTIFIER" "$APP_PATH/Info.plist"
         checkStatus
     fi
 
     # Update the version number properties in the Info.plist if a version number has been provided
-    if [ "$VERSION_NUMBER" != "" ];
-    then
+    if [ "$VERSION_NUMBER" != "" ]; then
         CURRENT_VERSION_NUMBER=$(PlistBuddy -c "Print :CFBundleVersion" "$APP_PATH/Info.plist")
-        if [ "$VERSION_NUMBER" != "$CURRENT_VERSION_NUMBER" ];
-        then
+        if [ "$VERSION_NUMBER" != "$CURRENT_VERSION_NUMBER" ]; then
             log "Updating the version from '$CURRENT_VERSION_NUMBER' to '$VERSION_NUMBER'"
             PlistBuddy -c "Set :CFBundleVersion $VERSION_NUMBER" "$APP_PATH/Info.plist"
             PlistBuddy -c "Set :CFBundleShortVersionString $VERSION_NUMBER" "$APP_PATH/Info.plist"
@@ -523,8 +507,7 @@ function resign {
     fi
 
     # Update short version string in the Info.plist if provided
-    if [[ -n "$SHORT_VERSION" ]];
-    then
+    if [[ -n "$SHORT_VERSION" ]]; then
         CURRENT_VALUE="$(PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Info.plist")"
         # Even if the old value is same - just update, less code, less debugging
         log "Updating the short version string (CFBundleShortVersionString) from '$CURRENT_VALUE' to '$SHORT_VERSION'"
@@ -532,8 +515,7 @@ function resign {
     fi
 
     # Update bundle version in the Info.plist if provided
-    if [[ -n "$BUNDLE_VERSION" ]];
-    then
+    if [[ -n "$BUNDLE_VERSION" ]]; then
         CURRENT_VALUE="$(PlistBuddy -c "Print :CFBundleVersion" "$APP_PATH/Info.plist")"
         # Even if the old value is same - just update, less code, less debugging
         log "Updating the bundle version (CFBundleVersion) from '$CURRENT_VALUE' to '$BUNDLE_VERSION'"
@@ -542,18 +524,15 @@ function resign {
 
     # Check for and resign any embedded frameworks (new feature for iOS 8 and above apps)
     FRAMEWORKS_DIR="$APP_PATH/Frameworks"
-    if [ -d "$FRAMEWORKS_DIR" ];
-    then
-        if [ "$TEAM_IDENTIFIER" == "" ];
-        then
+    if [ -d "$FRAMEWORKS_DIR" ]; then
+        if [ "$TEAM_IDENTIFIER" == "" ]; then
             error "ERROR: embedded frameworks detected, re-signing iOS 8 (or higher) applications wihout a team identifier in the certificate/profile does not work"
         fi
 
         log "Resigning embedded frameworks using certificate: '$CERTIFICATE'"
         for framework in "$FRAMEWORKS_DIR"/*
         do
-            if [[ "$framework" == *.framework || "$framework" == *.dylib ]]
-            then
+            if [[ "$framework" == *.framework || "$framework" == *.dylib ]]; then
                 log "Resigning '$framework'"
                 # Must not qote KEYCHAIN_FLAG because it needs to be unwrapped and passed to codesign with spaces
                 # shellcheck disable=SC2086
@@ -570,46 +549,37 @@ function resign {
     for key in "${NESTED_APP_REFERENCE_KEYS[@]}"; do
         # Check if Info.plist has a reference to another app or extension
         REF_BUNDLE_ID=$(PlistBuddy -c "Print ${key}" "$APP_PATH/Info.plist" 2>/dev/null)
-        if [ -n "$REF_BUNDLE_ID" ];
-        then
+        if [ -n "$REF_BUNDLE_ID" ]; then
             # Found a reference bundle id, now get the corresponding provisioning profile for this bundle id
             REF_PROVISION=$(provision_for_bundle_id "$REF_BUNDLE_ID")
             # Map to the new bundle id
             NEW_REF_BUNDLE_ID=$(bundle_id_for_provison "$REF_PROVISION")
             # Change if not the same and if doesn't contain wildcard
             # shellcheck disable=SC2049
-            if [[ "$REF_BUNDLE_ID" != "$NEW_REF_BUNDLE_ID" ]] && ! [[ "$NEW_REF_BUNDLE_ID" =~ \* ]];
-            then
+            if [[ "$REF_BUNDLE_ID" != "$NEW_REF_BUNDLE_ID" ]] && ! [[ "$NEW_REF_BUNDLE_ID" =~ \* ]]; then
                 log "Updating nested app or extension reference for ${key} key from ${REF_BUNDLE_ID} to ${NEW_REF_BUNDLE_ID}"
                 PlistBuddy -c "Set ${key} $NEW_REF_BUNDLE_ID" "$APP_PATH/Info.plist"
             fi
         fi
     done
 
-    if [ "$ENTITLEMENTS" != "" ];
-    then
-        if [ -n "$APP_IDENTIFIER_PREFIX" ];
-        then
+    if [ "$ENTITLEMENTS" != "" ]; then
+        if [ -n "$APP_IDENTIFIER_PREFIX" ]; then
             # sanity check the 'application-identifier' is present in the provided entitlements and matches the provisioning profile value
             ENTITLEMENTS_APP_ID_PREFIX=$(PlistBuddy -c "Print :application-identifier" "$ENTITLEMENTS" | grep -E '^[A-Z0-9]*' -o | tr -d '\n')
-            if [ "$ENTITLEMENTS_APP_ID_PREFIX" == "" ];
-            then
+            if [ "$ENTITLEMENTS_APP_ID_PREFIX" == "" ]; then
                 error "Provided entitlements file is missing a value for the required 'application-identifier' key"
-            elif [ "$ENTITLEMENTS_APP_ID_PREFIX" != "$APP_IDENTIFIER_PREFIX" ];
-            then
+            elif [ "$ENTITLEMENTS_APP_ID_PREFIX" != "$APP_IDENTIFIER_PREFIX" ]; then
                 error "Provided entitlements file's app identifier prefix value '$ENTITLEMENTS_APP_ID_PREFIX' does not match the provided provisioning profile's value '$APP_IDENTIFIER_PREFIX'"
             fi
         fi
 
-        if [ -n "$TEAM_IDENTIFIER" ];
-        then
+        if [ -n "$TEAM_IDENTIFIER" ]; then
             # sanity check the 'com.apple.developer.team-identifier' is present in the provided entitlements and matches the provisioning profile value
             ENTITLEMENTS_TEAM_IDENTIFIER=$(PlistBuddy -c "Print :com.apple.developer.team-identifier" "$ENTITLEMENTS" | tr -d '\n')
-            if [ "$ENTITLEMENTS_TEAM_IDENTIFIER" == "" ];
-            then
+            if [ "$ENTITLEMENTS_TEAM_IDENTIFIER" == "" ]; then
                 error "Provided entitlements file is missing a value for the required 'com.apple.developer.team-identifier' key"
-            elif [ "$ENTITLEMENTS_TEAM_IDENTIFIER" != "$TEAM_IDENTIFIER" ];
-            then
+            elif [ "$ENTITLEMENTS_TEAM_IDENTIFIER" != "$TEAM_IDENTIFIER" ]; then
                 error "Provided entitlements file's 'com.apple.developer.team-identifier' '$ENTITLEMENTS_TEAM_IDENTIFIER' does not match the provided provisioning profile's value '$TEAM_IDENTIFIER'"
             fi
         fi
@@ -619,8 +589,7 @@ function resign {
         cp -f "$ENTITLEMENTS" "$APP_PATH/archived-expanded-entitlements.xcent"
         /usr/bin/codesign ${VERBOSE} -f -s "$CERTIFICATE" --entitlements "$ENTITLEMENTS" "$APP_PATH"
         checkStatus
-    elif  [[ -n "${USE_APP_ENTITLEMENTS}" ]];
-    then
+    elif  [[ -n "${USE_APP_ENTITLEMENTS}" ]]; then
         # Extract entitlements from provisioning profile and from the app binary
         # then combine them together
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

As of Xcode 10, the App Store will no longer accept `xcent` files created by extracting the elements from the provisioning profile. Additionally, this file is not necessary. See [this Issue](https://github.com/fastlane/fastlane/issues/13684) for more information.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

Get the Xcode version and use that to determine whether or not we need to create a new xcent file for resigning.

closes #13684