### PR TITLE
Improves parse error reporting for non-conventional setups

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -56,7 +56,8 @@ module Fastlane
           eval(data, parsing_binding, relative_path) # using eval is ok for this case
           # rubocop:enable Security/Eval
         rescue SyntaxError => ex
-          if match = ex.to_s.match(/#{Regexp.escape(relative_path)}:(\d+)/)
+          match = ex.to_s.match(/#{Regexp.escape(relative_path)}:(\d+)/)
+          if match
             line = match[1]
             UI.content_error(data, line)
             UI.user_error!("Syntax error in your Fastfile on line #{line}: #{ex}")

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -62,7 +62,7 @@ module Fastlane
             UI.content_error(data, line)
             UI.user_error!("Syntax error in your Fastfile on line #{line}: #{ex}")
           else
-            UI.user_error!("Syntax error in your Fastfile on unknown line: #{ex}")
+            UI.user_error!("Syntax error in your Fastfile: #{ex}")
           end
         end
       end

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -56,9 +56,13 @@ module Fastlane
           eval(data, parsing_binding, relative_path) # using eval is ok for this case
           # rubocop:enable Security/Eval
         rescue SyntaxError => ex
-          line = ex.to_s.match(/#{Regexp.escape(relative_path)}:(\d+)/)[1]
-          UI.content_error(data, line)
-          UI.user_error!("Syntax error in your Fastfile on line #{line}: #{ex}")
+          if match = ex.to_s.match(/#{Regexp.escape(relative_path)}:(\d+)/)
+            line = match[1]
+            UI.content_error(data, line)
+            UI.user_error!("Syntax error in your Fastfile on line #{line}: #{ex}")
+          else
+            UI.user_error!("Syntax error in your Fastfile on unknown line: #{ex}")
+          end
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In some unconventional setups, the stringified error object doesn't match the format expected by the code and a useless `undefined method '[]' for nil:NilClass` error is thrown instead of the actual syntax error.

For example, in my Fastlane setup, I have multiple util files that I require into my `Fastfile`. This causes the `.match()` line to throw the nil error.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
I've left in the original functionality for conventional setups. However, in the case where the stringified error doesn't match the given regular expression, the code will still throw a useful error.