### PR TITLE
[match] fix/improve import keys/certificates now showing UI permission popup

### DIFF
--- a/fastlane/spec/actions_specs/import_certificate_spec.rb
+++ b/fastlane/spec/actions_specs/import_certificate_spec.rb
@@ -11,10 +11,10 @@ describe Fastlane do
         password = 'testpassword'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
+        expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -l 'Imported Private Key' -k #{''.shellescape} #{keychain_path.shellescape} &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain_path.shellescape} 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         allow(File).to receive(:file?).with(keychain_path).and_return(true)
@@ -38,10 +38,10 @@ describe Fastlane do
         password = '\"test pa$$word\"'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_security_import_command = "security import #{cert_name.shellescape} -k '#{keychain_path.shellescape}' -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
+        expected_security_import_command = "security import #{cert_name.shellescape} -k '#{keychain_path.shellescape}' -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        expected_set_key_partition_list_command = "security set-key-partition-list -S apple-tool:,apple: -l 'Imported Private Key' -k #{password.shellescape} #{keychain_path.shellescape} &> /dev/null"
+        expected_set_key_partition_list_command = "security set-key-partition-list -S apple-tool:,apple: -k #{password.shellescape} #{keychain_path.shellescape} 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         allow(File).to receive(:file?).with(keychain_path).and_return(true)
@@ -69,7 +69,7 @@ describe Fastlane do
         expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -l 'Imported Private Key' -k #{''.shellescape} #{keychain_path.shellescape} &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain_path.shellescape} 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         allow(File).to receive(:file?).with(keychain_path).and_return(true)

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -10,7 +10,7 @@ module FastlaneCore
       command << " -P #{certificate_password.shellescape}"
       command << " -T /usr/bin/codesign" # to not be asked for permission when running a tool like `gym` (before Sierra)
       command << " -T /usr/bin/security"
-      command << " &> /dev/null" unless output
+      command << " 1> /dev/null" unless output
 
       Helper.backticks(command, print: output)
 
@@ -19,10 +19,9 @@ module FastlaneCore
       if Helper.backticks('security -h | grep set-key-partition-list', print: false).length > 0
         command = "security set-key-partition-list"
         command << " -S apple-tool:,apple:"
-        command << " -l 'Imported Private Key'"
         command << " -k #{keychain_password.to_s.shellescape}"
         command << " #{keychain_path.shellescape}"
-        command << " &> /dev/null" # always disable stdout. This can be very verbose, and leak potentially sensitive info
+        command << " 1> /dev/null" # always disable stdout. This can be very verbose, and leak potentially sensitive info
 
         UI.command(command) if output
         Open3.popen3(command) do |stdin, stdout, stderr, thrd|
@@ -34,14 +33,21 @@ module FastlaneCore
           end
 
           unless thrd.value.success?
-            UI.error("")
-            UI.error("Could not configure imported keychain item (certificate) to prevent UI permission popup when code signing\n" \
-                     "Check if you supplied the correct `keychain_password` for keychain: `#{keychain_path}`\n" \
-                     "#{stderr.read.to_s.strip}")
-            UI.error("")
-            UI.error("Please look at the following docs to see how to set a keychain password:")
-            UI.error(" - https://docs.fastlane.tools/actions/sync_code_signing")
-            UI.error(" - https://docs.fastlane.tools/actions/get_certificates")
+            err = stderr.read.to_s.strip
+
+            # Inform user when no/wrong password was used as its needed to prevent UI permission popup from Xcode when signing
+            if err.include?("SecKeychainItemSetAccessWithPassword")
+              UI.error("")
+              UI.error("Could not configure imported keychain item (certificate) to prevent UI permission popup when code signing\n" \
+                       "Check if you supplied the correct `keychain_password` for keychain: `#{keychain_path}`\n" \
+                       "#{err}")
+              UI.error("")
+              UI.error("Please look at the following docs to see how to set a keychain password:")
+              UI.error(" - https://docs.fastlane.tools/actions/sync_code_signing")
+              UI.error(" - https://docs.fastlane.tools/actions/get_certificates")
+            else
+              UI.error(err)
+            end
           end
         end
       end

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -23,15 +23,11 @@ module FastlaneCore
         command << " #{keychain_path.shellescape}"
         command << " 1> /dev/null" # always disable stdout. This can be very verbose, and leak potentially sensitive info
 
+        # Showing loading indicator as this can take some time if a lot of keys installed
+        Helper.show_loading_indicator("Setting key partition list... (this can take a minute if there are a lot of keys installed)")
+
         UI.command(command) if output
         Open3.popen3(command) do |stdin, stdout, stderr, thrd|
-          if output
-            Helper.show_loading_indicator("Importing keys...")
-            UI.command(command)
-            UI.command_output(stdout.read)
-            Helper.hide_loading_indicator
-          end
-
           unless thrd.value.success?
             err = stderr.read.to_s.strip
 
@@ -50,6 +46,10 @@ module FastlaneCore
             end
           end
         end
+
+        # Hiding after Open3 finishes
+        Helper.hide_loading_indicator
+
       end
     end
   end

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -6,10 +6,10 @@ describe Match do
 
     describe 'import' do
       it 'finds a normal keychain name relative to ~/Library/Keychains' do
-        expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
+        expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -l 'Imported Private Key' -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
@@ -25,10 +25,10 @@ describe Match do
       it 'treats a keychain name it cannot find in ~/Library/Keychains as the full keychain path' do
         tmp_path = Dir.mktmpdir
         keychain = "#{tmp_path}/my/special.keychain"
-        expected_command = "security import item.path -k '#{keychain}' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
+        expected_command = "security import item.path -k '#{keychain}' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -l 'Imported Private Key' -k #{''.shellescape} #{keychain} &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain} 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with(keychain).and_return(true)
@@ -50,10 +50,10 @@ describe Match do
       end
 
       it "tries to find the macOS Sierra keychain too" do
-        expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain-db' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security &> /dev/null"
+        expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain-db' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -l 'Imported Private Key' -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db &> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain-db").and_return(true)


### PR DESCRIPTION
🤞 #14039 🤞 

## Fixes
1. Reroutes only stdout to `/dev/null` but not stderr since we need to show error messages
2. Removed `-l 'Imported Private Key'` as it seemed this was too specific and still caused the UI permission popup when code signing
3. Only showing specific error message about code signing when security error is `SecKeychainItemSetAccessWithPassword`