### PR TITLE
[Swift] Fix Parsing issue while executing latest_testflight_build_number action

### DIFF
--- a/fastlane/lib/fastlane/swift_fastlane_api_generator.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_api_generator.rb
@@ -191,12 +191,12 @@ func parseDictionaryHelper(fromString: String, function: String = #function) -> 
 
 func parseBool(fromString: String, function: String = #function) -> Bool {
   verbose(message: "parsing a Bool from data: \(fromString), from function: \(function)")
-  return NSString(string: fromString).boolValue
+  return NSString(string: fromString.trimmingCharacters(in: .punctuationCharacters)).boolValue
 }
 
 func parseInt(fromString: String, function: String = #function) -> Int {
-  verbose(message: "parsing a Bool from data: \(fromString), from function: \(function)")
-  return NSString(string: fromString).integerValue
+  verbose(message: "parsing an Int from data: \(fromString), from function: \(function)")
+  return NSString(string: fromString.trimmingCharacters(in: .punctuationCharacters)).integerValue
 }
       '
       return parsing_functions


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
The Ruby `latest_testflight_build_number` lane returns the build number as a String containing double-quotes which lead to failure while parsing to Int. 

<!-- If it fixes an open issue, please link to the issue here. -->
See issue https://github.com/fastlane/fastlane/issues/13678

### Description
<!-- Describe your changes in detail -->
Replacing all occurrences of double-quotes with an empty String fixed the bug.

<!-- Please describe in detail how you tested your changes. -->
Testing could be done by running the `latest_testflight_build_number` lane while using `Fastfile.Swift`.