### PR TITLE
Add healthkit access entitlement to the blacklist and transfer list

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -648,6 +648,8 @@ function resign {
             "com.apple.developer.homekit" \
             # If actually used by the App, this value will be set in its entitlements
             "com.apple.developer.healthkit" \
+            # If actually used by the App, this value will be set in its entitlements
+            "com.apple.developer.healthkit.access" \
             # PP list identifiers inconsistent with app-defined ones, must use App entitlements value
             "com.apple.developer.in-app-payments" \
             # If actually used by the App, this value will be set in its entitlements
@@ -706,6 +708,7 @@ function resign {
             "com.apple.developer.associated-domains" \
             "com.apple.developer.default-data-protection" \
             "com.apple.developer.healthkit" \
+            "com.apple.developer.healthkit.access" \
             "com.apple.developer.homekit" \
             "com.apple.developer.icloud-container-environment" \
             "com.apple.developer.icloud-container-identifiers" \


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
`com.apple.developer.healthkit` is an entitlement that should also be taken from the App. 
Before resigning:   
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
        <key>application-identifier</key>
        <string>application.identifier.healthkitswift</string>
        <key>aps-environment</key>
        <string>production</string>
        <key>beta-reports-active</key>
        <true/>
        <key>com.apple.developer.healthkit</key>
        <true/>
        <key>com.apple.developer.team-identifier</key>
        <string>TEAMID</string>
        <key>get-task-allow</key>
        <false/>
</dict>
</plist>.  
``` 
After running `resign.sh HealthKit_sample.ipa  XXXXX  -p "Healthkitswift_test_distribution.mobileprovision" --use-app-entitlements fastlane_resigned.healthkit.ipa`:
```
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
        <key>application-identifier</key>
        <string>application.identifier.healthkitswift</string>
        <key>aps-environment</key>
        <string>production</string>
        <key>beta-reports-active</key>
        <true/>
        <key>com.apple.developer.healthkit</key>
        <true/>
        <key>com.apple.developer.healthkit.access</key>
        <array>
                <string>health-records</string>
        </array>
        <key>com.apple.developer.team-identifier</key>
        <string>TEAMID</string>
        <key>get-task-allow</key>
        <false/>
</dict>
</plist>
```
This is obviously not correct, with this patch it's back to the original entitlements.

### Description

Added the `"com.apple.developer.healthkit.access"` entitlements to the list of entitlements that should not be taken from the provisioning profile but from the app. 
