### PR TITLE
[docs] Improve documentation for get_version_number

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -106,14 +106,17 @@ module Fastlane
       end
 
       def self.details
-        "This action will return the current version number set on your project."
+        [
+          "This action will return the current version number set on your project.",
+          "Make sure that any frameworks or test targets don't have different version numbers from the main project, as it can cause the wrong version number to be returned. Note that some references to the version may not show within the Xcode UI, so worth checking the project file XML and Info.plist files to be sure too."
+        ].join("\n")
       end
 
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :xcodeproj,
                              env_name: "FL_VERSION_NUMBER_PROJECT",
-                             description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
+                             description: "Path to the main Xcode project to read version number from, optional. By default will use the first Xcode project found within the project root directory",
                              optional: true,
                              verify_block: proc do |value|
                                UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with?(".xcworkspace")
@@ -121,11 +124,11 @@ module Fastlane
                              end),
           FastlaneCore::ConfigItem.new(key: :target,
                              env_name: "FL_VERSION_NUMBER_TARGET",
-                             description: "Specify a specific target if you have multiple per project, optional",
+                             description: "Target name, optional. Will be needed if you have more than one non-test target, to avoid being prompted to select one",
                              optional: true),
           FastlaneCore::ConfigItem.new(key: :configuration,
                              env_name: "FL_VERSION_NUMBER_CONFIGURATION",
-                             description: "Specify a specific configuration if you have multiple per target, optional",
+                             description: "Configuration name, optional. Will be needed if you have altered the configurations from the default or your version number depends on the configuration selected",
                              optional: true)
         ]
       end
@@ -146,7 +149,11 @@ module Fastlane
 
       def self.example_code
         [
-          'version = get_version_number(xcodeproj: "Project.xcodeproj")'
+          'version = get_version_number(xcodeproj: "Project.xcodeproj")',
+          'version = get_version_number(
+            xcodeproj: "Project.xcodeproj",
+            target: "App"
+          )'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -106,10 +106,7 @@ module Fastlane
       end
 
       def self.details
-        [
-          "This action will return the current version number set on your project.",
-          "Make sure that any frameworks or test targets don't have different version numbers from the main project to prevent the wrong version number to be returned. Note that some references to the version may not show within the Xcode UI but are viewable in project file XML and Info.plist files."
-        ].join("\n")
+        "This action will return the current version number set on your project."
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -108,7 +108,7 @@ module Fastlane
       def self.details
         [
           "This action will return the current version number set on your project.",
-          "Make sure that any frameworks or test targets don't have different version numbers from the main project, as it can cause the wrong version number to be returned. Note that some references to the version may not show within the Xcode UI, so worth checking the project file XML and Info.plist files to be sure too."
+          "Make sure that any frameworks or test targets don't have different version numbers from the main project to prevent the wrong version number to be returned. Note that some references to the version may not show within the Xcode UI but are viewable in project file XML and Info.plist files."
         ].join("\n")
       end
 
@@ -124,7 +124,7 @@ module Fastlane
                              end),
           FastlaneCore::ConfigItem.new(key: :target,
                              env_name: "FL_VERSION_NUMBER_TARGET",
-                             description: "Target name, optional. Will be needed if you have more than one non-test target, to avoid being prompted to select one",
+                             description: "Target name, optional. Will be needed if you have more than one non-test target to avoid being prompted to select one",
                              optional: true),
           FastlaneCore::ConfigItem.new(key: :configuration,
                              env_name: "FL_VERSION_NUMBER_CONFIGURATION",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

When I first used the get_version_number action on a project, there was an issue with it getting the wrong version number due to a stray number in the configuration of one of the project's frameworks. I also felt some extra detail on the options you can provide are helpful.

### Description

Add clearer documentation of options that can be specified.
Add explanation of an issue that can occur if there are multiple targets that have different version numbers specified. When this happens, the wrong version number can sometimes be returned.
