### PR TITLE
[spaceship] support --verbose for `fastlane spaceauth` 

### DIFF
--- a/spaceship/lib/spaceship/commands_generator.rb
+++ b/spaceship/lib/spaceship/commands_generator.rb
@@ -24,6 +24,7 @@ module Spaceship
       program :help_formatter, :compact
 
       global_option('-u', '--user USERNAME', 'Specify the Apple ID you want to log in with')
+      global_option('--verbose') { FastlaneCore::Globals.verbose = true }
 
       command :playground do |c|
         c.syntax = 'fastlane spaceship playground'


### PR DESCRIPTION
`fastlane spaceauth` didn't support `--verbose`, which is handy to get verbose output from spaceship when stuff is going wrong.

closes #13750