### PR TITLE
[spaceship] Retry request when App Store Connect raises Bad Gateway

### DIFF
--- a/spaceship/lib/spaceship/errors.rb
+++ b/spaceship/lib/spaceship/errors.rb
@@ -71,6 +71,9 @@ module Spaceship
   # Raised when 500 is received from App Store Connect
   class InternalServerError < BasicPreferredInfoError; end
 
+  # Raised when 502 is received from App Store Connect
+  class BadGatewayError < BasicPreferredInfoError; end
+
   # Raised when 504 is received from App Store Connect
   class GatewayTimeoutError < BasicPreferredInfoError; end
 end

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -100,6 +100,7 @@ describe Spaceship::Client do
       Faraday::Error::TimeoutError,
       Faraday::Error::ConnectionFailed,
       Faraday::ParsingError,
+      Spaceship::BadGatewayError,
       Spaceship::InternalServerError,
       Spaceship::GatewayTimeoutError
     ].each do |thrown|
@@ -124,6 +125,43 @@ describe Spaceship::Client do
       expect do
         subject.req_home
       end.to raise_error(Spaceship::Client::AppleTimeoutError)
+    end
+
+    it "raises BadGatewayError when response contains 'Bad Gateway'" do
+      body = <<BODY
+      <!DOCTYPE html>
+<html lang="en">
+<head>
+    <style>
+        body {
+            font-family: "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
+            font-size: 15px;
+            font-weight: 200;
+            line-height: 20px;
+            color: #4c4c4c;
+            text-align: center;
+        }
+
+        .section {
+            margin-top: 50px;
+        }
+    </style>
+</head>
+<body>
+<div class="section">
+    <h1>&#63743;</h1>
+
+    <h3>Bad Gateway</h3>
+    <p>Correlation Key: XXXXXXXXXXXXXXXXXXXX</p>
+</div>
+</body>
+</html>
+BODY
+      stub_client_retry_auth(502, 1, 200, body)
+
+      expect do
+        subject.req_home
+      end.to raise_error(Spaceship::Client::BadGatewayError)
     end
 
     it "successfully retries request after logging in again when UnauthorizedAccess Error raised" do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Sometimes, App Store Connect raises Bad Gateway.

```html
<!DOCTYPE html>
<html lang="en">
<head>
    <style>
        body {
            font-family: "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
            font-size: 15px;
            font-weight: 200;
            line-height: 20px;
            color: #4c4c4c;
            text-align: center;
        }

        .section {
            margin-top: 50px;
        }
    </style>
</head>
<body>
<div class="section">
    <h1>&#63743;</h1>

    <h3>Bad Gateway</h3>
    <p>Correlation Key: XXXXXXXXXXXXXXXXXXXXX </p>
</div>
</body>
</html>
```

When fastlane/deliver is waiting a processing phase, lane execution is stoped due to this error.

We want to ignore this error and retry requests.

### Description

- Defined BadGateway error
- If BadGateway is raised, fastlane attempt to retry sending.