### PR TITLE
[supply] Checking for interactive mode before user's input when creating from config

### DIFF
--- a/fastlane/spec/actions_specs/create_app_on_managed_play_store_spec.rb
+++ b/fastlane/spec/actions_specs/create_app_on_managed_play_store_spec.rb
@@ -23,7 +23,7 @@ describe Fastlane do
             Fastlane::FastFile.new.parse("lane :test do
               create_app_on_managed_play_store()
             end").runner.execute(:test)
-          end.to raise_error(FastlaneCore::Interface::FastlaneError, /Could not load authentication file. Make sure it has been added as an enviroment variable as 'json_key' or 'json_key_data' for raw data/)
+          end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not load Google authentication. Make sure it has been added as an environment variable in 'json_key' or 'json_key_data'")
         end
       end
 

--- a/fastlane/spec/actions_specs/create_app_on_managed_play_store_spec.rb
+++ b/fastlane/spec/actions_specs/create_app_on_managed_play_store_spec.rb
@@ -7,14 +7,23 @@ describe Fastlane do
 
       describe "without :json_key or :json_key_data" do
         it "without :json_key or :json_key_data - could not find file" do
+          expect(UI).to receive(:interactive?).and_return(true)
           expect(UI).to receive(:important).with("To not be asked about this value, you can specify it using 'json_key'")
           expect(UI).to receive(:input).with(anything).and_return("not_a_file")
-
           expect do
             Fastlane::FastFile.new.parse("lane :test do
               create_app_on_managed_play_store()
             end").runner.execute(:test)
           end.to raise_error(FastlaneCore::Interface::FastlaneError, /Could not find service account json file at path/)
+        end
+
+        it "without :json_key or :json_key_data - crashes in a not an interactive place" do
+          expect(UI).to receive(:interactive?).and_return(false)
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              create_app_on_managed_play_store()
+            end").runner.execute(:test)
+          end.to raise_error(FastlaneCore::Interface::FastlaneError, /Could not load authentication file. Make sure it has been added as an enviroment variable as 'json_key' or 'json_key_data' for raw data/)
         end
       end
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -13,12 +13,12 @@ module Supply
     attr_accessor :client
 
     def self.make_from_config(params: nil)
-      kei_io = service_account_authentication(params)
+      kei_io = service_account_authentication(params: params)
       return self.new(service_account_json: kei_io, params: params)
     end
 
     # Supply authentication file
-    def self.service_account_authentication(params = nil)
+    def self.service_account_authentication(params: nil)
       if params.nil?
         params = Supply.config
       end
@@ -100,7 +100,7 @@ module Supply
     # @!group Login
     #####################################################
 
-    def self.service_account_authentication(params = nil)
+    def self.service_account_authentication(params: nil)
       if params.nil?
         params = Supply.config
       end

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -14,7 +14,7 @@ module Supply
 
     def self.make_from_config(params: nil)
       params ||= Supply.config
-      service_account_data = AbstractGoogleServiceClient.service_account_authentication(params: params)
+      service_account_data = self.service_account_authentication(params: params)
       return self.new(service_account_json: service_account_data, params: params)
     end
 
@@ -24,7 +24,7 @@ module Supply
         if UI.interactive?
           UI.important("To not be asked about this value, you can specify it using 'json_key'")
           json_key_path = UI.input("The service account json file used to authenticate with Google: ")
-          json_key_path = File.expand_path(json_key_path)
+          json_key_path = File.expand_path(json_key_ºpath)
 
           UI.user_error!("Could not find service account json file at path '#{json_key_path}'") unless File.exist?(json_key_path)
           params[:json_key] = json_key_path

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -14,7 +14,7 @@ module Supply
 
     def self.make_from_config(params: nil)
       params ||= Supply.config
-      service_account_data = service_account_authentication(params: params)
+      service_account_data = AbstractGoogleServiceClient.service_account_authentication(params: params)
       return self.new(service_account_json: service_account_data, params: params)
     end
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -99,7 +99,7 @@ module Supply
 
     def self.service_account_authentication(params: nil)
       if params[:json_key] || params[:json_key_data]
-        super(params)
+        super(params: params)
       elsif params[:key] && params[:issuer]
         require 'google/api_client/auth/key_utils'
         UI.important("This type of authentication is deprecated. Please consider using JSON authentication instead")

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -24,7 +24,7 @@ module Supply
         if UI.interactive?
           UI.important("To not be asked about this value, you can specify it using 'json_key'")
           json_key_path = UI.input("The service account json file used to authenticate with Google: ")
-          json_key_path = File.expand_path(json_key_ºpath)
+          json_key_path = File.expand_path(json_key_path)
 
           UI.user_error!("Could not find service account json file at path '#{json_key_path}'") unless File.exist?(json_key_path)
           params[:json_key] = json_key_path

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -31,7 +31,7 @@ module Supply
           UI.user_error!("Could not find service account json file at path '#{json_key_path}'") unless File.exist?(json_key_path)
           params[:json_key] = json_key_path
         else
-          UI.user_error!("Could not load authentication file. Make sure it has been added as an enviroment variable as 'json_key' or 'json_key_data' for raw data")
+          UI.user_error!("Could not load Google authentication. Make sure it has been added as an environment variable in 'json_key' or 'json_key_data'")
         end
       end
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -101,14 +101,14 @@ module Supply
     #####################################################
 
     def self.service_account_authentication(params = nil)
+      if params.nil?
+        params = Supply.config
+      end
+
       if params[:json_key] || params[:json_key_data]
         super(params)
       else
         if params[:path_to_key] && params[:issuer]
-          if params.nil?
-            params = Supply.config
-          end
-
           require 'google/api_client/auth/key_utils'
           UI.important("This type of authentication is deprecated. Please consider using JSON authentication instead")
           key = Google::APIClient::KeyUtils.load_from_pkcs12(File.expand_path(parms[:path_to_key]), 'notasecret')

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -111,7 +111,7 @@ module Supply
         if params[:key] && params[:issuer]
           require 'google/api_client/auth/key_utils'
           UI.important("This type of authentication is deprecated. Please consider using JSON authentication instead")
-          key = Google::APIClient::KeyUtils.load_from_pkcs12(File.expand_path(parms[:key]), 'notasecret')
+          key = Google::APIClient::KeyUtils.load_from_pkcs12(File.expand_path(params[:key]), 'notasecret')
           cred_json = {
             private_key: key.to_s,
             client_email: params[:issuer]

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -16,7 +16,6 @@ module Supply
       if params.nil?
         params = Supply.config
       end
-      
       kei_io = service_account_authentication(params: params)
       return self.new(service_account_json: kei_io, params: params)
     end

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -13,6 +13,10 @@ module Supply
     attr_accessor :client
 
     def self.make_from_config(params: nil)
+      if params.nil?
+        params = Supply.config
+      end
+      
       kei_io = service_account_authentication(params: params)
       return self.new(service_account_json: kei_io, params: params)
     end

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -108,10 +108,10 @@ module Supply
       if params[:json_key] || params[:json_key_data]
         super(params)
       else
-        if params[:path_to_key] && params[:issuer]
+        if params[:key] && params[:issuer]
           require 'google/api_client/auth/key_utils'
           UI.important("This type of authentication is deprecated. Please consider using JSON authentication instead")
-          key = Google::APIClient::KeyUtils.load_from_pkcs12(File.expand_path(parms[:path_to_key]), 'notasecret')
+          key = Google::APIClient::KeyUtils.load_from_pkcs12(File.expand_path(parms[:key]), 'notasecret')
           cred_json = {
             private_key: key.to_s,
             client_email: params[:issuer]

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -19,10 +19,6 @@ module Supply
 
     # Supply authentication file
     def self.service_account_authentication(params: nil)
-      if params.nil?
-        params = Supply.config
-      end
-
       unless params[:json_key] || params[:json_key_data]
         if UI.interactive?
           UI.important("To not be asked about this value, you can specify it using 'json_key'")
@@ -101,10 +97,6 @@ module Supply
     #####################################################
 
     def self.service_account_authentication(params: nil)
-      if params.nil?
-        params = Supply.config
-      end
-
       if params[:json_key] || params[:json_key_data]
         super(params)
       else

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -13,13 +13,27 @@ module Supply
     attr_accessor :client
 
     def self.make_from_config(params: nil)
-      unless params[:json_key] || params[:json_key_data]
-        UI.important("To not be asked about this value, you can specify it using 'json_key'")
-        json_key_path = UI.input("The service account json file used to authenticate with Google: ")
-        json_key_path = File.expand_path(json_key_path)
+      kei_io = service_account_authentication(params)
+      return self.new(service_account_json: kei_io, params: params)
+    end
 
-        UI.user_error!("Could not find service account json file at path '#{json_key_path}'") unless File.exist?(json_key_path)
-        params[:json_key] = json_key_path
+    # Supply authentication file
+    def self.service_account_authentication(params = nil)
+      if params.nil?
+        params = Supply.config
+      end
+
+      unless params[:json_key] || params[:json_key_data]
+        if UI.interactive?
+          UI.important("To not be asked about this value, you can specify it using 'json_key'")
+          json_key_path = UI.input("The service account json file used to authenticate with Google: ")
+          json_key_path = File.expand_path(json_key_path)
+
+          UI.user_error!("Could not find service account json file at path '#{json_key_path}'") unless File.exist?(json_key_path)
+          params[:json_key] = json_key_path
+        else
+          UI.user_error!("Could not load authentication file. Make sure it has been added as an enviroment variable as 'json_key' or 'json_key_data' for raw data")
+        end
       end
 
       if params[:json_key]
@@ -28,7 +42,7 @@ module Supply
         service_account_json = StringIO.new(params[:json_key_data])
       end
 
-      return self.new(service_account_json: service_account_json, params: params)
+      service_account_json
     end
 
     # Initializes the service and its auth_client using the specified information
@@ -86,40 +100,28 @@ module Supply
     # @!group Login
     #####################################################
 
-    # instantiate a client given the supplied configuration
-    def self.make_from_config(params: nil)
-      if params.nil?
-        params = Supply.config
-      end
-
-      # first consider deprecated params
-      unless params[:json_key] || params[:json_key_data] || (params[:key] && params[:issuer])
-        UI.important("To not be asked about this value, you can specify it using 'json_key'")
-        params[:json_key] = UI.input("The service account json file used to authenticate with Google: ")
-      end
-
-      super(params: params)
-    end
-
-    # Initializes the client and its auth_client using the specified information
-    # @param service_account_json: The raw service account Json data
-    # @param path_to_key: The path to your p12 file (@deprecated)
-    # @param issuer: Email address for oauth (@deprecated)
-    def initialize(path_to_key: nil, issuer: nil, service_account_json: nil, params: nil)
-      if service_account_json
-        key_io = service_account_json
+    def self.service_account_authentication(params = nil)
+      if params[:json_key] || params[:json_key_data]
+        super(params)
       else
-        # deprecated
-        require 'google/api_client/auth/key_utils'
-        key = Google::APIClient::KeyUtils.load_from_pkcs12(File.expand_path(path_to_key), 'notasecret')
-        cred_json = {
-          private_key: key.to_s,
-          client_email: issuer
-        }
-        key_io = StringIO.new(MultiJson.dump(cred_json))
-      end
+        if params[:path_to_key] && params[:issuer]
+          if params.nil?
+            params = Supply.config
+          end
 
-      super(service_account_json: key_io, params: params)
+          require 'google/api_client/auth/key_utils'
+          UI.important("This type of authentication is deprecated. Please consider using JSON authentication instead")
+          key = Google::APIClient::KeyUtils.load_from_pkcs12(File.expand_path(parms[:path_to_key]), 'notasecret')
+          cred_json = {
+            private_key: key.to_s,
+            client_email: params[:issuer]
+          }
+          service_account_json = StringIO.new(MultiJson.dump(cred_json))
+          service_account_json
+        else
+          UI.user_error!("No authentication parameters were specified. These must be provided in order to authenticate with Google")
+        end
+      end
     end
 
     #####################################################


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
These changes are being made to fix [#14128](https://github.com/fastlane/fastlane/issues/14128). This issue is an unexpected behaviour in CI with supply action.

### Description
When any `AbstractGoogleServiceClient` is being created from configuration, it searches for authentication parameters for authenticating with Google. I've moved this logic to an independent method, which can be overloaded from any of its child. 

`PlaycustomappClient` will still be using just the non deprecated way, so if you don't provide 'json_key' or 'json_key_data' params using `CreateAppOnManagedPlayStoreAction`, Fastlane will crash, as specified in [this PR](https://github.com/fastlane/fastlane/pull/13431). 

In the other hand, the old `Client` will still support both of the authentication types, but printing an important message on UI, making an advice on using the JSON files.

The issue was fixed by wrapping the input line into a condition, which asks whether the UI is interactive or not. If this checks fails, Fastlane will crash.

Existing tests were fixed in order to make them work with these changes, and also added a new case into the "without :json_key or :json_key_data" set.