### PR TITLE
[deliver] Reset the summary rating

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -166,6 +166,11 @@ module Deliver
                                      optional: true,
                                      is_string: false,
                                      default_value: false),
+        FastlaneCore::ConfigItem.new(key: :reset_ratings,
+                                    description: "Reset the summary rating when you release a new verion of the application",
+                                    optional: true,
+                                    is_string: false,
+                                    default_value: false),
 
         # other app configuration
         FastlaneCore::ConfigItem.new(key: :price_tier,

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -167,7 +167,7 @@ module Deliver
                                      is_string: false,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :reset_ratings,
-                                    description: "Reset the summary rating when you release a new verion of the application",
+                                    description: "Reset the summary rating when you release a new version of the application",
                                     optional: true,
                                     is_string: false,
                                     default_value: false),

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -130,6 +130,7 @@ module Deliver
       set_trade_representative_contact_information(v, options)
       set_review_information(v, options)
       set_app_rating(v, options)
+      v.ratings_reset = options[:reset_ratings]
 
       Helper.show_loading_indicator("Uploading metadata to App Store Connect")
       v.save!

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -147,6 +147,7 @@ describe Deliver::UploadMetadata do
       allow(version).to receive(:release_on_approval=)
       allow(version).to receive(:toggle_phased_release)
       allow(version).to receive(:auto_release_date=)
+      allow(version).to receive(:ratings_reset=)
       allow(version).to receive(:description)
       allow(version).to receive(:send).and_return(version_info)
       allow(app).to receive(:edit_version).and_return(version)
@@ -199,6 +200,7 @@ describe Deliver::UploadMetadata do
       allow(version).to receive(:release_on_approval=)
       allow(version).to receive(:toggle_phased_release)
       allow(version).to receive(:auto_release_date=)
+      allow(version).to receive(:ratings_reset=)
       allow(app).to receive(:edit_version).and_return(version)
       allow(app).to receive(:details).and_return(details)
       allow(details).to receive(:save!)
@@ -230,6 +232,7 @@ describe Deliver::UploadMetadata do
       allow(version).to receive(:release_on_approval=)
       allow(version).to receive(:toggle_phased_release)
       allow(version).to receive(:auto_release_date=)
+      allow(version).to receive(:ratings_reset=)
       allow(app).to receive(:edit_version).and_return(version)
       allow(app).to receive(:details).and_return(details)
       allow(details).to receive(:save!)
@@ -253,6 +256,44 @@ describe Deliver::UploadMetadata do
       it "toggle_phased_release is not called" do
         uploader.upload(app: app)
         expect(version).not_to(have_received(:toggle_phased_release).with(enabled: false))
+      end
+    end
+  end
+
+  context "with reset_ratings" do
+    let(:app) { double('app') }
+    let(:version) { double('version') }
+    let(:details) { double('details') }
+    before do
+      allow(uploader).to receive(:verify_available_languages!)
+      allow(version).to receive(:save!)
+      allow(version).to receive(:release_on_approval=)
+      allow(version).to receive(:toggle_phased_release)
+      allow(version).to receive(:auto_release_date)
+      allow(version).to receive(:ratings_reset=)
+      allow(app).to receive(:edit_version).and_return(version)
+      allow(app).to receive(:details).and_return(details)
+      allow(details).to receive(:save!)
+    end
+
+    context 'with true' do
+      it "ratings_reset is called" do
+        uploader.upload(reset_ratings: true, app: app)
+        expect(version).to have_received(:ratings_reset=).with(true)
+      end
+    end
+
+    context 'with false' do
+      it "ratings_reset is called" do
+        uploader.upload(reset_ratings: false, app: app)
+        expect(version).to have_received(:ratings_reset=).with(false)
+      end
+    end
+
+    context 'without value' do
+      it "ratings_reset is not called" do
+        uploader.upload(app: app)
+        expect(version).not_to(have_received(:ratings_reset=).with(false))
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -266,6 +266,16 @@ phased_release(true)
 phased_release(false)
 ```
 
+##### reset_ratings
+
+Reset your app's summary rating for all territories. If set to `true`, it will reset rating when this version is released. Default behavior is to keep existing rating.
+
+```ruby-skip-tests
+reset_ratings(true)
+# or
+reset_ratings(false)
+```
+
 ##### app_rating_config_path
 You can set the app age ratings using _deliver_. You'll have to create and store a `JSON` configuration file. Copy the [template](https://github.com/fastlane/fastlane/blob/master/deliver/assets/example_rating_config.json) to your project folder and pass the path to the `JSON` file using the `app_rating_config_path` option.
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
A quick summary of the ratings feature from [Apple](https://developer.apple.com/app-store/ratings-and-reviews/):

> Ratings and reviews influence how your app ranks in search results, and can affect whether someone downloads your app. Users can rate your app on a scale of 1 to 5 stars. They can also add a written review for iOS and macOS apps. 

> Individual ratings inform your app’s summary rating, which is displayed on your product page and in search results. This summary rating is specific to each territory on the App Store and you can reset it when you release a new version of your app. However, we recommend using this feature sparingly; while resetting the summary rating can ensure that it reflects the most current version of your app — useful if an update addresses users’ previous concerns — having few ratings may discourage potential users from downloading your app.

You can reset ratings while uploading the new version to AppStore via AppStoreConnect - there's a checkbox for doing that. 

<!-- Why is this change required? What problem does it solve? -->
For now it is not possible to reset the summary rating via `deliver` tool - the input parameter is missing. This change is about adding `reset_ratings` parameter and make it possible to reset the summary rating of your application. 

<!-- If it fixes an open issue, please link to the issue here. -->
closes https://github.com/fastlane/fastlane/issues/14266

### Description
<!-- Describe your changes in detail -->
I added the new optional input parameter to the `deliver` options: `reset_ratings`. 

💡 Wondering if I should modify/add something to `deliver` docs or it is going to be updated automatically based on the changes in `options.rb` file? 🤔 

<!-- Please describe in detail how you tested your changes. -->
I added unit tests although I'd really appreciate the help with manual testing 🙏 🙏 