### PR TITLE
Add human-readable storage identifier string to various match outputs

### DIFF
--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -168,8 +168,9 @@ module Match
 
           [file_type, components[2]]
         end
+
         puts(Terminal::Table.new({
-          title: "Files that are going to be deleted".green,
+          title: "Files that are going to be deleted".green + "\n" + self.storage.human_readble_description,
           headings: ["Type", "File Name"],
           rows: rows
         }))

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -170,7 +170,7 @@ module Match
         end
 
         puts(Terminal::Table.new({
-          title: "Files that are going to be deleted".green + "\n" + self.storage.human_readble_description,
+          title: "Files that are going to be deleted".green + "\n" + self.storage.human_readable_description,
           headings: ["Type", "File Name"],
           rows: rows
         }))

--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -96,6 +96,10 @@ module Match
         checkout_branch unless self.branch == "master"
       end
 
+      def human_readble_description
+        "Git Repo [#{self.git_url}]"
+      end
+
       def delete_files(files_to_delete: [], custom_message: nil)
         # No specific list given, e.g. this happens on `fastlane match nuke`
         # We just want to run `git add -A` to commit everything

--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -96,7 +96,7 @@ module Match
         checkout_branch unless self.branch == "master"
       end
 
-      def human_readble_description
+      def human_readable_description
         "Git Repo [#{self.git_url}]"
       end
 

--- a/match/lib/match/storage/google_cloud_storage.rb
+++ b/match/lib/match/storage/google_cloud_storage.rb
@@ -100,7 +100,7 @@ module Match
         end
       end
 
-      def human_readble_description
+      def human_readable_description
         "Google Cloud Bucket [#{self.project_id}/#{self.bucket_name}]"
       end
 

--- a/match/lib/match/storage/google_cloud_storage.rb
+++ b/match/lib/match/storage/google_cloud_storage.rb
@@ -98,7 +98,10 @@ module Match
           UI.message("Deleting '#{target_path}' from Google Cloud Storage bucket '#{self.bucket_name}'...")
           file.delete
         end
-        finished_pushing_message
+      end
+
+      def human_readble_description
+        "Google Cloud Bucket [#{self.project_id}/#{self.bucket_name}]"
       end
 
       def upload_files(files_to_upload: [], custom_message: nil)
@@ -118,7 +121,6 @@ module Match
           UI.verbose("Uploading '#{target_path}' to Google Cloud Storage...")
           bucket.create_file(current_file, target_path)
         end
-        finished_pushing_message
       end
 
       def skip_docs
@@ -126,10 +128,6 @@ module Match
       end
 
       private
-
-      def finished_pushing_message
-        UI.success("Finished applying changes up to Google Cloud Storage on bucket '#{self.bucket_name}'")
-      end
 
       def bucket
         @_bucket ||= self.gc_storage.bucket(self.bucket_name)

--- a/match/lib/match/storage/interface.rb
+++ b/match/lib/match/storage/interface.rb
@@ -31,6 +31,12 @@ module Match
         not_implemented(__method__)
       end
 
+      # Returns a short string describing + identifing the current
+      # storage backend. This will be printed when nuking a storage
+      def human_readble_description
+        not_implemented(__method__)
+      end
+
       # Call this method after locally modifying the files
       # This will commit the changes and push it back to the
       # given remote server
@@ -62,8 +68,10 @@ module Match
             end
 
             self.upload_files(files_to_upload: files_to_commit, custom_message: custom_message)
+            UI.message("Finished uploading files to #{self.human_readble_description}")
           elsif files_to_delete.count > 0
             self.delete_files(files_to_delete: files_to_delete, custom_message: custom_message)
+            UI.message("Finished deleting files from #{self.human_readble_description}")
           else
             UI.user_error!("Neither `files_to_commit` nor `files_to_delete` were provided to the `save_changes!` method call")
           end

--- a/match/lib/match/storage/interface.rb
+++ b/match/lib/match/storage/interface.rb
@@ -33,7 +33,7 @@ module Match
 
       # Returns a short string describing + identifing the current
       # storage backend. This will be printed when nuking a storage
-      def human_readble_description
+      def human_readable_description
         not_implemented(__method__)
       end
 
@@ -68,10 +68,10 @@ module Match
             end
 
             self.upload_files(files_to_upload: files_to_commit, custom_message: custom_message)
-            UI.message("Finished uploading files to #{self.human_readble_description}")
+            UI.message("Finished uploading files to #{self.human_readable_description}")
           elsif files_to_delete.count > 0
             self.delete_files(files_to_delete: files_to_delete, custom_message: custom_message)
-            UI.message("Finished deleting files from #{self.human_readble_description}")
+            UI.message("Finished deleting files from #{self.human_readable_description}")
           else
             UI.user_error!("Neither `files_to_commit` nor `files_to_delete` were provided to the `save_changes!` method call")
           end


### PR DESCRIPTION
So beautiful, this will make it much easier for developers to understand what's going on

**Git**
![screen shot 2018-12-11 at 1 27 09 pm](https://user-images.githubusercontent.com/869950/49821517-a0ad8880-fd48-11e8-8ee7-f8030b68929a.png)

**Google Cloud**
![screen shot 2018-12-11 at 1 26 38 pm](https://user-images.githubusercontent.com/869950/49821545-adca7780-fd48-11e8-9254-b3c0f77db226.png)

![screen shot 2018-12-11 at 1 26 31 pm](https://user-images.githubusercontent.com/869950/49821519-a0ad8880-fd48-11e8-99b0-9f08a857f42b.png)
