### PR TITLE
[spaceship] add a spaceship method to check Program License Agreement warnings

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -600,7 +600,7 @@ module Spaceship
       all_messages = []
 
       messages_request = request(:get, "https://olympus.itunes.apple.com/v1/contractMessages")
-      body = messagesRequest.body
+      body = messages_request.body
       if body
         body = JSON.parse(body) if body.kind_of?(String)
         body.map do |messages|

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -596,11 +596,10 @@ module Spaceship
     end
 
     # Get contract messages from App Store Connect's "olympus" endpoint
-    def fetch_program_license_agreement_messages()
-
+    def fetch_program_license_agreement_messages
       all_messages = []
 
-      messagesRequest = request(:get, "https://olympus.itunes.apple.com/v1/contractMessages")
+      messages_request = request(:get, "https://olympus.itunes.apple.com/v1/contractMessages")
       body = messagesRequest.body
       if body
         body = JSON.parse(body) if body.kind_of?(String)

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -595,6 +595,23 @@ module Spaceship
       ENV["FASTLANE_SESSION"] || ENV["SPACESHIP_SESSION"]
     end
 
+    # Get contract messages from App Store Connect's "olympus" endpoint
+    def fetch_program_license_agreement_messages()
+
+      all_messages = []
+
+      messagesRequest = request(:get, "https://olympus.itunes.apple.com/v1/contractMessages")
+      body = messagesRequest.body
+      if body
+        body = JSON.parse(body) if body.kind_of?(String)
+        body.map do |messages|
+          all_messages.push(messages["message"])
+        end
+      end
+
+      return all_messages
+    end
+
     #####################################################
     # @!group Helpers
     #####################################################

--- a/spaceship/spec/portal/fixtures/program_license_agreement_messages.json
+++ b/spaceship/spec/portal/fixtures/program_license_agreement_messages.json
@@ -1,0 +1,7 @@
+[ {
+    "id" : "contract_message",
+    "group" : "Alert",
+    "subject" : "",
+    "message" : "<b>Review the updated Paid Applications Schedule.</b><br />In order to update your existing apps, create new in-app purchases, and submit new apps to the App Store, the user with the Legal role (Team Agent) must review and accept the Paid Applications Schedule (Schedule 2 to the Apple Developer Program License Agreement) in the Agreements, Tax, and Banking module.<br /><br /> To accept this agreement, they must have already accepted the latest version of the Apple Developer Program License Agreement in their <a href=\"http://developer.apple.com/membercenter/index.action\">account on the developer website<a/>.<br />",
+    "priority" : null
+  } ]

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -312,6 +312,22 @@ describe Spaceship::Client do
         expect(response.first.keys).to include('certificateId', 'certificateType', 'certificate')
       end
     end
+
+    describe '#fetch_program_license_agreement_messages' do
+      it 'makes a request to fetch all Program License Agreement warnings from Olympus' do
+
+        # Stub the GET request that the method will make
+        PortalStubbing.adp_stub_fetch_program_license_agreement_messages
+
+        response = subject.fetch_program_license_agreement_messages
+
+        # The method should make a GET request to this URL:
+        expect(a_request(:get, 'https://olympus.itunes.apple.com/v1/contractMessages')).to have_been_made
+
+        # The method should just return the "message" key's value(s) in an array.
+        expect(response.first).to eq("<b>Review the updated Paid Applications Schedule.</b><br />In order to update your existing apps, create new in-app purchases, and submit new apps to the App Store, the user with the Legal role (Team Agent) must review and accept the Paid Applications Schedule (Schedule 2 to the Apple Developer Program License Agreement) in the Agreements, Tax, and Banking module.<br /><br /> To accept this agreement, they must have already accepted the latest version of the Apple Developer Program License Agreement in their <a href=\"http://developer.apple.com/membercenter/index.action\">account on the developer website<a/>.<br />")
+      end
+    end
   end
 
   describe 'keys api' do

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -315,7 +315,6 @@ describe Spaceship::Client do
 
     describe '#fetch_program_license_agreement_messages' do
       it 'makes a request to fetch all Program License Agreement warnings from Olympus' do
-
         # Stub the GET request that the method will make
         PortalStubbing.adp_stub_fetch_program_license_agreement_messages
 
@@ -325,7 +324,20 @@ describe Spaceship::Client do
         expect(a_request(:get, 'https://olympus.itunes.apple.com/v1/contractMessages')).to have_been_made
 
         # The method should just return the "message" key's value(s) in an array.
-        expect(response.first).to eq("<b>Review the updated Paid Applications Schedule.</b><br />In order to update your existing apps, create new in-app purchases, and submit new apps to the App Store, the user with the Legal role (Team Agent) must review and accept the Paid Applications Schedule (Schedule 2 to the Apple Developer Program License Agreement) in the Agreements, Tax, and Banking module.<br /><br /> To accept this agreement, they must have already accepted the latest version of the Apple Developer Program License Agreement in their <a href=\"http://developer.apple.com/membercenter/index.action\">account on the developer website<a/>.<br />")
+
+        expected_first_message = "<b>Review the updated Paid Applications \
+Schedule.</b><br />In order to update your existing apps, create \
+new in-app purchases, and submit new apps to the App Store, the \
+user with the Legal role (Team Agent) must review and accept the \
+Paid Applications Schedule (Schedule 2 to the Apple Developer \
+Program License Agreement) in the Agreements, Tax, and Banking \
+module.<br /><br /> To accept this agreement, they must have \
+already accepted the latest version of the Apple Developer \
+Program License Agreement in their <a href=\"\
+http://developer.apple.com/membercenter/index.action\">account on \
+the developer website<a/>.<br />"
+
+        expect(response.first).to eq(expected_first_message)
       end
     end
   end

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -338,5 +338,10 @@ class PortalStubbing
       stub_request(:get, "https://developer.apple.com/services-account/QH65B2/account/ios/profile/downloadProfileContent?provisioningProfileId=PP00000001&teamId=XXXXXXXXXX").
         to_return(status: 404, body: adp_read_fixture_file('download_certificate_failure.html'))
     end
+
+    def adp_stub_fetch_program_license_agreement_messages
+      stub_request(:get, 'https://olympus.itunes.apple.com/v1/contractMessages').
+      to_return(status: 200, body: adp_read_fixture_file('program_license_agreement_messages.json'), headers: { 'Content-Type' => 'application/json' })
+    end
   end
 end

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -341,7 +341,7 @@ class PortalStubbing
 
     def adp_stub_fetch_program_license_agreement_messages
       stub_request(:get, 'https://olympus.itunes.apple.com/v1/contractMessages').
-      to_return(status: 200, body: adp_read_fixture_file('program_license_agreement_messages.json'), headers: { 'Content-Type' => 'application/json' })
+        to_return(status: 200, body: adp_read_fixture_file('program_license_agreement_messages.json'), headers: { 'Content-Type' => 'application/json' })
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #13619 and #7000

I work with a client who develops, manages, and releases countless applications on behalf of their own clients. We needed a quick way to keep tabs on which of our clients' Apple Developer Accounts need updated Program License Agreement signatures.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
Add a new method named `fetch_program_license_agreement_messages` in `Spaceship::Portal.client` to be able to access any messages on Olympus for our client accounts in our `Fastfile`.