### PR TITLE
[spaceship] Fix Spaceship not returning AdHoc profile

### DIFF
--- a/sigh/lib/sigh/download_all.rb
+++ b/sigh/lib/sigh/download_all.rb
@@ -32,8 +32,6 @@ module Sigh
       FileUtils.mkdir_p(Sigh.config[:output_path])
 
       type_name = profile.class.pretty_type
-      type_name = "AdHoc" if profile.is_adhoc?
-
       profile_name = "#{type_name}_#{profile.uuid}_#{profile.app.bundle_id}.mobileprovision" # default name
 
       output_path = File.join(Sigh.config[:output_path], profile_name)

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -81,13 +81,6 @@ module Sigh
 
       # Take the provisioning profile name into account
       results = filter_profiles_by_name(results) if Sigh.config[:provisioning_name].to_s.length > 0
-
-      # Since September 20, 2016 spaceship doesn't distinguish between AdHoc and AppStore profiles
-      # any more, since it requires an additional request
-      # Instead we only call is_adhoc? on the matching profiles to speed up spaceship
-
-      results = filter_profiles_for_adhoc_or_app_store(results)
-
       return results if Sigh.config[:skip_certificate_verification]
 
       UI.message("Verifying certificates...")
@@ -156,18 +149,6 @@ module Sigh
         profiles = filtered
       end
       profiles
-    end
-
-    def filter_profiles_for_adhoc_or_app_store(profiles)
-      profiles.find_all do |current_profile|
-        if profile_type == Spaceship.provisioning_profile.ad_hoc
-          current_profile.is_adhoc?
-        elsif profile_type == Spaceship.provisioning_profile.app_store
-          !current_profile.is_adhoc?
-        else
-          true
-        end
-      end
     end
 
     def certificates_for_profile_and_platform

--- a/sigh/spec/stubbing.rb
+++ b/sigh/spec/stubbing.rb
@@ -12,7 +12,6 @@ def sigh_stub_spaceship(valid_profile = true, expect_create = false, expect_dele
   allow(profile).to receive(:valid?).and_return(valid_profile)
   allow(profile.class).to receive(:pretty_type).and_return("pretty")
   allow(profile).to receive(:download).and_return("FileContent")
-  allow(profile).to receive(:is_adhoc?).and_return(false)
   allow(profile).to receive(:name).and_return("profile name")
   if expect_delete
     expect(profile).to receive(:delete!)

--- a/spaceship/docs/DeveloperPortal.md
+++ b/spaceship/docs/DeveloperPortal.md
@@ -256,11 +256,6 @@ profiles = Spaceship::Portal.provisioning_profile.all
 profiles_appstore_adhoc = Spaceship::Portal.provisioning_profile.app_store.all
 profiles_appstore_adhoc = Spaceship::Portal.provisioning_profile.ad_hoc.all
 
-# To distinguish between App Store and Ad Hoc profiles use
-adhoc_only = profiles_appstore_adhoc.find_all do |current_profile|
-  current_profile.is_adhoc?
-end
-
 # Get all Development profiles
 profiles_dev = Spaceship::Portal.provisioning_profile.development.all
 

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -328,22 +328,7 @@ module Spaceship
           end
 
           return profiles if self == ProvisioningProfile
-
-          # To distinguish between AppStore and AdHoc profiles, we need to send
-          # a details request (see `profile_details`). This is an expensive operation
-          # which we can't do for every single provisioning profile
-          # Instead we'll treat App Store profiles the same way as Ad Hoc profiles
-          # Spaceship::Portal::ProvisioningProfile::AdHoc.all will return the same array as
-          # Spaceship::Portal::ProvisioningProfile::AppStore.all, containing only AppStore
-          # profiles. To determine if it's an Ad Hoc profile, you can use the
-          # is_adhoc? method on the profile.
-          klass = self
-          klass = AppStore if self == AdHoc
-
-          # only return the profiles that match the class
-          return profiles.select do |profile|
-            profile.class == klass
-          end
+          return profiles.select { |profile| profile.class == self }
         end
 
         # @return (Array) Returns all profiles registered for this account
@@ -545,14 +530,6 @@ module Spaceship
         end
 
         App.set_client(client).new(app_attributes)
-      end
-
-      # @return (Bool) Is this current provisioning profile adhoc?
-      #                AppStore and AdHoc profiles are the same except that AdHoc has devices
-      def is_adhoc?
-        return false unless self.kind_of?(AppStore) || self.kind_of?(AdHoc)
-
-        return devices.count > 0
       end
 
       # This is an expensive operation as it triggers a new request

--- a/spaceship/spec/portal/fixtures/dev_center_provisioning_profiles_response.json
+++ b/spaceship/spec/portal/fixtures/dev_center_provisioning_profiles_response.json
@@ -424,7 +424,7 @@
             "name": "1 Gut Altentann Ad Hoc",
             "status": "Active",
             "type": "iOS Distribution",
-            "distributionMethod": "store",
+            "distributionMethod": "adhoc",
             "proProPlatform": "ios",
             "version": "2",
             "dateExpire": "2015-11-25",

--- a/spaceship/spec/portal/fixtures/getProvisioningProfileAdHoc.action.json
+++ b/spaceship/spec/portal/fixtures/getProvisioningProfileAdHoc.action.json
@@ -17,7 +17,7 @@
     "name": "1 Gut Altentann Ad Hoc",
     "status": "Invalid",
     "type": "iOS Distribution",
-    "distributionMethod": "store",
+    "distributionMethod": "adhoc",
     "proProPlatform": "ios",
     "version": "2",
     "dateExpire": "2015-11-25",

--- a/spaceship/spec/portal/fixtures/listProvisioningProfiles.action.json
+++ b/spaceship/spec/portal/fixtures/listProvisioningProfiles.action.json
@@ -18,7 +18,7 @@
       "name": "1 Gut Altentann Ad Hoc",
       "status": "Active",
       "type": "iOS Distribution",
-      "distributionMethod": "store",
+      "distributionMethod": "adhoc",
       "proProPlatform": "ios",
       "version": "2",
       "dateExpire": "2015-11-25T01:00:00Z",

--- a/spaceship/spec/portal/fixtures/listProvisioningProfiles.action.plist
+++ b/spaceship/spec/portal/fixtures/listProvisioningProfiles.action.plist
@@ -14,7 +14,7 @@
         <key>type</key>
         <string>iOS Distribution</string>
         <key>distributionMethod</key>
-        <string>store</string>
+        <string>adhoc</string>
         <key>proProPlatform</key>
         <string>ios</string>
         <key>UUID</key>

--- a/spaceship/spec/provisioning_profile_spec.rb
+++ b/spaceship/spec/provisioning_profile_spec.rb
@@ -26,13 +26,13 @@ describe Spaceship::ProvisioningProfile do
 
     it 'should filter by the correct types' do
       expect(Spaceship::ProvisioningProfile::Development.all.count).to eq(1)
-      expect(Spaceship::ProvisioningProfile::AdHoc.all.count).to eq(6)
-      expect(Spaceship::ProvisioningProfile::AppStore.all.count).to eq(6)
+      expect(Spaceship::ProvisioningProfile::AdHoc.all.count).to eq(1)
+      expect(Spaceship::ProvisioningProfile::AppStore.all.count).to eq(5)
     end
 
-    it "AppStore and AdHoc are the same" do
+    it "AppStore and AdHoc are not the same" do
       Spaceship::ProvisioningProfile::AdHoc.all.each do |adhoc|
-        expect(Spaceship::ProvisioningProfile::AppStore.all.find_all { |a| a.id == adhoc.id }.count).to eq(1)
+        expect(Spaceship::ProvisioningProfile::AppStore.all.find_all { |a| a.id == adhoc.id }.count).to eq(0)
       end
     end
 
@@ -89,7 +89,7 @@ describe Spaceship::ProvisioningProfile do
       expect(profiles.count).to eq(6)
 
       expect(profiles.first.app.bundle_id).to eq('net.sunapps.1')
-      expect(profiles.first.distribution_method).to eq('store')
+      expect(profiles.first.distribution_method).to eq('adhoc')
     end
 
     it "returns the profile in an array if matching for tvos" do
@@ -110,10 +110,9 @@ describe Spaceship::ProvisioningProfile do
     end
   end
 
-  it "distribution_method stays app store, even though it's an AdHoc profile which contains devices" do
-    adhoc = Spaceship::ProvisioningProfile::AdHoc.all.find(&:is_adhoc?)
-
-    expect(adhoc.distribution_method).to eq('store')
+  it "distribution_method says `adhoc` for AdHoc profile" do
+    adhoc = Spaceship::ProvisioningProfile::AdHoc.all.first
+    expect(adhoc.distribution_method).to eq('adhoc')
     expect(adhoc.devices.count).to eq(2)
 
     device = adhoc.devices.first
@@ -340,36 +339,6 @@ describe Spaceship::ProvisioningProfile do
 
         profile.update!
       end
-    end
-  end
-
-  describe "#is_adhoc?" do
-    it "returns true when the profile is adhoc" do
-      profile = Spaceship::ProvisioningProfile::AdHoc.new
-      expect(profile).to receive(:devices).and_return(["device"])
-      expect(profile.is_adhoc?).to eq(true)
-    end
-
-    it "returns true when the profile is appstore with devices" do
-      profile = Spaceship::ProvisioningProfile::AppStore.new
-      expect(profile).to receive(:devices).and_return(["device"])
-      expect(profile.is_adhoc?).to eq(true)
-    end
-
-    it "returns false when the profile is appstore with no devices" do
-      profile = Spaceship::ProvisioningProfile::AppStore.new
-      expect(profile).to receive(:devices).and_return([])
-      expect(profile.is_adhoc?).to eq(false)
-    end
-
-    it "returns false when the profile is development" do
-      profile = Spaceship::ProvisioningProfile::Development.new
-      expect(profile.is_adhoc?).to eq(false)
-    end
-
-    it "returns false when the profile is inhouse" do
-      profile = Spaceship::ProvisioningProfile::InHouse.new
-      expect(profile.is_adhoc?).to eq(false)
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
Since something chaned API side that was causing `Can't find class 'adhoc'` and the attempt to fix in #13907 by handling the correct return type for AdHoc profiles, Spaceship was no more returning AdHoc profiles as they where still treated as AppStore profiles.

Link to open issue: #13936 #13916
All test passed.
All codestyle inspection passed

### Description
Remove workaround that treat Adhoc profiles as AppStore profile as it's no more needed
Remove the ProvisioningProfile `is_adhoc?` as it's no more required (known by the type)
Remove sigh filter_profiles_for_adhoc_or_app_store as it's no more needed
Remove ProvisioningProfile is_adhoc related tests
Update other tests
Update Documentation
Update AdHoc ProvisioningProfiles with `adhoc` as distributionMethod

Tested on my own projects with multiple profiles AppStore and Adhoc, all tests where done for both kind of profiles
- With profiles already created manually, detection is OK
- With no profiles, detection of no profile is OK > automatic creation of the right profiles
- With profiles previously created by sigh, detection is OK.
