### PR TITLE
 [precheck] Allow mentioning Google Drive

### DIFF
--- a/precheck/lib/precheck/rules/other_platforms_rule.rb
+++ b/precheck/lib/precheck/rules/other_platforms_rule.rb
@@ -19,7 +19,10 @@ module Precheck
     end
 
     def allowed_lowercased_words
-      ["google analytics"]
+      [
+        "google analytics",
+        "google drive"
+      ]
     end
 
     def lowercased_words_to_look_for

--- a/precheck/spec/rules/other_platforms_rule_spec.rb
+++ b/precheck/spec/rules/other_platforms_rule_spec.rb
@@ -1,0 +1,21 @@
+require 'precheck'
+
+module Precheck
+  describe Precheck do
+    describe Precheck::OtherPlatformsRule do
+      let(:rule) { OtherPlatformsRule.new }
+      let(:allowed_item) { TextItemToCheck.new("We have integration with the Files app so you can open documents stored in your Google Drive.", :description, "description") }
+      let(:forbidden_item) { TextItemToCheck.new("Google is really great.", :description, "description") }
+
+      it "passes for allowed text" do
+        result = rule.check_item(allowed_item)
+        expect(result.status).to eq(VALIDATION_STATES[:passed])
+      end
+
+      it "fails for mentioning competitors" do
+        result = rule.check_item(forbidden_item)
+        expect(result.status).to eq(VALIDATION_STATES[:failed])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This fixes a false positive in `precheck`. It is reasonable that apps might integrate with Google Drive and users would want to know about this from the App Store description. Our app PDF Viewer has been approving mentioning Google Drive.

### Description

I added an additional entry to the whitelist for mentioning other platforms. Google is on the blacklist because it is a competitor to Apple, then Google Analytics and Google Drive are whitelisted because iOS app may integrate with these services.

I added tests for `Precheck::OtherPlatformsRule`, just covering a one allowed case and one not allowed case. I don’t really know Ruby or any of the rig here so I copied and modified `curse_words_rule_spec.rb`.