### PR TITLE
Allow for the host of the Appetize API to be configured

### DIFF
--- a/fastlane/lib/fastlane/actions/appetize.rb
+++ b/fastlane/lib/fastlane/actions/appetize.rb
@@ -172,7 +172,7 @@ module Fastlane
         [
           'appetize(
             path: "./MyApp.zip",
-            api_host: "company.appetize.io" # only needed for enterprise hosted solution
+            api_host: "company.appetize.io", # only needed for enterprise hosted solution
             api_token: "yourapitoken", # get it from https://appetize.io/docs#request-api-token
             public_key: "your_public_key" # get it from https://appetize.io/dashboard
           )'

--- a/fastlane/lib/fastlane/actions/appetize.rb
+++ b/fastlane/lib/fastlane/actions/appetize.rb
@@ -4,6 +4,7 @@ module Fastlane
       APPETIZE_PUBLIC_KEY = :APPETIZE_PUBLIC_KEY
       APPETIZE_APP_URL = :APPETIZE_APP_URL
       APPETIZE_MANAGE_URL = :APPETIZE_MANAGE_URL
+      APPETIZE_API_HOST = :APPETIZE_API_HOST
     end
 
     class AppetizeAction < Action
@@ -54,7 +55,8 @@ module Fastlane
       end
 
       def self.appetize_url(options)
-        "https://api.appetize.io/v1/apps/#{options[:public_key]}"
+        Actions.lane_context[SharedValues::APPETIZE_API_HOST] = options[:api_host]
+        "https://#{options[:api_host]}/v1/apps/#{options[:public_key]}"
       end
       private_class_method :appetize_url
 
@@ -100,6 +102,14 @@ module Fastlane
 
       def self.available_options
         [
+          FastlaneCore::ConfigItem.new(key: :api_host,
+                                       env_name: "APPETIZE_API_HOST",
+                                       description: "Appetize API host",
+                                       is_string: true,
+                                       default_value: 'api.appetize.io',
+                                       verify_block: proc do |value|
+                                         UI.user_error!("API host should not contain the scheme e.g. `https`") if value.start_with?('https')
+                                       end),
           FastlaneCore::ConfigItem.new(key: :api_token,
                                        env_name: "APPETIZE_API_TOKEN",
                                        sensitive: true,
@@ -143,14 +153,15 @@ module Fastlane
 
       def self.output
         [
-          ['APPETIZE_PUBLIC_KEY', 'a public identifier for your app. Use this to update your app after it has been initially created'],
+          ['APPETIZE_API_HOST', 'Appetize API host.'],
+          ['APPETIZE_PUBLIC_KEY', 'a public identifier for your app. Use this to update your app after it has been initially created.'],
           ['APPETIZE_APP_URL', 'a page to test and share your app.'],
           ['APPETIZE_MANAGE_URL', 'a page to manage your app.']
         ]
       end
 
       def self.authors
-        ["klundberg", "giginet"]
+        ["klundberg", "giginet", "steprescott"]
       end
 
       def self.category
@@ -161,6 +172,7 @@ module Fastlane
         [
           'appetize(
             path: "./MyApp.zip",
+            api_host: "company.appetize.io" # only needed for enterprise hosted solution
             api_token: "yourapitoken", # get it from https://appetize.io/docs#request-api-token
             public_key: "your_public_key" # get it from https://appetize.io/dashboard
           )'

--- a/fastlane/lib/fastlane/actions/appetize.rb
+++ b/fastlane/lib/fastlane/actions/appetize.rb
@@ -172,6 +172,11 @@ module Fastlane
         [
           'appetize(
             path: "./MyApp.zip",
+            api_token: "yourapitoken", # get it from https://appetize.io/docs#request-api-token
+            public_key: "your_public_key" # get it from https://appetize.io/dashboard
+          )',
+          'appetize(
+            path: "./MyApp.zip",
             api_host: "company.appetize.io", # only needed for enterprise hosted solution
             api_token: "yourapitoken", # get it from https://appetize.io/docs#request-api-token
             public_key: "your_public_key" # get it from https://appetize.io/dashboard

--- a/fastlane/spec/actions_specs/appetize_spec.rb
+++ b/fastlane/spec/actions_specs/appetize_spec.rb
@@ -11,6 +11,7 @@ describe Fastlane do
       EOS
     end
 
+    let(:api_host) { 'custom.appetize.io' }
     let(:api_token) { 'mysecrettoken' }
     let(:url) { 'https://example.com/app.zip' }
     let(:http) { double('http') }
@@ -68,6 +69,21 @@ describe Fastlane do
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APPETIZE_PUBLIC_KEY]).to eql('sKdfjL')
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APPETIZE_APP_URL]).to eql('https://appetize.io/app/sKdfjL')
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APPETIZE_MANAGE_URL]).to eql('https://appetize.io/manage/private_Djksfj')
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APPETIZE_API_HOST]).to eql('api.appetize.io')
+      end
+
+      it "works with custom API URL" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            appetize({
+              api_host: '#{api_host}',
+              api_token: '#{api_token}',
+              url: '#{url}'
+            })
+          end").runner.execute(:test)
+        end.not_to(raise_error)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APPETIZE_API_HOST]).to eql(api_host)
       end
     end
   end

--- a/fastlane/spec/actions_specs/appetize_spec.rb
+++ b/fastlane/spec/actions_specs/appetize_spec.rb
@@ -72,7 +72,7 @@ describe Fastlane do
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APPETIZE_API_HOST]).to eql('api.appetize.io')
       end
 
-      it "works with custom API URL" do
+      it "works with custom API host" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             appetize({


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Appetize offer a hosted solution if you require dedicated instances. This solution then changes the host of the API from `api.appetize.io` to `<CUSTOM_API>.appetize.io`. This change will allow you to set a custom host that will be used when uploading the app.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
A new `ConfigItem` has been added named `api_host`. This has a default value of `api.appetize.io` and this will cater for most cases and therefore results in a **none breaking change**. Now with this new item the host can be changed to support any hosted Appetize solution.

A new test case has been added that provides test coverage for a custom or default api host.
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
