### PR TITLE
[spaceship] Improve Logger

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -251,7 +251,7 @@ module Spaceship
         end
 
         @logger.formatter = proc do |severity, datetime, progname, msg|
-          "#{sprintf('%-5.5s', severity)} [#{datetime.strftime('%H:%M:%S')}]: #{msg}\n"
+          "#{'%-5.5s' % severity} [#{datetime.strftime('%H:%M:%S')}]: #{msg}\n"
         end
       end
 
@@ -542,7 +542,7 @@ module Spaceship
         Faraday::Error::ConnectionFailed,
         Faraday::Error::TimeoutError, # New Faraday version: Faraday::TimeoutError => ex
         AppleTimeoutError,
-        GatewayTimeoutError,
+        GatewayTimeoutError
       tries -= 1
       unless tries.zero?
         msg = "Timeout received: '#{ex.class}', '#{ex.message}'. Retrying after 3 seconds (remaining: #{tries})..."
@@ -731,14 +731,18 @@ module Spaceship
           def url(value)
             @url = value
           end
+          
           attr_accessor :body
           attr_accessor :headers
+
           def geturl
             @url
           end
+
           def getbody
             @body
           end
+
           def getheaders
             @headers
           end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -621,9 +621,12 @@ module Spaceship
 
         content = expected_key ? response.body[expected_key] : response.body
       end
+
+      # if content (filled with whole body or just expected_key) is missing
       if content.nil?
         detect_most_common_errors_and_raise_exceptions(response.body) if response.body
         raise UnexpectedResponse, response.body
+      # else if it is a hash and `resultString` includes `NotAllowed`
       elsif content.kind_of?(Hash) && (content["resultString"] || "").include?("NotAllowed")
         # example content when doing a Developer Portal action with not enough permission
         # => {"responseId"=>"e5013d83-c5cb-4ba0-bb62-734a8d56007f",

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -732,38 +732,17 @@ module Spaceship
       if block_given?
         obj = Object.new
         class << obj
+          attr_writer :body, :headers, :params, :url
           # rubocop: disable Style/TrivialAccessors
-          # from my testing this advice is actually not true,
-          # the suggested replacement would be equal to `def url=(value)`
-          # so we have to disable instead of fix
-          def url(value)
-            @url = value
+          # the block calls `url` (not `url=`) so need to define `url` method
+          def url(url)
+            @url = url
           end
           # rubocop: enable Style/TrivialAccessors
-
-          attr_accessor :body
-          attr_accessor :headers
-          attr_accessor :params
-
-          def geturl
-            @url
-          end
-
-          def getbody
-            @body
-          end
-
-          def getheaders
-            @headers
-          end
-
-          def getparams
-            @params
-          end
         end
         obj.headers = {}
         yield(obj)
-        obj.public_send('get' + key)
+        obj.instance_variable_get("@#{key}")
       end
     end
 

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -705,8 +705,12 @@ module Spaceship
       url ||= extract_key_from_block('url', &block)
       body = extract_key_from_block('body', &block)
       if body
-        body = JSON.parse(body)
-        body['password'] = '***' if body['password']
+        begin
+          body = JSON.parse(body)
+          body['password'] = '***' if body.is_a?(Hash) && body.key?("password")
+        rescue JSON::ParserError => e  
+          # no json, no password
+        end
       end
       params_to_log = Hash(params).dup # to also work with nil
       params_to_log.delete(:accountPassword) # Dev Portal

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -251,7 +251,7 @@ module Spaceship
         end
 
         @logger.formatter = proc do |severity, datetime, progname, msg|
-          "[#{datetime.strftime('%H:%M:%S')}]: #{msg}\n"
+          "[#{severity} | #{datetime.strftime('%H:%M:%S')}]: #{msg}\n"
         end
       end
 

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -733,7 +733,7 @@ module Spaceship
         obj = Object.new
         class << obj
           # rubocop: disable Style/TrivialAccessors
-          # from my testing this advice is actually not true, 
+          # from my testing this advice is actually not true,
           # the suggested replacement would be equal to `def url=(value)`
           # so we have to disable instead of fix
           def url(value)

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -709,7 +709,7 @@ module Spaceship
         begin
           body = JSON.parse(body)
           body['password'] = '***' if body.kind_of?(Hash) && body.key?("password")
-        rescue JSON::ParserError  
+        rescue JSON::ParserError
           # no json, no password
         end
       end
@@ -732,9 +732,14 @@ module Spaceship
       if block_given?
         obj = Object.new
         class << obj
+          # rubocop: disable Style/TrivialAccessors
+          # from my testing this advice is actually not true, 
+          # the suggested replacement would be equal to `def url=(value)`
+          # so we have to disable instead of fix
           def url(value)
             @url = value
           end
+          # rubocop: enable Style/TrivialAccessors
 
           attr_accessor :body
           attr_accessor :headers
@@ -751,13 +756,13 @@ module Spaceship
           def getheaders
             @headers
           end
-          
+
           def getparams
             @params
           end
         end
         obj.headers = {}
-        block.call(obj)
+        yield(obj)
         obj.public_send('get' + key)
       end
     end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -593,7 +593,7 @@ module Spaceship
       headers['User-Agent'] = USER_AGENT
 
       # Before encoding the parameters, log them
-      log_request(method, url_or_path, params)
+      log_request(method, url_or_path, params, headers, &block)
 
       # form-encode the params only if there are params, and the block is not supplied.
       # this is so that certain requests can be made using the block for more control
@@ -701,7 +701,7 @@ module Spaceship
       end
     end
 
-    def log_request(method, url, params)
+    def log_request(method, url, params, headers = nil, &block)
       params_to_log = Hash(params).dup # to also work with nil
       params_to_log.delete(:accountPassword) # Dev Portal
       params_to_log.delete(:theAccountPW) # iTC
@@ -711,7 +711,7 @@ module Spaceship
       logger.info(">> #{method.upcase} #{url}: #{params_to_log.join(', ')}")
     end
 
-    def log_response(method, url, response)
+    def log_response(method, url, response, headers = nil, &block)
       body = response.body.kind_of?(String) ? response.body.force_encoding(Encoding::UTF_8) : response.body
       resp_hash = response.to_hash
       logger.debug("<< #{method.upcase} #{url}: #{resp_hash[:status]} #{body}")
@@ -722,7 +722,7 @@ module Spaceship
     def send_request(method, url_or_path, params, headers, &block)
       with_retry do
         response = @client.send(method, url_or_path, params, headers, &block)
-        log_response(method, url_or_path, response)
+        log_response(method, url_or_path, response, headers, &block)
 
         resp_hash = response.to_hash
         if resp_hash[:status] == 401

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -546,6 +546,7 @@ module Spaceship
       tries -= 1
       unless tries.zero?
         msg = "Timeout received: '#{ex.class}', '#{ex.message}'. Retrying after 3 seconds (remaining: #{tries})..."
+        puts(msg) if Spaceship::Globals.verbose?
         logger.warn(msg)
 
         sleep(3) unless Object.const_defined?("SpecHelper")
@@ -558,6 +559,7 @@ module Spaceship
       tries -= 1
       unless tries.zero?
         msg = "Internal Server Error received: '#{ex.class}', '#{ex.message}'. Retrying after 3 seconds (remaining: #{tries})..."
+        puts(msg) if Spaceship::Globals.verbose?
         logger.warn(msg)
 
         sleep(3) unless Object.const_defined?("SpecHelper")

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -251,7 +251,7 @@ module Spaceship
         end
 
         @logger.formatter = proc do |severity, datetime, progname, msg|
-          "[#{severity} | #{datetime.strftime('%H:%M:%S')}]: #{msg}\n"
+          "#{sprintf('%-5.5s', severity)} [#{datetime.strftime('%H:%M:%S')}]: #{msg}\n"
         end
       end
 

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -542,7 +542,7 @@ module Spaceship
         Faraday::Error::ConnectionFailed,
         Faraday::Error::TimeoutError, # New Faraday version: Faraday::TimeoutError => ex
         AppleTimeoutError,
-        GatewayTimeoutError
+        GatewayTimeoutError => ex
       tries -= 1
       unless tries.zero?
         msg = "Timeout received: '#{ex.class}', '#{ex.message}'. Retrying after 3 seconds (remaining: #{tries})..."

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -719,7 +719,7 @@ module Spaceship
       params_to_log = params_to_log.collect do |key, value|
         "{#{key}: #{value}}"
       end
-      logger.info(">> #{method.upcase} #{url}: #{body.to_json}#{params_to_log.join(', ')}")
+      logger.info(">> #{method.upcase} #{url}: #{body.to_json} #{params_to_log.join(', ')}")
     end
 
     def log_response(method, url, response, headers = nil, &block)

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -706,7 +706,7 @@ module Spaceship
       body = extract_key_from_block('body', &block)
       if body
         body = JSON.parse(body)
-        body['password'] = '***'
+        body['password'] = '***' if body['password']
       end
       params_to_log = Hash(params).dup # to also work with nil
       params_to_log.delete(:accountPassword) # Dev Portal

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -704,6 +704,12 @@ module Spaceship
     def log_request(method, url, params, headers = nil, &block)
       url ||= extract_key_from_block('url', &block)
       body = extract_key_from_block('body', &block)
+      if body
+        body = JSON.parse(body)
+        puts body
+        body['password'] = '***'
+        puts body
+      end
       params_to_log = Hash(params).dup # to also work with nil
       params_to_log.delete(:accountPassword) # Dev Portal
       params_to_log.delete(:theAccountPW) # iTC

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -706,9 +706,7 @@ module Spaceship
       body = extract_key_from_block('body', &block)
       if body
         body = JSON.parse(body)
-        puts body
         body['password'] = '***'
-        puts body
       end
       params_to_log = Hash(params).dup # to also work with nil
       params_to_log.delete(:accountPassword) # Dev Portal

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -540,21 +540,33 @@ module Spaceship
       return yield
     rescue \
         Faraday::Error::ConnectionFailed,
-        Faraday::Error::TimeoutError,
-        Faraday::ParsingError, # <h2>Internal Server Error</h2> with content type json
+        Faraday::Error::TimeoutError, # New Faraday version: Faraday::TimeoutError => ex
         AppleTimeoutError,
         GatewayTimeoutError,
-        InternalServerError => ex # New Faraday version: Faraday::TimeoutError => ex
       tries -= 1
       unless tries.zero?
-        logger.warn("Timeout received: '#{ex.message}'. Retrying after 3 seconds (remaining: #{tries})...")
+        msg = "Timeout received: '#{ex.class}', '#{ex.message}'. Retrying after 3 seconds (remaining: #{tries})..."
+        logger.warn(msg)
+
+        sleep(3) unless Object.const_defined?("SpecHelper")
+        retry
+      end
+      raise ex # re-raise the exception
+    rescue \
+        Faraday::ParsingError, # <h2>Internal Server Error</h2> with content type json
+        InternalServerError => ex
+      tries -= 1
+      unless tries.zero?
+        msg = "Internal Server Error received: '#{ex.class}', '#{ex.message}'. Retrying after 3 seconds (remaining: #{tries})..."
+        logger.warn(msg)
+
         sleep(3) unless Object.const_defined?("SpecHelper")
         retry
       end
       raise ex # re-raise the exception
     rescue UnauthorizedAccessError => ex
       if @loggedin && !(tries -= 1).zero?
-        msg = "Auth error received: '#{ex.message}'. Login in again then retrying after 3 seconds (remaining: #{tries})..."
+        msg = "Auth error received: '#{ex.class}', '#{ex.message}'. Login in again then retrying after 3 seconds (remaining: #{tries})..."
         puts(msg) if Spaceship::Globals.verbose?
         logger.warn(msg)
 

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -251,7 +251,8 @@ module Spaceship
         end
 
         @logger.formatter = proc do |severity, datetime, progname, msg|
-          "#{'%-5.5s' % severity} [#{datetime.strftime('%H:%M:%S')}]: #{msg}\n"
+          severity = format('%-5.5s', severity)
+          "#{severity} [#{datetime.strftime('%H:%M:%S')}]: #{msg}\n"
         end
       end
 
@@ -707,8 +708,8 @@ module Spaceship
       if body
         begin
           body = JSON.parse(body)
-          body['password'] = '***' if body.is_a?(Hash) && body.key?("password")
-        rescue JSON::ParserError => e  
+          body['password'] = '***' if body.kind_of?(Hash) && body.key?("password")
+        rescue JSON::ParserError  
           # no json, no password
         end
       end
@@ -734,18 +735,23 @@ module Spaceship
           def url(value)
             @url = value
           end
+
           attr_accessor :body
           attr_accessor :headers
           attr_accessor :params
+
           def geturl
             @url
           end
+
           def getbody
             @body
           end
+
           def getheaders
             @headers
           end
+          
           def getparams
             @params
           end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -735,20 +735,20 @@ module Spaceship
           def url(value)
             @url = value
           end
-          
           attr_accessor :body
           attr_accessor :headers
-
+          attr_accessor :params
           def geturl
             @url
           end
-
           def getbody
             @body
           end
-
           def getheaders
             @headers
+          end
+          def getparams
+            @params
           end
         end
         obj.headers = {}

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -732,7 +732,7 @@ module Spaceship
       if block_given?
         obj = Object.new
         class << obj
-          attr_writer :body, :headers, :params, :url
+          attr_accessor :body, :headers, :params, :url
           # rubocop: disable Style/TrivialAccessors
           # the block calls `url` (not `url=`) so need to define `url` method
           def url(url)

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -724,8 +724,7 @@ module Spaceship
     def log_response(method, url, response, headers = nil, &block)
       url ||= extract_key_from_block('url', &block)
       body = response.body.kind_of?(String) ? response.body.force_encoding(Encoding::UTF_8) : response.body
-      resp_hash = response.to_hash
-      logger.debug("<< #{method.upcase} #{url}: #{resp_hash[:status]} #{body}")
+      logger.debug("<< #{method.upcase} #{url}: #{response.status} #{body}")
     end
 
     def extract_key_from_block(key, &block)

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -708,12 +708,13 @@ module Spaceship
       params_to_log = params_to_log.collect do |key, value|
         "{#{key}: #{value}}"
       end
-      logger.info(">> #{method.upcase}: #{url} #{params_to_log.join(', ')}")
+      logger.info(">> #{method.upcase} #{url}: #{params_to_log.join(', ')}")
     end
 
     def log_response(method, url, response)
       body = response.body.kind_of?(String) ? response.body.force_encoding(Encoding::UTF_8) : response.body
-      logger.debug("<< #{method.upcase}: #{url}: #{body}")
+      resp_hash = response.to_hash
+      logger.debug("<< #{method.upcase} #{url}: #{resp_hash[:status]} #{body}")
     end
 
     # Actually sends the request to the remote server

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -638,7 +638,7 @@ module Spaceship
         #    "userLocale"=>"en_US",
         #    "requestUrl"=>"https://developer.apple.com/services-account/QH65B2/account/ios/certificate/downloadCertificateContent.action",
         #    "httpCode"=>200}
-        raise_insuffient_permission_error!(additional_error_string: content["userString"])
+        raise_insufficient_permission_error!(additional_error_string: content["userString"])
       else
         store_csrf_tokens(response)
         content
@@ -648,11 +648,11 @@ module Spaceship
     def detect_most_common_errors_and_raise_exceptions(body)
       # Check if the failure is due to missing permissions (App Store Connect)
       if body["messages"] && body["messages"]["error"].include?("Forbidden")
-        raise_insuffient_permission_error!
+        raise_insufficient_permission_error!
       elsif body["messages"] && body["messages"]["error"].include?("insufficient privileges")
         # Passing a specific `caller_location` here to make sure we return the correct method
         # With the default location the error would say that `parse_response` is the caller
-        raise_insuffient_permission_error!(caller_location: 3)
+        raise_insufficient_permission_error!(caller_location: 3)
       elsif body.to_s.include?("Internal Server Error - Read")
         raise InternalServerError, "Received an internal server error from App Store Connect / Developer Portal, please try again later"
       elsif body.to_s.include?("Gateway Timeout - In read")
@@ -663,7 +663,7 @@ module Spaceship
     end
 
     # This also gets called from subclasses
-    def raise_insuffient_permission_error!(additional_error_string: nil, caller_location: 2)
+    def raise_insufficient_permission_error!(additional_error_string: nil, caller_location: 2)
       # get the method name of the request that failed
       # `block in` is used very often for requests when surrounded for paging or retrying blocks
       # The ! is part of some methods when they modify or delete a resource, so we don't want to show it

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -593,8 +593,6 @@ module Spaceship
                    send_request(method, url_or_path, params, headers, &block)
                  end
 
-      log_response(method, url_or_path, response)
-
       return response
     end
 
@@ -706,6 +704,8 @@ module Spaceship
     def send_request(method, url_or_path, params, headers, &block)
       with_retry do
         response = @client.send(method, url_or_path, params, headers, &block)
+        log_response(method, url_or_path, response)
+
         resp_hash = response.to_hash
         if resp_hash[:status] == 401
           msg = "Auth lost"
@@ -716,6 +716,7 @@ module Spaceship
         if response.body.to_s.include?("<title>302 Found</title>")
           raise AppleTimeoutError.new, "Apple 302 detected - this might be temporary server error, check https://developer.apple.com/system-status/ to see if there is a known downtime"
         end
+
         return response
       end
     end

--- a/spaceship/lib/spaceship/spaceauth_runner.rb
+++ b/spaceship/lib/spaceship/spaceauth_runner.rb
@@ -23,7 +23,7 @@ module Spaceship
         puts("Please check your credentials and try again.".yellow)
         puts("This could be an issue with App Store Connect,".yellow)
         puts("Please try unsetting the FASTLANE_SESSION environment variable".yellow)
-        puts("and re-run `fastlane spaceauth`".yellow)
+        puts("(if it is set) and re-run `fastlane spaceauth`".yellow)
         raise "Problem connecting to App Store Connect"
       end
 

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -225,7 +225,7 @@ module Spaceship
         elsif errors.count == 1 && errors.first.include?("try again later")
           raise ITunesConnectTemporaryError.new, errors.first
         elsif errors.count == 1 && errors.first.include?("Forbidden")
-          raise_insuffient_permission_error!
+          raise_insufficient_permission_error!
         elsif flaky_api_call
           raise ITunesConnectPotentialServerError.new, errors.join(' ')
         else

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -41,7 +41,7 @@ describe Spaceship::Client do
 
   describe 'detect_most_common_errors_and_raise_exceptions' do
     it "raises Spaceship::InsufficientPermissions for Forbidden" do
-      body = JSON.generate({ messages: { error: "InsufficentPermissions" } })
+      body = JSON.generate({ messages: { error: "InsufficientPermissions" } })
       stub_client_request(Spaceship::InsufficientPermissions, 6, 200, body)
 
       expect do

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -42,8 +42,18 @@ describe Spaceship::Client do
   end
 
   describe 'detect_most_common_errors_and_raise_exceptions' do
+    # this test is strange, the `error` has a typo "InsufficentPermissions" and is not really relevant
+    it "raises Spaceship::InsufficientPermissions for InsufficentPermissions" do
+      body = JSON.generate({ messages: { error: "InsufficentPermissions" } })
+      stub_client_request(Spaceship::InsufficientPermissions, 6, 200, body)
+
+      expect do
+        subject.req_home
+      end.to raise_error(Spaceship::InsufficientPermissions)
+    end
+
     it "raises Spaceship::InsufficientPermissions for Forbidden" do
-      body = JSON.generate({ messages: { error: "InsufficientPermissions" } })
+      body = JSON.generate({ messages: { error: "Forbidden" } })
       stub_client_request(Spaceship::InsufficientPermissions, 6, 200, body)
 
       expect do

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -15,9 +15,11 @@ describe Spaceship::Client do
 
   class TestResponse
     attr_accessor :body
+    attr_accessor :status
 
-    def initialize(body = nil)
+    def initialize(body = nil, status = 200)
       @body = body
+      @status = status
     end
   end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`spaceship` logs each request it sends in `/tmp`. These logfiles are the easiest way to debug what spaceship is doing, and to find out why something is not working as it should.
 
Unfortunately that logging was not complete or even broken (many URLs were missing, POST body was missing, log severity was not output, the http response code was not logged and failing requests were even not logged at all) - which can be a problem like in https://github.com/fastlane/fastlane/issues/13666#issuecomment-441075575 :/

### Description
This PR makes sure that _all_ requests from spaceship are logged, include an URL all the time and a body if available (as this includes the login password, I overwrote it with `***`). I changed the log format to include severity and http status code.
 
A logfile of `fastlane spaceauth` in `master`:
```
# Logfile created on 2018-11-22 22:51:47 +0100 by logger.rb/56815
[22:51:47]: >> POST:  
[22:51:47]: << POST: : {"authType"=>"hsa2"}
[22:51:47]: >> GET:  
[22:51:48]: << GET: : {"trustedPhoneNumbers"=>[{"numberWithDialCode"=>"+49 ••••• •••••81", "pushMode"=>"sms", "obfuscatedNumber"=>"••••• •••••81", "id"=>2}, {"numberWithDialCode"=>"+49 •••• •••••85", "pushMode"=>"sms", "obfuscatedNumber"=>"•••• •••••85", "id"=>1}], "securityCode"=>{"length"=>6, "tooManyCodesSent"=>false, "tooManyCodesValidated"=>false, "securityCodeLocked"=>false}, "authenticationType"=>"hsa2", "recoveryUrl"=>"https://iforgot.apple.com/phone/add?prs_account_nm=piotrowski@gmail.com&autoSubmitAccount=true&appId=142", "cantUsePhoneNumberUrl"=>"https://iforgot.apple.com/iforgot/phone/add?context=cantuse&prs_account_nm=piotrowski@gmail.com&autoSubmitAccount=true&appId=142", "recoveryWebUrl"=>"https://iforgot.apple.com/password/verify/appleid?prs_account_nm=piotrowski@gmail.com&autoSubmitAccount=true&appId=142", "repairPhoneNumberUrl"=>"https://gsa.apple.com/appleid/account/manage/repair/verify/phone", "repairPhoneNumberWebUrl"=>"https://appleid.apple.com/widget/account/repair?#!repair", "aboutTwoFactorAuthenticationUrl"=>"https://support.apple.com/kb/HT204921", "autoVerified"=>false, "showAutoVerificationUI"=>false, "managedAccount"=>false, "supportsRecovery"=>true, "hsa2Account"=>true, "trustedPhoneNumber"=>{"numberWithDialCode"=>"+49 ••••• •••••81", "pushMode"=>"sms", "obfuscatedNumber"=>"••••• •••••81", "id"=>2}}
[22:51:52]: >> POST:  
[22:51:53]: << POST: : 
[22:51:53]: >> GET:  
[22:51:54]: << GET: : 
[22:51:54]: >> GET: https://olympus.itunes.apple.com/v1/session 
[22:51:55]: << GET: https://olympus.itunes.apple.com/v1/session: {"user"=>{"fullName"=>"Jan Piotrowski", "emailAddress"=>"piotrowski@gmail.com", "prsId"=>"1326870224"}, "provider"=>{"providerId"=>424253, "name"=>"Jan Piotrowski", "contentTypes"=>["SOFTWARE"], "subType"=>"INDIVIDUAL"}, "availableProviders"=>[{"providerId"=>424253, "name"=>"Jan Piotrowski", "contentTypes"=>["SOFTWARE"], "subType"=>"INDIVIDUAL"}], "backingType"=>"ITC", "backingTypes"=>["ITC"], "roles"=>["ADMIN", "LEGAL"], "unverifiedRoles"=>[], "featureFlags"=>["apiKeys"], "agreeToTerms"=>true, "termsSignatures"=>["ITC"], "modules"=>[{"key"=>"Apps", "name"=>"ITC.HomePage.Apps.IconText", "localizedName"=>"My Apps", "url"=>"https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/Apps@2x.d3ce493e56172e92aed6.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}, {"key"=>"AppAnalytics", "name"=>"ITC.HomePage.AppAnalytics.IconText", "localizedName"=>"App Analytics", "url"=>"https://analytics.itunes.apple.com/", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/AppAnalytics@2x.e19f711d943cb42d65b2.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}, {"key"=>"SalesTrends", "name"=>"ITC.HomePage.SalesTrends.IconText", "localizedName"=>"Sales and Trends", "url"=>"https://reportingitc2.apple.com/?", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/SalesTrends@2x.b1f802112426525d990a.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}, {"key"=>"FinancialReports", "name"=>"ITC.HomePage.FinancialReports.IconText", "localizedName"=>"Payments and Financial Reports", "url"=>"https://appstoreconnect.apple.com/itc/payments_and_financial_reports", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/FinancialReports@2x.a7b266a5136cc65c643b.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}, {"key"=>"Account", "name"=>"ITC.HomePage.Account.IconText", "localizedName"=>"Users and Access", "url"=>"https://appstoreconnect.apple.com/access/users", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/ManageUsers@2x.81511f3933fb2fb4b20d.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}, {"key"=>"ContractsTaxBanking", "name"=>"ITC.HomePage.ContractsTaxBanking.IconText", "localizedName"=>"Agreements, Tax, and Banking", "url"=>"https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/da/jumpTo?page=contracts", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/ContractsTaxBanking@2x.74466eb8570dd797602e.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}, {"key"=>"Resources", "name"=>"ITC.HomePage.Resources.IconText", "localizedName"=>"Resources and Help", "url"=>"https://itunespartner.apple.com/", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/Resources@2x.3c8d0d8c08e876cf9470.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}], "helpLinks"=>[{"key"=>"All", "url"=>"https://itunespartner.apple.com", "localizedText"=>"All Resources and Help"}, {"key"=>"News", "url"=>"https://itunespartner.apple.com/news/", "localizedText"=>"News"}, {"key"=>"Videos", "url"=>"https://itunespartner.apple.com/videos/", "localizedText"=>"Videos"}, {"key"=>"Guides", "url"=>"https://itunespartner.apple.com/guides/", "localizedText"=>"Guides"}, {"key"=>"FAQ", "url"=>"https://itunespartner.apple.com/faq/", "localizedText"=>"FAQ"}, {"key"=>"ContactUs", "url"=>"https://www.apple.com/itunes/go/itunesconnect/contactus", "localizedText"=>"Contact Us"}], "localizations"=>{"signIn"=>"Sign In", "personalDetails"=>"Edit Profile", "signOut"=>"Sign Out"}, "pccDto"=>nil, "publicUserId"=>"69a495f6-0104-5733-e053-5b8c7c1155b0", "accountHolder"=>nil}
```

And the same requests logged for this branch:
```
# Logfile created on 2018-11-22 22:59:26 +0100 by logger.rb/56815
INFO  [22:59:26]: >> POST https://idmsa.apple.com/appleauth/auth/signin: {"accountName":"piotrowski@gmail.com","password":"***","rememberMe":true}
DEBUG [22:59:27]: << POST https://idmsa.apple.com/appleauth/auth/signin: 409 {"authType"=>"hsa2"}
INFO  [22:59:27]: >> GET https://idmsa.apple.com/appleauth/auth: null
DEBUG [22:59:28]: << GET https://idmsa.apple.com/appleauth/auth: 200 {"trustedPhoneNumbers"=>[{"numberWithDialCode"=>"+49 ••••• •••••81", "pushMode"=>"sms", "obfuscatedNumber"=>"••••• •••••81", "id"=>2}, {"numberWithDialCode"=>"+49 •••• •••••85", "pushMode"=>"sms", "obfuscatedNumber"=>"•••• •••••85", "id"=>1}], "securityCode"=>{"length"=>6, "tooManyCodesSent"=>false, "tooManyCodesValidated"=>false, "securityCodeLocked"=>false}, "authenticationType"=>"hsa2", "recoveryUrl"=>"https://iforgot.apple.com/phone/add?prs_account_nm=piotrowski@gmail.com&autoSubmitAccount=true&appId=142", "cantUsePhoneNumberUrl"=>"https://iforgot.apple.com/iforgot/phone/add?context=cantuse&prs_account_nm=piotrowski@gmail.com&autoSubmitAccount=true&appId=142", "recoveryWebUrl"=>"https://iforgot.apple.com/password/verify/appleid?prs_account_nm=piotrowski@gmail.com&autoSubmitAccount=true&appId=142", "repairPhoneNumberUrl"=>"https://gsa.apple.com/appleid/account/manage/repair/verify/phone", "repairPhoneNumberWebUrl"=>"https://appleid.apple.com/widget/account/repair?#!repair", "aboutTwoFactorAuthenticationUrl"=>"https://support.apple.com/kb/HT204921", "autoVerified"=>false, "showAutoVerificationUI"=>false, "managedAccount"=>false, "supportsRecovery"=>true, "hsa2Account"=>true, "trustedPhoneNumber"=>{"numberWithDialCode"=>"+49 ••••• •••••81", "pushMode"=>"sms", "obfuscatedNumber"=>"••••• •••••81", "id"=>2}}
INFO  [22:59:38]: >> POST https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode: {"securityCode":{"code":"246313"}}
DEBUG [22:59:39]: << POST https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode: 204 
INFO  [22:59:39]: >> GET https://idmsa.apple.com/appleauth/auth/2sv/trust: null
DEBUG [22:59:40]: << GET https://idmsa.apple.com/appleauth/auth/2sv/trust: 204 
INFO  [22:59:40]: >> GET https://olympus.itunes.apple.com/v1/session: null
DEBUG [22:59:41]: << GET https://olympus.itunes.apple.com/v1/session: 200 {"user"=>{"fullName"=>"Jan Piotrowski", "emailAddress"=>"piotrowski@gmail.com", "prsId"=>"1326870224"}, "provider"=>{"providerId"=>424253, "name"=>"Jan Piotrowski", "contentTypes"=>["SOFTWARE"], "subType"=>"INDIVIDUAL"}, "availableProviders"=>[{"providerId"=>424253, "name"=>"Jan Piotrowski", "contentTypes"=>["SOFTWARE"], "subType"=>"INDIVIDUAL"}], "backingType"=>"ITC", "backingTypes"=>["ITC"], "roles"=>["ADMIN", "LEGAL"], "unverifiedRoles"=>[], "featureFlags"=>["apiKeys"], "agreeToTerms"=>true, "termsSignatures"=>["ITC"], "modules"=>[{"key"=>"Apps", "name"=>"ITC.HomePage.Apps.IconText", "localizedName"=>"My Apps", "url"=>"https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/Apps@2x.d3ce493e56172e92aed6.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}, {"key"=>"AppAnalytics", "name"=>"ITC.HomePage.AppAnalytics.IconText", "localizedName"=>"App Analytics", "url"=>"https://analytics.itunes.apple.com/", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/AppAnalytics@2x.e19f711d943cb42d65b2.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}, {"key"=>"SalesTrends", "name"=>"ITC.HomePage.SalesTrends.IconText", "localizedName"=>"Sales and Trends", "url"=>"https://reportingitc2.apple.com/?", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/SalesTrends@2x.b1f802112426525d990a.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}, {"key"=>"FinancialReports", "name"=>"ITC.HomePage.FinancialReports.IconText", "localizedName"=>"Payments and Financial Reports", "url"=>"https://appstoreconnect.apple.com/itc/payments_and_financial_reports", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/FinancialReports@2x.a7b266a5136cc65c643b.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}, {"key"=>"Account", "name"=>"ITC.HomePage.Account.IconText", "localizedName"=>"Users and Access", "url"=>"https://appstoreconnect.apple.com/access/users", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/ManageUsers@2x.81511f3933fb2fb4b20d.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}, {"key"=>"ContractsTaxBanking", "name"=>"ITC.HomePage.ContractsTaxBanking.IconText", "localizedName"=>"Agreements, Tax, and Banking", "url"=>"https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/da/jumpTo?page=contracts", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/ContractsTaxBanking@2x.74466eb8570dd797602e.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}, {"key"=>"Resources", "name"=>"ITC.HomePage.Resources.IconText", "localizedName"=>"Resources and Help", "url"=>"https://itunespartner.apple.com/", "iconUrl"=>"https://appstoreconnect.apple.com/static/img/ico_homepage/themed/apps/Resources@2x.3c8d0d8c08e876cf9470.png", "down"=>false, "visible"=>true, "hasNotifications"=>false}], "helpLinks"=>[{"key"=>"All", "url"=>"https://itunespartner.apple.com", "localizedText"=>"All Resources and Help"}, {"key"=>"News", "url"=>"https://itunespartner.apple.com/news/", "localizedText"=>"News"}, {"key"=>"Videos", "url"=>"https://itunespartner.apple.com/videos/", "localizedText"=>"Videos"}, {"key"=>"Guides", "url"=>"https://itunespartner.apple.com/guides/", "localizedText"=>"Guides"}, {"key"=>"FAQ", "url"=>"https://itunespartner.apple.com/faq/", "localizedText"=>"FAQ"}, {"key"=>"ContactUs", "url"=>"https://www.apple.com/itunes/go/itunesconnect/contactus", "localizedText"=>"Contact Us"}], "localizations"=>{"signIn"=>"Sign In", "personalDetails"=>"Edit Profile", "signOut"=>"Sign Out"}, "pccDto"=>nil, "publicUserId"=>"69a495f6-0104-5733-e053-5b8c7c1155b0", "accountHolder"=>nil}
```
### Caution!

1. This PR includes a really terrible `extract_key_from_block` method that I wrote to get a specific "key" out of a block.  
Faraday uses blocks to supply configuration to the client/request (by calling `req.url(...)` or setting e.g. `req.headers[...] = ...`) and I had no idea how to get these values _out_ of there. This is required as the URL of the request is only sometimes supplied as a proper param, but very often only in this block. And as logging the URLs was missing, I had to find a solution.  
Background here is that I still have problems to wrap my brain around how blocks actually works - in my native PHP they are just not a thing, and all the samples I found online are about outputting fruit names or counting stuff, so I was a bit lost on how to implement this here.  
So I ended up creating a fake Object that has the same methods and "properties" as the one Faraday seems to be using, and 3 getters with a known name I could use to extract the information I want.
How can I do this better? Pleeeeease help me to replace this shitty code.

2. This needs to be tested _really_ well. The additional code in the `log_*` methods caused several crashes after the naive implementation, just because the tests sent the data in a different format or structure than I initially expected. We have to make sure that all the other methods that are not properly tested (I am sure there are some of those for spaceship) do not cause similar crashes. 

3. Please take a look at the improved (?) log formatting. Does this work for you? Any problems? Logging HTTP request with params and body is notoriously difficult in a flat file (and not e.g. JSON), so I hope my idea here works.