### PR TITLE
Improve GitHub bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -17,11 +17,11 @@ about: If something isn't working as expected 🤔
 <!-- Please include what's happening, expected behavior, and any relevant code samples -->
 
 ##### Command executed
-<!-- The command you executed on the command line, that resulted in an error -->
+<!-- The command you executed on the command line that resulted in an error -->
 
 ##### Complete output when running fastlane, including the stack trace and command used
 <!-- 
-You can use `--capture_output` as the last commandline argument for many commands to get that collected for you. Otherwise, please do it manually.
+You can use `--capture_output` as the last command line argument for many commands to get that collected for you. Otherwise, please do it manually.
 Caution: The output of `--capture_output` could contain sensitive data such as application ids, certificate ids, or email addresses. Please make sure you double check the output and replace anything sensitive you don't wish to submit in the issue 
 -->
 
@@ -33,7 +33,7 @@ Caution: The output of `--capture_output` could contain sensitive data such as a
 
 <!-- 
 Please run `fastlane env` and copy the output below. This will help us help you.
-If you used `--capture_output` option, please remove this block as it is already included there. 
+If you used the `--capture_output` option, please remove this block as it is already included there. 
 -->
 
 <details>

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -4,7 +4,7 @@ about: If something isn't working as expected 🤔
 
 ---
 
-<!-- Thanks for helping _fastlane_! Before you submit your issue, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
+<!-- Thanks for helping fastlane! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->
 
 ### New Issue Checklist
 

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -16,20 +16,26 @@ about: If something isn't working as expected 🤔
 ### Issue Description
 <!-- Please include what's happening, expected behavior, and any relevant code samples -->
 
-##### Complete output when running fastlane, including the stack trace and command used
-<!-- You can use: `--capture_output` as the last commandline argument to get that collected for you -->
+##### Command executed
+<!-- The command you executed on the command line, that resulted in an error -->
 
-<!-- The output of `--capture_output` could contain sensitive data such as application ids, certificate ids, or email addresses, Please make sure you double check the output and replace anything sensitive you don't wish to submit in the issue -->
+##### Complete output when running fastlane, including the stack trace and command used
+<!-- 
+You can use `--capture_output` as the last commandline argument for many commands to get that collected for you. Otherwise, please do it manually.
+Caution: The output of `--capture_output` could contain sensitive data such as application ids, certificate ids, or email addresses. Please make sure you double check the output and replace anything sensitive you don't wish to submit in the issue 
+-->
 
 <details>
-  <pre>[INSERT OUTPUT HERE]</pre>
+  <pre> [REPLACE THIS WITH YOUR INFORMATION] </pre>
 </details>
 
 ### Environment
 
-<!-- Please run `fastlane env` and copy the output below. This will help us help you :+1:
-If you used `--capture_output` option, please remove this block as it is already included there. -->
+<!-- 
+Please run `fastlane env` and copy the output below. This will help us help you.
+If you used `--capture_output` option, please remove this block as it is already included there. 
+-->
 
 <details>
-  <pre>[INSERT OUTPUT HERE]</pre>
+  <pre> [REPLACE THIS WITH YOUR INFORMATION] </pre>
 </details>


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
While triaging the issues the last few weeks, I noticed a few recurring problems: the command being executed is missing, people apologize that `--capture_output` didn't work with their command - and many people still ignore the issue template completely even when it would be _very_ useful for them to fill it.

### Description
I hope some of these changes will help a bit:
- Explicitly ask for command that was executed
- Include that `--capture_output` doesn't work for all commands
- Remove Emoji that isn't rendered in the comment anyway
- Reformat multi line comments
- Replace `[INSERT OUTPUT HERE]` with `[REPLACE THIS WITH YOUR INFORMATION]` in the hope more people will actually do this
