### PR TITLE
14133 - Adding access_wifi param to modify_serviecs & produce

### DIFF
--- a/fastlane/lib/fastlane/actions/modify_services.rb
+++ b/fastlane/lib/fastlane/actions/modify_services.rb
@@ -44,6 +44,7 @@ module Fastlane
 
       def self.services_mapping
         {
+            access_wifi: 'access_wifi',
             app_group: 'app_group',
             apple_pay: 'apple_pay',
             associated_domains: 'associated_domains',

--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -12,6 +12,7 @@ module Produce
     SERVICE_CLOUDKIT = "cloudkit"
 
     ALLOWED_SERVICES = {
+      access_wifi: [SERVICE_ON, SERVICE_OFF],
       app_group: [SERVICE_ON, SERVICE_OFF],
       apple_pay: [SERVICE_ON, SERVICE_OFF],
       associated_domains: [SERVICE_ON, SERVICE_OFF],


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Adds `access_wifi` param for modifying services in the Apple Developer Portal.  This should resolve the following error when running `modify_services`

```SHELL
NoMethodError: [!] undefined method `access_wifi' for #<Object:0x00007fa15532bd58>
```

<!-- If it fixes an open issue, please link to the issue here. -->
Issue: https://github.com/fastlane/fastlane/issues/14133

### Description
<!-- Describe your changes in detail -->
Simply added the `access_wifi` parameter to product/modify_services

<!-- Please describe in detail how you tested your changes. -->
Ran rubocop and rspec commands from the contributing/testing document. 
