### PR TITLE
Fix support for specifying emulator serial

### DIFF
--- a/fastlane/lib/fastlane/helper/adb_helper.rb
+++ b/fastlane/lib/fastlane/helper/adb_helper.rb
@@ -26,7 +26,7 @@ module Fastlane
       # Run a certain action
       def trigger(command: nil, serial: nil)
         android_serial = serial != "" ? "ANDROID_SERIAL=#{serial}" : nil
-        command = [android_serial, adb_path.shellescape, command].join(" ").strip!
+        command = [android_serial, adb_path.shellescape, command].join(" ").strip
         Action.sh(command)
       end
 

--- a/fastlane/spec/actions_specs/adb_spec.rb
+++ b/fastlane/spec/actions_specs/adb_spec.rb
@@ -17,6 +17,22 @@ describe Fastlane do
         expect(result).to eq("./fastlane/README.md test command with multiple parts")
       end
 
+      it "generates a valid command when a non-empty serial is passed" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'test command with non-empty serial', adb_path: './fastlane/README.md', serial: 'emulator-1234')
+        end").runner.execute(:test)
+
+        expect(result).to eq("ANDROID_SERIAL=emulator-1234 ./fastlane/README.md test command with non-empty serial")
+      end
+
+      it "generates a valid command when an empty serial is passed" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'test command with empty serial', adb_path: './fastlane/README.md', serial: '')
+        end").runner.execute(:test)
+
+        expect(result).to eq("./fastlane/README.md test command with empty serial")
+      end
+
       it "picks up path from ANDROID_HOME environment variable" do
         stub_const('ENV', { 'ANDROID_HOME' => '/usr/local/android-sdk' })
         result = Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
The `strip!` function  that was added in #13846 returns nil if the string was not altered. [Ruby docs](https://ruby-doc.org/core-2.2.0/String.html#method-i-strip-21).  The adb action now fails whenever a serial _is_ specified with `no implicit conversion of nil into String` on line 42 (the Actions.sh call).

Since command is being set with the return value, `strip` should be used instead which will always return the new value, regardless of whether it was changed.

Can be easily replicated in irb
```
android_serial = 'emulator-5554'
adb_path = '/test'

command = 'devices'
command = [android_serial, adb_path, command].join(" ").strip!
puts command
# => nil
command = 'devices'
command = [android_serial, adb_path, command].join(" ").strip
puts command
# => emulator-5554 /test devices
``` 