### PR TITLE
[docs] fix typo in action CLI docs

### DIFF
--- a/fastlane/lib/assets/ActionDetails.md.erb
+++ b/fastlane/lib/assets/ActionDetails.md.erb
@@ -74,7 +74,7 @@ To pass parameters, make use of the `:` symbol, for example
 fastlane run <%= @action.action_name %> parameter1:"value1" parameter2:"value2"
 ```
 
-It's important to note that the CLI supports primative types like integers, floats, booleans, and strings. Arrays can be passed as a comma delimited string (e.g. `param:"1,2,3"`). Hashes are not currently supported.
+It's important to note that the CLI supports primitive types like integers, floats, booleans, and strings. Arrays can be passed as a comma delimited string (e.g. `param:"1,2,3"`). Hashes are not currently supported.
 
 It is recommended to add all _fastlane_ actions you use to your `Fastfile`.
 


### PR DESCRIPTION
### Checklist
* [x]  I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
* [x]  I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
* [x]  I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
* [x]  I've updated the documentation if necessary.

### Description
It's important to note that the CLI supports **primative** types... -> It's important to note that the CLI supports **primitive** types...