### PR TITLE
add ability to update a specific target's development team

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_team.rb
+++ b/fastlane/lib/fastlane/actions/update_project_team.rb
@@ -16,7 +16,7 @@ module Fastlane
           project = Xcodeproj::Project.open(project_path)
 
           # Fetch target
-          target = project.native_targets.find { |target| target.name == target_name }
+          target = project.native_targets.find { |native_target| native_target.name == target_name }
           UI.user_error!("Could not find target `#{target_name}` in the project `#{project_path}`") if target.nil?
 
           UI.message("Updating development team (#{params[:teamid]}) for target `#{target_name}` in the project '#{project_path}'")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
We build multiple apps from a single project. They all have their own target, but share extension targets. The `DEVELOPMENT_TEAM` need to be updated on the extension targets when building each app target. We don't want to change it across the project, just on the specific targets. Much like `update_app_identity`.

### Description
<!-- Describe your changes in detail -->
Sometimes you want to update the `DEVELOPMENT_TEAM` of just one target, instead of the entire project. This adds `target` as an option to `update_project_team`. When supplied the `DEVELOPMENT TEAM` of that one target will be updated instead of the entire project.

<!-- Please describe in detail how you tested your changes. -->
I tested this by integrating it into my company's build process. Running it multiple times while testing builds.
