### PR TITLE
[helpers] ignore Carthage directory while searching for xcodeproj packages

### DIFF
--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -35,9 +35,8 @@ module Fastlane
           # ensure that the xcodeproj passed in was OK
           UI.user_error!("Could not find the specified xcodeproj: #{xcodeproj_path}") unless File.directory?(xcodeproj_path)
         else
-          all_xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))]
-          # find an xcodeproj (ignoring the Cocoapods one)
-          xcodeproj_paths = Fastlane::Actions.ignore_cocoapods_path(all_xcodeproj_paths)
+          # find an xcodeproj (ignoring dependencies)
+          xcodeproj_paths = Fastlane::Helper::XcodeprojHelper.find(repo_path)
 
           # no projects found: error
           UI.user_error!('Could not find a .xcodeproj in the current repository\'s working directory.') if xcodeproj_paths.count == 0

--- a/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/hg_commit_version_bump.rb
@@ -24,9 +24,8 @@ module Fastlane
             UI.user_error!("Could not find the specified xcodeproj: #{xcodeproj_path}") unless File.directory?(xcodeproj_path)
           end
         else
-          all_xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))]
-          # find an xcodeproj (ignoring the Cocoapods one)
-          xcodeproj_paths = Fastlane::Actions.ignore_cocoapods_path(all_xcodeproj_paths)
+          # find an xcodeproj (ignoring dependencies)
+          xcodeproj_paths = Fastlane::Helper::XcodeprojHelper.find(repo_path)
 
           # no projects found: error
           UI.user_error!('Could not find a .xcodeproj in the current repository\'s working directory.') if xcodeproj_paths.count == 0

--- a/fastlane/lib/fastlane/helper/cocoapod_helper.rb
+++ b/fastlane/lib/fastlane/helper/cocoapod_helper.rb
@@ -1,7 +1,0 @@
-module Fastlane
-  module Actions
-    def self.ignore_cocoapods_path(all_xcodeproj_paths)
-      all_xcodeproj_paths.reject { |path| %r{/Pods/.*.xcodeproj} =~ path }
-    end
-  end
-end

--- a/fastlane/lib/fastlane/helper/xcodeproj_helper.rb
+++ b/fastlane/lib/fastlane/helper/xcodeproj_helper.rb
@@ -1,0 +1,12 @@
+module Fastlane
+  module Helper
+    class XcodeprojHelper
+      DEPENDENCY_MANAGER_DIRS = ['Pods', 'Carthage'].freeze
+
+      def self.find(dir)
+        xcodeproj_paths = Dir[File.expand_path(File.join(dir, '**/*.xcodeproj'))]
+        xcodeproj_paths.reject { |path| %r{/(#{DEPENDENCY_MANAGER_DIRS.join('|')})/.*.xcodeproj} =~ path }
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/hg_commit_version_bump_spec.rb
+++ b/fastlane/spec/actions_specs/hg_commit_version_bump_spec.rb
@@ -15,16 +15,6 @@ describe Fastlane do
         expect(result).to eq("hg commit -m 'Version Bump'")
       end
 
-      it 'return the project path when ignoring the cocoapods path' do
-        all_xcodeproj_paths = ["/Users/tmp/Developer/iOS/MyPods/MyProject/MyProject.xcodeproj", "/Users/tmp/Developer/iOS/MyPods/MyProject/Pods/Pods.xcodeproj"]
-        project_path = Fastlane::Actions.ignore_cocoapods_path(all_xcodeproj_paths)
-        expect(project_path).to eq(all_xcodeproj_paths[0..0])
-
-        all_xcodeproj_paths = ["/Users/tmp/Developer/iOS/MyPods/MyProject/MyProject.xcodeproj", "/Pods/SVPullToRefresh/Demo/SVPullToRefreshDemo.xcodeproj"]
-        project_path = Fastlane::Actions.ignore_cocoapods_path(all_xcodeproj_paths)
-        expect(project_path).to eq(all_xcodeproj_paths[0..0])
-      end
-
       it "passes when modified files are not a subset of expected files, but :force is true" do
         dirty_files = "file1,file3,file5"
         expected_files = "file1"

--- a/fastlane/spec/helper/xcodeproj_helper_spec.rb
+++ b/fastlane/spec/helper/xcodeproj_helper_spec.rb
@@ -17,7 +17,7 @@ describe Fastlane::Actions do
       FileUtils.mkdir_p(path)
 
       paths = Fastlane::Helper::XcodeprojHelper.find(dir)
-      expect(paths).to eq([path])
+      expect(paths).to contain_exactly(path)
     end
 
     it 'finds multiple nested' do
@@ -28,10 +28,10 @@ describe Fastlane::Actions do
       FileUtils.mkdir_p(secondary_path)
 
       paths = Fastlane::Helper::XcodeprojHelper.find(dir)
-      expect(paths).to eq([path, secondary_path])
+      expect(paths).to contain_exactly(path, secondary_path)
     end
 
-    it 'finds one, ignoring dependencies' do
+    it 'finds multiple nested, ignoring dependencies' do
       path = File.join(dir, PATH)
       FileUtils.mkdir_p(path)
 
@@ -44,7 +44,7 @@ describe Fastlane::Actions do
       FileUtils.mkdir_p(File.join(dir, CARTHAGE_FRAMEWORK_EXAMPLE_PATH))
 
       paths = Fastlane::Helper::XcodeprojHelper.find(dir)
-      expect(paths).to eq([path, secondary_path])
+      expect(paths).to contain_exactly(path, secondary_path)
     end
 
     after do

--- a/fastlane/spec/helper/xcodeproj_helper_spec.rb
+++ b/fastlane/spec/helper/xcodeproj_helper_spec.rb
@@ -1,0 +1,54 @@
+require 'fileutils'
+require 'tmpdir'
+
+describe Fastlane::Actions do
+  describe '#xcodeproj_helper' do
+    PATH = 'Project.xcodeproj'.freeze
+    SECONDARY_PATH = 'Secondary/Project.xcodeproj'.freeze
+    COCOAPODS_PATH = 'Pods/Pod.xcodeproj'.freeze
+    COCOAPODS_FRAMEWORK_EXAMPLE_PATH = 'Pods/Alamofire/Example/iOS Example.xcodeproj'.freeze
+    CARTHAGE_FRAMEWORK_PATH = 'Carthage/Checkouts/Alamofire/Alamofire.xcodeproj'.freeze
+    CARTHAGE_FRAMEWORK_EXAMPLE_PATH = 'Carthage/Checkouts/Alamofire/Example iOS Example.xcodeproj'.freeze
+
+    let(:dir) { Dir.mktmpdir }
+
+    it 'finds one' do
+      path = File.join(dir, PATH)
+      FileUtils.mkdir_p(path)
+
+      paths = Fastlane::Helper::XcodeprojHelper.find(dir)
+      expect(paths).to eq([path])
+    end
+
+    it 'finds multiple nested' do
+      path = File.join(dir, PATH)
+      FileUtils.mkdir_p(path)
+
+      secondary_path = File.join(dir, SECONDARY_PATH)
+      FileUtils.mkdir_p(secondary_path)
+
+      paths = Fastlane::Helper::XcodeprojHelper.find(dir)
+      expect(paths).to eq([path, secondary_path])
+    end
+
+    it 'finds one, ignoring dependencies' do
+      path = File.join(dir, PATH)
+      FileUtils.mkdir_p(path)
+
+      secondary_path = File.join(dir, SECONDARY_PATH)
+      FileUtils.mkdir_p(secondary_path)
+
+      FileUtils.mkdir_p(File.join(dir, COCOAPODS_PATH))
+      FileUtils.mkdir_p(File.join(dir, COCOAPODS_FRAMEWORK_EXAMPLE_PATH))
+      FileUtils.mkdir_p(File.join(dir, CARTHAGE_FRAMEWORK_PATH))
+      FileUtils.mkdir_p(File.join(dir, CARTHAGE_FRAMEWORK_EXAMPLE_PATH))
+
+      paths = Fastlane::Helper::XcodeprojHelper.find(dir)
+      expect(paths).to eq([path, secondary_path])
+    end
+
+    after do
+      FileUtils.rm_rf(dir)
+    end
+  end
+end


### PR DESCRIPTION
Hello, hello! 👋 

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
While searching for an `xcodeproj` package, `commit_version_bump` and `hg_commit_version_bump` actions ignore the ones under the Cocoapods directory, but not the Carthage directory.

### Description
The piece of code that filters `xcodeproj` packages under the Cocoapods directory is within a helper called `cocoapod_helper.rb`.

Instead of renaming this helper to something like `dependency_manager_helper.rb` and doing filtering for Carthage, this pull request introduces a new helper that focuses on finding `xcodeproj` packages for a given directory—also filtering dependencies. It also adds tests for this new helper, covering a few use cases.