### PR TITLE
[action] update_info_plist: Output error message if xcodeproj can not be found

### DIFF
--- a/fastlane/lib/fastlane/actions/update_info_plist.rb
+++ b/fastlane/lib/fastlane/actions/update_info_plist.rb
@@ -14,7 +14,7 @@ module Fastlane
 
           # Assign folder from parameter or search for xcodeproj file
           folder = params[:xcodeproj] || Dir["*.xcodeproj"].first
-          UI.user_error!("Could not figure out your xcodeproj path. Please specify it using the xcodeproj parameter") if folder.nil?
+          UI.user_error!("Could not figure out your xcodeproj path. Please specify it using the `xcodeproj` parameter") if folder.nil?
 
           if params[:scheme]
             project = Xcodeproj::Project.open(folder)

--- a/fastlane/lib/fastlane/actions/update_info_plist.rb
+++ b/fastlane/lib/fastlane/actions/update_info_plist.rb
@@ -14,6 +14,7 @@ module Fastlane
 
           # Assign folder from parameter or search for xcodeproj file
           folder = params[:xcodeproj] || Dir["*.xcodeproj"].first
+          UI.user_error!("You must specify an xcodeproj path") if folder.nil?
 
           if params[:scheme]
             project = Xcodeproj::Project.open(folder)

--- a/fastlane/lib/fastlane/actions/update_info_plist.rb
+++ b/fastlane/lib/fastlane/actions/update_info_plist.rb
@@ -14,7 +14,7 @@ module Fastlane
 
           # Assign folder from parameter or search for xcodeproj file
           folder = params[:xcodeproj] || Dir["*.xcodeproj"].first
-          UI.user_error!("You must specify an xcodeproj path") if folder.nil?
+          UI.user_error!("Could not figure out your xcodeproj path. Please specify it using the xcodeproj parameter") if folder.nil?
 
           if params[:scheme]
             project = Xcodeproj::Project.open(folder)

--- a/fastlane/spec/actions_specs/update_info_plist_spec.rb
+++ b/fastlane/spec/actions_specs/update_info_plist_spec.rb
@@ -10,101 +10,117 @@ describe Fastlane do
       let(:app_identifier) { "com.test.plist" }
       let(:display_name) { "Update Info Plist Test" }
 
-      before do
-        # Set up example info.plist
-        FileUtils.mkdir_p(test_path)
-        source = File.join(fixtures_path, proj_file)
-        destination = File.join(test_path, proj_file)
-
-        # Copy .xcodeproj fixture, as it will be modified during the test
-        FileUtils.cp_r(source, destination)
-        File.write(File.join(test_path, plist_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>CFBundleDisplayName</key><string>empty</string><key>CFBundleIdentifier</key><string>empty</string></dict></plist>')
+      describe "without an existing xcodeproj file" do
+        it "throws an error when the xcodeproj file does not exist" do
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              update_info_plist ({
+                plist_path: '#{plist_path}',
+                app_identifier: '#{app_identifier}',
+                display_name: '#{display_name}'
+              })
+            end").runner.execute(:test)
+          end.to raise_error("You must specify an xcodeproj path")
+        end
       end
 
-      it "updates the info plist based on the given properties" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          update_info_plist ({
-            xcodeproj: '#{xcodeproj}',
-            plist_path: '#{plist_path}',
-            app_identifier: '#{app_identifier}',
-            display_name: '#{display_name}'
-          })
-        end").runner.execute(:test)
-        expect(result).to include("<string>#{display_name}</string>")
-        expect(result).to include("<string>#{app_identifier}</string>")
-      end
+      describe "with existing xcodeproj file" do
+        before do
+          # Set up example info.plist
+          FileUtils.mkdir_p(test_path)
+          source = File.join(fixtures_path, proj_file)
+          destination = File.join(test_path, proj_file)
 
-      it "updates the info plist based on the given block" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          update_info_plist ({
-            xcodeproj: '#{xcodeproj}',
-            plist_path: '#{plist_path}',
-            block: lambda { |plist|
-              plist['CFBundleIdentifier'] = '#{app_identifier}'
-              plist['CFBundleDisplayName'] = '#{display_name}'
-            }
-          })
-        end").runner.execute(:test)
-        expect(result).to include("<string>#{display_name}</string>")
-        expect(result).to include("<string>#{app_identifier}</string>")
-      end
+          # Copy .xcodeproj fixture, as it will be modified during the test
+          FileUtils.cp_r(source, destination)
+          File.write(File.join(test_path, plist_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>CFBundleDisplayName</key><string>empty</string><key>CFBundleIdentifier</key><string>empty</string></dict></plist>')
+        end
 
-      it "obtains info plist from the scheme" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          update_info_plist ({
-            xcodeproj: '#{xcodeproj}',
-            scheme: '#{scheme}',
-            block: lambda { |plist|
-              plist['TEST_PLIST_SUCCESSFULLY_RETRIEVED'] = true
-            }
-          })
-        end").runner.execute(:test)
-        expect(result).to include("TEST_PLIST_SUCCESSFULLY_RETRIEVED")
-      end
-
-      it "throws an error when the info plist file does not exist" do
-        # This is path update_info_plist creates to locate the plist file.
-        full_path = [test_path, proj_file, '..', "NOEXIST-#{plist_path}"].join(File::SEPARATOR)
-
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
+        it "updates the info plist based on the given properties" do
+          result = Fastlane::FastFile.new.parse("lane :test do
             update_info_plist ({
               xcodeproj: '#{xcodeproj}',
-              plist_path: 'NOEXIST-#{plist_path}',
+              plist_path: '#{plist_path}',
               app_identifier: '#{app_identifier}',
               display_name: '#{display_name}'
             })
           end").runner.execute(:test)
-        end.to raise_error("Couldn't find info plist file at path '#{full_path}'")
-      end
+          expect(result).to include("<string>#{display_name}</string>")
+          expect(result).to include("<string>#{app_identifier}</string>")
+        end
 
-      it "throws an error when the scheme does not exist" do
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
+        it "updates the info plist based on the given block" do
+          result = Fastlane::FastFile.new.parse("lane :test do
             update_info_plist ({
               xcodeproj: '#{xcodeproj}',
-              scheme: 'NOEXIST-#{scheme}',
-              app_identifier: '#{app_identifier}',
-              display_name: '#{display_name}'
+              plist_path: '#{plist_path}',
+              block: lambda { |plist|
+                plist['CFBundleIdentifier'] = '#{app_identifier}'
+                plist['CFBundleDisplayName'] = '#{display_name}'
+              }
             })
           end").runner.execute(:test)
-        end.to raise_error("Couldn't find scheme named 'NOEXIST-#{scheme}'")
-      end
+          expect(result).to include("<string>#{display_name}</string>")
+          expect(result).to include("<string>#{app_identifier}</string>")
+        end
 
-      it "returns 'false' if no plist parameters are specified" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          update_info_plist ({
-            xcodeproj: '#{xcodeproj}',
-            plist_path: 'NOEXIST-#{plist_path}'
-          })
-        end").runner.execute(:test)
-        expect(result).to eq(false)
-      end
+        it "obtains info plist from the scheme" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            update_info_plist ({
+              xcodeproj: '#{xcodeproj}',
+              scheme: '#{scheme}',
+              block: lambda { |plist|
+                plist['TEST_PLIST_SUCCESSFULLY_RETRIEVED'] = true
+              }
+            })
+          end").runner.execute(:test)
+          expect(result).to include("TEST_PLIST_SUCCESSFULLY_RETRIEVED")
+        end
 
-      after do
-        # Clean up files
-        File.delete(File.join(test_path, plist_path))
-        FileUtils.rm_rf(xcodeproj)
+        it "throws an error when the info plist file does not exist" do
+          # This is path update_info_plist creates to locate the plist file.
+          full_path = [test_path, proj_file, '..', "NOEXIST-#{plist_path}"].join(File::SEPARATOR)
+
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              update_info_plist ({
+                xcodeproj: '#{xcodeproj}',
+                plist_path: 'NOEXIST-#{plist_path}',
+                app_identifier: '#{app_identifier}',
+                display_name: '#{display_name}'
+              })
+            end").runner.execute(:test)
+          end.to raise_error("Couldn't find info plist file at path '#{full_path}'")
+        end
+
+        it "throws an error when the scheme does not exist" do
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              update_info_plist ({
+                xcodeproj: '#{xcodeproj}',
+                scheme: 'NOEXIST-#{scheme}',
+                app_identifier: '#{app_identifier}',
+                display_name: '#{display_name}'
+              })
+            end").runner.execute(:test)
+          end.to raise_error("Couldn't find scheme named 'NOEXIST-#{scheme}'")
+        end
+
+        it "returns 'false' if no plist parameters are specified" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            update_info_plist ({
+              xcodeproj: '#{xcodeproj}',
+              plist_path: 'NOEXIST-#{plist_path}'
+            })
+          end").runner.execute(:test)
+          expect(result).to eq(false)
+        end
+
+        after do
+          # Clean up files
+          File.delete(File.join(test_path, plist_path))
+          FileUtils.rm_rf(xcodeproj)
+        end
       end
     end
   end

--- a/fastlane/spec/actions_specs/update_info_plist_spec.rb
+++ b/fastlane/spec/actions_specs/update_info_plist_spec.rb
@@ -20,7 +20,7 @@ describe Fastlane do
                 display_name: '#{display_name}'
               })
             end").runner.execute(:test)
-          end.to raise_error("You must specify an xcodeproj path")
+          end.to raise_error("Could not figure out your xcodeproj path. Please specify it using the xcodeproj parameter")
         end
       end
 

--- a/fastlane/spec/actions_specs/update_info_plist_spec.rb
+++ b/fastlane/spec/actions_specs/update_info_plist_spec.rb
@@ -20,7 +20,7 @@ describe Fastlane do
                 display_name: '#{display_name}'
               })
             end").runner.execute(:test)
-          end.to raise_error("Could not figure out your xcodeproj path. Please specify it using the xcodeproj parameter")
+          end.to raise_error("Could not figure out your xcodeproj path. Please specify it using the `xcodeproj` parameter")
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes: https://github.com/fastlane/fastlane/issues/13927

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
* Wrote a test to confirm defective behaviour
* Checked against project setup described in ticket and see if the `conversion of nil` error has been replaced by a more descriptive error message