### PR TITLE
[action] download_dsyms: fix downloading the latest build

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -113,7 +113,7 @@ module Fastlane
       end
 
       def self.get_version(latest_version)
-        candidate_build = latest_version.candidate_builds.first
+        candidate_build = latest_version.candidate_builds.max_by(&:upload_date)
         if candidate_build.nil?
           latest_version.version
         else

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -8,6 +8,7 @@ describe Fastlane do
       let(:train2) { double('train2') }
       let(:build) { double('build') }
       let(:build2) { double('build2') }
+      let(:build3) { double('build3') }
       let(:build_detail) { double('build_detail') }
       let(:download_url) { 'https://example.com/myapp-dsym' }
       before do
@@ -51,11 +52,14 @@ describe Fastlane do
           allow(app).to receive(:edit_version).and_return(version)
           allow(version).to receive(:version).and_return('2.0.0')
           allow(version).to receive(:build_version).and_return('2')
-          allow(version).to receive(:candidate_builds).and_return([build2])
+          allow(version).to receive(:candidate_builds).and_return([build2, build3])
           allow(build2).to receive(:train_version).and_return('2.0.0')
+          allow(build2).to receive(:upload_date).and_return(1_547_145_145_000)
+          allow(build3).to receive(:train_version).and_return('2.0.0')
+          allow(build3).to receive(:upload_date).and_return(1_547_196_482_000)
         end
         it 'downloads only dsyms of latest build in latest train' do
-          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2])
+          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2, build3])
           expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '2', platform: :ios).and_return(build_detail)
           expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build2.build_version, nil)
           Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -51,11 +51,11 @@ describe Fastlane do
           # latest
           allow(app).to receive(:edit_version).and_return(version)
           allow(version).to receive(:version).and_return('2.0.0')
-          allow(version).to receive(:build_version).and_return('2')
           allow(version).to receive(:candidate_builds).and_return([build2, build3])
           allow(build2).to receive(:train_version).and_return('2.0.0')
           allow(build2).to receive(:upload_date).and_return(1_547_145_145_000)
           allow(build3).to receive(:train_version).and_return('2.0.0')
+          allow(build3).to receive(:build_version).and_return('2')
           allow(build3).to receive(:upload_date).and_return(1_547_196_482_000)
         end
         it 'downloads only dsyms of latest build in latest train' do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #14091

### Description
- Do not use the first candidate build but the latest one (the one with the most recent `upload_date`).
- Take the build number from the build and not from the version.

Cc @giginet 