### PR TITLE
[scan] Use slack action to post scan test results

### DIFF
--- a/scan/lib/scan/slack_poster.rb
+++ b/scan/lib/scan/slack_poster.rb
@@ -1,3 +1,6 @@
+require 'fastlane/action'
+require 'fastlane/actions/slack'
+
 require_relative 'module'
 
 module Scan

--- a/scan/lib/scan/slack_poster.rb
+++ b/scan/lib/scan/slack_poster.rb
@@ -12,56 +12,44 @@ module Scan
         channel = ('#' + channel) unless ['#', '@'].include?(channel[0]) # send message to channel by default
       end
 
-      require 'slack-notifier'
-      notifier = Slack::Notifier.new(Scan.config[:slack_url]) do
-        defaults(channel: channel,
-                username: 'fastlane')
-      end
+      fields = []
 
-      attachments = []
-
-      if Scan.config[:slack_message]
-        attachments << {
-          text: Scan.config[:slack_message].to_s,
-          color: "good"
+      if results[:build_errors]
+        fields << {
+          title: 'Build Errors',
+          value: results[:build_errors].to_s,
+          short: true
         }
       end
 
-      attachments << {
-        text: "Build Errors: #{results[:build_errors] || 0}",
-        color: results[:build_errors].to_i > 0 ? "danger" : "good",
-        short: true
-      }
-
       if results[:failures]
-        attachments << {
-          text: "Test Failures: #{results[:failures]}",
-          color: results[:failures].to_i > 0 ? "danger" : "good",
+        fields << {
+          title: 'Test Failures',
+          value: results[:failures].to_s,
           short: true
         }
       end
 
       if results[:tests] && results[:failures]
-        attachments << {
-          text: "Successful Tests: #{results[:tests] - results[:failures]}",
-          color: "good",
+        fields << {
+          title: 'Successful Tests',
+          value: (results[:tests] - results[:failures]).to_s,
           short: true
         }
       end
 
-      result = notifier.ping("#{Scan.project.app_name} Tests:",
-                             icon_url: 'https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png',
-                             attachments: attachments)
-      result = result.first
-
-      if result.code.to_i == 200
-        UI.success('Successfully sent Slack notification')
-      elsif result.code.to_i == 404
-        UI.error("The Slack URL you provided could not be reached (404)")
-      else
-        UI.error("The Slack notification could not be sent:")
-        UI.error(result.to_s)
-      end
+      Fastlane::Actions::SlackAction.run({
+        message: "#{Scan.project.app_name} Tests:\n#{Scan.config[:slack_message]}",
+        channel: channel,
+        slack_url: Scan.config[:slack_url].to_s,
+        success: results[:build_errors].to_i == 0 && results[:failures].to_i == 0,
+        username: 'fastlane',
+        icon_url: 'https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png',
+        payload: {},
+        attachment_properties: {
+          fields: fields
+        }
+      })
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Hi team, this is the PR that addresses my question in #13783 

I've implemented the change as I'd like to have more consistent Slack messages when running test builds between iOS and Android, so using the Slack Action keeps them the same across the board.

### Description
Excuse the `rubocop` fails, I'm not very proficient with ruby, this is my first go at it. I think there's a cyclic dependency cause I call `Firebase` from within the `SlackPoster` class
