### PR TITLE
[spaceship] Docs: Fix vendor_id description

### DIFF
--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -25,7 +25,7 @@ module Spaceship
       #   "Spaceship App"
       attr_accessor :name
 
-      # @return (String) The Vendor ID provided by App Store Connect
+      # @return (String) The SKU (Stock keeping unit) you provided for this app for internal tracking
       # @example
       #   "1435592086"
       attr_accessor :vendor_id


### PR DESCRIPTION
Previous description text was incorrect. SKU is not automatically generated by Apple, but rather something internally created by the developer. 

> A unique ID for your bundle. You can use letters, numbers, hyphens, periods, and underscore. The SKU cannot start with a hyphen, period, or underscore.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Previous description was incorrect. Fixing that with this commit.
