### PR TITLE
[match] clear_changes after saving for all storage options

### DIFF
--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -205,8 +205,6 @@ module Match
                                             print_command: FastlaneCore::Globals.verbose?)
           end
         end
-
-        self.clear_changes
       rescue => ex
         UI.error("Couldn't commit or push changes back to git...")
         UI.error(ex)

--- a/match/lib/match/storage/interface.rb
+++ b/match/lib/match/storage/interface.rb
@@ -76,6 +76,7 @@ module Match
             UI.user_error!("Neither `files_to_commit` nor `files_to_delete` were provided to the `save_changes!` method call")
           end
         end
+        self.clear_changes
       end
 
       def upload_files(files_to_upload: [], custom_message: nil)


### PR DESCRIPTION
Fixes #14312

- delete file not cleaning git
- in side chdir block deleting folder.


### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

1. while deleting git files its not cleaning the git storage.
2. in Dir.chdir block we are calling self.clear_changes, its not logically correct and it throws error some time.

