### PR TITLE
[spaceship] Fix logging of non-JSON request bodies

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -775,7 +775,7 @@ module Spaceship
           body_to_log = body.to_json
         rescue JSON::ParserError
           # no json, no password to replace
-          body_to_log = "[request body can not be represented as JSON]"
+          body_to_log = "[non JSON body]"
         end
       end
       params_to_log = Hash(params).dup # to also work with nil

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -766,12 +766,16 @@ module Spaceship
     def log_request(method, url, params, headers = nil, &block)
       url ||= extract_key_from_block('url', &block)
       body = extract_key_from_block('body', &block)
+      body_to_log = '[undefined body]'
       if body
         begin
           body = JSON.parse(body)
+          # replace password in body if present
           body['password'] = '***' if body.kind_of?(Hash) && body.key?("password")
+          body_to_log = body.to_json
         rescue JSON::ParserError
-          # no json, no password
+          # no json, no password to replace
+          body_to_log = "[request body can not be represented as JSON]"
         end
       end
       params_to_log = Hash(params).dup # to also work with nil
@@ -780,7 +784,7 @@ module Spaceship
       params_to_log = params_to_log.collect do |key, value|
         "{#{key}: #{value}}"
       end
-      logger.info(">> #{method.upcase} #{url}: #{body.to_json} #{params_to_log.join(', ')}")
+      logger.info(">> #{method.upcase} #{url}: #{body_to_log} #{params_to_log.join(', ')}")
     end
 
     def log_response(method, url, response, headers = nil, &block)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
#13815 reported problems with the new logging code.

### Description
When sending a request with an image as the body, the current code failed. I rewrote this, so it is handled gracefully and logged correctly.

---

closes #13815
replaces #13823