### PR TITLE
Fix AdbHelper

### DIFF
--- a/fastlane/lib/fastlane/helper/adb_helper.rb
+++ b/fastlane/lib/fastlane/helper/adb_helper.rb
@@ -26,7 +26,7 @@ module Fastlane
       # Run a certain action
       def trigger(command: nil, serial: nil)
         android_serial = serial != "" ? "ANDROID_SERIAL=#{serial}" : nil
-        command = [android_serial, adb_path.shellescape, command.shellescape].join(" ")
+        command = [android_serial, adb_path.shellescape, command].join(" ")
         Action.sh(command)
       end
 

--- a/fastlane/lib/fastlane/helper/adb_helper.rb
+++ b/fastlane/lib/fastlane/helper/adb_helper.rb
@@ -26,7 +26,7 @@ module Fastlane
       # Run a certain action
       def trigger(command: nil, serial: nil)
         android_serial = serial != "" ? "ANDROID_SERIAL=#{serial}" : nil
-        command = [android_serial, adb_path.shellescape, command].join(" ")
+        command = [android_serial, adb_path.shellescape, command].join(" ").strip!
         Action.sh(command)
       end
 

--- a/fastlane/spec/actions_specs/adb_spec.rb
+++ b/fastlane/spec/actions_specs/adb_spec.rb
@@ -6,7 +6,15 @@ describe Fastlane do
           adb(command: 'test', adb_path: './fastlane/README.md')
         end").runner.execute(:test)
 
-        expect(result).to eq(" ./fastlane/README.md test")
+        expect(result).to eq("./fastlane/README.md test")
+      end
+
+      it "generates a valid command for commands with multiple parts" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'test command with multiple parts', adb_path: './fastlane/README.md')
+        end").runner.execute(:test)
+
+        expect(result).to eq("./fastlane/README.md test command with multiple parts")
       end
 
       it "picks up path from ANDROID_HOME environment variable" do
@@ -15,7 +23,17 @@ describe Fastlane do
           adb(command: 'test')
         end").runner.execute(:test)
 
-        expect(result).to eq(" /usr/local/android-sdk/platform-tools/adb test")
+        expect(result).to eq("/usr/local/android-sdk/platform-tools/adb test")
+      end
+
+      it "picks up path from ANDROID_HOME environment variable and handles path that has to be made safe" do
+        stub_const('ENV', { 'ANDROID_HOME' => '/usr/local/android-sdk/with space' })
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'test')
+        end").runner.execute(:test)
+
+        path = "/usr/local/android-sdk/with space/platform-tools/adb".shellescape
+        expect(result).to eq("#{path} test")
       end
 
       it "picks up path from ANDROID_SDK_ROOT environment variable" do
@@ -24,7 +42,7 @@ describe Fastlane do
           adb(command: 'test')
         end").runner.execute(:test)
 
-        expect(result).to eq(" /usr/local/android-sdk/platform-tools/adb test")
+        expect(result).to eq("/usr/local/android-sdk/platform-tools/adb test")
       end
 
       it "picks up path from ANDROID_SDK environment variable" do
@@ -33,7 +51,7 @@ describe Fastlane do
           adb(command: 'test')
         end").runner.execute(:test)
 
-        expect(result).to eq(" /usr/local/android-sdk/platform-tools/adb test")
+        expect(result).to eq("/usr/local/android-sdk/platform-tools/adb test")
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
https://github.com/fastlane/fastlane/pull/13692 added one `shellescape` too much and broke the execution of `adb` commands with several parts: `foo` works, `foo bar` is escaped to `foo\ bar` and does not work any more.

### Description
- Removes the `.shellescape`
- Adds tests for the multi part command case and the other case where shellescape of the path is actually needed (code added in #13692)
- Adds `.strip!` to the command, adapts the tests to not expect commands to be prefixed with an additional space

---

closes #13845