### PR TITLE
[spaceship] Fixed trailer upload failing due to missing preview file

### DIFF
--- a/spaceship/lib/spaceship/du/utilities.rb
+++ b/spaceship/lib/spaceship/du/utilities.rb
@@ -40,7 +40,7 @@ module Spaceship
     # @param video_path (String) the path to the video file
     # @param timestamp (String) the `ffmpeg` timestamp format (e.g. 00.00)
     # @param dimensions (Array) the dimension of the screenshot to generate
-    # @return the path to the TempFile containing the generated screenshot
+    # @return the TempFile containing the generated screenshot
     def grab_video_preview(video_path, timestamp, dimensions)
       width, height = dimensions
       require 'tempfile'
@@ -50,7 +50,7 @@ module Spaceship
       # puts "COMMAND: #{command}"
       `#{command}`
       raise "Failed to grab screenshot at #{timestamp} from #{video_path} (using #{command})" unless $CHILD_STATUS.to_i == 0
-      tmp.path
+      tmp
     end
 
     # identifies the resolution of a video using `ffmpeg`

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -567,7 +567,10 @@ module Spaceship
           else
             # IDEA: optimization, we could avoid fetching the screenshot if the timestamp hasn't changed
             video_preview_resolution = video_preview_resolution_for(device, trailer_path)
-            video_preview_path = Utilities.grab_video_preview(trailer_path, timestamp, video_preview_resolution)
+
+            # Keep a reference of the video_preview here to avoid Ruby getting rid of the Tempfile in the meanwhile
+            video_preview = Utilities.grab_video_preview(trailer_path, timestamp, video_preview_resolution)
+            video_preview_path = video_preview.path
           end
           video_preview_file = UploadFile.from_path(video_preview_path)
           video_preview_data = client.upload_trailer_preview(self, video_preview_file, device)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Spaceship kept failing on me when uploading an app trailer. After some debugging it turned out that Ruby gets rid of the temporary video preview file that is saved before the upload, and by the time the upload is done that file is missing. This fixes #14020

### Description
I changed the utilities method that takes the video preview to return the Tempfile itself instead of just the path. This way the file only gets cleaned up after the whole action is finished.
I tried the same video that failed to upload before, with this change the upload worked fine for me.

Please keep in mind that I'm not a Ruby expert - if there's a nicer trick to solve this I'm happy to hear about it ;)