### PR TITLE
[action] download_dsyms: min_version

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -25,6 +25,7 @@ module Fastlane
         build_number = params[:build_number]
         platform = params[:platform]
         output_directory = params[:output_directory]
+        min_version = Gem::Version.new(params[:min_version])
 
         # Set version if it is latest
         if version == 'latest'
@@ -56,6 +57,12 @@ module Fastlane
             UI.verbose("Version #{version} doesn't match: #{train.version_string}")
             next
           end
+
+          if min_version && min_version > Gem::Version.new(train.version_string)
+            UI.verbose("Min version #{min_version} not reached: #{train.version_string}")
+            next
+          end
+
           app.tunes_all_builds_for_train(train: train.version_string, platform: platform).each do |build|
             UI.verbose("Found build version: #{build.build_version}, comparing to supplied build_number: #{build_number}")
             if build_number && build.build_version != build_number
@@ -207,6 +214,11 @@ module Fastlane
                                        env_name: "DOWNLOAD_DSYMS_BUILD_NUMBER",
                                        description: "The app build_number for dSYMs you wish to download",
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :min_version,
+                                       short_option: "-m",
+                                       env_name: "DOWNLOAD_DSYMS_MIN_VERSION",
+                                       description: "The minimum app version for dSYMs you wish to download",
+                                       optional: true), 
           FastlaneCore::ConfigItem.new(key: :output_directory,
                                        short_option: "-s",
                                        env_name: "DOWNLOAD_DSYMS_OUTPUT_DIRECTORY",
@@ -236,7 +248,8 @@ module Fastlane
       def self.example_code
         [
           'download_dsyms',
-          'download_dsyms(version: "1.0.0", build_number: "345")'
+          'download_dsyms(version: "1.0.0", build_number: "345")',
+          'download_dsyms(min_version: "1.2.3")'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -52,7 +52,11 @@ module Fastlane
         UI.message(message.join(" "))
 
         app.tunes_all_build_trains(platform: platform).each do |train|
-          UI.verbose("Found train: #{train.version_string}, comparing to supplied version: #{version}")
+          message = []
+          message << "Found train (version): #{train.version_string}"
+          message << ", comparing to supplied version: #{version}" if version
+          UI.verbose(message.join(" "))
+
           if version && version != train.version_string
             UI.verbose("Version #{version} doesn't match: #{train.version_string}")
             next
@@ -64,14 +68,19 @@ module Fastlane
           end
 
           app.tunes_all_builds_for_train(train: train.version_string, platform: platform).each do |build|
-            UI.verbose("Found build version: #{build.build_version}, comparing to supplied build_number: #{build_number}")
+            message = []
+            message << "Found build version: #{build.build_version}"
+            message << ", comparing to supplied build_number: #{build_number}" if build_number
+            UI.verbose(message.join(" "))
+
             if build_number && build.build_version != build_number
               UI.verbose("build_version: #{build.build_version} doesn't match: #{build_number}")
               next
             end
 
             begin
-              UI.verbose("Build_version: #{build.build_version} matches #{build_number}, grabbing dsym_url")
+              UI.verbose("Build_version: #{build.build_version} matches #{build_number}, grabbing dsym_url") if build_number
+
               build_details = app.tunes_build_details(train: train.version_string, build_number: build.build_version, platform: platform)
               download_url = build_details.dsym_url
               UI.verbose("dsym_url: #{download_url}")
@@ -217,7 +226,7 @@ module Fastlane
                                        short_option: "-m",
                                        env_name: "DOWNLOAD_DSYMS_MIN_VERSION",
                                        description: "The minimum app version for dSYMs you wish to download",
-                                       optional: true), 
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :output_directory,
                                        short_option: "-s",
                                        env_name: "DOWNLOAD_DSYMS_OUTPUT_DIRECTORY",

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -25,7 +25,7 @@ module Fastlane
         build_number = params[:build_number]
         platform = params[:platform]
         output_directory = params[:output_directory]
-        min_version = Gem::Version.new(params[:min_version])
+        min_version = Gem::Version.new(params[:min_version]) if params[:min_version]
 
         # Set version if it is latest
         if version == 'latest'

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -71,7 +71,6 @@ module Fastlane
             end
 
             begin
-              # need to call reload here or dsym_url is nil
               UI.verbose("Build_version: #{build.build_version} matches #{build_number}, grabbing dsym_url")
               build_details = app.tunes_build_details(train: train.version_string, build_number: build.build_version, platform: platform)
               download_url = build_details.dsym_url

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -27,7 +27,24 @@ describe Fastlane do
         allow(Fastlane::Actions::DownloadDsymsAction).to receive(:download)       
       end
 
+      context 'with no special options' do
+        it 'downloads all dsyms of all builds in all trains' do
+          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2])
+          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2])
+          expect(app).to receive(:tunes_build_details).with(train: '1.0.0', build_number: '1', platform: :ios).and_return(build_detail)
+          expect(app).to receive(:tunes_build_details).with(train: '1.0.0', build_number: '2', platform: :ios).and_return(build_detail)
+          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '1', platform: :ios).and_return(build_detail)
+          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '2', platform: :ios).and_return(build_detail)
           expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train.version_string, build.build_version, nil)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train.version_string, build2.build_version, nil)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build.build_version, nil)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build2.build_version, nil)
+          Fastlane::FastFile.new.parse("lane :test do
+              download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp')
+          end").runner.execute(:test)
+        end
+      end
+
       context 'when version is latest' do
         before do
           # latest

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -24,7 +24,7 @@ describe Fastlane do
         allow(train2).to receive(:version_string).and_return('2.0.0')
         allow(build).to receive(:build_version).and_return('1')
         allow(build2).to receive(:build_version).and_return('2')
-        allow(Fastlane::Actions::DownloadDsymsAction).to receive(:download)       
+        allow(Fastlane::Actions::DownloadDsymsAction).to receive(:download)
       end
 
       context 'with no special options' do

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -1,34 +1,46 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "download_dsyms" do
+      # 1 app, 2 trains/versions, 2 builds each
       let(:app) { double('app') }
       let(:version) { double('version') }
-      let(:build) { double('build') }
       let(:train) { double('train') }
+      let(:train2) { double('train2') }
+      let(:build) { double('build') }
+      let(:build2) { double('build2') }
       let(:build_detail) { double('build_detail') }
       let(:download_url) { 'https://example.com/myapp-dsym' }
       before do
+        # login
         allow(Spaceship::Tunes).to receive(:login)
         allow(Spaceship::Tunes).to receive(:select_team)
         allow(Spaceship::Application).to receive(:find).and_return(app)
-        allow(app).to receive(:edit_version).and_return(version)
-        allow(version).to receive(:version).and_return('1.0.0')
-        allow(version).to receive(:build_version).and_return('1.0.0')
-        allow(version).to receive(:candidate_builds).and_return([build])
-        allow(build).to receive(:train_version).and_return('2.0.0')
-        allow(Fastlane::Actions::DownloadDsymsAction).to receive(:download)
-        allow(app).to receive(:tunes_all_build_trains).and_return([train])
-        allow(train).to receive(:version_string).and_return('2.0.0')
-        allow(build).to receive(:build_version).and_return('1.0.0')
+        # trains
+        allow(app).to receive(:tunes_all_build_trains).and_return([train, train2])
+        # build_detail + download
         allow(build_detail).to receive(:dsym_url).and_return(download_url)
         allow(app).to receive(:bundle_id).and_return('tools.fastlane.myapp')
+        allow(train).to receive(:version_string).and_return('1.0.0')
+        allow(train2).to receive(:version_string).and_return('2.0.0')
+        allow(build).to receive(:build_version).and_return('1')
+        allow(build2).to receive(:build_version).and_return('2')
+        allow(Fastlane::Actions::DownloadDsymsAction).to receive(:download)       
       end
 
-      context 'when version is latest' do
-        it do
-          expect(app).to receive(:tunes_all_builds_for_train).and_return([build])
-          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '1.0.0', platform: :ios).and_return(build_detail)
           expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train.version_string, build.build_version, nil)
+      context 'when version is latest' do
+        before do
+          # latest
+          allow(app).to receive(:edit_version).and_return(version)
+          allow(version).to receive(:version).and_return('2.0.0')
+          allow(version).to receive(:build_version).and_return('2')
+          allow(version).to receive(:candidate_builds).and_return([build2])
+          allow(build2).to receive(:train_version).and_return('2.0.0')
+        end
+        it 'downloads only dsyms of latest build in latest train' do
+          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2])
+          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '2', platform: :ios).and_return(build_detail)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build2.build_version, nil)
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', version: 'latest')
           end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -63,6 +63,20 @@ describe Fastlane do
           end").runner.execute(:test)
         end
       end
+
+      context 'when min_version is set' do
+        it 'downloads only dsyms of trains newer than or equal min_version' do
+          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2])
+          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '1', platform: :ios).and_return(build_detail)
+          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '2', platform: :ios).and_return(build_detail)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build.build_version, nil)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build2.build_version, nil)
+
+          Fastlane::FastFile.new.parse("lane :test do
+              download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', min_version: '2.0.0')
+          end").runner.execute(:test)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When having many versions and builds, `download_dsyms` can take a long time. Often you only need the dsyms since a specific still supported version.

### Description
This PR implements a `min_version` option you can set to skip all the earlier versions:

```
download_dsyms(
      min_version: '0.0.2'
    )
```

leads to:

```
...
INFO [2019-01-15 18:02:50.12]: Login successful
INFO [2019-01-15 18:02:51.17]: Looking for dSYM files for org.example.foo
DEBUG [2019-01-15 18:02:51.75]: Found train (version): 0.0.1
DEBUG [2019-01-15 18:02:51.75]: Min version 0.0.2 not reached: 0.0.1
DEBUG [2019-01-15 18:02:51.75]: Found train (version): 0.0.2
DEBUG [2019-01-15 18:02:52.18]: Found build version: 1
DEBUG [2019-01-15 18:02:53.43]: dsym_url:
INFO [2019-01-15 18:02:53.43]: No dSYM URL for 1 (0.0.2)
...
```

It also improve the existing test case, adds one for the plain action usage and of course another one for the new `min_version` option.

---

closes #13951