### PR TITLE
[action] add labels to create_pull_request

### DIFF
--- a/fastlane/lib/fastlane/actions/create_pull_request.rb
+++ b/fastlane/lib/fastlane/actions/create_pull_request.rb
@@ -33,9 +33,31 @@ module Fastlane
           html_url = json['html_url']
           UI.success("Successfully created pull request ##{number}. You can see it at '#{html_url}'")
 
+          # Add labels to pull request
+          add_labels(params, number) if params[:labels]
+
           Actions.lane_context[SharedValues::CREATE_PULL_REQUEST_HTML_URL] = html_url
           return html_url
         end
+      end
+
+      def self.add_labels(params, number)
+        payload = {
+          'labels' => params[:labels]
+        }
+        GithubApiAction.run(
+          server_url: params[:api_url],
+          api_token: params[:api_token],
+          http_method: 'PATCH',
+          path: "repos/#{params[:repo]}/issues/#{number}",
+          body: payload,
+          error_handlers: {
+            '*' => proc do |result|
+              UI.error("GitHub responded with #{result[:status]}: #{result[:body]}")
+              return nil
+            end
+          }
+        )
       end
 
       #####################################################
@@ -71,6 +93,11 @@ module Fastlane
                                        env_name: "GITHUB_PULL_REQUEST_BODY",
                                        description: "The contents of the pull request",
                                        is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :labels,
+                                       env_name: "GITHUB_PULL_REQUEST_LABELS",
+                                       description: "The labels for the pull request",
+                                       type: Array,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :head,
                                        env_name: "GITHUB_PULL_REQUEST_HEAD",

--- a/fastlane/spec/actions_specs/create_pull_request_spec.rb
+++ b/fastlane/spec/actions_specs/create_pull_request_spec.rb
@@ -14,6 +14,17 @@ describe Fastlane do
                 'User-Agent' => 'fastlane-github_api'
               }
             ).to_return(status: 201, body: response_body, headers: {})
+
+          number = JSON.parse(response_body)["number"]
+          stub_request(:patch, "https://api.github.com/repos/fastlane/fastlane/issues/#{number}").
+            with(
+              body: '{"labels":["fastlane","is","awesome"]}',
+              headers: {
+                'Authorization' => 'Basic MTIzNDU2Nzg5',
+                'Host' => 'api.github.com:443',
+                'User-Agent' => 'fastlane-github_api'
+              }
+            ).to_return(status: 200, body: "", headers: {})
         end
 
         it 'correctly submits to github' do
@@ -23,6 +34,21 @@ describe Fastlane do
                 api_token: '123456789',
                 title: 'test PR',
                 repo: 'fastlane/fastlane',
+              )
+            end
+          ").runner.execute(:test)
+
+          expect(result).to eq('https://github.com/fastlane/fastlane/pull/1347')
+        end
+
+        it 'correctly submits to github with labels' do
+          result = Fastlane::FastFile.new.parse("
+            lane :test do
+              create_pull_request(
+                api_token: '123456789',
+                title: 'test PR',
+                repo: 'fastlane/fastlane',
+                labels: ['fastlane', 'is', 'awesome']
               )
             end
           ").runner.execute(:test)


### PR DESCRIPTION
Fixes  #13979

## Description
PATCH to the issue to add labels

### Example
```sh
fastlane run create_pull_request title:"test" body:"test_body" repo:"joshdholtz/Sentry-Android" head:"bug-hunt" labels:"bug,invalid"
```

<img width="464" alt="screen shot 2018-12-21 at 5 24 10 pm" src="https://user-images.githubusercontent.com/401294/50367403-97d96580-0545-11e9-89a8-e7b2c46de994.png">
