### PR TITLE
Improve Spaceship API documentation

### DIFF
--- a/spaceship/docs/AppStoreConnect.md
+++ b/spaceship/docs/AppStoreConnect.md
@@ -1,13 +1,25 @@
-App Store Connect API
-====================
+# App Store Connect API
 
-# Usage
+- [Usage](#usage)
+  * [Login](#login)
+  * [Applications](#applications)
+  * [AppVersions](#appversions)
+  * [Select a build for review](#select-a-build-for-review)
+  * [Build Trains (TestFlight)](#build-trains-testflight)
+  * [Builds](#builds)
+  * [Processing builds](#processing-builds)
+  * [Submit app for App Store Review](#submit-app-for-app-store-review)
+  * [Testers](#testers)
+  * [App ratings & reviews](#app-ratings--reviews)
+- [License](#license)
+
+## Usage
 
 To quickly play around with _spaceship_ launch `irb` in your terminal and execute `require "spaceship"`.
 
-In general the classes are pre-fixed with the `Tunes` module.
+In general the classes are pre-fixed with the `Tunes` module. This name is an artifact from when "App Store Connect" was still called "iTunes Connect".
 
-## Login
+### Login
 
 *Note*: If you use both the Developer Portal and App Store Connect API, you'll have to login on both, as the user might have different user credentials.
 
@@ -17,7 +29,7 @@ Spaceship::Tunes.login("felix@krausefx.com", "password")
 Spaceship::Tunes.select_team # call this method to let the user select a team
 ```
 
-## Applications
+### Applications
 
 ```ruby
 # Fetch all available applications
@@ -61,7 +73,7 @@ To change the price of the app (it's not necessary to call `save!` when updating
 app.update_price_tier!("3")
 ```
 
-## AppVersions
+### AppVersions
 
 <img src="/spaceship/assets/docs/AppVersions.png" width="500">
 
@@ -185,7 +197,7 @@ attr_reader :screenshots
 
 **Important**: For a complete documentation with the return type, description and notes for each of the properties, check out [app_version.rb](https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/tunes/app_version.rb).
 
-## Select a build for review
+### Select a build for review
 
 ```ruby
 version = app.edit_version
@@ -195,7 +207,7 @@ version.select_build(builds.first)
 version.save!
 ```
 
-## Build Trains (TestFlight)
+### Build Trains (TestFlight)
 
 <img src="/spaceship/assets/docs/BuildTrains.png" width="700">
 
@@ -223,7 +235,7 @@ build = train.builds.first
 train.update_testing_status!(true, 'external')
 ```
 
-## Builds
+### Builds
 
 ```ruby
 # Continue from the BuildTrains example
@@ -257,7 +269,7 @@ parameters = {
 build.submit_for_beta_review!(parameters)
 ```
 
-## Processing builds
+### Processing builds
 
 To also access those builds that are "stuck" at `Processing` at App Store Connect for a while:
 
@@ -265,7 +277,7 @@ To also access those builds that are "stuck" at `Processing` at App Store Connec
 app.all_processing_builds       # => Array of processing builds for this application
 ```
 
-## Submit app for App Store Review
+### Submit app for App Store Review
 
 ```ruby
 submission = app.create_submission
@@ -281,7 +293,7 @@ submission.complete!
 
 For a full list of available options, check out [app_submission.rb](https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/tunes/app_submission.rb).
 
-## Testers
+### Testers
 
 There are 3 types of testers:
 
@@ -324,7 +336,7 @@ Spaceship::Tunes::SandboxTester.delete!(['sandbox@test.com', 'sandbox2@test.com'
 Spaceship::Tunes::SandboxTester.delete_all!
 ```
 
-## App ratings & reviews
+### App ratings & reviews
 
 ```ruby
 # Get the rating summary for an application
@@ -344,6 +356,6 @@ reviews = ratings.reviews("US") # => Array of hashes representing review data
 
 ```
 
-### License
+## License
 
 > This project and all fastlane tools are in no way affiliated with Apple Inc. This project is open source under the MIT license, which means you have full access to the source code and can modify it to fit your own needs. All fastlane tools run on your own computer or server, so your credentials or other sensitive information will never leave your own computer. You are responsible for how you use fastlane tools.

--- a/spaceship/docs/DeveloperPortal.md
+++ b/spaceship/docs/DeveloperPortal.md
@@ -1,11 +1,33 @@
-Developer Portal API
-====================
+# Developer Portal API
 
-# Usage
+- [Usage](#usage)
+  * [Login](#login)
+  * [Apps](#apps)
+    + [App Services](#app-services)
+  * [App Groups](#app-groups)
+  * [iCloud Containers](#icloud-containers)
+  * [Apple Pay Merchants](#apple-pay-merchants)
+  * [Passbook](#passbook)
+  * [Certificates](#certificates)
+    + [Code Signing Certificates](#code-signing-certificates)
+    + [Push Certificates](#push-certificates)
+    + [Create a Certificate](#create-a-certificate)
+  * [Provisioning Profiles](#provisioning-profiles)
+    + [Receiving profiles](#receiving-profiles)
+    + [Create a Provisioning Profile](#create-a-provisioning-profile)
+    + [Repair all broken provisioning profiles](#repair-all-broken-provisioning-profiles)
+  * [Devices](#devices)
+  * [Enterprise](#enterprise)
+  * [Multiple Spaceships](#multiple-spaceships)
+  * [More cool things you can do](#more-cool-things-you-can-do)
+  * [Example Data](#example-data)
+- [License](#license)
+
+## Usage
 
 To quickly play around with _spaceship_ launch `irb` in your terminal and execute `require "spaceship"`.
 
-## Login
+### Login
 
 *Note*: If you use both the Developer Portal and App Store Connect API, you'll have to login on both, as the user might have different user credentials.
 
@@ -15,7 +37,7 @@ Spaceship::Portal.login("felix@krausefx.com", "password")
 Spaceship::Portal.select_team # call this method to let the user select a team
 ```
 
-## Apps
+### Apps
 
 ```ruby
 # Fetch all available apps
@@ -33,7 +55,7 @@ end
 app = Spaceship::Portal.app.create!(bundle_id: "com.krausefx.app_name", name: "fastlane App")
 ```
 
-### App Services
+#### App Services
 
 App Services are part of the application, however, they are one of the few things that can be changed about the app once it has been created.
 
@@ -79,7 +101,7 @@ app.update_service(Spaceship::Portal.app_service.passbook.off)
 app.update_service(Spaceship::Portal.app_service.cloud_kit.cloud_kit)
 ```
 
-## App Groups
+### App Groups
 
 ```ruby
 # Fetch all existing app groups
@@ -102,7 +124,7 @@ group = Spaceship::Portal.app_group.create!(group_id: "group.com.example.another
 app = app.associate_groups([group])
 ```
 
-## iCloud Containers
+### iCloud Containers
 
 ```ruby
 # Fetch all existing containers
@@ -125,7 +147,7 @@ container = Spaceship::Portal.cloud_container.create!(identifier: "iCloud.com.ex
 app = app.associate_cloud_containers([container])
 ```
 
-## Apple Pay Merchants
+### Apple Pay Merchants
 
 ```ruby
 # Fetch all existing merchants
@@ -150,7 +172,7 @@ another_merchant.delete!
 app = app.associate_merchants([sandbox_merchant, production_merchant])
 ```
 
-## Passbook
+### Passbook
 
 ```ruby
 # Fetch all existing passbooks
@@ -167,14 +189,14 @@ passbook = Spaceship::Portal.passbook.find("pass.com.example.passbook").delete!
 
 ```
 
-## Certificates
+### Certificates
 
 ```ruby
 # Fetch all available certificates (includes signing and push profiles)
 certificates = Spaceship::Portal.certificate.all
 ```
 
-### Code Signing Certificates
+#### Code Signing Certificates
 
 ```ruby
 # Production identities
@@ -187,7 +209,7 @@ dev_certs = Spaceship::Portal.certificate.development.all
 cert_content = prod_certs.first.download
 ```
 
-### Push Certificates
+#### Push Certificates
 ```ruby
 # Production push profiles
 prod_push_certs = Spaceship::Portal.certificate.production_push.all
@@ -207,7 +229,7 @@ csr, pkey = Spaceship::Portal.certificate.create_certificate_signing_request
 Spaceship::Portal.certificate.production_push.create!(csr: csr, bundle_id: "com.krausefx.app")
 ```
 
-### Create a Certificate
+#### Create a Certificate
 
 ```ruby
 # Create a new certificate signing request
@@ -217,9 +239,9 @@ csr, pkey = Spaceship::Portal.certificate.create_certificate_signing_request
 Spaceship::Portal.certificate.production.create!(csr: csr)
 ```
 
-## Provisioning Profiles
+### Provisioning Profiles
 
-### Receiving profiles
+#### Receiving profiles
 
 ```ruby
 ##### Finding #####
@@ -263,7 +285,7 @@ first_profile = matching_profiles.first
 File.write("output.mobileprovision", first_profile.download)
 ```
 
-### Create a Provisioning Profile
+#### Create a Provisioning Profile
 
 ```ruby
 # Choose the certificate to use
@@ -283,7 +305,7 @@ profile = Spaceship::Portal.provisioning_profile.ad_hoc.create!(bundle_id: "com.
 File.write("NewProfile.mobileprovision", profile.download)
 ```
 
-### Repair all broken provisioning profiles
+#### Repair all broken provisioning profiles
 
 ```ruby
 # Select all 'Invalid' or 'Expired' provisioning profiles
@@ -301,7 +323,7 @@ end
 Spaceship::Portal.provisioning_profile.all.find_all { |p| !p.valid? || !p.certificate_valid? }.map(&:repair!)
 ```
 
-## Devices
+### Devices
 
 ```ruby
 # Get all enabled devices
@@ -325,7 +347,7 @@ disabled_devices = Spaceship::Portal.device.all(include_disabled: true).select(&
 Spaceship::Portal.device.create!(name: "Private iPhone 6", udid: "5814abb3...")
 ```
 
-## Enterprise
+### Enterprise
 
 ```ruby
 # Use the InHouse class to get all enterprise certificates
@@ -339,7 +361,7 @@ profile = Spaceship::Portal.provisioning_profile.in_house.create!(bundle_id: "co
 profiles = Spaceship::Portal.provisioning_profile.in_house.all
 ```
 
-## Multiple Spaceships
+### Multiple Spaceships
 
 Sometimes one _spaceship_ just isn't enough. That's why this library has its own Spaceship Launcher to launch and use multiple _spaceships_ at the same time :rocket:
 
@@ -358,7 +380,7 @@ devices.each do |device|
 end
 ```
 
-## More cool things you can do
+### More cool things you can do
 ```ruby
 # Find a profile with a specific name
 profile = Spaceship::Portal.provisioning_profile.development.all.find { |p| p.name == "Name" }
@@ -382,7 +404,7 @@ app.update_name!('New App Name')
 app.delete!
 ```
 
-## Example Data
+### Example Data
 
 Some unnecessary information was removed, check out [provisioning_profile.rb](https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/portal/provisioning_profile.rb) for all available attributes.
 
@@ -419,6 +441,6 @@ The example data below is a provisioning profile, containing a device, certifica
 >
 ```
 
-### License
+## License
 
 > This project and all fastlane tools are in no way affiliated with Apple Inc. This project is open source under the MIT license, which means you have full access to the source code and can modify it to fit your own needs. All fastlane tools run on your own computer or server, so your credentials or other sensitive information will never leave your own computer. You are responsible for how you use fastlane tools.


### PR DESCRIPTION
Spaceship has API documentation for both "targets", App Store Connect and the Developer Portal. I fixed the headline levels and added table of contents (using https://ecotrust-canada.github.io/markdown-toc/) to make it easier to get an overview.