### PR TITLE
Fix undefined local variable `output_path` in JUnitGenerator

### DIFF
--- a/fastlane/lib/fastlane/junit_generator.rb
+++ b/fastlane/lib/fastlane/junit_generator.rb
@@ -18,7 +18,7 @@ module Fastlane
         File.write(path, xml)
       rescue => ex
         UI.error(ex)
-        UI.error("Couldn't save report.xml at path '#{File.expand_path(output_path)}', make sure you have write access to the containing directory.")
+        UI.error("Couldn't save report.xml at path '#{File.expand_path(path)}', make sure you have write access to the containing directory.")
       end
 
       return path


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

NameError occurs when JUnitGenerator fails to write `report.xml`.

```
NameError: [!] undefined local variable or method `output_path' for Fastlane::JUnitGenerator:Class
```
