### PR TITLE
[fastlane] fix keychain shellescaping

### DIFF
--- a/fastlane/spec/actions_specs/create_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/create_keychain_spec.rb
@@ -20,7 +20,7 @@ describe Fastlane do
         expect(result[1]).to_not(include("-u"))
         expect(result[1]).to include(keychain_path.to_s)
         expect(result[2]).to start_with("security list-keychains -s")
-        expect(result[2]).to end_with(File.expand_path(keychain_path.to_s).to_s)
+        expect(result[2]).to end_with(File.expand_path(keychain_path.to_s).shellescape.to_s)
       end
 
       it "works with name and password that contain spaces or `\"`" do

--- a/fastlane/spec/actions_specs/create_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/create_keychain_spec.rb
@@ -2,43 +2,50 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Create keychain Integration" do
       it "works with name and password" do
+        keychain_password = "testpassword"
+        keychain_name = "test.keychain"
+        keychain_path = "~/Library/Keychains/#{keychain_name}"
         result = Fastlane::FastFile.new.parse("lane :test do
           create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
+            name: '#{keychain_name}',
+            password: '#{keychain_password}',
           })
         end").runner.execute(:test)
 
         expect(result.size).to eq(3)
-        expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
-
-        expect(result[1]).to start_with('security set-keychain-settings')
-        expect(result[1]).to include('-t 300')
-        expect(result[1]).to_not(include('-l'))
-        expect(result[1]).to_not(include('-u'))
-        expect(result[1]).to include('~/Library/Keychains/test.keychain')
+        expect(result[0]).to eq("security create-keychain -p #{keychain_password.shellescape} #{keychain_path.shellescape}")
+        expect(result[1]).to start_with("security set-keychain-settings")
+        expect(result[1]).to include("-t 300")
+        expect(result[1]).to_not(include("-l"))
+        expect(result[1]).to_not(include("-u"))
+        expect(result[1]).to include(keychain_path.to_s)
         expect(result[2]).to start_with("security list-keychains -s")
-        expect(result[2]).to end_with(File.expand_path('~/Library/Keychains/test.keychain').to_s)
+        expect(result[2]).to end_with(File.expand_path(keychain_path.to_s).to_s)
       end
 
       it "works with name and password that contain spaces or `\"`" do
-        password = "\"test password\""
+        keychain_password = "\"test password\""
+        keychain_name = "test.keychain"
+        keychain_path = "~/Library/Keychains/#{keychain_name}"
         result = Fastlane::FastFile.new.parse("lane :test do
           create_keychain ({
-            name: 'test.keychain',
-            password: '#{password}',
+            name: '#{keychain_name}',
+            password: '#{keychain_password}',
           })
         end").runner.execute(:test)
 
         expect(result.size).to eq(3)
-        expect(result[0]).to eq(%(security create-keychain -p #{password.shellescape} ~/Library/Keychains/test.keychain))
+        expect(result[0]).to eq("security create-keychain -p #{keychain_password.shellescape} #{keychain_path.shellescape}")
       end
 
       it "works with keychain-settings and name and password" do
+        keychain_password = "testpassword"
+        keychain_name = "test.keychain"
+        keychain_path = "~/Library/Keychains/#{keychain_name}"
         result = Fastlane::FastFile.new.parse("lane :test do
           create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
+            name: '#{keychain_name}',
+            password: '#{keychain_password}',
             timeout: 600,
             lock_when_sleeps: true,
             lock_after_timeout: true,
@@ -46,62 +53,71 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result.size).to eq(3)
-        expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
+        expect(result[0]).to eq("security create-keychain -p #{keychain_password.shellescape} #{keychain_path.shellescape}")
 
-        expect(result[1]).to start_with('security set-keychain-settings')
-        expect(result[1]).to include('-t 600')
-        expect(result[1]).to include('-l')
-        expect(result[1]).to include('-u')
-        expect(result[1]).to include('~/Library/Keychains/test.keychain')
+        expect(result[1]).to start_with("security set-keychain-settings")
+        expect(result[1]).to include("-t 600")
+        expect(result[1]).to include("-l")
+        expect(result[1]).to include("-u")
+        expect(result[1]).to include(keychain_path.shellescape.to_s)
       end
 
       it "works with default_keychain and name and password" do
+        keychain_password = "testpassword"
+        keychain_name = "test.keychain"
+        keychain_path = "~/Library/Keychains/#{keychain_name}"
         result = Fastlane::FastFile.new.parse("lane :test do
           create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
+            name: '#{keychain_name}',
+            password: '#{keychain_password}',
             default_keychain: true,
           })
         end").runner.execute(:test)
 
         expect(result.size).to eq(4)
-        expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
+        expect(result[0]).to eq("security create-keychain -p #{keychain_password.shellescape} #{keychain_path.shellescape}")
 
-        expect(result[1]).to eq('security default-keychain -s ~/Library/Keychains/test.keychain')
+        expect(result[1]).to eq("security default-keychain -s #{keychain_path.shellescape}")
 
-        expect(result[2]).to start_with('security set-keychain-settings')
-        expect(result[2]).to include('-t 300')
-        expect(result[2]).to_not(include('-l'))
-        expect(result[2]).to_not(include('-u'))
-        expect(result[2]).to include('~/Library/Keychains/test.keychain')
+        expect(result[2]).to start_with("security set-keychain-settings")
+        expect(result[2]).to include("-t 300")
+        expect(result[2]).to_not(include("-l"))
+        expect(result[2]).to_not(include("-u"))
+        expect(result[2]).to include(keychain_path.shellescape.to_s)
       end
 
       it "works with unlock and name and password" do
+        keychain_password = "testpassword"
+        keychain_name = "test.keychain"
+        keychain_path = "~/Library/Keychains/#{keychain_name}"
         result = Fastlane::FastFile.new.parse("lane :test do
           create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
+            name: '#{keychain_name}',
+            password: '#{keychain_password}',
             unlock: true,
           })
         end").runner.execute(:test)
 
         expect(result.size).to eq(4)
-        expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
+        expect(result[0]).to eq("security create-keychain -p #{keychain_password.shellescape} #{keychain_path.shellescape}")
 
-        expect(result[1]).to eq('security unlock-keychain -p testpassword ~/Library/Keychains/test.keychain')
+        expect(result[1]).to eq("security unlock-keychain -p #{keychain_password.shellescape} #{keychain_path.shellescape}")
 
-        expect(result[2]).to start_with('security set-keychain-settings')
-        expect(result[2]).to include('-t 300')
-        expect(result[2]).to_not(include('-l'))
-        expect(result[2]).to_not(include('-u'))
-        expect(result[2]).to include('~/Library/Keychains/test.keychain')
+        expect(result[2]).to start_with("security set-keychain-settings")
+        expect(result[2]).to include("-t 300")
+        expect(result[2]).to_not(include("-l"))
+        expect(result[2]).to_not(include("-u"))
+        expect(result[2]).to include(keychain_path.shellescape.to_s)
       end
 
       it "works with :path param" do
+        keychain_password = "testpassword"
+        keychain_name = "test.keychain"
+        keychain_path = "/tmp/#{keychain_name}"
         result = Fastlane::FastFile.new.parse("lane :test do
           create_keychain ({
-            path: '/tmp/test.keychain',
-            password: 'testpassword',
+            path: '#{keychain_path}',
+            password: '#{keychain_password}',
             default_keychain: true,
             unlock: true,
             timeout: 600,
@@ -111,23 +127,26 @@ describe Fastlane do
           })
         end").runner.execute(:test)
         expect(result.size).to eq(4)
-        expect(result[0]).to eq('security create-keychain -p testpassword /tmp/test.keychain')
+        expect(result[0]).to eq("security create-keychain -p #{keychain_password.shellescape} #{keychain_path.shellescape}")
 
-        expect(result[1]).to eq('security default-keychain -s /tmp/test.keychain')
-        expect(result[2]).to eq('security unlock-keychain -p testpassword /tmp/test.keychain')
+        expect(result[1]).to eq("security default-keychain -s #{keychain_path.shellescape}")
+        expect(result[2]).to eq("security unlock-keychain -p #{keychain_password.shellescape} #{keychain_path.shellescape}")
 
-        expect(result[3]).to start_with('security set-keychain-settings')
-        expect(result[3]).to include('-t 600')
-        expect(result[3]).to include('-l')
-        expect(result[3]).to include('-u')
-        expect(result[3]).to include('/tmp/test.keychain')
+        expect(result[3]).to start_with("security set-keychain-settings")
+        expect(result[3]).to include("-t 600")
+        expect(result[3]).to include("-l")
+        expect(result[3]).to include("-u")
+        expect(result[3]).to include(keychain_path.shellescape.to_s)
       end
 
       it "works with all params" do
+        keychain_password = "testpassword"
+        keychain_name = "test.keychain"
+        keychain_path = "~/Library/Keychains/#{keychain_name}"
         result = Fastlane::FastFile.new.parse("lane :test do
           create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
+            name: '#{keychain_name}',
+            password: '#{keychain_password}',
             default_keychain: true,
             unlock: true,
             timeout: 600,
@@ -138,16 +157,16 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result.size).to eq(4)
-        expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
+        expect(result[0]).to eq("security create-keychain -p #{keychain_password.shellescape} #{keychain_path.shellescape}")
 
-        expect(result[1]).to eq('security default-keychain -s ~/Library/Keychains/test.keychain')
-        expect(result[2]).to eq('security unlock-keychain -p testpassword ~/Library/Keychains/test.keychain')
+        expect(result[1]).to eq("security default-keychain -s #{keychain_path.shellescape}")
+        expect(result[2]).to eq("security unlock-keychain -p #{keychain_password.shellescape} #{keychain_path.shellescape}")
 
-        expect(result[3]).to start_with('security set-keychain-settings')
-        expect(result[3]).to include('-t 600')
-        expect(result[3]).to include('-l')
-        expect(result[3]).to include('-u')
-        expect(result[3]).to include('~/Library/Keychains/test.keychain')
+        expect(result[3]).to start_with("security set-keychain-settings")
+        expect(result[3]).to include("-t 600")
+        expect(result[3]).to include("-l")
+        expect(result[3]).to include("-u")
+        expect(result[3]).to include(keychain_path.shellescape.to_s)
       end
     end
   end

--- a/fastlane/spec/actions_specs/import_certificate_spec.rb
+++ b/fastlane/spec/actions_specs/import_certificate_spec.rb
@@ -11,7 +11,7 @@ describe Fastlane do
         password = 'testpassword'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
+        expected_command = "security import #{cert_name.shellescape} -k #{keychain_path.shellescape} -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain_path.shellescape} 1> /dev/null"
@@ -38,7 +38,7 @@ describe Fastlane do
         password = '\"test pa$$word\"'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_security_import_command = "security import #{cert_name.shellescape} -k '#{keychain_path.shellescape}' -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
+        expected_security_import_command = "security import #{cert_name.shellescape} -k #{keychain_path.shellescape} -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         expected_set_key_partition_list_command = "security set-key-partition-list -S apple-tool:,apple: -k #{password.shellescape} #{keychain_path.shellescape} 1> /dev/null"
@@ -66,7 +66,7 @@ describe Fastlane do
         password = 'testpassword'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security"
+        expected_command = "security import #{cert_name.shellescape} -k #{keychain_path.shellescape} -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain_path.shellescape} 1> /dev/null"

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -6,7 +6,7 @@ module FastlaneCore
     def self.import_file(path, keychain_path, keychain_password: "", certificate_password: "", output: FastlaneCore::Globals.verbose?)
       UI.user_error!("Could not find file '#{path}'") unless File.exist?(path)
 
-      command = "security import #{path.shellescape} -k '#{keychain_path.shellescape}'"
+      command = "security import #{path.shellescape} -k #{keychain_path.shellescape}"
       command << " -P #{certificate_password.shellescape}"
       command << " -T /usr/bin/codesign" # to not be asked for permission when running a tool like `gym` (before Sierra)
       command << " -T /usr/bin/security"

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -6,13 +6,14 @@ describe Match do
 
     describe 'import' do
       it 'finds a normal keychain name relative to ~/Library/Keychains' do
-        expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
+        keychain_path = "#{Dir.home}/Library/Keychains/login.keychain"
+        expected_command = "security import item.path -k #{keychain_path.shellescape} -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain_path.shellescape} 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
-        expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
+        expect(File).to receive(:file?).with(keychain_path).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with('item.path').and_return(true)
 
@@ -25,7 +26,7 @@ describe Match do
       it 'treats a keychain name it cannot find in ~/Library/Keychains as the full keychain path' do
         tmp_path = Dir.mktmpdir
         keychain = "#{tmp_path}/my/special.keychain"
-        expected_command = "security import item.path -k '#{keychain}' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
+        expected_command = "security import item.path -k #{keychain.shellescape} -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain} 1> /dev/null"
@@ -50,13 +51,14 @@ describe Match do
       end
 
       it "tries to find the macOS Sierra keychain too" do
-        expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain-db' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
+        keychain_path = "#{Dir.home}/Library/Keychains/login.keychain-db"
+        expected_command = "security import item.path -k #{keychain_path.shellescape} -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db 1> /dev/null"
+        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{keychain_path.shellescape} 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
-        expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain-db").and_return(true)
+        expect(File).to receive(:file?).with(keychain_path).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with("item.path").and_return(true)
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

There are issues with keychains being escaped and/or used in an inconsistent way. 
See issue #14310 for a description and reproduction steps.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

1. The first commit ensures that keychain creation security commands use the escaped keychain path and avoids double escaping via `.shelljoin` 

   From the shelljoin docs:
   > All elements are joined into a single string with fields separated by a space, where each element is escaped for the Bourne shell and stringified using to_s.

2. The second commit removes the quotes around the escaped keychain path while importing.

   From the shellescape docs:
   > Note that a resulted string should be used unquoted and is not intended for use in double quotes nor in single quotes.

3. ~~The third commit constrains the certificate check to the provided keychain. 
   Through my test Fastfile (see #14310), I discovered that if my credentials were in any keychain in the search path, they would not be installed in the provided/target keychain. 
   I thought this was odd so I added this commit even though it is not directly related to the underlying issues.~~ 
   **Upate:** This commit was moved to a new branch to be evaluated a separate PR.

Testing consisted of manually running a Fastfile (see #14310) with control and test scenarios and comparison with command line executions of the security command. 

The unit tests do not actually execute the commands, but compare the command that would be issued to an expected value. I updated the unit tests to reflect my changes and identify things I missed.

**Note:** I doubt it is a complete solution but a step in the right direction. Please let me know of any changes or extensions. I hope this helps!
