### PR TITLE
Improve AdbHelper

### DIFF
--- a/fastlane/lib/fastlane/helper/adb_helper.rb
+++ b/fastlane/lib/fastlane/helper/adb_helper.rb
@@ -18,7 +18,7 @@ module Fastlane
       def initialize(adb_path: nil)
         android_home = ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK']
         if (adb_path.nil? || adb_path == "adb") && android_home
-          adb_path = Pathname.new(android_home).join("platform-tools/adb").to_s
+          adb_path = File.join(android_home, "platform-tools", "adb")
         end
         self.adb_path = adb_path
       end

--- a/fastlane/lib/fastlane/helper/adb_helper.rb
+++ b/fastlane/lib/fastlane/helper/adb_helper.rb
@@ -26,7 +26,7 @@ module Fastlane
       # Run a certain action
       def trigger(command: nil, serial: nil)
         android_serial = serial != "" ? "ANDROID_SERIAL=#{serial}" : nil
-        command = [android_serial, adb_path, command].join(" ")
+        command = [android_serial, adb_path.shellescape, command.shellescape].join(" ")
         Action.sh(command)
       end
 
@@ -38,7 +38,7 @@ module Fastlane
       def load_all_devices
         self.devices = []
 
-        command = [adb_path, "devices"].join(" ")
+        command = [adb_path.shellescape, "devices"].join(" ")
         output = Actions.sh(command, log: false)
         output.split("\n").each do |line|
           if (result = line.match(/(.*)\tdevice$/))

--- a/fastlane/spec/actions_specs/adb_devices_spec.rb
+++ b/fastlane/spec/actions_specs/adb_devices_spec.rb
@@ -1,7 +1,7 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "adb_devices" do
-      it "generates a valid command" do
+      it "generates an empty list of devices" do
         result = Fastlane::FastFile.new.parse("lane :test do
           adb_devices(adb_path: '/some/path/to/adb')
         end").runner.execute(:test)
@@ -9,7 +9,7 @@ describe Fastlane do
         expect(result).to match_array([])
       end
 
-      it "generates a valid command when ANDROID_SDK_ROOT is set" do
+      it "generates an empty list of devices when ANDROID_SDK_ROOT is set" do
         result = Fastlane::FastFile.new.parse("lane :test do
           ENV['ANDROID_SDK_ROOT'] = '/usr/local/android-sdk'
           adb_devices()


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
While using `adb_devices` on Windows on CI (Azure Pipelines) I encountered several problems: The generated ADB path had both `/` and `\`, the generated command wasn't properly escaped. While debugging this, I also noticed wrong test description.

### Description
- Properly build the adb_path
- Apply .shellescape on parts of the command
- Better describe what the test actually does and expects
