### PR TITLE
[match] fix match adhoc RuntimeError error

### DIFF
--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -199,6 +199,8 @@ module Spaceship
                     Development
                   when 'store'
                     AppStore
+                  when 'adhoc'
+                    AdHoc
                   when 'inhouse'
                     InHouse
                   when 'direct'


### PR DESCRIPTION
Closes #13905

It seems something changed on the API end that
is suddenly causing "adhoc" to show up as a
distribution method, yet the case statement
wasn't previously handling it.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Closes #13905

### Description
Adds a missing "adhoc" case statement to handle new values coming from the API.
