### PR TITLE
[spaceship] remove application and version from app submission params

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_submission.rb
+++ b/spaceship/lib/spaceship/tunes/app_submission.rb
@@ -136,7 +136,8 @@ module Spaceship
         if self.content_rights_has_rights.nil? || self.content_rights_contains_third_party_content.nil?
           raw_data_clone.set(["contentRights"], nil)
         end
-        raw_data_clone.delete("version")
+        raw_data_clone.delete(:version)
+        raw_data_clone.delete(:application)
 
         # Check whether the application makes use of IDFA or not
         # and automatically set the mandatory limitsTracking value in the request JSON accordingly.


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
json parse error occured when I submit for review. 
I checked request params and params included not key value objects but `spaceship` class objects. 

```error
SystemStackError: stack level too deep
 /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:140:in `initialize_dup'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:140:in `dup'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:140:in `block in as_json'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:140:in `map'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:140:in `as_json'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:140:in `block in as_json'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:140:in `map'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:140:in `as_json'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:128:in `as_json'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:159:in `block in as_json'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:159:in `each'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:159:in `map'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:159:in `as_json'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:50:in `as_json'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:159:in `block in as_json'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:159:in `each'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:159:in `map'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:159:in `as_json'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:140:in `block in as_json'

-------

/Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:159:in `block in as_json'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:159:in `each'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:159:in `map'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:159:in `as_json'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/json/encoding.rb:35:in `encode'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/json/encoding.rb:22:in `encode'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:37:in `to_json_with_active_support_encoder'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/fastlane-2.108.0/spaceship/lib/spaceship/base.rb:66:in `to_json'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/fastlane-2.108.0/spaceship/lib/spaceship/tunes/tunes_client.rb:1104:in `block in send_app_submission'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/faraday-0.15.3/lib/faraday/connection.rb:384:in `block in run_request'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/faraday-0.15.3/lib/faraday/connection.rb:398:in `block in build_request'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/faraday-0.15.3/lib/faraday/request.rb:26:in `block in create'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/faraday-0.15.3/lib/faraday/request.rb:25:in `tap'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/faraday-0.15.3/lib/faraday/request.rb:25:in `create'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/faraday-0.15.3/lib/faraday/connection.rb:394:in `build_request'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/faraday-0.15.3/lib/faraday/connection.rb:379:in `run_request'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/faraday-0.15.3/lib/faraday/connection.rb:175:in `post'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/fastlane-2.108.0/spaceship/lib/spaceship/client.rb:699:in `block in send_request'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/fastlane-2.108.0/spaceship/lib/spaceship/client.rb:532:in `with_retry'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/fastlane-2.108.0/spaceship/lib/spaceship/client.rb:698:in `send_request'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/fastlane-2.108.0/spaceship/lib/spaceship/client.rb:586:in `request'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/fastlane-2.108.0/spaceship/lib/spaceship/tunes/tunes_client.rb:1102:in `send_app_submission'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/fastlane-2.108.0/spaceship/lib/spaceship/tunes/app_submission.rb:162:in `complete!'
  /Users/marumemomo/code/myProject/Bundler/ruby/2.3.0/gems/fastlane-2.108.0/deliver/lib/deliver/submit_for_review.rb:28:in `submit!'
```

### Description
I removed `spaceship` class objects from request params `app_submission.complete!` .

I cannot release by deliver now, I wish merge this PR. 
Thank you!
