### PR TITLE
[match][spaceship] better message when invalid team id or team name and pass match's team_name in to sigh and cert

### DIFF
--- a/match/lib/match/generator.rb
+++ b/match/lib/match/generator.rb
@@ -15,6 +15,7 @@ module Match
         force: true, # we don't need a certificate without its private key, we only care about a new certificate
         username: params[:username],
         team_id: params[:team_id],
+        team_name: params[:team_name],
         keychain_path: FastlaneCore::Helper.keychain_path(params[:keychain_name]),
         keychain_password: params[:keychain_password]
       })
@@ -63,6 +64,7 @@ module Match
         provisioning_name: profile_name,
         ignore_profiles_with_different_name: true,
         team_id: params[:team_id],
+        team_name: params[:team_name],
         template_name: params[:template_name]
       }
 

--- a/spaceship/lib/spaceship/portal/ui/select_team.rb
+++ b/spaceship/lib/spaceship/portal/ui/select_team.rb
@@ -82,7 +82,7 @@ module Spaceship
           # Better message to inform user of misconfiguration as Apple now provides less friendly error as of 2019-02-12
           # "Access Unavailable - You currently don't have access to this membership resource. Contact your team's Account Holder, Josh Holtz, or an Admin."
           # https://github.com/fastlane/fastlane/issues/14228
-          puts "Couldn't find team with Name '#{team_name}. Make sure you have the proper permissions for this team'"
+          puts("Couldn't find team with Name '#{team_name}. Make sure you have the proper permissions for this team'")
         end
 
         return teams[0]['teamId'] if teams.count == 1 # user is just in one team

--- a/spaceship/lib/spaceship/portal/ui/select_team.rb
+++ b/spaceship/lib/spaceship/portal/ui/select_team.rb
@@ -71,7 +71,7 @@ module Spaceship
           # This is especially important as Developer Portal team IDs are deprecated and should be replaced with App Store Connect teamIDs
           # "Access Unavailable - You currently don't have access to this membership resource. Contact your team's Account Holder, Josh Holtz, or an Admin."
           # https://github.com/fastlane/fastlane/issues/14228
-          puts "Couldn't find team with ID '#{team_id}'. Make sure your are using the correct App Store Connect team ID and have the proper permissions for this team"
+          puts("Couldn't find team with ID '#{team_id}'. Make sure your are using the correct App Store Connect team ID and have the proper permissions for this team")
         end
 
         if team_name.length > 0

--- a/spaceship/lib/spaceship/portal/ui/select_team.rb
+++ b/spaceship/lib/spaceship/portal/ui/select_team.rb
@@ -67,7 +67,11 @@ module Spaceship
             return team['teamId'] if team['teamId'].strip == team_id
             return team['teamId'] if team['currentTeamMember']['teamMemberId'].to_s.strip == team_id
           end
-          puts("Couldn't find team with ID '#{team_id}'")
+          # Better message to inform user of misconfiguration as Apple now provides less friendly error as of 2019-02-12
+          # This is especially important as Developer Portal team IDs are deprecated and should be replaced with App Store Connect teamIDs
+          # "Access Unavailable - You currently don't have access to this membership resource. Contact your team's Account Holder, Josh Holtz, or an Admin."
+          # https://github.com/fastlane/fastlane/issues/14228
+          puts "Couldn't find team with ID '#{team_id}'. Make sure your are using the correct App Store Connect team ID and have the proper permissions for this team"
         end
 
         if team_name.length > 0
@@ -75,7 +79,10 @@ module Spaceship
           teams.each_with_index do |team, i|
             return team['teamId'] if team['name'].strip == team_name
           end
-          puts("Couldn't find team with Name '#{team_name}'")
+          # Better message to inform user of misconfiguration as Apple now provides less friendly error as of 2019-02-12
+          # "Access Unavailable - You currently don't have access to this membership resource. Contact your team's Account Holder, Josh Holtz, or an Admin."
+          # https://github.com/fastlane/fastlane/issues/14228
+          puts "Couldn't find team with Name '#{team_name}. Make sure you have the proper permissions for this team'"
         end
 
         return teams[0]['teamId'] if teams.count == 1 # user is just in one team


### PR DESCRIPTION
Fixes #14228

## Issue 1
Invalid `team_id` or `team_name` passed into `select_team` would do a simple `puts`

### Description
- This got lost in the output
- This is now especially not great that Developer Portal team ID is deprecated in favor of App Store Connect team ID
- Any setups that were dependent on this will get a really gross error from Apple basically saying invalid team ID but its not easy to figure out what the proper solution is

### Solution
- Better message that explains wrong `team_id` and `team_name` about using the App Store Connect team ID

## Issue 2
`match` was not forwarding `team_name` to `cert` and `sigh`

### Description
- This is actually what cause my issue in the first issue
- I was passing `team_name` into `match` via an option but `cert` and `sigh` were picking up the `team_name` from an environment variable or somewhere else

### Solution
- Pass `team_name` all the places