### PR TITLE
[core] skip setting partition list if key is already imported

### DIFF
--- a/fastlane/spec/actions_specs/import_certificate_spec.rb
+++ b/fastlane/spec/actions_specs/import_certificate_spec.rb
@@ -20,8 +20,8 @@ describe Fastlane do
         allow(File).to receive(:file?).with(keychain_path).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
+        allow(Open3).to receive(:popen3).with(expected_command)
         allow(Open3).to receive(:popen3).with(allowed_command)
-        expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: false)
 
         Fastlane::FastFile.new.parse("lane :test do
           import_certificate ({
@@ -47,8 +47,8 @@ describe Fastlane do
         allow(File).to receive(:file?).with(keychain_path).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
-        expect(Open3).to receive(:popen3).with(expected_set_key_partition_list_command)
-        expect(FastlaneCore::Helper).to receive(:backticks).with(expected_security_import_command, print: false)
+        allow(Open3).to receive(:popen3).with(expected_security_import_command)
+        allow(Open3).to receive(:popen3).with(expected_set_key_partition_list_command)
 
         Fastlane::FastFile.new.parse("lane :test do
           import_certificate ({
@@ -75,8 +75,8 @@ describe Fastlane do
         allow(File).to receive(:file?).with(keychain_path).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with(cert_name).and_return(true)
+        allow(Open3).to receive(:popen3).with(expected_command)
         allow(Open3).to receive(:popen3).with(allowed_command)
-        expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: true)
 
         Fastlane::FastFile.new.parse("lane :test do
           import_certificate ({

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -12,8 +12,27 @@ module FastlaneCore
       command << " -T /usr/bin/security"
       command << " 1> /dev/null" unless output
 
-      Helper.backticks(command, print: output)
+      UI.command(command) if output
+      Open3.popen3(command) do |stdin, stdout, stderr, thrd|
+        UI.command_output(stdout.read.to_s) if output
 
+        # Set partition list only if success since it can be a time consuming process if a lot of keys are installed
+        if thrd.value.success?
+          set_partition_list(path, keychain_path, keychain_password: keychain_password, certificate_password: certificate_password, output: output)
+        else
+          # Output verbose if file is already installed since not an error otherwise we will show the whole error
+          err = stderr.read.to_s.strip
+          if err.include?("SecKeychainItemImport") && err.include?("The specified item already exists in the keychain")
+            type = File.extname(".p12") ? "Key" : "Certificate"
+            UI.verbose("#{type} '#{File.basename(path)}' is already installed on this machine")
+          else
+            UI.error(err)
+          end
+        end
+      end
+    end
+
+    def self.set_partition_list(path, keychain_path, keychain_password: "", output: FastlaneCore::Globals.verbose?)
       # When security supports partition lists, also add the partition IDs
       # See https://openradar.appspot.com/28524119
       if Helper.backticks('security -h | grep set-key-partition-list', print: false).length > 0
@@ -33,14 +52,14 @@ module FastlaneCore
 
             # Inform user when no/wrong password was used as its needed to prevent UI permission popup from Xcode when signing
             if err.include?("SecKeychainItemSetAccessWithPassword")
-              UI.error("")
-              UI.error("Could not configure imported keychain item (certificate) to prevent UI permission popup when code signing\n" \
+              UI.important("")
+              UI.important("Could not configure imported keychain item (certificate) to prevent UI permission popup when code signing\n" \
                        "Check if you supplied the correct `keychain_password` for keychain: `#{keychain_path}`\n" \
                        "#{err}")
-              UI.error("")
-              UI.error("Please look at the following docs to see how to set a keychain password:")
-              UI.error(" - https://docs.fastlane.tools/actions/sync_code_signing")
-              UI.error(" - https://docs.fastlane.tools/actions/get_certificates")
+              UI.important("")
+              UI.important("Please look at the following docs to see how to set a keychain password:")
+              UI.important(" - https://docs.fastlane.tools/actions/sync_code_signing")
+              UI.important(" - https://docs.fastlane.tools/actions/get_certificates")
             else
               UI.error(err)
             end

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -23,7 +23,7 @@ module FastlaneCore
           # Output verbose if file is already installed since not an error otherwise we will show the whole error
           err = stderr.read.to_s.strip
           if err.include?("SecKeychainItemImport") && err.include?("The specified item already exists in the keychain")
-            type = File.extname(".p12") ? "Key" : "Certificate"
+            type = File.extname(path) == ".p12" ? "Key" : "Certificate"
             UI.verbose("#{type} '#{File.basename(path)}' is already installed on this machine")
           else
             UI.error(err)

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -18,7 +18,7 @@ module FastlaneCore
 
         # Set partition list only if success since it can be a time consuming process if a lot of keys are installed
         if thrd.value.success?
-          set_partition_list(path, keychain_path, keychain_password: keychain_password, certificate_password: certificate_password, output: output)
+          set_partition_list(path, keychain_path, keychain_password: keychain_password, output: output)
         else
           # Output verbose if file is already installed since not an error otherwise we will show the whole error
           err = stderr.read.to_s.strip

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -23,8 +23,7 @@ module FastlaneCore
           # Output verbose if file is already installed since not an error otherwise we will show the whole error
           err = stderr.read.to_s.strip
           if err.include?("SecKeychainItemImport") && err.include?("The specified item already exists in the keychain")
-            type = File.extname(path) == ".p12" ? "Key" : "Certificate"
-            UI.verbose("#{type} '#{File.basename(path)}' is already installed on this machine")
+            UI.verbose("'#{File.basename(path)}' is already installed on this machine")
           else
             UI.error(err)
           end

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -169,7 +169,6 @@ module Match
         self.files_to_commit << private_key_path
       else
         cert_path = certs.last
-
         if Helper.mac?
           UI.message("Installing certificate...")
 
@@ -185,6 +184,7 @@ module Match
 
           # Import the private key
           # there seems to be no good way to check if it's already installed - so just install it
+          # Key will only be added to the partition list if it isn't already installed
           Utils.import(keys.last, params[:keychain_name], password: params[:keychain_password])
         else
           UI.message("Skipping installation of certificate as it would not work on this operating system.")

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -16,8 +16,8 @@ describe Match do
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with('item.path').and_return(true)
 
+        allow(Open3).to receive(:popen3).with(expected_command)
         allow(Open3).to receive(:popen3).with(allowed_command)
-        expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: FastlaneCore::Globals.verbose?)
 
         Match::Utils.import('item.path', 'login.keychain')
       end
@@ -35,8 +35,8 @@ describe Match do
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with('item.path').and_return(true)
 
+        allow(Open3).to receive(:popen3).with(expected_command)
         allow(Open3).to receive(:popen3).with(allowed_command)
-        expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: FastlaneCore::Globals.verbose?)
 
         Match::Utils.import('item.path', keychain)
       end
@@ -60,8 +60,8 @@ describe Match do
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with("item.path").and_return(true)
 
+        allow(Open3).to receive(:popen3).with(expected_command)
         allow(Open3).to receive(:popen3).with(allowed_command)
-        expect(FastlaneCore::Helper).to receive(:backticks).with(expected_command, print: FastlaneCore::Globals.verbose?)
 
         Match::Utils.import('item.path', "login.keychain")
       end


### PR DESCRIPTION
Fixes #14039

## Issues
There were two outstanding issues/improvements from the recent keychain importer changes.
1. The `UI.error` was too strong/bold and causing users to think there were actually importing issues in their import so it was moved to a `UI.important`
2. Certificates were being skipped if they were already installed but this was not happening with keys
  - With the addition of the recent keychain importer PRs, `set-partition-lists` would always run which would be skipped for certificates that were already installed but would get run for every key
  - If a user had a lot of keys installed, this would add a lot of extra unnecessary time since key was already imported
  - This `set-partition-lists` also requires the keychain password which (if not provided) which show that overly loud `UI.error` about how to solve
  - Skipping installed keys will speed up the match process along with showing unnecessary warning/errors 

## Description
1. Changed `UI.error` to `UI.important` for the warning/suggestion on how to improve that their match process
2. Using `Open3` instead of `Helper.backticks` so that we can get the success/error status and look at the output error to see if its a duplicate key so that we can skip the `set-partition-lists` process