### PR TITLE
[frameit] Automate measuring of "slot" offsets and width

### DIFF
--- a/frameit/frames_generator/Gemfile
+++ b/frameit/frames_generator/Gemfile
@@ -1,4 +1,6 @@
+source('https://rubygems.org')
+
 gem 'colored'
-gem 'mini_magick', '~> 4.5.1' # To open, edit and export PSD files
+gem 'mini_magick', '~> 4.9.0' # To open, edit and export PSD files and support ImageMagick 7
 gem 'pry'
 gem 'rake'

--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -20,7 +20,7 @@ DEVICE_COLORS = [
   "White",
   "Yellow",
   "Gray",
-  "Coral",
+  "Coral"
 ]
 
 task(:generate_device_frames) do
@@ -45,7 +45,7 @@ task(:generate_device_frames) do
   mkdir_p(output) unless File.directory?(output)
 
   image_assets = []
-  offsets = Hash.new
+  offsets = {}
   (Dir["raw/Phones/Apple*/Device/*.png"] + Dir["raw/Computers/Apple*/Device/*.png"] + Dir["raw/Tablets/Apple*/Device/*.png"]).each do |current_raw|
     basename = File.basename(current_raw)
     next if DEVICES_TO_SKIP.include?(basename)
@@ -58,9 +58,9 @@ task(:generate_device_frames) do
     convert_image_resource(sanitaized_file_path)
     image_assets << sanitaized_basename
 
-    x, y, width, height = measure_slot(sanitaized_file_path)
+    x, y, width = measure_slot(sanitaized_file_path)
     device_name = sanitize_device_name(sanitaized_basename)
-    offsets["#{device_name}"] = {'offset' => "+#{x}+#{y}", 'width' => width}
+    offsets[device_name.to_s] = { 'offset' => "+#{x}+#{y}", 'width' => width }
   end
 
   raise "Could not find any images, make sure to copy all extracted files into ./raw" if image_assets.count < 10
@@ -71,7 +71,7 @@ task(:generate_device_frames) do
   File.write(File.join(output, "version.txt"), current_time)
   puts("Wrote the current time stamp to version.txt")
 
-  File.write(File.join(output, "offsets.json"), JSON.pretty_generate({'portrait': offsets}))
+  File.write(File.join(output, "offsets.json"), JSON.pretty_generate({ 'portrait' => offsets }))
   puts("Wrote the slot offsets to offsets.json")
 
   cp_r(output, "output/latest")
@@ -114,7 +114,7 @@ def measure_slot(path)
   command_output = convert.call
 
   sh("rm #{tmp_output}", verbose: false)
-  
+
   raw_dimensions = command_output.split("\n")[1].strip
   dimensions = /(\d+)x(\d+)\+(\d+)\+(\d+)/.match(raw_dimensions)
   x = dimensions[3]
@@ -128,9 +128,8 @@ def sanitize_device_name(filename)
   basename = File.basename(filename, File.extname(filename))
   basename = basename.gsub("Apple", "")
   basename = basename.gsub("-", " ")
-  DEVICE_COLORS.each { |color| basename.slice! color }
+  DEVICE_COLORS.each { |color| basename.slice!(color) }
   basename.strip
 end
 
 task(default: [:generate_device_frames])
-

--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -45,7 +45,7 @@ task(:generate_device_frames) do
   mkdir_p(output) unless File.directory?(output)
 
   image_assets = []
-  offsets = {}
+  devices = Hash.new { |h, k| h[k] = [] }
   (Dir["raw/Phones/Apple*/Device/*.png"] + Dir["raw/Computers/Apple*/Device/*.png"] + Dir["raw/Tablets/Apple*/Device/*.png"]).each do |current_raw|
     basename = File.basename(current_raw)
     next if DEVICES_TO_SKIP.include?(basename)
@@ -60,7 +60,7 @@ task(:generate_device_frames) do
 
     x, y, width = measure_slot(sanitized_file_path)
     device_name = sanitize_device_name(sanitized_basename)
-    offsets[device_name.to_s] = { 'offset' => "+#{x}+#{y}", 'width' => width }
+    devices[device_name] << { filename: sanitized_basename, x: x, y: y, width: width }
   end
 
   raise "Could not find any images, make sure to copy all extracted files into ./raw" if image_assets.count < 10
@@ -71,8 +71,21 @@ task(:generate_device_frames) do
   File.write(File.join(output, "version.txt"), current_time)
   puts("Wrote the current time stamp to version.txt")
 
+  # Create `offests.json` file
+  offsets = {}
+  devices.each do |device, models|
+    offsets[device] = { offset: "+#{models[0][:x]}+#{models[0][:y]}", width: models[0][:width] }
+  end
   File.write(File.join(output, "offsets.json"), JSON.pretty_generate({ 'portrait' => offsets }))
   puts("Wrote the slot offsets to offsets.json")
+
+  # Check if the offsets for a device are identical for all colors
+  devices.each do |device, models|
+    next if models.all? { |m| m[:x] == (models[0][:x]) && m[:y] == (models[0][:y]) && m[:width] == (models[0][:width]) }
+    puts("The offsets for #{device} are not identical for all colors:".yellow)
+    models.each { |m| puts("#{m[:filename]} +#{m[:x]}+#{m[:y]}, #{m[:width]}") }
+    puts("You can either keep the value in `offset.json` or replace it with a more appropriate value from above.")
+  end
 
   cp_r(output, "output/latest")
 
@@ -142,7 +155,7 @@ def sanitize_device_name(filename)
   basename = basename.gsub("Apple", "")
   basename = basename.gsub("-", " ")
   DEVICE_COLORS.each { |color| basename.slice!(color) }
-  basename.strip
+  basename.strip.to_s
 end
 
 task(default: [:generate_device_frames])

--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -52,14 +52,14 @@ task(:generate_device_frames) do
 
     cp(current_raw, output)
     output_file_path = File.join(output, basename)
-    sanitaized_basename = sanitize_filename(basename)
-    sanitaized_file_path = File.join(output, sanitaized_basename)
-    mv(output_file_path, sanitaized_file_path) unless output_file_path == sanitaized_file_path
-    convert_image_resource(sanitaized_file_path)
-    image_assets << sanitaized_basename
+    sanitized_basename = sanitize_filename(basename)
+    sanitized_file_path = File.join(output, sanitized_basename)
+    mv(output_file_path, sanitized_file_path) unless output_file_path == sanitized_file_path
+    convert_image_resource(sanitized_file_path)
+    image_assets << sanitized_basename
 
-    x, y, width = measure_slot(sanitaized_file_path)
-    device_name = sanitize_device_name(sanitaized_basename)
+    x, y, width = measure_slot(sanitized_file_path)
+    device_name = sanitize_device_name(sanitized_basename)
     offsets[device_name.to_s] = { 'offset' => "+#{x}+#{y}", 'width' => width }
   end
 

--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -118,16 +118,22 @@ end
 def measure_slot(path)
   tmp_output = Time.now.to_i.to_s + ".png"
 
-  convert = MiniMagick::Tool::Convert.new
-  convert << path
-  convert.negate # it makes white, black and black, white, adjusting all the colors to match
-  # connected-component analysis uniquely labels connected components in an image
-  convert.define("connected-components:verbose=true") # it enables a verbose output to the shell console
-  convert.define("connected-components:area-threshold=100") # it eliminates small objects by merging them with their larger neighbors
-  convert.connected_components("8") # it visits 8 neighbors
-  convert.auto_level
-  convert << tmp_output
-  command_output = convert.call
+  begin
+    command_output = MiniMagick::Tool::Magick.new do |magick|
+      magick << path
+      magick.negate # it makes white, black and black, white, adjusting all the colors to match
+      # connected-component analysis uniquely labels connected components in an image
+      magick.define("connected-components:verbose=true") # it enables a verbose output to the shell console
+      magick.define("connected-components:area-threshold=100") # it eliminates small objects by merging them with their larger neighbors
+      magick.connected_components("8") # it visits 8 neighbors
+      magick.auto_level
+      magick << tmp_output
+    end
+  rescue StandardError => e
+    puts(e)
+    puts("The functionality of slot measurements does not work with ImageMagick older than 7.x".red)
+    exit!
+  end
 
   sh("rm #{tmp_output}", verbose: false)
 

--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -82,9 +82,11 @@ task(:generate_device_frames) do
   # Check if the offsets for a device are identical for all colors
   devices.each do |device, models|
     next if models.all? { |m| m[:x] == (models[0][:x]) && m[:y] == (models[0][:y]) && m[:width] == (models[0][:width]) }
-    puts("The offsets for #{device} are not identical for all colors:".yellow)
+    puts
+    puts("The offsets for #{device} are not identical for all colors:".red)
     models.each { |m| puts("#{m[:filename]} +#{m[:x]}+#{m[:y]}, #{m[:width]}") }
     puts("You can either keep the value in `offset.json` or replace it with a more appropriate value from above.")
+    puts
   end
 
   cp_r(output, "output/latest")

--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -105,16 +105,29 @@ def measure_slot(path)
 
   convert = MiniMagick::Tool::Convert.new
   convert << path
-  convert.negate
-  convert.define("connected-components:verbose=true")
-  convert.define("connected-components:area-threshold=100")
-  convert.connected_components("8")
+  convert.negate # it makes white, black and black, white, adjusting all the colors to match
+  # connected-component analysis uniquely labels connected components in an image
+  convert.define("connected-components:verbose=true") # it enables a verbose output to the shell console
+  convert.define("connected-components:area-threshold=100") # it eliminates small objects by merging them with their larger neighbors
+  convert.connected_components("8") # it visits 8 neighbors
   convert.auto_level
   convert << tmp_output
   command_output = convert.call
 
   sh("rm #{tmp_output}", verbose: false)
 
+  # The example of the command ouput:
+  #
+  # Objects (id: bounding-box centroid area mean-color):
+  #   494: 640x1136+67+239 386.5,806.5 727040 srgb(255,255,255)
+  #   4: 767x1605+0+0 385.4,801.2 478199 srgb(0,0,0)
+  #   522: 115x1004+0+601 12.1,1244.6 10023 srgb(255,255,255)
+  #   0: 517x232+0+0 125.3,36.3 8303 srgb(255,255,255)
+  #   8: 131x115+636+0 731.1,26.2 3908 srgb(255,255,255)
+  #   561: 108x108+659+1497 740.4,1578.0 2954 srgb(255,255,255)
+  #   500: 7x48+0+301 3.0,323.7 325 srgb(255,255,255)
+  #   511: 7x42+0+454 3.0,473.7 283 srgb(255,255,255)
+  #
   raw_dimensions = command_output.split("\n")[1].strip
   dimensions = /(\d+)x(\d+)\+(\d+)\+(\d+)/.match(raw_dimensions)
   x = dimensions[3]

--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -7,6 +7,22 @@ DEVICES_TO_SKIP = [
   "Apple iMac.png" # we don't currently support iMac
 ]
 
+DEVICE_COLORS = [
+  "Space Gray",
+  "Rose Gold",
+  "Jet Black",
+  "Matte Black",
+  "Silver",
+  "Gold",
+  "Green",
+  "Blue",
+  "Red",
+  "White",
+  "Yellow",
+  "Gray",
+  "Coral",
+]
+
 task(:generate_device_frames) do
   MiniMagick.configure do |config|
     config.validate_on_create = false
@@ -29,6 +45,7 @@ task(:generate_device_frames) do
   mkdir_p(output) unless File.directory?(output)
 
   image_assets = []
+  offsets = Hash.new
   (Dir["raw/Phones/Apple*/Device/*.png"] + Dir["raw/Computers/Apple*/Device/*.png"] + Dir["raw/Tablets/Apple*/Device/*.png"]).each do |current_raw|
     basename = File.basename(current_raw)
     next if DEVICES_TO_SKIP.include?(basename)
@@ -40,6 +57,10 @@ task(:generate_device_frames) do
     mv(output_file_path, sanitaized_file_path) unless output_file_path == sanitaized_file_path
     convert_image_resource(sanitaized_file_path)
     image_assets << sanitaized_basename
+
+    x, y, width, height = measure_slot(sanitaized_file_path)
+    device_name = sanitize_device_name(sanitaized_basename)
+    offsets["#{device_name}"] = {'offset' => "+#{x}+#{y}", 'width' => width}
   end
 
   raise "Could not find any images, make sure to copy all extracted files into ./raw" if image_assets.count < 10
@@ -50,8 +71,8 @@ task(:generate_device_frames) do
   File.write(File.join(output, "version.txt"), current_time)
   puts("Wrote the current time stamp to version.txt")
 
-  cp("offsets.json", File.join(output, "offsets.json"))
-  puts("Copied over offsets.json")
+  File.write(File.join(output, "offsets.json"), JSON.pretty_generate({'portrait': offsets}))
+  puts("Wrote the slot offsets to offsets.json")
 
   cp_r(output, "output/latest")
 
@@ -79,4 +100,37 @@ def convert_image_resource(path)
   image.write(path)
 end
 
+def measure_slot(path)
+  tmp_output = Time.now.to_i.to_s + ".png"
+
+  convert = MiniMagick::Tool::Convert.new
+  convert << path
+  convert.negate
+  convert.define("connected-components:verbose=true")
+  convert.define("connected-components:area-threshold=100")
+  convert.connected_components("8")
+  convert.auto_level
+  convert << tmp_output
+  command_output = convert.call
+
+  sh("rm #{tmp_output}", verbose: false)
+  
+  raw_dimensions = command_output.split("\n")[1].strip
+  dimensions = /(\d+)x(\d+)\+(\d+)\+(\d+)/.match(raw_dimensions)
+  x = dimensions[3]
+  y = dimensions[4]
+  width = dimensions[1]
+  height = dimensions[2]
+  return x.to_i, y.to_i, width.to_i, height.to_i
+end
+
+def sanitize_device_name(filename)
+  basename = File.basename(filename, File.extname(filename))
+  basename = basename.gsub("Apple", "")
+  basename = basename.gsub("-", " ")
+  DEVICE_COLORS.each { |color| basename.slice! color }
+  basename.strip
+end
+
 task(default: [:generate_device_frames])
+


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
closes https://github.com/fastlane/fastlane/issues/14094

> Currently we have to manually measure the offsets and width of the "slot" where the screenshots will be placed. We should automate that as part of the frame update process.

### Description
In order to detect a "slot" on a device image, we are looking for transparent areas.  The detection is based on [this]( https://stackoverflow.com/questions/26244191/imagemagick-detect-coordinates-of-transparent-areas) solution. We are analysing the output command and parse the dimensions of the slot. Below you can find an example of raw command output for iPhone 5c image:

```bash
$ convert Apple\ iPhone\ 5c\ Blue.png -alpha extract -negate           \
   -define connected-components:verbose=true       \
   -define connected-components:area-threshold=100 \
   -connected-components 8 -auto-level  result.png
Objects (id: bounding-box centroid area mean-color):
  494: 640x1136+67+239 386.5,806.5 727040 srgb(255,255,255)
  4: 767x1605+0+0 385.4,801.2 478199 srgb(0,0,0)
  522: 115x1004+0+601 12.1,1244.6 10023 srgb(255,255,255)
  0: 517x232+0+0 125.3,36.3 8303 srgb(255,255,255)
  8: 131x115+636+0 731.1,26.2 3908 srgb(255,255,255)
  561: 108x108+659+1497 740.4,1578.0 2954 srgb(255,255,255)
  500: 7x48+0+301 3.0,323.7 325 srgb(255,255,255)
  511: 7x42+0+454 3.0,473.7 283 srgb(255,255,255)
```
By parsing the first line (the largest transparent area)  of the verbose log`494: 640x1136+67+239 386.5,806.5 727040 srgb(255,255,255)`, we get the dimensions: x = 67, y = 239, width = 640, height = 1136.

I tested it by running `rake` command and comparing generated `offsets.json` file to the original `offests.json` file from the repository. The final results are the same as the current `offests.json` values except that we are adding `Macbook` now. 

I've added a few comments to start  discussion and double check those part of the code are okay, or maybe we could improve them. 

Thanks 🙇 🙇 