### PR TITLE
[action] Fix version regex in increment_version_number

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -23,11 +23,14 @@ module Fastlane
           '&&'
         ].join(' ')
 
-        current_version = Actions.sh(
-          "#{command_prefix} agvtool what-marketing-version -terse1",
-          log: FastlaneCore::Globals.verbose?,
-          error_callback: ->(result) { current_version = '' }
-        ).split("\n").last
+        begin
+          current_version = Actions
+                            .sh("#{command_prefix} agvtool what-marketing-version -terse1", log: FastlaneCore::Globals.verbose?)
+                            .split("\n")
+                            .last
+        rescue
+          current_version = ''
+        end
 
         version_regex = /^\d+\.\d+\.\d+$/
         if params[:version_number]

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -29,7 +29,7 @@ module Fastlane
           error_callback: ->(result) { current_version = '' }
         ).split("\n").last
 
-        version_regex = /^\d+.\d+.\d+$/
+        version_regex = /^\d+\.\d+\.\d+$/
         if params[:version_number]
           UI.verbose("Your current version (#{current_version}) does not respect the format A.B.C") unless current_version =~ version_regex
 

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -25,8 +25,9 @@ module Fastlane
 
         current_version = `#{command_prefix} agvtool what-marketing-version -terse1`.split("\n").last || ''
 
+        version_regex = /^\d+.\d+.\d+$/
         if params[:version_number]
-          UI.verbose("Your current version (#{current_version}) does not respect the format A.B.C") unless current_version =~ /\d.\d.\d/
+          UI.verbose("Your current version (#{current_version}) does not respect the format A.B.C") unless current_version =~ version_regex
 
           # Specific version
           next_version_number = params[:version_number]
@@ -34,7 +35,7 @@ module Fastlane
           if Helper.test?
             version_array = [1, 0, 0]
           else
-            UI.user_error!("Your current version (#{current_version}) does not respect the format A.B.C") unless current_version =~ /\d+.\d+.\d+/
+            UI.user_error!("Your current version (#{current_version}) does not respect the format A.B.C") unless current_version =~ version_regex
             version_array = current_version.split(".").map(&:to_i)
           end
 

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -23,7 +23,11 @@ module Fastlane
           '&&'
         ].join(' ')
 
-        current_version = `#{command_prefix} agvtool what-marketing-version -terse1`.split("\n").last || ''
+        current_version = Actions.sh(
+          "#{command_prefix} agvtool what-marketing-version -terse1",
+          log: FastlaneCore::Globals.verbose?,
+          error_callback: ->(result) { current_version = '' }
+        ).split("\n").last
 
         version_regex = /^\d+.\d+.\d+$/
         if params[:version_number]

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -36,12 +36,8 @@ module Fastlane
           # Specific version
           next_version_number = params[:version_number]
         else
-          if Helper.test?
-            version_array = [1, 0, 0]
-          else
-            UI.user_error!("Your current version (#{current_version}) does not respect the format A.B.C") unless current_version =~ version_regex
-            version_array = current_version.split(".").map(&:to_i)
-          end
+          UI.user_error!("Your current version (#{current_version}) does not respect the format A.B.C") unless current_version =~ version_regex
+          version_array = current_version.split(".").map(&:to_i)
 
           case params[:bump_type]
           when "patch"

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -28,6 +28,7 @@ module Fastlane
                             .sh("#{command_prefix} agvtool what-marketing-version -terse1", log: FastlaneCore::Globals.verbose?)
                             .split("\n")
                             .last
+                            .strip
         rescue
           current_version = ''
         end

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -1,9 +1,11 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Increment Version Number Integration" do
-      require 'shellwords'
-
       it "it increments all targets patch version number" do
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool what-marketing-version/, any_args)
+          .once
+          .and_return("1.0.0")
         Fastlane::FastFile.new.parse("lane :test do
           increment_version_number
         end").runner.execute(:test)
@@ -12,6 +14,10 @@ describe Fastlane do
       end
 
       it "it increments all targets minor version number" do
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool what-marketing-version/, any_args)
+          .once
+          .and_return("1.0.0")
         Fastlane::FastFile.new.parse("lane :test do
           increment_version_number(bump_type: 'minor')
         end").runner.execute(:test)
@@ -20,6 +26,10 @@ describe Fastlane do
       end
 
       it "it increments all targets minor version major" do
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool what-marketing-version/, any_args)
+          .once
+          .and_return("1.0.0")
         Fastlane::FastFile.new.parse("lane :test do
           increment_version_number(bump_type: 'major')
         end").runner.execute(:test)
@@ -52,6 +62,10 @@ describe Fastlane do
       end
 
       it "returns the new version as return value" do
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool what-marketing-version/, any_args)
+          .once
+          .and_return("1.0.0")
         result = Fastlane::FastFile.new.parse("lane :test do
           increment_version_number(bump_type: 'major')
         end").runner.execute(:test)
@@ -67,12 +81,24 @@ describe Fastlane do
         end.to raise_error("Could not find Xcode project")
       end
 
-      it "raises an exception when use passes workspace" do
+      it "raises an exception when user passes workspace" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             increment_version_number(xcodeproj: 'project.xcworkspace')
           end").runner.execute(:test)
         end.to raise_error("Please pass the path to the project, not the workspace")
+      end
+
+      it "raises an exception when unable to calculate new version" do
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool what-marketing-version/, any_args)
+          .once
+          .and_return("1.0.2-alpha")
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            increment_version_number
+          end").runner.execute(:test)
+        end.to raise_error("Your current version (1.0.2-alpha) does not respect the format A.B.C")
       end
     end
   end

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -93,12 +93,12 @@ describe Fastlane do
         expect(Fastlane::Actions).to receive(:sh)
           .with(/agvtool what-marketing-version/, any_args)
           .once
-          .and_return("1.0.2-alpha")
+          .and_return("00000")
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             increment_version_number
           end").runner.execute(:test)
-        end.to raise_error("Your current version (1.0.2-alpha) does not respect the format A.B.C")
+        end.to raise_error("Your current version (00000) does not respect the format A.B.C")
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Noticed that regexes to validate version format between https://github.com/fastlane/fastlane/pull/14005/files#diff-5a9635727c1c2c153502b19faacb2320L29 and https://github.com/fastlane/fastlane/pull/14005/files#diff-5a9635727c1c2c153502b19faacb2320L37 are different and both are not strict enough.

### Description

This PR fixes the regex for version format check and also write tests for the case.