### PR TITLE
[supply] Add option to pass version codes to retain

### DIFF
--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -228,7 +228,17 @@ module Supply
                                      optional: true,
                                      description: "When promoting to a new track, deactivate the binary in the origin track",
                                      is_string: false,
-                                     default_value: true)
+                                     default_value: true),
+        FastlaneCore::ConfigItem.new(key: :version_codes_to_retain,
+                                     optional: true,
+                                     type: Array,
+                                     description: "An array of version codes to retain when publishing a new APK",
+                                     verify_block: proc do |version_codes|
+                                       UI.user_error!("Could not evaluate array from '#{version_codes}'") unless version_codes.kind_of?(Array)
+                                       version_codes.each do |version_code|
+                                         UI.user_error!("Version code '#{version_code}' is not an integer") unless version_code.kind_of?(Integer)
+                                       end
+                                     end)
       ]
     end
     # rubocop:enable Metrics/PerceivedComplexity

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -28,6 +28,8 @@ module Supply
       apk_version_codes.concat(upload_bundles) unless Supply.config[:skip_upload_aab]
       upload_mapping(apk_version_codes)
 
+      apk_version_codes.concat(Supply.config[:version_codes_to_retain]) if Supply.config[:version_codes_to_retain]
+
       # Only update tracks if we have version codes
       # Updating a track with empty version codes can completely clear out a track
       update_track(apk_version_codes) unless apk_version_codes.empty?

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -340,5 +340,24 @@ describe Supply do
         Supply::Uploader.new.check_superseded_tracks([106])
       end
     end
+
+    describe '#perform_upload with version_codes_to_retain' do
+      let(:client) { double('client') }
+      let(:config) { { apk: 'some/path/app.apk', version_codes_to_retain: [2, 3] } }
+
+      before do
+        Supply.config = config
+        allow(Supply::Client).to receive(:make_from_config).and_return(client)
+        allow(client).to receive(:upload_apk).with(config[:apk]).and_return(1) # newly uploaded version code
+        allow(client).to receive(:begin_edit).and_return(nil)
+        allow(client).to receive(:commit_current_edit!).and_return(nil)
+      end
+
+      it 'should update track with correct version codes' do
+        uploader = Supply::Uploader.new
+        expect(uploader).to receive(:update_track).with([1, 2, 3]).once
+        uploader.perform_upload
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Currently when using `supply` to push a new APK to Google Play, old version codes on the track get replaced by the newly uploaded version. If you want to keep old versions around (i.e. to support old API levels) those would be removed by Fastlane.

### Description

This PR adds an option to `supply` to specify `version_codes_to_retain`. It uses the same wording *retain* as is used in the Google Play developer console.

The documentation for the newly added parameter should be auto-generated.