### PR TITLE
[ci] updating homebrew cache key due to recent homebrew 1.9 push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ jobs:
           key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
       - restore_cache:
           keys:
-            - v3-homebrew-{{ epoch }}
-            - v3-homebrew
+            - v4-homebrew-{{ epoch }}
+            - v4-homebrew
       - run:
           name: Setup Build
           command: |
@@ -28,7 +28,7 @@ jobs:
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
 
       - save_cache:
-          key: v3-homebrew-{{ epoch }}
+          key: v4-homebrew-{{ epoch }}
           paths:
             - /usr/local/Homebrew
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ jobs:
     macos:
       xcode: "9.0.0"
     environment:
-      HOMEBREW_LOGS: ~/homebrew-logs
       CIRCLE_TEST_REPORTS: ~/test-reports
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
@@ -17,8 +16,8 @@ jobs:
           key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
       - restore_cache:
           keys:
-            - v4-homebrew-{{ epoch }}
-            - v4-homebrew
+            - v5-homebrew-{{ epoch }}
+            - v5-homebrew
       - run:
           name: Setup Build
           command: |
@@ -29,7 +28,7 @@ jobs:
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
 
       - save_cache:
-          key: v4-homebrew-{{ epoch }}
+          key: v5-homebrew-{{ epoch }}
           paths:
             - /usr/local/Homebrew
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     macos:
       xcode: "9.0.0"
     environment:
+      HOMEBREW_LOGS: ~/homebrew-logs
       CIRCLE_TEST_REPORTS: ~/test-reports
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
           command: |
             mkdir -p ~/test-reports
             echo "2.3" > .ruby-version
+            brew config
+            brew doctor
             gem update --system
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle


### PR DESCRIPTION
CircleCI jobs started failing when trying to load homebrew cache due to newest homebrew 1.9 release (I think).

🤞hoping this fixes it