### PR TITLE
[scan] resort and group options

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -247,7 +247,7 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :xctestrun,
                                      short_option: "-X",
                                      env_name: "SCAN_XCTESTRUN",
-                                     description: "Run tests using the provided .xctestrun file",
+                                     description: "Run tests using the provided `.xctestrun` file",
                                      conflicting_options: [:build_for_testing],
                                      is_string: true,
                                      optional: true),

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -73,7 +73,7 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :toolchain,
                                      env_name: "SCAN_TOOLCHAIN",
                                      conflicting_options: [:xctestrun],
-                                     description: "The toolchain that should be used for building the application (e.g. com.apple.dt.toolchain.Swift_2_3, org.swift.30p620160816a)",
+                                     description: "The toolchain that should be used for building the application (e.g. `com.apple.dt.toolchain.Swift_2_3, org.swift.30p620160816a`)",
                                      optional: true,
                                      is_string: false),
         FastlaneCore::ConfigItem.new(key: :clean,

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -81,7 +81,7 @@ module Scan
                                      description: "The bundle identifier of the app to uninstall (only needed when enabling reinstall_app)",
                                      code_gen_sensitive: true,
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
-                                     default_value_dynamic: true)
+                                     default_value_dynamic: true),
 
         # tests to run
         FastlaneCore::ConfigItem.new(key: :only_testing,
@@ -229,13 +229,6 @@ module Scan
                                      description: "Generate the json compilation database with clang naming convention (compile_commands.json)",
                                      is_string: false,
                                      default_value: false),
-        FastlaneCore::ConfigItem.new(key: :custom_report_file_name,
-                                     env_name: "SCAN_CUSTOM_REPORT_FILE_NAME",
-                                     description: "Sets custom full report file name when generating a single report",
-                                     deprecated: "Use `--output_files` instead",
-                                     conflicting_options: [:output_files],
-                                     optional: true,
-                                     is_string: true),
 
         # concurrency
         FastlaneCore::ConfigItem.new(key: :max_concurrent_simulators,
@@ -338,6 +331,13 @@ module Scan
                                      description: "Use only if you're a pro, use the other options instead",
                                      is_string: false,
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :custom_report_file_name,
+                                     env_name: "SCAN_CUSTOM_REPORT_FILE_NAME",
+                                     description: "Sets custom full report file name when generating a single report",
+                                     deprecated: "Use `--output_files` instead",
+                                     conflicting_options: [:output_files],
+                                     optional: true,
+                                     is_string: true)
 
       ]
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`scan` has 47 parameters. 

### Description
I grouped, resorted and commented them.
