### PR TITLE
Update create_app_online.md

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/create_app_online.md
+++ b/fastlane/lib/fastlane/actions/docs/create_app_online.md
@@ -236,9 +236,11 @@ lane :release do
     # Optional
     # App services can be enabled during app creation
     enable_services: {
+      access_wifi: "on",             # Valid values: "on", "off"
       app_group: "on",               # Valid values: "on", "off"
       apple_pay: "on",               # Valid values: "on", "off"
       associated_domains: "on",      # Valid values: "on", "off"
+      auto_fill_credential: "on",    # Valid values: "on", "off"
       data_protection: "complete",   # Valid values: "complete", "unlessopen", "untilfirstauth",
       game_center: "on",             # Valid values: "on", "off"
       health_kit: "on",              # Valid values: "on", "off"
@@ -249,7 +251,7 @@ lane :release do
       inter_app_audio: "on",         # Valid values: "on", "off"
       passbook: "on",                # Valid values: "on", "off"
       multipath: "on",               # Valid values: "on", "off"
-      network_extensions: "on",      # Valid values: "on", "off"
+      network_extension: "on",       # Valid values: "on", "off"
       nfc_tag_reading: "on",         # Valid values: "on", "off"
       personal_vpn: "on",            # Valid values: "on", "off"
       passbook: "on",                # Valid values: "on", "off" (deprecated)


### PR DESCRIPTION
Update the example Fastfile usage of `produce` with updated service keys and values

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Using the example Fastfile usage should work, not throw errors.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
This adds the latest keys and valid values for the `enable_services` hash, and fixes a typo in the `network_extension` key.