### PR TITLE
[frameit] Fix inconsistent dimensions on device frames

### DIFF
--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -75,7 +75,10 @@ end
 def convert_image_resource(path)
   puts("Updating and trimming image file '#{path}'")
   image = MiniMagick::Image.open(path)
-  image.trim
+  image.combine_options do |co|
+    co.fuzz("90%")
+    co.trim("+repage")
+  end
   image.write(path)
 end
 

--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -76,8 +76,8 @@ def convert_image_resource(path)
   puts("Updating and trimming image file '#{path}'")
   image = MiniMagick::Image.open(path)
   image.combine_options do |co|
-    co.fuzz("90%")
-    co.trim("+repage")
+    co.fuzz("90%") # color disimilarity threshold to get all shadows, see https://github.com/fastlane/fastlane/pull/14199
+    co.trim("+repage") # `+repage` removes meta-data
   end
   image.write(path)
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
closes https://github.com/fastlane/fastlane/issues/14093 

The device frames processed by our script have inconsistent dimensions. It messes with the code of `frameit` and produces an inconsistent output. 

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

Even though we were trimming the background from the image, the extra 1, 2 or pixels were still there. The root cause was that there was not enough color difference between the shadow and device color, i.e. space gray or jet black models. 

The solution was to set percent color disimilarity threshold: `fuzz(90%)`.
`+repage` option has been added to remove a meta-data for further processing. 

The way I was testing the fix:
1. Run `rake` command. 
2. Check the dimensions of generated frames in `latest` 

<img width="424" alt="6s" src="https://user-images.githubusercontent.com/10795657/52358221-e54b5c80-2a37-11e9-8ff3-f6f48b9c7eac.png">
<img width="531" alt="7" src="https://user-images.githubusercontent.com/10795657/52358233-e9777a00-2a37-11e9-82c2-01408c97a851.png">
<img width="526" alt="7_plus" src="https://user-images.githubusercontent.com/10795657/52358242-ed0b0100-2a37-11e9-90d4-e0d4d54575e5.png">
<img width="319" alt="8_plus" src="https://user-images.githubusercontent.com/10795657/52358250-f09e8800-2a37-11e9-82ca-f38f3a8840c8.png">


Thanks!