### PR TITLE
[fastlane] load actions for tools

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -102,6 +102,12 @@ module Fastlane
             # When we launch this feature, this should never be the case
             abort("#{tool_name} can't be called via `fastlane #{tool_name}`, run '#{tool_name}' directly instead".red)
           end
+
+          # Some of the tools use other actions so need to load all
+          # actions before we start the tool generator
+          # Example: scan uses slack
+          Fastlane.load_actions
+
           commands_generator.start
         elsif tool_name == "fastlane-credentials"
           require 'credentials_manager'


### PR DESCRIPTION
Fixes #14211

## Description
`scan` calls the `slack` action after a run which works fine when calling from a `Fastfile`. However, actions are not loaded when tools are called directly via CLI like... 
```sh
fastlane scan --scheme "MyApp-DEV" --slack_url "https://hooks.slack.com/services...
```

## Solution
We now will call `Fastlane.load_actions` before the tool's command generator is started.

