### PR TITLE
[git_commit] add skip_git_hooks option

### DIFF
--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -8,7 +8,9 @@ module Fastlane
           paths = params[:path].map(&:shellescape).join(' ')
         end
 
-        result = Actions.sh("git commit -m #{params[:message].shellescape} #{paths}")
+        skip_git_hooks = params[:skip_git_hooks] ? '--no-verify' : ''
+
+        result = Actions.sh("git commit -m #{params[:message].shellescape} #{paths} #{skip_git_hooks}".strip)
         UI.success("Successfully committed \"#{params[:path]}\" 💾.")
         return result
       end
@@ -27,7 +29,11 @@ module Fastlane
                                        description: "The file you want to commit",
                                        is_string: false),
           FastlaneCore::ConfigItem.new(key: :message,
-                                       description: "The commit message that should be used")
+                                       description: "The commit message that should be used"),
+          FastlaneCore::ConfigItem.new(key: :skip_git_hooks,
+                                       description: "Set to true to pass --no-verify to git",
+                                       type: Boolean,
+                                       optional: true)
         ]
       end
 
@@ -50,7 +56,8 @@ module Fastlane
         [
           'git_commit(path: "./version.txt", message: "Version Bump")',
           'git_commit(path: ["./version.txt", "./changelog.txt"], message: "Version Bump")',
-          'git_commit(path: ["./*.txt", "./*.md"], message: "Update documentation")'
+          'git_commit(path: ["./*.txt", "./*.md"], message: "Update documentation")',
+          'git_commit(path: ["./*.txt", "./*.md"], message: "Update documentation", skip_git_hooks: true)'
         ]
       end
 

--- a/fastlane/spec/actions_specs/git_commit_spec.rb
+++ b/fastlane/spec/actions_specs/git_commit_spec.rb
@@ -44,6 +44,14 @@ describe Fastlane do
         end").runner.execute(:test)
         expect(result).to eq("git commit -m #{message.shellescape} ./fastlane/README.md")
       end
+
+      it "generates the correct git command when configured to skip git hooks" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          git_commit(path: './fastlane/README.md', message: 'message', skip_git_hooks: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("git commit -m message ./fastlane/README.md --no-verify")
+      end
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I've some git commit hooks setup on a repository that do some quite time intensive checks / tests - when using fastlane to manage my application deployments it's not necessary to run these checks when committing the version bump.

This came up as part of setting up an android release lane. The same issue with running git commits happens on my ios release lane, but I figured I'd submit this one first, and if the change is desirable then I can also implement a similar fix for the `increment_build_number` action.

### Description
Added a ConfigItem option to git_commit which takes a boolean, defaults to false, and appends '--no-verify' if the value is true.

To test the changes I wrote an rspec test case, which passes, as well as did a couple of android builds / deploys using my local fastlane fork.
