### PR TITLE
[scan] Customizing the slack post action with custom username and icon/image

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -327,7 +327,7 @@ module Scan
                                      env_name: "SCAN_SLACK_USE_WEBHOOK_CONFIGURED_USERNAME_AND_ICON",
                                      description: "Use webhook's default username and icon settings? (true/false)",
                                      default_value: false,
-                                     is_string: false,
+                                     type: Boolean,
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :slack_username,
                                      env_name: "SCAN_SLACK_USERNAME",

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -3,6 +3,7 @@ require 'credentials_manager/appfile_config'
 require_relative 'module'
 
 module Scan
+  # rubocop:disable Metrics/ClassLength
   class Options
     def self.verify_type(item_name, acceptable_types, value)
       type_ok = [Array, String].any? { |type| value.kind_of?(type) }
@@ -322,6 +323,24 @@ module Scan
                                      env_name: "SCAN_SLACK_MESSAGE",
                                      description: "The message included with each message posted to slack",
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :slack_use_webhook_configured_username_and_icon,
+                                     env_name: "SCAN_SLACK_USE_WEBHOOK_CONFIGURED_USERNAME_AND_ICON",
+                                     description: "Use webhook's default username and icon settings? (true/false)",
+                                     default_value: false,
+                                     is_string: false,
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :slack_username,
+                                     env_name: "SCAN_SLACK_USERNAME",
+                                     description: "Overrides the webhook's username property if slack_use_webhook_configured_username_and_icon is false",
+                                     default_value: "fastlane",
+                                     is_string: true,
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :slack_icon_url,
+                                     env_name: "SCAN_SLACK_ICON_URL",
+                                     description: "Overrides the webhook's image property if slack_use_webhook_configured_username_and_icon is false",
+                                     default_value: "https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png",
+                                     is_string: true,
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :skip_slack,
                                      description: "Don't publish to slack, even when an URL is given",
                                      is_string: false,
@@ -349,4 +368,5 @@ module Scan
       ]
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/scan/lib/scan/slack_poster.rb
+++ b/scan/lib/scan/slack_poster.rb
@@ -15,6 +15,8 @@ module Scan
         channel = ('#' + channel) unless ['#', '@'].include?(channel[0]) # send message to channel by default
       end
 
+      username = Scan.config[:slack_use_webhook_configured_username_and_icon] ? nil : Scan.config[:slack_username]
+      icon_url = Scan.config[:slack_use_webhook_configured_username_and_icon] ? nil : Scan.config[:slack_icon_url]
       fields = []
 
       if results[:build_errors]
@@ -46,8 +48,8 @@ module Scan
         channel: channel,
         slack_url: Scan.config[:slack_url].to_s,
         success: results[:build_errors].to_i == 0 && results[:failures].to_i == 0,
-        username: 'fastlane',
-        icon_url: 'https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png',
+        username: username,
+        icon_url: icon_url,
         payload: {},
         attachment_properties: {
           fields: fields


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
As discussed with @joshdholtz in #13791, we agreed that hardcoding the username for the slack post is not great, same goes with the icon url I believe. This PR adds the ability for users to customize the username and icon/image for the slack webhook, or users can choose to use the webhook configured ones.

### Description
The `slack_username`, `slack_icon_url` and `slack_use_webhook_configured_username_and_icon` mirror the same parameters from the `slack` action, however with `slack_` prefix as these are specifically used for posting the slack message.

One thing I've had to disable is `# rubocop:disable Metrics/ClassLength` inside the Scan/Options class as this has become too big now. I did see that we do that elsewhere (ie. Deliver/Options class) so I took the liberty of disabling/enabling this, but let me know if you'd like me to change this.
