### PR TITLE
[deliver] add missing require

### DIFF
--- a/deliver/lib/deliver/download_screenshots.rb
+++ b/deliver/lib/deliver/download_screenshots.rb
@@ -1,4 +1,5 @@
 require_relative 'module'
+require 'open-uri'
 
 module Deliver
   class DownloadScreenshots


### PR DESCRIPTION
It seems this fix has been merged into master and released, and for some reason it is not in master anymore.
https://github.com/fastlane/fastlane/pull/13526
