### PR TITLE
[core] added loading indicator for importing keys command

### DIFF
--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -24,8 +24,10 @@ module FastlaneCore
 
         Open3.popen3(command) do |stdin, stdout, stderr, thrd|
           if output
+            Helper.show_loading_indicator("Importing keys...")
             UI.command(command)
             UI.command_output(stdout.read)
+            Helper.hide_loading_indicator
           end
 
           unless thrd.value.success?


### PR DESCRIPTION
Sometimes it takes a lot of time to run command `security set-key-partition-list` in https://github.com/fastlane/fastlane/blob/f9db58aa8059cf2a47cb00939e9566efeffe69cc/fastlane_core/lib/fastlane_core/keychain_importer.rb#L20-L20

Adding a loading indicator to give feedback to the user that the keys are being imported.