### PR TITLE
[resign.sh] Fix icloud-container-environment value

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -63,6 +63,9 @@
 # new features November 2018
 # 1. only create the archived-expanded-entitlements.xcent file if the version of Xcode < 9.3 as Xcode 10 does not create it.
 #
+# new features January 2019
+# 1. fixed bug where the com.apple.icloud-container-environment entitlement was being assigned an incorrect value
+#
 
 # Logging functions
 
@@ -743,7 +746,19 @@ function resign {
                 # This value is set by Xcode during export (manually selected for Development and AdHoc, automatically set to Production for Store)
                 # Would need an additional dedicated option to specify the iCloud environment to be used (Development or Production)
                 # For now, we assume Production is to be used when signing with a Distribution certificate, Development if not
-                if [[ "$CERTIFICATE" =~ "Distribution:" ]]; then
+                local certificate_name=$CERTIFICATE
+                local sha1_pattern='[0-9A-F]{40}'
+
+                if [[ "$CERTIFICATE" =~ $sha1_pattern ]]; then
+                    log "Certificate $CERTIFICATE matches a SHA1 pattern"
+                    local certificate_matches="$( security find-identity -v -p codesigning | grep -m 1 "$CERTIFICATE" )"
+                    if [ -n "$certificate_matches" ]; then
+                        certificate_name="$( sed -E s/[^\"]+\"\([^\"]+\)\".*/\\1/ <<< $certificate_matches )"
+                        log "Certificate name: $certificate_name"
+                    fi
+                fi
+
+                if [[ "$certificate_name" =~ "Distribution:" ]]; then
                     ICLOUD_ENV="Production"
                 else
                     ICLOUD_ENV="Development"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
The `com.apple.developer.icloud-container-environment` entitlement was being incorrectly set to `development` when using app entitlements if passing in a SHA1 as the `CERTIFICATE` parameter. This behavior appears to have been introduced by this [pull request](https://github.com/fastlane/fastlane/pull/4898/files) which added the ability to pass the SHA1 instead of the certificate name.
<!-- If it fixes an open issue, please link to the issue here. -->
Partially fixes this [issue](https://github.com/fastlane/fastlane/issues/13740) pertaining to entitlements when resigning.

### Description
<!-- Describe your changes in detail -->
When iterating over the entitlement transfer rules, there is a specific check for `com.apple.developer.icloud-container-environment`, within this check, I added a regex to check if `CERTIFICATE` matches a SHA1. If it does, I get the name of the identity by grepping `security find-identity`.
<!-- Please describe in detail how you tested your changes. -->
Used the below script to test various types of inputs including non-SHA1 inputs. Additionally, I resigned our IPAs using the fastlane `resign` action and checked the embedded entitlements. The entitlement was correctly set to `production` if the certificate's name contained `Distribution:`.

```
CERTIFICATE="CERTIFICATE_VALUE"
sha1_pattern='[0-9A-F]{40}'
if [[ "$CERTIFICATE" =~ $sha1_pattern ]]; then
  certificate_matches="$(security find-identity -v -p codesigning | grep -m 1 "$CERTIFICATE")"
  if [ -n "$certificate_matches" ]; then
    certificate_name="$( sed -E s/[^\"]+\"\([^\"]+\)\".*/\\1/ <<< $certificate_matches )"
    echo "$certificate_name"
  fi
fi
```