### PR TITLE
[spaceship] support --verbose for `fastlane spaceauth`

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -614,9 +614,12 @@ module Spaceship
 
         content = expected_key ? response.body[expected_key] : response.body
       end
+
+      # if content (filled with whole body or just expected_key) is missing
       if content.nil?
         detect_most_common_errors_and_raise_exceptions(response.body) if response.body
         raise UnexpectedResponse, response.body
+      # else if it is a hash and `resultString` includes `NotAllowed`
       elsif content.kind_of?(Hash) && (content["resultString"] || "").include?("NotAllowed")
         # example content when doing a Developer Portal action with not enough permission
         # => {"responseId"=>"e5013d83-c5cb-4ba0-bb62-734a8d56007f",

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -251,7 +251,7 @@ module Spaceship
         end
 
         @logger.formatter = proc do |severity, datetime, progname, msg|
-          "[#{datetime.strftime('%H:%M:%S')}]: #{msg}\n"
+          "[#{severity} | #{datetime.strftime('%H:%M:%S')}]: #{msg}\n"
         end
       end
 

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -539,6 +539,7 @@ module Spaceship
       tries -= 1
       unless tries.zero?
         msg = "Timeout received: '#{ex.class}', '#{ex.message}'. Retrying after 3 seconds (remaining: #{tries})..."
+        puts(msg) if Spaceship::Globals.verbose?
         logger.warn(msg)
 
         sleep(3) unless Object.const_defined?("SpecHelper")
@@ -551,6 +552,7 @@ module Spaceship
       tries -= 1
       unless tries.zero?
         msg = "Internal Server Error received: '#{ex.class}', '#{ex.message}'. Retrying after 3 seconds (remaining: #{tries})..."
+        puts(msg) if Spaceship::Globals.verbose?
         logger.warn(msg)
 
         sleep(3) unless Object.const_defined?("SpecHelper")

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -586,8 +586,6 @@ module Spaceship
                    send_request(method, url_or_path, params, headers, &block)
                  end
 
-      log_response(method, url_or_path, response)
-
       return response
     end
 
@@ -699,6 +697,8 @@ module Spaceship
     def send_request(method, url_or_path, params, headers, &block)
       with_retry do
         response = @client.send(method, url_or_path, params, headers, &block)
+        log_response(method, url_or_path, response)
+
         resp_hash = response.to_hash
         if resp_hash[:status] == 401
           msg = "Auth lost"
@@ -709,6 +709,7 @@ module Spaceship
         if response.body.to_s.include?("<title>302 Found</title>")
           raise AppleTimeoutError.new, "Apple 302 detected - this might be temporary server error, check https://developer.apple.com/system-status/ to see if there is a known downtime"
         end
+
         return response
       end
     end

--- a/spaceship/lib/spaceship/commands_generator.rb
+++ b/spaceship/lib/spaceship/commands_generator.rb
@@ -24,6 +24,7 @@ module Spaceship
       program :help_formatter, :compact
 
       global_option('-u', '--user USERNAME', 'Specify the Apple ID you want to log in with')
+      global_option('--verbose') { FastlaneCore::Globals.verbose = true }
 
       command :playground do |c|
         c.syntax = 'fastlane spaceship playground'


### PR DESCRIPTION
`fastlane spaceauth` didn't support `--verbose`, which is handy to get verbose output from spaceship when stuff is going wrong.