### PR TITLE
[match] Better Windows (and Linux) support

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -254,7 +254,9 @@ module Fastlane
           branch_option = "--branch #{branch}" if branch != 'HEAD'
 
           UI.message("Cloning remote git repo...")
-          Actions.sh("GIT_TERMINAL_PROMPT=0 git clone '#{url}' '#{clone_folder}' --depth 1 -n #{branch_option}")
+          Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
+            Actions.sh("git clone #{url.shellescape} #{clone_folder.shellescape} --depth 1 -n #{branch_option}")
+          end
 
           unless version.nil?
             req = Gem::Requirement.new(version)
@@ -263,14 +265,14 @@ module Fastlane
             UI.user_error!("No tag found matching #{version.inspect}") if checkout_param.nil?
           end
 
-          Actions.sh("cd '#{clone_folder}' && git checkout #{checkout_param} '#{path}'")
+          Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{path.shellescape}")
 
           # We also want to check out all the local actions of this fastlane setup
           containing = path.split(File::SEPARATOR)[0..-2]
           containing = "." if containing.count == 0
           actions_folder = File.join(containing, "actions")
           begin
-            Actions.sh("cd '#{clone_folder}' && git checkout #{checkout_param} '#{actions_folder}'")
+            Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{actions_folder.shellescape}")
           rescue
             # We don't care about a failure here, as local actions are optional
           end
@@ -290,10 +292,12 @@ module Fastlane
 
     def fetch_remote_tags(folder: nil)
       UI.message("Fetching remote git tags...")
-      Actions.sh("cd '#{folder}' && GIT_TERMINAL_PROMPT=0 git fetch --all --tags -q")
+      Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
+        Actions.sh("cd #{folder.shellescape} && git fetch --all --tags -q")
+      end
 
       # Fetch all possible tags
-      git_tags_string = Actions.sh("cd '#{folder}' && git tag -l")
+      git_tags_string = Actions.sh("cd #{folder.shellescape} && git tag -l")
       git_tags = git_tags_string.split("\n")
 
       # Sort tags based on their version number

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -299,6 +299,22 @@ module FastlaneCore
       Helper.backticks(command, print: print)
     end
 
+    # Executes the provided block after adjusting the ENV to have the
+    # provided keys and values set as defined in hash. After the block
+    # completes, restores the ENV to its previous state.
+    def self.with_env_values(hash, &block)
+      old_vals = ENV.select { |k, v| hash.include?(k) }
+      hash.each do |k, v|
+        ENV[k] = hash[k]
+      end
+      yield
+    ensure
+      hash.each do |k, v|
+        ENV.delete(k) unless old_vals.include?(k)
+        ENV[k] = old_vals[k]
+      end
+    end
+
     # loading indicator
     #
 

--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -26,7 +26,14 @@ module FastlaneCore
       def parse(path, keychain_path = nil)
         require 'plist'
 
-        plist = Plist.parse_xml(decode(path, keychain_path))
+        if Helper.mac?
+          plist = Plist.parse_xml(decode(path, keychain_path))
+        else
+          # `decode` only works on Mac because of `security`, fallback `openssl`
+          # via https://stackoverflow.com/a/14379814/252627
+          xml = `openssl smime -inform der -verify -noverify -in #{path}` 
+          plist = Plist.parse_xml(xml)
+        end
         if (plist || []).count > 5
           plist
         else

--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -31,7 +31,7 @@ module FastlaneCore
         else
           # `decode` only works on Mac because of `security`, fallback `openssl`
           # via https://stackoverflow.com/a/14379814/252627
-          xml = `openssl smime -inform der -verify -noverify -in #{path}` 
+          xml = `openssl smime -inform der -verify -noverify -in #{path}`
           plist = Plist.parse_xml(xml)
         end
         if (plist || []).count > 5

--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -26,14 +26,7 @@ module FastlaneCore
       def parse(path, keychain_path = nil)
         require 'plist'
 
-        if Helper.mac?
-          plist = Plist.parse_xml(decode(path, keychain_path))
-        else
-          # `decode` only works on Mac because of `security`, fallback `openssl`
-          # via https://stackoverflow.com/a/14379814/252627
-          xml = `openssl smime -inform der -verify -noverify -in #{path}`
-          plist = Plist.parse_xml(xml)
-        end
+        plist = Plist.parse_xml(decode(path, keychain_path))
         if (plist || []).count > 5
           plist
         else
@@ -98,10 +91,16 @@ module FastlaneCore
           err = "#{dir}/cms.err"
           # we want to prevent the error output to mix up with the standard output because of
           # /dev/null: https://github.com/fastlane/fastlane/issues/6387
-          if keychain_path.nil?
-            decoded = `security cms -D -i "#{path}" 2> #{err}`
+          if Helper.mac?
+            if keychain_path.nil?
+              decoded = `security cms -D -i "#{path}" 2> #{err}`
+            else
+              decoded = `security cms -D -i "#{path}" -k "#{keychain_path.shellescape}" 2> #{err}`
+            end
           else
-            decoded = `security cms -D -i "#{path}" -k "#{keychain_path.shellescape}" 2> #{err}`
+            # `security` only works on Mac, fallback to `openssl`
+            # via https://stackoverflow.com/a/14379814/252627
+            decoded = `openssl smime -inform der -verify -noverify -in #{path} 2> #{err}`
           end
           UI.error("Failure to decode #{path}. Exit: #{$?.exitstatus}: #{File.read(err)}") if $?.exitstatus != 0
           decoded

--- a/match/lib/match/encryption/openssl.rb
+++ b/match/lib/match/encryption/openssl.rb
@@ -110,7 +110,7 @@ module Match
       def encrypt_specific_file(path: nil, password: nil)
         UI.user_error!("No password supplied") if password.to_s.strip.length == 0
 
-        data_to_encrypt = File.read(path)
+        data_to_encrypt = File.binread(path)
         salt = SecureRandom.random_bytes(8)
 
         # The :: is important, as there is a name clash

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -174,6 +174,10 @@ module Match
                                      description: "The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. \"Apple Pay Pass Suppression Development\")",
                                      optional: true,
                                      default_value: nil),
+        FastlaneCore::ConfigItem.new(key: :export_path,
+                                     env_name: "MATCH_EXPORT_PATH",
+                                     description: "Path to export certificates, key and profile",
+                                     optional: true),
 
         # other
         FastlaneCore::ConfigItem.new(key: :verbose,

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -174,9 +174,9 @@ module Match
                                      description: "The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. \"Apple Pay Pass Suppression Development\")",
                                      optional: true,
                                      default_value: nil),
-        FastlaneCore::ConfigItem.new(key: :export_path,
-                                     env_name: "MATCH_EXPORT_PATH",
-                                     description: "Path to export certificates, key and profile",
+        FastlaneCore::ConfigItem.new(key: :output_path,
+                                     env_name: "MATCH_OUTPUT_PATH",
+                                     description: "Path in which to export certificates, key and profile",
                                      optional: true),
 
         # other

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -185,7 +185,6 @@ module Match
           Utils.import(keys.last, params[:keychain_name], password: params[:keychain_password])
         else
           UI.message("Skipping installation of certificate as it would not work on this operating system.")
-          # TODO move table from below in here, so it better reflects that cert was not installed but downloaded (and copied to x)
         end
 
         if params[:export_path]
@@ -253,8 +252,6 @@ module Match
 
       if Helper.mac?
         installed_profile = FastlaneCore::ProvisioningProfile.install(profile, keychain_path)
-      else
-        # TODO move table from below in here, so it better reflects that cert was not installed but downloaded (and copied to x)
       end
       parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
       uuid = parsed["UUID"]

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -207,7 +207,9 @@ module Match
       profile_name = names.join("_").gsub("*", '\*') # this is important, as it shouldn't be a wildcard
       base_dir = File.join(prefixed_working_directory(working_directory), "profiles", prov_type.to_s)
       profiles = Dir[File.join(base_dir, "#{profile_name}.mobileprovision")]
-      keychain_path = FastlaneCore::Helper.keychain_path(params[:keychain_name]) unless params[:keychain_name].nil?
+      if Helper.mac?
+        keychain_path = FastlaneCore::Helper.keychain_path(params[:keychain_name]) unless params[:keychain_name].nil?
+      end
 
       # Install the provisioning profiles
       profile = profiles.last
@@ -241,8 +243,12 @@ module Match
         self.files_to_commit << profile
       end
 
-      installed_profile = FastlaneCore::ProvisioningProfile.install(profile, keychain_path)
-      parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
+      if Helper.mac?
+        installed_profile = FastlaneCore::ProvisioningProfile.install(profile, keychain_path)
+        parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
+      else
+        parsed = FastlaneCore::ProvisioningProfile.parse(profile)
+      end
       uuid = parsed["UUID"]
 
       if spaceship && !spaceship.profile_exists(username: params[:username], uuid: uuid)

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -234,7 +234,7 @@ module Match
         if params[:readonly]
           UI.error("No matching provisioning profiles found for '#{profile_name}'")
           UI.error("A new one cannot be created because you enabled `readonly`")
-          if Dir.exist?(base_dir)
+          if Dir.exist?(base_dir) # folder for `prov_type` does not exist on first match use for that type
             all_profiles = Dir.entries(base_dir).reject { |f| f.start_with?(".") }
             UI.error("Provisioning profiles in your repo for type `#{prov_type}`:")
             all_profiles.each { |p| UI.error("- '#{p}'") }

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -233,11 +233,13 @@ module Match
 
       if profile.nil? || params[:force]
         if params[:readonly]
-          all_profiles = Dir.entries(base_dir).reject { |f| f.start_with?(".") }
           UI.error("No matching provisioning profiles found for '#{profile_name}'")
           UI.error("A new one cannot be created because you enabled `readonly`")
-          UI.error("Provisioning profiles in your repo for type `#{prov_type}`:")
-          all_profiles.each { |p| UI.error("- '#{p}'") }
+          if Dir.exist?(base_dir)
+            all_profiles = Dir.entries(base_dir).reject { |f| f.start_with?(".") }
+            UI.error("Provisioning profiles in your repo for type `#{prov_type}`:")
+            all_profiles.each { |p| UI.error("- '#{p}'") }
+          end
           UI.error("If you are certain that a profile should exist, double-check the recent changes to your match repository")
           UI.user_error!("No matching provisioning profiles found and can not create a new one because you enabled `readonly`. Check the output above for more information.")
         end

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -24,7 +24,7 @@ module Match
 
     def run(params)
       self.files_to_commit = []
-      
+
       FileUtils.mkdir_p(params[:output_path]) if params[:output_path]
 
       FastlaneCore::PrintTable.print_values(config: params,

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -251,11 +251,10 @@ module Match
 
       if Helper.mac?
         installed_profile = FastlaneCore::ProvisioningProfile.install(profile, keychain_path)
-        parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
       else
         # TODO move table from below in here, so it better reflects that cert was not installed but downloaded (and copied to x)
-        parsed = FastlaneCore::ProvisioningProfile.parse(profile)
       end
+      parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
       uuid = parsed["UUID"]
 
       if params[:export_path]

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -24,6 +24,8 @@ module Match
 
     def run(params)
       self.files_to_commit = []
+      
+      FileUtils.mkdir_p(params[:output_path]) if params[:output_path]
 
       FastlaneCore::PrintTable.print_values(config: params,
                                              title: "Summary for match #{Fastlane::VERSION}")

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -185,6 +185,12 @@ module Match
           Utils.import(keys.last, params[:keychain_name], password: params[:keychain_password])
         else
           UI.message("Skipping installation of certificate as it would not work on this operating system.")
+          # TODO move table from below in here, so it better reflects that cert was not installed but downloaded (and copied to x)
+        end
+
+        if params[:export_path]
+          FileUtils.cp(cert_path, params[:export_path])
+          FileUtils.cp(keys.last, params[:export_path])
         end
 
         # Get and print info of certificate
@@ -247,9 +253,14 @@ module Match
         installed_profile = FastlaneCore::ProvisioningProfile.install(profile, keychain_path)
         parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
       else
+        # TODO move table from below in here, so it better reflects that cert was not installed but downloaded (and copied to x)
         parsed = FastlaneCore::ProvisioningProfile.parse(profile)
       end
       uuid = parsed["UUID"]
+
+      if params[:export_path]
+        FileUtils.cp(profile, params[:export_path])
+      end
 
       if spaceship && !spaceship.profile_exists(username: params[:username], uuid: uuid)
         # This profile is invalid, let's remove the local file and generate a new one

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -189,9 +189,9 @@ module Match
           UI.message("Skipping installation of certificate as it would not work on this operating system.")
         end
 
-        if params[:export_path]
-          FileUtils.cp(cert_path, params[:export_path])
-          FileUtils.cp(keys.last, params[:export_path])
+        if params[:output_path]
+          FileUtils.cp(cert_path, params[:output_path])
+          FileUtils.cp(keys.last, params[:output_path])
         end
 
         # Get and print info of certificate
@@ -258,8 +258,8 @@ module Match
       parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
       uuid = parsed["UUID"]
 
-      if params[:export_path]
-        FileUtils.cp(profile, params[:export_path])
+      if params[:output_path]
+        FileUtils.cp(profile, params[:output_path])
       end
 
       if spaceship && !spaceship.profile_exists(username: params[:username], uuid: uuid)

--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -74,9 +74,11 @@ module Match
 
         begin
           # GIT_TERMINAL_PROMPT will fail the `git clone` command if user credentials are missing
-          FastlaneCore::CommandExecutor.execute(command: "GIT_TERMINAL_PROMPT=0 #{command}",
-                                              print_all: FastlaneCore::Globals.verbose?,
-                                          print_command: FastlaneCore::Globals.verbose?)
+          Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
+            FastlaneCore::CommandExecutor.execute(command: command,
+                                                print_all: FastlaneCore::Globals.verbose?,
+                                            print_command: FastlaneCore::Globals.verbose?)
+          end
         rescue
           UI.error("Error cloning certificates repo, please make sure you have read access to the repository you want to use")
           if self.branch && self.clone_branch_directly
@@ -186,13 +188,15 @@ module Match
       def git_push(commands: [], commit_message: nil)
         commit_message ||= generate_commit_message
         commands << "git commit -m #{commit_message.shellescape}"
-        commands << "GIT_TERMINAL_PROMPT=0 git push origin #{self.branch.shellescape}"
+        commands << "git push origin #{self.branch.shellescape}"
 
         UI.message("Pushing changes to remote git repo...")
-        commands.each do |command|
-          FastlaneCore::CommandExecutor.execute(command: command,
+        Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
+          commands.each do |command|
+            FastlaneCore::CommandExecutor.execute(command: command,
                                                 print_all: FastlaneCore::Globals.verbose?,
-                                                print_command: FastlaneCore::Globals.verbose?)
+                                            print_command: FastlaneCore::Globals.verbose?)
+          end
         end
 
         self.clear_changes

--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -60,7 +60,7 @@ module Match
         # No existing working directory, creating a new one now
         self.working_directory = Dir.mktmpdir
 
-        command = "git clone '#{self.git_url}' '#{self.working_directory}'"
+        command = "git clone #{self.git_url.shellescape} #{self.working_directory.shellescape}"
         if self.shallow_clone
           command << " --depth 1 --no-single-branch"
         elsif self.clone_branch_directly

--- a/match/lib/match/utils.rb
+++ b/match/lib/match/utils.rb
@@ -32,7 +32,7 @@ module Match
     end
 
     def self.get_cert_info(cer_certificate_path)
-      cert = OpenSSL::X509::Certificate.new(File.read(cer_certificate_path))
+      cert = OpenSSL::X509::Certificate.new(File.binread(cer_certificate_path))
 
       # openssl output:
       # subject= /UID={User ID}/CN={Certificate Name}/OU={Certificate User}/O={Organisation}/C={Country}
@@ -54,7 +54,7 @@ module Match
                       .push([openssl_keys_to_readable_keys.fetch("notBefore"), cert.not_before])
                       .push([openssl_keys_to_readable_keys.fetch("notAfter"), cert.not_after])
     rescue => ex
-      UI.error(ex)
+      UI.error("get_cert_info: #{ex}")
       return {}
     end
 

--- a/match/spec/encryption/openssl_spec.rb
+++ b/match/spec/encryption/openssl_spec.rb
@@ -2,9 +2,10 @@ describe Match do
   describe Match::Encryption::OpenSSL do
     before do
       @directory = Dir.mktmpdir
-      @content = "#{Time.now.to_i} so random"
-      @full_path = File.join(@directory, "randomFile.mobileprovision")
-      File.write(@full_path, @content)
+      profile_path = "./match/spec/fixtures/test.mobileprovision"
+      FileUtils.cp(profile_path, @directory)
+      @full_path = File.join(@directory, "test.mobileprovision")
+      @content = File.binread(@full_path)
       @git_url = "https://github.com/fastlane/fastlane/tree/master/so_random"
       allow(Dir).to receive(:mktmpdir).and_return(@directory)
       ENV["MATCH_PASSWORD"] = '2"QAHg@v(Qp{=*n^'
@@ -15,12 +16,12 @@ describe Match do
       )
     end
 
-    it "encrypt" do
+    it "first encrypt, different content, then decrypt, initial content again" do
       @e.encrypt_files
-      expect(File.read(@full_path)).to_not(eq(@content))
+      expect(File.binread(@full_path)).to_not(eq(@content))
 
       @e.decrypt_files
-      expect(File.read(@full_path)).to eq(@content)
+      expect(File.binread(@full_path)).to eq(@content)
     end
 
     it "raises an exception if invalid password is passed" do

--- a/match/spec/storage/git_storage_spec.rb
+++ b/match/spec/storage/git_storage_spec.rb
@@ -17,7 +17,7 @@ describe Match do
         expect(Dir).to receive(:mktmpdir).and_return(path)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         shallow_clone = true
-        command = "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{path}' --depth 1 --no-single-branch"
+        command = "git clone #{git_url.shellescape} #{path.shellescape} --depth 1 --no-single-branch"
         to_params = {
           command: command,
           print_all: nil,
@@ -44,7 +44,7 @@ describe Match do
         expect(Dir).to receive(:mktmpdir).and_return(path)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         shallow_clone = false
-        command = "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{path}'"
+        command = "git clone #{git_url.shellescape} #{path.shellescape}"
         to_params = {
           command: command,
           print_all: nil,
@@ -74,7 +74,7 @@ describe Match do
         shallow_clone = false
 
         expected_commands = [
-          "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{path}'",
+          "git clone #{git_url.shellescape} #{path.shellescape}",
           "git --no-pager branch --list origin/#{git_branch} --no-color -r",
           "git checkout --orphan #{git_branch}",
           "git reset --hard"
@@ -118,8 +118,8 @@ describe Match do
           "git add #{random_file}",
           "git add match_version.txt",
           "git commit -m " + '[fastlane] Updated appstore and platform ios'.shellescape,
-          "GIT_TERMINAL_PROMPT=0 git push origin master",
-          "GIT_TERMINAL_PROMPT=0 git clone '#{git_url}' '#{path}'"
+          "git push origin master",
+          "git clone #{git_url.shellescape} #{path.shellescape}"
         ]
 
         expected_commands.each do |command|

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -199,13 +199,16 @@ module Sigh
         true
       end
 
-      unless Sigh.config[:skip_certificate_verification]
-        certificates = certificates.find_all do |c|
-          file = Tempfile.new('cert')
-          file.write(c.download_raw)
-          file.close
+      # verify certificates
+      if Helper.mac?
+        unless Sigh.config[:skip_certificate_verification]
+          certificates = certificates.find_all do |c|
+            file = Tempfile.new('cert')
+            file.write(c.download_raw)
+            file.close
 
-          FastlaneCore::CertChecker.installed?(file.path)
+            FastlaneCore::CertChecker.installed?(file.path)
+          end
         end
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`match`/`sync_code_signing` doesn't work on Windows (and Linux) right now.

### Description
This PR improves the support by fixing quite a few bugs and moving Mac only code behind `if`s.

- Fix the `git` commands to clone the match git repo
- Fix the reading of certificate information
- Use `openssl` as a fallback when decoding provisioning profiles if not on Mac (and `security` does not exist)
- Skip the installation of certificate, key and provisioning profile into the Keychain if not on Mac
- Add a new `output_path` option where certificate, key and provisionig profile are saved to (which is necessary on non Mac machines, as there is no import into the non existing Keychain where one could export those manually)
- Fix a general crash when running match (with readonly) for types that are not in storage yet (closes #13965)
- Fix encryption/openssl test so this can actually fail on Windows where this currently is broken: Change encryption/openssl test to work on real provisioningprofile (binary data) + properly read files so comparison can work
- Fix encryption (on Windows)
- Skip sigh certificate verification on non-Mac

