### PR TITLE
[core] remove leftover launch and completion analytics from UpdateChecker

### DIFF
--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -17,14 +17,6 @@ module FastlaneCore
 
       Thread.new do
         begin
-          send_launch_analytic_events_for(gem_name)
-        rescue
-          # we don't want to show a stack trace if something goes wrong
-        end
-      end
-
-      Thread.new do
-        begin
           server_results[gem_name] = fetch_latest(gem_name)
         rescue
           # we don't want to show a stack trace if something goes wrong
@@ -46,14 +38,6 @@ module FastlaneCore
     end
 
     def self.show_update_status(gem_name, current_version)
-      Thread.new do
-        begin
-          send_completion_events_for(gem_name)
-        rescue
-          # we don't want to show a stack trace if something goes wrong
-        end
-      end
-
       if update_available?(gem_name, current_version)
         show_update_message(gem_name, current_version)
       end
@@ -120,179 +104,6 @@ module FastlaneCore
 
     def self.generate_fetch_url(gem_name)
       "https://rubygems.org/api/v1/gems/#{gem_name}.json"
-    end
-
-    def self.send_launch_analytic_events_for(gem_name)
-      return if FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
-      ci = Helper.ci?.to_s
-      app_id_guesser = FastlaneCore::AppIdentifierGuesser.new(args: ARGV, gem_name: gem_name)
-      project_hash = app_id_guesser.p_hash
-      p_hash = project_hash if project_hash
-      platform = @platform if @platform # this has to be called after `p_hash`
-
-      send_launch_analytic_events(p_hash, gem_name, platform, ci)
-    end
-
-    def self.send_launch_analytic_events(p_hash, tool, platform, ci)
-      timestamp_seconds = Time.now.to_i
-
-      analytics = []
-      analytics << event_for_p_hash(p_hash, tool, platform, timestamp_seconds) if p_hash
-      analytics << event_for_launch(tool, ci, timestamp_seconds)
-
-      send_events(analytics)
-    end
-
-    def self.event_for_p_hash(p_hash, tool, platform, timestamp_seconds)
-      {
-        event_source: {
-          oauth_app_name: oauth_app_name,
-          product: 'fastlane'
-        },
-        actor: {
-          name: 'project',
-          detail: p_hash
-        },
-        action: {
-          name: 'update_checked'
-        },
-        primary_target: {
-          name: 'tool',
-          detail: tool || 'unknown'
-        },
-        secondary_target: {
-          name: 'platform',
-          detail: secondary_target_string(platform || 'unknown')
-        },
-        millis_since_epoch: timestamp_seconds * 1000,
-        version: 1
-      }
-    end
-
-    def self.event_for_launch(tool, ci, timestamp_seconds)
-      {
-        event_source: {
-          oauth_app_name: oauth_app_name,
-          product: 'fastlane'
-        },
-        actor: {
-          name: 'tool',
-          detail: tool || 'unknown'
-        },
-        action: {
-          name: 'launched'
-        },
-        primary_target: {
-          name: 'ci',
-          detail: ci
-        },
-        secondary_target: {
-          name: 'launch',
-          detail: secondary_target_string('')
-        },
-        millis_since_epoch: timestamp_seconds * 1000,
-        version: 1
-      }
-    end
-
-    def self.send_completion_events_for(gem_name)
-      return if FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
-
-      ci = Helper.ci?.to_s
-      install_method = if Helper.rubygems?
-                         'gem'
-                       elsif Helper.bundler?
-                         'bundler'
-                       elsif Helper.mac_app?
-                         'mac_app'
-                       elsif Helper.contained_fastlane?
-                         'standalone'
-                       elsif Helper.homebrew?
-                         'homebrew'
-                       else
-                         'unknown'
-                       end
-      duration = (Time.now - start_time).to_i
-      timestamp_seconds = Time.now.to_i
-
-      send_completion_events(gem_name, ci, install_method, duration, timestamp_seconds)
-    end
-
-    def self.send_events(analytics)
-      analytic_event_body = { analytics: analytics }.to_json
-
-      url = ENV["FASTLANE_METRICS_URL"] || "https://fastlane-metrics.fabric.io/public"
-      Excon.post(url,
-                 body: analytic_event_body,
-                 headers: { "Content-Type" => 'application/json' })
-    end
-
-    def self.event_for_completion(tool, ci, duration, timestamp_seconds)
-      {
-        event_source: {
-          oauth_app_name: oauth_app_name,
-          product: 'fastlane'
-        },
-        actor: {
-          name: 'tool',
-          detail: tool || 'unknown'
-        },
-        action: {
-          name: 'completed_with_duration'
-        },
-        primary_target: {
-          name: 'duration',
-          detail: duration.to_s
-        },
-        secondary_target: {
-          name: 'ci',
-          detail: secondary_target_string(ci)
-        },
-        millis_since_epoch: timestamp_seconds * 1000,
-        version: 1
-      }
-    end
-
-    def self.event_for_install_method(tool, ci, install_method, timestamp_seconds)
-      {
-        event_source: {
-          oauth_app_name: oauth_app_name,
-          product: 'fastlane'
-        },
-        actor: {
-          name: 'tool',
-          detail: tool || 'unknown'
-        },
-        action: {
-          name: 'completed_with_install_method'
-        },
-        primary_target: {
-          name: 'install_method',
-          detail: install_method
-        },
-        secondary_target: {
-          name: 'ci',
-          detail: secondary_target_string(ci)
-        },
-        millis_since_epoch: timestamp_seconds * 1000,
-        version: 1
-      }
-    end
-
-    def self.secondary_target_string(string)
-      return string
-    end
-
-    def self.oauth_app_name
-      return 'fastlane-refresher'
-    end
-
-    def self.send_completion_events(tool, ci, install_method, duration, timestamp_seconds)
-      analytics = []
-      analytics << event_for_completion(tool, ci, duration, timestamp_seconds)
-      analytics << event_for_install_method(tool, ci, install_method, timestamp_seconds)
-
-      send_events(analytics)
     end
   end
 end

--- a/fastlane_core/spec/app_identifier_guesser_spec.rb
+++ b/fastlane_core/spec/app_identifier_guesser_spec.rb
@@ -1,0 +1,41 @@
+require 'fastlane_core/analytics/app_identifier_guesser'
+
+describe FastlaneCore do
+  describe FastlaneCore::AppIdentifierGuesser do
+    def android_hash_of(value)
+      hash_of("android_project_#{value}")
+    end
+
+    def hash_of(value)
+      Digest::SHA256.hexdigest("p#{value}fastlan3_SAlt")
+    end
+
+    describe "#p_hash?" do
+      let(:package_name) { 'com.test.app' }
+
+      before do
+        ENV.delete("FASTLANE_OPT_OUT_USAGE")
+      end
+
+      it "chooses the correct param for package name for supply" do
+        args = ["--skip_upload_screenshots", "-a", "beta", "-p", package_name]
+        guesser = FastlaneCore::AppIdentifierGuesser.new(args: args, gem_name: 'supply')
+
+        expect(guesser.p_hash).to eq(android_hash_of(package_name))
+      end
+
+      it "chooses the correct param for package name for screengrab" do
+        args = ["--skip_open_summary", "-a", package_name, "-p", "com.test.app.test"]
+
+        guesser = FastlaneCore::AppIdentifierGuesser.new(args: args, gem_name: 'screengrab')
+        expect(guesser.p_hash).to eq(android_hash_of(package_name))
+      end
+
+      it "chooses the correct param for package name for gym" do
+        args = ["--clean", "-a", package_name, "-p", "test.xcodeproj"]
+        guesser = FastlaneCore::AppIdentifierGuesser.new(args: args, gem_name: 'gym')
+        expect(guesser.p_hash).to eq(hash_of(package_name))
+      end
+    end
+  end
+end

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -1,16 +1,8 @@
 require 'fastlane_core/update_checker/update_checker'
-require 'fastlane_core/analytics/app_identifier_guesser'
 
 describe FastlaneCore do
   describe FastlaneCore::UpdateChecker do
     let(:name) { 'fastlane' }
-    def android_hash_of(value)
-      hash_of("android_project_#{value}")
-    end
-
-    def hash_of(value)
-      Digest::SHA256.hexdigest("p#{value}fastlan3_SAlt")
-    end
 
     describe "#update_available?" do
       it "no update is available" do
@@ -74,107 +66,6 @@ describe FastlaneCore do
         with_env_values('FASTLANE_SELF_CONTAINED' => 'false') do
           expect(FastlaneCore::UpdateChecker.update_command).to eq("the Fabric app. Launch the app and navigate to the fastlane tab to get the most recent version.")
         end
-      end
-    end
-
-    describe "#p_hash?" do
-      let(:package_name) { 'com.test.app' }
-
-      before do
-        ENV.delete("FASTLANE_OPT_OUT_USAGE")
-      end
-
-      it "chooses the correct param for package name for supply" do
-        args = ["--skip_upload_screenshots", "-a", "beta", "-p", package_name]
-        guesser = FastlaneCore::AppIdentifierGuesser.new(args: args, gem_name: 'supply')
-
-        expect(guesser.p_hash).to eq(android_hash_of(package_name))
-      end
-
-      it "chooses the correct param for package name for screengrab" do
-        args = ["--skip_open_summary", "-a", package_name, "-p", "com.test.app.test"]
-
-        guesser = FastlaneCore::AppIdentifierGuesser.new(args: args, gem_name: 'screengrab')
-        expect(guesser.p_hash).to eq(android_hash_of(package_name))
-      end
-
-      it "chooses the correct param for package name for gym" do
-        args = ["--clean", "-a", package_name, "-p", "test.xcodeproj"]
-        guesser = FastlaneCore::AppIdentifierGuesser.new(args: args, gem_name: 'gym')
-        expect(guesser.p_hash).to eq(hash_of(package_name))
-      end
-    end
-
-    describe "#send_launch_analytic_events_for" do
-      before do
-        ENV.delete("FASTLANE_OPT_OUT_USAGE")
-        allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
-      end
-
-      it "sends no events when opted out" do
-        with_env_values('FASTLANE_OPT_OUT_USAGE' => 'true') do
-          expect(FastlaneCore::UpdateChecker).to_not(receive(:send_events))
-          FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
-        end
-      end
-
-      it "has no p_hash event when no project defined" do
-        expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|
-          expect(analytics.size).to eq(1)
-          expect(analytics.find_all { |a| a[:actor][:detail] == 'fastlane' && a[:action][:name] == 'launched' }.size).to eq(1)
-        end
-
-        FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
-      end
-
-      it "identifies CI correctly" do
-        allow(FastlaneCore::Helper).to receive(:ci?).and_return(true)
-
-        expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|
-          expect(analytics.size).to eq(1)
-          expect(analytics.find_all { |a| a[:primary_target][:detail] == 'true' && a[:action][:name] == 'launched' }.size).to eq(1)
-        end
-
-        FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
-      end
-
-      it "contains p_hash event and uses the bundle identifier and hashes the value if available" do
-        stub_const('ENV', { 'PILOT_APP_IDENTIFIER' => 'com.krausefx.app' })
-        p_hashed_id = hash_of(ENV["PILOT_APP_IDENTIFIER"])
-
-        expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|
-          expect(analytics.size).to eq(2)
-          expect(analytics.find_all { |a| a[:actor][:detail] == 'fastlane' && a[:action][:name] == 'launched' }.size).to eq(1)
-          expect(analytics.find_all { |a| a[:actor][:name] == 'project' && a[:action][:name] == 'update_checked' && a[:actor][:detail] == p_hashed_id }.size).to eq(1)
-        end
-
-        FastlaneCore::UpdateChecker.send_launch_analytic_events_for("fastlane")
-      end
-    end
-
-    describe "#send_completion_events_for" do
-      before do
-        ENV.delete("FASTLANE_OPT_OUT_USAGE")
-        allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
-      end
-
-      it "sends no events when opted out" do
-        with_env_values('FASTLANE_OPT_OUT_USAGE' => 'true') do
-          expect(FastlaneCore::UpdateChecker).to_not(receive(:send_events))
-          FastlaneCore::UpdateChecker.send_completion_events_for("fastlane")
-        end
-      end
-
-      it "contains duration event and a install method event" do
-        allow(FastlaneCore::UpdateChecker).to receive(:start_time).and_return(Time.now)
-        allow(FastlaneCore::Helper).to receive(:rubygems?).and_return(true)
-        expect(FastlaneCore::UpdateChecker).to receive(:send_events) do |analytics|
-          expect(analytics.size).to eq(2)
-          expect(analytics.find_all { |a| a[:actor][:detail] == 'fastlane' && a[:action][:name] == 'completed_with_duration' && a[:primary_target][:detail] }.size).to eq(1)
-          expect(analytics.find_all { |a| a[:action][:name] == 'completed_with_install_method' && a[:primary_target][:detail] == 'gem' && a[:secondary_target][:detail] == 'false' }.size).to eq(1)
-        end
-
-        FastlaneCore::UpdateChecker.send_completion_events_for("fastlane")
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`UpdateChecker` still contains some Fabric analytics code that is used on launch and on completion. Besides the data not being used, it is also causing problems because it is run in a thread and one of its methods uses `Dir.chdir`, which then can lead to race conditions.

### Description
Remove the analytics code from `UpdateChecker`, move `AppIdentifierGuesser` tests into their own file.
