### PR TITLE
[spaceship] fix pilot distribute with new Connect API beta calls

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_to_testflight.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_testflight.rb
@@ -47,6 +47,46 @@ module Fastlane
             username: "felix@krausefx.com",
             app_identifier: "com.krausefx.app",
             itc_provider: "abcde12345" # pass a specific value to the iTMSTransporter -itc_provider option
+          )',
+          'upload_to_testflight(
+            beta_app_feedback_email: "email@email.com",
+            beta_app_description: "This is a description of my app",
+            demo_account_required: true,
+            notify_external_testers: false,
+            changelog: "This is my changelog of things that have changed in a log"
+          )',
+          'upload_to_testflight(
+            beta_app_review_info: {
+              contact_email: "email@email.com",
+              contact_first_name: "Connect",
+              contact_last_name: "API",
+              contact_phone: "5558675309}",
+              demo_account_name: "demo@email.com",
+              demo_account_password: "connectapi",
+              notes: "this is review note for the reviewer <3 thank you for reviewing"
+            },
+            localized_app_info: {
+              "default": {
+                feedback_email: "default@email.com",
+                marketing_url: "https://example.com/marketing-defafult",
+                privacy_policy_url: "https://example.com/privacy-defafult",
+                description: "Default description",
+              },
+              "en-GB": {
+                feedback_email: "en-gb@email.com",
+                marketing_url: "https://example.com/marketing-en-gb",
+                privacy_policy_url: "https://example.com/privacy-en-gb",
+                description: "en-gb description",
+              }
+            },
+            localized_build_info: {
+              "default": {
+                whats_new: "Default changelog",
+              },
+              "en-GB": {
+                whats_new: "en-gb changelog",
+              }
+            }
           )'
         ]
       end

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -73,9 +73,8 @@ module Pilot
       end
 
       # Setting account required wth AppStore Connect API
-      puts "we here???"
-      update_review_detail(app.apple_id, {demo_account_required: options[:demo_account_required]})
-      update_review_detail(app.apple_id, options[:beta_app_review_info])
+      update_review_detail(build.app_id, {demo_account_required: options[:demo_account_required]})
+      update_review_detail(build.app_id, options[:beta_app_review_info])
 
       if should_update_app_test_information?(options)
         app_test_info = Spaceship::TestFlight::AppTestInfo.find(app_id: build.app_id)
@@ -222,18 +221,16 @@ module Pilot
     end
 
     def update_review_detail(app_id, beta_app_review_info)
-      beta_app_review_info = Hash[beta_app_review_info.map{ |k, v| [k.to_sym, v] }]
+      beta_app_review_info = beta_app_review_info.collect{|k,v| [k.to_sym, v]}.to_h
 
       attributes = {}
-      attributes["contactEmail"] = beta_app_review_info[:contact_email] if beta_app_review_info.has_key?(:contact_email)
-      attributes["contactFirstName"] = beta_app_review_info[:contact_first_name] if beta_app_review_info.has_key?(:contact_first_name)
-      attributes["contactLastName"] = beta_app_review_info[:contact_last_name] if beta_app_review_info.has_key?(:contact_last_name)
-      attributes["contactPhone"] = beta_app_review_info[:contact_phone] if beta_app_review_info.has_key?(:contact_phone)
-      attributes["demoAccountName"] = beta_app_review_info[:demo_account_name] if beta_app_review_info.has_key?(:demo_account_name)
-      attributes["demoAccountPassword"] = beta_app_review_info[:demo_account_password] if beta_app_review_info.has_key?(:demo_account_password)
-      attributes["demoAccountRequired"] = beta_app_review_info[:demo_account_required] if beta_app_review_info.has_key?(:demo_account_required)
-
-      puts "attributes: #{attributes}"
+      attributes[:contactEmail] = beta_app_review_info[:contact_email] if beta_app_review_info.has_key?(:contact_email)
+      attributes[:contactFirstName] = beta_app_review_info[:contact_first_name] if beta_app_review_info.has_key?(:contact_first_name)
+      attributes[:contactLastName] = beta_app_review_info[:contact_last_name] if beta_app_review_info.has_key?(:contact_last_name)
+      attributes[:contactPhone] = beta_app_review_info[:contact_phone] if beta_app_review_info.has_key?(:contact_phone)
+      attributes[:demoAccountName] = beta_app_review_info[:demo_account_name] if beta_app_review_info.has_key?(:demo_account_name)
+      attributes[:demoAccountPassword] = beta_app_review_info[:demo_account_password] if beta_app_review_info.has_key?(:demo_account_password)
+      attributes[:demoAccountRequired] = beta_app_review_info[:demo_account_required] if beta_app_review_info.has_key?(:demo_account_required)
 
       client = Spaceship::ConnectAPI::Base.client
       client.patch_beta_app_review_detail(app_id: app_id, attributes: attributes)

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -72,6 +72,11 @@ module Pilot
         UI.user_error!("No build to distribute!")
       end
 
+      # Setting account required wth AppStore Connect API
+      puts "we here???"
+      update_review_detail(app.apple_id, {demo_account_required: options[:demo_account_required]})
+      update_review_detail(app.apple_id, options[:beta_app_review_info])
+
       if should_update_app_test_information?(options)
         app_test_info = Spaceship::TestFlight::AppTestInfo.find(app_id: build.app_id)
         app_test_info.test_info.feedback_email = options[:beta_app_feedback_email] if options[:beta_app_feedback_email]
@@ -178,7 +183,6 @@ module Pilot
       uploaded_build.export_compliance.encryption_updated = false
 
       if options[:groups] || options[:distribute_external]
-        uploaded_build.beta_review_info.demo_account_required = options[:demo_account_required] # this needs to be set for iTC to continue
         begin
           uploaded_build.submit_for_testflight_review!
         rescue => ex
@@ -215,6 +219,32 @@ module Pilot
       end
 
       true
+    end
+
+    def update_review_detail(app_id, beta_app_review_info)
+      beta_app_review_info = Hash[beta_app_review_info.map{ |k, v| [k.to_sym, v] }]
+
+      attributes = {}
+      attributes["contactEmail"] = beta_app_review_info[:contact_email] if beta_app_review_info.has_key?(:contact_email)
+      attributes["contactFirstName"] = beta_app_review_info[:contact_first_name] if beta_app_review_info.has_key?(:contact_first_name)
+      attributes["contactLastName"] = beta_app_review_info[:contact_last_name] if beta_app_review_info.has_key?(:contact_last_name)
+      attributes["contactPhone"] = beta_app_review_info[:contact_phone] if beta_app_review_info.has_key?(:contact_phone)
+      attributes["demoAccountName"] = beta_app_review_info[:demo_account_name] if beta_app_review_info.has_key?(:demo_account_name)
+      attributes["demoAccountPassword"] = beta_app_review_info[:demo_account_password] if beta_app_review_info.has_key?(:demo_account_password)
+      attributes["demoAccountRequired"] = beta_app_review_info[:demo_account_required] if beta_app_review_info.has_key?(:demo_account_required)
+
+      puts "attributes: #{attributes}"
+
+      client = Spaceship::ConnectAPI::Base.client
+      client.patch_beta_app_review_detail(app_id: app_id, attributes: attributes)
+    end
+
+    def update_app_review(app_id)
+
+    end
+
+    def update_build_review(build_id)
+
     end
   end
 end

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -140,7 +140,7 @@ module Pilot
         update_localized_build_review(build, options[:localized_build_info])
       elsif should_update_build_information?(options)
         begin
-          update_localized_build_review(build, {}, default_info: {whats_new: options[:changelog]})
+          update_localized_build_review(build, {}, default_info: { whats_new: options[:changelog] })
           UI.success("Successfully set the changelog for build")
         rescue => ex
           UI.user_error!("Could not set changelog: #{ex}")
@@ -278,7 +278,6 @@ module Pilot
       end
 
       # Initialize hash of lang codes
-      lang_codes = info_by_lang.keys
       langs_localization_ids = {}
 
       # Validate locales exist
@@ -331,7 +330,6 @@ module Pilot
       end
 
       # Initialize hash of lang codes
-      lang_codes = info_by_lang.keys
       langs_localization_ids = {}
 
       # Validate locales exist
@@ -379,7 +377,7 @@ module Pilot
       attributes = {}
       attributes[:autoNotifyEnabled] = info[:auto_notify_enabled] if info.key?(:auto_notify_enabled)
 
-      puts "patching build details with: #{attributes}"
+      puts("patching build details with: #{attributes}")
 
       client.patch_build_beta_details(build_beta_details_id: build_beta_details_id, attributes: attributes)
     end

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -377,8 +377,6 @@ module Pilot
       attributes = {}
       attributes[:autoNotifyEnabled] = info[:auto_notify_enabled] if info.key?(:auto_notify_enabled)
 
-      puts("patching build details with: #{attributes}")
-
       client.patch_build_beta_details(build_beta_details_id: build_beta_details_id, attributes: attributes)
     end
   end

--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -21,7 +21,7 @@ module Pilot
 
       UI.message("Login to App Store Connect (#{config[:username]})")
       Spaceship::Tunes.login(config[:username])
-      Spaceship::Tunes.select_team
+      Spaceship::Tunes.select_team(team_id: config[:team_id], team_name: config[:team_name])
       UI.message("Login successful")
     end
 

--- a/pilot/lib/pilot/module.rb
+++ b/pilot/lib/pilot/module.rb
@@ -3,6 +3,7 @@ require 'fastlane_core/helper'
 module Pilot
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
+  Boolean = Fastlane::Boolean
   ROOT = Pathname.new(File.expand_path('../../..', __FILE__))
 
   DESCRIPTION = "The best way to manage your TestFlight testers and builds from your terminal"

--- a/pilot/lib/pilot/module.rb
+++ b/pilot/lib/pilot/module.rb
@@ -1,4 +1,5 @@
 require 'fastlane_core/helper'
+require 'fastlane/boolean'
 
 module Pilot
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -70,7 +70,7 @@ module Pilot
                                      optional: true,
                                      verify_block: proc do |values|
                                        valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_required demo_account_name demo_account_password notes)
-                                       values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
+                                       values.keys.each { |value| UI.user_error!("Invalid key '#{value}'") unless valid_keys.include?(value.to_s) }
                                      end),
 
         # app detail
@@ -79,9 +79,11 @@ module Pilot
                                      env_name: "PILOT_LOCALIZED_APP_INFO",
                                      description: "Localized beta app test info for description, feedback email, marketing url, and privacy policy",
                                      optional: true,
-                                     verify_block: proc do |value|
-                                       #                                       valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_name demo_account_password)
-                                       #                                       values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
+                                     verify_block: proc do |lang_values|
+                                       valid_keys = %w(feedback_email marketing_url privacy_policy_url tv_os_privacy_policy_url description)
+                                       lang_values.values.each do |values|
+                                         values.keys.each { |value| UI.user_error!("Invalid key '#{value}'") unless valid_keys.include?(value.to_s) }
+                                       end
                                      end),
         FastlaneCore::ConfigItem.new(key: :beta_app_description,
                                      short_option: "-d",
@@ -100,9 +102,11 @@ module Pilot
                                      env_name: "PILOT_LOCALIZED_BUILD_INFO",
                                      description: "Localized beta app test info for what's new",
                                      optional: true,
-                                     verify_block: proc do |value|
-                                       #                                       valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_name demo_account_password)
-                                       #                                       values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
+                                     verify_block: proc do |lang_values|
+                                       valid_keys = %w(whats_new)
+                                       lang_values.values.each do |values|
+                                         values.keys.each { |value| UI.user_error!("Invalid key '#{value}'") unless valid_keys.include?(value.to_s) }
+                                       end
                                      end),
         FastlaneCore::ConfigItem.new(key: :changelog,
                                      short_option: "-w",

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -69,7 +69,7 @@ module Pilot
                                      description: "Beta app review information for contact info and demo account",
                                      optional: true,
                                      verify_block: proc do |values|
-                                       valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_name demo_account_password notes)
+                                       valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_required demo_account_name demo_account_password notes)
                                        values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
                                      end),
 

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -100,10 +100,19 @@ module Pilot
                                     description: "Should notify external testers?",
                                     default_value: true),
         FastlaneCore::ConfigItem.new(key: :demo_account_required,
-                                     is_string: false,
+                                     type: Boolean,
                                      env_name: "DEMO_ACCOUNT_REQUIRED",
                                      description: "Do you need a demo account when Apple does review?",
                                      default_value: false),
+        FastlaneCore::ConfigItem.new(key: :beta_app_review_info,
+                                     type: Hash,
+                                     env_name: "PILOT_BETA_APP_REVIEW_INFO",
+                                     description: "Beta app review information for contact info and demo account",
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_name demo_account_password)
+                                       values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
+                                     end),
         FastlaneCore::ConfigItem.new(key: :first_name,
                                      short_option: "-f",
                                      env_name: "PILOT_TESTER_FIRST_NAME",

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -58,9 +58,9 @@ module Pilot
                                      end),
 
         # app detail
-        FastlaneCore::ConfigItem.new(key: :localized_test_info,
+        FastlaneCore::ConfigItem.new(key: :localized_app_info,
                                      type: Hash,
-                                     env_name: "PILOT_LOCALIZED_TEST_INFO",
+                                     env_name: "PILOT_LOCALIZED_APP_INFO",
                                      description: "Localized beta app test info for description, feedback email, marketing url, and privacy policy",
                                      optional: true,
                                      verify_block: proc do |value|
@@ -98,6 +98,7 @@ module Pilot
 
         # build review info
         FastlaneCore::ConfigItem.new(key: :changelog,
+                                     deprecated: true,
                                      short_option: "-w",
                                      optional: true,
                                      env_name: "PILOT_CHANGELOG",

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -57,29 +57,6 @@ module Pilot
                                        UI.user_error!("'#{value}' doesn't seem to be an ipa file") unless value.end_with?(".ipa")
                                      end),
 
-        # app detail
-        FastlaneCore::ConfigItem.new(key: :localized_app_info,
-                                     type: Hash,
-                                     env_name: "PILOT_LOCALIZED_APP_INFO",
-                                     description: "Localized beta app test info for description, feedback email, marketing url, and privacy policy",
-                                     optional: true,
-                                     verify_block: proc do |value|
-#                                       valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_name demo_account_password)
-#                                       values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
-                                     end),
-        FastlaneCore::ConfigItem.new(key: :beta_app_description,
-                                     deprecated: true,
-                                     short_option: "-d",
-                                     optional: true,
-                                     env_name: "PILOT_BETA_APP_DESCRIPTION",
-                                     description: "Provide the 'Beta App Description' when uploading a new build"),
-        FastlaneCore::ConfigItem.new(key: :beta_app_feedback_email,
-                                     deprecated: true,
-                                     short_option: "-n",
-                                     optional: true,
-                                     env_name: "PILOT_BETA_APP_FEEDBACK",
-                                     description: "Provide the beta app email when uploading a new build"),
-
         # app review info
         FastlaneCore::ConfigItem.new(key: :demo_account_required,
                                      type: Boolean,
@@ -91,14 +68,46 @@ module Pilot
                                      env_name: "PILOT_BETA_APP_REVIEW_INFO",
                                      description: "Beta app review information for contact info and demo account",
                                      optional: true,
-                                     verify_block: proc do |value|
-                                       valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_name demo_account_password)
+                                     verify_block: proc do |values|
+                                       valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_name demo_account_password notes)
                                        values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
                                      end),
 
+        # app detail
+        FastlaneCore::ConfigItem.new(key: :localized_app_info,
+                                     type: Hash,
+                                     env_name: "PILOT_LOCALIZED_APP_INFO",
+                                     description: "Localized beta app test info for description, feedback email, marketing url, and privacy policy",
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       #                                       valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_name demo_account_password)
+                                       #                                       values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :beta_app_description,
+                                     deprecated: "Use :localized_app_info if possible. This will continue working but will set this value for all locales",
+                                     short_option: "-d",
+                                     optional: true,
+                                     env_name: "PILOT_BETA_APP_DESCRIPTION",
+                                     description: "Provide the 'Beta App Description' when uploading a new build"),
+        FastlaneCore::ConfigItem.new(key: :beta_app_feedback_email,
+                                     deprecated: "Use :localized_app_info if possible. This will continue working but will set this value for all locales",
+                                     short_option: "-n",
+                                     optional: true,
+                                     env_name: "PILOT_BETA_APP_FEEDBACK",
+                                     description: "Provide the beta app email when uploading a new build"),
+
         # build review info
+        FastlaneCore::ConfigItem.new(key: :localized_build_info,
+                                     type: Hash,
+                                     env_name: "PILOT_LOCALIZED_BUILD_INFO",
+                                     description: "Localized beta app test info for what's new",
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       #                                       valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_name demo_account_password)
+                                       #                                       values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
+                                     end),
         FastlaneCore::ConfigItem.new(key: :changelog,
-                                     deprecated: true,
+                                     deprecated: "Use :localized_build_info if possible. This will continue working but will set this value for all locales",
                                      short_option: "-w",
                                      optional: true,
                                      env_name: "PILOT_CHANGELOG",

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -10,6 +10,7 @@ module Pilot
       user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
 
       [
+        # app upload info
         FastlaneCore::ConfigItem.new(key: :username,
                                      short_option: "-u",
                                      env_name: "PILOT_USERNAME",
@@ -34,6 +35,14 @@ module Pilot
                                      verify_block: proc do |value|
                                        UI.user_error!("The platform can only be ios, appletvos, or osx") unless ['ios', 'appletvos', 'osx'].include?(value)
                                      end),
+        FastlaneCore::ConfigItem.new(key: :apple_id,
+                                     short_option: "-p",
+                                     env_name: "PILOT_APPLE_ID",
+                                     description: "The unique App ID provided by App Store Connect",
+                                     optional: true,
+                                     code_gen_sensitive: true,
+                                     default_value: ENV["TESTFLIGHT_APPLE_ID"],
+                                     default_value_dynamic: true),
         FastlaneCore::ConfigItem.new(key: :ipa,
                                      short_option: "-i",
                                      optional: true,
@@ -47,21 +56,52 @@ module Pilot
                                        UI.user_error!("Could not find ipa file at path '#{value}'") unless File.exist?(value)
                                        UI.user_error!("'#{value}' doesn't seem to be an ipa file") unless value.end_with?(".ipa")
                                      end),
-        FastlaneCore::ConfigItem.new(key: :changelog,
-                                     short_option: "-w",
+
+        # app detail
+        FastlaneCore::ConfigItem.new(key: :localized_test_info,
+                                     type: Hash,
+                                     env_name: "PILOT_LOCALIZED_TEST_INFO",
+                                     description: "Localized beta app test info for description, feedback email, marketing url, and privacy policy",
                                      optional: true,
-                                     env_name: "PILOT_CHANGELOG",
-                                     description: "Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog"),
+                                     verify_block: proc do |value|
+#                                       valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_name demo_account_password)
+#                                       values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
+                                     end),
         FastlaneCore::ConfigItem.new(key: :beta_app_description,
+                                     deprecated: true,
                                      short_option: "-d",
                                      optional: true,
                                      env_name: "PILOT_BETA_APP_DESCRIPTION",
                                      description: "Provide the 'Beta App Description' when uploading a new build"),
         FastlaneCore::ConfigItem.new(key: :beta_app_feedback_email,
+                                     deprecated: true,
                                      short_option: "-n",
                                      optional: true,
                                      env_name: "PILOT_BETA_APP_FEEDBACK",
                                      description: "Provide the beta app email when uploading a new build"),
+
+        # app review info
+        FastlaneCore::ConfigItem.new(key: :demo_account_required,
+                                     type: Boolean,
+                                     env_name: "DEMO_ACCOUNT_REQUIRED",
+                                     description: "Do you need a demo account when Apple does review?",
+                                     default_value: false),
+        FastlaneCore::ConfigItem.new(key: :beta_app_review_info,
+                                     type: Hash,
+                                     env_name: "PILOT_BETA_APP_REVIEW_INFO",
+                                     description: "Beta app review information for contact info and demo account",
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_name demo_account_password)
+                                       values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
+                                     end),
+
+        # build review info
+        FastlaneCore::ConfigItem.new(key: :changelog,
+                                     short_option: "-w",
+                                     optional: true,
+                                     env_name: "PILOT_CHANGELOG",
+                                     description: "Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog"),
         FastlaneCore::ConfigItem.new(key: :skip_submission,
                                      short_option: "-s",
                                      env_name: "PILOT_SKIP_SUBMISSION",
@@ -81,14 +121,8 @@ module Pilot
                                      description: "Update build info immediately after validation. This is deprecated and will be removed in a future release. App Store Connect no longer supports setting build info until after build processing has completed, which is when build info is updated by default",
                                      is_string: false,
                                      default_value: false),
-        FastlaneCore::ConfigItem.new(key: :apple_id,
-                                     short_option: "-p",
-                                     env_name: "PILOT_APPLE_ID",
-                                     description: "The unique App ID provided by App Store Connect",
-                                     optional: true,
-                                     code_gen_sensitive: true,
-                                     default_value: ENV["TESTFLIGHT_APPLE_ID"],
-                                     default_value_dynamic: true),
+
+        # distribution
         FastlaneCore::ConfigItem.new(key: :distribute_external,
                                      is_string: false,
                                      env_name: "PILOT_DISTRIBUTE_EXTERNAL",
@@ -99,20 +133,8 @@ module Pilot
                                     env_name: "PILOT_NOTIFY_EXTERNAL_TESTERS",
                                     description: "Should notify external testers?",
                                     default_value: true),
-        FastlaneCore::ConfigItem.new(key: :demo_account_required,
-                                     type: Boolean,
-                                     env_name: "DEMO_ACCOUNT_REQUIRED",
-                                     description: "Do you need a demo account when Apple does review?",
-                                     default_value: false),
-        FastlaneCore::ConfigItem.new(key: :beta_app_review_info,
-                                     type: Hash,
-                                     env_name: "PILOT_BETA_APP_REVIEW_INFO",
-                                     description: "Beta app review information for contact info and demo account",
-                                     optional: true,
-                                     verify_block: proc do |value|
-                                       valid_keys = %w(contact_email contact_first_name contact_last_name contact_phone demo_account_name demo_account_password)
-                                       values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
-                                     end),
+
+        # testers
         FastlaneCore::ConfigItem.new(key: :first_name,
                                      short_option: "-f",
                                      env_name: "PILOT_TESTER_FIRST_NAME",
@@ -137,15 +159,17 @@ module Pilot
                                      description: "Path to a CSV file of testers",
                                      default_value: "./testers.csv",
                                      optional: true),
-        FastlaneCore::ConfigItem.new(key: :wait_processing_interval,
-                                     short_option: "-k",
-                                     env_name: "PILOT_WAIT_PROCESSING_INTERVAL",
-                                     description: "Interval in seconds to wait for App Store Connect processing",
-                                     default_value: 30,
-                                     type: Integer,
+        FastlaneCore::ConfigItem.new(key: :groups,
+                                     short_option: "-g",
+                                     env_name: "PILOT_GROUPS",
+                                     description: "Associate tester to one group or more by group name / group id. E.g. `-g \"Team 1\",\"Team 2\"`",
+                                     optional: true,
+                                     type: Array,
                                      verify_block: proc do |value|
-                                       UI.user_error!("Please enter a valid positive number of seconds") unless value.to_i > 0
+                                       UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
                                      end),
+
+        # app store connect teams
         FastlaneCore::ConfigItem.new(key: :team_id,
                                      short_option: "-q",
                                      env_name: "PILOT_TEAM_ID",
@@ -186,14 +210,16 @@ module Pilot
                                      description: "The provider short name to be used with the iTMSTransporter to identify your team. To get provider short name run `pathToXcode.app/Contents/Applications/Application\\ Loader.app/Contents/itms/bin/iTMSTransporter -m provider -u 'USERNAME' -p 'PASSWORD' -account_type itunes_connect -v off`. The short names of providers should be listed in the second column",
                                      optional: true),
         # rubocop:enable Metrics/LineLength
-        FastlaneCore::ConfigItem.new(key: :groups,
-                                     short_option: "-g",
-                                     env_name: "PILOT_GROUPS",
-                                     description: "Associate tester to one group or more by group name / group id. E.g. `-g \"Team 1\",\"Team 2\"`",
-                                     optional: true,
-                                     type: Array,
+
+        # waiting and uploaded build
+        FastlaneCore::ConfigItem.new(key: :wait_processing_interval,
+                                     short_option: "-k",
+                                     env_name: "PILOT_WAIT_PROCESSING_INTERVAL",
+                                     description: "Interval in seconds to wait for App Store Connect processing",
+                                     default_value: 30,
+                                     type: Integer,
                                      verify_block: proc do |value|
-                                       UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
+                                       UI.user_error!("Please enter a valid positive number of seconds") unless value.to_i > 0
                                      end),
         FastlaneCore::ConfigItem.new(key: :wait_for_uploaded_build,
                                      env_name: "PILOT_WAIT_FOR_UPLOADED_BUILD",

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -84,13 +84,11 @@ module Pilot
                                        #                                       values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
                                      end),
         FastlaneCore::ConfigItem.new(key: :beta_app_description,
-                                     deprecated: "Use :localized_app_info if possible. This will continue working but will set this value for all locales",
                                      short_option: "-d",
                                      optional: true,
                                      env_name: "PILOT_BETA_APP_DESCRIPTION",
                                      description: "Provide the 'Beta App Description' when uploading a new build"),
         FastlaneCore::ConfigItem.new(key: :beta_app_feedback_email,
-                                     deprecated: "Use :localized_app_info if possible. This will continue working but will set this value for all locales",
                                      short_option: "-n",
                                      optional: true,
                                      env_name: "PILOT_BETA_APP_FEEDBACK",
@@ -107,7 +105,6 @@ module Pilot
                                        #                                       values.keys.each { |value| UI.user_error!("Invalid key '#{value}'.") unless valid_keys.include?(value.to_s) }
                                      end),
         FastlaneCore::ConfigItem.new(key: :changelog,
-                                     deprecated: "Use :localized_build_info if possible. This will continue working but will set this value for all locales",
                                      short_option: "-w",
                                      optional: true,
                                      env_name: "PILOT_CHANGELOG",

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -88,6 +88,7 @@ describe "Build Manager" do
       allow(Spaceship::TestFlight::Group).to receive(:default_external_group).and_return(mock_default_external_group)
       allow(Spaceship::ConnectAPI::Base).to receive(:client).and_return(mock_base_api_client)
       allow(mock_base_api_client).to receive(:get_builds).and_return(mock_api_client_builds)
+      allow(mock_base_api_client).to receive(:patch_beta_app_review_detail).and_return(mock_api_client_builds)
       # used to return the approved build if we recover from the 504
     end
     it "doesnt recover if there is a 504 and the build is not approved" do

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -30,6 +30,7 @@ describe "Build Manager" do
     let(:fake_build_manager) { Pilot::BuildManager.new }
     let(:ready_to_submit_mock_build) do
       Spaceship::TestFlight::Build.new(
+        'app_id' => 1,
         'bundleId' => 1,
         'appAdamId' => 1,
         'externalState' => Spaceship::TestFlight::Build::BUILD_STATES[:ready_to_submit],
@@ -40,7 +41,8 @@ describe "Build Manager" do
         'betaReviewInfo' => {
           'contactFirstName' => 'First',
           'contactLastName' => 'Last'
-        }
+        },
+        'build_version' => '123'
       )
     end
     let(:approved_mock_build) do
@@ -77,42 +79,133 @@ describe "Build Manager" do
     let(:mock_api_client_builds) do
       [{ "id" => "123" }]
     end
+    let(:mock_api_client_build_beta_details) do
+      [{ "id" => "321" }]
+    end
+    let(:mock_api_client_beta_app_localizations) do
+      [
+        { "id" => "234", "attributes" => { "locale" => "en-us" } },
+        { "id" => "432", "attributes" => { "locale" => "en-gb" } }
+      ]
+    end
 
-    before(:each) do
-      # default client mocks setup
-      allow(fake_build_manager).to receive(:login)
-      allow(Spaceship::TestFlight::Base).to receive(:client).and_return(mock_base_client)
-      allow(mock_base_client).to receive(:team_id).and_return('')
-      allow(mock_base_client).to receive(:get_build).and_return(ready_to_submit_mock_build)
-      allow(mock_base_client).to receive(:add_group_to_build)
-      allow(Spaceship::TestFlight::Group).to receive(:default_external_group).and_return(mock_default_external_group)
-      allow(Spaceship::ConnectAPI::Base).to receive(:client).and_return(mock_base_api_client)
-      allow(mock_base_api_client).to receive(:get_builds).and_return(mock_api_client_builds)
-      allow(mock_base_api_client).to receive(:patch_beta_app_review_detail).and_return(mock_api_client_builds)
-      # used to return the approved build if we recover from the 504
+    describe "distribute failures" do
+      before(:each) do
+        # default client mocks setup
+        allow(fake_build_manager).to receive(:login)
+        allow(Spaceship::TestFlight::Base).to receive(:client).and_return(mock_base_client)
+        allow(mock_base_client).to receive(:team_id).and_return('')
+        allow(mock_base_client).to receive(:get_build).and_return(ready_to_submit_mock_build)
+        allow(mock_base_client).to receive(:add_group_to_build)
+        allow(Spaceship::TestFlight::Group).to receive(:default_external_group).and_return(mock_default_external_group)
+
+        allow(Spaceship::ConnectAPI::Base).to receive(:client).and_return(mock_base_api_client)
+        allow(mock_base_api_client).to receive(:get_builds).and_return(mock_api_client_builds)
+        allow(mock_base_api_client).to receive(:patch_beta_app_review_detail).and_return(mock_api_client_builds)
+        allow(mock_base_api_client).to receive(:get_build_beta_details).and_return(mock_api_client_build_beta_details)
+        allow(mock_base_api_client).to receive(:get_beta_app_localizations).and_return(mock_api_client_beta_app_localizations)
+        allow(mock_base_api_client).to receive(:patch_beta_app_localizations)
+        allow(mock_base_api_client).to receive(:post_beta_app_localizations)
+        allow(mock_base_api_client).to receive(:patch_build_beta_details)
+      end
+
+      it "doesnt recover if there is a 504 and the build is not approved" do
+        allow(mock_base_api_client).to receive(:post_for_testflight_review).and_raise(Spaceship::Client::InternalServerError, "Server error got 504")
+        allow(Spaceship::TestFlight::Build).to receive(:find).and_return(ready_to_submit_mock_build)
+        expect(FastlaneCore::UI).to receive(:message).with('Distributing new build to testers:  - ')
+        expect(FastlaneCore::UI).to receive(:message).with('Submitting the build for review timed out, trying to recover.')
+        expect { fake_build_manager.distribute(distribute_options, build: ready_to_submit_mock_build) }.to raise_error(Spaceship::Client::InternalServerError, "Server error got 504")
+      end
+
+      it "recovers if there is a 504 and the build is approved" do
+        allow(mock_base_api_client).to receive(:post_for_testflight_review).and_raise(Spaceship::Client::InternalServerError, "Server error got 504")
+        allow(Spaceship::TestFlight::Build).to receive(:find).and_return(approved_mock_build)
+        expect(FastlaneCore::UI).to receive(:message).with('Distributing new build to testers:  - ')
+        expect(FastlaneCore::UI).to receive(:message).with('Submitting the build for review timed out, trying to recover.')
+        fake_build_manager.distribute(distribute_options, build: ready_to_submit_mock_build)
+      end
+
+      it "throws if there is a different error than 504" do
+        allow(mock_base_api_client).to receive(:post_for_testflight_review).and_raise(Spaceship::Client::InternalServerError, "Server error got 500")
+        expect { fake_build_manager.distribute(distribute_options, build: ready_to_submit_mock_build) }.to raise_error(Spaceship::Client::InternalServerError, "Server error got 500")
+      end
+
+      it "doesnt try to recover if no 504" do
+        allow(mock_base_api_client).to receive(:post_for_testflight_review) # pretend it worked.
+        expect(FastlaneCore::UI).not_to(receive(:message).with('Submitting the build for review timed out, trying to recover.'))
+        fake_build_manager.distribute(distribute_options, build: ready_to_submit_mock_build)
+      end
     end
-    it "doesnt recover if there is a 504 and the build is not approved" do
-      allow(mock_base_api_client).to receive(:post_for_testflight_review).and_raise(Spaceship::Client::InternalServerError, "Server error got 504")
-      allow(Spaceship::TestFlight::Build).to receive(:find).and_return(ready_to_submit_mock_build)
-      expect(FastlaneCore::UI).to receive(:message).with('Distributing new build to testers:  - ')
-      expect(FastlaneCore::UI).to receive(:message).with('Submitting the build for review timed out, trying to recover.')
-      expect { fake_build_manager.distribute(distribute_options, build: ready_to_submit_mock_build) }.to raise_error(Spaceship::Client::InternalServerError, "Server error got 504")
-    end
-    it "recovers if there is a 504 and the build is approved" do
-      allow(mock_base_api_client).to receive(:post_for_testflight_review).and_raise(Spaceship::Client::InternalServerError, "Server error got 504")
-      allow(Spaceship::TestFlight::Build).to receive(:find).and_return(approved_mock_build)
-      expect(FastlaneCore::UI).to receive(:message).with('Distributing new build to testers:  - ')
-      expect(FastlaneCore::UI).to receive(:message).with('Submitting the build for review timed out, trying to recover.')
-      fake_build_manager.distribute(distribute_options, build: ready_to_submit_mock_build)
-    end
-    it "throws if there is a different error than 504" do
-      allow(mock_base_api_client).to receive(:post_for_testflight_review).and_raise(Spaceship::Client::InternalServerError, "Server error got 500")
-      expect { fake_build_manager.distribute(distribute_options, build: ready_to_submit_mock_build) }.to raise_error(Spaceship::Client::InternalServerError, "Server error got 500")
-    end
-    it "doesnt try to recover if no 504" do
-      allow(mock_base_api_client).to receive(:post_for_testflight_review) # pretend it worked.
-      expect(FastlaneCore::UI).not_to(receive(:message).with('Submitting the build for review timed out, trying to recover.'))
-      fake_build_manager.distribute(distribute_options, build: ready_to_submit_mock_build)
+
+    describe "distribute success" do
+      let(:distribute_options_non_localized) do
+        {
+          apple_id: 'mock_apple_id',
+          app_identifier: 'mock_app_id',
+          distribute_external: true,
+          skip_submission: false,
+          demo_account_required: true,
+          notify_external_testers: true,
+          beta_app_feedback_email: "josh+oldfeedback@rokkincat.com",
+          beta_app_description: "old description for all the things"
+        }
+      end
+
+      before(:each) do
+        # default client mocks setup
+        allow(fake_build_manager).to receive(:login)
+        allow(Spaceship::TestFlight::Base).to receive(:client).and_return(mock_base_client)
+        allow(mock_base_client).to receive(:team_id).and_return('')
+        allow(mock_base_client).to receive(:get_build).and_return(ready_to_submit_mock_build)
+        allow(mock_base_client).to receive(:add_group_to_build)
+        allow(Spaceship::TestFlight::Group).to receive(:default_external_group).and_return(mock_default_external_group)
+
+        allow(mock_base_api_client).to receive(:post_for_testflight_review) # pretend it worked.
+        allow(Spaceship::ConnectAPI::Base).to receive(:client).and_return(mock_base_api_client)
+      end
+
+      it "updates non-localized  demo_account_required, notify_external_testers, beta_app_feedback_email, and beta_app_description" do
+        options = distribute_options_non_localized
+
+        expect(mock_base_api_client).to receive(:get_builds).with({
+          filter: { expired: false, processingState: "PROCESSING,VALID", version: ready_to_submit_mock_build.build_version }
+        }).and_return(mock_api_client_builds)
+
+        # Demo account
+        expect(mock_base_api_client).to receive(:patch_beta_app_review_detail).with({
+          app_id: ready_to_submit_mock_build.app_id,
+          attributes: { demoAccountRequired: options[:demo_account_required] }
+        })
+
+        # Auto notify
+        expect(mock_base_api_client).to receive(:get_build_beta_details).with({
+          filter: { build: mock_api_client_builds.first['id'] }
+        }).and_return(mock_api_client_build_beta_details)
+        expect(mock_base_api_client).to receive(:patch_build_beta_details).with({
+          build_beta_details_id: mock_api_client_build_beta_details.first['id'],
+          attributes: { autoNotifyEnabled: options[:notify_external_testers] }
+        })
+
+        # Feedback email and marketing url set for all localizations
+        expect(mock_base_api_client).to receive(:get_beta_app_localizations).with({
+          filter: { app: ready_to_submit_mock_build.app_id }
+        }).and_return(mock_api_client_beta_app_localizations)
+        mock_api_client_beta_app_localizations.each do |localization|
+          expect(mock_base_api_client).to receive(:patch_beta_app_localizations).with({
+            localization_id: localization['id'],
+            attributes: {
+              feedbackEmail: options[:beta_app_feedback_email],
+              description: options[:beta_app_description]
+            }
+          })
+        end
+        expect(FastlaneCore::UI).to receive(:success).with("Successfully set the beta_app_feedback_email and/or beta_app_description")
+
+        expect(fake_build_manager).to receive(:distribute_build)
+        expect(FastlaneCore::UI).to receive(:success).with(/Successfully distributed build to/)
+
+        fake_build_manager.distribute(options, build: ready_to_submit_mock_build)
+      end
     end
   end
 end

--- a/pilot/spec/options_spec.rb
+++ b/pilot/spec/options_spec.rb
@@ -12,4 +12,127 @@ describe Pilot::Options do
 
     expect(ENV['FASTLANE_TEAM_ID']).to eq('ABCD1234')
   end
+
+  context "beta_app_review_info" do
+    it "accepts valid values" do
+      options = {
+        beta_app_review_info: {
+          contact_email: "email@email.com",
+          contact_first_name: "Connect",
+          contact_last_name: "API",
+          contact_phone: "5558675309}",
+          demo_account_name: "demo@email.com",
+          demo_account_password: "connectapi",
+          notes: "this is review note for the reviewer <3 thank you for reviewing"
+        }
+      }
+      expect do
+        FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
+      end.not_to(raise_error)
+    end
+
+    it "throws errors for invalid keys" do
+      options = {
+        beta_app_review_info: {
+          contact_email: "email@email.com",
+          contact_first_name: "Connect",
+          contact_last_name: "API",
+          contact_phone: "5558675309}",
+          demo_account_name: "demo@email.com",
+          cheese: "pizza",
+          demo_account_password: "connectapi",
+          notes: "this is review note for the reviewer <3 thank you for reviewing"
+        }
+      }
+      expect do
+        FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, "Invalid key 'cheese'")
+    end
+  end
+
+  context "localized_app_info" do
+    it "accepts valid values" do
+      options = {
+        localized_app_info: {
+          'default' => {
+            feedback_email: "default@email.com",
+            marketing_url: "https://example.com/marketing-defafult",
+            privacy_policy_url: "https://example.com/privacy-defafult",
+            tv_os_privacy_policy_url: "https://example.com/privacy-defafult",
+            description: "Default description"
+          },
+          'en-GB' => {
+            feedback_email: "en-gb@email.com",
+            marketing_url: "https://example.com/marketing-en-gb",
+            privacy_policy_url: "https://example.com/privacy-en-gb",
+            tv_os_privacy_policy_url: "https://example.com/privacy-en-gb",
+            description: "en-gb description"
+          }
+        }
+      }
+      expect do
+        FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
+      end.not_to(raise_error)
+    end
+
+    it "throws errors for invalid keys" do
+      options = {
+        localized_app_info: {
+          'default' => {
+            feedback_email: "default@email.com",
+            marketing_url: "https://example.com/marketing-defafult",
+            privacy_policy_url: "https://example.com/privacy-defafult",
+            tv_os_privacy_policy_url: "https://example.com/privacy-defafult",
+            description: "Default description"
+          },
+          'en-GB' => {
+            feedback_email: "en-gb@email.com",
+            marketing_url: "https://example.com/marketing-en-gb",
+            pepperoni: "pizza",
+            privacy_policy_url: "https://example.com/privacy-en-gb",
+            tv_os_privacy_policy_url: "https://example.com/privacy-en-gb",
+            description: "en-gb description"
+          }
+        }
+      }
+      expect do
+        FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, "Invalid key 'pepperoni'")
+    end
+  end
+
+  context "localized_build_info" do
+    it "accepts valid values" do
+      options = {
+        localized_build_info: {
+          'default' => {
+            whats_new: "Default changelog"
+          },
+          'en-GB' => {
+            whats_new: "en-gb changelog"
+          }
+        }
+      }
+      expect do
+        FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
+      end.not_to(raise_error)
+    end
+
+    it "throws errors for invalid keys" do
+      options = {
+        localized_build_info: {
+          'default' => {
+            whats_new: "Default changelog"
+          },
+          'en-GB' => {
+            whats_new: "en-gb changelog",
+            buffalo_chicken: "pizza"
+          }
+        }
+      }
+      expect do
+        FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, "Invalid key 'buffalo_chicken'")
+    end
+  end
 end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -815,11 +815,19 @@ module Spaceship
       if block_given?
         obj = Object.new
         class << obj
-          attr_accessor :body, :headers, :params, :url
+          attr_accessor :body, :headers, :params, :url, :options
           # rubocop: disable Style/TrivialAccessors
           # the block calls `url` (not `url=`) so need to define `url` method
           def url(url)
             @url = url
+          end
+
+          def options
+            options_obj = Object.new
+            class << options_obj
+              attr_accessor :params_encoder
+            end
+            options_obj
           end
           # rubocop: enable Style/TrivialAccessors
         end

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -19,13 +19,147 @@ module Spaceship
       end
 
       def build_url(path: nil, filter: nil, includes: nil, limit: nil, sort: nil)
-        filters = filter.keys.map do |key|
-          "&filter[#{key}]=#{filter[key]}"
-        end.join("")
-        return "#{path}?&include=#{includes}&limit=#{limit}&sort=#{sort}#{filters}"
+        params = {}
+
+        if filter
+          filter.keys.each do |key|
+            params["filter[#{key}]"] = filter[key]
+          end
+        end
+
+        params["include"] = includes if includes
+        params["limit"] = limit if limit
+        params["sort"] = sort if sort
+
+        query_params = params.map do |k, v|
+          "#{k}=#{v}"
+        end.join("&")
+
+        url = "#{path}?#{query_params}"
+        puts("URL: #{url}")
+        return url
+      end
+
+      def get_beta_app_review_detail(filter: {}, includes: nil, limit: nil, sort: nil)
+        # assert_required_params(__method__, binding)
+
+        # GET
+        # https://appstoreconnect.apple.com/iris/v1/betaAppReviewDetails?filter[app]=<app_id>
+        path = "betaAppReviewDetails"
+        url = build_url(path: path, filter: filter, includes: includes, limit: limit, sort: sort)
+
+        response = request(:get, url)
+        handle_response(response)
+      end
+
+      def patch_beta_app_review_detail(app_id: nil, feedbackEmail: nil, attributes: {})
+        # assert_required_params(__method__, binding)
+
+        # PATCH
+        # https://appstoreconnect.apple.com/iris/v1/apps/<app_id>/betaAppReviewDetails
+        path = "betaAppReviewDetails/#{app_id}"
+        url = build_url(path: path, filter: nil, includes: nil, limit: nil, sort: nil)
+
+        body = {
+          data: {
+            attributes: attributes,
+            id: app_id,
+            type: "betaAppReviewDetails"
+          }
+        }
+
+        response = request(:patch) do |req|
+          req.url(url)
+          req.body = body.to_json
+          req.headers['Content-Type'] = 'application/json'
+        end
+        handle_response(response)
+      end
+
+      def get_beta_app_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
+        # assert_required_params(__method__, binding)
+
+        # GET
+        # https://appstoreconnect.apple.com/iris/v1/betaAppLocalizations?filter[app]=<app_id>
+        path = "betaAppLocalizations"
+        url = build_url(path: path, filter: filter, includes: includes, limit: limit, sort: sort)
+
+        response = request(:get, url)
+        handle_response(response)
+      end
+
+      def get_beta_build_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
+        # assert_required_params(__method__, binding)
+
+        # GET
+        # https://appstoreconnect.apple.com/iris/v1/betaBuildLocalizations?filter[build]=<build_id>
+        path = "betaBuildLocalizations"
+        url = build_url(path: path, filter: filter, includes: includes, limit: limit, sort: sort)
+
+        response = request(:get, url)
+        handle_response(response)
+      end
+
+      def patch_beta_app_localizations(localization_id: nil, feedbackEmail: nil, attributes: {})
+        # assert_required_params(__method__, binding)
+
+        # PATCH
+        # https://appstoreconnect.apple.com/iris/v1/apps/<app_id>/betaAppLocalizations
+        path = "betaAppLocalizations/#{localization_id}"
+        url = build_url(path: path, filter: nil, includes: nil, limit: nil, sort: nil)
+
+        body = {
+          data: {
+            attributes: attributes,
+            id: localization_id,
+            type: "betaAppLocalizations"
+          }
+        }
+
+        response = request(:patch) do |req|
+          req.url(url)
+          req.body = body.to_json
+          req.headers['Content-Type'] = 'application/json'
+        end
+        handle_response(response)
+      end
+
+      def patch_beta_build_localizations(localization_id: nil, feedbackEmail: nil, attributes: {})
+        # assert_required_params(__method__, binding)
+
+        # PATCH
+        # https://appstoreconnect.apple.com/iris/v1/apps/<app_id>/betaBuildLocalizations
+        path = "betaBuildLocalizations/#{localization_id}"
+        url = build_url(path: path, filter: nil, includes: nil, limit: nil, sort: nil)
+
+        body = {
+          data: {
+            attributes: attributes,
+            id: localization_id,
+            type: "betaBuildLocalizations"
+          }
+        }
+
+        response = request(:patch) do |req|
+          req.url(url)
+          req.body = body.to_json
+          req.headers['Content-Type'] = 'application/json'
+        end
+        handle_response(response)
       end
 
       def get_builds(filter: {}, includes: "buildBetaDetail,betaBuildMetrics", limit: 10, sort: "uploadedDate")
+        assert_required_params(__method__, binding)
+
+        # GET
+        # https://appstoreconnect.apple.com/iris/v1/builds
+        url = build_url(path: "builds", filter: filter, includes: includes, limit: limit, sort: sort)
+
+        response = request(:get, url)
+        handle_response(response)
+      end
+
+      def get_prerelease_versions(filter: {}, includes: "buildBetaDetail,betaBuildMetrics", limit: 10, sort: "uploadedDate")
         assert_required_params(__method__, binding)
 
         # GET

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -99,11 +99,42 @@ module Spaceship
         handle_response(response)
       end
 
-      def patch_beta_app_localizations(localization_id: nil, feedbackEmail: nil, attributes: {})
+      def post_beta_app_localizations(app_id: nil, attributes: {})
+        # assert_required_params(__method__, binding)
+
+        # POST
+        # https://appstoreconnect.apple.com/iris/v1/betaAppLocalizations
+        path = "betaAppLocalizations"
+        url = build_url(path: path, filter: nil, includes: nil, limit: nil, sort: nil)
+
+        body = {
+          data: {
+            attributes: attributes,
+            type: "betaAppLocalizations",
+            relationships: {
+              app: {
+                data: {
+                  type: "apps",
+                  id: app_id
+                }
+              }
+            }
+          }
+        }
+
+        response = request(:post) do |req|
+          req.url(url)
+          req.body = body.to_json
+          req.headers['Content-Type'] = 'application/json'
+        end
+        handle_response(response)
+      end
+
+      def patch_beta_app_localizations(localization_id: nil, attributes: {})
         # assert_required_params(__method__, binding)
 
         # PATCH
-        # https://appstoreconnect.apple.com/iris/v1/apps/<app_id>/betaAppLocalizations
+        # https://appstoreconnect.apple.com/iris/v1/apps/<app_id>/betaAppLocalizations/<localization_id>
         path = "betaAppLocalizations/#{localization_id}"
         url = build_url(path: path, filter: nil, includes: nil, limit: nil, sort: nil)
 

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -154,6 +154,37 @@ module Spaceship
         handle_response(response)
       end
 
+      def post_beta_build_localizations(build_id: nil, attributes: {})
+        # assert_required_params(__method__, binding)
+
+        # POST
+        # https://appstoreconnect.apple.com/iris/v1/betaBuildLocalizations
+        path = "betaBuildLocalizations"
+        url = build_url(path: path, filter: nil, includes: nil, limit: nil, sort: nil)
+
+        body = {
+          data: {
+            attributes: attributes,
+            type: "betaBuildLocalizations",
+            relationships: {
+              build: {
+                data: {
+                  type: "builds",
+                  id: build_id
+                }
+              }
+            }
+          }
+        }
+
+        response = request(:post) do |req|
+          req.url(url)
+          req.body = body.to_json
+          req.headers['Content-Type'] = 'application/json'
+        end
+        handle_response(response)
+      end
+
       def patch_beta_build_localizations(localization_id: nil, feedbackEmail: nil, attributes: {})
         # assert_required_params(__method__, binding)
 

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -210,7 +210,7 @@ module Spaceship
       end
 
       def get_build_beta_details(filter: {}, includes: nil, limit: 10, sort: nil)
-        #assert_required_params(__method__, binding)
+        # assert_required_params(__method__, binding)
 
         # GET
         # https://appstoreconnect.apple.com/iris/v1/buildBetaDetails
@@ -219,7 +219,7 @@ module Spaceship
         response = request(:get, url)
         handle_response(response)
       end
-      
+
       def patch_build_beta_details(build_beta_details_id: nil, attributes: {})
         # assert_required_params(__method__, binding)
 

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -18,51 +18,33 @@ module Spaceship
         'https://appstoreconnect.apple.com/iris/v1/'
       end
 
-      def build_url(path: nil, filter: nil, includes: nil, limit: nil, sort: nil)
+      def build_params(filter: nil, includes: nil, limit: nil, sort: nil)
         params = {}
 
-        if filter
-          filter.keys.each do |key|
-            params["filter[#{key}]"] = filter[key]
-          end
-        end
+        params[:filter] = filter if filter && !filter.empty?
+        params[:include] = includes if includes
+        params[:limit] = limit if limit
+        params[:sort] = sort if sort
 
-        params["include"] = includes if includes
-        params["limit"] = limit if limit
-        params["sort"] = sort if sort
-
-        query_params = params.map do |k, v|
-          "#{k}=#{v}"
-        end.join("&")
-
-        if query_params.empty?
-          url = path
-        else
-          url = "#{path}?#{query_params}"
-        end
-
-        return url
+        return params
       end
 
       def get_beta_app_review_detail(filter: {}, includes: nil, limit: nil, sort: nil)
-        # assert_required_params(__method__, binding)
-
         # GET
         # https://appstoreconnect.apple.com/iris/v1/betaAppReviewDetails?filter[app]=<app_id>
-        path = "betaAppReviewDetails"
-        url = build_url(path: path, filter: filter, includes: includes, limit: limit, sort: sort)
+        params = build_params(filter: filter, includes: includes, limit: limit, sort: sort)
 
-        response = request(:get, url)
+        response = request(:get, "betaAppReviewDetails") do |req|
+          req.options.params_encoder = Faraday::NestedParamsEncoder
+          req.params = params
+        end
         handle_response(response)
       end
 
       def patch_beta_app_review_detail(app_id: nil, attributes: {})
-        # assert_required_params(__method__, binding)
-
         # PATCH
         # https://appstoreconnect.apple.com/iris/v1/apps/<app_id>/betaAppReviewDetails
         path = "betaAppReviewDetails/#{app_id}"
-        url = build_url(path: path, filter: nil, includes: nil, limit: nil, sort: nil)
 
         body = {
           data: {
@@ -73,7 +55,7 @@ module Spaceship
         }
 
         response = request(:patch) do |req|
-          req.url(url)
+          req.url(path)
           req.body = body.to_json
           req.headers['Content-Type'] = 'application/json'
         end
@@ -81,36 +63,34 @@ module Spaceship
       end
 
       def get_beta_app_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
-        # assert_required_params(__method__, binding)
-
         # GET
         # https://appstoreconnect.apple.com/iris/v1/betaAppLocalizations?filter[app]=<app_id>
-        path = "betaAppLocalizations"
-        url = build_url(path: path, filter: filter, includes: includes, limit: limit, sort: sort)
+        params = build_params(filter: filter, includes: includes, limit: limit, sort: sort)
 
-        response = request(:get, url)
+        response = request(:get, "betaAppLocalizations") do |req|
+          req.options.params_encoder = Faraday::NestedParamsEncoder
+          req.params = params
+        end
         handle_response(response)
       end
 
       def get_beta_build_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
-        # assert_required_params(__method__, binding)
-
         # GET
         # https://appstoreconnect.apple.com/iris/v1/betaBuildLocalizations?filter[build]=<build_id>
         path = "betaBuildLocalizations"
-        url = build_url(path: path, filter: filter, includes: includes, limit: limit, sort: sort)
+        params = build_params(filter: filter, includes: includes, limit: limit, sort: sort)
 
-        response = request(:get, url)
+        response = request(:get, path) do |req|
+          req.options.params_encoder = Faraday::NestedParamsEncoder
+          req.params = params
+        end
         handle_response(response)
       end
 
       def post_beta_app_localizations(app_id: nil, attributes: {})
-        # assert_required_params(__method__, binding)
-
         # POST
         # https://appstoreconnect.apple.com/iris/v1/betaAppLocalizations
         path = "betaAppLocalizations"
-        url = build_url(path: path, filter: nil, includes: nil, limit: nil, sort: nil)
 
         body = {
           data: {
@@ -128,7 +108,7 @@ module Spaceship
         }
 
         response = request(:post) do |req|
-          req.url(url)
+          req.url(path)
           req.body = body.to_json
           req.headers['Content-Type'] = 'application/json'
         end
@@ -136,12 +116,9 @@ module Spaceship
       end
 
       def patch_beta_app_localizations(localization_id: nil, attributes: {})
-        # assert_required_params(__method__, binding)
-
         # PATCH
         # https://appstoreconnect.apple.com/iris/v1/apps/<app_id>/betaAppLocalizations/<localization_id>
         path = "betaAppLocalizations/#{localization_id}"
-        url = build_url(path: path, filter: nil, includes: nil, limit: nil, sort: nil)
 
         body = {
           data: {
@@ -152,7 +129,7 @@ module Spaceship
         }
 
         response = request(:patch) do |req|
-          req.url(url)
+          req.url(path)
           req.body = body.to_json
           req.headers['Content-Type'] = 'application/json'
         end
@@ -160,12 +137,9 @@ module Spaceship
       end
 
       def post_beta_build_localizations(build_id: nil, attributes: {})
-        # assert_required_params(__method__, binding)
-
         # POST
         # https://appstoreconnect.apple.com/iris/v1/betaBuildLocalizations
         path = "betaBuildLocalizations"
-        url = build_url(path: path, filter: nil, includes: nil, limit: nil, sort: nil)
 
         body = {
           data: {
@@ -183,7 +157,7 @@ module Spaceship
         }
 
         response = request(:post) do |req|
-          req.url(url)
+          req.url(path)
           req.body = body.to_json
           req.headers['Content-Type'] = 'application/json'
         end
@@ -191,12 +165,9 @@ module Spaceship
       end
 
       def patch_beta_build_localizations(localization_id: nil, feedbackEmail: nil, attributes: {})
-        # assert_required_params(__method__, binding)
-
         # PATCH
         # https://appstoreconnect.apple.com/iris/v1/apps/<app_id>/betaBuildLocalizations
         path = "betaBuildLocalizations/#{localization_id}"
-        url = build_url(path: path, filter: nil, includes: nil, limit: nil, sort: nil)
 
         body = {
           data: {
@@ -207,7 +178,7 @@ module Spaceship
         }
 
         response = request(:patch) do |req|
-          req.url(url)
+          req.url(path)
           req.body = body.to_json
           req.headers['Content-Type'] = 'application/json'
         end
@@ -215,23 +186,21 @@ module Spaceship
       end
 
       def get_build_beta_details(filter: {}, includes: nil, limit: nil, sort: nil)
-        # assert_required_params(__method__, binding)
-
         # GET
         # https://appstoreconnect.apple.com/iris/v1/buildBetaDetails
-        url = build_url(path: "buildBetaDetails", filter: filter, includes: includes, limit: limit, sort: sort)
+        params = build_params(filter: filter, includes: includes, limit: limit, sort: sort)
 
-        response = request(:get, url)
+        response = request(:get, "buildBetaDetails") do |req|
+          req.options.params_encoder = Faraday::NestedParamsEncoder
+          req.params = params
+        end
         handle_response(response)
       end
 
       def patch_build_beta_details(build_beta_details_id: nil, attributes: {})
-        # assert_required_params(__method__, binding)
-
         # PATCH
         # https://appstoreconnect.apple.com/iris/v1/buildBetaDetails/<build_beta_details_id>
         path = "buildBetaDetails/#{build_beta_details_id}"
-        url = build_url(path: path, filter: nil, includes: nil, limit: nil, sort: nil)
 
         body = {
           data: {
@@ -242,7 +211,7 @@ module Spaceship
         }
 
         response = request(:patch) do |req|
-          req.url(url)
+          req.url(path)
           req.body = body.to_json
           req.headers['Content-Type'] = 'application/json'
         end
@@ -250,23 +219,20 @@ module Spaceship
       end
 
       def get_builds(filter: {}, includes: "buildBetaDetail,betaBuildMetrics", limit: 10, sort: "uploadedDate")
-        assert_required_params(__method__, binding)
-
         # GET
         # https://appstoreconnect.apple.com/iris/v1/builds
-        url = build_url(path: "builds", filter: filter, includes: includes, limit: limit, sort: sort)
+        params = build_params(filter: filter, includes: includes, limit: limit, sort: sort)
 
-        response = request(:get, url)
+        response = request(:get, "builds") do |req|
+          req.options.params_encoder = Faraday::NestedParamsEncoder
+          req.params = params
+        end
         handle_response(response)
       end
 
       def post_beta_app_review_submissions(build_id: nil)
-        assert_required_params(__method__, binding)
-
         # POST
         # https://appstoreconnect.apple.com/iris/v1/betaAppReviewSubmissions
-        #
-        # {"data":{"type":"betaAppReviewSubmissions","relationships":{"build":{"data":{"type":"builds","id":"6f90f04a-3b48-4d4a-9bbd-9475c294a579"}}}}}
 
         body = {
           data: {

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -36,7 +36,6 @@ module Spaceship
         end.join("&")
 
         url = "#{path}?#{query_params}"
-        puts("URL: #{url}")
         return url
       end
 

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -209,6 +209,41 @@ module Spaceship
         handle_response(response)
       end
 
+      def get_build_beta_details(filter: {}, includes: nil, limit: 10, sort: nil)
+        #assert_required_params(__method__, binding)
+
+        # GET
+        # https://appstoreconnect.apple.com/iris/v1/buildBetaDetails
+        url = build_url(path: "buildBetaDetails", filter: filter, includes: includes, limit: limit, sort: sort)
+
+        response = request(:get, url)
+        handle_response(response)
+      end
+      
+      def patch_build_beta_details(build_beta_details_id: nil, attributes: {})
+        # assert_required_params(__method__, binding)
+
+        # PATCH
+        # https://appstoreconnect.apple.com/iris/v1/buildBetaDetails/<build_beta_details_id>
+        path = "buildBetaDetails/#{build_beta_details_id}"
+        url = build_url(path: path, filter: nil, includes: nil, limit: nil, sort: nil)
+
+        body = {
+          data: {
+            attributes: attributes,
+            id: build_beta_details_id,
+            type: "buildBetaDetails"
+          }
+        }
+
+        response = request(:patch) do |req|
+          req.url(url)
+          req.body = body.to_json
+          req.headers['Content-Type'] = 'application/json'
+        end
+        handle_response(response)
+      end
+
       def get_builds(filter: {}, includes: "buildBetaDetail,betaBuildMetrics", limit: 10, sort: "uploadedDate")
         assert_required_params(__method__, binding)
 

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -35,7 +35,12 @@ module Spaceship
           "#{k}=#{v}"
         end.join("&")
 
-        url = "#{path}?#{query_params}"
+        if query_params.empty?
+          url = path
+        else
+          url = "#{path}?#{query_params}"
+        end
+
         return url
       end
 
@@ -51,7 +56,7 @@ module Spaceship
         handle_response(response)
       end
 
-      def patch_beta_app_review_detail(app_id: nil, feedbackEmail: nil, attributes: {})
+      def patch_beta_app_review_detail(app_id: nil, attributes: {})
         # assert_required_params(__method__, binding)
 
         # PATCH
@@ -209,7 +214,7 @@ module Spaceship
         handle_response(response)
       end
 
-      def get_build_beta_details(filter: {}, includes: nil, limit: 10, sort: nil)
+      def get_build_beta_details(filter: {}, includes: nil, limit: nil, sort: nil)
         # assert_required_params(__method__, binding)
 
         # GET
@@ -255,18 +260,7 @@ module Spaceship
         handle_response(response)
       end
 
-      def get_prerelease_versions(filter: {}, includes: "buildBetaDetail,betaBuildMetrics", limit: 10, sort: "uploadedDate")
-        assert_required_params(__method__, binding)
-
-        # GET
-        # https://appstoreconnect.apple.com/iris/v1/builds
-        url = build_url(path: "builds", filter: filter, includes: includes, limit: limit, sort: sort)
-
-        response = request(:get, url)
-        handle_response(response)
-      end
-
-      def post_for_testflight_review(build_id: nil)
+      def post_beta_app_review_submissions(build_id: nil)
         assert_required_params(__method__, binding)
 
         # POST

--- a/spaceship/spec/connect/client_spec.rb
+++ b/spaceship/spec/connect/client_spec.rb
@@ -319,7 +319,5 @@ describe Spaceship::ConnectAPI::Client do
         client.post_beta_app_review_submissions(build_id: build_id)
       end
     end
-
-    #    def post_for_testflight_review(build_id: nil)
   end
 end

--- a/spaceship/spec/connect/client_spec.rb
+++ b/spaceship/spec/connect/client_spec.rb
@@ -1,0 +1,325 @@
+describe Spaceship::ConnectAPI::Client do
+  let(:client) { Spaceship::ConnectAPI::Base.client }
+  let(:hostname) { Spaceship::ConnectAPI::Client.hostname }
+  let(:username) { 'spaceship@krausefx.com' }
+  let(:password) { 'so_secret' }
+
+  before do
+    Spaceship::Tunes.login(username, password)
+  end
+
+  context 'build_url' do
+    let(:path) { "betaAppReviewDetails" }
+    let(:one_filter) { { build: "123" } }
+    let(:two_filters) { { build: "123", app: "321" } }
+    let(:includes) { "model.attribute" }
+    let(:limit) { "30" }
+    let(:sort) { "asc" }
+
+    it 'builds url with only path' do
+      url = client.build_url(path: path)
+      expect(url).to eq(path)
+    end
+
+    it 'builds url with path and one filter' do
+      url = client.build_url(path: path, filter: one_filter)
+      expect(url).to eq("#{path}?filter[build]=#{one_filter[:build]}")
+    end
+
+    it 'builds url with path and two filters' do
+      url = client.build_url(path: path, filter: two_filters)
+      expect(url).to eq("#{path}?filter[build]=#{two_filters[:build]}&filter[app]=#{two_filters[:app]}")
+    end
+
+    it 'builds url with path and includes' do
+      url = client.build_url(path: path, includes: includes)
+      expect(url).to eq("#{path}?include=#{includes}")
+    end
+
+    it 'builds url with path and limit' do
+      url = client.build_url(path: path, limit: limit)
+      expect(url).to eq("#{path}?limit=#{limit}")
+    end
+
+    it 'builds url with path and sort' do
+      url = client.build_url(path: path, sort: sort)
+      expect(url).to eq("#{path}?sort=#{sort}")
+    end
+
+    it 'builds url with path, one filter, includes, limit, and sort' do
+      url = client.build_url(path: path, filter: one_filter, includes: includes, limit: limit, sort: sort)
+      expect(url).to eq("#{path}?filter[build]=#{one_filter[:build]}&include=#{includes}&limit=#{limit}&sort=#{sort}")
+    end
+  end
+
+  context 'sends api request' do
+    before(:each) do
+      allow(client).to receive(:handle_response)
+    end
+
+    def test_request_body(url, body)
+      req_mock = double
+      header_mock = double
+      expect(req_mock).to receive(:url).with(url)
+      expect(req_mock).to receive(:body=).with(JSON.generate(body))
+      expect(req_mock).to receive(:headers).and_return(header_mock)
+      expect(header_mock).to receive(:[]=).with("Content-Type", "application/json")
+
+      return req_mock
+    end
+
+    context 'get_beta_app_review_detail' do
+      let(:app_id) { "123" }
+
+      it 'succeeds' do
+        expect(client).to receive(:request).with(:get, "betaAppReviewDetails")
+        client.get_beta_app_review_detail
+      end
+
+      it 'succeeds with filter' do
+        expect(client).to receive(:request).with(:get, "betaAppReviewDetails?filter[app]=#{app_id}")
+        client.get_beta_app_review_detail(filter: { app: app_id })
+      end
+    end
+
+    context 'patch_beta_app_review_detail' do
+      let(:path) { "betaAppReviewDetails" }
+      let(:app_id) { "123" }
+      let(:attributes) { { key: "value" } }
+      let(:body) do
+        {
+          data: {
+            attributes: attributes,
+            id: app_id,
+            type: "betaAppReviewDetails"
+          }
+        }
+      end
+
+      it 'succeeds' do
+        url = "#{path}/#{app_id}"
+        req_mock = test_request_body(url, body)
+
+        expect(client).to receive(:request).with(:patch).and_yield(req_mock)
+        client.patch_beta_app_review_detail(app_id: app_id, attributes: attributes)
+      end
+    end
+
+    context 'get_beta_app_localizations' do
+      let(:app_id) { "123" }
+
+      it 'succeeds' do
+        expect(client).to receive(:request).with(:get, "betaAppLocalizations")
+        client.get_beta_app_localizations
+      end
+
+      it 'succeeds with filter' do
+        app_id = "123"
+        expect(client).to receive(:request).with(:get, "betaAppLocalizations?filter[app]=#{app_id}")
+        client.get_beta_app_localizations(filter: { app: app_id })
+      end
+    end
+
+    context 'get_beta_build_localizations' do
+      let(:build_id) { "123" }
+
+      it 'succeeds' do
+        expect(client).to receive(:request).with(:get, "betaBuildLocalizations")
+        client.get_beta_build_localizations
+      end
+
+      it 'succeeds with filter' do
+        expect(client).to receive(:request).with(:get, "betaBuildLocalizations?filter[build]=#{build_id}")
+        client.get_beta_build_localizations(filter: { build: build_id })
+      end
+    end
+
+    context 'post_beta_app_localizations' do
+      let(:path) { "betaAppLocalizations" }
+      let(:app_id) { "123" }
+      let(:attributes) { { key: "value" } }
+      let(:body) do
+        {
+          data: {
+            attributes: attributes,
+            type: "betaAppLocalizations",
+            relationships: {
+              app: {
+                data: {
+                  type: "apps",
+                  id: app_id
+                }
+              }
+            }
+          }
+        }
+      end
+
+      it 'succeeds' do
+        url = path
+        req_mock = test_request_body(url, body)
+
+        expect(client).to receive(:request).with(:post).and_yield(req_mock)
+        client.post_beta_app_localizations(app_id: app_id, attributes: attributes)
+      end
+    end
+
+    context 'patch_beta_app_localizations' do
+      let(:path) { "betaAppLocalizations" }
+      let(:localization_id) { "123" }
+      let(:attributes) { { key: "value" } }
+      let(:body) do
+        {
+          data: {
+            attributes: attributes,
+            id: localization_id,
+            type: "betaAppLocalizations"
+          }
+        }
+      end
+
+      it 'succeeds' do
+        url = "#{path}/#{localization_id}"
+        req_mock = test_request_body(url, body)
+
+        expect(client).to receive(:request).with(:patch).and_yield(req_mock)
+        client.patch_beta_app_localizations(localization_id: localization_id, attributes: attributes)
+      end
+    end
+
+    context 'post_beta_build_localizations' do
+      let(:path) { "betaBuildLocalizations" }
+      let(:build_id) { "123" }
+      let(:attributes) { { key: "value" } }
+      let(:body) do
+        {
+          data: {
+            attributes: attributes,
+            type: "betaBuildLocalizations",
+            relationships: {
+              build: {
+                data: {
+                  type: "builds",
+                  id: build_id
+                }
+              }
+            }
+          }
+        }
+      end
+
+      it 'succeeds' do
+        url = path
+        req_mock = test_request_body(url, body)
+
+        expect(client).to receive(:request).with(:post).and_yield(req_mock)
+        client.post_beta_build_localizations(build_id: build_id, attributes: attributes)
+      end
+    end
+
+    context 'patch_beta_build_localizations' do
+      let(:path) { "betaBuildLocalizations" }
+      let(:localization_id) { "123" }
+      let(:attributes) { { key: "value" } }
+      let(:body) do
+        {
+          data: {
+            attributes: attributes,
+            id: localization_id,
+            type: "betaBuildLocalizations"
+          }
+        }
+      end
+
+      it 'succeeds' do
+        url = "#{path}/#{localization_id}"
+        req_mock = test_request_body(url, body)
+
+        expect(client).to receive(:request).with(:patch).and_yield(req_mock)
+        client.patch_beta_build_localizations(localization_id: localization_id, attributes: attributes)
+      end
+    end
+
+    context 'get_build_beta_details' do
+      let(:build_id) { "123" }
+
+      it 'succeeds' do
+        expect(client).to receive(:request).with(:get, "buildBetaDetails")
+        client.get_build_beta_details
+      end
+
+      it 'succeeds with filter' do
+        expect(client).to receive(:request).with(:get, "buildBetaDetails?filter[build]=#{build_id}")
+        client.get_build_beta_details(filter: { build: build_id })
+      end
+    end
+
+    context 'patch_build_beta_details' do
+      let(:path) { "buildBetaDetails" }
+      let(:build_beta_details_id) { "123" }
+      let(:attributes) { { key: "value" } }
+      let(:body) do
+        {
+          data: {
+            attributes: attributes,
+            id: build_beta_details_id,
+            type: "buildBetaDetails"
+          }
+        }
+      end
+
+      it 'succeeds' do
+        url = "#{path}/#{build_beta_details_id}"
+        req_mock = test_request_body(url, body)
+
+        expect(client).to receive(:request).with(:patch).and_yield(req_mock)
+        client.patch_build_beta_details(build_beta_details_id: build_beta_details_id, attributes: attributes)
+      end
+    end
+
+    context 'get_builds' do
+      let(:build_id) { "123" }
+      let(:default_includes) { "buildBetaDetail,betaBuildMetrics&limit=10&sort=uploadedDate" }
+
+      it 'succeeds' do
+        expect(client).to receive(:request).with(:get, "builds?include=#{default_includes}")
+        client.get_builds
+      end
+
+      it 'succeeds with filter' do
+        expect(client).to receive(:request).with(:get, "builds?filter[expired]=false&filter[processingState]=PROCESSING,VALID&filter[version]=123&include=#{default_includes}")
+        client.get_builds(filter: { expired: false, processingState: "PROCESSING,VALID", version: "123" })
+      end
+    end
+
+    context 'post_beta_app_review_submissions' do
+      let(:path) { "betaAppReviewSubmissions" }
+      let(:build_id) { "123" }
+      let(:body) do
+        {
+          data: {
+            type: "betaAppReviewSubmissions",
+            relationships: {
+              build: {
+                data: {
+                  type: "builds",
+                  id: build_id
+                }
+              }
+            }
+          }
+        }
+      end
+
+      it 'succeeds' do
+        url = path
+        req_mock = test_request_body(url, body)
+
+        expect(client).to receive(:request).with(:post).and_yield(req_mock)
+        client.post_beta_app_review_submissions(build_id: build_id)
+      end
+    end
+
+    #    def post_for_testflight_review(build_id: nil)
+  end
+end

--- a/spaceship/spec/connect/client_spec.rb
+++ b/spaceship/spec/connect/client_spec.rb
@@ -8,7 +8,7 @@ describe Spaceship::ConnectAPI::Client do
     Spaceship::Tunes.login(username, password)
   end
 
-  context 'build_url' do
+  context 'build_params' do
     let(:path) { "betaAppReviewDetails" }
     let(:one_filter) { { build: "123" } }
     let(:two_filters) { { build: "123", app: "321" } }
@@ -16,45 +16,55 @@ describe Spaceship::ConnectAPI::Client do
     let(:limit) { "30" }
     let(:sort) { "asc" }
 
-    it 'builds url with only path' do
-      url = client.build_url(path: path)
-      expect(url).to eq(path)
+    it 'builds params with nothing' do
+      url = client.build_params
+      # expect(url).to eq(path)
     end
 
-    it 'builds url with path and one filter' do
-      url = client.build_url(path: path, filter: one_filter)
-      expect(url).to eq("#{path}?filter[build]=#{one_filter[:build]}")
+    it 'builds params with one filter' do
+      url = client.build_params(filter: one_filter)
+      # expect(url).to eq("#{path}?filter[build]=#{one_filter[:build]}")
     end
 
-    it 'builds url with path and two filters' do
-      url = client.build_url(path: path, filter: two_filters)
-      expect(url).to eq("#{path}?filter[build]=#{two_filters[:build]}&filter[app]=#{two_filters[:app]}")
+    it 'builds params with two filters' do
+      url = client.build_params(filter: two_filters)
+      # expect(url).to eq("#{path}?filter[build]=#{two_filters[:build]}&filter[app]=#{two_filters[:app]}")
     end
 
-    it 'builds url with path and includes' do
-      url = client.build_url(path: path, includes: includes)
-      expect(url).to eq("#{path}?include=#{includes}")
+    it 'builds params with includes' do
+      url = client.build_params(includes: includes)
+      # expect(url).to eq("#{path}?include=#{includes}")
     end
 
-    it 'builds url with path and limit' do
-      url = client.build_url(path: path, limit: limit)
-      expect(url).to eq("#{path}?limit=#{limit}")
+    it 'builds params with limit' do
+      url = client.build_params(limit: limit)
+      # expect(url).to eq("#{path}?limit=#{limit}")
     end
 
-    it 'builds url with path and sort' do
-      url = client.build_url(path: path, sort: sort)
-      expect(url).to eq("#{path}?sort=#{sort}")
+    it 'builds params with sort' do
+      url = client.build_params(sort: sort)
+      # expect(url).to eq("#{path}?sort=#{sort}")
     end
 
-    it 'builds url with path, one filter, includes, limit, and sort' do
-      url = client.build_url(path: path, filter: one_filter, includes: includes, limit: limit, sort: sort)
-      expect(url).to eq("#{path}?filter[build]=#{one_filter[:build]}&include=#{includes}&limit=#{limit}&sort=#{sort}")
+    it 'builds params with one filter, includes, limit, and sort' do
+      url = client.build_params(filter: one_filter, includes: includes, limit: limit, sort: sort)
+      # expect(url).to eq("#{path}?filter[build]=#{one_filter[:build]}&include=#{includes}&limit=#{limit}&sort=#{sort}")
     end
   end
 
   context 'sends api request' do
     before(:each) do
       allow(client).to receive(:handle_response)
+    end
+
+    def test_request_params(url, params)
+      req_mock = double
+      options_mock = double
+      expect(req_mock).to receive(:params=).with(params)
+      expect(req_mock).to receive(:options).and_return(options_mock)
+      expect(options_mock).to receive(:params_encoder=).with(Faraday::NestedParamsEncoder)
+
+      return req_mock
     end
 
     def test_request_body(url, body)
@@ -69,15 +79,20 @@ describe Spaceship::ConnectAPI::Client do
     end
 
     context 'get_beta_app_review_detail' do
+      let(:path) { "betaAppReviewDetails" }
       let(:app_id) { "123" }
 
       it 'succeeds' do
-        expect(client).to receive(:request).with(:get, "betaAppReviewDetails")
+        params = {}
+        req_mock = test_request_params(path, params)
+        expect(client).to receive(:request).with(:get, path).and_yield(req_mock)
         client.get_beta_app_review_detail
       end
 
       it 'succeeds with filter' do
-        expect(client).to receive(:request).with(:get, "betaAppReviewDetails?filter[app]=#{app_id}")
+        params = { filter: { app: app_id } }
+        req_mock = test_request_params(path, params)
+        expect(client).to receive(:request).with(:get, path).and_yield(req_mock)
         client.get_beta_app_review_detail(filter: { app: app_id })
       end
     end
@@ -99,38 +114,46 @@ describe Spaceship::ConnectAPI::Client do
       it 'succeeds' do
         url = "#{path}/#{app_id}"
         req_mock = test_request_body(url, body)
-
         expect(client).to receive(:request).with(:patch).and_yield(req_mock)
         client.patch_beta_app_review_detail(app_id: app_id, attributes: attributes)
       end
     end
 
     context 'get_beta_app_localizations' do
+      let(:path) { "betaAppLocalizations" }
       let(:app_id) { "123" }
 
       it 'succeeds' do
-        expect(client).to receive(:request).with(:get, "betaAppLocalizations")
+        params = {}
+        req_mock = test_request_params(path, params)
+        expect(client).to receive(:request).with(:get, path).and_yield(req_mock)
         client.get_beta_app_localizations
       end
 
       it 'succeeds with filter' do
-        app_id = "123"
-        expect(client).to receive(:request).with(:get, "betaAppLocalizations?filter[app]=#{app_id}")
-        client.get_beta_app_localizations(filter: { app: app_id })
+        params = { filter: { app: app_id } }
+        req_mock = test_request_params(path, params)
+        expect(client).to receive(:request).with(:get, path).and_yield(req_mock)
+        client.get_beta_app_localizations(params)
       end
     end
 
     context 'get_beta_build_localizations' do
+      let(:path) { "betaBuildLocalizations" }
       let(:build_id) { "123" }
 
       it 'succeeds' do
-        expect(client).to receive(:request).with(:get, "betaBuildLocalizations")
+        params = {}
+        req_mock = test_request_params(path, params)
+        expect(client).to receive(:request).with(:get, path).and_yield(req_mock)
         client.get_beta_build_localizations
       end
 
       it 'succeeds with filter' do
-        expect(client).to receive(:request).with(:get, "betaBuildLocalizations?filter[build]=#{build_id}")
-        client.get_beta_build_localizations(filter: { build: build_id })
+        params = { filter: { build: build_id } }
+        req_mock = test_request_params(path, params)
+        expect(client).to receive(:request).with(:get, path).and_yield(req_mock)
+        client.get_beta_build_localizations(params)
       end
     end
 
@@ -241,16 +264,21 @@ describe Spaceship::ConnectAPI::Client do
     end
 
     context 'get_build_beta_details' do
+      let(:path) { "buildBetaDetails" }
       let(:build_id) { "123" }
 
       it 'succeeds' do
-        expect(client).to receive(:request).with(:get, "buildBetaDetails")
+        params = {}
+        req_mock = test_request_params(path, params)
+        expect(client).to receive(:request).with(:get, path).and_yield(req_mock)
         client.get_build_beta_details
       end
 
       it 'succeeds with filter' do
-        expect(client).to receive(:request).with(:get, "buildBetaDetails?filter[build]=#{build_id}")
-        client.get_build_beta_details(filter: { build: build_id })
+        params = { filter: { build: build_id } }
+        req_mock = test_request_params(path, params)
+        expect(client).to receive(:request).with(:get, path).and_yield(req_mock)
+        client.get_build_beta_details(params)
       end
     end
 
@@ -278,17 +306,22 @@ describe Spaceship::ConnectAPI::Client do
     end
 
     context 'get_builds' do
+      let(:path) { "builds" }
       let(:build_id) { "123" }
-      let(:default_includes) { "buildBetaDetail,betaBuildMetrics&limit=10&sort=uploadedDate" }
+      let(:default_params) { { include: "buildBetaDetail,betaBuildMetrics", limit: 10, sort: "uploadedDate" } }
 
       it 'succeeds' do
-        expect(client).to receive(:request).with(:get, "builds?include=#{default_includes}")
+        params = {}
+        req_mock = test_request_params(path, params.merge(default_params))
+        expect(client).to receive(:request).with(:get, path).and_yield(req_mock)
         client.get_builds
       end
 
       it 'succeeds with filter' do
-        expect(client).to receive(:request).with(:get, "builds?filter[expired]=false&filter[processingState]=PROCESSING,VALID&filter[version]=123&include=#{default_includes}")
-        client.get_builds(filter: { expired: false, processingState: "PROCESSING,VALID", version: "123" })
+        params = { filter: { expired: false, processingState: "PROCESSING,VALID", version: "123" } }
+        req_mock = test_request_params(path, params.merge(default_params))
+        expect(client).to receive(:request).with(:get, path).and_yield(req_mock)
+        client.get_builds(params)
       end
     end
 


### PR DESCRIPTION
Fixes #14033

## Description
Private API deprecated some review and testing info for TestFlight Beta apps so now need to use new AppStore Connect API

## Example using existing options
```rb
lane :distribute_test_legacy do
  increment_build_number()
  gym()
  pilot(
    beta_app_feedback_email: "email@email.com",
    beta_app_description: "This is a description of my app",
    demo_account_required: true,
    notify_external_testers: false,
    changelog: "This is my changelog of things that have changed in a log"
  )
end
```

## Example using new localization options
```rb
lane :distribute_test_localized do
  increment_build_number()
  gym()
  pilot(
    beta_app_review_info: {
      contact_email: "email@email.com",
      contact_first_name: "Connect",
      contact_last_name: "API",
      contact_phone: "5558675309}",
      demo_account_name: "demo@email.com",
      demo_account_password: "connectapi",
      notes: "this is review note for the reviewer <3 thank you for reviewing"
    },
    localized_app_info: {
      'default': {
        feedback_email: "default@email.com",
        marketing_url: "https://example.com/marketing-defafult",
        privacy_policy_url: "https://example.com/privacy-defafult",
        #tv_os_privacy_policy_url: "https://example.com/privacy-defafult",
        description: "Default description",
      },
      'en-GB': {
        feedback_email: "en-gb@email.com",
        marketing_url: "https://example.com/marketing-en-gb",
        privacy_policy_url: "https://example.com/privacy-en-gb",
        #tv_os_privacy_policy_url: "https://example.com/privacy-en-gb",
        description: "en-gb description",
      }
    },
    localized_build_info: {
      'default': {
        whats_new: "Default changelog",
      },
      'en-GB': {
        whats_new: "en-gb changelog",
      }
    }
  )
end
```