### PR TITLE
[snapshot] Improve SnapshotHelper.swift to support snapshotting for multiple apps.

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -156,7 +156,7 @@ open class Snapshot: NSObject {
         sleep(1) // Waiting for the animation to be finished (kind of)
 
         #if os(OSX)
-            XCUIApplication().typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
+            Snapshot.app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
         #else
             
             guard let app = self.app else {
@@ -182,7 +182,7 @@ open class Snapshot: NSObject {
             return
         #endif
 
-        let networkLoadingIndicator = XCUIApplication().otherElements.deviceStatusBars.networkLoadingIndicators.element
+        let networkLoadingIndicator = Snapshot.app.otherElements.deviceStatusBars.networkLoadingIndicators.element
         let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
         _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
     }
@@ -257,7 +257,7 @@ private extension XCUIElementQuery {
     }
 
     var deviceStatusBars: XCUIElementQuery {
-        let deviceWidth = XCUIApplication().windows.firstMatch.frame.width
+        let deviceWidth = Snapshot.app.windows.firstMatch.frame.width
 
         let isStatusBar = NSPredicate { (evaluatedObject, _) in
             guard let element = evaluatedObject as? XCUIElementAttributes else { return false }

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -62,7 +62,7 @@ enum SnapshotError: Error, CustomDebugStringConvertible {
 
 @objcMembers
 open class Snapshot: NSObject {
-    static var app: XCUIApplication?
+    static var app: XCUIApplication!
     static var cacheDirectory: URL?
     static var screenshotsDirectory: URL? {
         return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
@@ -277,4 +277,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.13]
+// SnapshotHelperVersion [1.14]


### PR DESCRIPTION
#11834 duplicate.

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)

### Motivation and Context
Subsequent call to `XCUIApplication()` would rise an exception if UITest was previously setup with `XCUIApplication(bundleIdentifier:)`.
Replacing `XCUIApplication()` with `Snapshot.app` is safe because `app` variable was previously initialized via `setupSnapshot()` function invocation.
Reusing an existing `Snapshot.app` variable will enable multiple apps testing by leveraging `XCUIApplication(bundleIdentifier:)` from user tests.

### Description
Support multiple apps testing flows with native XCUIApplication(bundleIdentifier:).