### PR TITLE
[gemspec] raise upper limit on Bundler version to include 2.x.x

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -87,7 +87,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('security', '= 0.1.3') # macOS Keychain manager, a dead project, no updates expected
   spec.add_dependency('xcpretty-travis-formatter', '>= 0.0.3')
   spec.add_dependency('dotenv', '>= 2.1.1', '< 3.0.0')
-  spec.add_dependency('bundler', '>= 1.12.0', '< 2.0.0') # Used for fastlane plugins
+  spec.add_dependency('bundler', '>= 1.12.0', '< 3.0.0') # Used for fastlane plugins
   spec.add_dependency('faraday', '~> 0.9') # Used for deploygate, hockey and testfairy actions
   spec.add_dependency('faraday_middleware', '~> 0.9') # same as faraday
   spec.add_dependency('simctl', '~> 1.6.3') # Used for querying and interacting with iOS simulators


### PR DESCRIPTION
Resolves #14016. :key:

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Bundler 2.0 was recently released, and those users who want to upgrade cannot do so until this gem removes its requirement on Bundler being less than 2.0.  Moreover, users who are unable to satisfy the RubyGems ≥ 2.5.0 or Ruby ≥ 2.3 requirement imposed by Bundler 2.0 will not be forced to upgrade, I'm pretty sure. This PR just loosens the requirement. I thought about completely removing the upper bound, but decided not to.

Resolves #14016.

### Description
This PR is a one-liner change to the Gemspec.