### PR TITLE
[frameit] Add "Screenshot orientation" section to `frameit` documentation

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
@@ -223,7 +223,7 @@ One way to override the default behavior is editing the file name by adding `for
 
 ### `force_orientation_block`
 
-If the default behavior doesn't fit your needs and you don't want or can't rename your screenshots, you can customize _frameit_'s orientation behavior by setting a `force_orientation_block` parameter. The valid values are: `landscape_left` (home button on the left side), `:landscape_right` (home button on the right side), `:portrait` (home button on the bottom), `nil` (home button on the right side).
+If the default behavior doesn't fit your needs and you don't want or can't rename your screenshots, you can customize _frameit_'s orientation behavior by setting a `force_orientation_block` parameter. The valid values are: `:landscape_left` (home button on the left side), `:landscape_right` (home button on the right side), `:portrait` (home button on the bottom), `nil` (home button on the right side).
 
 ### Examples
 

--- a/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
@@ -235,7 +235,7 @@ frameit(
       when "iPad Pro (12.9-inch)-01LoginScreen" 
         :landscape_right
       when "iPhone 6 Plus-01LoginScreen"
-        : portrait
+        :portrait
       # and so on
     end
   end

--- a/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
@@ -215,6 +215,46 @@ The `keyword.strings` and `title.strings` are standard `.strings` file you alrea
 - These `.strings` files **MUST** be utf-8 (UTF-8) or utf-16 encoded (UTF-16 BE with BOM). They also must begin with an empty line. If you are having trouble see [issue #1740](https://github.com/fastlane/fastlane/issues/1740)
 - You **MUST** provide a background if you want titles. _frameit_ will not add the tiles if a background is not specified.
 
+### Screenshot orientation
+
+By default `frameit` adds a frame to your screenshot based on an orientation you took it. For a portrait (vertical orientation) it is going to add portrait frame and for a landscape (horizontal orientation) - landscape left.
+
+If you'd like to get a frame in a landscape right for your horizontal screenshots, you need to add `force_landscaperight` at the end of your screenshot's filename. 
+
+### `force_orientation_block`
+
+In a case you don't want to rename your screenshots or default behaviour does not meet your requirements, there's a way to customise it. In order to do so, you need to set `force_orientation_block` parameter.
+
+### Examples
+
+```ruby
+frameit(
+  path: "./fastlane/screenshots",
+  force_orientation_block: proc do |filename|
+    case filename
+      when "1Login" 
+        :landscape_left
+      when "2Profile"
+        :landscape_right
+      # and so on
+    end
+  end
+)
+```
+
+```ruby
+frameit(
+  silver: true,
+  path: "./fastlane/screenshots",
+  force_orientation_block: proc do |filename|
+    f = filename.downcase
+    if f.include?("landscape")
+      :landscape_right
+    end
+  end
+)
+```
+
 # Mac
 
 With _frameit_ it's possible to also frame macOS Application screenshots. You have to provide the following:

--- a/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
@@ -217,13 +217,13 @@ The `keyword.strings` and `title.strings` are standard `.strings` file you alrea
 
 ### Screenshot orientation
 
-By default _frameit_ adds a frame to your screenshot based on an orientation you took it. For a portrait (vertical orientation) it is going to add portrait frame and for a landscape (horizontal orientation) - landscape left.
+By default _frameit_ adds a frame to your screenshot based on an orientation you took it. For a portrait (vertical orientation) it is going to add portrait frame and for a landscape (horizontal orientation) - landscape left (= [Home button on the left side](https://developer.apple.com/documentation/uikit/uiinterfaceorientation/landscapeleft)).
 
-If you'd like to get a frame in a landscape right for your horizontal screenshots, you need to add `force_landscaperight` at the end of your screenshot's filename. 
+One way to override the default behavior is editing the file name by adding `force_landscaperight` to the end.
 
 ### `force_orientation_block`
 
-In a case you don't want to rename your screenshots or default behaviour does not meet your requirements, there's a way to customise it. In order to do so, you need to set `force_orientation_block` parameter.
+If the default behavior doesn't fit your needs and you don't want or can't rename your screenshots, you can customize _frameit_'s orientation behavior by setting a `force_orientation_block` parameter. The valid values are: `landscape_left` (home button on the left side), `:landscape_right` (home button on the right side), `:portrait` (home button on the bottom), `nil` (home button on the right side).
 
 ### Examples
 
@@ -232,10 +232,10 @@ frameit(
   path: "./fastlane/screenshots",
   force_orientation_block: proc do |filename|
     case filename
-      when "1Login" 
-        :landscape_left
-      when "2Profile"
+      when "iPad Pro (12.9-inch)-01LoginScreen" 
         :landscape_right
+      when "iPhone 6 Plus-01LoginScreen"
+        : portrait
       # and so on
     end
   end

--- a/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
@@ -217,7 +217,7 @@ The `keyword.strings` and `title.strings` are standard `.strings` file you alrea
 
 ### Screenshot orientation
 
-By default `frameit` adds a frame to your screenshot based on an orientation you took it. For a portrait (vertical orientation) it is going to add portrait frame and for a landscape (horizontal orientation) - landscape left.
+By default _frameit_ adds a frame to your screenshot based on an orientation you took it. For a portrait (vertical orientation) it is going to add portrait frame and for a landscape (horizontal orientation) - landscape left.
 
 If you'd like to get a frame in a landscape right for your horizontal screenshots, you need to add `force_landscaperight` at the end of your screenshot's filename. 
 

--- a/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
@@ -228,6 +228,7 @@ If the default behavior doesn't fit your needs and you don't want or can't renam
 ### Examples
 
 ```ruby
+# It matches the filename to the framed device orientation
 frameit(
   path: "./fastlane/screenshots",
   force_orientation_block: proc do |filename|
@@ -243,6 +244,7 @@ frameit(
 ```
 
 ```ruby
+# It frames the screenshots in landscape right whenever the filename contains `landscape` word
 frameit(
   silver: true,
   path: "./fastlane/screenshots",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
closes https://github.com/fastlane/fastlane/issues/14076 
The usage of `force_orientation_block` is not very well documented. 

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

We are introducing a brand new "Screenshot orientation" section. At the beginning, we are explaining the default behaviour of taking the screenshots. Later we are introducing `force_orientation_block ` parameter and wrapping it up with two simple examples from https://github.com/fastlane/fastlane/pull/11161. 

Thanks for reviewing it! 💪🏅 