### PR TITLE
[action] create_app_online: Fix option for specifying icloud container id

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/create_app_online.md
+++ b/fastlane/lib/fastlane/actions/docs/create_app_online.md
@@ -107,7 +107,7 @@ fastlane produce associate_group -a com.krausefx.app group.krausefx
 If you want to create a new iCloud Container:
 
 ```no-highlight
-fastlane produce cloud_container -ci iCloud.com.krausefx.app -n "Example iCloud Container"
+fastlane produce cloud_container -g iCloud.com.krausefx.app -n "Example iCloud Container"
 ```
 
 If you want to associate an app with an iCloud Container:


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Mismatch between [document](https://github.com/fastlane/fastlane/blame/347474dcba2b46654388da34d594314c712a7c4d/fastlane/lib/fastlane/actions/docs/create_app_online.md#L110) and [actual option](https://github.com/fastlane/fastlane/blob/e736791bdac8956d0e879f8821e1c606ee268f20/produce/lib/produce/commands_generator.rb#L163) when creating `icloud container` with `produce`
