### PR TITLE
Version bump to 2.114.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,23 +39,55 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
 <td id='luka-mirosevic'>
 <a href='https://github.com/lmirosevic'>
 <img src='https://github.com/lmirosevic.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/DanToml'>
+<img src='https://github.com/DanToml.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+</td>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+</tr>
+<tr>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
 <td id='iulian-onofrei'>
 <a href='https://github.com/revolter'>
@@ -65,11 +97,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
 <td id='fumiya-nakamura'>
 <a href='https://github.com/nafu'>
@@ -77,11 +109,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 <td id='jérôme-lacoste'>
 <a href='https://github.com/lacostej'>
@@ -89,31 +121,19 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
 </a>
-<h4 align='center'>Jimmy Dee</h4>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
 </tr>
 <tr>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
 </td>
 <td id='felix-krause'>
 <a href='https://github.com/KrauseFx'>
@@ -121,37 +141,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-</tr>
-<tr>
 <td id='kohki-miki'>
 <a href='https://github.com/giginet'>
 <img src='https://github.com/giginet.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/DanToml'>
-<img src='https://github.com/DanToml.png?size=140'>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
 </td>
 <td id='andrew-mcburney'>
 <a href='https://github.com/armcburney'>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,26 +15,26 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Stefan Natchev",
-                        "Jan Piotrowski",
-                        "Andrew McBurney",
+  spec.authors       = ["Danielle Tomlinson",
                         "Helmut Januschka",
-                        "Joshua Liebowitz",
-                        "Jorge Revuelta H",
-                        "Felix Krause",
-                        "Olivier Halligon",
                         "Manu Wallner",
-                        "Danielle Tomlinson",
-                        "Kohki Miki",
-                        "Maksym Grebenets",
-                        "Jérôme Lacoste",
-                        "Josh Holtz",
-                        "Fumiya Nakamura",
-                        "Matthew Ellis",
-                        "Aaron Brager",
+                        "Andrew McBurney",
                         "Luka Mirosevic",
+                        "Matthew Ellis",
                         "Iulian Onofrei",
-                        "Jimmy Dee"]
+                        "Stefan Natchev",
+                        "Jimmy Dee",
+                        "Jorge Revuelta H",
+                        "Kohki Miki",
+                        "Jan Piotrowski",
+                        "Jérôme Lacoste",
+                        "Olivier Halligon",
+                        "Joshua Liebowitz",
+                        "Aaron Brager",
+                        "Josh Holtz",
+                        "Felix Krause",
+                        "Fumiya Nakamura",
+                        "Maksym Grebenets"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.113.0'.freeze
+  VERSION = '2.114.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.113.0
+// Generated with fastlane 2.114.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1360,6 +1360,7 @@ func downloadDsyms(username: String,
                    platform: String = "ios",
                    version: String? = nil,
                    buildNumber: String? = nil,
+                   minVersion: String? = nil,
                    outputDirectory: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "download_dsyms", className: nil, args: [RubyCommand.Argument(name: "username", value: username),
                                                                                                 RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
@@ -1368,6 +1369,7 @@ func downloadDsyms(username: String,
                                                                                                 RubyCommand.Argument(name: "platform", value: platform),
                                                                                                 RubyCommand.Argument(name: "version", value: version),
                                                                                                 RubyCommand.Argument(name: "build_number", value: buildNumber),
+                                                                                                RubyCommand.Argument(name: "min_version", value: minVersion),
                                                                                                 RubyCommand.Argument(name: "output_directory", value: outputDirectory)])
   _ = runner.executeCommand(command)
 }
@@ -1468,6 +1470,7 @@ func frameScreenshots(white: Bool? = nil,
                       forceDeviceType: String? = nil,
                       useLegacyIphone5s: Bool = false,
                       useLegacyIphone6s: Bool = false,
+                      useLegacyIphonex: Bool = false,
                       forceOrientationBlock: String? = nil,
                       path: String = "./") {
   let command = RubyCommand(commandID: "", methodName: "frame_screenshots", className: nil, args: [RubyCommand.Argument(name: "white", value: white),
@@ -1477,6 +1480,7 @@ func frameScreenshots(white: Bool? = nil,
                                                                                                    RubyCommand.Argument(name: "force_device_type", value: forceDeviceType),
                                                                                                    RubyCommand.Argument(name: "use_legacy_iphone5s", value: useLegacyIphone5s),
                                                                                                    RubyCommand.Argument(name: "use_legacy_iphone6s", value: useLegacyIphone6s),
+                                                                                                   RubyCommand.Argument(name: "use_legacy_iphonex", value: useLegacyIphonex),
                                                                                                    RubyCommand.Argument(name: "force_orientation_block", value: forceOrientationBlock),
                                                                                                    RubyCommand.Argument(name: "path", value: path)])
   _ = runner.executeCommand(command)
@@ -1488,6 +1492,7 @@ func frameit(white: Bool? = nil,
              forceDeviceType: String? = nil,
              useLegacyIphone5s: Bool = false,
              useLegacyIphone6s: Bool = false,
+             useLegacyIphonex: Bool = false,
              forceOrientationBlock: String? = nil,
              path: String = "./") {
   let command = RubyCommand(commandID: "", methodName: "frameit", className: nil, args: [RubyCommand.Argument(name: "white", value: white),
@@ -1497,6 +1502,7 @@ func frameit(white: Bool? = nil,
                                                                                          RubyCommand.Argument(name: "force_device_type", value: forceDeviceType),
                                                                                          RubyCommand.Argument(name: "use_legacy_iphone5s", value: useLegacyIphone5s),
                                                                                          RubyCommand.Argument(name: "use_legacy_iphone6s", value: useLegacyIphone6s),
+                                                                                         RubyCommand.Argument(name: "use_legacy_iphonex", value: useLegacyIphonex),
                                                                                          RubyCommand.Argument(name: "force_orientation_block", value: forceOrientationBlock),
                                                                                          RubyCommand.Argument(name: "path", value: path)])
   _ = runner.executeCommand(command)
@@ -2665,6 +2671,7 @@ func runTests(workspace: String? = nil,
               device: String? = nil,
               devices: [String]? = nil,
               skipDetectDevices: Bool = false,
+              resetSimulator: Bool = false,
               reinstallApp: Bool = false,
               appIdentifier: String? = nil,
               onlyTesting: String? = nil,
@@ -2712,6 +2719,7 @@ func runTests(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "device", value: device),
                                                                                            RubyCommand.Argument(name: "devices", value: devices),
                                                                                            RubyCommand.Argument(name: "skip_detect_devices", value: skipDetectDevices),
+                                                                                           RubyCommand.Argument(name: "reset_simulator", value: resetSimulator),
                                                                                            RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                            RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                            RubyCommand.Argument(name: "only_testing", value: onlyTesting),
@@ -2801,6 +2809,7 @@ func scan(workspace: String? = scanfile.workspace,
           device: String? = scanfile.device,
           devices: [String]? = scanfile.devices,
           skipDetectDevices: Bool = scanfile.skipDetectDevices,
+          resetSimulator: Bool = scanfile.resetSimulator,
           reinstallApp: Bool = scanfile.reinstallApp,
           appIdentifier: String? = scanfile.appIdentifier,
           onlyTesting: String? = scanfile.onlyTesting,
@@ -2848,6 +2857,7 @@ func scan(workspace: String? = scanfile.workspace,
                                                                                       RubyCommand.Argument(name: "device", value: device),
                                                                                       RubyCommand.Argument(name: "devices", value: devices),
                                                                                       RubyCommand.Argument(name: "skip_detect_devices", value: skipDetectDevices),
+                                                                                      RubyCommand.Argument(name: "reset_simulator", value: resetSimulator),
                                                                                       RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                       RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                       RubyCommand.Argument(name: "only_testing", value: onlyTesting),
@@ -3316,12 +3326,14 @@ func splunkmint(dsym: String? = nil,
 func spm(command: String = "build",
          buildPath: String? = nil,
          packagePath: String? = nil,
+         xcconfig: String? = nil,
          configuration: String? = nil,
          xcprettyOutput: String? = nil,
          verbose: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "spm", className: nil, args: [RubyCommand.Argument(name: "command", value: command),
                                                                                      RubyCommand.Argument(name: "build_path", value: buildPath),
                                                                                      RubyCommand.Argument(name: "package_path", value: packagePath),
+                                                                                     RubyCommand.Argument(name: "xcconfig", value: xcconfig),
                                                                                      RubyCommand.Argument(name: "configuration", value: configuration),
                                                                                      RubyCommand.Argument(name: "xcpretty_output", value: xcprettyOutput),
                                                                                      RubyCommand.Argument(name: "verbose", value: verbose)])
@@ -3365,7 +3377,8 @@ func supply(packageName: String,
             rootUrl: String? = nil,
             checkSupersededTracks: Bool = false,
             timeout: Int = 300,
-            deactivateOnPromote: Bool = true) {
+            deactivateOnPromote: Bool = true,
+            versionCodesToRetain: [String]? = nil) {
   let command = RubyCommand(commandID: "", methodName: "supply", className: nil, args: [RubyCommand.Argument(name: "package_name", value: packageName),
                                                                                         RubyCommand.Argument(name: "track", value: track),
                                                                                         RubyCommand.Argument(name: "rollout", value: rollout),
@@ -3390,7 +3403,8 @@ func supply(packageName: String,
                                                                                         RubyCommand.Argument(name: "root_url", value: rootUrl),
                                                                                         RubyCommand.Argument(name: "check_superseded_tracks", value: checkSupersededTracks),
                                                                                         RubyCommand.Argument(name: "timeout", value: timeout),
-                                                                                        RubyCommand.Argument(name: "deactivate_on_promote", value: deactivateOnPromote)])
+                                                                                        RubyCommand.Argument(name: "deactivate_on_promote", value: deactivateOnPromote),
+                                                                                        RubyCommand.Argument(name: "version_codes_to_retain", value: versionCodesToRetain)])
   _ = runner.executeCommand(command)
 }
 func swiftlint(mode: String = "lint",
@@ -3865,7 +3879,8 @@ func uploadToPlayStore(packageName: String,
                        rootUrl: String? = nil,
                        checkSupersededTracks: Bool = false,
                        timeout: Int = 300,
-                       deactivateOnPromote: Bool = true) {
+                       deactivateOnPromote: Bool = true,
+                       versionCodesToRetain: [String]? = nil) {
   let command = RubyCommand(commandID: "", methodName: "upload_to_play_store", className: nil, args: [RubyCommand.Argument(name: "package_name", value: packageName),
                                                                                                       RubyCommand.Argument(name: "track", value: track),
                                                                                                       RubyCommand.Argument(name: "rollout", value: rollout),
@@ -3890,7 +3905,8 @@ func uploadToPlayStore(packageName: String,
                                                                                                       RubyCommand.Argument(name: "root_url", value: rootUrl),
                                                                                                       RubyCommand.Argument(name: "check_superseded_tracks", value: checkSupersededTracks),
                                                                                                       RubyCommand.Argument(name: "timeout", value: timeout),
-                                                                                                      RubyCommand.Argument(name: "deactivate_on_promote", value: deactivateOnPromote)])
+                                                                                                      RubyCommand.Argument(name: "deactivate_on_promote", value: deactivateOnPromote),
+                                                                                                      RubyCommand.Argument(name: "version_codes_to_retain", value: versionCodesToRetain)])
   _ = runner.executeCommand(command)
 }
 func uploadToTestflight(username: String,
@@ -4177,4 +4193,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.38]
+// FastlaneRunnerAPIVersion [0.9.39]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.113.0
+// Generated with fastlane 2.114.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.113.0
+// Generated with fastlane 2.114.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.113.0
+// Generated with fastlane 2.114.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.113.0
+// Generated with fastlane 2.114.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -5,6 +5,7 @@ protocol ScanfileProtocol: class {
   var device: String? { get }
   var devices: [String]? { get }
   var skipDetectDevices: Bool { get }
+  var resetSimulator: Bool { get }
   var reinstallApp: Bool { get }
   var appIdentifier: String? { get }
   var onlyTesting: String? { get }
@@ -55,6 +56,7 @@ extension ScanfileProtocol {
   var device: String? { return nil }
   var devices: [String]? { return nil }
   var skipDetectDevices: Bool { return false }
+  var resetSimulator: Bool { return false }
   var reinstallApp: Bool { return false }
   var appIdentifier: String? { return nil }
   var onlyTesting: String? { return nil }
@@ -100,4 +102,4 @@ extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.7]
+// FastlaneRunnerAPIVersion [0.9.8]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.113.0
+// Generated with fastlane 2.114.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.113.0
+// Generated with fastlane 2.114.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.113.0':**

* [deliver/frameit] frame latest iOS devices, skip uploading iPhone61 (#13774) via Dave Anderson
* [produce] allow to enable/disable `access_wifi` service (#13552) via Taimur Ayaz
* [scan] use slack action to post scan test results (#13791) via Gligor Kotushevski
* [spaceship] use default sort order for listing TestFlight testers (#13778) via Theodore Dubois
* [spaceship] fix creating and revoking Apple Keys (#13697) via Dominik Sokal
* [spm] add missing options (#13649) via Adriaan Duz
* [gemspec] update emoji_regex version requirement to 1.0 (#14052) via Kristofer Rye
* [supply] Add option to pass version codes to retain (#14035) via Ullrich Schäfer
* [action] download_dsyms: min_version (#14069) via Jan Piotrowski
* [scan] add reset_simulator option (#14053) via wag-miles
* [match] fix/improve import keys/certificates now showing UI permission popup (#14056) via Josh Holtz
* [action] fix prompt to not leave trailing new lines in input buffer when using multi_line_end_keyword (#13792) via Robin Kunde
* [resign] fix `keychain_path` parameter and output bug (#13889) via Milan Bombsch
* [Swift] fix Snapshot simulator launch arguments are empty by default (#13865) via Jean Mainguy
* [action] fix version regex in increment_version_number (#14005) via Takeru Chuganji
* [action] create_pull_request: fix documentation for return value (#14068) via Rodrigo Cardoso Buske
* [fastlane] accept `utf8` as valid locale + Automatically parse `locale` command (#13441) via Ivan Tham
* [action] create_app_online: Fix option for specifying icloud container id (#14064) via Eakawat Tantamjarik
* [fastlane] fix undefined local variable `output_path` in JUnitGenerator (#14048) via naoigcat
* [docs] update docs of each action to mention CLI call option (#14060) via Felix Krause
* [snapshot] preview: fix overlay top padding (#13828) via Claes Jacobsson
* [deliver] adds documentation for IDFA specifiers (#14051) via Ash Furrow
* [fastlane] added loading indicator for importing keys command (#13974) via Rishabh Tayal
* [scan] shellescape only-testing and skip-testing options (#14043) via Jan Piotrowski
* [action] update_info_plist: Output error message if xcodeproj can not be found (#13928) via Oliver Bayer
* [screengrab] update Android Library to API level 28 (#13231) via Niklas Baudy
* [action] explicitly unlink to keep references to temp files for crashlytics (#14037) via Takeru Chuganji
* [spaceship] copy cookie to clipboard (#13831) via Rishabh Tayal
