### PR TITLE
[docs] sigh: fix typo in options

### DIFF
--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -20,7 +20,7 @@ module Sigh
                                      end),
         FastlaneCore::ConfigItem.new(key: :developer_id,
                                      env_name: "SIGH_DEVELOPER_ID",
-                                     description: "Setting his flag will generate Developer ID profiles instead of App Store Profiles",
+                                     description: "Setting this flag will generate Developer ID profiles instead of App Store Profiles",
                                      is_string: false,
                                      default_value: false,
                                      conflicting_options: [:adhoc, :development],


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Changed typo for `developer_id` parameter in sigh
Setting **his** flag will... -> Setting **this** flag will...