### PR TITLE
[spaceship] Handle "Apple ID is locked" and other authentication errors better

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -491,13 +491,17 @@ module Spaceship
         # Unauthorized
         raise InvalidUserCredentialsError.new, "Invalid username and password combination. Used '#{user}' as the username."
       when 403
+        error_string = "Login worked, but access was forbidden. Try logging in on https://appstoreconnect.apple.com and see if any issues are raised to you there."
         # Forbidden
-        if response.body["serviceErrors"][0]["code"] == "-20209"
-          # Apple ID got locked by Apple for security reasons
-          raise InvalidUserCredentialsError.new, "This Apple ID has been locked for security reasons. Visit iForgot to reset your account (https://iforgot.apple.com)."
-        else
-          raise InvalidUserCredentialsError.new, "Login worked, but Apple reported that something was wrong anyway. Historically this has happened when an Apple ID got lost on Apple's end. See https://github.com/fastlane/fastlane/issues/14398"
+        case response.body["serviceErrors"][0]["code"]
+        when "-20209"
+          error_string = "This Apple ID has been locked for security reasons. Visit iForgot to reset your account (https://iforgot.apple.com)."
+          raise UnauthorizedAccessError.new, error_string
+        when "-20751"
+          error_string = "Login worked, but something went wrong anyway. This has happened when an Apple ID got lost on Apple's end. See https://github.com/fastlane/fastlane/issues/14398; try resetting your account over at https://iforgot.apple.com or contact Apple Developer Support https://developer.apple.com/contact/"
+          raise UnauthorizedAccessError.new, error_string
         end
+        raise UnauthorizedAccessError.new, error_string
       when 409
         # 2 step/factor is enabled for this account, first handle that
         handle_two_step_or_factor(response)


### PR DESCRIPTION
Apple id returning different status and messages when the Apple ID is not "alright". We should better handle the cases, so spaceship does not break.


### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

# Case: wrong password
```# Logfile created on 2019-03-12 17:52:12 +0100 by logger.rb/61378
INFO  [17:52:12]: >> GET https://olympus.itunes.apple.com/v1/session: [undefined body] 
DEBUG [17:52:13]: << GET https://olympus.itunes.apple.com/v1/session: 401 Unauthenticated

Request ID: LTG6ZX6EN55MAMQMQAYAKJN6.0.0

WARN  [17:52:13]: Auth lost
INFO  [17:52:13]: >> POST https://idmsa.apple.com/appleauth/auth/signin: {"accountName":"wrongpassword@acmecorp.com","password":"***","rememberMe":true} 
DEBUG [17:52:14]: << POST https://idmsa.apple.com/appleauth/auth/signin: 401 {"serviceErrors"=>[{"code"=>"-20101", "message"=>"Your Apple ID or password was incorrect."}]}
WARN  [17:52:14]: Auth lost
```

# Case: account locked by Apple
```# Logfile created on 2019-03-12 17:52:21 +0100 by logger.rb/61378
INFO  [17:52:21]: >> POST https://idmsa.apple.com/appleauth/auth/signin: {"accountName":"locked@acmecorp.com","password":"***","rememberMe":true} 
DEBUG [17:52:22]: << POST https://idmsa.apple.com/appleauth/auth/signin: 403 {"serviceErrors"=>[{"code"=>"-20209", "message"=>"This Apple ID has been locked for security reasons. Visit iForgot to reset your account (https://iforgot.apple.com)."}]}
```

# Case: Apple ID messed up by Apple (currently in process with dev support)
```# Logfile created on 2019-03-12 17:53:58 +0100 by logger.rb/61378
INFO  [17:53:58]: >> POST https://idmsa.apple.com/appleauth/auth/signin: {"accountName":"messedup@acmecorp.com","password":"***","rememberMe":true} 
DEBUG [17:53:59]: << POST https://idmsa.apple.com/appleauth/auth/signin: 403 {"serviceErrors"=>[{"code"=>"-20751", "message"=>"Your Apple ID or password was incorrect."}]}
```

# Need help with:
It's probably possible to have the error handling in a nicer way. With my quick fix I get the following messages: 
```Spaceship::Tunes::Error ({"serviceErrors"=>[{"code"=>"-20751", "message"=>"Your Apple ID or password was incorrect."}]})
aa=432B7D3AE74EF5684B3E447669F46985; Domain=idmsa.apple.com; Path=/; Secure; HttpOnly, dslang=US-EN; Domain=apple.com; Path=/; Secure; HttpOnly, site=USA; Domain=apple.com; Path=/; Secure; HttpOnly
```