### PR TITLE
Adds documentation for IDFA specifiers

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -184,7 +184,7 @@ module Deliver
                                      end),
         FastlaneCore::ConfigItem.new(key: :submission_information,
                                      short_option: "-b",
-                                     description: "Extra information for the submission (e.g. third party content)",
+                                     description: "Extra information for the submission (e.g. compliance specifications, IDFA settings)",
                                      is_string: false,
                                      optional: true),
 

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -412,6 +412,9 @@ end
 
 Omit `build_number` to let _fastlane_ automatically select the latest build number for the current version being edited for release from App Store Connect.
 
+### Compliance and IDFA settings
+
+Use the `submission_information` parameter for additional submission specifiers, including compliance and IDFA settings. Look at the Spaceship's [`app_submission.rb`](https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/tunes/app_submission.rb) file for options. See [this example](https://github.com/artsy/eigen/blob/faa02e2746194d8d7c11899474de9c517435eca4/fastlane/Fastfile#L131-L149).
 
 # Credentials
 


### PR DESCRIPTION
🔑 

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

Apple emphasizes the importance of accurate IDFA settings in its App Store submission web UI, but we've found it very difficult to find information about how to specify IDFA settings when submitting through Fastlane. This PR should help.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

I added a new section to the [deliver docs](https://docs.fastlane.tools/actions/deliver/#deliver) that explains where to add IDFA settings, including a link to an example from Artsy and a link to Spaceship's source code with submission settings.

I also modified the description of the `submission_information` to mention IDFA settings to help point users in the right direction. 

### Meta Feedback

I know the Fastlane team is looking for ways to make contributing to documentation easier, so I'd like to provide some feedback on how I found contributing to the docs.

The "Edit on GitHub" link at the top of the [docs page](https://docs.fastlane.tools/actions/deliver/#deliver) took me to this URL: https://github.com/fastlane/fastlane/edit/master/fastlane/lib/fastlane/actions/deliver.rb But that was obviously not where I had to make my changes. Then I looked in the [deliver readme](https://github.com/fastlane/fastlane/tree/master/deliver) and was pointed back to the docs page. I solved this eventually by cloning the whole repo and doing a project-wide search for text from the docs page, eventually finding an ERB-backed markdown file.

The generated documentation is really robust, but it's not easy to contribute to. Adding more links to places where the docs get generated would help, maybe even a "how to contribute to the docs" doc. /cc @KrauseFx 