### PR TITLE
[action] add symbols and booleans in modify_services action

### DIFF
--- a/fastlane/lib/fastlane/actions/modify_services.rb
+++ b/fastlane/lib/fastlane/actions/modify_services.rb
@@ -4,16 +4,14 @@ module Fastlane
       def self.run(params)
         require 'produce'
 
-        return if Helper.test?
-
         Produce.config = params
 
         Dir.chdir(FastlaneCore::FastlaneFolder.path || Dir.pwd) do
           require 'produce/service'
           services = params[:services]
 
-          enabled_services = services.select { |_k, v| v.to_sym == :on || v == true }.map { |k, v| [k, 'on'] }.to_h
-          disabled_services = services.reject { |_k, v| v.to_sym == :on || v == true }.map { |k, v| [k, 'off'] }.to_h
+          enabled_services = services.select { |_k, v| v == true || v.to_s == 'on' }.map { |k, v| [k, 'on'] }.to_h
+          disabled_services = services.reject { |_k, v| v == true || v.to_s == 'on' }.map { |k, v| [k, 'off'] }.to_h
 
           enabled_services_object = self.service_object
           enabled_services.each do |k, v|

--- a/fastlane/lib/fastlane/actions/modify_services.rb
+++ b/fastlane/lib/fastlane/actions/modify_services.rb
@@ -12,7 +12,7 @@ module Fastlane
           require 'produce/service'
           services = params[:services]
 
-          enabled_services = services.select { |_k, v| v == :on || v == 'on' || v == true }.map { |k, v| [k, 'on'] }.to_h
+          enabled_services = services.select { |_k, v| v.to_sym == :on || v == true }.map { |k, v| [k, 'on'] }.to_h
           disabled_services = services.reject { |_k, v| v.to_sym == :on || v == true }.map { |k, v| [k, 'off'] }.to_h
 
           enabled_services_object = self.service_object

--- a/fastlane/lib/fastlane/actions/modify_services.rb
+++ b/fastlane/lib/fastlane/actions/modify_services.rb
@@ -13,7 +13,7 @@ module Fastlane
           services = params[:services]
 
           enabled_services = services.select { |_k, v| v == :on || v == 'on' || v == true }.map { |k, v| [k, 'on'] }.to_h
-          disabled_services = services.reject { |_k, v| v == :on || v == 'on' || v == true }.map { |k, v| [k, 'off'] }.to_h
+          disabled_services = services.reject { |_k, v| v.to_sym == :on || v == true }.map { |k, v| [k, 'off'] }.to_h
 
           enabled_services_object = self.service_object
           enabled_services.each do |k, v|

--- a/fastlane/lib/fastlane/actions/modify_services.rb
+++ b/fastlane/lib/fastlane/actions/modify_services.rb
@@ -12,8 +12,8 @@ module Fastlane
           require 'produce/service'
           services = params[:services]
 
-          enabled_services = services.reject { |k, v| v == 'off' }
-          disabled_services = services.select { |k, v| v == 'off' }
+          enabled_services = services.select { |_k, v| v == :on || v == 'on' || v == true }.map { |k, v| [k, 'on'] }.to_h
+          disabled_services = services.reject { |_k, v| v == :on || v == 'on' || v == true }.map { |k, v| [k, 'off'] }.to_h
 
           enabled_services_object = self.service_object
           enabled_services.each do |k, v|
@@ -72,7 +72,7 @@ module Fastlane
 
       def self.allowed_services_description
         return Produce::DeveloperCenter::ALLOWED_SERVICES.map do |k, v|
-          "#{k}: (#{v.join('|')})"
+          "#{k}: (#{v.join('|')})(:on|:off)(true|false)"
         end.join(", ")
       end
 
@@ -158,9 +158,12 @@ module Fastlane
             app_identifier: "com.someorg.app",
             services: {
               push_notification: "on",
-              associated_domains: "off"
-            }
-          )'
+              associated_domains: "off",
+              wallet: :on,
+              apple_pay: :off,
+              data_protection: true,
+              multipath: false
+            })'
         ]
       end
 

--- a/fastlane/spec/actions_specs/modify_services_spec.rb
+++ b/fastlane/spec/actions_specs/modify_services_spec.rb
@@ -1,0 +1,34 @@
+require 'produce/service'
+
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "modify_services" do
+      it 'sends enable and disable with strings, symbols, and booleans' do
+        allow(Produce).to receive(:config)
+        expect(Produce::Service).to receive(:enable) do |options, args|
+          expect(options.push_notification).to eq('on')
+          expect(options.wallet).to eq('on')
+          expect(options.data_protection).to eq('on')
+        end
+        expect(Produce::Service).to receive(:disable) do |options, args|
+          expect(options.associated_domains).to eq('off')
+          expect(options.apple_pay).to eq('off')
+          expect(options.multipath).to eq('off')
+        end
+        Fastlane::FastFile.new.parse("lane :test do
+            modify_services(
+              username: 'test.account@gmail.com',
+              app_identifier: 'com.someorg.app',
+              services: {
+                push_notification: 'on',
+                associated_domains: 'off',
+                wallet: :on,
+                apple_pay: :off,
+                data_protection: true,
+                multipath: false
+            })
+        end").runner.execute(:test)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary. Action description updated.

### Motivation and Context
This changes allow users to use Symbols & Booleans as parameters in `service` hash in `modify_services_action`

Related to: https://github.com/fastlane/fastlane/issues/14202

### Description
- Added Symbols & Booleans as valid parameters in `modify_services_action`

Previous `modify_services` example:

```
    modify_services(
      app_identifier: 'com.company.product',
      team_id: 'A255399',
      services: {
        push_notification: 'on',
        associated_domains: 'off'
      }
    )
```

Proposed `modify_services` example (keeping previous example valid):

```
    modify_services(
      app_identifier: 'com.company.product',
      team_id: 'A255399',
      services: {
        push_notification: :on,
        associated_domains: :off
      }
    )
```
or
```
    modify_services(
      app_identifier: 'com.company.product',
      team_id: 'A255399',
      services: {
        push_notification: true,
        associated_domains: false
      }
    )
```

How did I test it?
- Tested locally with a project following [How to test your local changes](https://github.com/fastlane/fastlane/blob/master/Testing.md#testing-your-local-changes)
