### PR TITLE
[scan] Always zip build products

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -93,6 +93,7 @@ module Scan
       puts("")
 
       copy_simulator_logs
+      zip_build_products
 
       if result[:failures] > 0
         open_report
@@ -104,7 +105,6 @@ module Scan
         UI.test_failure!("Test execution failed. Exit status: #{tests_exit_status}")
       end
 
-      zip_build_products
       open_report
     end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`should_zip_build_products` has no effect if tests fail or if the test execution failed. As build products can be handy to debug these cases, I suggest to always zip them accordingly.

### Description
Moved `zip_build_products` call up so it's called before any premature exit. No need to update `should_zip_build_products` in my opinion.
