### PR TITLE
[action] CreateKeychainAction patch

### DIFF
--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -26,7 +26,7 @@ module Fastlane
         if !exists?(keychain_path)
           commands << Fastlane::Actions.sh("security create-keychain -p #{escaped_password} #{keychain_path}", log: false)
         elsif params[:require_create]
-          UI.user_error!("`require_create` option passed, but found keychain '#{keychain_path}', failing create_keychain action")
+          UI.abort_with_message!("`require_create` option passed, but found keychain '#{keychain_path}', failing create_keychain action")
         else
           UI.important("Found keychain '#{keychain_path}', creation skipped")
           UI.important("If creating a new Keychain DB is required please set the `require_create` option true to cause the action to fail")

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -63,7 +63,7 @@ module Fastlane
       def self.exists?(keychain_path)
         keychain_path = File.expand_path(keychain_path)
 
-        # Creating Keycahins using the security
+        # Creating Keychains using the security
         # CLI appends `-db` to the file name.
         File.exist?("#{keychain_path}-db") || File.exist?(keychain_path)
       end

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -22,7 +22,12 @@ module Fastlane
         end
 
         commands = []
-        commands << Fastlane::Actions.sh("security create-keychain -p #{escaped_password} #{keychain_path}", log: false)
+
+        if !exists?(keychain_path)
+          commands << Fastlane::Actions.sh("security create-keychain -p #{escaped_password} #{keychain_path}", log: false)
+        else
+          UI.important("Found keychain '#{keychain_path}', creation skipped")
+        end
 
         if params[:default_keychain]
           # if there is no default keychain - setting the original will fail - silent this error
@@ -50,6 +55,14 @@ module Fastlane
         end
 
         commands
+      end
+
+      def self.exists?(keychain_path)
+        keychain_path = File.expand_path(keychain_path)
+
+        # Creating Keycahins using the security
+        # CLI appends `-db` to the file name.
+        File.exist?("#{keychain_path}-db") || File.exist?(keychain_path)
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -25,8 +25,11 @@ module Fastlane
 
         if !exists?(keychain_path)
           commands << Fastlane::Actions.sh("security create-keychain -p #{escaped_password} #{keychain_path}", log: false)
+        elsif params[:require_create]
+          UI.user_error!("`require_create` option passed, but found keychain '#{keychain_path}', failing create_keychain action")
         else
           UI.important("Found keychain '#{keychain_path}', creation skipped")
+          UI.important("If creating a new Keychain DB is required please set the `require_create` option true to cause the action to fail")
         end
 
         if params[:default_keychain]
@@ -111,7 +114,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :add_to_search_list,
                                        description: 'Add keychain to search list',
                                        is_string: false,
-                                       default_value: true)
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :require_create,
+                                       description: 'Fail the action if the Keychain already exists',
+                                       is_string: false,
+                                       default_value: false)
         ]
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When running `setup_travis` or `setup_circle_ci` to perform setup actions on their respective CI environments creates a Keychain DB using the `create_keychain` action. And the `create_keychain` can only be run once per system (per CI job).

This causes error in the situation where you run multiple lanes separately in the same job, the error is due to the `create_keychain` action failing to be rerun since it already created the Keychain DB.

This is unideal as the correct placement for such action is in the `before_all` hook, and placing it inside specific lanes create unneeded coupling and dependence between different lanes.

More details are in the discussion in #13270.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

The change introduced allows `create_keychain` to be called multiple times without failing, by checking if the requested DB was created before and skipping the `security create-keychain` command needed to create it.

It also provides an option `require_create` which is a flag (defaulting to false) and if it is set to true it would cause the action to fail if the Keychain DB already exists, which could be very helpful in certain situations when you want to create a clean Keychain DB.

The implementation was done in the `create_keychain` action itself to avoid have to duplicate the logic whenever a new consumer wants this behaviour.