### PR TITLE
[spaceship] Use default sort order for listing TestFlight testers

### DIFF
--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -187,8 +187,8 @@ module Spaceship
         assert_required_params(__method__, binding)
         page_size = 40 # that's enforced by the iTC servers
         resulting_array = []
-        # Sort order is set to `default` instead of `email`, because any other sort order breaks
-        # pagination when dealing with lots of anonymous (public link) testers.
+        # Sort order is set to `default` instead of `email`, because any other sort order breaks pagination
+        # when dealing with lots of anonymous (public link) testers: https://github.com/fastlane/fastlane/pull/13778
         initial_url = "providers/#{team_id}/apps/#{app_id}/testers?limit=#{page_size}&sort=default&order=asc"
         response = request(:get, initial_url)
         link_from_response = proc do |r|

--- a/spaceship/lib/spaceship/test_flight/client.rb
+++ b/spaceship/lib/spaceship/test_flight/client.rb
@@ -187,7 +187,9 @@ module Spaceship
         assert_required_params(__method__, binding)
         page_size = 40 # that's enforced by the iTC servers
         resulting_array = []
-        initial_url = "providers/#{team_id}/apps/#{app_id}/testers?limit=#{page_size}&sort=email&order=asc"
+        # Sort order is set to `default` instead of `email`, because any other sort order breaks
+        # pagination when dealing with lots of anonymous (public link) testers.
+        initial_url = "providers/#{team_id}/apps/#{app_id}/testers?limit=#{page_size}&sort=default&order=asc"
         response = request(:get, initial_url)
         link_from_response = proc do |r|
           # I weep for Swift nil chaining

--- a/spaceship/spec/test_flight/client_spec.rb
+++ b/spaceship/spec/test_flight/client_spec.rb
@@ -177,7 +177,7 @@ describe Spaceship::TestFlight::Client do
     it 'executes the request' do
       MockAPI::TestFlightServer.get('/testflight/v2/providers/fake-team-id/apps/some-app-id/testers') {}
       subject.testers_for_app(app_id: app_id)
-      expect(WebMock).to have_requested(:get, 'https://appstoreconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/testers?limit=40&order=asc&sort=email')
+      expect(WebMock).to have_requested(:get, 'https://appstoreconnect.apple.com/testflight/v2/providers/fake-team-id/apps/some-app-id/testers?limit=40&order=asc&sort=default')
     end
   end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Apple's API is broken with email sort when dealing with thousands of anonymous (public link) testers. All anonymous testers have the same first name, last name, and email, so the sort order needs to be something other than those, and default seems to correspond to sorting by UUID.

With email sort order, it would return a page of results, then the "next" link would contain an offset starting with a comma (%2C). If you request that link, or change the offset in that link to anything else and try requesting that, it would return the first 40 testers sorted in reverseorder of UUID. I suspect this can be reproduced with any app with over 40 anonymous testers.

### Description
Some playing around in the spaceship REPL found that using default sort order fixed the problem. I tested it by exporting almost 10,000 anonymous testers from my app.