### PR TITLE
[deliver] Add screenshot dimensions of Apple TV 4K

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -207,6 +207,7 @@ module Deliver
       }
     end
 
+    # reference: https://help.apple.com/app-store-connect/#/devd274dd925
     def self.devices
       return {
         ScreenSize::IOS_65 => [
@@ -225,21 +226,21 @@ module Deliver
         ScreenSize::IOS_40 => [
           [640, 1136],
           [640, 1096],
-          [1136, 600] # landscape status bar is smaller
+          [1136, 600] # landscape without status bar
         ],
         ScreenSize::IOS_35 => [
           [640, 960],
           [640, 920],
-          [960, 600] # landscape status bar is smaller
+          [960, 600] # landscape without status bar
         ],
-        ScreenSize::IOS_IPAD => [
+        ScreenSize::IOS_IPAD => [ # 9.7 inch
           [1024, 748],
           [1024, 768],
           [2048, 1496],
           [2048, 1536],
-          [768, 1004],
+          [768, 1004], # portrait without status bar
           [768, 1024],
-          [1536, 2008],
+          [1536, 2008], # portrait without status bar
           [1536, 2048]
         ],
         ScreenSize::IOS_IPAD_10_5 => [
@@ -257,8 +258,8 @@ module Deliver
         ScreenSize::MAC => [
           [1280, 800],
           [1440, 900],
-          [2880, 1800],
-          [2560, 1600]
+          [2560, 1600],
+          [2880, 1800]
         ],
         ScreenSize::IOS_APPLE_WATCH => [
           [312, 390]
@@ -267,7 +268,8 @@ module Deliver
           [368, 448]
         ],
         ScreenSize::APPLE_TV => [
-          [1920, 1080]
+          [1920, 1080],
+          [3840, 2160]
         ]
       }
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently one can't upload Apple TV 4K screenshots, as reported in #13925.

### Description
Adds the size of the 4k screenshots.

fixes #13925
