### PR TITLE
Use `crash!` instead of `user_error!` on configuration access mis-use

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -211,7 +211,7 @@ module FastlaneCore
     # if 'ask' is true and the value is not present, the user will be prompted to provide a value
     # rubocop:disable Metrics/PerceivedComplexity
     def fetch(key, ask: true)
-      UI.user_error!("Key '#{key}' must be a symbol. Example :app_id.") unless key.kind_of?(Symbol)
+      UI.crash!("Key '#{key}' must be a symbol. Example :app_id.") unless key.kind_of?(Symbol)
 
       option = verify_options_key!(key)
 
@@ -263,7 +263,7 @@ module FastlaneCore
     # Overwrites or sets a new value for a given key
     # @param key [Symbol] Must be a symbol
     def set(key, value)
-      UI.user_error!("Key '#{key}' must be a symbol. Example :#{key}.") unless key.kind_of?(Symbol)
+      UI.crash!("Key '#{key}' must be a symbol. Example :#{key}.") unless key.kind_of?(Symbol)
       option = option_for_key(key)
 
       unless option


### PR DESCRIPTION
Since those methods are mostly used internally and for plugins, this will make debugging easier, as the crash will show the full stack trace, instead of just the error message