### PR TITLE
[match] resort and group options

### DIFF
--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -15,15 +15,7 @@ module Match
       user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
 
       [
-        FastlaneCore::ConfigItem.new(key: :git_url,
-                                     env_name: "MATCH_GIT_URL",
-                                     description: "URL to the git repo containing all the certificates",
-                                     optional: false,
-                                     short_option: "-r"),
-        FastlaneCore::ConfigItem.new(key: :git_branch,
-                                     env_name: "MATCH_GIT_BRANCH",
-                                     description: "Specific git branch to use",
-                                     default_value: 'master'),
+        # main
         FastlaneCore::ConfigItem.new(key: :type,
                                      env_name: "MATCH_TYPE",
                                      description: "Define the profile type, can be #{Match.environments.join(', ')}",
@@ -35,17 +27,13 @@ module Match
                                          UI.user_error!("Unsupported environment #{value}, must be in #{Match.environments.join(', ')}")
                                        end
                                      end),
-        FastlaneCore::ConfigItem.new(key: :storage_mode,
-                                     env_name: "MATCH_STORAGE_MODE",
-                                     description: "Define where you want to store your certificates",
-                                     is_string: true,
-                                     short_option: "-q",
-                                     default_value: 'git',
-                                     verify_block: proc do |value|
-                                       unless Match.storage_modes.include?(value)
-                                         UI.user_error!("Unsupported storage_mode #{value}, must be in #{Match.storage_modes.join(', ')}")
-                                       end
-                                     end),
+        FastlaneCore::ConfigItem.new(key: :readonly,
+                                     env_name: "MATCH_READONLY",
+                                     description: "Only fetch existing certificates and profiles, don't generate new ones",
+                                     is_string: false,
+                                     default_value: false),
+
+        # app
         FastlaneCore::ConfigItem.new(key: :app_identifier,
                                      short_option: "-a",
                                      env_name: "MATCH_APP_IDENTIFIER",
@@ -62,6 +50,81 @@ module Match
                                      description: "Your Apple ID Username",
                                      default_value: user,
                                      default_value_dynamic: true),
+        FastlaneCore::ConfigItem.new(key: :team_id,
+                                     short_option: "-b",
+                                     env_name: "FASTLANE_TEAM_ID",
+                                     description: "The ID of your Developer Portal team if you're in multiple teams",
+                                     optional: true,
+                                     code_gen_sensitive: true,
+                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:team_id),
+                                     default_value_dynamic: true),
+        FastlaneCore::ConfigItem.new(key: :team_name,
+                                     short_option: "-l",
+                                     env_name: "FASTLANE_TEAM_NAME",
+                                     description: "The name of your Developer Portal team if you're in multiple teams",
+                                     optional: true,
+                                     code_gen_sensitive: true,
+                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:team_name),
+                                     default_value_dynamic: true),
+
+        # Storage
+        FastlaneCore::ConfigItem.new(key: :storage_mode,
+                                     env_name: "MATCH_STORAGE_MODE",
+                                     description: "Define where you want to store your certificates",
+                                     is_string: true,
+                                     short_option: "-q",
+                                     default_value: 'git',
+                                     verify_block: proc do |value|
+                                       unless Match.storage_modes.include?(value)
+                                         UI.user_error!("Unsupported storage_mode #{value}, must be in #{Match.storage_modes.join(', ')}")
+                                       end
+                                     end),
+
+        # Storage: Git
+        FastlaneCore::ConfigItem.new(key: :git_url,
+                                     env_name: "MATCH_GIT_URL",
+                                     description: "URL to the git repo containing all the certificates",
+                                     optional: false,
+                                     short_option: "-r"),
+        FastlaneCore::ConfigItem.new(key: :git_branch,
+                                     env_name: "MATCH_GIT_BRANCH",
+                                     description: "Specific git branch to use",
+                                     default_value: 'master'),
+        FastlaneCore::ConfigItem.new(key: :git_full_name,
+                                     env_name: "MATCH_GIT_FULL_NAME",
+                                     description: "git user full name to commit",
+                                     optional: true,
+                                     default_value: nil),
+        FastlaneCore::ConfigItem.new(key: :git_user_email,
+                                     env_name: "MATCH_GIT_USER_EMAIL",
+                                     description: "git user email to commit",
+                                     optional: true,
+                                     default_value: nil),
+        FastlaneCore::ConfigItem.new(key: :shallow_clone,
+                                     env_name: "MATCH_SHALLOW_CLONE",
+                                     description: "Make a shallow clone of the repository (truncate the history to 1 revision)",
+                                     is_string: false,
+                                     default_value: false),
+        FastlaneCore::ConfigItem.new(key: :clone_branch_directly,
+                                     env_name: "MATCH_CLONE_BRANCH_DIRECTLY",
+                                     description: "Clone just the branch specified, instead of the whole repo. This requires that the branch already exists. Otherwise the command will fail",
+                                     is_string: false,
+                                     default_value: false),
+
+        # Storage: Google Cloud
+        FastlaneCore::ConfigItem.new(key: :google_cloud_bucket_name,
+                                     env_name: "MATCH_GOOGLE_CLOUD_BUCKET_NAME",
+                                     description: "Name of the Google Cloud Storage bucket to use",
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :google_cloud_keys_file,
+                                     env_name: "MATCH_GOOGLE_CLOUD_KEYS_FILE",
+                                     description: "Path to the gc_keys.json file",
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Could not find keys file at path '#{File.expand_path(value)}'") unless File.exist?(value)
+                                     end),
+
+        # Keychain
         FastlaneCore::ConfigItem.new(key: :keychain_name,
                                      short_option: "-s",
                                      env_name: "MATCH_KEYCHAIN_NAME",
@@ -73,68 +136,21 @@ module Match
                                      sensitive: true,
                                      description: "This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password",
                                      optional: true),
-        FastlaneCore::ConfigItem.new(key: :readonly,
-                                     env_name: "MATCH_READONLY",
-                                     description: "Only fetch existing certificates and profiles, don't generate new ones",
-                                     is_string: false,
-                                     default_value: false),
-        FastlaneCore::ConfigItem.new(key: :team_id,
-                                     short_option: "-b",
-                                     env_name: "FASTLANE_TEAM_ID",
-                                     description: "The ID of your Developer Portal team if you're in multiple teams",
-                                     optional: true,
-                                     code_gen_sensitive: true,
-                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:team_id),
-                                     default_value_dynamic: true),
-        FastlaneCore::ConfigItem.new(key: :git_full_name,
-                                     env_name: "MATCH_GIT_FULL_NAME",
-                                     description: "git user full name to commit",
-                                     optional: true,
-                                     default_value: nil),
-        FastlaneCore::ConfigItem.new(key: :git_user_email,
-                                     env_name: "MATCH_GIT_USER_EMAIL",
-                                     description: "git user email to commit",
-                                     optional: true,
-                                     default_value: nil),
-        FastlaneCore::ConfigItem.new(key: :team_name,
-                                     short_option: "-l",
-                                     env_name: "FASTLANE_TEAM_NAME",
-                                     description: "The name of your Developer Portal team if you're in multiple teams",
-                                     optional: true,
-                                     code_gen_sensitive: true,
-                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:team_name),
-                                     default_value_dynamic: true),
-        FastlaneCore::ConfigItem.new(key: :verbose,
-                                     env_name: "MATCH_VERBOSE",
-                                     description: "Print out extra information and all commands",
-                                     is_string: false,
-                                     default_value: false,
-                                     verify_block: proc do |value|
-                                       FastlaneCore::Globals.verbose = true if value
-                                     end),
+
+        # settings
         FastlaneCore::ConfigItem.new(key: :force,
                                      env_name: "MATCH_FORCE",
                                      description: "Renew the provisioning profiles every time you run match",
                                      is_string: false,
                                      default_value: false),
-        FastlaneCore::ConfigItem.new(key: :skip_confirmation,
-                                     env_name: "MATCH_SKIP_CONFIRMATION",
-                                     description: "Disables confirmation prompts during nuke, answering them with yes",
-                                     is_string: false,
-                                     default_value: false),
-        FastlaneCore::ConfigItem.new(key: :shallow_clone,
-                                     env_name: "MATCH_SHALLOW_CLONE",
-                                     description: "Make a shallow clone of the repository (truncate the history to 1 revision)",
-                                     is_string: false,
-                                     default_value: false),
-        FastlaneCore::ConfigItem.new(key: :clone_branch_directly,
-                                     env_name: "MATCH_CLONE_BRANCH_DIRECTLY",
-                                     description: "Clone just the branch specified, instead of the whole repo. This requires that the branch already exists. Otherwise the command will fail",
-                                     is_string: false,
-                                     default_value: false),
         FastlaneCore::ConfigItem.new(key: :force_for_new_devices,
                                      env_name: "MATCH_FORCE_FOR_NEW_DEVICES",
                                      description: "Renew the provisioning profiles if the device count on the developer portal has changed. Ignored for profile type 'appstore'",
+                                     is_string: false,
+                                     default_value: false),
+        FastlaneCore::ConfigItem.new(key: :skip_confirmation,
+                                     env_name: "MATCH_SKIP_CONFIRMATION",
+                                     description: "Disables confirmation prompts during nuke, answering them with yes",
                                      is_string: false,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :skip_docs,
@@ -158,18 +174,16 @@ module Match
                                      description: "The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. \"Apple Pay Pass Suppression Development\")",
                                      optional: true,
                                      default_value: nil),
-        FastlaneCore::ConfigItem.new(key: :google_cloud_bucket_name,
-                                     env_name: "MATCH_GOOGLE_CLOUD_BUCKET_NAME",
-                                     description: "Name of the Google Cloud Storage bucket to use",
-                                     optional: true),
-        FastlaneCore::ConfigItem.new(key: :google_cloud_keys_file,
-                                     env_name: "MATCH_GOOGLE_CLOUD_KEYS_FILE",
-                                     description: "Path to the gc_keys.json file",
-                                     optional: true,
-                                     verify_block: proc do |value|
-                                       UI.user_error!("Could not find keys file at path '#{File.expand_path(value)}'") unless File.exist?(value)
-                                     end)
 
+        # other
+        FastlaneCore::ConfigItem.new(key: :verbose,
+                                     env_name: "MATCH_VERBOSE",
+                                     description: "Print out extra information and all commands",
+                                     is_string: false,
+                                     default_value: false,
+                                     verify_block: proc do |value|
+                                       FastlaneCore::Globals.verbose = true if value
+                                     end)
       ]
     end
   end


### PR DESCRIPTION
`match` options were ordered pretty randomly, I tried to give them some structure by grouping and resorting. Now connected options are next to each other in the code and in the generated table in the docs.