### PR TITLE
[Swift] Fix frameit's Boolean options are generated as String? instead of Bool?

### DIFF
--- a/fastlane/lib/fastlane/actions/frame_screenshots.rb
+++ b/fastlane/lib/fastlane/actions/frame_screenshots.rb
@@ -32,7 +32,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :path,
                                        env_name: "FRAMEIT_SCREENSHOTS_PATH",
                                        description: "The path to the directory containing the screenshots",
-                                        default_value: Actions.lane_context[SharedValues::SNAPSHOT_SCREENSHOTS_PATH] || FastlaneCore::FastlaneFolder.path,
+                                       default_value: Actions.lane_context[SharedValues::SNAPSHOT_SCREENSHOTS_PATH] || FastlaneCore::FastlaneFolder.path,
                                        default_value_dynamic: true)
         ]
       end

--- a/frameit/lib/frameit/module.rb
+++ b/frameit/lib/frameit/module.rb
@@ -1,4 +1,5 @@
 require 'fastlane_core/helper'
+require 'fastlane/boolean'
 
 require_relative 'config_parser'
 
@@ -7,6 +8,7 @@ module Frameit
     attr_accessor :config
   end
 
+  Boolean = Fastlane::Boolean
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
   ROOT = Pathname.new(File.expand_path('../../..', __FILE__))

--- a/frameit/lib/frameit/options.rb
+++ b/frameit/lib/frameit/options.rb
@@ -8,22 +8,25 @@ module Frameit
       @options ||= [
 
         FastlaneCore::ConfigItem.new(key: :white,
-                                       env_name: "FRAMEIT_WHITE_FRAME",
-                                       description: "Use white device frames",
-                                       optional: true,
-                                       is_string: false),
+                                     env_name: "FRAMEIT_WHITE_FRAME",
+                                     description: "Use white device frames",
+                                     type: Boolean,
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :silver,
+                                     env_name: "FRAMEIT_SILVER_FRAME",
                                      description: "Use white device frames. Alias for :white",
-                                     optional: true,
-                                     is_string: false),
+                                     type: Boolean,
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :rose_gold,
+                                     env_name: "FRAMEIT_ROSE_GOLD_FRAME",
                                      description: "Use rose gold device frames. Alias for :rose_gold",
-                                     optional: true,
-                                     is_string: false),
+                                     type: Boolean,
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :gold,
+                                     env_name: "FRAMEIT_GOLD_FRAME",
                                      description: "Use gold device frames. Alias for :gold",
-                                     optional: true,
-                                     is_string: false),
+                                     type: Boolean,
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :force_device_type,
                                      env_name: "FRAMEIT_FORCE_DEVICE_TYPE",
                                      description: "Forces a given device type, useful for Mac screenshots, as their sizes vary",
@@ -35,29 +38,29 @@ module Frameit
                                        end
                                      end),
         FastlaneCore::ConfigItem.new(key: :use_legacy_iphone5s,
-                           env_name: "FRAMEIT_USE_LEGACY_IPHONE_5_S",
-                           is_string: false,
-                           description: "Use iPhone 5s instead of iPhone SE frames",
-                           default_value: false),
+                                     env_name: "FRAMEIT_USE_LEGACY_IPHONE_5_S",
+                                     description: "Use iPhone 5s instead of iPhone SE frames",
+                                     default_value: false,
+                                     type: Boolean),
         FastlaneCore::ConfigItem.new(key: :use_legacy_iphone6s,
-                           env_name: "FRAMEIT_USE_LEGACY_IPHONE_6_S",
-                           is_string: false,
-                           description: "Use iPhone 6s frames instead of iPhone 7 frames",
-                           default_value: false),
+                                     env_name: "FRAMEIT_USE_LEGACY_IPHONE_6_S",
+                                     description: "Use iPhone 6s frames instead of iPhone 7 frames",
+                                     default_value: false,
+                                     type: Boolean),
         FastlaneCore::ConfigItem.new(key: :force_orientation_block,
-                           type: :string_callback,
-                           description: "[Advanced] A block to customize your screenshots' device orientation",
-                           display_in_shell: false,
-                           optional: true,
-                           default_value: proc do |filename|
-                             f = filename.downcase
-                             if f.end_with?("force_landscapeleft")
-                               :landscape_left
-                             elsif f.end_with?("force_landscaperight")
-                               :landscape_right
-                             end
-                           end,
-                           default_value_dynamic: true)
+                                     type: :string_callback,
+                                     description: "[Advanced] A block to customize your screenshots' device orientation",
+                                     display_in_shell: false,
+                                     optional: true,
+                                     default_value: proc do |filename|
+                                       f = filename.downcase
+                                       if f.end_with?("force_landscapeleft")
+                                         :landscape_left
+                                       elsif f.end_with?("force_landscaperight")
+                                         :landscape_right
+                                       end
+                                     end,
+                                     default_value_dynamic: true)
       ]
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

See issue: https://github.com/fastlane/fastlane/issues/13879

When the `frameScreenshot` action is generated from Ruby to Swift, its implicit `Optional Boolean` parameters are interpreted as `String?` (default fallback for non-explicit Ruby types).

See issue: https://github.com/fastlane/fastlane/issues/13879

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

Giving the `Options Config type` explicitly allows the `generate_swift_api` action to detect the type.

### Discussion

Why are these Options `Optional` at the first place?
Could we simply have them required with a `default_value` of `false`?