### PR TITLE
[docs] Improve instructions for using Charles to debug spaceship

### DIFF
--- a/ToolsAndDebugging.md
+++ b/ToolsAndDebugging.md
@@ -28,45 +28,11 @@ DEBUG=1 bundle exec rspec
 You will then jump into an interactive debugger that allows you to print out variables, call methods and [much more](https://github.com/pry/pry/wiki).
 To continue running the original script use `control` + `d`
 
-## Debugging and patching [_spaceship_](https://spaceship.airforce) issues
+## Debugging and patching [_spaceship_](https://github.com/fastlane/fastlane/tree/master/spaceship) problems
 
 ### Introduction to _spaceship_
 
-_spaceship_ uses [Faraday](https://github.com/lostisland/faraday) to interact with multiple Apple API endpoints:
-
-- `https://idmsa.apple.com`: Used to authenticate to get a valid session
-- `https://developerservices2.apple.com`: For provisioning profiles and devices
-  - List provisioning profiles
-  - Register new devices
-- `https://developer.apple.com`:
-  - List all devices, certificates, apps and app groups
-  - Create new certificates, provisioning profiles and apps
-  - Disable/enable services on apps and assign them to app groups
-  - Delete certificates and apps
-  - Repair provisioning profiles
-  - Download provisioning profiles
-  - Team selection
-- `https://appstoreconnect.apple.com`:
-  - Managing apps
-  - Managing beta testers
-  - Submitting updates to review
-  - Managing app metadata
-- `https://du-itc.appstoreconnect.apple.com`:
-  - Upload icons, screenshots, trailers ...
-
-_spaceship_ is split into 3 layers:
-
-- `client.rb` which is the client superclass that contains all shared code between App Store Connect the Developer Portal
-- `tunes_client.rb` and `portal_client.rb` which are the implementations for both App Store Connect and Developer Portal. Those classes include the actual HTTP requests that are being sent:
-```ruby
-def app_version_data(app_id, version_platform: nil, version_id: nil)
-  r = request(:get, "ra/apps/#{app_id}/platforms/#{version_platform}/versions/#{version_id}")
-  parse_response(r, 'data')
-end
-```
-- _spaceship_ classes, e.g. `app_version.rb` which contain the API the user works with. These classes usually have some logic on how to handle responses.
-
-Don’t use any custom HTML parsing in _spaceship_, instead try to only use JSON and XML APIs.
+[_spaceship_](https://github.com/fastlane/fastlane/tree/master/spaceship) is fastlane's connection to Apple service. It is a Ruby library that exposes the Apple Developer Center and App Store Connect API. It’s super fast, well tested and supports all of the operations you can do via the browser. Scripting your Developer Center workflow has never been easier! 
 
 ### Verify the website works
 
@@ -77,7 +43,7 @@ If it is a server issue, it’s best to [file a radar](https://bugreport.apple.c
 
 <img src=".assets/ToolingCharlesEnableSSL.png" align="right" width="180" />
 
-This section explains how you can set up [Charles Proxy](https://www.charlesproxy.com/) to track local https traffic and inspect the requests and their responses. Charles is a paid application with a free option that’s usually good enough for a quick debugging session limited to 15 minutes. If you prefer a free open source alternative, check out [mitmproxy](https://mitmproxy.org/).
+This section explains how you can set up [Charles Proxy](https://www.charlesproxy.com/) to track local https traffic and inspect the requests and their responses. Charles is a paid application with a free option that’s usually good enough for a quick debugging session limited to 30 minutes. If you prefer a free open source alternative, check out [mitmproxy](https://mitmproxy.org/).
 
 First, download and install the latest version of [Charles Proxy](https://www.charlesproxy.com/). After the first launch, you’ll have to install its [Root Certificate](https://www.charlesproxy.com/documentation/using-charles/ssl-certificates/).
 
@@ -98,7 +64,7 @@ They key is to do the same action you want to test on both the website, and in _
 
 To pipe _spaceship_ requests through your local proxy, you need to set an environment variable:
 ```
-SPACESHIP_DEBUG=1 bundle exec fastlane spaceship
+SPACESHIP_DEBUG=1 bundle exec fastlane your_normal_command
 ```
 
 To make it easier to run the same script again, you can temporarily edit the `Rakefile` to look like this:

--- a/spaceship/docs/Architecture.md
+++ b/spaceship/docs/Architecture.md
@@ -1,5 +1,7 @@
 # Spaceship Architecture
 
+_spaceship_ uses [Faraday](https://github.com/lostisland/faraday) to interact with multiple Apple API endpoints:
+
 ## Overview
 
 Spaceship wraps various APIs using the following pattern:
@@ -9,3 +11,19 @@ The `client` is responsible for making HTTP requests for a given API or domain. 
 It is only responsible for creating the request and parsing the response. The best practice is for each method to have a single request and return the data from the response.
 
 The data models generally map to a REST resource or some logical grouping of data. Each data model has an instance of `client` which it can use to put or get data. It should encapsulate all interactions with the API, so other _fastlane_ tools interface with the data models, and not the `client` directly.
+
+## Technical
+
+_spaceship_ is split into 3 layers:
+
+- `client.rb` which is the client superclass that contains all shared code between App Store Connect the Developer Portal
+- `tunes_client.rb` and `portal_client.rb` which are the implementations for both App Store Connect and Developer Portal. Those classes include the actual HTTP requests that are being sent:
+```ruby
+def app_version_data(app_id, version_platform: nil, version_id: nil)
+  r = request(:get, "ra/apps/#{app_id}/platforms/#{version_platform}/versions/#{version_id}")
+  parse_response(r, 'data')
+end
+```
+- _spaceship_ classes, e.g. `app_version.rb` which contain the API the user works with. These classes usually have some logic on how to handle responses.
+
+Don’t use any custom HTML parsing in _spaceship_, instead try to only use JSON and XML APIs.

--- a/spaceship/docs/Debugging.md
+++ b/spaceship/docs/Debugging.md
@@ -20,6 +20,8 @@ Example logfile:
 
 _spaceship_ also comes with support for proxies (e.g. [Charles Web Proxy](https://www.charlesproxy.com/), free endless 30 minute trial available, available for all platforms) that listen on `https://127.0.0.1:8888`. Just set the environment variable `SPACESHIP_DEBUG` to activate.  
 
+Read the [section on configuring Charles Web Proxy in fastlane's "Tooling and Debugging" docs](https://github.com/fastlane/fastlane/blob/master/ToolsAndDebugging.md#setting-up-charles-web-proxy) for information on how to set it up.
+
 If your proxy is listening on another port or address, you can use `SPACESHIP_PROXY` to set this. Use `SPACESHIP_PROXY_SSL_VERIFY_NONE` to additionally disable certificate checking.
 
 ## Client configuration


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
ToolsAndDebugging.md and the spaceship docs had duplicated information and made it harder than necessary for someone to link to one location to instruct people on how to use Charles to create a traffic session.

### Description
Move the technical stuff to spaceship, crosslink back from spaceship to the existing Charles instructions. Fix tiny things along the way.
