### PR TITLE
Fixed incorrect language name in languageMapping.json

### DIFF
--- a/spaceship/lib/assets/languageMapping.json
+++ b/spaceship/lib/assets/languageMapping.json
@@ -245,7 +245,7 @@
     },
     {
         "locale": "sk-SK",
-        "name": "Romanian",
+        "name": "Slovak",
         "game-center": false,
         "itc_locale": "sk"        
     },


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

As mentioned in https://github.com/fastlane/fastlane/pull/14110#pullrequestreview-203722965, fixed incorrect language name in languageMapping.json
