### PR TITLE
[pilot] Do not use spaceship if both skip_waiting_for_build_processing and apple_id are set

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -10,11 +10,11 @@ require_relative 'manager'
 module Pilot
   class BuildManager < Manager
     def upload(options)
-      start(options) unless config[:skip_waiting_for_build_processing] && config[:apple_id]
+      start(options) unless options[:skip_waiting_for_build_processing] && options[:apple_id]
 
       options[:changelog] = self.class.sanitize_changelog(options[:changelog]) if options[:changelog]
 
-      UI.user_error!("No ipa file given") unless config[:ipa]
+      UI.user_error!("No ipa file given") unless options[:ipa]
 
       if options[:changelog].nil? && options[:distribute_external] == true
         if UI.interactive?
@@ -30,7 +30,7 @@ module Pilot
 
       platform = fetch_app_platform
       package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(app_id: fetch_only_apple_id,
-                                                                      ipa_path: config[:ipa],
+                                                                      ipa_path: options[:ipa],
                                                                   package_path: dir,
                                                                       platform: platform)
 
@@ -50,8 +50,8 @@ module Pilot
       end
 
       UI.message("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-      app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(config[:ipa])
-      app_build = FastlaneCore::IpaFileAnalyser.fetch_app_build(config[:ipa])
+      app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(options[:ipa])
+      app_build = FastlaneCore::IpaFileAnalyser.fetch_app_build(options[:ipa])
       latest_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: app.apple_id, platform: platform, train_version: app_version, build_version: app_build, poll_interval: config[:wait_processing_interval], strict_build_watch: config[:wait_for_uploaded_build])
 
       unless latest_build.train_version == app_version && latest_build.build_version == app_build

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -11,6 +11,7 @@ module Pilot
   class BuildManager < Manager
     def upload(options)
       start(options) unless options[:skip_waiting_for_build_processing] && options[:apple_id]
+      @config = options if options[:skip_waiting_for_build_processing] && options[:apple_id] # ugly as hell, we want to do that differently
 
       options[:changelog] = self.class.sanitize_changelog(options[:changelog]) if options[:changelog]
 

--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -43,9 +43,10 @@ module Pilot
     ################
 
     # this exists so there is a way to get the apple_id without using spaceship if the config value exists
-    def fetch_only_apple_id 
+    def fetch_only_apple_id
       apple_id = config[:apple_id]
       apple_id ||= app.apple_id
+      return apple_id
     end
 
     def fetch_apple_id

--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -27,7 +27,7 @@ module Pilot
 
     # The app object we're currently using
     def app
-      @apple_id ||= fetch_app_id
+      @apple_id ||= fetch_apple_id
 
       @app ||= Spaceship::Tunes::Application.find(@apple_id)
       unless @app
@@ -42,19 +42,25 @@ module Pilot
     # Config Related
     ################
 
-    def fetch_app_id
+    # this exists so there is a way to get the apple_id without using spaceship if the config value exists
+    def fetch_only_apple_id 
+      apple_id = config[:apple_id]
+      apple_id ||= app.apple_id
+    end
+
+    def fetch_apple_id
       return @apple_id if @apple_id
       config[:app_identifier] = fetch_app_identifier
 
       if config[:app_identifier]
         @app ||= Spaceship::Tunes::Application.find(config[:app_identifier])
         UI.user_error!("Couldn't find app '#{config[:app_identifier]}' on the account of '#{config[:username]}' on App Store Connect") unless @app
-        app_id ||= @app.apple_id
+        apple_id ||= @app.apple_id
       end
 
-      app_id ||= UI.input("Could not automatically find the app ID, please enter it here (e.g. 956814360): ")
+      apple_id ||= UI.input("Could not automatically find the app ID, please enter it here (e.g. 956814360): ")
 
-      return app_id
+      return apple_id
     end
 
     def fetch_app_identifier

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -119,9 +119,8 @@ describe "Build Manager" do
 
   describe "#upload" do
     describe "spaceship login (via Manager.login)" do
-
       let(:fake_build_manager) { Pilot::BuildManager.new }
-      let(:upload_options) do 
+      let(:upload_options) do
         {
           apple_id: 'mock_apple_id',
           skip_waiting_for_build_processing: true,
@@ -131,12 +130,12 @@ describe "Build Manager" do
 
       before(:each) do
         allow(fake_build_manager).to receive(:fetch_app_platform).and_return('ios')
-        
-        fake_ipauploadpackagebuilder = double()
+
+        fake_ipauploadpackagebuilder = double
         allow(fake_ipauploadpackagebuilder).to receive(:generate).and_return(true)
         allow(FastlaneCore::IpaUploadPackageBuilder).to receive(:new).and_return(fake_ipauploadpackagebuilder)
-        
-        fake_itunestransporter = double()
+
+        fake_itunestransporter = double
         allow(fake_itunestransporter).to receive(:upload).and_return(true)
         allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
       end
@@ -149,18 +148,18 @@ describe "Build Manager" do
         # clean options
         upload_options.delete(:apple_id)
         upload_options.delete(:skip_waiting_for_build_processing)
-        
+
         # allow the spaceship login method this time
         allow(fake_build_manager).to receive(:login)
-        
-        fake_app = double()
+
+        fake_app = double
         allow(fake_app).to receive(:apple_id).and_return(123)
         allow(fake_build_manager).to receive(:app).and_return(fake_app)
-        
+
         allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
         allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
-        
-        fake_build = double()
+
+        fake_build = double
         allow(fake_build).to receive(:train_version)
         allow(fake_build).to receive(:build_version)
         allow(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
@@ -169,8 +168,6 @@ describe "Build Manager" do
 
         fake_build_manager.upload(upload_options)
       end
-
     end
   end
-
 end

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -11,6 +11,7 @@ describe "Build Manager" do
       expect(changelog).to eq("1234")
     end
   end
+
   describe ".sanitize_changelog" do
     it "removes emoji" do
       changelog = "I'm 🦇B🏧an!"
@@ -24,7 +25,8 @@ describe "Build Manager" do
       expect(changelog).to eq(File.read("./pilot/spec/fixtures/build_manager/changelog_long_truncated"))
     end
   end
-  describe "distribute submits the build for review" do
+
+  describe "#distribute submits the build for review" do
     let(:mock_base_client) { "fake testflight base client" }
     let(:mock_base_api_client) { "fake api base client" }
     let(:fake_build_manager) { Pilot::BuildManager.new }


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

### TODO

- [ ] Add test that makes sure that spaceship is not called when both params are present
- [ ] Add documentation about how to upload without spaceship