### PR TITLE
gemspec: Update emoji_regex version requirement to 1.0

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -97,7 +97,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('google-api-client', '>= 0.21.2', '< 0.24.0') # Google API Client to access Play Publishing API
   spec.add_dependency('google-cloud-storage', '>= 1.15.0', '< 2.0.0') # Access Google Cloud Storage for match
 
-  spec.add_dependency('emoji_regex', '~> 0.1') # Used to scan for Emoji in the changelog
+  spec.add_dependency('emoji_regex', '~> 1.0') # Used to scan for Emoji in the changelog
 
   # Development only
   spec.add_development_dependency('rake', '< 12')

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -97,7 +97,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('google-api-client', '>= 0.21.2', '< 0.24.0') # Google API Client to access Play Publishing API
   spec.add_dependency('google-cloud-storage', '>= 1.15.0', '< 2.0.0') # Access Google Cloud Storage for match
 
-  spec.add_dependency('emoji_regex', '>= 0.1' , '< 2.0') # Used to scan for Emoji in the changelog
+  spec.add_dependency('emoji_regex', '>= 0.1', '< 2.0') # Used to scan for Emoji in the changelog
 
   # Development only
   spec.add_development_dependency('rake', '< 12')

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -97,7 +97,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('google-api-client', '>= 0.21.2', '< 0.24.0') # Google API Client to access Play Publishing API
   spec.add_dependency('google-cloud-storage', '>= 1.15.0', '< 2.0.0') # Access Google Cloud Storage for match
 
-  spec.add_dependency('emoji_regex', '~> 1.0') # Used to scan for Emoji in the changelog
+  spec.add_dependency('emoji_regex', '>= 0.1' , '< 2.0') # Used to scan for Emoji in the changelog
 
   # Development only
   spec.add_development_dependency('rake', '< 12')


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

`emoji_regex` is out of date, and this update did not break anything. It's used in `pilot/lib/pilot/build_manager.rb` and I've verified that the API hasn't changed.

### Description

I ran `bundle install` and then tested.