### PR TITLE
[frameit] fixed crash with gets when updating frames

### DIFF
--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -64,7 +64,7 @@ end
 
 def confirm
   puts("Press any key when you're ready to continue".yellow)
-  gets
+  STDIN.gets
 end
 
 def sanitize_filename(filename)


### PR DESCRIPTION
## Issue
`gets` but itself was throwing an error of...
```sh
➜  frames_generator git:(master) be rake generate_device_frames
Download and extract the latest devices from Facebook
  https://facebook.design/devices
Press any key when you're ready to continue
rake aborted!
Errno::ENOENT: No such file or directory @ rb_sysopen - generate_device_frames
/Users/josh/Projects/fastlane/fastlane/frameit/frames_generator/Rakefile:67:in `gets'
/Users/josh/Projects/fastlane/fastlane/frameit/frames_generator/Rakefile:67:in `gets'
/Users/josh/Projects/fastlane/fastlane/frameit/frames_generator/Rakefile:67:in `confirm'
/Users/josh/Projects/fastlane/fastlane/frameit/frames_generator/Rakefile:19:in `block in <top (required)>'
```

## Fix
Its safer to call `STDIN.gets` instead of just `gets` by itself