### PR TITLE
[match] fix change password to add files and fix breaking change on cert import

### DIFF
--- a/fastlane/spec/actions_specs/import_certificate_spec.rb
+++ b/fastlane/spec/actions_specs/import_certificate_spec.rb
@@ -14,7 +14,7 @@ describe Fastlane do
         expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain_path.shellescape}"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -l 'Imported Private Key' -k #{''.shellescape} #{keychain_path.shellescape} &> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         allow(File).to receive(:file?).with(keychain_path).and_return(true)
@@ -41,7 +41,7 @@ describe Fastlane do
         expected_security_import_command = "security import #{cert_name.shellescape} -k '#{keychain_path.shellescape}' -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        expected_set_key_partition_list_command = "security set-key-partition-list -S apple-tool:,apple: -k #{password.shellescape} #{keychain_path.shellescape}"
+        expected_set_key_partition_list_command = "security set-key-partition-list -S apple-tool:,apple: -l 'Imported Private Key' -k #{password.shellescape} #{keychain_path.shellescape} &> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         allow(File).to receive(:file?).with(keychain_path).and_return(true)
@@ -69,7 +69,7 @@ describe Fastlane do
         expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain_path.shellescape}"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -l 'Imported Private Key' -k #{''.shellescape} #{keychain_path.shellescape} &> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         allow(File).to receive(:file?).with(keychain_path).and_return(true)

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -22,15 +22,14 @@ module FastlaneCore
         command << " -l 'Imported Private Key'"
         command << " -k #{keychain_password.to_s.shellescape}"
         command << " #{keychain_path.shellescape}"
+        command << " 1> /dev/null" # always disable stdout. This can be very verbose, and leak potentially sensitive info
 
+        UI.command(command) if output
         Open3.popen3(command) do |stdin, stdout, stderr, thrd|
-          if output
-            UI.command(command)
-            UI.command_output(stdout.read)
-          end
-
           unless thrd.value.success?
-            UI.user_error!("Could not configure key to bypass permission popup:\n#{stderr.read}")
+            UI.user_error!("Could not configure key to bypass permission popup.\n" \
+                           "Check if you supplied the correct `keychain_password` for keychain: `#{keychain_path}`\n" \
+                           "#{stderr.read}")
           end
         end
       end

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -22,7 +22,7 @@ module FastlaneCore
         command << " -l 'Imported Private Key'"
         command << " -k #{keychain_password.to_s.shellescape}"
         command << " #{keychain_path.shellescape}"
-        command << " 1> /dev/null" # always disable stdout. This can be very verbose, and leak potentially sensitive info
+        command << " &> /dev/null" # always disable stdout. This can be very verbose, and leak potentially sensitive info
 
         UI.command(command) if output
         Open3.popen3(command) do |stdin, stdout, stderr, thrd|

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -25,7 +25,7 @@ module FastlaneCore
 
         Open3.popen3(command) do |stdin, stdout, stderr, thrd|
           # The execution would sometimes hang for keychains with a large list of items if not read
-          # Always need to read stdout for `security set-key-partition-list` (even if not showing output using UI.command_output) 
+          # Always need to read stdout for `security set-key-partition-list` (even if not showing output using UI.command_output)
           command_output = stdout.read
 
           if output
@@ -34,6 +34,7 @@ module FastlaneCore
           end
 
           unless thrd.value.success?
+            UI.error("")
             UI.error("Could not configure imported keychain item (certificate) to prevent UI permission popup when signing:\n#{stderr.read.to_s.strip}")
             UI.error("This was most likely caused by not providing a keychain password (or a correct keychain password)")
             UI.error("Please look at the following docs to see how to set a keychain password:")

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -24,8 +24,8 @@ module FastlaneCore
         command << " #{keychain_path.shellescape}"
 
         Open3.popen3(command) do |stdin, stdout, stderr, thrd|
-          # Need to read stdout even if not showing using UI.command_output
-          # The execution would sometimes hang for large keychain item list if the output of security `set-key-partition-list` not read
+          # The execution would sometimes hang for keychains with a large list of items if not read
+          # Always need to read stdout for `security set-key-partition-list` (even if not showing output using UI.command_output) 
           command_output = stdout.read
 
           if output

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -19,6 +19,7 @@ module FastlaneCore
       if Helper.backticks('security -h | grep set-key-partition-list', print: false).length > 0
         command = "security set-key-partition-list"
         command << " -S apple-tool:,apple:"
+        command << " -l 'Imported Private Key'"
         command << " -k #{keychain_password.to_s.shellescape}"
         command << " #{keychain_path.shellescape}"
 

--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -40,8 +40,8 @@ module Match
       encryption.store_password(to)
 
       message = "[fastlane] Changed passphrase"
-      encryption.encrypt_files
-      storage.save_changes!(custom_message: message)
+      files_to_commit = encryption.encrypt_files
+      storage.save_changes!(files_to_commit: files_to_commit, custom_message: message)
     end
 
     # This method is called from both here, and from `openssl.rb`

--- a/match/lib/match/encryption/openssl.rb
+++ b/match/lib/match/encryption/openssl.rb
@@ -29,15 +29,20 @@ module Match
       end
 
       def encrypt_files
+        files = []
         iterate(self.working_directory) do |current|
+          files << current
           encrypt_specific_file(path: current, password: password)
           UI.success("🔒  Encrypted '#{File.basename(current)}'") if FastlaneCore::Globals.verbose?
         end
         UI.success("🔒  Successfully encrypted certificates repo")
+        return files
       end
 
       def decrypt_files
+        files = []
         iterate(self.working_directory) do |current|
+          files << current
           begin
             decrypt_specific_file(path: current, password: password)
           rescue => ex
@@ -51,6 +56,7 @@ module Match
           UI.success("🔓  Decrypted '#{File.basename(current)}'") if FastlaneCore::Globals.verbose?
         end
         UI.success("🔓  Successfully decrypted certificates repo")
+        return files
       end
 
       def store_password(password)

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -9,7 +9,7 @@ describe Match do
         expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -l 'Imported Private Key' -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain &> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
@@ -28,7 +28,7 @@ describe Match do
         expected_command = "security import item.path -k '#{keychain}' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain}"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -l 'Imported Private Key' -k #{''.shellescape} #{keychain} &> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with(keychain).and_return(true)
@@ -53,7 +53,7 @@ describe Match do
         expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain-db' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -l 'Imported Private Key' -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db &> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain-db").and_return(true)


### PR DESCRIPTION
Fixes #13963
Fixes #13967 (an unintentional breaking change) 

## Fix #13963: for change password
`fastlane match change_password` got broken where no `files_to_commit` where being passed into `storage.save_changes!`. Added a fix where `encryption.encrypt_files` and `encryption.decrypt_files` returns all the files that were encrypted/decrypted so that file list could be used by implementations like `change_password` to use when calling `storage.save_changes!`

## Fix #13967: for breaking change when importing a cert
When working on this change I discovered a recent breaking change that was injected in #13967. The fix for this PR was 💯 (as a password **is** request to to set the partition list to prevent the UI permission modal from being popped up when using a newly imported cert for signing)...

But if no keychain password was a given a `UI.user_error!` was being thrown. A lot of users (including myself) rely on the login keychain when importing these and rely on not passing in a password (as we are already logged in). This `UI.user_error!` was preventing all of my existing implementations from working.

Even though this `UI.user_error!` was technically the correct way to implement this, this could cause havoc when users would upgrade to this newest version (as if code signing isn't already a nightmare 😝 ). So instead of erroring out this whole process, I added a change that would use `UI.error` to inform the user when exactly was failing, why, and how to fix it. This could eventually be replaced with a more specific doc link that explains this but this _should_ do for now 🤔 

### Example Output
```sh
[14:13:01]: Installing certificate...
[14:13:02]:
[14:13:02]: Could not configure imported keychain item (certificate) to prevent UI permission popup when code signing
Check if you supplied the correct `keychain_password` for keychain: `/Users/josh/Library/Keychains/login.keychain-db`
security: SecKeychainItemSetAccessWithPassword: The user name or passphrase you entered is not correct.
[14:13:02]:
[14:13:02]: Please look at the following docs to see how to set a keychain password:
[14:13:02]:  - https://docs.fastlane.tools/actions/sync_code_signing
[14:13:02]:  - https://docs.fastlane.tools/actions/get_certificates
```