### PR TITLE
[fastlane] Fix slack action when it adds `last_git_commit` when passing `adds last_git_commit_hash`

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -184,7 +184,7 @@ module Fastlane
 
       def self.generate_slack_attachments(options)
         color = (options[:success] ? 'good' : 'danger')
-        should_add_payload = ->(payload_name) { options[:default_payloads].nil? || options[:default_payloads].join(" ").include?(payload_name.to_s) }
+        should_add_payload = ->(payload_name) { options[:default_payloads].nil? || options[:default_payloads].map(&:to_sym).include?(payload_name.to_sym) }
 
         slack_attachment = {
           fallback: options[:message],

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -156,7 +156,7 @@ module Fastlane
               "Built by" => "Jenkins",
             },
             default_payloads: [:git_branch, :git_author], # Optional, lets you specify a whitelist of default payloads to include. Pass an empty array to suppress all the default payloads.
-                                                          # Don\'t add this key, or pass nil, if you want all the default payloads. The available default payloads are: `lane`, `test_result`, `git_branch`, `git_author`, `last_git_commit_message`, `last_git_commit_hash`.
+                                                          # Don\'t add this key, or pass nil, if you want all the default payloads. The available default payloads are: `lane`, `test_result`, `git_branch`, `git_author`, `last_git_commit`, `last_git_commit_hash`.
             attachment_properties: { # Optional, lets you specify any other properties available for attachments in the slack API (see https://api.slack.com/docs/attachments).
                                      # This hash is deep merged with the existing properties set using the other properties above. This allows your own fields properties to be appended to the existing fields that were created using the `payload` property for instance.
               thumb_url: "http://example.com/path/to/thumb.png",

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -141,6 +141,30 @@ describe Fastlane do
         expect(fields[1][:title]).to eq('Result')
         expect(fields[1][:value]).to eq('Error')
       end
+
+      # https://github.com/fastlane/fastlane/issues/14234
+      it "parses default_payloads without adding extra fields for git" do
+        channel = "#myChannel"
+        message = "Custom Message"
+
+        require 'fastlane/actions/slack'
+        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+          slack_url: 'https://127.0.0.1',
+          message: message,
+          success: false,
+          channel: channel,
+          default_payloads: [:git_branch, :last_git_commit_hash]
+        })
+
+        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+
+        fields = attachments[:fields]
+
+        expect(fields.count).to eq(2)
+
+        expect(fields[0][:title]).to eq('Git Branch')
+        expect(fields[1][:title]).to eq('Git Commit Hash')
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
The [slack action](https://docs.fastlane.tools/actions/slack/) prints out 3 payloads `git_branch`, `last_git_commit_hash` and `last_git_commit` whenever we pass **only** two of them - `git_branch`, `last_git_commit_hash`.

<!-- If it fixes an open issue, please link to the issue here. -->
closes https://github.com/fastlane/fastlane/issues/14234

### Description
<!-- Describe your changes in detail -->
The changes are about a way we were looking for a particular payload name in a `default_payloads` array. Before this change, we've been joining all of the items into a single string and check whether this string includes the payload name, i.e. 

```ruby
should_add_payload = ->(payload_name) { options[:default_payloads].nil? || options[:default_payloads].join(" ").include?(payload_name.to_s) }

options[:default_payloads] = [:git_branch, :last_git_commit_hash]
...
=> "git_branch last_git_commit_hash"

# we were iterating through each available option, so even though `last_git_commit` hasn't been provided with `default_payloads`, we were still finding this phrase as part of connected string

🙊 "git_branch last_git_commit_hash last_git_commit" includes `last_git_commit` 
```

This change introduced a new way of checking whether provided `default_payload` list contains payload name by leveraging Ruby symbols. 

<!-- Please describe in detail how you tested your changes. -->
The new unit test has been added to cover this case 💪 

🙇 🙇 