### PR TITLE
[spaceship] Fix creating and revoking Apple Keys

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -763,6 +763,8 @@ module Spaceship
     end
 
     def create_key!(name: nil, service_configs: nil)
+      fetch_csrf_token_for_keys
+
       params = {
         name: name,
         serviceConfigurations: service_configs,
@@ -779,6 +781,7 @@ module Spaceship
     end
 
     def revoke_key!(id: nil)
+      fetch_csrf_token_for_keys
       response = request(:post, 'account/auth/key/revoke', { teamId: team_id, keyId: id })
       parse_response(response)
     end
@@ -817,14 +820,26 @@ module Spaceship
     # profiles.
     # Source https://github.com/fastlane/fastlane/issues/5903
     def fetch_csrf_token_for_provisioning(mac: false)
-      req = request(:post, "account/#{platform_slug(mac)}/profile/listProvisioningProfiles.action", {
+      response = request(:post, "account/#{platform_slug(mac)}/profile/listProvisioningProfiles.action", {
          teamId: team_id,
          pageNumber: 1,
          pageSize: 1,
          sort: 'name=asc'
        })
 
-      parse_response(req, 'provisioningProfiles')
+      parse_response(response, 'provisioningProfiles')
+      return nil
+    end
+
+    def fetch_csrf_token_for_keys
+      response = request(:post, 'account/auth/key/list', {
+         teamId: team_id,
+         pageNumber: 1,
+         pageSize: 1,
+         sort: 'name=asc'
+       })
+
+      parse_response(response, 'keys')
       return nil
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I need to programmatically create a key on Apple Developer Portal. I tried to use the code from https://github.com/fastlane/fastlane/issues/9256#issuecomment-318471833 but I was getting `Bad request` error. I found out this is because the CSRF token is missing.

### Description
I added a new method `fetch_csrf_token_for_keys` in `SpaceShip::PortalClient` class, which is similar to the `fetch_csrf_token_for_provisioning` method which already exists. I also added two calls of this method - one in `create_key! and the second one in `revoke_key!`.

I tested creating an Apple Key with the code found in the previously mentioned Github Issue and it worked fine at that time.