### PR TITLE
[action] Fix `prompt` to not leave trailing new lines in input buffer when using multi_line_end_keyword

### DIFF
--- a/fastlane/lib/fastlane/actions/prompt.rb
+++ b/fastlane/lib/fastlane/actions/prompt.rb
@@ -15,7 +15,18 @@ module Fastlane
           # Multi line
           end_tag = params[:multi_line_end_keyword]
           UI.important("Submit inputs using \"#{params[:multi_line_end_keyword]}\"")
-          user_input = STDIN.gets(end_tag).chomp.gsub(end_tag, "").strip
+          user_input = ""
+          loop do
+            line = STDIN.gets
+            end_tag_index = line.index(end_tag)
+            if end_tag_index.nil?
+              user_input << line
+            else
+              user_input << line.slice(0, end_tag_index)
+              user_input = user_input.strip
+              break
+            end
+          end
         else
           # Standard one line input
           if params[:secure_text]

--- a/fastlane/spec/actions_specs/prompt_spec.rb
+++ b/fastlane/spec/actions_specs/prompt_spec.rb
@@ -2,12 +2,24 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "prompt" do
       it "uses the CI value if necessary" do
-        ENV["CI"] = '1'
+        # make prompt think we're running in CI mode
+        expect(FastlaneCore::UI).to receive(:interactive?).with(no_args).and_return(false)
+
         result = Fastlane::FastFile.new.parse("lane :test do
           prompt(text: 'text', ci_input: 'ci')
         end").runner.execute(:test)
         expect(result).to eq('ci')
-        ENV.delete('CI')
+      end
+
+      it "reads full lines from $stdin until encountering multi_line_end_keyword" do
+        # make prompt think we're running in interactive, non-CI mode
+        expect(FastlaneCore::UI).to receive(:interactive?).with(no_args).and_return(true)
+
+        expect($stdin).to receive(:gets).with(no_args).and_return("First line\n", "Second lineEND\n")
+        result = Fastlane::FastFile.new.parse("lane :test do
+          prompt(text: 'text', multi_line_end_keyword: 'END', ci_input: 'if this value is returned, prompt incorrectly assumes CI mode')
+        end").runner.execute(:test)
+        expect(result).to eq("First line\nSecond line")
       end
     end
   end


### PR DESCRIPTION

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #13538

### Description
Currently, prompt uses the following code to collect multiline input:
```ruby
user_input = STDIN.gets(end_tag).chomp.gsub(end_tag, "").strip 
```

This is problematic because everything in STDIN after `end_tag` remains in the buffer. At the very least, this will be a (platform specific) newline character, but could also be other text. This PR modifies the logic to drain the entire line of input containing `end_tag` while maintaining the existing behavior of not including text after the tag in `user_input`.