### PR TITLE
[snapshot] Set locale only when identifier is valid

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -115,7 +115,7 @@ open class Snapshot: NSObject {
             print("Couldn't detect/set locale...")
         }
         
-        if locale.isEmpty {
+        if locale.isEmpty && !deviceLanguage.isEmpty {
             locale = Locale(identifier: deviceLanguage).identifier
         }
         
@@ -277,4 +277,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.13]
+// SnapshotHelperVersion [1.14]


### PR DESCRIPTION


<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md) 🔑
- [ ] I've updated the documentation if necessary.

### Motivation and Context
Similar to #13555 and https://github.com/fastlane/fastlane/pull/13556, a CI machine was missing `~/Library/Caches/tools.fastlane/locale.txt` and `~/Library/Caches/tools.fastlane/language.txt` which ended up breaking date formatted strings where "January" was replaced with "M01", "February" with "M02", etc.

### Description
Fixed issue where a bad locale could be set if neither a locale nor language string could be detected.

If language.txt and locale.txt are both missing, the default value of `deviceLanguage` (the empty string) was incorrectly used to create the locale passed via `-AppleLocale`.