### PR TITLE
[gym] Detect true build configuration for archive action

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = Dir["*/lib"]
 
   spec.add_dependency('slack-notifier', '>= 2.0.0', '< 3.0.0') # Slack notifications
-  spec.add_dependency('xcodeproj', '>= 1.6.0', '< 2.0.0') # Modify Xcode projects
+  spec.add_dependency('xcodeproj', '>= 1.8.1', '< 2.0.0') # Modify Xcode projects
   spec.add_dependency('xcpretty', '~> 0.3.0') # prettify xcodebuild output
   spec.add_dependency('terminal-notifier', '>= 1.6.2', '< 2.0.0') # macOS notifications
   spec.add_dependency('terminal-table', '>= 1.4.5', '< 2.0.0') # Actions documentation

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -103,8 +103,8 @@ module FastlaneCore
     # returns the Xcodeproj::Workspace or nil if it is a project
     def workspace
       return nil unless workspace?
+
       @workspace ||= Xcodeproj::Workspace.new_from_xcworkspace(path)
-      @workspace.load_schemes(path)
       @workspace
     end
 

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -109,7 +109,7 @@ module Gym
       configuration = Gym.config[:configuration]
       configuration ||= extract_from_scheme.call if Gym.config[:scheme]
       configuration ||= self.project.default_build_settings(key: "CONFIGURATION")
-      configuration
+      return configuration
     end
 
     def detect_project_profile_mapping

--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -34,6 +34,14 @@ describe Gym::CodeSigningMapping do
       csm = Gym::CodeSigningMapping.new(project: project)
       expect(csm.detect_project_profile_mapping).to eq({ "family.wwdc.app" => "match AppStore family.wwdc.app", "family.wwdc.app.watchkitapp" => "match AppStore family.wwdc.app.watchkitapp", "family.wwdc.app.watchkitapp.watchkitextension" => "match AppStore family.wwdc.app.watchkitappextension" })
     end
+
+    it "detects the build configuration from selected scheme", requires_xcode: true do
+      workspace_path = "gym/spec/fixtures/projects/cocoapods/Example.xcworkspace"
+      project = FastlaneCore::Project.new({ workspace: workspace_path })
+      csm = Gym::CodeSigningMapping.new(project: project)
+      Gym.config[:scheme] = "Example (Debug)"
+      expect(csm.detect_project_profile_mapping).to eq({ "family.wwdc.app" => "match Development family.wwdc.app", "family.wwdc.app.watchkitapp" => "match Development family.wwdc.app.watchkitapp", "family.wwdc.app.watchkitapp.watchkitextension" => "match Development family.wwdc.app.watchkitappextension" })
+    end
   end
 
   describe "#detect_project_profile_mapping_for_tv_os" do

--- a/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/project.pbxproj
+++ b/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/project.pbxproj
@@ -724,7 +724,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = family.wwdc.app;
 				PRODUCT_NAME = "$(TARGET_NAME)ProductName";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore family.wwdc.app";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development family.wwdc.app";
 			};
 			name = Debug;
 		};
@@ -897,7 +897,7 @@
 				INFOPLIST_FILE = ExampleWatchOS/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = family.wwdc.app.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore family.wwdc.app.watchkitapp";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development family.wwdc.app.watchkitapp";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -966,7 +966,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = family.wwdc.app.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore family.wwdc.app.watchkitappextension";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development family.wwdc.app.watchkitappextension";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;

--- a/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/xcshareddata/xcschemes/Example (Debug).xcscheme
+++ b/gym/spec/fixtures/projects/cocoapods/Example.xcodeproj/xcshareddata/xcschemes/Example (Debug).xcscheme
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CAC1E1971B6A326100A8B23A"
+               BuildableName = "ExampleProductName.app"
+               BlueprintName = "Example"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CAC1E1B01B6A326100A8B23A"
+               BuildableName = "ExampleTests.xctest"
+               BlueprintName = "ExampleTests"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CAC1E1BB1B6A326200A8B23A"
+               BuildableName = "ExampleUITests.xctest"
+               BlueprintName = "ExampleUITests"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CAC1E1971B6A326100A8B23A"
+            BuildableName = "ExampleProductName.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CAC1E1971B6A326100A8B23A"
+            BuildableName = "ExampleProductName.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CAC1E1971B6A326100A8B23A"
+            BuildableName = "ExampleProductName.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory.
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a`.
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context

>If no build configuration is specified and -scheme is not passed then _[whatever is set as default configuration for command-line builds]_ is used.
>
>— [Technical Note TN2339: Building from the Command Line with Xcode FAQ, Listing 5](https://developer.apple.com/library/archive/technotes/tn2339/_index.html#//apple_ref/doc/uid/DTS40014588-CH1-SOURCECODE8)

Currently, Gym doesn't work like that when detecting the provisioning profile mapping. It actually goes straight to the default configuration for command-line builds **even if a scheme is given**.

This is unexpected behavior for projects which specify different bundle identifiers and code signing settings per scheme – as Gym, unlike Xcode, fails to find the proper provisioning profile mapping.

This pull request fixes that issue and makes Gym behave in the same way as Xcode.

### Description

In short, Gym now checks what configuration is set on the scheme used to archive the app, instead of just falling back directly to the "default for command-line builds" or, what's worse, to the first one it finds.

It does so by loading the scheme file using `Xcodeproj::XCScheme` and extracting the values from it. If no scheme was given or if there's a problem loading it, it falls back to existing behavior.

A new test case has been added to make sure the new behavior works as expected.