### PR TITLE
[spaceship] Fixed deprecated call using Faraday

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -212,10 +212,10 @@ module Spaceship
         if ENV['SPACESHIP_DEBUG']
           # for debugging only
           # This enables tracking of networking requests using Charles Web Proxy
-          c.proxy("https://127.0.0.1:8888")
+          c.proxy = "https://127.0.0.1:8888"
           c.ssl[:verify_mode] = OpenSSL::SSL::VERIFY_NONE
         elsif ENV["SPACESHIP_PROXY"]
-          c.proxy(ENV["SPACESHIP_PROXY"])
+          c.proxy = ENV["SPACESHIP_PROXY"]
           c.ssl[:verify_mode] = OpenSSL::SSL::VERIFY_NONE if ENV["SPACESHIP_PROXY_SSL_VERIFY_NONE"]
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I wanted to debug why I can't upload videos to AppStoreConnect using Spaceship, while doing that I noticed a warning about a deprecated Faraday call for setting the proxy. This fixes #14007

### Description
I replaced the now deprecated `proxy(x)` call with `proxy = x`. That seemed like an easy enough task as my first PR ;)
