### PR TITLE
[action] added Appcenter plugin link to use instead of hockeyApp

### DIFF
--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -187,4 +187,12 @@ class String
 
     self.gsub!(/^#{first_line_indent}/, "")
   end
+
+  def remove_markdown
+    string = self.gsub(/^>/, "") # remove Markdown quotes
+    string = string.gsub(/\[http[^\]]+\]\(([^)]+)\)/, '\1 🔗') # remove Markdown links
+    string = string.gsub(/\[([^\]]+)\]\(([^\)]+)\)/, '"\1" (\2 🔗)') # remove Markdown links with custom text
+    string = string.gsub("|", "") # remove new line preserve markers
+    return string
+  end
 end

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -183,7 +183,7 @@ module Fastlane
       end
 
       def self.description
-        "Deprecated and will be no longer supported on November 16, 2019. Refer to [App Center](https://github.com/Microsoft/fastlane-plugin-appcenter/)"
+        "Refer to [App Center](https://github.com/Microsoft/fastlane-plugin-appcenter/)"
       end
 
       def self.available_options
@@ -356,6 +356,9 @@ module Fastlane
 
       def self.details
         [
+          "HockeyApp will be no longer supported and will be transitioned into App Center on November 16, 2019.",
+          "Please migrate over to [App Center](https://github.com/Microsoft/fastlane-plugin-appcenter/)",
+          "",
           "Symbols will also be uploaded automatically if a `app.dSYM.zip` file is found next to `app.ipa`. In case it is located in a different place you can specify the path explicitly in the `:dsym` parameter.",
           "More information about the available options can be found in the [HockeyApp Docs](http://support.hockeyapp.net/kb/api/api-versions#upload-version)."
         ].join("\n")
@@ -386,7 +389,7 @@ module Fastlane
 
       def self.deprecated_notes
         [
-          "HockeyApp will be no longer supported and transitioned into App Center on November 16, 2019.",
+          "HockeyApp will be no longer supported and will be transitioned into App Center on November 16, 2019.",
           "Please migrate over to [App Center](https://github.com/Microsoft/fastlane-plugin-appcenter/)"
         ].join("\n")
       end

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -183,7 +183,7 @@ module Fastlane
       end
 
       def self.description
-        "Refer to [this](https://github.com/Microsoft/fastlane-plugin-appcenter/)"
+        "Deprecated and will be no longer supported on November 16, 2019. Refer to [App Center](https://github.com/Microsoft/fastlane-plugin-appcenter/)"
       end
 
       def self.available_options
@@ -381,7 +381,14 @@ module Fastlane
       end
 
       def self.category
-        :beta
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        [
+          "HockeyApp will be no longer supported and transitioned into App Center on November 16, 2019.",
+          "Please migrate over to [App Center](https://github.com/Microsoft/fastlane-plugin-appcenter/)"
+        ].join("\n")
       end
     end
     # rubocop:enable Metrics/ClassLength

--- a/fastlane/lib/fastlane/actions/hockey.rb
+++ b/fastlane/lib/fastlane/actions/hockey.rb
@@ -183,7 +183,7 @@ module Fastlane
       end
 
       def self.description
-        "Upload a new build to [HockeyApp](https://hockeyapp.net/)"
+        "Refer to [this](https://github.com/Microsoft/fastlane-plugin-appcenter/)"
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -21,7 +21,7 @@ module Fastlane
         end
 
         if action < Action
-          current << action.description if action.description
+          current << action.description.to_s.remove_markdown if action.description
 
           authors = Array(action.author || action.authors)
           current << authors.first.green if authors.count == 1
@@ -64,7 +64,7 @@ module Fastlane
         if Fastlane::Actions.is_deprecated?(action)
           puts("==========================================".deprecated)
           puts("This action (#{filter}) is deprecated".deprecated)
-          puts(action.deprecated_notes.to_s.deprecated) if action.deprecated_notes
+          puts(action.deprecated_notes.to_s.remove_markdown.deprecated) if action.deprecated_notes
           puts("==========================================\n".deprecated)
         end
 
@@ -107,16 +107,13 @@ module Fastlane
       rows = []
 
       if action.description
-        rows << [action.description]
+        description = action.description.to_s.remove_markdown
+        rows << [description]
         rows << [' ']
       end
 
       if action.details
-        details = action.details
-        details.gsub!(/^>/, "") # remove Markdown quotes
-        details.gsub!(/\[http[^\]]+\]\(([^)]+)\)/, '\1 🔗') # remove Markdown links
-        details.gsub!(/\[([^\]]+)\]\(([^\)]+)\)/, '"\1" (\2 🔗)') # remove Markdown links with custom text
-        details.gsub!("|", "") # remove new line preserve markers
+        details = action.details.to_s.remove_markdown
         details.split("\n").each do |detail|
           row = detail.empty? ? ' ' : detail
           rows << [row]

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -246,7 +246,7 @@ module Fastlane
             if Fastlane::Actions.is_deprecated?(class_ref)
               puts("==========================================".deprecated)
               puts("This action (#{method_sym}) is deprecated".deprecated)
-              puts(class_ref.deprecated_notes.to_s.deprecated) if class_ref.deprecated_notes
+              puts(class_ref.deprecated_notes.to_s.remove_markdown.deprecated) if class_ref.deprecated_notes
               puts("==========================================\n".deprecated)
             end
             class_ref.runner = self # needed to call another action form an action


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The change is required because is mentioning to use `hockeyApp`, which is obsolete, as an option to submit beta versions.
A note is added to refer to an `Appcenter` plugin instead

### Description

Added `Appcenter` link to refer to instead of HockeyApp
Tested my changes with the steps described in `Checklist`