### PR TITLE
[action] explicitly unlink to keep references to temp files for crashlytics

### DIFF
--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -12,22 +12,25 @@ module Fastlane
         if params[:notes]
           UI.error("Overwriting :notes_path, because you specified :notes") if params[:notes_path]
 
-          tempfiles << Helper::CrashlyticsHelper.write_to_tempfile(params[:notes], 'changelog')
-          params[:notes_path] = tempfiles.last.path
+          changelog = Helper::CrashlyticsHelper.write_to_tempfile(params[:notes], 'changelog')
+          tempfiles << changelog
+          params[:notes_path] = changelog.path
         elsif Actions.lane_context[SharedValues::FL_CHANGELOG] && !params[:notes_path]
           UI.message("Sending FL_CHANGELOG as release notes to Beta by Crashlytics")
 
-          tempfiles << Helper::CrashlyticsHelper.write_to_tempfile(
+          changelog = Helper::CrashlyticsHelper.write_to_tempfile(
             Actions.lane_context[SharedValues::FL_CHANGELOG], 'changelog'
           )
-          params[:notes_path] = tempfiles.last.path
+          tempfiles << changelog
+          params[:notes_path] = changelog.path
         end
 
         if params[:ipa_path]
           command = Helper::CrashlyticsHelper.generate_ios_command(params)
         elsif params[:apk_path]
-          tempfiles << Helper::CrashlyticsHelper.generate_android_manifest_tempfile
-          command = Helper::CrashlyticsHelper.generate_android_command(params, tempfiles.last.path)
+          android_manifest = Helper::CrashlyticsHelper.generate_android_manifest_tempfile
+          tempfiles << android_manifest
+          command = Helper::CrashlyticsHelper.generate_android_command(params, android_manifest.path)
         else
           UI.user_error!("You have to either pass an ipa or an apk file to the Crashlytics action")
         end

--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -26,12 +26,8 @@ module Fastlane
         if params[:ipa_path]
           command = Helper::CrashlyticsHelper.generate_ios_command(params)
         elsif params[:apk_path]
-          command = Helper::CrashlyticsHelper.generate_android_command(params)
-          # We have to generate an empty XML file to make the crashlytics CLI happy :)
-          tempfiles << Helper::CrashlyticsHelper.write_to_tempfile(
-            '<?xml version="1.0" encoding="utf-8"?><manifest></manifest>', 'xml'
-          )
-          command << "-androidManifest #{tempfiles.last.path.shellescape}"
+          tempfiles << Helper::CrashlyticsHelper.generate_android_manifest_tempfile
+          command = Helper::CrashlyticsHelper.generate_android_command(params, tempfiles.last.path)
         else
           UI.user_error!("You have to either pass an ipa or an apk file to the Crashlytics action")
         end

--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -56,7 +56,7 @@ module Fastlane
           return command
         end
 
-        def generate_android_command(params)
+        def generate_android_command(params, android_manifest_path)
           params[:crashlytics_path] = download_android_tools unless params[:crashlytics_path]
 
           UI.user_error!("The `crashlytics_path` must be a jar file for Android") unless params[:crashlytics_path].end_with?(".jar") || Helper.test?
@@ -71,6 +71,7 @@ module Fastlane
           command << "-apiKey #{params[:api_token]}"
           command << "-apiSecret #{params[:build_secret]}"
           command << "-uploadDist #{File.expand_path(params[:apk_path]).shellescape}"
+          command << "-androidManifest #{File.expand_path(android_manifest_path).shellescape}"
 
           # Optional
           command << "-betaDistributionEmails #{params[:emails].shellescape}" if params[:emails]
@@ -115,6 +116,11 @@ module Fastlane
           end
 
           return jar_path
+        end
+
+        def generate_android_manifest_tempfile
+          # We have to generate an empty XML file to make the crashlytics CLI happy :)
+          write_to_tempfile('<?xml version="1.0" encoding="utf-8"?><manifest></manifest>', 'xml')
         end
 
         def write_to_tempfile(value, tempfilename)

--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -57,12 +57,6 @@ module Fastlane
         end
 
         def generate_android_command(params)
-          # We have to generate an empty XML file to make the crashlytics CLI happy :)
-          require 'tempfile'
-          xml = Tempfile.new('xml')
-          xml.write('<?xml version="1.0" encoding="utf-8"?><manifest></manifest>')
-          xml.close
-
           params[:crashlytics_path] = download_android_tools unless params[:crashlytics_path]
 
           UI.user_error!("The `crashlytics_path` must be a jar file for Android") unless params[:crashlytics_path].end_with?(".jar") || Helper.test?
@@ -77,7 +71,6 @@ module Fastlane
           command << "-apiKey #{params[:api_token]}"
           command << "-apiSecret #{params[:build_secret]}"
           command << "-uploadDist #{File.expand_path(params[:apk_path]).shellescape}"
-          command << "-androidManifest #{xml.path.shellescape}"
 
           # Optional
           command << "-betaDistributionEmails #{params[:emails].shellescape}" if params[:emails]

--- a/fastlane/spec/actions_specs/crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/crashlytics_spec.rb
@@ -12,6 +12,11 @@ describe Fastlane do
       describe "Android" do
         describe "Valid parameters" do
           it "works with valid parameters" do
+            android_manifest = double(path: 'manifest')
+            expect(Fastlane::Helper::CrashlyticsHelper).to receive(:generate_android_manifest_tempfile)
+              .once
+              .and_return(android_manifest)
+            expect(android_manifest).to receive(:unlink).once
             command = Fastlane::FastFile.new.parse('lane :test do
               crashlytics(
                 crashlytics_path: "./fastlane/spec/fixtures/actions/crashlytics/submit",
@@ -29,18 +34,13 @@ describe Fastlane do
              "-apiKey api_token",
              "-apiSecret build_secret",
              "-uploadDist ",
+             "-androidManifest #{File.expand_path('manifest')}",
              "-betaDistributionReleaseNotesFilePath ",
              "-betaDistributionEmails email1@krausefx.com,email2@krausefx.com",
              "-betaDistributionGroupAliases testgroup",
              "-betaDistributionNotifications true"].each do |to_be|
               expect(command.join(" ")).to include(to_be)
             end
-
-            # These 2 parameters are temporary
-            # "-androidManifest '/var/folders/dh/6sxzb7_n37nb8s8pbbk_wc0c0000gn/T/xml20151005-29563-m97zs2'",
-            # "-betaDistributionReleaseNotesFilePath '/var/folders/dh/6sxzb7_n37nb8s8pbbk_wc0c0000gn/T/changelog20151005-29563-1o3uf3m'",
-            expect(command.join(" ")).to include("-betaDistributionReleaseNotesFilePath")
-            expect(command.join(" ")).to include("-androidManifest")
           end
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Try to solve https://github.com/fastlane/fastlane/issues/12566

### Description

Apparently sometimes GC runs before running actual sh and crashlytics action fails randomly because temp files are deleted..