### PR TITLE
Users optimization

### DIFF
--- a/spaceship/lib/spaceship/tunes/member.rb
+++ b/spaceship/lib/spaceship/tunes/member.rb
@@ -56,10 +56,11 @@ module Spaceship
 
       def selected_apps
         parsed_apps = []
+        all_apps = Application.all
         raw_data["userSoftwares"]["value"]["grantedSoftwareAdamIds"].each do |app_id|
-          parsed_apps << Application.find(app_id)
+          parsed_apps << all_apps.select { |app| app.apple_id == app_id }
         end
-        return parsed_apps
+        return parsed_apps.flatten
       end
 
       def not_accepted_invitation

--- a/spaceship/lib/spaceship/tunes/member.rb
+++ b/spaceship/lib/spaceship/tunes/member.rb
@@ -58,7 +58,7 @@ module Spaceship
         parsed_apps = []
         all_apps = Application.all
         raw_data["userSoftwares"]["value"]["grantedSoftwareAdamIds"].each do |app_id|
-          parsed_apps << all_apps.select { |app| !app.apple_id.nil? && app.apple_id == app_id }
+          parsed_apps << all_apps.select { |app| app.apple_id == app_id }
         end
         return parsed_apps.flatten
       end

--- a/spaceship/lib/spaceship/tunes/member.rb
+++ b/spaceship/lib/spaceship/tunes/member.rb
@@ -56,12 +56,10 @@ module Spaceship
 
       def selected_apps
         parsed_apps = []
-        all_apps = Application.all
-        $logger.info("[Fastlane/Spaceship] Found #{all_apps.count} apps")
         raw_data["userSoftwares"]["value"]["grantedSoftwareAdamIds"].each do |app_id|
-          parsed_apps << all_apps.select { |app| !app.apple_id.nil? && app.apple_id == app_id }
+          parsed_apps << Application.find(app_id)
         end
-        return parsed_apps.flatten
+        return parsed_apps
       end
 
       def not_accepted_invitation

--- a/spaceship/lib/spaceship/tunes/member.rb
+++ b/spaceship/lib/spaceship/tunes/member.rb
@@ -56,10 +56,12 @@ module Spaceship
 
       def selected_apps
         parsed_apps = []
+        all_apps = Application.all
+        $logger.info("[Fastlane/Spaceship] Found #{all_apps.count} apps")
         raw_data["userSoftwares"]["value"]["grantedSoftwareAdamIds"].each do |app_id|
-          parsed_apps << Application.find(app_id)
+          parsed_apps << all_apps.select { |app| !app.apple_id.nil? && app.apple_id == app_id }
         end
-        return parsed_apps
+        return parsed_apps.flatten
       end
 
       def not_accepted_invitation

--- a/spaceship/lib/spaceship/tunes/member.rb
+++ b/spaceship/lib/spaceship/tunes/member.rb
@@ -57,7 +57,6 @@ module Spaceship
       def selected_apps
         parsed_apps = []
         all_apps = Application.all
-        $logger.info("[Fastlane/Spaceship] Found #{all_apps.count} apps")
         raw_data["userSoftwares"]["value"]["grantedSoftwareAdamIds"].each do |app_id|
           parsed_apps << all_apps.select { |app| !app.apple_id.nil? && app.apple_id == app_id }
         end

--- a/spaceship/lib/spaceship/tunes/member.rb
+++ b/spaceship/lib/spaceship/tunes/member.rb
@@ -58,7 +58,7 @@ module Spaceship
         parsed_apps = []
         all_apps = Application.all
         raw_data["userSoftwares"]["value"]["grantedSoftwareAdamIds"].each do |app_id|
-          parsed_apps << all_apps.select { |app| app.apple_id == app_id }
+          parsed_apps << all_apps.select { |app| !app.apple_id.nil? && app.apple_id == app_id }
         end
         return parsed_apps.flatten
       end

--- a/spaceship/lib/spaceship/tunes/member.rb
+++ b/spaceship/lib/spaceship/tunes/member.rb
@@ -57,6 +57,7 @@ module Spaceship
       def selected_apps
         parsed_apps = []
         all_apps = Application.all
+        $logger.info("[Fastlane/Spaceship] Found #{all_apps.count} apps")
         raw_data["userSoftwares"]["value"]["grantedSoftwareAdamIds"].each do |app_id|
           parsed_apps << all_apps.select { |app| !app.apple_id.nil? && app.apple_id == app_id }
         end


### PR DESCRIPTION
By calling `Application.all` once, the GET request is only executed once per user, when `selected_apps` is called. Thanks @janpio for the tip!

Branch: "master" | Commit Type: "Bug fix" | Changes tested: "yes"

---
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
**Context:**
- I am trying to get all users in a account and fetch the app names each user has access to. 

**Problem:**
- If a user has access to 10 apps (as an example), `10` GET requests were sent to Apple.
- And if there are 100 users/account, `100 * 10 = 1000` GET requests would be sent to Apple.

**If it fixes an open issue, please link to the issue here.**
- https://github.com/fastlane/fastlane/issues/14070
- This doesn't fix the issue completely, but optimizes **the number of GET requests to only one per user** (which is a huge win I think).

### Description
- Get all `Applications` before the loop. `all_apps = Application.all`
- Run `select` on the local `all_apps` variable.

**Please describe in detail how you tested your changes.**
- I have about over 600 users in all of our accounts combined. When I ran my script for all users, I have only seen ~600 GET requests.
- I have also noticed it's very fast now, even if the user has access to over 250 apps.
