### PR TITLE
[action] create_pull_request: Fix documentation for return value

### DIFF
--- a/fastlane/lib/fastlane/actions/create_pull_request.rb
+++ b/fastlane/lib/fastlane/actions/create_pull_request.rb
@@ -132,7 +132,7 @@ module Fastlane
       end
 
       def self.return_value
-        "The parsed JSON when successful"
+        "The pull request URL when successful"
       end
 
       def self.example_code


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fix issue #14055, the documentation for the return value was wrong

### Description
Just changed the documentation to reflect what it really returns
