### PR TITLE
[zip] Handle symbolic links

### DIFF
--- a/fastlane/lib/fastlane/actions/zip.rb
+++ b/fastlane/lib/fastlane/actions/zip.rb
@@ -81,8 +81,13 @@ module Fastlane
           'zip(
             path: "MyApp.app",
             output_path: "Latest.app.zip",
+            verbose: false
+          )',
+          'zip(
+            path: "MyApp.app",
+            output_path: "Latest.app.zip",
             verbose: false,
-            symlinks: false
+            symlinks: true
           )'
         ]
       end

--- a/fastlane/lib/fastlane/actions/zip.rb
+++ b/fastlane/lib/fastlane/actions/zip.rb
@@ -18,6 +18,7 @@ module Fastlane
 
         Dir.chdir(File.expand_path("..", params[:path])) do # required to properly zip
           zip_options = params[:verbose] ? "r" : "rq"
+          zip_options += "y" if params[:symlinks]
 
           if params[:password]
             password_option = "-P '#{params[:password]}'"
@@ -60,7 +61,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :password,
                                        env_name: "FL_ZIP_PASSWORD",
                                        description: "Encrypt the contents of the zip archive using a password",
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :symlinks,
+                                       env_name: "FL_ZIP_SYMLINKS",
+                                       description: "Store symbolic links as such in the zip archive",
+                                       optional: true,
+                                       type: Boolean,
+                                       default_value: false)
         ]
       end
 
@@ -74,7 +81,8 @@ module Fastlane
           'zip(
             path: "MyApp.app",
             output_path: "Latest.app.zip",
-            verbose: false
+            verbose: false,
+            symlinks: false
           )'
         ]
       end


### PR DESCRIPTION
With symlinks option it is now possible to create a zip file that stores symbolic links to the archive

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fastlane comes with a Zip action that enable users to zip files and folders. But it does not handle symbolic links as links, but instead it include all linked files. This is not wanted when the folder to zip already contains the linked files.

### Description
I have improved the already existing Zip action to control whether symbloic links should be treated as symbolic links or not. 
By default the behaviour of the action hasn't changed. By setting symlinks: true the user will get a zip file that can contain symbolic links.

I tested this on my build system by creating a copy of the zip action and included it in my repo. It works as expected :)