### PR TITLE
[spaceship] Disable media scaling when a trailer is uploaded

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -515,10 +515,9 @@ module Spaceship
           # We only set this, if we actually successfully uploaded a new screenshot
           # for this device / language combination
           # if this value is not set, iTC will fallback to another device type for screenshots
-          language_details = raw_data_details.find { |d| d["language"] == language }["displayFamilies"]["value"]
-          device_language_details = language_details.find { |display_family| display_family['name'] == device }
           scaled_key = is_messages ? "messagesScaled" : "scaled"
-          device_language_details[scaled_key]["value"] = false
+          scaled_details = container_data_for_language_and_device(scaled_key, language, device)
+          scaled_details["value"] = false
 
           if existing_sort_orders.include?(sort_order) # replace
             device_lang_screenshots[existing_sort_orders.index(sort_order)] = new_screenshot

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -481,7 +481,7 @@ module Spaceship
       end
 
       # Uploads or removes a screenshot
-      # @param icon_path (String): The path to the screenshot. Use nil to remove it
+      # @param screenshot_path (String): The path to the screenshot. Use nil to remove it
       # @param sort_order (Fixnum): The sort_order, from 1 to 5
       # @param language (String): The language for this screenshot
       # @param device (string): The device for this screenshot


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
With the fix from #14028 uploading trailers works, now saving the version with the trailer failed for me. After some try and error I figured out that the issue is that fastlane still tries to turn on scaling for devices even if there is a trailer uploaded (and no screenshot). This fixes #14030 

### Description
I changed the code for the initial data setup, so that devices that have trailers are also disabling scaling. I also made sure to disable scaling at the end of uploading a new trailer.
I tested this by trying to upload the same video again, and now I could finally save it.

**Note:** I found several tests for the trailer-related code, but all of it is commented out. Should I add tests for my fix/try to get the existing tests working?