### PR TITLE
[docs] crashlytics: better `crashlytics_path` explanation and examples

### DIFF
--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -162,15 +162,24 @@ module Fastlane
       def self.details
         [
           "Additionally, you can specify `notes`, `emails`, `groups` and `notifications`.",
-          "Distributing to Groups: When using the `groups` parameter, it's important to use the group **alias** names for each group you'd like to distribute to. A group's alias can be found in the web UI. If you're viewing the Beta page, you can open the groups dialog by clicking the 'Manage Groups' button."
+          "Distributing to Groups: When using the `groups` parameter, it's important to use the group **alias** names for each group you'd like to distribute to. A group's alias can be found in the web UI. If you're viewing the Beta page, you can open the groups dialog by clicking the 'Manage Groups' button.",
+          "This action uses the `submit` binary provided by the Crashlytics framework. If the binary is not found in its usual path, you'll need to specify the path manually by using the `crashlytics_path` option."
         ].join("\n")
       end
 
       def self.example_code
         [
           'crashlytics',
-          'crashlytics(
-            crashlytics_path: "./Pods/Crashlytics/", # path to your Crashlytics submit binary.
+          '# If you installed Crashlytics via CocoaPods
+          crashlytics(
+            crashlytics_path: "./Pods/Crashlytics/submit", # path to your Crashlytics submit binary.
+            api_token: "...",
+            build_secret: "...",
+            ipa_path: "./app.ipa"
+          )',
+          '# If you installed Crashlytics via Carthage for iOS platform
+          crashlytics(
+            crashlytics_path: "./Carthage/Build/iOS/Crashlytics.framework/submit", # path to your Crashlytics submit binary.
             api_token: "...",
             build_secret: "...",
             ipa_path: "./app.ipa"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- crashlytics `crashlytics_path` option is not documented.
- Users are not understanding triggered warning when using crashlytics action
Link to open issue: [13574](https://github.com/fastlane/fastlane/issues/13574)
All test passed.
All codestyle inspection passed

### Description
Explain the `crashlytics_path` option usage
Add examples for using crashlytics action with CocoaPods and Carthage installation of Crashlytics framework
