### PR TITLE
[deliver] default html generator to current dir

### DIFF
--- a/deliver/lib/deliver/html_generator.rb
+++ b/deliver/lib/deliver/html_generator.rb
@@ -9,7 +9,8 @@ module Deliver
 
     def run(options, screenshots)
       begin
-        fastlane_path = FastlaneCore::FastlaneFolder.path
+        # Use fastlane folder or default to current directory
+        fastlane_path = FastlaneCore::FastlaneFolder.path || "."
         html_path = self.render(options, screenshots, fastlane_path)
       rescue => ex
         UI.error(ex.inspect)


### PR DESCRIPTION
Fixes #13512

## Description
Users who run `deliver` without a `Fastfile` (or a way to find the [fastfolder path](https://github.com/fastlane/fastlane/blob/master/fastlane_core/lib/fastlane_core/fastlane_folder.rb#L9-L14)) would get an error when joining on `nil`. This fallsback to current directory if no fastlane folder path is found.

## Testing
I was able to replicate this by running `deliver` in a directory without a Fastfile using a system install version of fastlane. I tested by change by creating a new fastlane gem (with my fix) and installing it as a system gem and it solved my issue.