### PR TITLE
Added option to spaceship to be able to release version to all users

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -624,6 +624,10 @@ module Spaceship
         client.release!(self.application.apple_id, self.version_id)
       end
 
+      def release_to_all_users!
+        client.release_to_all_users!(self.application.apple_id, self.version_id)
+      end
+
       #####################################################
       # @!group Promo codes
       #####################################################

--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -391,6 +391,18 @@ module Spaceship
       end
 
       #####################################################
+      # @!group release to all users
+      #####################################################
+
+      def release_to_all_users!
+        version = self.live_version
+        if version.nil?
+          raise "Could not find a valid version to release"
+        end
+        version.release_to_all_users!
+      end
+
+      #####################################################
       # @!group General
       #####################################################
       def setup

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -1147,6 +1147,24 @@ module Spaceship
     end
 
     #####################################################
+    # @!group release to all users
+    #####################################################
+
+    def release_to_all_users!(app_id, version)
+      raise "app_id is required" unless app_id
+      raise "version is required" unless version
+
+      r = request(:post) do |req|
+        req.url("ra/apps/#{app_id}/versions/#{version}/phasedRelease/state/COMPLETE")
+        req.headers['Content-Type'] = 'application/json'
+        req.body = app_id.to_s
+      end
+
+      handle_itc_response(r.body)
+      parse_response(r, 'data')
+    end
+
+    #####################################################
     # @!group in-app-purchases
     #####################################################
 

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -58,6 +58,7 @@ def before_each_spaceship
   TunesStubbing.itc_stub_candiate_builds
   TunesStubbing.itc_stub_pricing_tiers
   TunesStubbing.itc_stub_release_to_store
+  TunesStubbing.itc_stub_release_to_all_users
   TunesStubbing.itc_stub_promocodes
   TunesStubbing.itc_stub_generate_promocodes
   TunesStubbing.itc_stub_promocodes_history

--- a/spaceship/spec/tunes/app_version_spec.rb
+++ b/spaceship/spec/tunes/app_version_spec.rb
@@ -148,6 +148,18 @@ describe Spaceship::AppVersion, all: true do
       end
     end
 
+    describe "release an app version in phased release to all users" do
+      it "allows releasing the live version to all users" do
+        version = app.live_version
+
+        version.raw_status = 'readyForSale'
+
+        status = version.release_to_all_users!
+
+        expect(version.raw_status).to eq('readyForSale')
+      end
+    end
+
     describe "#url" do
       it "live version" do
         expect(app.live_version.url).to eq("https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/#{app.apple_id}/#{app.platform}/versioninfo/deliverable")

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -293,6 +293,13 @@ class TunesStubbing
                   headers: { "Content-Type" => "application/json" })
     end
 
+    def itc_stub_release_to_all_users
+      stub_request(:post, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/versions/812106519/phasedRelease/state/COMPLETE").
+        with(body: "898536088").
+        to_return(status: 200, body: itc_read_fixture_file("update_app_version_success.json"),
+                  headers: { "Content-Type" => "application/json" })
+    end
+
     def itc_stub_promocodes
       stub_request(:get, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/promocodes/versions").
         to_return(status: 200, body: itc_read_fixture_file("promocodes.json"),


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
There is no way to release a version to all users after phased release has started without doing it manually on iTunesConnect or waiting for the phased release to be completed.
#13940

### Description
I've added the necessary code to be able to release a live version to all users. I didn't need to modify existing code, so there should be no breaking changes. I've based my code on the existing release! methods.
I've tested that this new feature is working by actually releasing an app version which was currently on phased release to all users by using the locally modified version of fastlane.