### PR TITLE
[spaceship] Fix environment variable provided sessions

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -378,7 +378,7 @@ module Spaceship
       # Check if we have a cached/valid session here
       #
       # December 4th 2017 Apple introduced a rate limit - which is of course fine by itself -
-      # but unfortunately also rate limits successful logins. If if you call multiple tools in a 
+      # but unfortunately also rate limits successful logins. If you call multiple tools in a
       # lane (e.g. call match 5 times), this would lock you out of the account for a while.
       # By loading existing sessions and checking if they're valid, we're sending less login requests.
       # More context on why this change was necessary https://github.com/fastlane/fastlane/pull/11108

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -376,18 +376,14 @@ module Spaceship
     # This will also handle 2 step verification
     def send_shared_login_request(user, password)
       # Check if we have a cached/valid session here
-      # Fixes
-      #   - https://github.com/fastlane/fastlane/issues/10812
-      #   - https://github.com/fastlane/fastlane/issues/10793
       #
-      # Before 4th December 2017 we didn't load existing session from the disk
-      # but changed it, because Apple introduced a rate limit, which is fine by itself
-      # but unfortunately it also rate limits successful logins, meaning if you call multiple
-      # tools in a lane (e.g. call match 5 times), this would mean it locks you out of the account
-      # for a while.
-      # By loading existing sessions and checking if they're valid, we're sending less login requests
+      # December 4th 2017 Apple introduced a rate limit - which is of course fine by itself -
+      # but unfortunately also rate limits successful logins. If if you call multiple tools in a 
+      # lane (e.g. call match 5 times), this would lock you out of the account for a while.
+      # By loading existing sessions and checking if they're valid, we're sending less login requests.
       # More context on why this change was necessary https://github.com/fastlane/fastlane/pull/11108
       #
+      # If there was a successful manual login before, we have a session on disk
       if load_session_from_file
         # Check if the session is still valid here
         begin
@@ -405,9 +401,8 @@ module Spaceship
           # because either way, we'll have to do a fresh login, where we do the actual error handling
         end
       end
-
-      # If this is a CI, the user can pass the session via environment variable
-      # This is used for 2FA related sessions
+      #
+      # The user can pass the session via environment variable (Mainly used in CI environments)
       if load_session_from_env
         # see above
         begin
@@ -418,9 +413,8 @@ module Spaceship
           # see above
         end
       end
-
       #
-      # After this point, we sure have no valid session any more
+      # After this point, we sure have no valid session any more and have to create a new one
       #
 
       data = {
@@ -471,7 +465,7 @@ module Spaceship
         fetch_olympus_session
         return response
       when 409
-        # 2 factor is enabled for this account, first handle that
+        # 2 step/factor is enabled for this account, first handle that
         # and then get the olympus session
         handle_two_step(response)
         fetch_olympus_session

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -408,7 +408,19 @@ module Spaceship
 
       # If this is a CI, the user can pass the session via environment variable
       # This is used for 2FA related sessions
-      load_session_from_env
+      if load_session_from_env
+        # see above
+        begin
+          # see above
+          return true if fetch_olympus_session
+        rescue
+          # see above
+        end
+      end
+
+      #
+      # After this point, we sure have no valid session any more
+      #
 
       data = {
         accountName: user,

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -414,6 +414,7 @@ module Spaceship
           # see above
           return true if fetch_olympus_session
         rescue
+          puts("Session loaded from environment variable is not valid. Continuing with normal login.")
           # see above
         end
       end

--- a/spaceship/lib/spaceship/two_step_client.rb
+++ b/spaceship/lib/spaceship/two_step_client.rb
@@ -50,13 +50,8 @@ module Spaceship
       two_factor_url = "https://github.com/fastlane/fastlane/tree/master/spaceship#2-step-verification"
       puts("Two Factor Authentication for account '#{self.user}' is enabled")
 
-      if !File.exist?(persistent_cookie_path) && self.class.spaceship_session_env.to_s.length.zero?
-        puts("If you're running this in a non-interactive session (e.g. server or CI)")
-        puts("check out #{two_factor_url}")
-      else
-        # If the cookie is set but still required, the cookie is expired
-        puts("Your session cookie has been expired.")
-      end
+      puts("If you're running this in a non-interactive session (e.g. server or CI)")
+      puts("check out #{two_factor_url}")
 
       security_code = response.body["securityCode"]
       # {"length"=>6,


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
There are multiple reports (https://github.com/fastlane/fastlane/issues/13603, https://github.com/fastlane/fastlane/issues/13630, https://github.com/fastlane/fastlane/issues/13705, https://github.com/fastlane/fastlane/issues/13266) that logins with environment variables provided sessions (`FASTLANE_SESSION` from `fastlane spaceauth`) are failing. There is also a lot of confusion because the output always mentions `Your session cookie has been expired.`. 
Upon checking that code in https://github.com/fastlane/fastlane/pull/8764/files, I noticed that this was a false positive and there was no actual checking of the environment variable provided session at all.

### Description
I reverted the broken changes from #8764, added an actual check of the environment variable provided session, added some output if it is not valid any more and cleaned up the comments in that area a bit.