### PR TITLE
[spaceship] Do not attempt to log non-JSON bodies

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -766,10 +766,12 @@ module Spaceship
     def log_request(method, url, params, headers = nil, &block)
       url ||= extract_key_from_block('url', &block)
       body = extract_key_from_block('body', &block)
+      log_body = false
       if body
         begin
           body = JSON.parse(body)
           body['password'] = '***' if body.kind_of?(Hash) && body.key?("password")
+          log_body = true
         rescue JSON::ParserError
           # no json, no password
         end
@@ -780,7 +782,9 @@ module Spaceship
       params_to_log = params_to_log.collect do |key, value|
         "{#{key}: #{value}}"
       end
-      logger.info(">> #{method.upcase} #{url}: #{body.to_json} #{params_to_log.join(', ')}")
+      if log_body
+        logger.info(">> #{method.upcase} #{url}: #{body.to_json} #{params_to_log.join(', ')}")
+      end
     end
 
     def log_response(method, url, response, headers = nil, &block)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
'source sequence is illegal / malformed utf-8 (JSON :: GeneratorError)' error occurs when uploading ipa to iTunes connect with fastlane deliver.

As a result of analysis of the code, the 'body' of 'block' passed to this function 'log_request' contains information that is not JSON, such as uploaded PNG file. so if you try to convert it to JSON unconditionally it will cause problems.
#13815

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
In the case where the result of analyzing body is not JSON, logic that does not output body to log was added.
