### PR TITLE
[spaceship] Fix getting reviews on apps with no reviews

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -377,6 +377,10 @@ module Spaceship
 
         r = request(:get, rating_url)
         all_reviews.concat(parse_response(r, 'data')['reviews'])
+        
+        # The following lines throw errors when there are no reviews so exit out of the loop before them if the app has no reviews
+        break if all_reviews.count == 0
+        
         last_review_date = Time.at(all_reviews[-1]['value']['lastModified'] / 1000)
 
         if upto_date && last_review_date < upto_date

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -377,10 +377,10 @@ module Spaceship
 
         r = request(:get, rating_url)
         all_reviews.concat(parse_response(r, 'data')['reviews'])
-        
+
         # The following lines throw errors when there are no reviews so exit out of the loop before them if the app has no reviews
         break if all_reviews.count == 0
-        
+
         last_review_date = Time.at(all_reviews[-1]['value']['lastModified'] / 1000)
 
         if upto_date && last_review_date < upto_date


### PR DESCRIPTION
Fixed an error with getting reviews for an app with no reviews.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

Very quick simple fix so I think changes and reasoning are fairly obvious, previously there was an error when getting the reviews for an app with no reviews (some details on #14022 ), have added a line of code which, when there are no reviews, skips the lines which were causing the errors since in that scenario they are not needed.

Didn't actually download anything just edited the file locally on github - is there any way to complete the first 2 items on the checklist without downloading everything? Might it even be possible to skip that since I only added one line?

Thanks for all the hard work you guys put in,
Henry