### PR TITLE
[Swift] Fix Snapshot simulator launch arguments are empty by default

### DIFF
--- a/snapshot/lib/snapshot/simulator_launchers/launcher_configuration.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/launcher_configuration.rb
@@ -42,7 +42,9 @@ module Snapshot
 
       launch_arguments = Array(snapshot_config[:launch_arguments])
       # if more than 1 set of arguments, use a tuple with an index
-      if launch_arguments.count == 1
+      if launch_arguments.count == 0
+        @launch_args_set = [[""]]
+      elsif launch_arguments.count == 1
         @launch_args_set = [launch_arguments]
       else
         @launch_args_set = launch_arguments.map.with_index { |e, i| [i, e] }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

See issues:
- https://github.com/fastlane/fastlane/issues/13861
- https://github.com/fastlane/fastlane/issues/13114 

When running Snapshot in Swift, the default launch arguments array `[""]` in Swift, becomes `[]` in Ruby.
Because the launch arguments must **never** remain empty, the tests are not run and Snapshot immediately generates the HTML report. 
Enforcing a default fallback with the Array `[""]` in Ruby when the provided launch arguments are empty, solves the problem and allow the tests to run before the HTML report is generated.

See issues:
- https://github.com/fastlane/fastlane/issues/13861
- https://github.com/fastlane/fastlane/issues/13114 

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

When instantiating the Simulator Launcher Configuration, the code bellow checks the case when the provided `launch_arguments` are empty, and if so gives the default value `[[""]]`.