### PR TITLE
[frameit] debug mode

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -91,20 +91,20 @@ module Frameit
       # Debug Mode: Add filename to frame
       if self.debug_mode
         filename = File.basename(@frame_path, ".*")
-        filename.sub! 'Apple', '' # remove 'Apple'
+        filename.sub!('Apple', '') # remove 'Apple'
 
         width = screenshot.size[0]
-        font_size = width/20 # magic number that works well
+        font_size = width / 20 # magic number that works well
 
         offset_top = offset['offset'].split("+")[2].to_f
         annotate_offset = "+0+#{offset_top}" # magic number that works semi well
 
         frame.combine_options do |c|
-          c.gravity 'North'
-          c.undercolor '#00000080'
-          c.fill 'white'
-          c.pointsize font_size
-          c.annotate "#{annotate_offset}", "#{filename}"
+          c.gravity('North')
+          c.undercolor('#00000080')
+          c.fill('white')
+          c.pointsize(font_size)
+          c.annotate(annotate_offset.to_s, filename.to_s)
         end
       end
 

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -18,7 +18,7 @@ module Frameit
     attr_accessor :image # the current image used for editing
     attr_accessor :space_to_device
 
-    def initialize(screenshot, debug_mode)
+    def initialize(screenshot, debug_mode = false)
       @screenshot = screenshot
       self.debug_mode = debug_mode
     end

--- a/frameit/lib/frameit/options.rb
+++ b/frameit/lib/frameit/options.rb
@@ -70,7 +70,7 @@ module Frameit
                                      env_name: "FRAMEIT_DEBUG_MODE",
                                      description: "Output debug information in framed screenshots",
                                      default_value: false,
-                                     type: Boolean),
+                                     type: Boolean)
       ]
     end
   end

--- a/frameit/lib/frameit/options.rb
+++ b/frameit/lib/frameit/options.rb
@@ -65,7 +65,12 @@ module Frameit
                                          :landscape_right
                                        end
                                      end,
-                                     default_value_dynamic: true)
+                                     default_value_dynamic: true),
+        FastlaneCore::ConfigItem.new(key: :debug_mode,
+                                     env_name: "FRAMEIT_DEBUG_MODE",
+                                     description: "Output debug information in framed screenshots",
+                                     default_value: false,
+                                     type: Boolean),
       ]
     end
   end

--- a/frameit/lib/frameit/runner.rb
+++ b/frameit/lib/frameit/runner.rb
@@ -40,7 +40,7 @@ module Frameit
             if screenshot.mac?
               editor = MacEditor.new(screenshot)
             else
-              editor = Editor.new(screenshot)
+              editor = Editor.new(screenshot, Frameit.config[:debug_mode])
             end
             if editor.should_skip?
               UI.message("Skipping framing of screenshot #{screenshot.path}.  No title provided in your Framefile.json or title.strings.")


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Working with frameit can be confusing and frustrating, as the code is a bit of a black box. I started to work on fixing this in #14088, but quickly learned that there is missing something: a way to visually debug what frameit is doing.

### Description
This PR adds a `debug_mode` parameter to the action that enables some additional functionality when frameit is used. In this first iteration it adds the filename of the frame that is being used to frame a screenshot to the resulting picture. This makes it possible to quickly understand what frame was used.

Here are some examples of what it looks like used with a screenshot of a full pink app that shows the device or simulator name:

![ipad 5th generation -01startscreen_framed](https://user-images.githubusercontent.com/183673/51764479-9582a200-20d5-11e9-8fef-90ad23f01dae.png)
![ipad pro 12 9-inch -01startscreen_framed](https://user-images.githubusercontent.com/183673/51764484-974c6580-20d5-11e9-98b4-901d7a669f17.png)
![iphone 6s plus-01startscreen_framed](https://user-images.githubusercontent.com/183673/51764488-987d9280-20d5-11e9-93d9-9e30db45857d.png)
![iphone xs max-01startscreen_framed](https://user-images.githubusercontent.com/183673/51764490-9adfec80-20d5-11e9-9314-7189b4783c57.png)
![iphone se-01startscreen_framed](https://user-images.githubusercontent.com/183673/51764494-9ca9b000-20d5-11e9-90ff-2b0444f7db58.png)
![iphone 5s-01startscreen_framed](https://user-images.githubusercontent.com/183673/51764543-b814bb00-20d5-11e9-897f-438d48ade19b.png)


As you see, there are some mismatches - which means there is some further work on frameit needed.
