### PR TITLE
[action] Fix Crashlytics deprecated message for submit binary path

### DIFF
--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -24,7 +24,8 @@ module Fastlane
           path ||= Dir["./Pods/iOS/Crashlytics/Crashlytics.framework/submit"].last
           path ||= Dir["./**/Crashlytics.framework/submit"].last
 
-          if path && path.downcase.include?("crashlytics.framework")
+          downcase_path = path ? path.downcase : nil
+          if downcase_path && downcase_path.include?("pods") && downcase_path.include?("crashlytics.framework")
             UI.deprecated("Crashlytics has moved the submit binary outside of Crashlytics.framework directory as of 3.4.1. Please change :crashlytics_path to `<PODS_ROOT>/Crashlytics/submit`")
           end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
A deprecated message is always printed if the path of crashlytics submit binary is located under 'crashlytics.framework'.
While the deprecated message make sense for cocoapods install of crashlytics, it is not the case for other installation methods, like carthage.
Link to open issue: [13574](https://github.com/fastlane/fastlane/issues/13574)
All test passed.
All codestyle inspection passed

### Description
Added a test to check that the path also contains "pods" before displaying the deprecated message.
Tested path manipulation in/out to check that the deprecated message is printed only if "pods" is contained in the path.
