### PR TITLE
[supply] Enable obb updating

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
@@ -78,10 +78,24 @@ To gradually roll out a new build use
 fastlane supply --apk path/app.apk --track rollout --rollout 0.5
 ```
 
+### Expansion files (`.obb`)
+
 Expansion files (obbs) found under the same directory as your APK will also be uploaded together with your APK as long as:
 
 - they are identified as type 'main' or 'patch' (by containing 'main' or 'patch' in their file name)
 - you have at most one of each type
+
+If you only want to update the APK, but keep the expansion files from the previous version on Google Play use
+
+```no-highlight
+fastlane supply --apk path/app.apk --obb_main_references_version 21 --obb_main_file_size 666154207
+```
+
+or
+
+```no-highlight
+fastlane supply --apk path/app.apk --obb_patch_references_version 21 --obb_patch_file_size 666154207
+```
 
 ## Uploading an AAB
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -357,6 +357,23 @@ module Supply
       end
     end
 
+    def update_obb(apk_version_code, expansion_file_type, references_version, file_size)
+      ensure_active_edit!
+
+      call_google_api do
+        client.update_expansion_file(
+          current_package_name,
+          current_edit.id,
+          apk_version_code,
+          expansion_file_type,
+          Google::Apis::AndroidpublisherV2::ExpansionFile.new(
+            references_version: references_version,
+            file_size: file_size
+          )
+        )
+      end
+    end
+
     #####################################################
     # @!group Screenshots
     #####################################################

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -238,7 +238,27 @@ module Supply
                                        version_codes.each do |version_code|
                                          UI.user_error!("Version code '#{version_code}' is not an integer") unless version_code.kind_of?(Integer)
                                        end
-                                     end)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :obb_main_references_version,
+                                     env_name: "SUPPLY_OBB_MAIN_REFERENCES_VERSION",
+                                     description: "References version of 'main' expansion file",
+                                     optional: true,
+                                     type: Numeric),
+        FastlaneCore::ConfigItem.new(key: :obb_main_file_size,
+                                     env_name: "SUPPLY_OBB_MAIN_FILE SIZE",
+                                     description: "Size of 'main' expansion file in bytes",
+                                     optional: true,
+                                     type: Numeric),
+        FastlaneCore::ConfigItem.new(key: :obb_patch_references_version,
+                                     env_name: "SUPPLY_OBB_PATCH_REFERENCES_VERSION",
+                                     description: "References version of 'patch' expansion file",
+                                     optional: true,
+                                     type: Numeric),
+        FastlaneCore::ConfigItem.new(key: :obb_patch_file_size,
+                                     env_name: "SUPPLY_OBB_PATCH_FILE SIZE",
+                                     description: "Size of 'patch' expansion file in bytes",
+                                     optional: true,
+                                     type: Numeric)
       ]
     end
     # rubocop:enable Metrics/PerceivedComplexity

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -184,6 +184,20 @@ module Supply
         apk_version_code = client.upload_apk(apk_path)
         UI.user_error!("Could not upload #{apk_path}") unless apk_version_code
 
+        if Supply.config[:obb_main_references_version] && Supply.config[:obb_main_file_size]
+          update_obb(apk_version_code,
+                     'main',
+                     Supply.config[:obb_main_references_version],
+                     Supply.config[:obb_main_file_size])
+        end
+
+        if Supply.config[:obb_patch_references_version] && Supply.config[:obb_patch_file_size]
+          update_obb(apk_version_code,
+                     'patch',
+                     Supply.config[:obb_patch_references_version],
+                     Supply.config[:obb_patch_file_size])
+        end
+
         upload_obbs(apk_path, apk_version_code)
 
         if metadata_path
@@ -196,6 +210,14 @@ module Supply
         UI.message("No apk file found, you can pass the path to your apk using the `apk` option")
       end
       apk_version_code
+    end
+
+    def update_obb(apk_version_code, expansion_file_type, references_version, file_size)
+      UI.message("Updating '#{expansion_file_type}' expansion file from version '#{references_version}'...")
+      client.update_obb(apk_version_code,
+                        expansion_file_type,
+                        references_version,
+                        file_size)
     end
 
     def update_track(apk_version_codes)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I need upload new APKs without new expansion file but use old one.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
Add new options obb_main_references_version, obb_main_file_size size, obb_patch_references_version, obb_patch_file_size size to update APK and use old obb file.


