### PR TITLE
pod_lib_lint add param podspec

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_lib_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_lib_lint.rb
@@ -12,6 +12,8 @@ module Fastlane
           command << "--verbose"
         end
 
+        command << params[:podspec] if params[:podspec]
+
         if params[:sources]
           sources = params[:sources].join(",")
           command << "--sources='#{sources}'"
@@ -54,6 +56,10 @@ module Fastlane
                                        description: "Use bundle exec when there is a Gemfile presented",
                                        is_string: false,
                                        default_value: true),
+          FastlaneCore::ConfigItem.new(key: :podspec,
+                                       description: "pod lib lint podspec name",
+                                       optional: true,
+                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :verbose,
                                        description: "Allow output detail in console",
                                        optional: true,

--- a/fastlane/lib/fastlane/actions/pod_lib_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_lib_lint.rb
@@ -57,7 +57,7 @@ module Fastlane
                                        is_string: false,
                                        default_value: true),
           FastlaneCore::ConfigItem.new(key: :podspec,
-                                       description: "pod lib lint podspec name",
+                                       description: "Path of spec to lint",
                                        optional: true,
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :verbose,

--- a/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
+++ b/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
@@ -68,6 +68,14 @@ describe Fastlane do
 
         expect(result).to eq("bundle exec pod lib lint --swift-version=4.2")
       end
+
+      it "generates the correct pod lib lint command with podspec parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_lib_lint(podspec: 'fastlane')
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod lib lint fastlane")
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
If multiple podspecs, but just want push one podspec, you can set the param.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
example: 
```pod_lib_lint(podspec: aaaa.podspec)```
