### PR TITLE
[fastlane] fix prompt crash on multi_line_end_keyword: "^D"

### DIFF
--- a/fastlane/lib/fastlane/actions/prompt.rb
+++ b/fastlane/lib/fastlane/actions/prompt.rb
@@ -17,7 +17,8 @@ module Fastlane
           UI.important("Submit inputs using \"#{params[:multi_line_end_keyword]}\"")
           user_input = ""
           loop do
-            line = STDIN.gets
+            line = STDIN.gets # returns `nil` if called at end of file
+            break unless line
             end_tag_index = line.index(end_tag)
             if end_tag_index.nil?
               user_input << line


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
`prompt` action crashes when `multi_line_end_keyword` detects end of file character equals to `ctrl-d` (when you press Ctrl-d while inputting data).

<!-- If it fixes an open issue, please link to the issue here. -->
closes https://github.com/fastlane/fastlane/issues/14185

### Description
<!-- Describe your changes in detail -->
According to [Ruby docs](http://ruby-doc.org/core-2.1.0/IO.html#method-i-gets) `STDIN.gets`:

> Returns nil if called at end of file

Basically when you hit `ctrl-d` while inserting the lines of text to the prompt, you received:

```bash
.../fastlane/fastlane/lib/fastlane/actions/prompt.rb:22:in `block in run': [!] undefined method `index' for nil:NilClass (NoMethodError)
```
The fix is about checking whether `STDIN.gets` return a nil value which represents the end of file symbol 🎉 

<!-- Please describe in detail how you tested your changes. -->

I tested the changes by inserting two lines of text and hitting `ctrl-d`. 
I was trying to add a unit test but couldn't figure out how to mock returning `nil` value from `STDIN.gets` 😞 If you have any ideas how we could do that I am all ears 🙏 

Cheers 🙇 