### PR TITLE
check exit status of security command

### DIFF
--- a/fastlane/spec/actions_specs/import_certificate_spec.rb
+++ b/fastlane/spec/actions_specs/import_certificate_spec.rb
@@ -14,13 +14,13 @@ describe Fastlane do
         expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain_path.shellescape} &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain_path.shellescape}"
 
         allow(File).to receive(:file?).and_return(false)
         allow(File).to receive(:file?).with(keychain_path).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
-        allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: false)
+        allow(Open3).to receive(:popen3).with(allowed_command)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: false)
 
         Fastlane::FastFile.new.parse("lane :test do
@@ -41,13 +41,13 @@ describe Fastlane do
         expected_security_import_command = "security import #{cert_name.shellescape} -k '#{keychain_path.shellescape}' -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        expected_set_key_partition_list_command = "security set-key-partition-list -S apple-tool:,apple: -k #{password.shellescape} #{keychain_path.shellescape} &> /dev/null"
+        expected_set_key_partition_list_command = "security set-key-partition-list -S apple-tool:,apple: -k #{password.shellescape} #{keychain_path.shellescape}"
 
         allow(File).to receive(:file?).and_return(false)
         allow(File).to receive(:file?).with(keychain_path).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
-        expect(FastlaneCore::Helper).to receive(:backticks).with(expected_set_key_partition_list_command, print: false)
+        expect(Open3).to receive(:popen3).with(expected_set_key_partition_list_command)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_security_import_command, print: false)
 
         Fastlane::FastFile.new.parse("lane :test do
@@ -75,7 +75,7 @@ describe Fastlane do
         allow(File).to receive(:file?).with(keychain_path).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
-        allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: true)
+        allow(Open3).to receive(:popen3).with(allowed_command)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: true)
 
         Fastlane::FastFile.new.parse("lane :test do

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -9,14 +9,14 @@ describe Match do
         expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with('item.path').and_return(true)
 
-        allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: FastlaneCore::Globals.verbose?)
+        allow(Open3).to receive(:popen3).with(allowed_command)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: FastlaneCore::Globals.verbose?)
 
         Match::Utils.import('item.path', 'login.keychain')
@@ -28,14 +28,14 @@ describe Match do
         expected_command = "security import item.path -k '#{keychain}' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain} &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain}"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with(keychain).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with('item.path').and_return(true)
 
-        allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: FastlaneCore::Globals.verbose?)
+        allow(Open3).to receive(:popen3).with(allowed_command)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: FastlaneCore::Globals.verbose?)
 
         Match::Utils.import('item.path', keychain)
@@ -53,14 +53,14 @@ describe Match do
         expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain-db' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain-db").and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with("item.path").and_return(true)
 
-        allow(FastlaneCore::Helper).to receive(:backticks).with(allowed_command, print: FastlaneCore::Globals.verbose?)
+        allow(Open3).to receive(:popen3).with(allowed_command)
         expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: FastlaneCore::Globals.verbose?)
 
         Match::Utils.import('item.path', "login.keychain")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
During a keychain import, the `security set-key-partition-list` would fail silently if the keychain password was not supplied correctly.

This would cause `CodeSign` to have a gui popup requesting permissions to access the keychain.

This command failed silently because `Helper.backticks` never considers the exit status of the command.

Related Issue: #6866

### Description
This PR removes the usage of `Helper.backticks` to use `popen3` which gives better control over stdout, stderr and the exit status.

Previously this command would fail silently but now it will raise an error:
```
Could not configure key to bypass permission popup:
security: SecKeychainItemSetAccessWithPassword: The user name or passphrase you entered is not correct
```

If you see this error, you may need to provide the `MATCH_KEYCHAIN_PASSWORD` environment variable. If the keychain is `login.keychain` then the password would be the user's login password. If you cannot or do not want to use this password, please consider adding a new keychain.
