### PR TITLE
[resign.sh] Fix bundle ID update in patched entitlements

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -787,7 +787,7 @@ function resign {
         OLD_BUNDLE_ID="$(PlistBuddy -c "Print :CFBundleIdentifier" "$TEMP_DIR/oldInfo.plist")"
         NEW_BUNDLE_ID="$(bundle_id_for_provison "$NEW_PROVISION")"
         log "Replacing old bundle ID '$OLD_BUNDLE_ID' with new bundle ID '$NEW_BUNDLE_ID' in patched entitlements"
-        sed -i .bak "s/$OLD_BUNDLE_ID/$NEW_BUNDLE_ID/g" "$PATCHED_ENTITLEMENTS"
+        sed -i .bak "s!${OLD_BUNDLE_ID}</string>!${NEW_BUNDLE_ID}</string>!g" "$PATCHED_ENTITLEMENTS"
 
         log "Resigning application using certificate: '$CERTIFICATE'"
         log "and patched entitlements:"

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -787,6 +787,12 @@ function resign {
         OLD_BUNDLE_ID="$(PlistBuddy -c "Print :CFBundleIdentifier" "$TEMP_DIR/oldInfo.plist")"
         NEW_BUNDLE_ID="$(bundle_id_for_provison "$NEW_PROVISION")"
         log "Replacing old bundle ID '$OLD_BUNDLE_ID' with new bundle ID '$NEW_BUNDLE_ID' in patched entitlements"
+        # Note: ideally we'd match against the opening <string> tag too, but this isn't possible
+        # because $OLD_BUNDLE_ID and $NEW_BUNDLE_ID do not include the team ID prefix which is
+        # present in the entitlements file.
+        # e.g. <string>AB1GP98Q19.com.example.foo</string>
+        #         vs
+        #      com.example.foo
         sed -i .bak "s!${OLD_BUNDLE_ID}</string>!${NEW_BUNDLE_ID}</string>!g" "$PATCHED_ENTITLEMENTS"
 
         log "Resigning application using certificate: '$CERTIFICATE'"


### PR DESCRIPTION
When the new bundle ID is a prefix of the old bundle ID, and the patched
entitlements file contains the correct ID already, the code old ended up
duplicate the suffix in the entitlements.

e.g. old ID: com.example.foo
     new ID: com.example.fooBar

Would result in a bundle ID of com.example.fooBarBar in the entitlements
file.

Fixes #9550

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #9550

### Description
In the resign.sh script, sed matches against the old bundle ID, replacing it with the new one. This is problematic if (a) the bundle ID is already correct and (b) if the old bundle ID is a suffix of the new one. Fix is to also match against the </string> tag.

(One question I had btw is: is this logic even needed? Presumably the new bundle ID will already be correct if it is extracted out of the provisioning profile? I'm guessing though there are cases I'm not aware of so just fixed it this way).